### PR TITLE
feat(nfl): cache + auto-renew api.nfl.com token; NFL_ACCESS_TOKEN env override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
+- [0.0.58 (in development)](#0058-in-development)
+  - [NFL — automatic `api.nfl.com` token caching + `NFL_ACCESS_TOKEN` override](#nfl--automatic-apinflcom-token-caching--nfl_access_token-override)
+  - [Internal — Fox data key single-sourced](#internal--fox-data-key-single-sourced)
 - [0.0.57 Release: June 10, 2026](#0057-release-june-10-2026)
   - [Fox Sports Bifrost wrappers (CFB, NBA, MBB, NHL, MLB)](#fox-sports-bifrost-wrappers-cfb-nba-mbb-nhl-mlb)
     - [CFB — Fox as a backup source for the EPA/WPA play processor (`fox_cfb_play_process`)](#cfb--fox-as-a-backup-source-for-the-epawpa-play-processor-fox_cfb_play_process)
@@ -88,6 +91,16 @@
 - [0.0.5 Release: October 20, 2021](#005-release-october-20-2021)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## 0.0.58 (in development)
+
+### NFL — automatic `api.nfl.com` token caching + `NFL_ACCESS_TOKEN` override
+
+The `api.nfl.com` bearer token is now minted once and cached in-process, then auto-renewed just before its JWT `exp` — so back-to-back `nfl_*` / `nfl_api_*` calls reuse a single token instead of POSTing to `/identity/v3/token` on every call, with no setup and no manual refresh. A new optional `NFL_ACCESS_TOKEN` env var injects a pre-minted bearer token verbatim (skipping the mint + cache); the existing `NFL_CLIENT_KEY` / `NFL_CLIENT_SECRET` credential overrides still apply. `nfl_clear_token_cache()` forces a fresh mint, and `nfl_token_gen(force_refresh=True)` re-mints on demand.
+
+### Internal — Fox data key single-sourced
+
+`sportsdataverse.cfb.cfb_fox_ext.FOX_DATA_KEY` is now imported from `sportsdataverse._fox_layout.DATA_KEY` so the bundled public Fox key and its `SDV_PY_FOX_DATA_KEY` env override live in exactly one place instead of being duplicated.
 
 ## 0.0.57 Release: June 10, 2026
 

--- a/docs/src/pages/CHANGELOG.md
+++ b/docs/src/pages/CHANGELOG.md
@@ -2,6 +2,9 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
+- [0.0.58 (in development)](#0058-in-development)
+  - [NFL — automatic `api.nfl.com` token caching + `NFL_ACCESS_TOKEN` override](#nfl--automatic-apinflcom-token-caching--nfl_access_token-override)
+  - [Internal — Fox data key single-sourced](#internal--fox-data-key-single-sourced)
 - [0.0.57 Release: June 10, 2026](#0057-release-june-10-2026)
   - [Fox Sports Bifrost wrappers (CFB, NBA, MBB, NHL, MLB)](#fox-sports-bifrost-wrappers-cfb-nba-mbb-nhl-mlb)
     - [CFB — Fox as a backup source for the EPA/WPA play processor (`fox_cfb_play_process`)](#cfb--fox-as-a-backup-source-for-the-epawpa-play-processor-fox_cfb_play_process)
@@ -88,6 +91,16 @@
 - [0.0.5 Release: October 20, 2021](#005-release-october-20-2021)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## 0.0.58 (in development)
+
+### NFL — automatic `api.nfl.com` token caching + `NFL_ACCESS_TOKEN` override
+
+The `api.nfl.com` bearer token is now minted once and cached in-process, then auto-renewed just before its JWT `exp` — so back-to-back `nfl_*` / `nfl_api_*` calls reuse a single token instead of POSTing to `/identity/v3/token` on every call, with no setup and no manual refresh. A new optional `NFL_ACCESS_TOKEN` env var injects a pre-minted bearer token verbatim (skipping the mint + cache); the existing `NFL_CLIENT_KEY` / `NFL_CLIENT_SECRET` credential overrides still apply. `nfl_clear_token_cache()` forces a fresh mint, and `nfl_token_gen(force_refresh=True)` re-mints on demand.
+
+### Internal — Fox data key single-sourced
+
+`sportsdataverse.cfb.cfb_fox_ext.FOX_DATA_KEY` is now imported from `sportsdataverse._fox_layout.DATA_KEY` so the bundled public Fox key and its `SDV_PY_FOX_DATA_KEY` env override live in exactly one place instead of being duplicated.
 
 ## 0.0.57 Release: June 10, 2026
 

--- a/sportsdataverse/cfb/cfb_fox_ext.py
+++ b/sportsdataverse/cfb/cfb_fox_ext.py
@@ -13,7 +13,6 @@ is added to ``tools/codegen``, this module can be regenerated.
 
 from __future__ import annotations
 
-import os
 import re
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union, overload
 
@@ -23,6 +22,7 @@ if TYPE_CHECKING:
     import pandas as pd
 
 from sportsdataverse._codegen_runtime import _get
+from sportsdataverse._fox_layout import DATA_KEY as FOX_DATA_KEY  # single source of truth for the public Fox key
 
 __all__ = [
     "fox_cfb_pbp",
@@ -36,9 +36,9 @@ __all__ = [
 ]
 
 FOX_BASE = "https://api.foxsports.com/bifrost/v1"
-# Public data-tier key shipped in the foxsports.com web bundle. Overridable via
-# the SDV_PY_FOX_DATA_KEY env var so a key rotation does not require a release.
-FOX_DATA_KEY = os.getenv("SDV_PY_FOX_DATA_KEY", "jE7yBJVRNAwdDesMgTzTXUUSx1It41Fq")
+# FOX_DATA_KEY (the public foxsports.com data-tier key, env-overridable via
+# SDV_PY_FOX_DATA_KEY) is imported from sportsdataverse._fox_layout above so the
+# bundled default and its env override live in exactly one place.
 
 _HEADERS = {"Origin": "https://www.foxsports.com", "Referer": "https://www.foxsports.com/"}
 

--- a/sportsdataverse/nfl/nfl_games.py
+++ b/sportsdataverse/nfl/nfl_games.py
@@ -10,11 +10,24 @@ the site ships to every browser). They are the defaults below and can be overrid
 via the ``NFL_CLIENT_KEY`` / ``NFL_CLIENT_SECRET`` environment variables (or the
 function arguments) if NFL rotates them or you have your own. No login / personal
 account is involved -- the minted token carries the anonymous ``free`` plan.
+
+Token handling is fully automatic: a minted token is cached in-process and reused
+until just before its JWT ``exp``, then transparently re-minted -- no setup, no
+manual refresh. Everything is overridable by env var when desired (all optional):
+
+* ``NFL_ACCESS_TOKEN`` -- use this bearer token verbatim (skips minting + caching;
+  you manage its lifetime). Highest precedence.
+* ``NFL_CLIENT_KEY`` / ``NFL_CLIENT_SECRET`` -- mint tokens with these credentials
+  instead of the bundled public web-app pair.
 """
 
 from __future__ import annotations
 
+import base64
+import json
 import os
+import threading
+import time
 import uuid
 from typing import Dict, Optional
 
@@ -34,31 +47,37 @@ _DEFAULT_UA = (
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36"
 )
 
+# In-process token cache so back-to-back wrapper calls share one minted token
+# instead of POSTing to /identity/v3/token every time. Keyed by the resolving
+# client key so swapping credentials never serves a stale token. Guarded by a lock
+# for thread-safe minting.
+_TOKEN_LOCK = threading.Lock()
+_TOKEN_CACHE: Dict[str, object] = {}  # {"token": str, "key": str, "exp": float}
+# Renew this many seconds before the JWT's own ``exp`` so a call never races expiry.
+_TOKEN_SKEW_SECONDS = 120
+# Conservative lifetime used only when a token's ``exp`` claim can't be parsed.
+_TOKEN_FALLBACK_TTL = 300
 
-def nfl_token_gen(client_key: Optional[str] = None, client_secret: Optional[str] = None) -> str:
-    """Mint a fresh ``api.nfl.com`` access token via ``/identity/v3/token``.
 
-    Wraps the anonymous device-token grant the NFL.com web app uses. Credentials
-    resolve in this order: explicit ``client_key``/``client_secret`` args ->
-    ``NFL_CLIENT_KEY``/``NFL_CLIENT_SECRET`` env vars -> the bundled public
-    ``WEB_DESKTOP`` web-app credentials.
+def _jwt_exp(token: str) -> Optional[float]:
+    """Best-effort read of a JWT's ``exp`` (unix seconds); ``None`` if unparseable.
 
-    Args:
-        client_key: Override the client key (else env var, else the web default).
-        client_secret: Override the client secret (else env var, else the default).
-
-    Returns:
-        str: The bearer ``accessToken`` string.
-
-    Example:
-        Mint a token and inspect its prefix::
-
-            from sportsdataverse.nfl.nfl_games import nfl_token_gen
-            token = nfl_token_gen()
-            assert isinstance(token, str) and token.startswith("ey")
+    The token is ``header.payload.signature``; the payload segment is base64url
+    decoded and its ``exp`` claim returned. No signature verification -- only the
+    expiry is needed to schedule renewal.
     """
-    key = client_key or os.environ.get("NFL_CLIENT_KEY", _DEFAULT_CLIENT_KEY)
-    secret = client_secret or os.environ.get("NFL_CLIENT_SECRET", _DEFAULT_CLIENT_SECRET)
+    try:
+        payload_b64 = token.split(".")[1]
+        payload_b64 += "=" * (-len(payload_b64) % 4)  # restore base64 padding
+        claims = json.loads(base64.urlsafe_b64decode(payload_b64))
+        exp = claims.get("exp")
+        return float(exp) if exp is not None else None
+    except Exception:  # noqa: BLE001 -- any decode/parse failure -> unknown expiry
+        return None
+
+
+def _mint_token(key: str, secret: str) -> str:
+    """POST the anonymous device-token grant and return the bearer ``accessToken``."""
     data = {
         "clientKey": key,
         "clientSecret": secret,
@@ -76,15 +95,87 @@ def nfl_token_gen(client_key: Optional[str] = None, client_secret: Optional[str]
     return resp.json()["accessToken"]
 
 
+def nfl_clear_token_cache() -> None:
+    """Drop the cached ``api.nfl.com`` token (forces a fresh mint on the next call)."""
+    with _TOKEN_LOCK:
+        _TOKEN_CACHE.clear()
+
+
+def nfl_token_gen(
+    client_key: Optional[str] = None,
+    client_secret: Optional[str] = None,
+    force_refresh: bool = False,
+) -> str:
+    """Return a valid ``api.nfl.com`` bearer token, minting + caching as needed.
+
+    The token is cached in-process and reused until ~2 min before its own JWT
+    ``exp``, then transparently re-minted -- so callers never have to think about
+    expiry or refresh. The first call (or any call after expiry / ``force_refresh``)
+    mints a fresh token via the anonymous device-token grant at ``/identity/v3/token``.
+
+    Resolution order (all overrides optional):
+
+    1. ``NFL_ACCESS_TOKEN`` env var -- returned verbatim, skipping minting and
+       caching (you supply + manage the token). Ignored if explicit credentials
+       are passed.
+    2. Credentials: explicit ``client_key``/``client_secret`` args ->
+       ``NFL_CLIENT_KEY``/``NFL_CLIENT_SECRET`` env vars -> the bundled public
+       ``WEB_DESKTOP`` web-app pair.
+
+    Args:
+        client_key: Override the client key (else env var, else the web default).
+        client_secret: Override the client secret (else env var, else the default).
+        force_refresh: Mint a new token even if a cached one is still valid.
+
+    Returns:
+        str: The bearer ``accessToken`` string.
+
+    Example:
+        Token is minted once and reused across calls::
+
+            from sportsdataverse.nfl.nfl_games import nfl_token_gen
+            token = nfl_token_gen()                # mints + caches
+            assert nfl_token_gen() == token        # served from cache
+            assert isinstance(token, str) and token.startswith("ey")
+    """
+    # 1. A user-supplied token via env wins outright (their own / paid-plan token),
+    #    unless explicit credentials were passed (which mean "mint with these").
+    if client_key is None and client_secret is None:
+        env_token = os.environ.get("NFL_ACCESS_TOKEN")
+        if env_token:
+            return env_token
+
+    # 2. Resolve credentials, then serve a cached token or mint a fresh one.
+    key = client_key or os.environ.get("NFL_CLIENT_KEY", _DEFAULT_CLIENT_KEY)
+    secret = client_secret or os.environ.get("NFL_CLIENT_SECRET", _DEFAULT_CLIENT_SECRET)
+    now = time.time()
+    with _TOKEN_LOCK:
+        if (
+            not force_refresh
+            and _TOKEN_CACHE.get("token")
+            and _TOKEN_CACHE.get("key") == key
+            and float(_TOKEN_CACHE.get("exp", 0)) - _TOKEN_SKEW_SECONDS > now
+        ):
+            return str(_TOKEN_CACHE["token"])
+        token = _mint_token(key, secret)
+        exp = _jwt_exp(token)
+        _TOKEN_CACHE.clear()
+        _TOKEN_CACHE.update(
+            {"token": token, "key": key, "exp": exp if exp is not None else now + _TOKEN_FALLBACK_TTL},
+        )
+        return token
+
+
 def nfl_headers_gen(token: Optional[str] = None) -> Dict[str, str]:
     """Build the request-header dict expected by ``api.nfl.com``.
 
-    Mints a fresh bearer token via :func:`nfl_token_gen` (unless ``token`` is
-    supplied) and combines it with the browser-style headers the NFL.com web app
-    sends. Reuse the returned dict across calls to avoid re-minting tokens.
+    Obtains a bearer token via :func:`nfl_token_gen` (which caches + auto-renews,
+    or honors ``NFL_ACCESS_TOKEN``) unless ``token`` is supplied, and combines it
+    with the browser-style headers the NFL.com web app sends. Token caching already
+    avoids re-minting, so callers rarely need to thread ``token``/``headers`` by hand.
 
     Args:
-        token: An existing access token to reuse; mints a fresh one when ``None``.
+        token: An existing access token to reuse; uses the cached/minted one when ``None``.
 
     Returns:
         Dict[str, str]: Header dict ready to drop into ``requests.get``.

--- a/tests/nfl/test_nfl_token_cache.py
+++ b/tests/nfl/test_nfl_token_cache.py
@@ -1,0 +1,132 @@
+"""Offline tests for the ``api.nfl.com`` token cache + env overrides.
+
+All tests mock :func:`sportsdataverse.nfl.nfl_games._mint_token` (the only thing
+that touches the network), so nothing here hits ``/identity/v3/token``. They
+cover:
+
+- A minted token is cached and reused across calls (one mint, not N).
+- ``force_refresh=True`` re-mints even when a cached token is still valid.
+- A token whose JWT ``exp`` is within the renewal skew is re-minted next call.
+- Switching credentials (different client key) invalidates the cache.
+- ``NFL_ACCESS_TOKEN`` short-circuits minting entirely (and is ignored when
+  explicit credentials are passed).
+- ``nfl_clear_token_cache()`` forces a fresh mint.
+- ``_jwt_exp`` reads the ``exp`` claim and tolerates malformed tokens.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+
+import pytest
+
+from sportsdataverse.nfl import nfl_games
+
+
+def _make_jwt(exp: float | None) -> str:
+    """Build a throwaway ``header.payload.sig`` JWT carrying an ``exp`` claim."""
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
+    claims = {} if exp is None else {"exp": exp}
+    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).rstrip(b"=").decode()
+    return f"{header}.{payload}.sig"
+
+
+@pytest.fixture(autouse=True)
+def _clean_token_state(monkeypatch):
+    """Clear the module token cache + NFL_* env vars around every test."""
+    nfl_games.nfl_clear_token_cache()
+    for var in ("NFL_ACCESS_TOKEN", "NFL_CLIENT_KEY", "NFL_CLIENT_SECRET"):
+        monkeypatch.delenv(var, raising=False)
+    yield
+    nfl_games.nfl_clear_token_cache()
+
+
+def _patch_mint(monkeypatch, exp_offset: float = 3600.0):
+    """Patch ``_mint_token`` with a call-counting stub returning fresh JWTs.
+
+    Returns the ``calls`` list whose length is the mint count; each minted token
+    is distinct and expires ``exp_offset`` seconds from mint time.
+    """
+    calls: list[tuple[str, str]] = []
+
+    def fake_mint(key: str, secret: str) -> str:
+        calls.append((key, secret))
+        return _make_jwt(time.time() + exp_offset) + f".{len(calls)}"
+
+    monkeypatch.setattr(nfl_games, "_mint_token", fake_mint)
+    return calls
+
+
+def test_token_cached_across_calls(monkeypatch):
+    calls = _patch_mint(monkeypatch)
+    first = nfl_games.nfl_token_gen()
+    second = nfl_games.nfl_token_gen()
+    assert first == second
+    assert len(calls) == 1  # minted once, served from cache thereafter
+
+
+def test_force_refresh_remints(monkeypatch):
+    calls = _patch_mint(monkeypatch)
+    nfl_games.nfl_token_gen()
+    nfl_games.nfl_token_gen(force_refresh=True)
+    assert len(calls) == 2
+
+
+def test_expiry_within_skew_triggers_remint(monkeypatch):
+    # exp only 10s out -> inside the 120s renewal skew -> next call re-mints.
+    calls = _patch_mint(monkeypatch, exp_offset=10.0)
+    nfl_games.nfl_token_gen()
+    nfl_games.nfl_token_gen()
+    assert len(calls) == 2
+
+
+def test_distinct_credentials_invalidate_cache(monkeypatch):
+    calls = _patch_mint(monkeypatch)
+    nfl_games.nfl_token_gen()  # bundled default key
+    nfl_games.nfl_token_gen(client_key="other-key", client_secret="other-secret")
+    assert len(calls) == 2
+    assert calls[1] == ("other-key", "other-secret")
+
+
+def test_env_access_token_short_circuits(monkeypatch):
+    calls = _patch_mint(monkeypatch)
+    monkeypatch.setenv("NFL_ACCESS_TOKEN", "user-supplied-token")
+    assert nfl_games.nfl_token_gen() == "user-supplied-token"
+    assert len(calls) == 0  # never minted
+
+
+def test_env_token_ignored_when_explicit_credentials(monkeypatch):
+    calls = _patch_mint(monkeypatch)
+    monkeypatch.setenv("NFL_ACCESS_TOKEN", "user-supplied-token")
+    token = nfl_games.nfl_token_gen(client_key="k", client_secret="s")
+    assert token != "user-supplied-token"
+    assert len(calls) == 1
+
+
+def test_clear_token_cache_forces_remint(monkeypatch):
+    calls = _patch_mint(monkeypatch)
+    nfl_games.nfl_token_gen()
+    nfl_games.nfl_clear_token_cache()
+    nfl_games.nfl_token_gen()
+    assert len(calls) == 2
+
+
+def test_headers_gen_uses_cached_token(monkeypatch):
+    calls = _patch_mint(monkeypatch)
+    headers = nfl_games.nfl_headers_gen()
+    again = nfl_games.nfl_headers_gen()
+    assert headers["Authorization"].startswith("Bearer ")
+    assert headers == again
+    assert len(calls) == 1  # both header builds shared one minted token
+
+
+def test_jwt_exp_reads_claim():
+    exp = 1893456000.0  # 2030-01-01
+    assert nfl_games._jwt_exp(_make_jwt(exp)) == exp
+
+
+def test_jwt_exp_tolerates_malformed():
+    assert nfl_games._jwt_exp("not-a-jwt") is None
+    assert nfl_games._jwt_exp(_make_jwt(None)) is None  # payload has no exp


### PR DESCRIPTION
## Summary

Makes `api.nfl.com` auth **automatic and under-the-hood**, and adds an opt-in env override — while confirming Fox / HockeyTech need nothing (static keys).

### NFL.com token caching (the real win)
Previously every `nfl_*` / `nfl_api_*` call POSTed to `/identity/v3/token` to mint a fresh bearer token before the data call. Now:
- The token is **minted once and cached in-process**, then **auto-renewed ~2 min before its JWT `exp`** (read from the token itself, no signature check). Back-to-back calls reuse one token. No setup, no manual refresh.
- Thread-safe (module lock); cache is keyed by the resolving client key so swapping credentials never serves a stale token.
- `nfl_clear_token_cache()` and `nfl_token_gen(force_refresh=True)` for explicit control.

### Env overrides (all optional)
- **`NFL_ACCESS_TOKEN`** *(new)* — inject a pre-minted bearer token verbatim (skips mint + cache; you manage its lifetime). Highest precedence; ignored when explicit `client_key`/`client_secret` args are passed.
- `NFL_CLIENT_KEY` / `NFL_CLIENT_SECRET` *(existing)* — mint with your own credentials instead of the bundled public `WEB_DESKTOP` pair.

### Fox key single-sourced
`cfb_fox_ext.FOX_DATA_KEY` now imports from `_fox_layout.DATA_KEY` — the bundled public Fox key + its `SDV_PY_FOX_DATA_KEY` env override live in one place instead of two. **Fox and HockeyTech are static-key APIs** (a `?apikey=` query param, no token, no expiry), so there's nothing to cache/renew — they already work with zero interaction out of the box, and the env override is just an escape hatch for upstream key rotation.

## Test plan
- [x] `tests/nfl/test_nfl_token_cache.py` (offline, mocks the mint): caching, `force_refresh`, exp-driven renewal, credential-keyed invalidation, `NFL_ACCESS_TOKEN` short-circuit + precedence, clear-cache, headers reuse, `_jwt_exp` parsing — 10 passed.
- [x] NFL + CFB offline suites: 207 passed, 58 skipped.
- [x] `ruff` clean; Fox dedup verified (`cfb_fox_ext.FOX_DATA_KEY is _fox_layout.DATA_KEY`).

> Independent of #98 (NFL native cutover) — different files, no conflict. The only overlap is the `0.0.58 (in development)` CHANGELOG heading both branches add; trivial additive merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented automatic in-process caching and auto-renewal of NFL API bearer tokens with optional environment variable override.
  * Added token cache management helpers for explicit refresh and clearing operations.

* **Documentation**
  * Updated changelog for upcoming release documenting NFL token caching functionality and internal data consolidation improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->