### PR TITLE
ctrl+f vertical, replace with diagonal

### DIFF
--- a/sportsdataverse/cfb/cfb_game_rosters.py
+++ b/sportsdataverse/cfb/cfb_game_rosters.py
@@ -89,7 +89,7 @@ def helper_cfb_team_items(items, **kwargs):
         for k in pop_cols:
             team.pop(k, None)
         team_row = pl.from_pandas(pd.json_normalize(team, sep="_"))
-        teams_df = pl.concat([teams_df, team_row], how="vertical")
+        teams_df = pl.concat([teams_df, team_row], how="diagonal")
 
     teams_df.columns = [
         "team_id",
@@ -131,7 +131,7 @@ def helper_cfb_roster_items(items, summary_url, **kwargs):
         team_roster.columns = [col.replace("$ref", "href") for col in team_roster.columns]
         team_roster.columns = [underscore(c) for c in team_roster.columns]
         team_roster = team_roster.with_columns(team_id=pl.lit(tm).cast(pl.Int32))
-        game_rosters = pl.concat([game_rosters, team_roster], how="vertical")
+        game_rosters = pl.concat([game_rosters, team_roster], how="diagonal")
     game_rosters = game_rosters.drop(["period", "for_player_id", "active"])
     game_rosters = game_rosters.with_columns(
         player_id=pl.col("player_id").cast(pl.Int64), team_id=pl.col("team_id").cast(pl.Int32)

--- a/sportsdataverse/cfb/cfb_loaders.py
+++ b/sportsdataverse/cfb/cfb_loaders.py
@@ -37,7 +37,7 @@ def load_cfb_pbp(seasons: List[int], return_as_pandas=False) -> pl.DataFrame:
         if int(i) < 2003:
             raise SeasonNotFoundError("season cannot be less than 2003")
         i_data = pl.read_parquet(CFB_BASE_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -65,7 +65,7 @@ def load_cfb_schedule(seasons: List[int], return_as_pandas=False) -> pl.DataFram
             raise SeasonNotFoundError("season cannot be less than 2002")
         i_data = pl.read_parquet(CFB_TEAM_SCHEDULE_URL.format(season=i), use_pyarrow=True, columns=None)
         # data = data.append(i_data)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -92,7 +92,7 @@ def load_cfb_rosters(seasons: List[int], return_as_pandas=False) -> pl.DataFrame
         if int(i) < 2004:
             raise SeasonNotFoundError("season cannot be less than 2004")
         i_data = pl.read_parquet(CFB_ROSTER_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -122,7 +122,7 @@ def load_cfb_team_info(seasons: List[int], return_as_pandas=False) -> pl.DataFra
             i_data = pl.read_parquet(CFB_TEAM_INFO_URL.format(season=i), use_pyarrow=True, columns=None)
         except Exception:
             print(f"We don't seem to have data for the {i} season.")
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 

--- a/sportsdataverse/cfb/cfb_schedule.py
+++ b/sportsdataverse/cfb/cfb_schedule.py
@@ -221,7 +221,7 @@ def espn_cfb_calendar(season=None, groups=None, ondays=None, return_as_pandas=Fa
                     sep="_",
                 )
 
-                full_schedule = pl.concat([full_schedule, pl.from_pandas(reg)], how="vertical")
+                full_schedule = pl.concat([full_schedule, pl.from_pandas(reg)], how="diagonal")
 
         full_schedule = full_schedule.with_columns(season=season)
 

--- a/sportsdataverse/mbb/mbb_game_rosters.py
+++ b/sportsdataverse/mbb/mbb_game_rosters.py
@@ -85,7 +85,7 @@ def helper_mbb_team_items(items, **kwargs):
         for k in pop_cols:
             team.pop(k, None)
         team_row = pl.from_pandas(pd.json_normalize(team, sep="_"))
-        teams_df = pl.concat([teams_df, team_row], how="vertical")
+        teams_df = pl.concat([teams_df, team_row], how="diagonal")
 
     teams_df.columns = [
         "team_id",
@@ -127,7 +127,7 @@ def helper_mbb_roster_items(items, summary_url, **kwargs):
         team_roster.columns = [col.replace("$ref", "href") for col in team_roster.columns]
         team_roster.columns = [underscore(c) for c in team_roster.columns]
         team_roster = team_roster.with_columns(team_id=pl.lit(tm).cast(pl.Int32))
-        game_rosters = pl.concat([game_rosters, team_roster], how="vertical")
+        game_rosters = pl.concat([game_rosters, team_roster], how="diagonal")
     game_rosters = game_rosters.drop(["period", "for_player_id", "active"])
     game_rosters = game_rosters.with_columns(
         player_id=pl.col("player_id").cast(pl.Int64), team_id=pl.col("team_id").cast(pl.Int32)

--- a/sportsdataverse/mbb/mbb_loaders.py
+++ b/sportsdataverse/mbb/mbb_loaders.py
@@ -36,7 +36,7 @@ def load_mbb_pbp(seasons: List[int], return_as_pandas=False) -> pl.DataFrame:
         if int(i) < 2002:
             raise SeasonNotFoundError("season cannot be less than 2002")
         i_data = pl.read_parquet(MBB_BASE_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -64,7 +64,7 @@ def load_mbb_team_boxscore(seasons: List[int], return_as_pandas=False) -> pl.Dat
         if int(i) < 2002:
             raise SeasonNotFoundError("season cannot be less than 2002")
         i_data = pl.read_parquet(MBB_TEAM_BOX_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -92,7 +92,7 @@ def load_mbb_player_boxscore(seasons: List[int], return_as_pandas=False) -> pl.D
         if int(i) < 2002:
             raise SeasonNotFoundError("season cannot be less than 2002")
         i_data = pl.read_parquet(MBB_PLAYER_BOX_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -120,5 +120,5 @@ def load_mbb_schedule(seasons: List[int], return_as_pandas=False) -> pl.DataFram
         if int(i) < 2002:
             raise SeasonNotFoundError("season cannot be less than 2002")
         i_data = pl.read_parquet(MBB_TEAM_SCHEDULE_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data

--- a/sportsdataverse/nba/nba_game_rosters.py
+++ b/sportsdataverse/nba/nba_game_rosters.py
@@ -90,7 +90,7 @@ def helper_nba_team_items(items, **kwargs):
         for k in pop_cols:
             team.pop(k, None)
         team_row = pl.from_pandas(pd.json_normalize(team, sep="_"))
-        teams_df = pl.concat([teams_df, team_row], how="vertical")
+        teams_df = pl.concat([teams_df, team_row], how="diagonal")
 
     teams_df.columns = [
         "team_id",
@@ -129,7 +129,7 @@ def helper_nba_roster_items(items, summary_url, **kwargs):
         team_roster.columns = [col.replace("$ref", "href") for col in team_roster.columns]
         team_roster.columns = [underscore(c) for c in team_roster.columns]
         team_roster = team_roster.with_columns(team_id=pl.lit(tm).cast(pl.Int32))
-        game_rosters = pl.concat([game_rosters, team_roster], how="vertical")
+        game_rosters = pl.concat([game_rosters, team_roster], how="diagonal")
     game_rosters = game_rosters.drop(["period", "for_player_id", "active"])
     game_rosters = game_rosters.with_columns(
         player_id=pl.col("player_id").cast(pl.Int64), team_id=pl.col("team_id").cast(pl.Int32)

--- a/sportsdataverse/nba/nba_loaders.py
+++ b/sportsdataverse/nba/nba_loaders.py
@@ -36,7 +36,7 @@ def load_nba_pbp(seasons: List[int], return_as_pandas=False) -> pl.DataFrame:
         if int(i) < 2002:
             raise SeasonNotFoundError("season cannot be less than 2002")
         i_data = pl.read_parquet(NBA_BASE_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -64,7 +64,7 @@ def load_nba_team_boxscore(seasons: List[int], return_as_pandas=False) -> pl.Dat
         if int(i) < 2002:
             raise SeasonNotFoundError("season cannot be less than 2002")
         i_data = pl.read_parquet(NBA_TEAM_BOX_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -92,7 +92,7 @@ def load_nba_player_boxscore(seasons: List[int], return_as_pandas=False) -> pl.D
         if int(i) < 2002:
             raise SeasonNotFoundError("season cannot be less than 2002")
         i_data = pl.read_parquet(NBA_PLAYER_BOX_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -120,5 +120,5 @@ def load_nba_schedule(seasons: List[int], return_as_pandas=False) -> pl.DataFram
         if int(i) < 2002:
             raise SeasonNotFoundError("season cannot be less than 2002")
         i_data = pl.read_parquet(NBA_TEAM_SCHEDULE_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data

--- a/sportsdataverse/nfl/nfl_game_rosters.py
+++ b/sportsdataverse/nfl/nfl_game_rosters.py
@@ -92,7 +92,7 @@ def helper_nfl_team_items(items, **kwargs):
         for k in pop_cols:
             team.pop(k, None)
         team_row = pl.from_pandas(pd.json_normalize(team, sep="_"))
-        teams_df = pl.concat([teams_df, team_row], how="vertical")
+        teams_df = pl.concat([teams_df, team_row], how="diagonal")
     print(teams_df.columns)
     teams_df.columns = [
         "team_id",
@@ -134,7 +134,7 @@ def helper_nfl_roster_items(items, summary_url, **kwargs):
         team_roster.columns = [col.replace("$ref", "href") for col in team_roster.columns]
         team_roster.columns = [underscore(c) for c in team_roster.columns]
         team_roster = team_roster.with_columns(team_id=pl.lit(tm).cast(pl.Int32))
-        game_rosters = pl.concat([game_rosters, team_roster], how="vertical")
+        game_rosters = pl.concat([game_rosters, team_roster], how="diagonal")
     game_rosters = game_rosters.drop(["period", "for_player_id", "active"])
     game_rosters = game_rosters.with_columns(
         player_id=pl.col("player_id").cast(pl.Int64), team_id=pl.col("team_id").cast(pl.Int32)

--- a/sportsdataverse/nfl/nfl_loaders.py
+++ b/sportsdataverse/nfl/nfl_loaders.py
@@ -59,7 +59,7 @@ def load_nfl_pbp(seasons: List[int], return_as_pandas=False) -> pl.DataFrame:
     for i in tqdm(seasons):
         season_not_found_error(int(i), 1999)
         i_data = pl.read_parquet(NFL_BASE_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -89,7 +89,7 @@ def load_nfl_schedule(seasons: List[int], return_as_pandas=False) -> pl.DataFram
             # i_data = pd.read_parquet(NFL_TEAM_SCHEDULE_URL.format(season = i), engine='auto', columns=None)
             i_data = read_r(download_file(schedule_url, f"{tempdirname}/nfl_sched_{i}.rds"))[None]
             i_data = pl.DataFrame(i_data)
-            data = pl.concat([data, i_data], how="vertical")
+            data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -225,7 +225,7 @@ def load_nfl_pfr_weekly_pass(seasons: List[int], return_as_pandas=False) -> pl.D
     for i in tqdm(seasons):
         season_not_found_error(int(i), 2018)
         i_data = pl.read_parquet(NFL_PFR_WEEK_PASS_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -273,7 +273,7 @@ def load_nfl_pfr_weekly_rush(seasons: List[int], return_as_pandas=False) -> pl.D
     for i in tqdm(seasons):
         season_not_found_error(int(i), 2018)
         i_data = pl.read_parquet(NFL_PFR_WEEK_RUSH_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -321,7 +321,7 @@ def load_nfl_pfr_weekly_rec(seasons: List[int], return_as_pandas=False) -> pl.Da
     for i in tqdm(seasons):
         season_not_found_error(int(i), 2018)
         i_data = pl.read_parquet(NFL_PFR_WEEK_REC_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -369,7 +369,7 @@ def load_nfl_pfr_weekly_def(seasons: List[int], return_as_pandas=False) -> pl.Da
     for i in tqdm(seasons):
         season_not_found_error(int(i), 2018)
         i_data = pl.read_parquet(NFL_PFR_WEEK_DEF_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -393,7 +393,7 @@ def load_nfl_rosters(seasons: List[int], return_as_pandas=False) -> pl.DataFrame
     for i in tqdm(seasons):
         season_not_found_error(int(i), 1920)
         i_data = pl.read_parquet(NFL_ROSTER_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -417,7 +417,7 @@ def load_nfl_weekly_rosters(seasons: List[int], return_as_pandas=False) -> pl.Da
     for i in tqdm(seasons):
         season_not_found_error(int(i), 2002)
         i_data = pl.read_parquet(NFL_WEEKLY_ROSTER_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -479,7 +479,7 @@ def load_nfl_snap_counts(seasons: List[int], return_as_pandas=False) -> pl.DataF
     for i in tqdm(seasons):
         season_not_found_error(int(i), 2012)
         i_data = pl.read_parquet(NFL_SNAP_COUNTS_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -503,7 +503,7 @@ def load_nfl_pbp_participation(seasons: List[int], return_as_pandas=False) -> pl
     for i in tqdm(seasons):
         season_not_found_error(int(i), 2016)
         i_data = pl.read_parquet(NFL_PBP_PARTICIPATION_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -527,7 +527,7 @@ def load_nfl_injuries(seasons: List[int], return_as_pandas=False) -> pl.DataFram
     for i in tqdm(seasons):
         season_not_found_error(int(i), 2009)
         i_data = pl.read_parquet(NFL_INJURIES_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -551,7 +551,7 @@ def load_nfl_depth_charts(seasons: List[int], return_as_pandas=False) -> pl.Data
     for i in tqdm(seasons):
         season_not_found_error(int(i), 2001)
         i_data = pl.read_parquet(NFL_DEPTH_CHARTS_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 

--- a/sportsdataverse/nfl/nfl_schedule.py
+++ b/sportsdataverse/nfl/nfl_schedule.py
@@ -169,7 +169,7 @@ def espn_nfl_calendar(season=None, ondays=None, return_as_pandas=False, **kwargs
                     errors="ignore",
                     sep="_",
                 )
-                full_schedule = pl.concat([full_schedule, pl.from_pandas(reg)], how="vertical")
+                full_schedule = pl.concat([full_schedule, pl.from_pandas(reg)], how="diagonal")
         full_schedule = full_schedule.with_columns(season=season)
         full_schedule = full_schedule.janitor.clean_names()
         full_schedule = full_schedule.rename({"week_value": "week", "season_type_value": "season_type"})

--- a/sportsdataverse/nhl/nhl_api.py
+++ b/sportsdataverse/nhl/nhl_api.py
@@ -58,5 +58,5 @@ def nhl_api_schedule(start_date: str, end_date: str, return_as_pandas=False, **k
     pbp_txt_games = pl.DataFrame()
     for date in pbp_txt["dates"]:
         game = pl.from_pandas(pd.json_normalize(date, record_path="games", meta=["date"]))
-        pbp_txt_games = pl.concat([pbp_txt_games, game], how="vertical")
+        pbp_txt_games = pl.concat([pbp_txt_games, game], how="diagonal")
     return pbp_txt_games.to_pandas() if return_as_pandas else pbp_txt_games

--- a/sportsdataverse/nhl/nhl_game_rosters.py
+++ b/sportsdataverse/nhl/nhl_game_rosters.py
@@ -94,7 +94,7 @@ def helper_nhl_team_items(items, **kwargs):
         for k in pop_cols:
             team.pop(k, None)
         team_row = pl.from_pandas(pd.json_normalize(team, sep="_"))
-        teams_df = pl.concat([teams_df, team_row], how="vertical")
+        teams_df = pl.concat([teams_df, team_row], how="diagonal")
 
     teams_df.columns = [
         "team_id",

--- a/sportsdataverse/nhl/nhl_loaders.py
+++ b/sportsdataverse/nhl/nhl_loaders.py
@@ -36,7 +36,7 @@ def load_nhl_pbp(seasons: List[int], return_as_pandas=False) -> pl.DataFrame:
         if int(i) < 2011:
             raise SeasonNotFoundError("season cannot be less than 2011")
         i_data = pl.read_parquet(NHL_BASE_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -63,7 +63,7 @@ def load_nhl_schedule(seasons: List[int], return_as_pandas=False) -> pl.DataFram
         if int(i) < 2002:
             raise SeasonNotFoundError("season cannot be less than 2002")
         i_data = pl.read_parquet(NHL_TEAM_SCHEDULE_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -91,7 +91,7 @@ def load_nhl_team_boxscore(seasons: List[int], return_as_pandas=False) -> pl.Dat
         if int(i) < 2011:
             raise SeasonNotFoundError("season cannot be less than 2011")
         i_data = pl.read_parquet(NHL_TEAM_BOX_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -119,7 +119,7 @@ def load_nhl_player_boxscore(seasons: List[int], return_as_pandas=False) -> pl.D
         if int(i) < 2011:
             raise SeasonNotFoundError("season cannot be less than 2011")
         i_data = pl.read_parquet(NHL_PLAYER_BOX_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 

--- a/sportsdataverse/wbb/wbb_game_rosters.py
+++ b/sportsdataverse/wbb/wbb_game_rosters.py
@@ -85,7 +85,7 @@ def helper_wbb_team_items(items, **kwargs):
         for k in pop_cols:
             team.pop(k, None)
         team_row = pl.from_pandas(pd.json_normalize(team, sep="_"))
-        teams_df = pl.concat([teams_df, team_row], how="vertical")
+        teams_df = pl.concat([teams_df, team_row], how="diagonal")
 
     teams_df.columns = [
         "team_id",
@@ -127,7 +127,7 @@ def helper_wbb_roster_items(items, summary_url, **kwargs):
         team_roster.columns = [col.replace("$ref", "href") for col in team_roster.columns]
         team_roster.columns = [underscore(c) for c in team_roster.columns]
         team_roster = team_roster.with_columns(team_id=pl.lit(tm).cast(pl.Int32))
-        game_rosters = pl.concat([game_rosters, team_roster], how="vertical")
+        game_rosters = pl.concat([game_rosters, team_roster], how="diagonal")
     game_rosters = game_rosters.drop(["period", "for_player_id", "active"])
     game_rosters = game_rosters.with_columns(
         player_id=pl.col("player_id").cast(pl.Int64), team_id=pl.col("team_id").cast(pl.Int32)

--- a/sportsdataverse/wbb/wbb_loaders.py
+++ b/sportsdataverse/wbb/wbb_loaders.py
@@ -36,7 +36,7 @@ def load_wbb_pbp(seasons: List[int], return_as_pandas=False) -> pl.DataFrame:
         if int(i) < 2002:
             raise SeasonNotFoundError("season cannot be less than 2002")
         i_data = pl.read_parquet(WBB_BASE_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -64,7 +64,7 @@ def load_wbb_team_boxscore(seasons: List[int], return_as_pandas=False) -> pl.Dat
         if int(i) < 2002:
             raise ValueError("season cannot be less than 2002")
         i_data = pl.read_parquet(WBB_TEAM_BOX_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -92,7 +92,7 @@ def load_wbb_player_boxscore(seasons: List[int], return_as_pandas=False) -> pl.D
         if int(i) < 2002:
             raise ValueError("season cannot be less than 2002")
         i_data = pl.read_parquet(WBB_PLAYER_BOX_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -120,5 +120,5 @@ def load_wbb_schedule(seasons: List[int], return_as_pandas=False) -> pl.DataFram
         if int(i) < 2002:
             raise ValueError("season cannot be less than 2002")
         i_data = pl.read_parquet(WBB_TEAM_SCHEDULE_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data

--- a/sportsdataverse/wnba/wnba_game_rosters.py
+++ b/sportsdataverse/wnba/wnba_game_rosters.py
@@ -90,7 +90,7 @@ def helper_wnba_team_items(items, **kwargs):
         for k in pop_cols:
             team.pop(k, None)
         team_row = pl.from_pandas(pd.json_normalize(team, sep="_"))
-        teams_df = pl.concat([teams_df, team_row], how="vertical")
+        teams_df = pl.concat([teams_df, team_row], how="diagonal")
 
     teams_df.columns = [
         "team_id",
@@ -130,7 +130,7 @@ def helper_wnba_roster_items(items, summary_url, **kwargs):
         team_roster.columns = [col.replace("$ref", "href") for col in team_roster.columns]
         team_roster.columns = [underscore(c) for c in team_roster.columns]
         team_roster = team_roster.with_columns(team_id=pl.lit(tm).cast(pl.Int32))
-        game_rosters = pl.concat([game_rosters, team_roster], how="vertical")
+        game_rosters = pl.concat([game_rosters, team_roster], how="diagonal")
     game_rosters = game_rosters.drop(["period", "for_player_id", "active"])
     game_rosters = game_rosters.with_columns(
         player_id=pl.col("player_id").cast(pl.Int64), team_id=pl.col("team_id").cast(pl.Int32)

--- a/sportsdataverse/wnba/wnba_loaders.py
+++ b/sportsdataverse/wnba/wnba_loaders.py
@@ -36,7 +36,7 @@ def load_wnba_pbp(seasons: List[int], return_as_pandas=False) -> pl.DataFrame:
         if int(i) < 2002:
             raise SeasonNotFoundError("season cannot be less than 2002")
         i_data = pl.read_parquet(WNBA_BASE_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -64,7 +64,7 @@ def load_wnba_team_boxscore(seasons: List[int], return_as_pandas=False) -> pl.Da
         if int(i) < 2002:
             raise ValueError("season cannot be less than 2002")
         i_data = pl.read_parquet(WNBA_TEAM_BOX_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -92,7 +92,7 @@ def load_wnba_player_boxscore(seasons: List[int], return_as_pandas=False) -> pl.
         if int(i) < 2002:
             raise ValueError("season cannot be less than 2002")
         i_data = pl.read_parquet(WNBA_PLAYER_BOX_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -120,5 +120,5 @@ def load_wnba_schedule(seasons: List[int], return_as_pandas=False) -> pl.DataFra
         if int(i) < 2002:
             raise ValueError("season cannot be less than 2002")
         i_data = pl.read_parquet(WNBA_TEAM_SCHEDULE_URL.format(season=i), use_pyarrow=True, columns=None)
-        data = pl.concat([data, i_data], how="vertical")
+        data = pl.concat([data, i_data], how="diagonal")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data


### PR DESCRIPTION
when doing broad sweeps, pl.concat can sometimes fail due to mismatched columns between different years' tables. Changing 'vertical' to 'diagonal' fixes that; it causes column name matching, and creation of new columns (with backfilled nans for previous concat entries) when needed.

NB: when running pytest locally, am getting a lot of errors in test_dl_utils. I suspect some changes to urllib/requests in a later version of python may cause issues with how the exception block is being handled.

in any event, the exception handling logic for `download` likely needs rewritten. For example, the logger expects `response` to exist, when in reality, an exception raising inside session.get will cause response to never be written. A mock response object thus has to be instantiated prior to logging the status codes and so on.

also of note: consider refactoring the manual retry handling using adapters, eg [here](https://stackoverflow.com/questions/15431044/can-i-set-max-retries-for-requests-request)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the data concatenation method from "vertical" to "diagonal" across various loaders and roster files for improved data structure and consistency. This change impacts College Football (CFB), Men's Basketball (MBB), NBA, NFL, NHL, Women's Basketball (WBB), and WNBA data processing modules.
	- Made column modifications in certain data frames for better alignment and consistency across the board.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->