### PR TITLE
29 example sdvcfbcfb teams call results in error

### DIFF
--- a/Sphinx-docs/_build/markdown/sportsdataverse.cfb.md
+++ b/Sphinx-docs/_build/markdown/sportsdataverse.cfb.md
@@ -4,13 +4,13 @@
 
 ## sportsdataverse.cfb.cfb_loaders module
 
+### sportsdataverse.cfb.cfb_loaders.get_cfb_teams()
 
-### sportsdataverse.cfb.cfb_loaders.cfb_teams()
 Load college football team ID information and logos
 
 Example:
 
-    cfb_df = sportsdataverse.cfb.cfb_teams()
+    cfb_df = sportsdataverse.cfb.get_cfb_teams()
 
 Args:
 
@@ -18,8 +18,8 @@ Returns:
 
     pd.DataFrame: Pandas dataframe containing teams available for the requested seasons.
 
-
 ### sportsdataverse.cfb.cfb_loaders.load_cfb_pbp(seasons: List[int])
+
 Load college football play by play data going back to 2003
 
 Example:
@@ -38,8 +38,8 @@ Raises:
 
     ValueError: If season is less than 2003.
 
-
 ### sportsdataverse.cfb.cfb_loaders.load_cfb_rosters(seasons: List[int])
+
 Load roster data
 
 Example:
@@ -58,8 +58,8 @@ Raises:
 
     ValueError: If season is less than 2014.
 
-
 ### sportsdataverse.cfb.cfb_loaders.load_cfb_schedule(seasons: List[int])
+
 Load college football schedule data
 
 Example:
@@ -78,8 +78,8 @@ Raises:
 
     ValueError: If season is less than 2002.
 
-
 ### sportsdataverse.cfb.cfb_loaders.load_cfb_team_info(seasons: List[int])
+
 Load college football team info
 
 Example:
@@ -100,18 +100,18 @@ Raises:
 
 ## sportsdataverse.cfb.cfb_pbp module
 
-
 ### class sportsdataverse.cfb.cfb_pbp.CFBPlayProcess(gameId=0)
+
 Bases: `object`
 
+#### \_\_init\_\_(gameId=0)
 
-#### \__init__(gameId=0)
-Initialize self.  See help(type(self)) for accurate signature.
-
+Initialize self. See help(type(self)) for accurate signature.
 
 #### create_box_score()
 
 #### espn_cfb_pbp()
+
 espn_cfb_pbp() - Pull the game by id. Data from API endpoints: college-football/playbyplay, college-football/summary
 
 Args:
@@ -130,16 +130,16 @@ Example:
 
     cfb_df = sportsdataverse.cfb.CFBPlayProcess(gameId=401256137).espn_cfb_pbp()
 
-
 #### gameId( = 0)
 
 #### ran_pipeline( = False)
 
 #### run_processing_pipeline()
+
 ## sportsdataverse.cfb.cfb_schedule module
 
-
 ### sportsdataverse.cfb.cfb_schedule.espn_cfb_calendar(season=None, groups=None)
+
 espn_cfb_calendar - look up the men’s college football calendar for a given season
 
 Args:
@@ -155,8 +155,8 @@ Raises:
 
     ValueError: If season is less than 2002.
 
-
 ### sportsdataverse.cfb.cfb_schedule.espn_cfb_schedule(dates=None, week=None, season_type=None, groups=None, limit=500)
+
 espn_cfb_schedule - look up the college football schedule for a given season
 
 Args:
@@ -173,8 +173,8 @@ Returns:
 
 ## sportsdataverse.cfb.cfb_teams module
 
-
 ### sportsdataverse.cfb.cfb_teams.espn_cfb_teams(groups=None)
+
 espn_cfb_teams - look up the college football teams
 
 Args:

--- a/docs/docs/cfb/index.md
+++ b/docs/docs/cfb/index.md
@@ -4,13 +4,13 @@
 
 ## sportsdataverse.cfb.cfb_loaders module
 
+### sportsdataverse.cfb.cfb_loaders.get_cfb_teams()
 
-### sportsdataverse.cfb.cfb_loaders.cfb_teams()
 Load college football team ID information and logos
 
 Example:
 
-    cfb_df = sportsdataverse.cfb.cfb_teams()
+    cfb_df = sportsdataverse.cfb.get_cfb_teams()
 
 Args:
 
@@ -18,8 +18,8 @@ Returns:
 
     pd.DataFrame: Pandas dataframe containing teams available for the requested seasons.
 
-
 ### sportsdataverse.cfb.cfb_loaders.load_cfb_pbp(seasons: List[int])
+
 Load college football play by play data going back to 2003
 
 Example:
@@ -38,8 +38,8 @@ Raises:
 
     ValueError: If season is less than 2003.
 
-
 ### sportsdataverse.cfb.cfb_loaders.load_cfb_rosters(seasons: List[int])
+
 Load roster data
 
 Example:
@@ -58,8 +58,8 @@ Raises:
 
     ValueError: If season is less than 2014.
 
-
 ### sportsdataverse.cfb.cfb_loaders.load_cfb_schedule(seasons: List[int])
+
 Load college football schedule data
 
 Example:
@@ -78,8 +78,8 @@ Raises:
 
     ValueError: If season is less than 2002.
 
-
 ### sportsdataverse.cfb.cfb_loaders.load_cfb_team_info(seasons: List[int])
+
 Load college football team info
 
 Example:
@@ -100,18 +100,18 @@ Raises:
 
 ## sportsdataverse.cfb.cfb_pbp module
 
-
 ### class sportsdataverse.cfb.cfb_pbp.CFBPlayProcess(gameId=0)
+
 Bases: `object`
 
+#### \_\_init\_\_(gameId=0)
 
-#### \__init__(gameId=0)
-Initialize self.  See help(type(self)) for accurate signature.
-
+Initialize self. See help(type(self)) for accurate signature.
 
 #### create_box_score()
 
 #### espn_cfb_pbp()
+
 espn_cfb_pbp() - Pull the game by id. Data from API endpoints: college-football/playbyplay, college-football/summary
 
 Args:
@@ -130,16 +130,16 @@ Example:
 
     cfb_df = sportsdataverse.cfb.CFBPlayProcess(gameId=401256137).espn_cfb_pbp()
 
-
 #### gameId( = 0)
 
 #### ran_pipeline( = False)
 
 #### run_processing_pipeline()
+
 ## sportsdataverse.cfb.cfb_schedule module
 
-
 ### sportsdataverse.cfb.cfb_schedule.espn_cfb_calendar(season=None, groups=None)
+
 espn_cfb_calendar - look up the men’s college football calendar for a given season
 
 Args:
@@ -155,8 +155,8 @@ Raises:
 
     ValueError: If season is less than 2002.
 
-
 ### sportsdataverse.cfb.cfb_schedule.espn_cfb_schedule(dates=None, week=None, season_type=None, groups=None, limit=500)
+
 espn_cfb_schedule - look up the college football schedule for a given season
 
 Args:
@@ -173,8 +173,8 @@ Returns:
 
 ## sportsdataverse.cfb.cfb_teams module
 
-
 ### sportsdataverse.cfb.cfb_teams.espn_cfb_teams(groups=None)
+
 espn_cfb_teams - look up the college football teams
 
 Args:

--- a/sportsdataverse/cfb/cfb_loaders.py
+++ b/sportsdataverse/cfb/cfb_loaders.py
@@ -113,14 +113,17 @@ def load_cfb_team_info(seasons: List[int]) -> pd.DataFrame:
     for i in tqdm(seasons):
         if int(i) < 2002:
             raise SeasonNotFoundError("season cannot be less than 2002")
-        i_data = pd.read_parquet(CFB_TEAM_INFO_URL.format(season = i), engine='auto', columns=None)
+        try:
+            i_data = pd.read_parquet(CFB_TEAM_INFO_URL.format(season = i), engine='auto', columns=None)
+        except:
+            print(f'We don\'t seem to have data for the {i} season.')
         data = data.append(i_data)
     #Give each row a unique index
     data.reset_index(drop=True, inplace=True)
 
     return data
 
-def cfb_teams() -> pd.DataFrame:
+def get_cfb_teams() -> pd.DataFrame:
     """Load college football team ID information and logos
 
     Example:
@@ -132,4 +135,5 @@ def cfb_teams() -> pd.DataFrame:
         pd.DataFrame: Pandas dataframe containing teams available for the requested seasons.
     """
     df = pd.read_parquet(CFB_TEAM_LOGO_URL, engine='auto', columns=None)
+    
     return df

--- a/sportsdataverse/config.py
+++ b/sportsdataverse/config.py
@@ -1,11 +1,11 @@
 SGITHUB = 'https://raw.githubusercontent.com/sportsdataverse/'
 NFLVERSEGITHUB='https://raw.githubusercontent.com/nflverse/'
 
-CFB_BASE_URL = SGITHUB+'cfbfastR-data/master/pbp/parquet/play_by_play_{season}.parquet'
-CFB_ROSTER_URL = SGITHUB+'cfbfastR-data/master/rosters/parquet/rosters_{season}.parquet'
-CFB_TEAM_LOGO_URL  = SGITHUB+'cfbfastR-data/master/teams/teams_colors_logos.parquet'
-CFB_TEAM_SCHEDULE_URL = SGITHUB+'cfbfastR-data/master/schedules/parquet/schedules_{season}.parquet'
-CFB_TEAM_INFO_URL = SGITHUB+'cfbfastR-data/master/team_info/parquet/team_info_{season}.parquet'
+CFB_BASE_URL = SGITHUB+'cfbfastR-data/main/pbp/parquet/play_by_play_{season}.parquet'
+CFB_ROSTER_URL = SGITHUB+'cfbfastR-data/main/rosters/parquet/rosters_{season}.parquet'
+CFB_TEAM_LOGO_URL  = SGITHUB+'cfbfastR-data/main/teams/teams_colors_logos.parquet'
+CFB_TEAM_SCHEDULE_URL = SGITHUB+'cfbfastR-data/main/schedules/parquet/schedules_{season}.parquet'
+CFB_TEAM_INFO_URL = SGITHUB+'cfbfastR-data/main/team_info/parquet/team_info_{season}.parquet'
 
 NFL_BASE_URL = NFLVERSEGITHUB+'nflfastR-data/master/data/play_by_play_{season}.parquet'
 NFL_PLAYER_STATS_URL = NFLVERSEGITHUB+'nflfastR-data/master/data/player_stats.parquet'

--- a/test.py
+++ b/test.py
@@ -1,3 +1,3 @@
 import sportsdataverse as sdv
-cfb_df = sdv.cfb.cfb_teams()
+cfb_df = sdv.cfb.get_cfb_teams()
 print(cfb_df)

--- a/test.py
+++ b/test.py
@@ -1,0 +1,3 @@
+import sportsdataverse as sdv
+cfb_df = sdv.cfb.cfb_teams()
+print(cfb_df)


### PR DESCRIPTION
An edge case issue was identified within the sportsdataverse.cfb.cfb_teams() function, where python would throw a` 'module' object is not callable error` for the user.

A solution to fix this issue, involves renaming the function to sportsdataverse.cfb.get_cfb_teams(), to avoid this specific error to happen.