### PR TITLE
fix(ci): don't let one notebook flake skip the weekly tutorials refresh

### DIFF
--- a/.github/workflows/live-tests-cron.yml
+++ b/.github/workflows/live-tests-cron.yml
@@ -97,7 +97,13 @@ jobs:
           ODDS_API_KEY: ${{ secrets.ODDS_API_KEY }}
         run: |
           set -o pipefail
-          uv run --frozen python tools/codegen/render_notebooks.py 2>&1 | tee render-notebooks.log
+          # render_notebooks.py exits 1 if ANY of the 12 live notebooks flakes, but
+          # it still writes the pages that DID render. `|| true` keeps that partial
+          # failure from aborting the step here (under `set -o pipefail`) so the
+          # commit/PR below still publishes the refreshed pages — failed notebooks
+          # simply keep their prior page (no diff). Without this, one weekly flake
+          # (near-certain across 12 live notebooks) skips the refresh entirely.
+          uv run --frozen python tools/codegen/render_notebooks.py 2>&1 | tee render-notebooks.log || true
           if git diff --quiet -- docs/docs/tutorials; then
             echo "No tutorial changes to publish."
             exit 0

--- a/tools/codegen/render_notebooks.py
+++ b/tools/codegen/render_notebooks.py
@@ -177,7 +177,9 @@ def main() -> int:
                 continue
         _clean_outputs(nb)
         body = _fix_links(_to_markdown(nb, stem))
-        (OUT_DIR / f"{stem}.md").write_text(_normalize_md(_frontmatter(label, position) + body), encoding="utf-8")
+        (OUT_DIR / f"{stem}.md").write_text(
+            _normalize_md(_frontmatter(label, position) + body), encoding="utf-8", newline="\n"
+        )
         print(f"  wrote {OUT_DIR / f'{stem}.md'}")
 
     if failures:


### PR DESCRIPTION
The `live-tests-cron` render step runs `render_notebooks.py | tee` under
`set -o pipefail`. `render_notebooks.py` exits 1 if **any** of the 12 live
notebooks flakes (`allow_errors=False`), so pipefail aborts the step at the
render line — before the `git diff` / commit / push / PR logic — and
`continue-on-error: true` hides it. Result: the `auto/tutorials-refresh` PR has
**never** been opened, and the website's tutorials stay code-only (no executed
cell outputs).

`render_notebooks.py` already writes the pages that rendered and only skips the
failed ones, so a best-effort refresh works fine. Append `|| true` so a partial
failure no longer aborts the step.

Also write rendered pages with `newline="\n"` (LF) so a local Windows run matches
the Linux cron instead of emitting CRLF.

Follow-up PR does a one-time refresh so the outputs go live now without waiting
for the next Monday cron.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the automated notebook rendering process to be more resilient against temporary failures, allowing workflows to continue while preserving detailed logs for troubleshooting.

* **Chores**
  * Standardized newline formatting in generated tutorial documentation files to ensure consistent output across all operating systems and development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->