### PR TITLE
docs(tutorials): refresh executed notebook pages with live outputs

### DIFF
--- a/docs/docs/tutorials/01_quickstart.md
+++ b/docs/docs/tutorials/01_quickstart.md
@@ -101,6 +101,26 @@ import sportsdataverse.odds as odds
   "ahl", "ohl", "whl", "qmjhl", "odds")]
 ```
 
+
+
+
+    ['ahl',
+     'cfb',
+     'mbb',
+     'mlb',
+     'nba',
+     'nfl',
+     'nhl',
+     'odds',
+     'ohl',
+     'pwhl',
+     'qmjhl',
+     'wbb',
+     'whl',
+     'wnba']
+
+
+
 Live endpoints are seasonal and occasionally rate-limited, and the
 naming-convention loops below fan out **many** live calls at once — so a tiny
 `safe()` helper runs every network call defensively. You get the frame when the
@@ -125,6 +145,9 @@ HAS_KEY = bool(os.environ.get("ODDS_API_KEY"))
 print("ODDS_API_KEY set:", HAS_KEY,
       "— odds cells will" + ("" if HAS_KEY else " NOT") + " run live")
 ```
+
+    ODDS_API_KEY set: False — odds cells will NOT run live
+
 
 ## 🧭 2 · The naming-convention superpower
 
@@ -156,6 +179,33 @@ for lg in ["nba", "wnba", "nhl", "mlb"]:
 pl.DataFrame(rows)  # same columns, same shape — one contract, four leagues
 ```
 
+    ✅ espn_nba_teams
+
+
+    ✅ espn_wnba_teams
+    ✅ espn_nhl_teams
+
+
+    ✅ espn_mlb_teams
+
+
+
+
+
+    shape: (4, 4)
+    ┌────────┬───────────────────┬─────────┬────────┐
+    │ league ┆ fn                ┆ n_teams ┆ n_cols │
+    │ ---    ┆ ---               ┆ ---     ┆ ---    │
+    │ str    ┆ str               ┆ i64     ┆ i64    │
+    ╞════════╪═══════════════════╪═════════╪════════╡
+    │ NBA    ┆ espn_nba_teams()  ┆ 30      ┆ 14     │
+    │ WNBA   ┆ espn_wnba_teams() ┆ 15      ┆ 14     │
+    │ NHL    ┆ espn_nhl_teams()  ┆ 32      ┆ 14     │
+    │ MLB    ┆ espn_mlb_teams()  ┆ 30      ┆ 14     │
+    └────────┴───────────────────┴─────────┴────────┘
+
+
+
 Same trick for the **scoreboard** and **standings** families — the call is
 identical, only the slug changes.
 
@@ -170,6 +220,11 @@ stand = safe("espn_nba_standings", lambda: call("standings", "nba"))
 print("NFL scoreboard rows:", None if board is None else board.height,
       "| NBA standings rows:", None if stand is None else getattr(stand, "height", None))
 ```
+
+    ✅ espn_nfl_scoreboard
+    ✅ espn_nba_standings
+    NFL scoreboard rows: 16 | NBA standings rows: 30
+
 
 ### 📦 The loaders follow one pattern too
 
@@ -186,6 +241,11 @@ for sport in ["nba", "wnba", "nhl"]:
     print(f"load_{sport}_pbp(seasons=[{season}])  ->  signature is identical for every sport")
 # (we don't pull all of them here — that's a lot of parquet; Recipe 3 runs one.)
 ```
+
+    load_nba_pbp(seasons=[2024])  ->  signature is identical for every sport
+    load_wnba_pbp(seasons=[2024])  ->  signature is identical for every sport
+    load_nhl_pbp(seasons=[2024])  ->  signature is identical for every sport
+
 
 ### 🏒 The HockeyTech leagues share one surface
 
@@ -213,6 +273,39 @@ for lg, mod in HOCKEYTECH.items():
 pl.DataFrame(rows)
 ```
 
+    ✅ most_recent_ahl_season
+
+
+    ✅ most_recent_ohl_season
+
+
+    ✅ most_recent_whl_season
+
+
+    ✅ most_recent_qmjhl_season
+
+
+    ✅ most_recent_pwhl_season
+
+
+
+
+
+    shape: (5, 4)
+    ┌────────┬──────────────────┬───────────────────┬────────┐
+    │ league ┆ schedule_fn      ┆ standings_fn      ┆ season │
+    │ ---    ┆ ---              ┆ ---               ┆ ---    │
+    │ str    ┆ str              ┆ str               ┆ i64    │
+    ╞════════╪══════════════════╪═══════════════════╪════════╡
+    │ AHL    ┆ ahl_schedule()   ┆ ahl_standings()   ┆ 2026   │
+    │ OHL    ┆ ohl_schedule()   ┆ ohl_standings()   ┆ 2026   │
+    │ WHL    ┆ whl_schedule()   ┆ whl_standings()   ┆ 2026   │
+    │ QMJHL  ┆ qmjhl_schedule() ┆ qmjhl_standings() ┆ 2027   │
+    │ PWHL   ┆ pwhl_schedule()  ┆ pwhl_standings()  ┆ 2027   │
+    └────────┴──────────────────┴───────────────────┴────────┘
+
+
+
 ### 🔎 Discovery helpers — when you don't know the name yet
 
 Four top-level helpers let you *search* the surface instead of guessing:
@@ -230,6 +323,16 @@ for lg, fns in hits.items():
     print(f"{lg:>4}: {', '.join(fns)}")
 ```
 
+     cfb: espn_cfb_scoreboard, scoreboard_event_parsing, yahoo_cfb_scoreboard
+     mbb: espn_mbb_scoreboard, scoreboard_event_parsing
+     mlb: espn_mlb_scoreboard
+     nba: espn_nba_scoreboard, scoreboard_event_parsing
+     nfl: espn_nfl_scoreboard, scoreboard_event_parsing
+     nhl: espn_nhl_scoreboard, nhl_scoreboard, parse_nhl_web_scoreboard, scoreboard_event_parsing
+     wbb: espn_wbb_scoreboard, scoreboard_event_parsing
+    wnba: espn_wnba_scoreboard, scoreboard_event_parsing
+
+
 
 ```python
 # How big is each league's surface?
@@ -239,6 +342,27 @@ pl.DataFrame({"league": list(counts.keys()), "n_functions": list(counts.values()
 ```
 
 
+
+
+    shape: (8, 2)
+    ┌────────┬─────────────┐
+    │ league ┆ n_functions │
+    │ ---    ┆ ---         │
+    │ str    ┆ i64         │
+    ╞════════╪═════════════╡
+    │ nhl    ┆ 337         │
+    │ mlb    ┆ 239         │
+    │ nfl    ┆ 233         │
+    │ cfb    ┆ 166         │
+    │ wnba   ┆ 162         │
+    │ mbb    ┆ 158         │
+    │ nba    ┆ 157         │
+    │ wbb    ┆ 151         │
+    └────────┴─────────────┘
+
+
+
+
 ```python
 # Fuzzy lookups — no IDs to memorize:
 team = sdv.find_team("Lakers", "nba")
@@ -246,6 +370,10 @@ ath = sdv.find_athlete("LeBron", "nba")
 print("team  ->", None if team is None else f"{team['displayName']} (id={team['id']})")
 print("athlete ->", None if ath is None else f"{ath['displayName']} (id={ath['id']})")
 ```
+
+    team  -> Los Angeles Lakers (id=13)
+    athlete -> LeBron James (id=1966)
+
 
 ## 🍳 3 · Twenty cross-sport recipes
 
@@ -266,6 +394,27 @@ cols = ["team_id", "team_abbreviation", "team_display_name", "team_location"]
  if wbb_teams is not None and wbb_teams.height else "WBB teams unavailable right now")
 ```
 
+    ✅ espn_wbb_teams
+
+
+
+
+
+    shape: (5, 4)
+    ┌─────────┬───────────────────┬────────────────────────────┬───────────────────┐
+    │ team_id ┆ team_abbreviation ┆ team_display_name          ┆ team_location     │
+    │ ---     ┆ ---               ┆ ---                        ┆ ---               │
+    │ str     ┆ str               ┆ str                        ┆ str               │
+    ╞═════════╪═══════════════════╪════════════════════════════╪═══════════════════╡
+    │ 2000    ┆ ACU               ┆ Abilene Christian Wildcats ┆ Abilene Christian │
+    │ 2005    ┆ AF                ┆ Air Force Falcons          ┆ Air Force         │
+    │ 2006    ┆ AKR               ┆ Akron Zips                 ┆ Akron             │
+    │ 2010    ┆ AAMU              ┆ Alabama A&M Bulldogs       ┆ Alabama A&M       │
+    │ 333     ┆ ALA               ┆ Alabama Crimson Tide       ┆ Alabama           │
+    └─────────┴───────────────────┴────────────────────────────┴───────────────────┘
+
+
+
 ### Recipe 2 — Any league's scoreboard 📋
 
 `espn_<lg>_scoreboard()` returns today's slate as a tidy frame. Same call for
@@ -277,6 +426,43 @@ sb = safe("espn_mlb_scoreboard", lambda: sdv.espn_mlb_scoreboard())
 (sb.head() if sb is not None and getattr(sb, "height", 0)
  else "no MLB games on the board right now")
 ```
+
+    ✅ espn_mlb_scoreboard
+
+
+
+
+
+    shape: (5, 50)
+    ┌───────────┬───────────┬───────────┬───────────┬───┬───────────┬───────────┬───────────┬──────────┐
+    │ game_id   ┆ uid       ┆ date      ┆ name      ┆ … ┆ away_logo ┆ away_scor ┆ away_winn ┆ away_ran │
+    │ ---       ┆ ---       ┆ ---       ┆ ---       ┆   ┆ ---       ┆ e         ┆ er        ┆ k        │
+    │ str       ┆ str       ┆ str       ┆ str       ┆   ┆ str       ┆ ---       ┆ ---       ┆ ---      │
+    │           ┆           ┆           ┆           ┆   ┆           ┆ str       ┆ str       ┆ str      │
+    ╞═══════════╪═══════════╪═══════════╪═══════════╪═══╪═══════════╪═══════════╪═══════════╪══════════╡
+    │ 401815722 ┆ s:1~l:10~ ┆ 2026-06-1 ┆ Miami     ┆ … ┆ https://a ┆ 0         ┆ null      ┆ null     │
+    │           ┆ e:4018157 ┆ 2T22:40Z  ┆ Marlins   ┆   ┆ .espncdn. ┆           ┆           ┆          │
+    │           ┆ 22        ┆           ┆ at Pittsb ┆   ┆ com/i/tea ┆           ┆           ┆          │
+    │           ┆           ┆           ┆ urgh Pi…  ┆   ┆ mlo…      ┆           ┆           ┆          │
+    │ 401815725 ┆ s:1~l:10~ ┆ 2026-06-1 ┆ Seattle   ┆ … ┆ https://a ┆ 0         ┆ null      ┆ null     │
+    │           ┆ e:4018157 ┆ 2T22:45Z  ┆ Mariners  ┆   ┆ .espncdn. ┆           ┆           ┆          │
+    │           ┆ 25        ┆           ┆ at Washin ┆   ┆ com/i/tea ┆           ┆           ┆          │
+    │           ┆           ┆           ┆ gton…     ┆   ┆ mlo…      ┆           ┆           ┆          │
+    │ 401815724 ┆ s:1~l:10~ ┆ 2026-06-1 ┆ San Diego ┆ … ┆ https://a ┆ 0         ┆ null      ┆ null     │
+    │           ┆ e:4018157 ┆ 2T23:05Z  ┆ Padres at ┆   ┆ .espncdn. ┆           ┆           ┆          │
+    │           ┆ 24        ┆           ┆ Baltimore ┆   ┆ com/i/tea ┆           ┆           ┆          │
+    │           ┆           ┆           ┆ …         ┆   ┆ mlo…      ┆           ┆           ┆          │
+    │ 401815721 ┆ s:1~l:10~ ┆ 2026-06-1 ┆ Detroit   ┆ … ┆ https://a ┆ 0         ┆ null      ┆ null     │
+    │           ┆ e:4018157 ┆ 2T23:10Z  ┆ Tigers at ┆   ┆ .espncdn. ┆           ┆           ┆          │
+    │           ┆ 21        ┆           ┆ Cleveland ┆   ┆ com/i/tea ┆           ┆           ┆          │
+    │           ┆           ┆           ┆ Gu…       ┆   ┆ mlo…      ┆           ┆           ┆          │
+    │ 401815726 ┆ s:1~l:10~ ┆ 2026-06-1 ┆ Texas     ┆ … ┆ https://a ┆ 0         ┆ null      ┆ null     │
+    │           ┆ e:4018157 ┆ 2T23:10Z  ┆ Rangers   ┆   ┆ .espncdn. ┆           ┆           ┆          │
+    │           ┆ 26        ┆           ┆ at Boston ┆   ┆ com/i/tea ┆           ┆           ┆          │
+    │           ┆           ┆           ┆ Red So…   ┆   ┆ mlo…      ┆           ┆           ┆          │
+    └───────────┴───────────┴───────────┴───────────┴───┴───────────┴───────────┴───────────┴──────────┘
+
+
 
 ### Recipe 3 — Load any sport's season play-by-play 📦
 
@@ -292,6 +478,28 @@ print("WNBA 2024 pbp rows:", None if wnba_pbp is None else wnba_pbp.height)
  if wnba_pbp is not None and wnba_pbp.height else "pbp unavailable right now")
 ```
 
+    ✅ load_wnba_pbp([2024])
+    WNBA 2024 pbp rows: 101501
+
+
+
+
+
+    shape: (5, 4)
+    ┌───────────┬───────────────┬─────────────────────┬─────────────────────────────────┐
+    │ game_id   ┆ period_number ┆ clock_display_value ┆ text                            │
+    │ ---       ┆ ---           ┆ ---                 ┆ ---                             │
+    │ i32       ┆ i32           ┆ str                 ┆ str                             │
+    ╞═══════════╪═══════════════╪═════════════════════╪═════════════════════════════════╡
+    │ 401726992 ┆ 1             ┆ 10:00               ┆ Napheesa Collier vs. Jonquel J… │
+    │ 401726992 ┆ 1             ┆ 9:35                ┆ Napheesa Collier makes 3-foot … │
+    │ 401726992 ┆ 1             ┆ 9:12                ┆ Sabrina Ionescu misses 24-foot… │
+    │ 401726992 ┆ 1             ┆ 9:09                ┆ Bridget Carleton defensive reb… │
+    │ 401726992 ┆ 1             ┆ 8:55                ┆ Betnijah Laney-Hamilton person… │
+    └───────────┴───────────────┴─────────────────────┴─────────────────────────────────┘
+
+
+
 ### Recipe 4 — The same box-score shape for two different sports 🪞
 
 `load_<sport>_team_boxscore` returns the same *kind* of frame for basketball and
@@ -304,6 +512,14 @@ nhl_box = safe("load_nhl_team_boxscore([2024])", lambda: sdv.load_nhl_team_boxsc
 print("NBA team-box shape:", None if nba_box is None else nba_box.shape)
 print("NHL team-box shape:", None if nhl_box is None else nhl_box.shape)
 ```
+
+    ✅ load_nba_team_boxscore([2024])
+
+
+    ✅ load_nhl_team_boxscore([2024])
+    NBA team-box shape: (2640, 57)
+    NHL team-box shape: (2800, 19)
+
 
 ### Recipe 5 — Standings for several leagues at once 🔁
 
@@ -320,6 +536,29 @@ for lg in ["nba", "nhl", "mlb"]:
 pl.DataFrame(rows)
 ```
 
+    ✅ espn_nba_standings
+    ✅ espn_nhl_standings
+
+
+    ✅ espn_mlb_standings
+
+
+
+
+
+    shape: (3, 3)
+    ┌────────┬──────┬──────┐
+    │ league ┆ rows ┆ cols │
+    │ ---    ┆ ---  ┆ ---  │
+    │ str    ┆ i64  ┆ i64  │
+    ╞════════╪══════╪══════╡
+    │ NBA    ┆ 30   ┆ 31   │
+    │ NHL    ┆ 32   ┆ 35   │
+    │ MLB    ┆ 30   ┆ 46   │
+    └────────┴──────┴──────┘
+
+
+
 ### Recipe 6 — Find a team by name 🔎
 
 `find_team` fuzzy-matches across the ESPN leagues and hands back the team dict
@@ -332,6 +571,16 @@ for nm, lg in [("Patriots", "nfl"), ("Yankees", "mlb"), ("Bruins", "nhl"), ("Cri
     print(f"{lg:>3}  {nm:<14} -> {None if t is None else t['displayName']} (id={None if t is None else t['id']})")
 ```
 
+    nfl  Patriots       -> New England Patriots (id=17)
+    mlb  Yankees        -> New York Yankees (id=10)
+
+
+    nhl  Bruins         -> Boston Bruins (id=1)
+
+
+    cfb  Crimson Tide   -> Alabama Crimson Tide (id=333)
+
+
 ### Recipe 7 — Find an athlete by name 🏃
 
 `find_athlete` does the same for players — great for grabbing an ESPN athlete
@@ -343,6 +592,15 @@ for nm, lg in [("Caitlin Clark", "wnba"), ("Patrick Mahomes", "nfl"), ("Connor M
     a = sdv.find_athlete(nm, lg)
     print(f"{lg:>4}  {nm:<16} -> {None if a is None else a['displayName']} (id={None if a is None else a['id']})")
 ```
+
+    wnba  Caitlin Clark    -> None (id=None)
+
+
+     nfl  Patrick Mahomes  -> Patrick Mahomes (id=3139477)
+
+
+     nhl  Connor McDavid   -> Connor McDavid (id=3895074)
+
 
 ### Recipe 8 — A team and its roster, end to end 👥
 
@@ -360,6 +618,43 @@ if lal is not None:
  else "roster unavailable right now")
 ```
 
+    ✅ espn_nba_team_roster(team_id=13)
+
+
+
+
+
+    shape: (5, 68)
+    ┌─────────┬────────────┬───────────┬───────────┬───┬───────────┬───────────┬───────────┬───────────┐
+    │ id      ┆ uid        ┆ guid      ┆ first_nam ┆ … ┆ birth_pla ┆ hand_type ┆ hand_abbr ┆ hand_disp │
+    │ ---     ┆ ---        ┆ ---       ┆ e         ┆   ┆ ce_state  ┆ ---       ┆ eviation  ┆ lay_value │
+    │ str     ┆ str        ┆ str       ┆ ---       ┆   ┆ ---       ┆ str       ┆ ---       ┆ ---       │
+    │         ┆            ┆           ┆ str       ┆   ┆ str       ┆           ┆ str       ┆ str       │
+    ╞═════════╪════════════╪═══════════╪═══════════╪═══╪═══════════╪═══════════╪═══════════╪═══════════╡
+    │ 4278129 ┆ s:40~l:46~ ┆ 9af41ea8- ┆ Deandre   ┆ … ┆ null      ┆ null      ┆ null      ┆ null      │
+    │         ┆ a:4278129  ┆ a24c-025f ┆           ┆   ┆           ┆           ┆           ┆           │
+    │         ┆            ┆ -a63f-826 ┆           ┆   ┆           ┆           ┆           ┆           │
+    │         ┆            ┆ 3fb…      ┆           ┆   ┆           ┆           ┆           ┆           │
+    │ 3945274 ┆ s:40~l:46~ ┆ 583794eb- ┆ Luka      ┆ … ┆ null      ┆ null      ┆ null      ┆ null      │
+    │         ┆ a:3945274  ┆ 0f38-9bbd ┆           ┆   ┆           ┆           ┆           ┆           │
+    │         ┆            ┆ -3e25-9dd ┆           ┆   ┆           ┆           ┆           ┆           │
+    │         ┆            ┆ 33b…      ┆           ┆   ┆           ┆           ┆           ┆           │
+    │ 4066648 ┆ s:40~l:46~ ┆ 40c1bcf6- ┆ Rui       ┆ … ┆ null      ┆ null      ┆ null      ┆ null      │
+    │         ┆ a:4066648  ┆ 675b-f217 ┆           ┆   ┆           ┆           ┆           ┆           │
+    │         ┆            ┆ -f97c-1d6 ┆           ┆   ┆           ┆           ┆           ┆           │
+    │         ┆            ┆ 280…      ┆           ┆   ┆           ┆           ┆           ┆           │
+    │ 4397077 ┆ s:40~l:46~ ┆ 4cd92ac1- ┆ Jaxson    ┆ … ┆ OK        ┆ null      ┆ null      ┆ null      │
+    │         ┆ a:4397077  ┆ 73ce-653d ┆           ┆   ┆           ┆           ┆           ┆           │
+    │         ┆            ┆ -c3b1-9c6 ┆           ┆   ┆           ┆           ┆           ┆           │
+    │         ┆            ┆ 8e9…      ┆           ┆   ┆           ┆           ┆           ┆           │
+    │ 4683774 ┆ s:40~l:46~ ┆ 456f71fd- ┆ Bronny    ┆ … ┆ OH        ┆ null      ┆ null      ┆ null      │
+    │         ┆ a:4683774  ┆ 2ce5-3f50 ┆           ┆   ┆           ┆           ┆           ┆           │
+    │         ┆            ┆ -8d0d-f30 ┆           ┆   ┆           ┆           ┆           ┆           │
+    │         ┆            ┆ c01…      ┆           ┆   ┆           ┆           ┆           ┆           │
+    └─────────┴────────────┴───────────┴───────────┴───┴───────────┴───────────┴───────────┴───────────┘
+
+
+
 ### Recipe 9 — polars → pandas in one keyword 🐼
 
 Every wrapper honors `return_as_pandas=True`. Same data, different frame — handy
@@ -372,6 +667,12 @@ teams_pd = safe("espn_wnba_teams (pandas)", lambda: sdv.espn_wnba_teams(return_a
 print("polars:", type(teams_pl).__name__, None if teams_pl is None else teams_pl.shape)
 print("pandas:", type(teams_pd).__name__, None if teams_pd is None else teams_pd.shape)
 ```
+
+    ✅ espn_wnba_teams (polars)
+    ✅ espn_wnba_teams (pandas)
+    polars: DataFrame (15, 14)
+    pandas: DataFrame (15, 14)
+
 
 ### Recipe 10 — The `return_parsed` toggle on a native API 🎛️
 
@@ -386,6 +687,12 @@ print("parsed ->", type(parsed).__name__, None if parsed is None else getattr(pa
 print("raw    ->", type(raw).__name__, "(top-level keys:", None if not isinstance(raw, dict) else list(raw.keys())[:4], ")")
 ```
 
+    ✅ nhl_standings (parsed)
+    ✅ nhl_standings (raw dict)
+    parsed -> DataFrame (32, 84)
+    raw    -> dict (top-level keys: ['wildCardIndicator', 'standingsDateTimeUtc', 'standings'] )
+
+
 ### Recipe 11 — 🏈 Premium NFL pull (`api.nfl.com`)
 
 `nfl_standings()` hits the league's own API and returns one tidy row per team.
@@ -398,6 +705,30 @@ cols = ["team_abbr", "team_full_name", "overall_wins", "overall_losses",
 (nfl_st.select([c for c in cols if c in nfl_st.columns]).head(8)
  if nfl_st is not None and getattr(nfl_st, "height", 0) else "NFL standings unavailable right now")
 ```
+
+    ✅ nfl_standings (api.nfl.com)
+
+
+
+
+
+    shape: (8, 3)
+    ┌────────────────────┬──────────────┬────────────────┐
+    │ team_full_name     ┆ overall_wins ┆ overall_losses │
+    │ ---                ┆ ---          ┆ ---            │
+    │ str                ┆ i64          ┆ i64            │
+    ╞════════════════════╪══════════════╪════════════════╡
+    │ Arizona Cardinals  ┆ 8            ┆ 9              │
+    │ Atlanta Falcons    ┆ 8            ┆ 9              │
+    │ Baltimore Ravens   ┆ 12           ┆ 5              │
+    │ Buffalo Bills      ┆ 13           ┆ 4              │
+    │ Carolina Panthers  ┆ 5            ┆ 12             │
+    │ Chicago Bears      ┆ 5            ┆ 12             │
+    │ Cincinnati Bengals ┆ 9            ┆ 8              │
+    │ Cleveland Browns   ┆ 3            ┆ 14             │
+    └────────────────────┴──────────────┴────────────────┘
+
+
 
 ### Recipe 12 — ⚾ Premium MLB pull (MLB Stats API + parser)
 
@@ -416,6 +747,32 @@ keep = ["standings_division_name", "team_name", "wins", "losses", "winning_perce
  if mlb_st is not None and getattr(mlb_st, "height", 0) else "MLB standings unavailable right now")
 ```
 
+    ✅ MLB standings (Stats API + parser)
+
+
+
+
+
+    shape: (10, 6)
+    ┌─────────────────────────┬───────────┬──────┬────────┬────────────────────┬────────────┐
+    │ standings_division_name ┆ team_name ┆ wins ┆ losses ┆ winning_percentage ┆ games_back │
+    │ ---                     ┆ ---       ┆ ---  ┆ ---    ┆ ---                ┆ ---        │
+    │ str                     ┆ str       ┆ i64  ┆ i64    ┆ str                ┆ str        │
+    ╞═════════════════════════╪═══════════╪══════╪════════╪════════════════════╪════════════╡
+    │ null                    ┆ Yankees   ┆ 94   ┆ 68     ┆ .580               ┆ -          │
+    │ null                    ┆ Orioles   ┆ 91   ┆ 71     ┆ .562               ┆ 3.0        │
+    │ null                    ┆ Red Sox   ┆ 81   ┆ 81     ┆ .500               ┆ 13.0       │
+    │ null                    ┆ Rays      ┆ 80   ┆ 82     ┆ .494               ┆ 14.0       │
+    │ null                    ┆ Blue Jays ┆ 74   ┆ 88     ┆ .457               ┆ 20.0       │
+    │ null                    ┆ Guardians ┆ 92   ┆ 69     ┆ .571               ┆ -          │
+    │ null                    ┆ Royals    ┆ 86   ┆ 76     ┆ .531               ┆ 6.5        │
+    │ null                    ┆ Tigers    ┆ 86   ┆ 76     ┆ .531               ┆ 6.5        │
+    │ null                    ┆ Twins     ┆ 82   ┆ 80     ┆ .506               ┆ 10.5       │
+    │ null                    ┆ White Sox ┆ 41   ┆ 121    ┆ .253               ┆ 51.5       │
+    └─────────────────────────┴───────────┴──────┴────────┴────────────────────┴────────────┘
+
+
+
 ### Recipe 13 — ⚾ MLB Statcast — the premium tracking firehose
 
 `statcast_search()` returns one row per pitch — the raw Baseball Savant tracking
@@ -432,6 +789,37 @@ show = [c for c in ["game_date", "player_name", "pitch_type", "release_speed",
  if pitches is not None and getattr(pitches, "height", 0) else "no Statcast rows for that day right now")
 ```
 
+    ✅ statcast_search (1 day)
+
+
+
+
+
+    shape: (10, 7)
+    ┌────────────┬───────────────┬────────────┬──────────────┬──────────────┬──────────────┬───────────┐
+    │ game_date  ┆ player_name   ┆ pitch_type ┆ release_spee ┆ launch_speed ┆ launch_angle ┆ events    │
+    │ ---        ┆ ---           ┆ ---        ┆ d            ┆ ---          ┆ ---          ┆ ---       │
+    │ str        ┆ str           ┆ str        ┆ ---          ┆ f64          ┆ i64          ┆ str       │
+    │            ┆               ┆            ┆ f64          ┆              ┆              ┆           │
+    ╞════════════╪═══════════════╪════════════╪══════════════╪══════════════╪══════════════╪═══════════╡
+    │ 2024-07-01 ┆ Alonso, Pete  ┆ FF         ┆ 94.8         ┆ 78.0         ┆ 46           ┆ field_out │
+    │ 2024-07-01 ┆ Alonso, Pete  ┆ FF         ┆ 96.6         ┆ null         ┆ null         ┆ null      │
+    │ 2024-07-01 ┆ Alonso, Pete  ┆ FF         ┆ 96.3         ┆ 73.3         ┆ 20           ┆ null      │
+    │ 2024-07-01 ┆ Alonso, Pete  ┆ FF         ┆ 97.2         ┆ null         ┆ null         ┆ null      │
+    │ 2024-07-01 ┆ Alonso, Pete  ┆ FF         ┆ 95.6         ┆ null         ┆ null         ┆ null      │
+    │ 2024-07-01 ┆ Varsho,       ┆ FF         ┆ 97.4         ┆ null         ┆ null         ┆ strikeout │
+    │            ┆ Daulton       ┆            ┆              ┆              ┆              ┆           │
+    │ 2024-07-01 ┆ Alonso, Pete  ┆ FF         ┆ 95.8         ┆ null         ┆ null         ┆ null      │
+    │ 2024-07-01 ┆ Varsho,       ┆ KC         ┆ 84.0         ┆ 94.3         ┆ -12          ┆ null      │
+    │            ┆ Daulton       ┆            ┆              ┆              ┆              ┆           │
+    │ 2024-07-01 ┆ Martinez,     ┆ FF         ┆ 97.5         ┆ null         ┆ null         ┆ strikeout │
+    │            ┆ J.D.          ┆            ┆              ┆              ┆              ┆           │
+    │ 2024-07-01 ┆ Martinez,     ┆ FF         ┆ 96.6         ┆ null         ┆ null         ┆ null      │
+    │            ┆ J.D.          ┆            ┆              ┆              ┆              ┆           │
+    └────────────┴───────────────┴────────────┴──────────────┴──────────────┴──────────────┴───────────┘
+
+
+
 ### Recipe 14 — 🏒 Premium NHL pull (`api-web`)
 
 `nhl_standings()` reads the modern NHL `api-web` feed — one row per team, parsed
@@ -445,6 +833,30 @@ keep = ["team_abbrev", "team_name", "wins", "losses", "ot_losses", "points",
 (nhl_st.select([c for c in keep if c in nhl_st.columns]).head(8)
  if nhl_st is not None and getattr(nhl_st, "height", 0) else "NHL standings unavailable right now")
 ```
+
+    ✅ nhl_standings (api-web)
+
+
+
+
+
+    shape: (8, 6)
+    ┌──────┬────────┬───────────┬────────┬─────────────────┬───────────────┐
+    │ wins ┆ losses ┆ ot_losses ┆ points ┆ conference_name ┆ division_name │
+    │ ---  ┆ ---    ┆ ---       ┆ ---    ┆ ---             ┆ ---           │
+    │ i64  ┆ i64    ┆ i64       ┆ i64    ┆ str             ┆ str           │
+    ╞══════╪════════╪═══════════╪════════╪═════════════════╪═══════════════╡
+    │ 55   ┆ 16     ┆ 11        ┆ 121    ┆ Western         ┆ Central       │
+    │ 53   ┆ 22     ┆ 7         ┆ 113    ┆ Eastern         ┆ Metropolitan  │
+    │ 50   ┆ 20     ┆ 12        ┆ 112    ┆ Western         ┆ Central       │
+    │ 50   ┆ 23     ┆ 9         ┆ 109    ┆ Eastern         ┆ Atlantic      │
+    │ 50   ┆ 26     ┆ 6         ┆ 106    ┆ Eastern         ┆ Atlantic      │
+    │ 48   ┆ 24     ┆ 10        ┆ 106    ┆ Eastern         ┆ Atlantic      │
+    │ 46   ┆ 24     ┆ 12        ┆ 104    ┆ Western         ┆ Central       │
+    │ 45   ┆ 27     ┆ 10        ┆ 100    ┆ Eastern         ┆ Atlantic      │
+    └──────┴────────┴───────────┴────────┴─────────────────┴───────────────┘
+
+
 
 ### Recipe 15 — 🏒 NHL EDGE tracking leaderboard
 
@@ -460,6 +872,16 @@ edge = safe("nhl_edge_skater_speed_top_10",
  else "NHL EDGE leaderboard unavailable right now")
 ```
 
+    ⏭️  nhl_edge_skater_speed_top_10: unavailable right now (NoESPNDataError)
+
+
+
+
+
+    'NHL EDGE leaderboard unavailable right now'
+
+
+
 ### Recipe 16 — 🏒 Premium PWHL pull (HockeyTech)
 
 The women's pro league rides the HockeyTech feed. `pwhl_standings()` returns the
@@ -474,6 +896,20 @@ print("standings rows:", None if pwhl_st is None else getattr(pwhl_st, "height",
 (pwhl_st.head() if pwhl_st is not None and getattr(pwhl_st, "height", 0)
  else "PWHL standings unavailable right now")
 ```
+
+    ⏭️  pwhl_standings: unavailable right now (ValueError)
+
+
+    ✅ load_pwhl_schedules([2024])
+    standings rows: None | schedule rows: 85
+
+
+
+
+
+    'PWHL standings unavailable right now'
+
+
 
 ### Recipe 17 — 🏒 Junior hockey: schedule for all four CHL/AHL loops 🔁
 
@@ -492,6 +928,47 @@ for lg, mod in {"ahl": ahl, "ohl": ohl, "whl": whl, "qmjhl": qmjhl}.items():
 pl.DataFrame(rows)
 ```
 
+    ✅ ahl season
+
+
+    ✅ ahl_schedule
+
+
+    ✅ ohl season
+
+
+    ✅ ohl_schedule
+
+
+    ✅ whl season
+
+
+    ✅ whl_schedule
+
+
+    ✅ qmjhl season
+
+
+    ✅ qmjhl_schedule
+
+
+
+
+
+    shape: (4, 3)
+    ┌────────┬────────┬───────┐
+    │ league ┆ season ┆ games │
+    │ ---    ┆ ---    ┆ ---   │
+    │ str    ┆ i64    ┆ i64   │
+    ╞════════╪════════╪═══════╡
+    │ AHL    ┆ 2026   ┆ 10000 │
+    │ OHL    ┆ 2026   ┆ 10000 │
+    │ WHL    ┆ 2026   ┆ 10000 │
+    │ QMJHL  ┆ 2027   ┆ 10000 │
+    └────────┴────────┴───────┘
+
+
+
 ### Recipe 18 — 🎲 A quick odds peek (key-guarded)
 
 `odds.toa_sports()` lists every in-season sport/league key — it's **free**
@@ -507,6 +984,13 @@ else:
     out = "set ODDS_API_KEY to run: odds.toa_sports()  (free, doesn't touch quota)"
 out
 ```
+
+
+
+
+    "set ODDS_API_KEY to run: odds.toa_sports()  (free, doesn't touch quota)"
+
+
 
 ### Recipe 19 — 🎲 Live odds for a league (key-guarded)
 
@@ -526,6 +1010,13 @@ else:
 out
 ```
 
+
+
+
+    "set ODDS_API_KEY to run: odds.toa_sports_odds(sport='americanfootball_nfl')"
+
+
+
 ### Recipe 20 — Count the whole surface, per league 🔢
 
 `function_count()` returns the exposed-function tally for every league — a quick
@@ -540,6 +1031,30 @@ df = (pl.DataFrame({"league": list(counts.keys()), "n_functions": list(counts.va
 print("Total wrappers across the counted leagues:", sum(counts.values()))
 df
 ```
+
+    Total wrappers across the counted leagues: 1603
+
+
+
+
+
+    shape: (8, 2)
+    ┌────────┬─────────────┐
+    │ league ┆ n_functions │
+    │ ---    ┆ ---         │
+    │ str    ┆ i64         │
+    ╞════════╪═════════════╡
+    │ nhl    ┆ 337         │
+    │ mlb    ┆ 239         │
+    │ nfl    ┆ 233         │
+    │ cfb    ┆ 166         │
+    │ wnba   ┆ 162         │
+    │ mbb    ┆ 158         │
+    │ nba    ┆ 157         │
+    │ wbb    ┆ 151         │
+    └────────┴─────────────┘
+
+
 
 ## 🎉 Where to next
 

--- a/docs/docs/tutorials/02_cfb_intro.md
+++ b/docs/docs/tutorials/02_cfb_intro.md
@@ -70,6 +70,9 @@ SEASON = most_recent_cfb_season()
 print('most recent CFB season:', SEASON)
 ```
 
+    most recent CFB season: 2025
+
+
 ESPN's live endpoints are seasonal and occasionally rate-limited, so a tiny
 `safe()` helper runs the riskier calls defensively — you get the frame when
 the feed is up, and a friendly one-liner when it isn't (never a scary
@@ -109,6 +112,32 @@ schedule.select([
 ]).head()
 ```
 
+    schedule shape: (3734, 31)
+
+
+
+
+
+    shape: (5, 8)
+    ┌───────────┬──────┬─────────────┬─────────────┬────────────┬────────────┬────────────┬────────────┐
+    │ game_id   ┆ week ┆ home_team   ┆ away_team   ┆ home_point ┆ away_point ┆ home_confe ┆ neutral_si │
+    │ ---       ┆ ---  ┆ ---         ┆ ---         ┆ s          ┆ s          ┆ rence      ┆ te         │
+    │ i32       ┆ i32  ┆ str         ┆ str         ┆ ---        ┆ ---        ┆ ---        ┆ ---        │
+    │           ┆      ┆             ┆             ┆ i32        ┆ i32        ┆ str        ┆ bool       │
+    ╞═══════════╪══════╪═════════════╪═════════════╪════════════╪════════════╪════════════╪════════════╡
+    │ 401525434 ┆ 1    ┆ Notre Dame  ┆ Navy        ┆ 42         ┆ 3          ┆ FBS Indepe ┆ true       │
+    │           ┆      ┆             ┆             ┆            ┆            ┆ ndents     ┆            │
+    │ 401540199 ┆ 1    ┆ Mercer      ┆ North       ┆ 17         ┆ 7          ┆ Southern   ┆ true       │
+    │           ┆      ┆             ┆ Alabama     ┆            ┆            ┆            ┆            │
+    │ 401520145 ┆ 1    ┆ Jacksonvill ┆ UTEP        ┆ 17         ┆ 14         ┆ Conference ┆ false      │
+    │           ┆      ┆ e State     ┆             ┆            ┆            ┆ USA        ┆            │
+    │ 401532392 ┆ 1    ┆ San Diego   ┆ Ohio        ┆ 20         ┆ 13         ┆ Mountain   ┆ false      │
+    │           ┆      ┆ State       ┆             ┆            ┆            ┆ West       ┆            │
+    │ 401540628 ┆ 1    ┆ UAlbany     ┆ Fordham     ┆ 34         ┆ 13         ┆ CAA        ┆ false      │
+    └───────────┴──────┴─────────────┴─────────────┴────────────┴────────────┴────────────┴────────────┘
+
+
+
 ## 👥 Premium loaders: rosters
 
 [`load_cfb_rosters`](../cfb/reference/loaders.md#load_cfb_rosters) gives you
@@ -125,6 +154,27 @@ rosters.select([
 ]).head()
 ```
 
+    rosters shape: (22467, 18)
+
+
+
+
+
+    shape: (5, 7)
+    ┌────────────┬────────────┬───────────┬───────────────────┬──────────┬────────┬────────────┐
+    │ athlete_id ┆ first_name ┆ last_name ┆ team              ┆ position ┆ jersey ┆ home_state │
+    │ ---        ┆ ---        ┆ ---       ┆ ---               ┆ ---      ┆ ---    ┆ ---        │
+    │ str        ┆ str        ┆ str       ┆ str               ┆ str      ┆ i32    ┆ str        │
+    ╞════════════╪════════════╪═══════════╪═══════════════════╪══════════╪════════╪════════════╡
+    │ 102597     ┆ Will       ┆ Rogers    ┆ Mississippi State ┆ QB       ┆ 7      ┆ MS         │
+    │ 107494     ┆ Trey       ┆ Sanders   ┆ TCU               ┆ RB       ┆ 2      ┆ FL         │
+    │ 146583     ┆ John       ┆ Adams     ┆ Temple            ┆ WR       ┆ 17     ┆ NJ         │
+    │ 160900     ┆ Will       ┆ Johnson   ┆ Michigan          ┆ null     ┆ null   ┆ null       │
+    │ 169499     ┆ Ryan       ┆ Johnson   ┆ Akron             ┆ DL       ┆ 4      ┆ MS         │
+    └────────────┴────────────┴───────────┴───────────────────┴──────────┴────────┴────────────┘
+
+
+
 ## 🏟️ Premium loaders: team info
 
 [`load_cfb_team_info`](../cfb/reference/loaders.md#load_cfb_team_info)
@@ -140,6 +190,35 @@ team_info.select([
     'venue_name', 'city', 'state', 'dome',
 ]).head()
 ```
+
+    team_info shape: (1840, 28)
+
+
+
+
+
+    shape: (5, 8)
+    ┌─────────┬───────────────┬───────────────┬──────────────┬──────────────┬──────────┬───────┬───────┐
+    │ team_id ┆ school        ┆ conference    ┆ classificati ┆ venue_name   ┆ city     ┆ state ┆ dome  │
+    │ ---     ┆ ---           ┆ ---           ┆ on           ┆ ---          ┆ ---      ┆ ---   ┆ ---   │
+    │ i32     ┆ str           ┆ str           ┆ ---          ┆ str          ┆ str      ┆ str   ┆ bool  │
+    │         ┆               ┆               ┆ str          ┆              ┆          ┆       ┆       │
+    ╞═════════╪═══════════════╪═══════════════╪══════════════╪══════════════╪══════════╪═══════╪═══════╡
+    │ 2000    ┆ Abilene       ┆ UAC           ┆ fcs          ┆ Wildcat      ┆ Abilene  ┆ TX    ┆ false │
+    │         ┆ Christian     ┆               ┆              ┆ Stadium (TX) ┆          ┆       ┆       │
+    │ 2001    ┆ Adams State   ┆ Rocky         ┆ ii           ┆ Rex Stadium  ┆ Alamosa  ┆ CO    ┆ false │
+    │         ┆               ┆ Mountain      ┆              ┆              ┆          ┆       ┆       │
+    │ 2003    ┆ Adrian        ┆ Michigan      ┆ iii          ┆ Docking      ┆ Adrian   ┆ MI    ┆ false │
+    │         ┆               ┆               ┆              ┆ Stadium      ┆          ┆       ┆       │
+    │ 2005    ┆ Air Force     ┆ Mountain West ┆ fbs          ┆ Falcon       ┆ Colorado ┆ CO    ┆ false │
+    │         ┆               ┆               ┆              ┆ Stadium      ┆ Springs  ┆       ┆       │
+    │ 2006    ┆ Akron         ┆ Mid-American  ┆ fbs          ┆ Summa Field  ┆ Akron    ┆ OH    ┆ false │
+    │         ┆               ┆               ┆              ┆ at           ┆          ┆       ┆       │
+    │         ┆               ┆               ┆              ┆ InfoCision   ┆          ┆       ┆       │
+    │         ┆               ┆               ┆              ┆ Stad…        ┆          ┆       ┆       │
+    └─────────┴───────────────┴───────────────┴──────────────┴──────────────┴──────────┴───────┴───────┘
+
+
 
 ## 🎬 Premium loaders: play-by-play with EPA
 
@@ -169,6 +248,34 @@ have = [c for c in cols if c in pbp.columns]
 pbp.select(have).head() if have else 'pbp not published for these seasons right now'
 ```
 
+    ✅ load_cfb_pbp 2023
+
+
+    ✅ load_cfb_pbp 2022
+
+
+    ✅ load_cfb_pbp 2021
+    pbp season: 2021 | pbp shape: (137046, 370)
+
+
+
+
+
+    shape: (5, 6)
+    ┌───────────┬─────────────────────┬──────┬──────────┬───────────┬───────────┐
+    │ game_id   ┆ start.pos_team.name ┆ down ┆ distance ┆ EPA       ┆ wpa       │
+    │ ---       ┆ ---                 ┆ ---  ┆ ---      ┆ ---       ┆ ---       │
+    │ i64       ┆ str                 ┆ f64  ┆ f64      ┆ f64       ┆ f64       │
+    ╞═══════════╪═════════════════════╪══════╪══════════╪═══════════╪═══════════╡
+    │ 401281942 ┆ Miami               ┆ null ┆ null     ┆ -1.024319 ┆ -0.605042 │
+    │ 401281942 ┆ Alabama             ┆ null ┆ null     ┆ -0.345141 ┆ -0.434851 │
+    │ 401281942 ┆ Alabama             ┆ null ┆ null     ┆ -0.666759 ┆ -0.000523 │
+    │ 401281942 ┆ Alabama             ┆ null ┆ null     ┆ -0.298288 ┆ -0.000052 │
+    │ 401281942 ┆ Alabama             ┆ null ┆ null     ┆ -0.20101  ┆ -0.000039 │
+    └───────────┴─────────────────────┴──────┴──────────┴───────────┴───────────┘
+
+
+
 ## 📡 Live from ESPN: the scoreboard
 
 When you need *today's* slate (or a specific date), the ESPN wrappers shine.
@@ -192,6 +299,27 @@ else:
 out
 ```
 
+    ✅ ESPN scoreboard
+
+
+
+
+
+    shape: (5, 4)
+    ┌───────────┬─────────────────────────────────┬────────────┬─────────────────────────┐
+    │ game_id   ┆ name                            ┆ short_name ┆ status_type_description │
+    │ ---       ┆ ---                             ┆ ---        ┆ ---                     │
+    │ str       ┆ str                             ┆ str        ┆ str                     │
+    ╞═══════════╪═════════════════════════════════╪════════════╪═════════════════════════╡
+    │ 401520430 ┆ Georgia Bulldogs at Georgia Te… ┆ UGA @ GT   ┆ Final                   │
+    │ 401520434 ┆ Ohio State Buckeyes at Michiga… ┆ OSU @ MICH ┆ Final                   │
+    │ 401524068 ┆ Washington State Cougars at Wa… ┆ WSU @ WASH ┆ Final                   │
+    │ 401520429 ┆ Florida State Seminoles at Flo… ┆ FSU @ FLA  ┆ Final                   │
+    │ 401520427 ┆ Alabama Crimson Tide at Auburn… ┆ ALA @ AUB  ┆ Final                   │
+    └───────────┴─────────────────────────────────┴────────────┴─────────────────────────┘
+
+
+
 ## 🏫 Live from ESPN: teams (and their `team_id`s)
 
 [`espn_cfb_teams`](../cfb/reference/additional.md#espn_cfb_teams) lists every
@@ -209,6 +337,30 @@ else:
     out = 'teams unavailable right now'
 out
 ```
+
+    ✅ ESPN teams
+
+
+
+
+
+    shape: (8, 4)
+    ┌─────────┬───────────────────┬──────────────┬───────────────────┐
+    │ team_id ┆ team_location     ┆ team_name    ┆ team_abbreviation │
+    │ ---     ┆ ---               ┆ ---          ┆ ---               │
+    │ str     ┆ str               ┆ str          ┆ str               │
+    ╞═════════╪═══════════════════╪══════════════╪═══════════════════╡
+    │ 2000    ┆ Abilene Christian ┆ Wildcats     ┆ ACU               │
+    │ 2001    ┆ Adams State       ┆ Grizzlies    ┆ ADSU              │
+    │ 2003    ┆ Adrian            ┆ Bulldogs     ┆ ADR               │
+    │ 2005    ┆ Air Force         ┆ Falcons      ┆ AF                │
+    │ 2006    ┆ Akron             ┆ Zips         ┆ AKR               │
+    │ 2010    ┆ Alabama A&M       ┆ Bulldogs     ┆ AAMU              │
+    │ 333     ┆ Alabama           ┆ Crimson Tide ┆ ALA               │
+    │ 2011    ┆ Alabama State     ┆ Hornets      ┆ ALST              │
+    └─────────┴───────────────────┴──────────────┴───────────────────┘
+
+
 
 ## 🍳 Cookbook: common CFB tasks
 
@@ -232,6 +384,29 @@ needed — the release frame already stores points as integers.
              'home_points', 'away_points', 'total_points'])
     .head(10))
 ```
+
+
+
+
+    shape: (10, 6)
+    ┌──────┬──────────────────────┬────────────────────┬─────────────┬─────────────┬──────────────┐
+    │ week ┆ home_team            ┆ away_team          ┆ home_points ┆ away_points ┆ total_points │
+    │ ---  ┆ ---                  ┆ ---                ┆ ---         ┆ ---         ┆ ---          │
+    │ i32  ┆ str                  ┆ str                ┆ i32         ┆ i32         ┆ i32          │
+    ╞══════╪══════════════════════╪════════════════════╪═════════════╪═════════════╪══════════════╡
+    │ 9    ┆ Colby College        ┆ Middlebury         ┆ null        ┆ null        ┆ null         │
+    │ 9    ┆ Bowdoin              ┆ Trinity (CT)       ┆ null        ┆ null        ┆ null         │
+    │ 9    ┆ Bates                ┆ Williams           ┆ null        ┆ null        ┆ null         │
+    │ 11   ┆ Worcester St         ┆ Framingham State   ┆ null        ┆ null        ┆ null         │
+    │ 10   ┆ Defiance College     ┆ Rose-Hulman        ┆ 54          ┆ 78          ┆ 132          │
+    │ 10   ┆ Muskingum University ┆ Wilmington (OH)    ┆ 64          ┆ 63          ┆ 127          │
+    │ 2    ┆ Coast Guard          ┆ Anna Maria College ┆ 93          ┆ 24          ┆ 117          │
+    │ 13   ┆ Oklahoma             ┆ TCU                ┆ 69          ┆ 45          ┆ 114          │
+    │ 3    ┆ Texas State          ┆ Jackson State      ┆ 77          ┆ 34          ┆ 111          │
+    │ 10   ┆ Cornell College (IA) ┆ Illinois College   ┆ 34          ┆ 76          ┆ 110          │
+    └──────┴──────────────────────┴────────────────────┴─────────────┴─────────────┴──────────────┘
+
+
 
 ### Recipe 2 — Team offensive EPA/play leaderboard 📈
 
@@ -263,6 +438,30 @@ else:
 out
 ```
 
+
+
+
+    shape: (15, 3)
+    ┌──────────────────┬───────┬──────────────┐
+    │ offense          ┆ plays ┆ epa_per_play │
+    │ ---              ┆ ---   ┆ ---          │
+    │ str              ┆ u32   ┆ f64          │
+    ╞══════════════════╪═══════╪══════════════╡
+    │ Ohio State       ┆ 972   ┆ 0.28         │
+    │ Western Kentucky ┆ 1021  ┆ 0.195        │
+    │ Virginia         ┆ 914   ┆ 0.178        │
+    │ Oregon State     ┆ 897   ┆ 0.17         │
+    │ Oklahoma         ┆ 970   ┆ 0.154        │
+    │ …                ┆ …     ┆ …            │
+    │ Wake Forest      ┆ 1071  ┆ 0.121        │
+    │ Alabama          ┆ 1202  ┆ 0.115        │
+    │ Nevada           ┆ 980   ┆ 0.114        │
+    │ Missouri         ┆ 906   ┆ 0.113        │
+    │ TCU              ┆ 730   ┆ 0.112        │
+    └──────────────────┴───────┴──────────────┘
+
+
+
 ### Recipe 3 — A team's roster, sorted by position 🧩
 
 Join the loaded roster against `team_info` to resolve a school name to its
@@ -287,6 +486,32 @@ else:
     out = f'no roster rows for {team_name} (try another school string)'
 out
 ```
+
+    Michigan: 144 players
+
+
+
+
+
+    shape: (10, 2)
+    ┌──────────┬─────────┐
+    │ position ┆ players │
+    │ ---      ┆ ---     │
+    │ str      ┆ u32     │
+    ╞══════════╪═════════╡
+    │ DB       ┆ 23      │
+    │ OL       ┆ 21      │
+    │ WR       ┆ 19      │
+    │ LB       ┆ 18      │
+    │ DE       ┆ 12      │
+    │ DL       ┆ 12      │
+    │ RB       ┆ 11      │
+    │ TE       ┆ 11      │
+    │ QB       ┆ 6       │
+    │ PK       ┆ 6       │
+    └──────────┴─────────┘
+
+
 
 ### Recipe 4 — Who was on the field? Per-play participants 🕵️
 
@@ -313,6 +538,33 @@ else:
     out = 'participants feed quiet right now (offseason / rate limit)'
 out
 ```
+
+    ✅ play participants 401628334
+
+
+
+
+
+    shape: (5, 5)
+    ┌───────────────────┬───────────────────┬───────────────────┬───────────────────┬──────────────────┐
+    │ play_id           ┆ kicker_player_nam ┆ returner_player_n ┆ passer_player_nam ┆ receiver_player_ │
+    │ ---               ┆ e                 ┆ ame               ┆ e                 ┆ name             │
+    │ i64               ┆ ---               ┆ ---               ┆ ---               ┆ ---              │
+    │                   ┆ str               ┆ str               ┆ str               ┆ str              │
+    ╞═══════════════════╪═══════════════════╪═══════════════════╪═══════════════════╪══════════════════╡
+    │ 40162833410184990 ┆ Michael Lantz     ┆ Zavion Thomas     ┆ null              ┆ null             │
+    │ 2                 ┆                   ┆                   ┆                   ┆                  │
+    │ 40162833410185440 ┆ null              ┆ null              ┆ Garrett Nussmeier ┆ Kyren Lacy       │
+    │ 1                 ┆                   ┆                   ┆                   ┆                  │
+    │ 40162833410185750 ┆ null              ┆ null              ┆ Garrett Nussmeier ┆ Kyren Lacy       │
+    │ 1                 ┆                   ┆                   ┆                   ┆                  │
+    │ 40162833410185960 ┆ null              ┆ null              ┆ null              ┆ null             │
+    │ 1                 ┆                   ┆                   ┆                   ┆                  │
+    │ 40162833410186700 ┆ null              ┆ null              ┆ Garrett Nussmeier ┆ CJ Daniels       │
+    │ 1                 ┆                   ┆                   ┆                   ┆                  │
+    └───────────────────┴───────────────────┴───────────────────┴───────────────────┴──────────────────┘
+
+
 
 ### Recipe 5 — Build a standings table from the schedule 🏆
 
@@ -345,6 +597,29 @@ standings_tbl = (
 standings_tbl.head(10)
 ```
 
+
+
+
+    shape: (10, 4)
+    ┌──────────────────────────┬──────┬────────┬─────────┐
+    │ team                     ┆ wins ┆ losses ┆ win_pct │
+    │ ---                      ┆ ---  ┆ ---    ┆ ---     │
+    │ str                      ┆ u32  ┆ u32    ┆ f64     │
+    ╞══════════════════════════╪══════╪════════╪═════════╡
+    │ Harding University       ┆ 15   ┆ 0      ┆ 1.0     │
+    │ South Dakota State       ┆ 15   ┆ 0      ┆ 1.0     │
+    │ Michigan                 ┆ 15   ┆ 0      ┆ 1.0     │
+    │ Colorado School Of Mines ┆ 14   ┆ 1      ┆ 0.933   │
+    │ Washington               ┆ 14   ┆ 1      ┆ 0.933   │
+    │ Cortland                 ┆ 14   ┆ 1      ┆ 0.933   │
+    │ North Central College    ┆ 14   ┆ 1      ┆ 0.933   │
+    │ Randolph-Macon           ┆ 13   ┆ 1      ┆ 0.929   │
+    │ Georgia                  ┆ 13   ┆ 1      ┆ 0.929   │
+    │ Florida State            ┆ 13   ┆ 1      ┆ 0.929   │
+    └──────────────────────────┴──────┴────────┴─────────┘
+
+
+
 ### Recipe 6 — End-of-season Elo power ratings ⚡
 
 Every schedule row ships pre- and post-game **Elo** ratings. Grab each team's most recent post-game Elo (sort by week, take the first) for a tidy, ready-to-rank power table — no model to fit.
@@ -372,6 +647,30 @@ elo = (
 )
 elo.head(15)
 ```
+
+
+
+
+    shape: (15, 2)
+    ┌───────────────┬───────────┐
+    │ team          ┆ final_elo │
+    │ ---           ┆ ---       │
+    │ str           ┆ i32       │
+    ╞═══════════════╪═══════════╡
+    │ Michigan      ┆ 2174      │
+    │ Georgia       ┆ 2111      │
+    │ Ohio State    ┆ 2108      │
+    │ Penn State    ┆ 2061      │
+    │ Texas         ┆ 2050      │
+    │ …             ┆ …         │
+    │ Florida State ┆ 1951      │
+    │ Kansas State  ┆ 1942      │
+    │ Washington    ┆ 1883      │
+    │ SMU           ┆ 1861      │
+    │ James Madison ┆ 1835      │
+    └───────────────┴───────────┘
+
+
 
 ### Recipe 7 — One team's full game log 📜
 
@@ -405,6 +704,30 @@ gamelog = (
 gamelog.head(16) if gamelog.height else f'no games found for {team}'
 ```
 
+
+
+
+    shape: (15, 6)
+    ┌──────┬───────────────┬─────────┬─────────────┬────────┬──────────────┐
+    │ week ┆ opponent      ┆ pts_for ┆ pts_against ┆ margin ┆ neutral_site │
+    │ ---  ┆ ---           ┆ ---     ┆ ---         ┆ ---    ┆ ---          │
+    │ i32  ┆ str           ┆ i32     ┆ i32         ┆ i32    ┆ bool         │
+    ╞══════╪═══════════════╪═════════╪═════════════╪════════╪══════════════╡
+    │ 1    ┆ East Carolina ┆ 30      ┆ 3           ┆ 27     ┆ false        │
+    │ 1    ┆ Washington    ┆ 34      ┆ 13          ┆ 21     ┆ true         │
+    │ 1    ┆ Alabama       ┆ 27      ┆ 20          ┆ 7      ┆ true         │
+    │ 2    ┆ UNLV          ┆ 35      ┆ 7           ┆ 28     ┆ false        │
+    │ 3    ┆ Bowling Green ┆ 31      ┆ 6           ┆ 25     ┆ false        │
+    │ …    ┆ …             ┆ …       ┆ …           ┆ …      ┆ …            │
+    │ 10   ┆ Purdue        ┆ 41      ┆ 13          ┆ 28     ┆ false        │
+    │ 11   ┆ Penn State    ┆ 24      ┆ 15          ┆ 9      ┆ false        │
+    │ 12   ┆ Maryland      ┆ 31      ┆ 24          ┆ 7      ┆ false        │
+    │ 13   ┆ Ohio State    ┆ 30      ┆ 24          ┆ 6      ┆ false        │
+    │ 14   ┆ Iowa          ┆ 26      ┆ 0           ┆ 26     ┆ true         │
+    └──────┴───────────────┴─────────┴─────────────┴────────┴──────────────┘
+
+
+
 ### Recipe 8 — Rushing leaders, EPA included 🏃
 
 Premium play-by-play means leaderboards aren't just totals — they carry **efficiency**. Filter to designed runs, sum the yards, and average the EPA per carry to separate the bell-cows from the truly explosive backs.
@@ -433,6 +756,30 @@ else:
 out
 ```
 
+
+
+
+    shape: (15, 4)
+    ┌────────────────────┬─────────┬──────────┬──────────────┐
+    │ rusher_player_name ┆ carries ┆ rush_yds ┆ epa_per_rush │
+    │ ---                ┆ ---     ┆ ---      ┆ ---          │
+    │ str                ┆ u32     ┆ i64      ┆ f64          │
+    ╞════════════════════╪═════════╪══════════╪══════════════╡
+    │ Lew Nichols III    ┆ 315     ┆ 1765     ┆ -0.022       │
+    │ Abram Smith        ┆ 257     ┆ 1599     ┆ 0.165        │
+    │ Tyler Allgeier     ┆ 272     ┆ 1592     ┆ 0.127        │
+    │ Kenneth Walker III ┆ 251     ┆ 1576     ┆ 0.062        │
+    │ Sincere McCormick  ┆ 288     ┆ 1480     ┆ -0.035       │
+    │ …                  ┆ …       ┆ …        ┆ …            │
+    │ Rasheen Ali        ┆ 237     ┆ 1365     ┆ 0.049        │
+    │ Brian Robinson Jr. ┆ 271     ┆ 1361     ┆ 0.004        │
+    │ Breece Hall        ┆ 222     ┆ 1336     ┆ 0.095        │
+    │ B.J. Baylor        ┆ 222     ┆ 1336     ┆ 0.145        │
+    │ Hassan Haskins     ┆ 268     ┆ 1324     ┆ 0.134        │
+    └────────────────────┴─────────┴──────────┴──────────────┘
+
+
+
 ### Recipe 9 — The most thrilling games of the year 🎢
 
 cfbfastR's schedule ships an `excitement_index` (a win-probability swinginess score). Sort it descending and you've ranked the season's white-knuckle finishes in one line.
@@ -450,6 +797,29 @@ thrillers = (
 thrillers
 ```
 
+
+
+
+    shape: (10, 6)
+    ┌──────┬──────────────────┬────────────────┬─────────────┬─────────────┬──────────────────┐
+    │ week ┆ home_team        ┆ away_team      ┆ home_points ┆ away_points ┆ excitement_index │
+    │ ---  ┆ ---              ┆ ---            ┆ ---         ┆ ---         ┆ ---              │
+    │ i32  ┆ str              ┆ str            ┆ i32         ┆ i32         ┆ f64              │
+    ╞══════╪══════════════════╪════════════════╪═════════════╪═════════════╪══════════════════╡
+    │ 7    ┆ Southern         ┆ Lincoln (CA)   ┆ 45          ┆ 18          ┆ 14.267416        │
+    │ 9    ┆ Western Carolina ┆ Mercer         ┆ 38          ┆ 45          ┆ 13.938438        │
+    │ 11   ┆ Bucknell         ┆ Georgetown     ┆ 47          ┆ 50          ┆ 12.731991        │
+    │ 3    ┆ Tennessee State  ┆ Gardner-Webb   ┆ 27          ┆ 25          ┆ 12.041674        │
+    │ 6    ┆ Brown            ┆ Rhode Island   ┆ 30          ┆ 34          ┆ 11.825262        │
+    │ 3    ┆ Eastern Illinois ┆ Illinois State ┆ 14          ┆ 13          ┆ 11.431072        │
+    │ 5    ┆ Robert Morris    ┆ Howard         ┆ 10          ┆ 35          ┆ 11.33141         │
+    │ 6    ┆ Lindenwood       ┆ Tennessee Tech ┆ 23          ┆ 0           ┆ 11.198615        │
+    │ 10   ┆ New Hampshire    ┆ Villanova      ┆ 33          ┆ 45          ┆ 11.10256         │
+    │ 4    ┆ Eastern Illinois ┆ McNeese        ┆ 31          ┆ 28          ┆ 10.873191        │
+    └──────┴──────────────────┴────────────────┴─────────────┴─────────────┴──────────────────┘
+
+
+
 ### Recipe 10 — Where does the talent come from? 🗺️
 
 Roll the season roster up by `home_state` to map the recruiting footprint of college football — a quick reminder of just how much of the sport flows out of a handful of states.
@@ -466,6 +836,30 @@ talent_map = (
 )
 talent_map
 ```
+
+
+
+
+    shape: (15, 2)
+    ┌────────────┬─────────┐
+    │ home_state ┆ players │
+    │ ---        ┆ ---     │
+    │ str        ┆ u32     │
+    ╞════════════╪═════════╡
+    │ TX         ┆ 2526    │
+    │ FL         ┆ 1853    │
+    │ CA         ┆ 1748    │
+    │ GA         ┆ 1584    │
+    │ OH         ┆ 825     │
+    │ …          ┆ …       │
+    │ PA         ┆ 574     │
+    │ TN         ┆ 559     │
+    │ NJ         ┆ 534     │
+    │ MD         ┆ 512     │
+    │ SC         ┆ 472     │
+    └────────────┴─────────┘
+
+
 
 ### Recipe 11 — Conference vs. non-conference, by margin 🔀
 
@@ -492,6 +886,21 @@ splits = (
 )
 splits
 ```
+
+
+
+
+    shape: (2, 4)
+    ┌─────────────────┬───────┬────────────┬──────────────────┐
+    │ conference_game ┆ games ┆ avg_margin ┆ avg_total_points │
+    │ ---             ┆ ---   ┆ ---        ┆ ---              │
+    │ bool            ┆ u32   ┆ f64        ┆ f64              │
+    ╞═════════════════╪═══════╪════════════╪══════════════════╡
+    │ false           ┆ 362   ┆ 22.2       ┆ 54.0             │
+    │ true            ┆ 548   ┆ 15.2       ┆ 53.5             │
+    └─────────────────┴───────┴────────────┴──────────────────┘
+
+
 
 ### Recipe 12 — Biggest betting favorites in history 💸
 
@@ -521,6 +930,33 @@ else:
 out
 ```
 
+    ✅ load_cfb_betting_lines
+    biggest favorites, 2019 season:
+
+
+
+
+
+    shape: (10, 3)
+    ┌─────────────────────────────────┬──────┬────────────┐
+    │ game_desc                       ┆ abbr ┆ avg_spread │
+    │ ---                             ┆ ---  ┆ ---        │
+    │ str                             ┆ str  ┆ f64        │
+    ╞═════════════════════════════════╪══════╪════════════╡
+    │ Western Carolina@Alabama        ┆ BAMA ┆ -58.0      │
+    │ New Mexico State@Alabama        ┆ BAMA ┆ -54.9      │
+    │ Arkansas-Pine Bluff@TCU         ┆ TCU  ┆ -54.0      │
+    │ Ohio State@Rutgers              ┆ OSU  ┆ -52.2      │
+    │ Northwestern State@LSU          ┆ LSU  ┆ -51.6      │
+    │ Murray State@Georgia            ┆ UGA  ┆ -49.2      │
+    │ Wofford@Clemson                 ┆ CLE  ┆ -48.5      │
+    │ Oklahoma Panhandle State@Sam H… ┆ SHS  ┆ -47.5      │
+    │ Butler@North Dakota State       ┆ NDS  ┆ -47.5      │
+    │ Idaho@Penn State                ┆ PSU  ┆ -47.3      │
+    └─────────────────────────────────┴──────┴────────────┘
+
+
+
 ### Recipe 13 — Hand it to pandas 🐼
 
 Every loader takes `return_as_pandas=True`, and any polars frame converts with `.to_pandas()`. Once it's a pandas DataFrame the whole pandas/`numpy`/`scikit-learn` world opens up — here, a one-call `.describe()` of scoring across the season.
@@ -536,6 +972,24 @@ score_pd['total_points'] = score_pd['home_points'] + score_pd['away_points']
 print(type(score_pd).__module__)
 score_pd.describe().round(1)
 ```
+
+    pandas
+
+
+
+
+
+           home_points  away_points  total_points
+    count       3730.0       3730.0        3730.0
+    mean          28.9         24.3          53.1
+    std           16.0         15.0          17.8
+    min            0.0          0.0           0.0
+    25%           17.0         14.0          41.0
+    50%           28.0         23.0          52.0
+    75%           38.0         34.0          65.0
+    max           96.0         91.0         132.0
+
+
 
 ## 🗞️ Live tour: standings, polls, leaders & recruits
 
@@ -561,6 +1015,37 @@ rankings = safe('ESPN rankings (polls)', sdv.cfb.espn_cfb_rankings)
        else 'standings & rankings unavailable right now'))
 ```
 
+    ✅ ESPN standings
+
+
+    ✅ ESPN rankings (polls)
+
+
+
+
+
+    shape: (5, 26)
+    ┌────────────┬────────────┬─────────┬────────────┬───┬────────────┬───────────┬───────────┬────────┐
+    │ group_name ┆ group_abbr ┆ team_id ┆ team_name  ┆ … ┆ vs         ┆ vs. conf. ┆ vs ap top ┆ vs usa │
+    │ ---        ┆ eviation   ┆ ---     ┆ ---        ┆   ┆ division   ┆ ---       ┆ 25        ┆ ranked │
+    │ str        ┆ ---        ┆ str     ┆ str        ┆   ┆ ---        ┆ str       ┆ ---       ┆ teams  │
+    │            ┆ str        ┆         ┆            ┆   ┆ str        ┆           ┆ str       ┆ ---    │
+    │            ┆            ┆         ┆            ┆   ┆            ┆           ┆           ┆ str    │
+    ╞════════════╪════════════╪═════════╪════════════╪═══╪════════════╪═══════════╪═══════════╪════════╡
+    │ American   ┆ American   ┆ 249     ┆ Mean Green ┆ … ┆ null       ┆ null      ┆ null      ┆ null   │
+    │ Conference ┆            ┆         ┆            ┆   ┆            ┆           ┆           ┆        │
+    │ American   ┆ American   ┆ 2655    ┆ Green Wave ┆ … ┆ null       ┆ null      ┆ null      ┆ null   │
+    │ Conference ┆            ┆         ┆            ┆   ┆            ┆           ┆           ┆        │
+    │ American   ┆ American   ┆ 151     ┆ Pirates    ┆ … ┆ null       ┆ null      ┆ null      ┆ null   │
+    │ Conference ┆            ┆         ┆            ┆   ┆            ┆           ┆           ┆        │
+    │ American   ┆ American   ┆ 58      ┆ Bulls      ┆ … ┆ null       ┆ null      ┆ null      ┆ null   │
+    │ Conference ┆            ┆         ┆            ┆   ┆            ┆           ┆           ┆        │
+    │ American   ┆ American   ┆ 235     ┆ Tigers     ┆ … ┆ null       ┆ null      ┆ null      ┆ null   │
+    │ Conference ┆            ┆         ┆            ┆   ┆            ┆           ┆           ┆        │
+    └────────────┴────────────┴─────────┴────────────┴───┴────────────┴───────────┴───────────┴────────┘
+
+
+
 
 ```python
 leaders = safe(
@@ -577,6 +1062,24 @@ recruits = safe(
        if recruits is not None and getattr(recruits, 'height', 0)
        else 'leaders & recruits unavailable right now'))
 ```
+
+    ✅ ESPN passing leaders
+    ✅ ESPN recruiting class
+
+
+
+
+
+    shape: (1, 2)
+    ┌──────┬─────────────────────────────────┐
+    │ code ┆ message                         │
+    │ ---  ┆ ---                             │
+    │ i64  ┆ str                             │
+    ╞══════╪═════════════════════════════════╡
+    │ 400  ┆ http://sports.core.api.espn.pv… │
+    └──────┴─────────────────────────────────┘
+
+
 
 ## 🧪 Bonus: process one game from scratch with `CFBPlayProcess`
 
@@ -605,6 +1108,27 @@ else:
     out = 'live PBP pipeline quiet right now'
 out
 ```
+
+    ✅ CFBPlayProcess 401628334
+
+
+
+
+
+    shape: (5, 5)
+    ┌────────┬──────────┬──────┬──────────┬───────────┐
+    │ period ┆ pos_team ┆ down ┆ distance ┆ EPA       │
+    │ ---    ┆ ---      ┆ ---  ┆ ---      ┆ ---       │
+    │ i64    ┆ i64      ┆ i64  ┆ i64      ┆ f64       │
+    ╞════════╪══════════╪══════╪══════════╪═══════════╡
+    │ 1      ┆ 99       ┆ 1    ┆ 10       ┆ -1.309487 │
+    │ 1      ┆ 99       ┆ 1    ┆ 10       ┆ 1.130336  │
+    │ 1      ┆ 99       ┆ 1    ┆ 10       ┆ 0.963541  │
+    │ 1      ┆ 99       ┆ 1    ┆ 10       ┆ -0.674958 │
+    │ 1      ┆ 99       ┆ 2    ┆ 8        ┆ 0.250361  │
+    └────────┴──────────┴──────┴──────────┴───────────┘
+
+
 
 ## 🎉 Where to next
 

--- a/docs/docs/tutorials/03_nfl_intro.md
+++ b/docs/docs/tutorials/03_nfl_intro.md
@@ -74,6 +74,13 @@ pl.Config.set_tbl_cols(8)  # keep wide frames readable in the notebook
 
 ```
 
+
+
+
+    polars.config.Config
+
+
+
 Native NFL.com / NextGen endpoints and ESPN are *live* services — great
 in-season, occasionally grumpy in the offseason or behind a flaky network. A
 tiny `safe()` helper runs each live call defensively: you get the frame when
@@ -116,6 +123,16 @@ standings.shape if standings is not None else "standings unavailable"
 
 ```
 
+    ✅ NFL.com standings
+
+
+
+
+
+    (32, 53)
+
+
+
 
 ```python
 cols = [
@@ -129,6 +146,43 @@ cols = [
  if standings is not None else "standings unavailable")
 
 ```
+
+
+
+
+    shape: (10, 8)
+    ┌────────────┬────────────┬────────────┬───────────┬───────────┬───────────┬───────────┬───────────┐
+    │ team_full_ ┆ conference ┆ division_r ┆ overall_w ┆ overall_l ┆ overall_t ┆ division_ ┆ division_ │
+    │ name       ┆ _rank      ┆ ank        ┆ ins       ┆ osses     ┆ ies       ┆ wins      ┆ losses    │
+    │ ---        ┆ ---        ┆ ---        ┆ ---       ┆ ---       ┆ ---       ┆ ---       ┆ ---       │
+    │ str        ┆ i64        ┆ i64        ┆ i64       ┆ i64       ┆ i64       ┆ i64       ┆ i64       │
+    ╞════════════╪════════════╪════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
+    │ Detroit    ┆ 1          ┆ 1          ┆ 15        ┆ 2         ┆ 0         ┆ 6         ┆ 0         │
+    │ Lions      ┆            ┆            ┆           ┆           ┆           ┆           ┆           │
+    │ Kansas     ┆ 1          ┆ 1          ┆ 15        ┆ 2         ┆ 0         ┆ 5         ┆ 1         │
+    │ City       ┆            ┆            ┆           ┆           ┆           ┆           ┆           │
+    │ Chiefs     ┆            ┆            ┆           ┆           ┆           ┆           ┆           │
+    │ Buffalo    ┆ 2          ┆ 1          ┆ 13        ┆ 4         ┆ 0         ┆ 5         ┆ 1         │
+    │ Bills      ┆            ┆            ┆           ┆           ┆           ┆           ┆           │
+    │ Philadelph ┆ 2          ┆ 1          ┆ 14        ┆ 3         ┆ 0         ┆ 5         ┆ 1         │
+    │ ia Eagles  ┆            ┆            ┆           ┆           ┆           ┆           ┆           │
+    │ Baltimore  ┆ 3          ┆ 1          ┆ 12        ┆ 5         ┆ 0         ┆ 4         ┆ 2         │
+    │ Ravens     ┆            ┆            ┆           ┆           ┆           ┆           ┆           │
+    │ Tampa Bay  ┆ 3          ┆ 1          ┆ 10        ┆ 7         ┆ 0         ┆ 4         ┆ 2         │
+    │ Buccaneers ┆            ┆            ┆           ┆           ┆           ┆           ┆           │
+    │ Houston    ┆ 4          ┆ 1          ┆ 10        ┆ 7         ┆ 0         ┆ 5         ┆ 1         │
+    │ Texans     ┆            ┆            ┆           ┆           ┆           ┆           ┆           │
+    │ Los        ┆ 4          ┆ 1          ┆ 10        ┆ 7         ┆ 0         ┆ 4         ┆ 2         │
+    │ Angeles    ┆            ┆            ┆           ┆           ┆           ┆           ┆           │
+    │ Rams       ┆            ┆            ┆           ┆           ┆           ┆           ┆           │
+    │ Los        ┆ 5          ┆ 2          ┆ 11        ┆ 6         ┆ 0         ┆ 4         ┆ 2         │
+    │ Angeles    ┆            ┆            ┆           ┆           ┆           ┆           ┆           │
+    │ Chargers   ┆            ┆            ┆           ┆           ┆           ┆           ┆           │
+    │ Minnesota  ┆ 5          ┆ 2          ┆ 14        ┆ 3         ┆ 0         ┆ 4         ┆ 2         │
+    │ Vikings    ┆            ┆            ┆           ┆           ┆           ┆           ┆           │
+    └────────────┴────────────┴────────────┴───────────┴───────────┴───────────┴───────────┴───────────┘
+
+
 
 ## 👥 Rosters & the week calendar
 
@@ -152,6 +206,30 @@ cols = ["team_abbreviation", "team_full_name", "team_conference_abbr", "team_div
 
 ```
 
+    ✅ NFL.com rosters
+
+
+
+
+
+    shape: (8, 4)
+    ┌───────────────────┬────────────────────┬──────────────────────┬─────────────────────────┐
+    │ team_abbreviation ┆ team_full_name     ┆ team_conference_abbr ┆ team_division_full_name │
+    │ ---               ┆ ---                ┆ ---                  ┆ ---                     │
+    │ str               ┆ str                ┆ str                  ┆ str                     │
+    ╞═══════════════════╪════════════════════╪══════════════════════╪═════════════════════════╡
+    │ ARI               ┆ Arizona Cardinals  ┆ NFC                  ┆ NFC West                │
+    │ ATL               ┆ Atlanta Falcons    ┆ NFC                  ┆ NFC South               │
+    │ BAL               ┆ Baltimore Ravens   ┆ AFC                  ┆ AFC North               │
+    │ BUF               ┆ Buffalo Bills      ┆ AFC                  ┆ AFC East                │
+    │ CAR               ┆ Carolina Panthers  ┆ NFC                  ┆ NFC South               │
+    │ CHI               ┆ Chicago Bears      ┆ NFC                  ┆ NFC North               │
+    │ CIN               ┆ Cincinnati Bengals ┆ AFC                  ┆ AFC North               │
+    │ CLE               ┆ Cleveland Browns   ┆ AFC                  ┆ AFC North               │
+    └───────────────────┴────────────────────┴──────────────────────┴─────────────────────────┘
+
+
+
 
 ```python
 weeks = safe("NFL.com weeks", lambda: nfl.nfl_weeks(season=SEASON, season_type="REG"))
@@ -160,6 +238,30 @@ cols = ["season", "week", "week_type", "date_begin", "date_end", "bye_teams"]
  if weeks is not None else "weeks unavailable")
 
 ```
+
+    ✅ NFL.com weeks
+
+
+
+
+
+    shape: (8, 6)
+    ┌────────┬──────┬───────────┬────────────┬────────────┬─────────────────────────────────┐
+    │ season ┆ week ┆ week_type ┆ date_begin ┆ date_end   ┆ bye_teams                       │
+    │ ---    ┆ ---  ┆ ---       ┆ ---        ┆ ---        ┆ ---                             │
+    │ i64    ┆ i64  ┆ str       ┆ str        ┆ str        ┆ str                             │
+    ╞════════╪══════╪═══════════╪════════════╪════════════╪═════════════════════════════════╡
+    │ 2024   ┆ 18   ┆ REG       ┆ 2025-01-01 ┆ 2025-01-08 ┆ []                              │
+    │ 2024   ┆ 17   ┆ REG       ┆ 2024-12-24 ┆ 2025-01-01 ┆ []                              │
+    │ 2024   ┆ 16   ┆ REG       ┆ 2024-12-18 ┆ 2024-12-24 ┆ []                              │
+    │ 2024   ┆ 15   ┆ REG       ┆ 2024-12-11 ┆ 2024-12-18 ┆ []                              │
+    │ 2024   ┆ 14   ┆ REG       ┆ 2024-12-04 ┆ 2024-12-11 ┆ [{'id': '10400325-48de-3d6a-be… │
+    │ 2024   ┆ 13   ┆ REG       ┆ 2024-11-27 ┆ 2024-12-04 ┆ []                              │
+    │ 2024   ┆ 12   ┆ REG       ┆ 2024-11-20 ┆ 2024-11-27 ┆ [{'id': '10400200-f401-4e53-51… │
+    │ 2024   ┆ 11   ┆ REG       ┆ 2024-11-13 ┆ 2024-11-20 ┆ [{'id': '10403800-517c-7b8c-65… │
+    └────────┴──────┴───────────┴────────────┴────────────┴─────────────────────────────────┘
+
+
 
 ## 🏥 The weekly injury report
 
@@ -183,6 +285,37 @@ cols = [
 
 ```
 
+    ✅ NFL.com injuries
+
+
+
+
+
+    shape: (10, 6)
+    ┌─────────────────┬─────────────────┬──────────┬─────────────────┬───────────────┬─────────────────┐
+    │ team_full_name  ┆ person_display_ ┆ position ┆ injuries        ┆ injury_status ┆ practice_status │
+    │ ---             ┆ name            ┆ ---      ┆ ---             ┆ ---           ┆ ---             │
+    │ str             ┆ ---             ┆ str      ┆ str             ┆ str           ┆ str             │
+    │                 ┆ str             ┆          ┆                 ┆               ┆                 │
+    ╞═════════════════╪═════════════════╪══════════╪═════════════════╪═══════════════╪═════════════════╡
+    │ Atlanta Falcons ┆ Ta'Quon Graham  ┆ DE       ┆ []              ┆ null          ┆ LIMITED         │
+    │ Atlanta Falcons ┆ Antonio         ┆ CB       ┆ ['Groin']       ┆ OUT           ┆ DIDNOT          │
+    │                 ┆ Hamilton        ┆          ┆                 ┆               ┆                 │
+    │ Atlanta Falcons ┆ Grady Jarrett   ┆ DT       ┆ []              ┆ null          ┆ DIDNOT          │
+    │ Atlanta Falcons ┆ Nate Landman    ┆ LB       ┆ []              ┆ null          ┆ FULL            │
+    │ Atlanta Falcons ┆ Chris Lindstrom ┆ G        ┆ ['Evaluated for ┆ null          ┆ null            │
+    │                 ┆                 ┆          ┆ a possible hea… ┆               ┆                 │
+    │ Atlanta Falcons ┆ Jake Matthews   ┆ T        ┆ []              ┆ null          ┆ LIMITED         │
+    │ Atlanta Falcons ┆ David Onyemata  ┆ DT       ┆ []              ┆ null          ┆ DIDNOT          │
+    │ Atlanta Falcons ┆ Kyle Pitts      ┆ TE       ┆ []              ┆ null          ┆ FULL            │
+    │ Baltimore       ┆ Rasheen Ali     ┆ RB       ┆ ['Neck']        ┆ DOUBTFUL      ┆ LIMITED         │
+    │ Ravens          ┆                 ┆          ┆                 ┆               ┆                 │
+    │ Baltimore       ┆ Adisa Isaac     ┆ LB       ┆ ['Hamstring']   ┆ OUT           ┆ DIDNOT          │
+    │ Ravens          ┆                 ┆          ┆                 ┆               ┆                 │
+    └─────────────────┴─────────────────┴──────────┴─────────────────┴───────────────┴─────────────────┘
+
+
+
 ## 📋 Per-game details for a week
 
 Need the full slate with drive charts, broadcast info and embedded standings?
@@ -203,6 +336,30 @@ cols = ["week", "date", "game_type", "away_team_full_name", "home_team_full_name
  if wgd is not None else "weekly game details unavailable")
 
 ```
+
+    ✅ NFL.com weekly game details
+
+
+
+
+
+    shape: (8, 6)
+    ┌──────┬────────────┬─────────────┬──────────────────────┬─────────────────────┬───────────┐
+    │ week ┆ date       ┆ game_type   ┆ away_team_full_name  ┆ home_team_full_name ┆ status    │
+    │ ---  ┆ ---        ┆ ---         ┆ ---                  ┆ ---                 ┆ ---       │
+    │ i64  ┆ str        ┆ str         ┆ str                  ┆ str                 ┆ str       │
+    ╞══════╪════════════╪═════════════╪══════════════════════╪═════════════════════╪═══════════╡
+    │ 1    ┆ 2024-09-06 ┆ UNSPECIFIED ┆ Baltimore Ravens     ┆ Kansas City Chiefs  ┆ SCHEDULED │
+    │ 1    ┆ 2024-09-07 ┆ UNSPECIFIED ┆ Green Bay Packers    ┆ Philadelphia Eagles ┆ SCHEDULED │
+    │ 1    ┆ 2024-09-08 ┆ UNSPECIFIED ┆ Pittsburgh Steelers  ┆ Atlanta Falcons     ┆ SCHEDULED │
+    │ 1    ┆ 2024-09-08 ┆ UNSPECIFIED ┆ Arizona Cardinals    ┆ Buffalo Bills       ┆ SCHEDULED │
+    │ 1    ┆ 2024-09-08 ┆ UNSPECIFIED ┆ Tennessee Titans     ┆ Chicago Bears       ┆ SCHEDULED │
+    │ 1    ┆ 2024-09-08 ┆ UNSPECIFIED ┆ New England Patriots ┆ Cincinnati Bengals  ┆ SCHEDULED │
+    │ 1    ┆ 2024-09-08 ┆ UNSPECIFIED ┆ Houston Texans       ┆ Indianapolis Colts  ┆ SCHEDULED │
+    │ 1    ┆ 2024-09-08 ┆ UNSPECIFIED ┆ Jacksonville Jaguars ┆ Miami Dolphins      ┆ SCHEDULED │
+    └──────┴────────────┴─────────────┴──────────────────────┴─────────────────────┴───────────┘
+
+
 
 ## ⚡ NextGen Stats: the tracking layer
 
@@ -232,6 +389,38 @@ cols = [
 
 ```
 
+    ✅ NGS passing statboard
+
+
+
+
+
+    shape: (10, 7)
+    ┌──────────────┬──────────────┬──────────────┬─────────────┬─────────────┬───────────┬─────────────┐
+    │ playerName   ┆ passerRating ┆ completionPe ┆ avgTimeToTh ┆ aggressiven ┆ passYards ┆ passTouchdo │
+    │ ---          ┆ ---          ┆ rcentageAbov ┆ row         ┆ ess         ┆ ---       ┆ wns         │
+    │ str          ┆ f64          ┆ eExpec…      ┆ ---         ┆ ---         ┆ i64       ┆ ---         │
+    │              ┆              ┆ ---          ┆ f64         ┆ f64         ┆           ┆ i64         │
+    │              ┆              ┆ f64          ┆             ┆             ┆           ┆             │
+    ╞══════════════╪══════════════╪══════════════╪═════════════╪═════════════╪═══════════╪═════════════╡
+    │ Lamar        ┆ 119.629044   ┆ -0.194641    ┆ 3.144269    ┆ 10.970464   ┆ 4172      ┆ 41          │
+    │ Jackson      ┆              ┆              ┆             ┆             ┆           ┆             │
+    │ Jared Goff   ┆ 111.769481   ┆ 5.054879     ┆ 2.787295    ┆ 11.502783   ┆ 4629      ┆ 37          │
+    │ Joe Burrow   ┆ 108.537832   ┆ 4.521902     ┆ 2.710951    ┆ 15.797546   ┆ 4918      ┆ 43          │
+    │ Baker        ┆ 106.761696   ┆ 2.17107      ┆ 2.6982      ┆ 10.877193   ┆ 4500      ┆ 41          │
+    │ Mayfield     ┆              ┆              ┆             ┆             ┆           ┆             │
+    │ Jalen Hurts  ┆ 103.687673   ┆ 6.305457     ┆ 3.1313      ┆ 16.34349    ┆ 2903      ┆ 18          │
+    │ Sam Darnold  ┆ 102.534404   ┆ 2.799064     ┆ 3.083395    ┆ 13.944954   ┆ 4319      ┆ 35          │
+    │ Justin       ┆ 101.703042   ┆ 2.391567     ┆ 2.910539    ┆ 15.873016   ┆ 3870      ┆ 23          │
+    │ Herbert      ┆              ┆              ┆             ┆             ┆           ┆             │
+    │ Josh Allen   ┆ 101.384576   ┆ 0.781139     ┆ 2.886884    ┆ 16.770186   ┆ 3731      ┆ 28          │
+    │ Tua          ┆ 101.362782   ┆ 1.696667     ┆ 2.416476    ┆ 12.280702   ┆ 2867      ┆ 19          │
+    │ Tagovailoa   ┆              ┆              ┆             ┆             ┆           ┆             │
+    │ Derek Carr   ┆ 101.022999   ┆ 3.222724     ┆ 2.758918    ┆ 11.111111   ┆ 2145      ┆ 15          │
+    └──────────────┴──────────────┴──────────────┴─────────────┴─────────────┴───────────┴─────────────┘
+
+
+
 And [`nfl_ngs_leaders`](../nfl/reference/additional.md#nfl_ngs_leaders)
 serves the highlight-reel top-N boards — each row is the *play* that earned
 the leader their spot. Categories include `"speed"` (fastest ball carriers),
@@ -249,6 +438,38 @@ cols = ["leader_playerName", "leader_teamAbbr", "leader_maxSpeed", "leader_yards
  if fast is not None else "NGS leaders unavailable")
 
 ```
+
+    ✅ NGS fastest ball carriers
+
+
+
+
+
+    shape: (8, 5)
+    ┌───────────────────┬─────────────────┬─────────────────┬──────────────┬───────────────────────────┐
+    │ leader_playerName ┆ leader_teamAbbr ┆ leader_maxSpeed ┆ leader_yards ┆ play_playDescription      │
+    │ ---               ┆ ---             ┆ ---             ┆ ---          ┆ ---                       │
+    │ str               ┆ str             ┆ f64             ┆ i64          ┆ str                       │
+    ╞═══════════════════╪═════════════════╪═════════════════╪══════════════╪═══════════════════════════╡
+    │ KaVontae Turpin   ┆ DAL             ┆ 22.356818       ┆ 64           ┆ (15:00) (Shotgun) C.Rush  │
+    │                   ┆                 ┆                 ┆              ┆ pass …                    │
+    │ Brian Thomas Jr.  ┆ JAX             ┆ 22.152273       ┆ 85           ┆ (7:12) (Shotgun)          │
+    │                   ┆                 ┆                 ┆              ┆ T.Lawrence pa…            │
+    │ Jahmyr Gibbs      ┆ DET             ┆ 22.029546       ┆ 70           ┆ (4:07) (Shotgun) J.Gibbs  │
+    │                   ┆                 ┆                 ┆              ┆ left …                    │
+    │ Saquon Barkley    ┆ PHI             ┆ 21.927273       ┆ 55           ┆ (11:04) (No Huddle,       │
+    │                   ┆                 ┆                 ┆              ┆ Shotgun) S…               │
+    │ Saquon Barkley    ┆ PHI             ┆ 21.906818       ┆ 72           ┆ (2:54) (Shotgun)          │
+    │                   ┆                 ┆                 ┆              ┆ S.Barkley lef…            │
+    │ Nico Collins      ┆ HOU             ┆ 21.886364       ┆ 55           ┆ (12:56) C.Stroud pass     │
+    │                   ┆                 ┆                 ┆              ┆ deep mid…                 │
+    │ James Cook        ┆ BUF             ┆ 21.845455       ┆ 65           ┆ (8:48) A.Anderson         │
+    │                   ┆                 ┆                 ┆              ┆ reported in …             │
+    │ KaVontae Turpin   ┆ DAL             ┆ 21.845455       ┆ 18           ┆ J.Elliott kicks 60 yards  │
+    │                   ┆                 ┆                 ┆              ┆ from …                    │
+    └───────────────────┴─────────────────┴─────────────────┴──────────────┴───────────────────────────┘
+
+
 
 ## 📦 nflverse loaders: the bulk-data workhorses
 
@@ -271,6 +492,13 @@ pbp.shape
 ```
 
 
+
+
+    (49492, 372)
+
+
+
+
 ```python
 (pbp
     .filter(pl.col("play_type").is_not_null())
@@ -278,6 +506,43 @@ pbp.shape
     .head(8))
 
 ```
+
+
+
+
+    shape: (8, 9)
+    ┌────────────────┬─────┬──────┬─────────┬───┬───────────┬──────────────┬───────────┬───────────────┐
+    │ game_id        ┆ qtr ┆ down ┆ ydstogo ┆ … ┆ play_type ┆ yards_gained ┆ epa       ┆ desc          │
+    │ ---            ┆ --- ┆ ---  ┆ ---     ┆   ┆ ---       ┆ ---          ┆ ---       ┆ ---           │
+    │ str            ┆ f64 ┆ f64  ┆ f64     ┆   ┆ str       ┆ f64          ┆ f64       ┆ str           │
+    ╞════════════════╪═════╪══════╪═════════╪═══╪═══════════╪══════════════╪═══════════╪═══════════════╡
+    │ 2024_01_ARI_BU ┆ 1.0 ┆ null ┆ 0.0     ┆ … ┆ kickoff   ┆ 0.0          ┆ 0.257819  ┆ 2-T.Bass      │
+    │ F              ┆     ┆      ┆         ┆   ┆           ┆              ┆           ┆ kicks 65      │
+    │                ┆     ┆      ┆         ┆   ┆           ┆              ┆           ┆ yards from B… │
+    │ 2024_01_ARI_BU ┆ 1.0 ┆ 1.0  ┆ 10.0    ┆ … ┆ run       ┆ 3.0          ┆ -0.200602 ┆ (15:00)       │
+    │ F              ┆     ┆      ┆         ┆   ┆           ┆              ┆           ┆ 6-J.Conner up │
+    │                ┆     ┆      ┆         ┆   ┆           ┆              ┆           ┆ the midd…     │
+    │ 2024_01_ARI_BU ┆ 1.0 ┆ 2.0  ┆ 7.0     ┆ … ┆ pass      ┆ 22.0         ┆ 2.028874  ┆ (14:27)       │
+    │ F              ┆     ┆      ┆         ┆   ┆           ┆              ┆           ┆ 1-K.Murray    │
+    │                ┆     ┆      ┆         ┆   ┆           ┆              ┆           ┆ pass short …  │
+    │ 2024_01_ARI_BU ┆ 1.0 ┆ 1.0  ┆ 10.0    ┆ … ┆ pass      ┆ 9.0          ┆ 0.754242  ┆ (13:43)       │
+    │ F              ┆     ┆      ┆         ┆   ┆           ┆              ┆           ┆ (Shotgun)     │
+    │                ┆     ┆      ┆         ┆   ┆           ┆              ┆           ┆ 1-K.Murray p… │
+    │ 2024_01_ARI_BU ┆ 1.0 ┆ 2.0  ┆ 1.0     ┆ … ┆ run       ┆ 2.0          ┆ -0.029602 ┆ (13:02)       │
+    │ F              ┆     ┆      ┆         ┆   ┆           ┆              ┆           ┆ 6-J.Conner up │
+    │                ┆     ┆      ┆         ┆   ┆           ┆              ┆           ┆ the midd…     │
+    │ 2024_01_ARI_BU ┆ 1.0 ┆ 1.0  ┆ 10.0    ┆ … ┆ run       ┆ 2.0          ┆ -0.247749 ┆ (12:26)       │
+    │ F              ┆     ┆      ┆         ┆   ┆           ┆              ┆           ┆ (Shotgun)     │
+    │                ┆     ┆      ┆         ┆   ┆           ┆              ┆           ┆ 6-J.Conner l… │
+    │ 2024_01_ARI_BU ┆ 1.0 ┆ 2.0  ┆ 8.0     ┆ … ┆ run       ┆ 2.0          ┆ -0.530139 ┆ (11:51)       │
+    │ F              ┆     ┆      ┆         ┆   ┆           ┆              ┆           ┆ 6-J.Conner    │
+    │                ┆     ┆      ┆         ┆   ┆           ┆              ┆           ┆ left end to…  │
+    │ 2024_01_ARI_BU ┆ 1.0 ┆ 3.0  ┆ 6.0     ┆ … ┆ pass      ┆ 8.0          ┆ 1.6808    ┆ (11:08)       │
+    │ F              ┆     ┆      ┆         ┆   ┆           ┆              ┆           ┆ (Shotgun)     │
+    │                ┆     ┆      ┆         ┆   ┆           ┆              ┆           ┆ 1-K.Murray p… │
+    └────────────────┴─────┴──────┴─────────┴───┴───────────┴──────────────┴───────────┴───────────────┘
+
+
 
 
 ```python
@@ -290,6 +555,28 @@ ngs_release = nfl.load_nfl_nextgen_stats([SEASON], stat_type="passing")
     .head(8))
 
 ```
+
+
+
+
+    shape: (8, 6)
+    ┌─────────────────────┬───────────┬──────────┬────────────┬────────────────────────┬───────────────┐
+    │ player_display_name ┆ team_abbr ┆ attempts ┆ pass_yards ┆ completion_percentage_ ┆ passer_rating │
+    │ ---                 ┆ ---       ┆ ---      ┆ ---        ┆ above_ex…              ┆ ---           │
+    │ str                 ┆ str       ┆ i32      ┆ i32        ┆ ---                    ┆ f64           │
+    │                     ┆           ┆          ┆            ┆ f64                    ┆               │
+    ╞═════════════════════╪═══════════╪══════════╪════════════╪════════════════════════╪═══════════════╡
+    │ Lamar Jackson       ┆ BAL       ┆ 474      ┆ 4172       ┆ -0.194641              ┆ 119.629044    │
+    │ Jared Goff          ┆ DET       ┆ 539      ┆ 4629       ┆ 5.054879               ┆ 111.769481    │
+    │ Joe Burrow          ┆ CIN       ┆ 652      ┆ 4918       ┆ 4.521902               ┆ 108.537832    │
+    │ Baker Mayfield      ┆ TB        ┆ 570      ┆ 4500       ┆ 2.17107                ┆ 106.761696    │
+    │ Jalen Hurts         ┆ PHI       ┆ 361      ┆ 2903       ┆ 6.305457               ┆ 103.687673    │
+    │ Sam Darnold         ┆ MIN       ┆ 545      ┆ 4319       ┆ 2.799064               ┆ 102.534404    │
+    │ Justin Herbert      ┆ LAC       ┆ 504      ┆ 3870       ┆ 2.391567               ┆ 101.703042    │
+    │ Josh Allen          ┆ BUF       ┆ 483      ┆ 3731       ┆ 0.781139               ┆ 101.384576    │
+    └─────────────────────┴───────────┴──────────┴────────────┴────────────────────────┴───────────────┘
+
+
 
 ## 🔵 Secondary path: ESPN (quick & no-auth)
 
@@ -307,6 +594,36 @@ cols = ["id", "away_display_name", "home_display_name", "away_score", "home_scor
  if espn_sched is not None else "ESPN schedule unavailable")
 
 ```
+
+    ✅ ESPN schedule
+
+
+
+
+
+    shape: (8, 6)
+    ┌───────────┬────────────────────┬───────────────────┬────────────┬────────────┬───────────────────┐
+    │ id        ┆ away_display_name  ┆ home_display_name ┆ away_score ┆ home_score ┆ status_type_descr │
+    │ ---       ┆ ---                ┆ ---               ┆ ---        ┆ ---        ┆ iption            │
+    │ str       ┆ str                ┆ str               ┆ str        ┆ str        ┆ ---               │
+    │           ┆                    ┆                   ┆            ┆            ┆ str               │
+    ╞═══════════╪════════════════════╪═══════════════════╪════════════╪════════════╪═══════════════════╡
+    │ 401671744 ┆ Pittsburgh         ┆ Atlanta Falcons   ┆ 18         ┆ 10         ┆ Final             │
+    │           ┆ Steelers           ┆                   ┆            ┆            ┆                   │
+    │ 401671617 ┆ Arizona Cardinals  ┆ Buffalo Bills     ┆ 28         ┆ 34         ┆ Final             │
+    │ 401671719 ┆ Tennessee Titans   ┆ Chicago Bears     ┆ 17         ┆ 24         ┆ Final             │
+    │ 401671628 ┆ New England        ┆ Cincinnati        ┆ 16         ┆ 10         ┆ Final             │
+    │           ┆ Patriots           ┆ Bengals           ┆            ┆            ┆                   │
+    │ 401671861 ┆ Houston Texans     ┆ Indianapolis      ┆ 29         ┆ 27         ┆ Final             │
+    │           ┆                    ┆ Colts             ┆            ┆            ┆                   │
+    │ 401671849 ┆ Jacksonville       ┆ Miami Dolphins    ┆ 17         ┆ 20         ┆ Final             │
+    │           ┆ Jaguars            ┆                   ┆            ┆            ┆                   │
+    │ 401671734 ┆ Carolina Panthers  ┆ New Orleans       ┆ 10         ┆ 47         ┆ Final             │
+    │           ┆                    ┆ Saints            ┆            ┆            ┆                   │
+    │ 401671712 ┆ Minnesota Vikings  ┆ New York Giants   ┆ 28         ┆ 6          ┆ Final             │
+    └───────────┴────────────────────┴───────────────────┴────────────┴────────────┴───────────────────┘
+
+
 
 ## 🍳 Cookbook: common NFL tasks
 
@@ -342,6 +659,27 @@ out
 
 ```
 
+    ✅ injury report
+
+
+
+
+
+    shape: (5, 4)
+    ┌──────────────────┬─────────────────────┬──────────┬─────────────────────────────────┐
+    │ team_full_name   ┆ person_display_name ┆ position ┆ injuries                        │
+    │ ---              ┆ ---                 ┆ ---      ┆ ---                             │
+    │ str              ┆ str                 ┆ str      ┆ str                             │
+    ╞══════════════════╪═════════════════════╪══════════╪═════════════════════════════════╡
+    │ Atlanta Falcons  ┆ Antonio Hamilton    ┆ CB       ┆ ['Groin']                       │
+    │ Baltimore Ravens ┆ Adisa Isaac         ┆ LB       ┆ ['Hamstring']                   │
+    │ Baltimore Ravens ┆ Kyle Van Noy        ┆ LB       ┆ ['gameday concussion protocol … │
+    │ Buffalo Bills    ┆ Taron Johnson       ┆ CB       ┆ ['Forearm']                     │
+    │ Buffalo Bills    ┆ Javon Solomon       ┆ DE       ┆ ['Oblique']                     │
+    └──────────────────┴─────────────────────┴──────────┴─────────────────────────────────┘
+
+
+
 ### Recipe 2 — CPOE leaderboard from NextGen Stats 🎯
 
 Who's beating expectation as a passer? Rank qualified QBs by **completion
@@ -367,6 +705,33 @@ cpoe
 
 ```
 
+    ✅ NGS passing board
+
+
+
+
+
+    shape: (10, 5)
+    ┌────────────────┬──────────┬──────────────────────┬────────────────────────────────┬──────────────┐
+    │ playerName     ┆ attempts ┆ completionPercentage ┆ completionPercentageAboveExpec ┆ passerRating │
+    │ ---            ┆ ---      ┆ ---                  ┆ …                              ┆ ---          │
+    │ str            ┆ i64      ┆ f64                  ┆ ---                            ┆ f64          │
+    │                ┆          ┆                      ┆ f64                            ┆              │
+    ╞════════════════╪══════════╪══════════════════════╪════════════════════════════════╪══════════════╡
+    │ Jalen Hurts    ┆ 361      ┆ 68.698061            ┆ 6.305457                       ┆ 103.687673   │
+    │ Jared Goff     ┆ 539      ┆ 72.356215            ┆ 5.054879                       ┆ 111.769481   │
+    │ Joe Burrow     ┆ 652      ┆ 70.552147            ┆ 4.521902                       ┆ 108.537832   │
+    │ Geno Smith     ┆ 578      ┆ 70.415225            ┆ 3.854464                       ┆ 93.202134    │
+    │ Kirk Cousins   ┆ 453      ┆ 66.887417            ┆ 3.442009                       ┆ 88.61755     │
+    │ Derek Carr     ┆ 279      ┆ 67.741935            ┆ 3.222724                       ┆ 101.022999   │
+    │ Drake Maye     ┆ 338      ┆ 66.568047            ┆ 2.986893                       ┆ 88.079389    │
+    │ Brock Purdy    ┆ 455      ┆ 65.934066            ┆ 2.983077                       ┆ 96.076007    │
+    │ Sam Darnold    ┆ 545      ┆ 66.238532            ┆ 2.799064                       ┆ 102.534404   │
+    │ Justin Herbert ┆ 504      ┆ 65.873016            ┆ 2.391567                       ┆ 101.703042   │
+    └────────────────┴──────────┴──────────────────────┴────────────────────────────────┴──────────────┘
+
+
+
 ### Recipe 3 — Standings → division winners 🏆
 
 Take the premium standings and pull the team that tops each division. One
@@ -391,6 +756,30 @@ else:
 winners
 
 ```
+
+    ✅ standings
+
+
+
+
+
+    shape: (8, 3)
+    ┌──────────────────────┬──────────────┬────────────────┐
+    │ team_full_name       ┆ overall_wins ┆ overall_losses │
+    │ ---                  ┆ ---          ┆ ---            │
+    │ str                  ┆ i64          ┆ i64            │
+    ╞══════════════════════╪══════════════╪════════════════╡
+    │ Baltimore Ravens     ┆ 12           ┆ 5              │
+    │ Buffalo Bills        ┆ 13           ┆ 4              │
+    │ Detroit Lions        ┆ 15           ┆ 2              │
+    │ Houston Texans       ┆ 10           ┆ 7              │
+    │ Kansas City Chiefs   ┆ 15           ┆ 2              │
+    │ Los Angeles Rams     ┆ 10           ┆ 7              │
+    │ Philadelphia Eagles  ┆ 14           ┆ 3              │
+    │ Tampa Bay Buccaneers ┆ 10           ┆ 7              │
+    └──────────────────────┴──────────────┴────────────────┘
+
+
 
 ### Recipe 4 — A game's NextGen passer splits 🔬
 
@@ -420,6 +809,28 @@ out
 
 ```
 
+    ✅ NGS schedule
+
+
+    ✅ NGS gamecenter 2024090500
+
+
+
+
+
+    shape: (2, 8)
+    ┌─────────┬──────────┬────────────────┬──────────┬─────────────┬──────────┬───────────┬────────────┐
+    │ side    ┆ teamAbbr ┆ playerName     ┆ position ┆ completions ┆ attempts ┆ passYards ┆ touchdowns │
+    │ ---     ┆ ---      ┆ ---            ┆ ---      ┆ ---         ┆ ---      ┆ ---       ┆ ---        │
+    │ str     ┆ str      ┆ str            ┆ str      ┆ i64         ┆ i64      ┆ i64       ┆ i64        │
+    ╞═════════╪══════════╪════════════════╪══════════╪═════════════╪══════════╪═══════════╪════════════╡
+    │ home    ┆ KC       ┆ Patrick        ┆ QB       ┆ 20          ┆ 28       ┆ 291       ┆ 1          │
+    │         ┆          ┆ Mahomes        ┆          ┆             ┆          ┆           ┆            │
+    │ visitor ┆ BAL      ┆ Lamar Jackson  ┆ QB       ┆ 26          ┆ 41       ┆ 273       ┆ 1          │
+    └─────────┴──────────┴────────────────┴──────────┴─────────────┴──────────┴───────────┴────────────┘
+
+
+
 ### Recipe 5 — Season rushing leaders 🏃
 
 Roll the weekly box scores in [`load_nfl_player_stats`](../nfl/reference/additional.md#load_nfl_player_stats) up to season totals and crown the ground-game kings (≥150 carries).
@@ -447,6 +858,29 @@ else:
 rush_lb
 ```
 
+
+
+
+    shape: (10, 6)
+    ┌─────────────────────┬─────────────┬─────────┬──────────┬─────────┬──────────┐
+    │ player_display_name ┆ recent_team ┆ carries ┆ rush_yds ┆ rush_td ┆ rush_epa │
+    │ ---                 ┆ ---         ┆ ---     ┆ ---      ┆ ---     ┆ ---      │
+    │ str                 ┆ str         ┆ i32     ┆ f64      ┆ i32     ┆ f64      │
+    ╞═════════════════════╪═════════════╪═════════╪══════════╪═════════╪══════════╡
+    │ Saquon Barkley      ┆ PHI         ┆ 345     ┆ 2005.0   ┆ 13      ┆ 34.1     │
+    │ Derrick Henry       ┆ BAL         ┆ 325     ┆ 1921.0   ┆ 16      ┆ 40.6     │
+    │ Bijan Robinson      ┆ ATL         ┆ 304     ┆ 1456.0   ┆ 14      ┆ 16.9     │
+    │ Jonathan Taylor     ┆ IND         ┆ 303     ┆ 1431.0   ┆ 11      ┆ -21.0    │
+    │ Jahmyr Gibbs        ┆ DET         ┆ 250     ┆ 1412.0   ┆ 16      ┆ 35.1     │
+    │ Josh Jacobs         ┆ GB          ┆ 301     ┆ 1329.0   ┆ 15      ┆ -18.3    │
+    │ Kyren Williams      ┆ LA          ┆ 316     ┆ 1299.0   ┆ 14      ┆ -23.5    │
+    │ Chuba Hubbard       ┆ CAR         ┆ 250     ┆ 1195.0   ┆ 10      ┆ 9.7      │
+    │ Aaron Jones         ┆ MIN         ┆ 255     ┆ 1138.0   ┆ 5       ┆ -13.4    │
+    │ Bucky Irving        ┆ TB          ┆ 207     ┆ 1122.0   ┆ 8       ┆ 20.9     │
+    └─────────────────────┴─────────────┴─────────┴──────────┴─────────┴──────────┘
+
+
+
 ### Recipe 6 — The most efficient offenses (EPA/play) 📈
 
 Expected points added is the modeller's favourite efficiency yardstick. Average `epa` over every run/pass in [`load_nfl_pbp`](../nfl/reference/loaders.md#load_nfl_pbp) to rank offenses.
@@ -470,6 +904,29 @@ else:
     epa_off = "pbp schema changed — epa/posteam columns missing"
 epa_off
 ```
+
+
+
+
+    shape: (10, 3)
+    ┌─────────┬──────────────┬───────┐
+    │ posteam ┆ epa_per_play ┆ plays │
+    │ ---     ┆ ---          ┆ ---   │
+    │ str     ┆ f64          ┆ u32   │
+    ╞═════════╪══════════════╪═══════╡
+    │ BAL     ┆ 0.219        ┆ 1167  │
+    │ BUF     ┆ 0.19         ┆ 1202  │
+    │ DET     ┆ 0.165        ┆ 1164  │
+    │ WAS     ┆ 0.132        ┆ 1308  │
+    │ TB      ┆ 0.129        ┆ 1128  │
+    │ PHI     ┆ 0.119        ┆ 1341  │
+    │ CIN     ┆ 0.09         ┆ 1069  │
+    │ GB      ┆ 0.071        ┆ 1081  │
+    │ SF      ┆ 0.069        ┆ 1014  │
+    │ ARI     ┆ 0.067        ┆ 1031  │
+    └─────────┴──────────────┴───────┘
+
+
 
 ### Recipe 7 — Third-down conversion kings 🔑
 
@@ -495,6 +952,29 @@ else:
 third
 ```
 
+
+
+
+    shape: (10, 4)
+    ┌─────────┬─────────────┬──────────┬──────────┐
+    │ posteam ┆ conversions ┆ attempts ┆ conv_pct │
+    │ ---     ┆ ---         ┆ ---      ┆ ---      │
+    │ str     ┆ f64         ┆ u32      ┆ f64      │
+    ╞═════════╪═════════════╪══════════╪══════════╡
+    │ TB      ┆ 115.0       ┆ 226      ┆ 50.9     │
+    │ BAL     ┆ 109.0       ┆ 214      ┆ 50.9     │
+    │ KC      ┆ 123.0       ┆ 255      ┆ 48.2     │
+    │ DET     ┆ 101.0       ┆ 213      ┆ 47.4     │
+    │ CIN     ┆ 100.0       ┆ 214      ┆ 46.7     │
+    │ BUF     ┆ 107.0       ┆ 237      ┆ 45.1     │
+    │ WAS     ┆ 118.0       ┆ 262      ┆ 45.0     │
+    │ ARI     ┆ 83.0        ┆ 192      ┆ 43.2     │
+    │ SF      ┆ 84.0        ┆ 196      ┆ 42.9     │
+    │ PHI     ┆ 114.0       ┆ 278      ┆ 41.0     │
+    └─────────┴─────────────┴──────────┴──────────┘
+
+
+
 ### Recipe 8 — Red-zone touchdown efficiency 🎯
 
 Filter the play-by-play to snaps inside the opponent's 20 (`yardline_100 ≤ 20`) and see which offenses actually punch it in instead of settling for three.
@@ -519,6 +999,29 @@ else:
 redzone
 ```
 
+
+
+
+    shape: (10, 4)
+    ┌─────────┬────────┬──────────┬────────┐
+    │ posteam ┆ rz_tds ┆ rz_plays ┆ td_pct │
+    │ ---     ┆ ---    ┆ ---      ┆ ---    │
+    │ str     ┆ f64    ┆ u32      ┆ f64    │
+    ╞═════════╪════════╪══════════╪════════╡
+    │ BAL     ┆ 55.0   ┆ 178      ┆ 30.9   │
+    │ TB      ┆ 47.0   ┆ 175      ┆ 26.9   │
+    │ BUF     ┆ 55.0   ┆ 232      ┆ 23.7   │
+    │ DEN     ┆ 36.0   ┆ 157      ┆ 22.9   │
+    │ DET     ┆ 54.0   ┆ 239      ┆ 22.6   │
+    │ GB      ┆ 43.0   ┆ 195      ┆ 22.1   │
+    │ SEA     ┆ 27.0   ┆ 125      ┆ 21.6   │
+    │ NO      ┆ 25.0   ┆ 120      ┆ 20.8   │
+    │ NYJ     ┆ 31.0   ┆ 150      ┆ 20.7   │
+    │ WAS     ┆ 52.0   ┆ 255      ┆ 20.4   │
+    └─────────┴────────┴──────────┴────────┘
+
+
+
 ### Recipe 9 — Snap-share workhorse running backs 🐴
 
 [`load_nfl_snap_counts`](../nfl/reference/loaders.md#load_nfl_snap_counts) carries `offense_pct` per game — average it to find the backs their teams simply would not take off the field.
@@ -542,6 +1045,29 @@ else:
     workhorses = "snap_counts schema changed — offense_pct/position missing"
 workhorses
 ```
+
+
+
+
+    shape: (10, 4)
+    ┌─────────────────┬──────┬──────────────┬───────┐
+    │ player          ┆ team ┆ avg_snap_pct ┆ games │
+    │ ---             ┆ ---  ┆ ---          ┆ ---   │
+    │ str             ┆ str  ┆ f64          ┆ u32   │
+    ╞═════════════════╪══════╪══════════════╪═══════╡
+    │ Kyren Williams  ┆ LA   ┆ 87.2         ┆ 18    │
+    │ Jonathan Taylor ┆ IND  ┆ 80.3         ┆ 14    │
+    │ Chuba Hubbard   ┆ CAR  ┆ 77.3         ┆ 15    │
+    │ Bijan Robinson  ┆ ATL  ┆ 75.4         ┆ 17    │
+    │ Saquon Barkley  ┆ PHI  ┆ 75.1         ┆ 20    │
+    │ Breece Hall     ┆ NYJ  ┆ 72.4         ┆ 16    │
+    │ Alvin Kamara    ┆ NO   ┆ 70.9         ┆ 14    │
+    │ Tony Pollard    ┆ TEN  ┆ 67.8         ┆ 16    │
+    │ D'Andre Swift   ┆ CHI  ┆ 66.8         ┆ 17    │
+    │ Aaron Jones     ┆ MIN  ┆ 63.7         ┆ 18    │
+    └─────────────────┴──────┴──────────────┴───────┘
+
+
 
 ### Recipe 10 — Receiving leaders, then a hop into pandas 🐼
 
@@ -572,6 +1098,23 @@ else:
 rec_out
 ```
 
+
+
+
+      player_display_name recent_team  rec  rec_yds  yards_per_rec  catch_rate
+    0       Ja'Marr Chase         CIN  127   1708.0           13.4        72.6
+    1    Justin Jefferson         MIN  103   1533.0           14.9        66.9
+    2        Brian Thomas         JAX   87   1282.0           14.7        65.4
+    3        Drake London         ATL  100   1271.0           12.7        63.3
+    4   Amon-Ra St. Brown         DET  115   1263.0           11.0        81.6
+    5         Jerry Jeudy         CLE   90   1229.0           13.7        62.1
+    6        Malik Nabers         NYG  109   1204.0           11.0        64.1
+    7         CeeDee Lamb         DAL  101   1194.0           11.8        66.4
+    8        Brock Bowers          LV  112   1194.0           10.7        73.2
+    9       Ladd McConkey         LAC   82   1149.0           14.0        73.2
+
+
+
 ### Recipe 11 — Who gets open? NextGen separation 🛰️
 
 The receiving statboard exposes a tracking-only metric box scores can't: **average separation** at the catch point. Rank qualified targets (≥80) to find the route-runners defenders can't shadow.
@@ -596,6 +1139,33 @@ else:
     sep = "NGS receiving statboard unavailable"
 sep
 ```
+
+    ✅ NGS receiving statboard
+
+
+
+
+
+    shape: (10, 6)
+    ┌───────────────────┬─────────────────┬───────────────┬──────────────────┬─────────────────┬───────┐
+    │ player_displayNam ┆ player_position ┆ avgSeparation ┆ avgYACAboveExpec ┆ catchPercentage ┆ yards │
+    │ e                 ┆ ---             ┆ ---           ┆ tation           ┆ ---             ┆ ---   │
+    │ ---               ┆ str             ┆ f64           ┆ ---              ┆ f64             ┆ i64   │
+    │ str               ┆                 ┆               ┆ f64              ┆                 ┆       │
+    ╞═══════════════════╪═════════════════╪═══════════════╪══════════════════╪═════════════════╪═══════╡
+    │ Khalil Shakir     ┆ WR              ┆ 4.253744      ┆ 1.420359         ┆ 76.0            ┆ 821   │
+    │ Demario Douglas   ┆ WR              ┆ 4.010062      ┆ 0.298947         ┆ 75.862069       ┆ 621   │
+    │ Zay Flowers       ┆ WR              ┆ 3.9155        ┆ 1.636763         ┆ 63.793103       ┆ 1059  │
+    │ Xavier Worthy     ┆ WR              ┆ 3.773458      ┆ 0.445979         ┆ 60.204082       ┆ 638   │
+    │ Zach Ertz         ┆ TE              ┆ 3.631374      ┆ -0.207435        ┆ 72.527473       ┆ 654   │
+    │ George Kittle     ┆ TE              ┆ 3.582076      ┆ 2.110873         ┆ 82.978723       ┆ 1106  │
+    │ Sam LaPorta       ┆ TE              ┆ 3.529115      ┆ 1.433347         ┆ 72.289157       ┆ 726   │
+    │ Brock Bowers      ┆ TE              ┆ 3.515527      ┆ 0.982977         ┆ 73.202614       ┆ 1194  │
+    │ Trey McBride      ┆ TE              ┆ 3.511888      ┆ 0.637703         ┆ 75.510204       ┆ 1146  │
+    │ Jonnu Smith       ┆ TE              ┆ 3.49632       ┆ 0.848143         ┆ 79.279279       ┆ 884   │
+    └───────────────────┴─────────────────┴───────────────┴──────────────────┴─────────────────┴───────┘
+
+
 
 ### Recipe 12 — The nail-biters: closest games of the season 😬
 
@@ -623,6 +1193,29 @@ else:
 nailbiters
 ```
 
+
+
+
+    shape: (10, 8)
+    ┌──────┬───────────┬────────────┬───────────┬────────────┬────────┬─────────────┬────────────┐
+    │ week ┆ away_team ┆ away_score ┆ home_team ┆ home_score ┆ margin ┆ spread_line ┆ total_line │
+    │ ---  ┆ ---       ┆ ---        ┆ ---       ┆ ---        ┆ ---    ┆ ---         ┆ ---        │
+    │ i32  ┆ str       ┆ i32        ┆ str       ┆ i32        ┆ i32    ┆ f64         ┆ f64        │
+    ╞══════╪═══════════╪════════════╪═══════════╪════════════╪════════╪═════════════╪════════════╡
+    │ 2    ┆ CIN       ┆ 25         ┆ KC        ┆ 26         ┆ 1      ┆ 6.5         ┆ 47.5       │
+    │ 2    ┆ ATL       ┆ 22         ┆ PHI       ┆ 21         ┆ 1      ┆ 5.5         ┆ 46.5       │
+    │ 4    ┆ DEN       ┆ 10         ┆ NYJ       ┆ 9          ┆ 1      ┆ 7.5         ┆ 39.5       │
+    │ 5    ┆ ARI       ┆ 24         ┆ SF        ┆ 23         ┆ 1      ┆ 7.0         ┆ 48.5       │
+    │ 8    ┆ ARI       ┆ 28         ┆ MIA       ┆ 27         ┆ 1      ┆ 4.0         ┆ 46.5       │
+    │ 9    ┆ NO        ┆ 22         ┆ CAR       ┆ 23         ┆ 1      ┆ -7.0        ┆ 43.5       │
+    │ 10   ┆ CIN       ┆ 34         ┆ BAL       ┆ 35         ┆ 1      ┆ 6.0         ┆ 53.0       │
+    │ 10   ┆ PIT       ┆ 28         ┆ WAS       ┆ 27         ┆ 1      ┆ 1.5         ┆ 45.0       │
+    │ 11   ┆ GB        ┆ 20         ┆ CHI       ┆ 19         ┆ 1      ┆ -6.0        ┆ 41.0       │
+    │ 11   ┆ IND       ┆ 28         ┆ NYJ       ┆ 27         ┆ 1      ┆ 4.0         ┆ 43.0       │
+    └──────┴───────────┴────────────┴───────────┴────────────┴────────┴─────────────┴────────────┘
+
+
+
 ## 🗓️ Season helpers
 
 Handy when you want "the current/most-recent season" instead of hard-coding a
@@ -638,6 +1231,13 @@ calendar; `most_recent_nfl_season()` gives the latest season with data.
 }
 
 ```
+
+
+
+
+    {'current_season': 2025, 'current_week': 22, 'most_recent_season': 2025}
+
+
 
 ## 🎉 Where to next
 

--- a/docs/docs/tutorials/04_nba_intro.md
+++ b/docs/docs/tutorials/04_nba_intro.md
@@ -66,6 +66,9 @@ SEASON = most_recent_nba_season()
 print('current NBA season:', SEASON)
 ```
 
+    current NBA season: 2026
+
+
 ESPN endpoints are live and seasonal, so we'll route every network call
 through a tiny `safe()` helper. When the feed is up you get the frame; when
 it's mid-offseason or briefly rate-limited you get a friendly one-liner
@@ -97,6 +100,31 @@ teams = safe('teams', sdv.nba.espn_nba_teams)
  if teams is not None else 'teams feed unavailable')
 ```
 
+    ✅ teams — 30 rows
+
+
+
+
+
+    shape: (10, 5)
+    ┌─────────┬───────────────┬───────────┬───────────────────┬────────────┐
+    │ team_id ┆ team_location ┆ team_name ┆ team_abbreviation ┆ team_color │
+    │ ---     ┆ ---           ┆ ---       ┆ ---               ┆ ---        │
+    │ str     ┆ str           ┆ str       ┆ str               ┆ str        │
+    ╞═════════╪═══════════════╪═══════════╪═══════════════════╪════════════╡
+    │ 1       ┆ Atlanta       ┆ Hawks     ┆ ATL               ┆ c8102e     │
+    │ 2       ┆ Boston        ┆ Celtics   ┆ BOS               ┆ 008348     │
+    │ 17      ┆ Brooklyn      ┆ Nets      ┆ BKN               ┆ 000000     │
+    │ 30      ┆ Charlotte     ┆ Hornets   ┆ CHA               ┆ 008ca8     │
+    │ …       ┆ …             ┆ …         ┆ …                 ┆ …          │
+    │ 6       ┆ Dallas        ┆ Mavericks ┆ DAL               ┆ 0064b1     │
+    │ 7       ┆ Denver        ┆ Nuggets   ┆ DEN               ┆ 0e2240     │
+    │ 8       ┆ Detroit       ┆ Pistons   ┆ DET               ┆ 1d428a     │
+    │ 9       ┆ Golden State  ┆ Warriors  ┆ GS                ┆ fdb927     │
+    └─────────┴───────────────┴───────────┴───────────────────┴────────────┘
+
+
+
 ## 📅 Today on the slate (scoreboard)
 
 [`espn_nba_scoreboard`](../nba/reference/site.md#espn_nba_scoreboard) returns a
@@ -113,6 +141,24 @@ keep = ['game_id', 'short_name', 'home_abbreviation', 'away_abbreviation',
  if sb is not None and sb.height else 'no games on that date')
 ```
 
+    ✅ scoreboard — 1 rows
+
+
+
+
+
+    shape: (1, 7)
+    ┌───────────┬────────────┬───────────────┬───────────────┬────────────┬────────────┬───────────────┐
+    │ game_id   ┆ short_name ┆ home_abbrevia ┆ away_abbrevia ┆ home_score ┆ away_score ┆ status_type_d │
+    │ ---       ┆ ---        ┆ tion          ┆ tion          ┆ ---        ┆ ---        ┆ etail         │
+    │ str       ┆ str        ┆ ---           ┆ ---           ┆ str        ┆ str        ┆ ---           │
+    │           ┆            ┆ str           ┆ str           ┆            ┆            ┆ str           │
+    ╞═══════════╪════════════╪═══════════════╪═══════════════╪════════════╪════════════╪═══════════════╡
+    │ 401656359 ┆ DAL @ BOS  ┆ BOS           ┆ DAL           ┆ 107        ┆ 89         ┆ Final         │
+    └───────────┴────────────┴───────────────┴───────────────┴────────────┴────────────┴───────────────┘
+
+
+
 ## 🏆 Standings
 
 [`espn_nba_standings`](../nba/reference/site.md#espn_nba_standings) gives one
@@ -128,6 +174,32 @@ cols = ['team_display_name', 'wins', 'losses', 'win_percent', 'games_behind',
           .sort('win_percent', descending=True).head(10)
  if standings is not None and standings.height else 'standings unavailable')
 ```
+
+    ✅ standings — 30 rows
+
+
+
+
+
+    shape: (10, 7)
+    ┌───────────────────────┬──────┬────────┬─────────────┬──────────────┬────────────────────┬────────┐
+    │ team_display_name     ┆ wins ┆ losses ┆ win_percent ┆ games_behind ┆ point_differential ┆ streak │
+    │ ---                   ┆ ---  ┆ ---    ┆ ---         ┆ ---          ┆ ---                ┆ ---    │
+    │ str                   ┆ f64  ┆ f64    ┆ f64         ┆ f64          ┆ f64                ┆ f64    │
+    ╞═══════════════════════╪══════╪════════╪═════════════╪══════════════╪════════════════════╪════════╡
+    │ Oklahoma City Thunder ┆ 64.0 ┆ 18.0   ┆ 0.7804878   ┆ 0.0          ┆ 914.0              ┆ -2.0   │
+    │ San Antonio Spurs     ┆ 62.0 ┆ 20.0   ┆ 0.756098    ┆ 2.0          ┆ 681.0              ┆ -1.0   │
+    │ Detroit Pistons       ┆ 60.0 ┆ 22.0   ┆ 0.731707    ┆ 0.0          ┆ 669.0              ┆ 3.0    │
+    │ Boston Celtics        ┆ 56.0 ┆ 26.0   ┆ 0.682927    ┆ 4.0          ┆ 631.0              ┆ 2.0    │
+    │ …                     ┆ …    ┆ …      ┆ …           ┆ …            ┆ …                  ┆ …      │
+    │ Los Angeles Lakers    ┆ 53.0 ┆ 29.0   ┆ 0.646341    ┆ 11.0         ┆ 145.0              ┆ 3.0    │
+    │ Cleveland Cavaliers   ┆ 52.0 ┆ 30.0   ┆ 0.634146    ┆ 8.0          ┆ 336.0              ┆ 1.0    │
+    │ Houston Rockets       ┆ 52.0 ┆ 30.0   ┆ 0.634146    ┆ 12.0         ┆ 428.0              ┆ 1.0    │
+    │ Minnesota             ┆ 49.0 ┆ 33.0   ┆ 0.597561    ┆ 15.0         ┆ 275.0              ┆ 2.0    │
+    │ Timberwolves          ┆      ┆        ┆             ┆              ┆                    ┆        │
+    └───────────────────────┴──────┴────────┴─────────────┴──────────────┴────────────────────┴────────┘
+
+
 
 ## 🍳 Cookbook: common NBA tasks
 
@@ -154,6 +226,31 @@ cols = ['full_name', 'jersey', 'position_abbreviation', 'height', 'weight', 'age
  if roster is not None and roster.height else 'roster unavailable')
 ```
 
+    ✅ roster 2 — 16 rows
+
+
+
+
+
+    shape: (10, 6)
+    ┌───────────────────┬────────┬───────────────────────┬────────┬────────┬─────┐
+    │ full_name         ┆ jersey ┆ position_abbreviation ┆ height ┆ weight ┆ age │
+    │ ---               ┆ ---    ┆ ---                   ┆ ---    ┆ ---    ┆ --- │
+    │ str               ┆ str    ┆ str                   ┆ f64    ┆ f64    ┆ i64 │
+    ╞═══════════════════╪════════╪═══════════════════════╪════════╪════════╪═════╡
+    │ Dalano Banton     ┆ 45     ┆ F                     ┆ 80.0   ┆ 203.0  ┆ 26  │
+    │ Jaylen Brown      ┆ 7      ┆ G                     ┆ 78.0   ┆ 223.0  ┆ 29  │
+    │ Luka Garza        ┆ 52     ┆ C                     ┆ 82.0   ┆ 243.0  ┆ 27  │
+    │ Hugo Gonzalez     ┆ 28     ┆ G                     ┆ 78.0   ┆ 200.0  ┆ 20  │
+    │ …                 ┆ …      ┆ …                     ┆ …      ┆ …      ┆ …   │
+    │ Payton Pritchard  ┆ 11     ┆ G                     ┆ 73.0   ┆ 195.0  ┆ 28  │
+    │ Neemias Queta     ┆ 88     ┆ C                     ┆ 84.0   ┆ 248.0  ┆ 26  │
+    │ Baylor Scheierman ┆ 55     ┆ G                     ┆ 78.0   ┆ 205.0  ┆ 25  │
+    │ Max Shulga        ┆ 44     ┆ G                     ┆ 76.0   ┆ 210.0  ┆ 23  │
+    └───────────────────┴────────┴───────────────────────┴────────┴────────┴─────┘
+
+
+
 ### Recipe 2 — One team's season schedule 📆
 
 [`espn_nba_team_schedule`](../nba/reference/site.md#espn_nba_team_schedule)
@@ -168,6 +265,27 @@ cols = ['id', 'date', 'name', 'short_name', 'season_year']
 (tsched.select([c for c in cols if c in tsched.columns]).head()
  if tsched is not None and tsched.height else 'team schedule unavailable')
 ```
+
+    ✅ team schedule 2 — 7 rows
+
+
+
+
+
+    shape: (5, 5)
+    ┌───────────┬───────────────────┬─────────────────────────────────┬────────────┬─────────────┐
+    │ id        ┆ date              ┆ name                            ┆ short_name ┆ season_year │
+    │ ---       ┆ ---               ┆ ---                             ┆ ---        ┆ ---         │
+    │ str       ┆ str               ┆ str                             ┆ str        ┆ i64         │
+    ╞═══════════╪═══════════════════╪═════════════════════════════════╪════════════╪═════════════╡
+    │ 401869191 ┆ 2026-04-19T17:00Z ┆ Philadelphia 76ers at Boston C… ┆ PHI @ BOS  ┆ 2026        │
+    │ 401869396 ┆ 2026-04-21T23:00Z ┆ Philadelphia 76ers at Boston C… ┆ PHI @ BOS  ┆ 2026        │
+    │ 401869404 ┆ 2026-04-24T23:00Z ┆ Boston Celtics at Philadelphia… ┆ BOS @ PHI  ┆ 2026        │
+    │ 401869406 ┆ 2026-04-26T23:00Z ┆ Boston Celtics at Philadelphia… ┆ BOS @ PHI  ┆ 2026        │
+    │ 401869408 ┆ 2026-04-28T23:00Z ┆ Philadelphia 76ers at Boston C… ┆ PHI @ BOS  ┆ 2026        │
+    └───────────┴───────────────────┴─────────────────────────────────┴────────────┴─────────────┘
+
+
 
 ### Recipe 3 — A player's game log ⛹️
 
@@ -185,6 +303,27 @@ cols = ['event_date', 'opponent_abbreviation', 'home_away', 'game_result', 'scor
 (gamelog.select([c for c in cols if c in gamelog.columns]).head()
  if gamelog is not None and gamelog.height else 'gamelog unavailable')
 ```
+
+    ✅ LeBron gamelog — 73 rows
+
+
+
+
+
+    shape: (5, 8)
+    ┌────────────┬───────────────────────┬───────────┬─────────────┬───────┬────────┬────────┬────────┐
+    │ event_date ┆ opponent_abbreviation ┆ home_away ┆ game_result ┆ score ┆ stat_0 ┆ stat_1 ┆ stat_2 │
+    │ ---        ┆ ---                   ┆ ---       ┆ ---         ┆ ---   ┆ ---    ┆ ---    ┆ ---    │
+    │ str        ┆ str                   ┆ str       ┆ str         ┆ str   ┆ str    ┆ str    ┆ str    │
+    ╞════════════╪═══════════════════════╪═══════════╪═════════════╪═══════╪════════╪════════╪════════╡
+    │ null       ┆ null                  ┆ null      ┆ null        ┆ null  ┆ 40     ┆ 8-18   ┆ 44.4   │
+    │ null       ┆ null                  ┆ null      ┆ null        ┆ null  ┆ 37     ┆ 7-19   ┆ 36.8   │
+    │ null       ┆ null                  ┆ null      ┆ null        ┆ null  ┆ 38     ┆ 9-18   ┆ 50.0   │
+    │ null       ┆ null                  ┆ null      ┆ null        ┆ null  ┆ 36     ┆ 12-17  ┆ 70.6   │
+    │ null       ┆ null                  ┆ null      ┆ null        ┆ null  ┆ 37     ┆ 10-25  ┆ 40.0   │
+    └────────────┴───────────────────────┴───────────┴─────────────┴───────┴────────┴────────┴────────┘
+
+
 
 ### Recipe 4 — Top scorers from the box-score release 🥇
 
@@ -214,6 +353,31 @@ else:
 out
 ```
 
+    ✅ player boxscore release — 34853 rows
+
+
+
+
+
+    shape: (10, 6)
+    ┌─────────────────────────┬───────────────────┬─────┬──────┬──────┬──────┐
+    │ athlete_display_name    ┆ team_abbreviation ┆ gp  ┆ ppg  ┆ rpg  ┆ apg  │
+    │ ---                     ┆ ---               ┆ --- ┆ ---  ┆ ---  ┆ ---  │
+    │ str                     ┆ str               ┆ u32 ┆ f64  ┆ f64  ┆ f64  │
+    ╞═════════════════════════╪═══════════════════╪═════╪══════╪══════╪══════╡
+    │ Luka Doncic             ┆ LAL               ┆ 64  ┆ 33.5 ┆ 7.7  ┆ 8.3  │
+    │ Shai Gilgeous-Alexander ┆ OKC               ┆ 83  ┆ 30.5 ┆ 4.0  ┆ 6.8  │
+    │ Jaylen Brown            ┆ BOS               ┆ 78  ┆ 28.4 ┆ 6.8  ┆ 5.0  │
+    │ Kawhi Leonard           ┆ LAC               ┆ 66  ┆ 27.8 ┆ 6.4  ┆ 3.6  │
+    │ …                       ┆ …                 ┆ …   ┆ …    ┆ …    ┆ …    │
+    │ Giannis Antetokounmpo   ┆ MIL               ┆ 36  ┆ 27.6 ┆ 9.8  ┆ 5.4  │
+    │ Donovan Mitchell        ┆ CLE               ┆ 88  ┆ 27.5 ┆ 4.6  ┆ 5.1  │
+    │ Nikola Jokic            ┆ DEN               ┆ 71  ┆ 27.5 ┆ 12.9 ┆ 10.6 │
+    │ Lauri Markkanen         ┆ UTAH              ┆ 42  ┆ 26.7 ┆ 6.9  ┆ 2.1  │
+    └─────────────────────────┴───────────────────┴─────┴──────┴──────┴──────┘
+
+
+
 ### Recipe 5 — Offense vs defense, every team 🛡️
 
 The [`load_nba_team_boxscore`](../nba/reference/loaders.md#load_nba_team_boxscore)
@@ -240,6 +404,31 @@ else:
 out
 ```
 
+    ✅ team boxscore release — 2650 rows
+
+
+
+
+
+    shape: (10, 5)
+    ┌───────────────────┬─────┬─────────┬─────────┬──────┐
+    │ team_abbreviation ┆ gp  ┆ off_ppg ┆ def_ppg ┆ net  │
+    │ ---               ┆ --- ┆ ---     ┆ ---     ┆ ---  │
+    │ str               ┆ u32 ┆ f64     ┆ f64     ┆ f64  │
+    ╞═══════════════════╪═════╪═════════╪═════════╪══════╡
+    │ OKC               ┆ 97  ┆ 118.5   ┆ 108.0   ┆ 10.5 │
+    │ STARS             ┆ 3   ┆ 41.3    ┆ 32.7    ┆ 8.6  │
+    │ SA                ┆ 105 ┆ 118.4   ┆ 110.4   ┆ 8.0  │
+    │ NY                ┆ 101 ┆ 116.6   ┆ 108.6   ┆ 8.0  │
+    │ …                 ┆ …   ┆ …       ┆ …       ┆ …    │
+    │ HOU               ┆ 88  ┆ 114.1   ┆ 109.4   ┆ 4.7  │
+    │ DEN               ┆ 88  ┆ 121.1   ┆ 116.6   ┆ 4.5  │
+    │ CHA               ┆ 84  ┆ 115.8   ┆ 111.5   ┆ 4.3  │
+    │ CLE               ┆ 100 ┆ 117.4   ┆ 114.6   ┆ 2.8  │
+    └───────────────────┴─────┴─────────┴─────────┴──────┘
+
+
+
 ### Recipe 6 — Who lived behind the arc? 🎯
 
 Sum makes and attempts across the season to get each team's true
@@ -263,6 +452,28 @@ else:
     out = 'team box-score release unavailable'
 out
 ```
+
+
+
+
+    shape: (10, 4)
+    ┌───────────────────┬──────┬──────┬──────────────┐
+    │ team_abbreviation ┆ made ┆ att  ┆ three_pt_pct │
+    │ ---               ┆ ---  ┆ ---  ┆ ---          │
+    │ str               ┆ i32  ┆ i32  ┆ f64          │
+    ╞═══════════════════╪══════╪══════╪══════════════╡
+    │ WORLD             ┆ 11   ┆ 26   ┆ 42.3         │
+    │ STRIPES           ┆ 21   ┆ 52   ┆ 40.4         │
+    │ DEN               ┆ 1221 ┆ 3127 ┆ 39.0         │
+    │ MIL               ┆ 1240 ┆ 3205 ┆ 38.7         │
+    │ …                 ┆ …    ┆ …    ┆ …            │
+    │ LAC               ┆ 1033 ┆ 2807 ┆ 36.8         │
+    │ ATL               ┆ 1269 ┆ 3455 ┆ 36.7         │
+    │ MIN               ┆ 1254 ┆ 3423 ┆ 36.6         │
+    │ OKC               ┆ 1336 ┆ 3662 ┆ 36.5         │
+    └───────────────────┴──────┴──────┴──────────────┘
+
+
 
 ### Recipe 7 — Double-double machines 💪
 
@@ -293,6 +504,31 @@ else:
 out
 ```
 
+    ✅ player boxscore release — 34853 rows
+
+
+
+
+
+    shape: (10, 3)
+    ┌──────────────────────┬───────────────────┬────────────────┐
+    │ athlete_display_name ┆ team_abbreviation ┆ double_doubles │
+    │ ---                  ┆ ---               ┆ ---            │
+    │ str                  ┆ str               ┆ u32            │
+    ╞══════════════════════╪═══════════════════╪════════════════╡
+    │ Karl-Anthony Towns   ┆ NY                ┆ 69             │
+    │ Nikola Jokic         ┆ DEN               ┆ 61             │
+    │ Victor Wembanyama    ┆ SA                ┆ 53             │
+    │ Jalen Johnson        ┆ ATL               ┆ 51             │
+    │ …                    ┆ …                 ┆ …              │
+    │ Donovan Clingan      ┆ POR               ┆ 37             │
+    │ Rudy Gobert          ┆ MIN               ┆ 37             │
+    │ Alperen Sengun       ┆ HOU               ┆ 37             │
+    │ Bam Adebayo          ┆ MIA               ┆ 35             │
+    └──────────────────────┴───────────────────┴────────────────┘
+
+
+
 ### Recipe 8 — A tidy standings table 🏆
 
 The [`load_nba_standings`](../nba/reference/loaders.md#load_nba_standings)
@@ -317,6 +553,39 @@ else:
     out = 'standings release unavailable'
 out
 ```
+
+    ✅ standings release — 690 rows
+
+
+
+
+
+    shape: (12, 7)
+    ┌─────────────────────┬────────────┬────────┬─────────────┬────────────────────┬────────────┬──────┐
+    │ team_abbreviation   ┆ group_name ┆ losses ┆ playoffSeed ┆ pointDifferential  ┆ winPercent ┆ wins │
+    │ ---                 ┆ ---        ┆ ---    ┆ ---         ┆ ---                ┆ ---        ┆ ---  │
+    │ str                 ┆ str        ┆ f64    ┆ f64         ┆ f64                ┆ f64        ┆ f64  │
+    ╞═════════════════════╪════════════╪════════╪═════════════╪════════════════════╪════════════╪══════╡
+    │ OKC                 ┆ Western    ┆ 18.0   ┆ 1.0         ┆ 914.0              ┆ 0.7804878  ┆ 64.0 │
+    │                     ┆ Conference ┆        ┆             ┆                    ┆            ┆      │
+    │ SA                  ┆ Western    ┆ 20.0   ┆ 2.0         ┆ 681.0              ┆ 0.756098   ┆ 62.0 │
+    │                     ┆ Conference ┆        ┆             ┆                    ┆            ┆      │
+    │ DET                 ┆ Eastern    ┆ 22.0   ┆ 1.0         ┆ 669.0              ┆ 0.731707   ┆ 60.0 │
+    │                     ┆ Conference ┆        ┆             ┆                    ┆            ┆      │
+    │ BOS                 ┆ Eastern    ┆ 26.0   ┆ 2.0         ┆ 631.0              ┆ 0.682927   ┆ 56.0 │
+    │                     ┆ Conference ┆        ┆             ┆                    ┆            ┆      │
+    │ …                   ┆ …          ┆ …      ┆ …           ┆ …                  ┆ …          ┆ …    │
+    │ HOU                 ┆ Western    ┆ 30.0   ┆ 5.0         ┆ 428.0              ┆ 0.634146   ┆ 52.0 │
+    │                     ┆ Conference ┆        ┆             ┆                    ┆            ┆      │
+    │ MIN                 ┆ Western    ┆ 33.0   ┆ 6.0         ┆ 275.0              ┆ 0.597561   ┆ 49.0 │
+    │                     ┆ Conference ┆        ┆             ┆                    ┆            ┆      │
+    │ ATL                 ┆ Eastern    ┆ 36.0   ┆ 6.0         ┆ 198.0              ┆ 0.5609756  ┆ 46.0 │
+    │                     ┆ Conference ┆        ┆             ┆                    ┆            ┆      │
+    │ TOR                 ┆ Eastern    ┆ 36.0   ┆ 5.0         ┆ 232.0              ┆ 0.5609756  ┆ 46.0 │
+    │                     ┆ Conference ┆        ┆             ┆                    ┆            ┆      │
+    └─────────────────────┴────────────┴────────┴─────────────┴────────────────────┴────────────┴──────┘
+
+
 
 ### Recipe 9 — Built on threes (shot release + a join) 🧱
 
@@ -348,6 +617,31 @@ else:
 out
 ```
 
+    ✅ shots release — 298190 rows
+
+
+
+
+
+    shape: (10, 3)
+    ┌───────────────────┬─────────────┬────────────────┐
+    │ team_abbreviation ┆ threes_made ┆ pct_pts_from_3 │
+    │ ---               ┆ ---         ┆ ---            │
+    │ str               ┆ u32         ┆ f64            │
+    ╞═══════════════════╪═════════════╪════════════════╡
+    │ CHA               ┆ 1373        ┆ 50.0           │
+    │ GS                ┆ 1316        ┆ 48.2           │
+    │ MIL               ┆ 1240        ┆ 46.9           │
+    │ BOS               ┆ 1377        ┆ 46.8           │
+    │ …                 ┆ …           ┆ …              │
+    │ BKN               ┆ 1073        ┆ 44.6           │
+    │ MEM               ┆ 1143        ┆ 43.3           │
+    │ ATL               ┆ 1269        ┆ 43.0           │
+    │ CHI               ┆ 1144        ┆ 42.9           │
+    └───────────────────┴─────────────┴────────────────┘
+
+
+
 ### Recipe 10 — Head-to-head, game by game 🤝
 
 Filter the team box-score release to one matchup and you get the full
@@ -371,6 +665,23 @@ else:
     out = 'team box-score release unavailable'
 out
 ```
+
+
+
+
+    shape: (4, 5)
+    ┌────────────┬────────────────┬────────────┬─────────────────────┬─────────────┐
+    │ game_date  ┆ team_home_away ┆ team_score ┆ opponent_team_score ┆ team_winner │
+    │ ---        ┆ ---            ┆ ---        ┆ ---                 ┆ ---         │
+    │ date       ┆ str            ┆ i32        ┆ i32                 ┆ bool        │
+    ╞════════════╪════════════════╪════════════╪═════════════════════╪═════════════╡
+    │ 2025-10-24 ┆ away           ┆ 95         ┆ 105                 ┆ false       │
+    │ 2025-12-02 ┆ home           ┆ 123        ┆ 117                 ┆ true        │
+    │ 2026-02-08 ┆ home           ┆ 89         ┆ 111                 ┆ false       │
+    │ 2026-04-09 ┆ away           ┆ 106        ┆ 112                 ┆ false       │
+    └────────────┴────────────────┴────────────┴─────────────────────┴─────────────┘
+
+
 
 ### Recipe 11 — Who's banged up? 🩹 (pandas interop)
 
@@ -402,6 +713,31 @@ else:
 out
 ```
 
+    ✅ injuries — 27 rows
+
+
+
+
+
+    shape: (12, 2)
+    ┌───────────────────────┬────────────────┐
+    │ display_name          ┆ players_listed │
+    │ ---                   ┆ ---            │
+    │ str                   ┆ i64            │
+    ╞═══════════════════════╪════════════════╡
+    │ Memphis Grizzlies     ┆ 13             │
+    │ Brooklyn Nets         ┆ 10             │
+    │ Chicago Bulls         ┆ 10             │
+    │ Indiana Pacers        ┆ 9              │
+    │ …                     ┆ …              │
+    │ Utah Jazz             ┆ 8              │
+    │ New Orleans Pelicans  ┆ 6              │
+    │ Golden State Warriors ┆ 4              │
+    │ Miami Heat            ┆ 4              │
+    └───────────────────────┴────────────────┘
+
+
+
 ## 🎬 Play-by-play & game rosters
 
 Now for the granular stuff. [`espn_nba_pbp`](../nba/reference/additional.md)
@@ -419,6 +755,23 @@ pbp = safe('pbp payload', lambda: sdv.nba.espn_nba_pbp(game_id=GAME_ID))
 (list(pbp.keys())[:8] if isinstance(pbp, dict) else 'pbp unavailable')
 ```
 
+    ✅ pbp payload — 22 rows
+
+
+
+
+
+    ['gameId',
+     'plays',
+     'winprobability',
+     'boxscore',
+     'header',
+     'format',
+     'broadcasts',
+     'videos']
+
+
+
 
 ```python
 plays = (pl.DataFrame(pbp['plays'], infer_schema_length=None)
@@ -427,6 +780,29 @@ cols = ['period.number', 'clock.displayValue', 'text', 'homeScore', 'awayScore',
 (plays.select([c for c in cols if c in plays.columns]).head()
  if plays is not None and plays.height else 'no plays parsed')
 ```
+
+
+
+
+    shape: (5, 6)
+    ┌───────────────┬────────────────────┬───────────────────────┬───────────┬───────────┬─────────────┐
+    │ period.number ┆ clock.displayValue ┆ text                  ┆ homeScore ┆ awayScore ┆ scoringPlay │
+    │ ---           ┆ ---                ┆ ---                   ┆ ---       ┆ ---       ┆ ---         │
+    │ i64           ┆ str                ┆ str                   ┆ i64       ┆ i64       ┆ bool        │
+    ╞═══════════════╪════════════════════╪═══════════════════════╪═══════════╪═══════════╪═════════════╡
+    │ 1             ┆ 12:00              ┆ Myles Turner vs.      ┆ 0         ┆ 0         ┆ false       │
+    │               ┆                    ┆ Anthony Davis…        ┆           ┆           ┆             │
+    │ 1             ┆ 11:42              ┆ Aaron Nesmith makes   ┆ 0         ┆ 3         ┆ true        │
+    │               ┆                    ┆ 26-foot th…           ┆           ┆           ┆             │
+    │ 1             ┆ 11:17              ┆ Austin Reaves misses  ┆ 0         ┆ 3         ┆ false       │
+    │               ┆                    ┆ driving l…            ┆           ┆           ┆             │
+    │ 1             ┆ 11:14              ┆ Austin Reaves         ┆ 0         ┆ 3         ┆ false       │
+    │               ┆                    ┆ offensive reboun…     ┆           ┆           ┆             │
+    │ 1             ┆ 11:12              ┆ Austin Reaves misses  ┆ 0         ┆ 3         ┆ false       │
+    │               ┆                    ┆ 14-foot t…            ┆           ┆           ┆             │
+    └───────────────┴────────────────────┴───────────────────────┴───────────┴───────────┴─────────────┘
+
+
 
 ### Slice it: every 3-pointer in the game 🎯
 
@@ -448,6 +824,28 @@ else:
 out
 ```
 
+
+
+
+    shape: (10, 5)
+    ┌───────────────┬────────────────────┬─────────────────────────────────┬───────────┬───────────┐
+    │ period.number ┆ clock.displayValue ┆ text                            ┆ homeScore ┆ awayScore │
+    │ ---           ┆ ---                ┆ ---                             ┆ ---       ┆ ---       │
+    │ i64           ┆ str                ┆ str                             ┆ i64       ┆ i64       │
+    ╞═══════════════╪════════════════════╪═════════════════════════════════╪═══════════╪═══════════╡
+    │ 1             ┆ 11:42              ┆ Aaron Nesmith makes 26-foot th… ┆ 0         ┆ 3         │
+    │ 1             ┆ 10:14              ┆ Andrew Nembhard makes 23-foot … ┆ 2         ┆ 6         │
+    │ 1             ┆ 9:58               ┆ LeBron James makes 26-foot thr… ┆ 5         ┆ 6         │
+    │ 1             ┆ 5:44               ┆ Myles Turner makes 25-foot thr… ┆ 15        ┆ 19        │
+    │ …             ┆ …                  ┆ …                               ┆ …         ┆ …         │
+    │ 2             ┆ 10:05              ┆ Max Christie makes 25-foot thr… ┆ 41        ┆ 40        │
+    │ 2             ┆ 9:39               ┆ Obi Toppin makes 27-foot three… ┆ 41        ┆ 43        │
+    │ 2             ┆ 8:44               ┆ Aaron Nesmith makes 26-foot th… ┆ 41        ┆ 49        │
+    │ 2             ┆ 7:02               ┆ Rui Hachimura makes 22-foot th… ┆ 51        ┆ 51        │
+    └───────────────┴────────────────────┴─────────────────────────────────┴───────────┴───────────┘
+
+
+
 ### Who played? Game rosters 📋
 
 [`espn_nba_game_rosters`](../nba/reference/additional.md) returns both teams'
@@ -461,6 +859,31 @@ cols = ['athlete_display_name', 'team_abbreviation', 'starter', 'jersey', 'posit
 (grosters.select([c for c in cols if c in grosters.columns]).head(10)
  if grosters is not None and grosters.height else 'game rosters unavailable')
 ```
+
+    ✅ game rosters — 26 rows
+
+
+
+
+
+    shape: (10, 4)
+    ┌──────────────────────┬───────────────────┬─────────┬────────┐
+    │ athlete_display_name ┆ team_abbreviation ┆ starter ┆ jersey │
+    │ ---                  ┆ ---               ┆ ---     ┆ ---    │
+    │ str                  ┆ str               ┆ bool    ┆ str    │
+    ╞══════════════════════╪═══════════════════╪═════════╪════════╡
+    │ LeBron James         ┆ LAL               ┆ true    ┆ 23     │
+    │ Anthony Davis        ┆ LAL               ┆ true    ┆ 23     │
+    │ Rui Hachimura        ┆ LAL               ┆ true    ┆ 28     │
+    │ Spencer Dinwiddie    ┆ LAL               ┆ true    ┆ 26     │
+    │ …                    ┆ …                 ┆ …       ┆ …      │
+    │ Cam Reddish          ┆ LAL               ┆ false   ┆ 5      │
+    │ Jaxson Hayes         ┆ LAL               ┆ false   ┆ 11     │
+    │ Max Christie         ┆ LAL               ┆ false   ┆ 00     │
+    │ Harry Giles III      ┆ LAL               ┆ false   ┆ 20     │
+    └──────────────────────┴───────────────────┴─────────┴────────┘
+
+
 
 ## 📦 Bulk season data with the loaders
 
@@ -481,6 +904,27 @@ cols = ['id', 'date', 'home_display_name', 'away_display_name', 'home_score', 'a
 (sched.select([c for c in cols if c in sched.columns]).head()
  if sched is not None and sched.height else 'schedule release unavailable')
 ```
+
+    ✅ schedule release — 1332 rows
+
+
+
+
+
+    shape: (5, 6)
+    ┌───────────┬───────────────────┬───────────────────┬───────────────────┬────────────┬────────────┐
+    │ id        ┆ date              ┆ home_display_name ┆ away_display_name ┆ home_score ┆ away_score │
+    │ ---       ┆ ---               ┆ ---               ┆ ---               ┆ ---        ┆ ---        │
+    │ i32       ┆ str               ┆ str               ┆ str               ┆ i32        ┆ i32        │
+    ╞═══════════╪═══════════════════╪═══════════════════╪═══════════════════╪════════════╪════════════╡
+    │ 401859969 ┆ 2026-06-20T00:30Z ┆ San Antonio Spurs ┆ New York Knicks   ┆ 0          ┆ 0          │
+    │ 401859968 ┆ 2026-06-17T00:30Z ┆ New York Knicks   ┆ San Antonio Spurs ┆ 0          ┆ 0          │
+    │ 401859967 ┆ 2026-06-14T00:30Z ┆ San Antonio Spurs ┆ New York Knicks   ┆ 0          ┆ 0          │
+    │ 401859966 ┆ 2026-06-11T00:30Z ┆ New York Knicks   ┆ San Antonio Spurs ┆ 107        ┆ 106        │
+    │ 401859965 ┆ 2026-06-09T00:30Z ┆ New York Knicks   ┆ San Antonio Spurs ┆ 111        ┆ 115        │
+    └───────────┴───────────────────┴───────────────────┴───────────────────┴────────────┴────────────┘
+
+
 
 ### Pipeline: the highest-scoring games of the season 🔥
 
@@ -506,6 +950,28 @@ else:
     out = 'schedule release unavailable'
 out
 ```
+
+
+
+
+    shape: (10, 5)
+    ┌───────────────────┬──────────────────────┬────────────────────────┬────────────┬────────────┐
+    │ date              ┆ home_display_name    ┆ away_display_name      ┆ home_score ┆ away_score │
+    │ ---               ┆ ---                  ┆ ---                    ┆ ---        ┆ ---        │
+    │ str               ┆ str                  ┆ str                    ┆ i32        ┆ i32        │
+    ╞═══════════════════╪══════════════════════╪════════════════════════╪════════════╪════════════╡
+    │ 2025-12-21T20:30Z ┆ Atlanta Hawks        ┆ Chicago Bulls          ┆ 150        ┆ 152        │
+    │ 2025-11-17T01:00Z ┆ Utah Jazz            ┆ Chicago Bulls          ┆ 150        ┆ 147        │
+    │ 2026-03-25T23:00Z ┆ Philadelphia 76ers   ┆ Chicago Bulls          ┆ 157        ┆ 137        │
+    │ 2026-04-08T00:00Z ┆ New Orleans Pelicans ┆ Utah Jazz              ┆ 156        ┆ 137        │
+    │ …                 ┆ …                    ┆ …                      ┆ …          ┆ …          │
+    │ 2026-04-01T23:00Z ┆ Washington Wizards   ┆ Philadelphia 76ers     ┆ 131        ┆ 153        │
+    │ 2026-03-12T02:30Z ┆ LA Clippers          ┆ Minnesota Timberwolves ┆ 153        ┆ 128        │
+    │ 2025-11-15T01:00Z ┆ Milwaukee Bucks      ┆ Charlotte Hornets      ┆ 147        ┆ 134        │
+    │ 2026-01-10T18:00Z ┆ Cleveland Cavaliers  ┆ Minnesota Timberwolves ┆ 146        ┆ 134        │
+    └───────────────────┴──────────────────────┴────────────────────────┴────────────┴────────────┘
+
+
 
 ## 🎉 Where to next
 

--- a/docs/docs/tutorials/05_wbb_intro.md
+++ b/docs/docs/tutorials/05_wbb_intro.md
@@ -58,6 +58,9 @@ SEASON = 2025  # the 2024-25 season — UConn's title run
 print('most recent wbb season:', wbb.most_recent_wbb_season())
 ```
 
+    most recent wbb season: 2026
+
+
 ESPN's live endpoints are **seasonal** — polls, injuries, and live scoreboards go quiet in the offseason, and any network call can hiccup. So we use a tiny `safe()` helper: you get the frame when the feed is up, and a friendly one-liner when it isn't (never a scary traceback). 🛟 The `load_wbb_*` parquet loaders are rock-solid year-round, so we lean on those for anything historical.
 
 
@@ -89,6 +92,32 @@ teams = safe('teams', wbb.espn_wbb_teams)
  if has_rows(teams) else 'teams unavailable')
 ```
 
+    ✅ teams
+
+
+
+
+
+    shape: (10, 5)
+    ┌─────────┬─────────────────────┬──────────────┬───────────────────┬────────────────────────────┐
+    │ team_id ┆ team_location       ┆ team_name    ┆ team_abbreviation ┆ team_display_name          │
+    │ ---     ┆ ---                 ┆ ---          ┆ ---               ┆ ---                        │
+    │ str     ┆ str                 ┆ str          ┆ str               ┆ str                        │
+    ╞═════════╪═════════════════════╪══════════════╪═══════════════════╪════════════════════════════╡
+    │ 2000    ┆ Abilene Christian   ┆ Wildcats     ┆ ACU               ┆ Abilene Christian Wildcats │
+    │ 2005    ┆ Air Force           ┆ Falcons      ┆ AF                ┆ Air Force Falcons          │
+    │ 2006    ┆ Akron               ┆ Zips         ┆ AKR               ┆ Akron Zips                 │
+    │ 2010    ┆ Alabama A&M         ┆ Bulldogs     ┆ AAMU              ┆ Alabama A&M Bulldogs       │
+    │ 333     ┆ Alabama             ┆ Crimson Tide ┆ ALA               ┆ Alabama Crimson Tide       │
+    │ 2011    ┆ Alabama State       ┆ Lady Hornets ┆ ALST              ┆ Alabama State Lady Hornets │
+    │ 2016    ┆ Alcorn State        ┆ Lady Braves  ┆ ALCN              ┆ Alcorn State Lady Braves   │
+    │ 44      ┆ American University ┆ Eagles       ┆ AMER              ┆ American University Eagles │
+    │ 2026    ┆ App State           ┆ Mountaineers ┆ APP               ┆ App State Mountaineers     │
+    │ 9       ┆ Arizona State       ┆ Sun Devils   ┆ ASU               ┆ Arizona State Sun Devils   │
+    └─────────┴─────────────────────┴──────────────┴───────────────────┴────────────────────────────┘
+
+
+
 ## 👥 Team roster
 
 [`espn_wbb_team_roster`](../wbb/reference/site.md#espn_wbb_team_roster) takes a `team_id` and `season` and returns one row per player. Here's the 2024-25 **UConn Huskies** (`team_id=2509`) — the eventual national champions, led by Paige Bueckers.
@@ -99,6 +128,34 @@ uconn = safe('UConn roster', lambda: wbb.espn_wbb_team_roster(team_id=2509, seas
 (uconn.select(['athlete_id', 'full_name', 'jersey', 'position_abbreviation', 'display_height', 'display_weight']).head(12)
  if has_rows(uconn) else 'roster unavailable')
 ```
+
+    ✅ UConn roster
+
+
+
+
+
+    shape: (12, 6)
+    ┌────────────┬────────────────────┬────────┬─────────────────────┬────────────────┬────────────────┐
+    │ athlete_id ┆ full_name          ┆ jersey ┆ position_abbreviati ┆ display_height ┆ display_weight │
+    │ ---        ┆ ---                ┆ ---    ┆ on                  ┆ ---            ┆ ---            │
+    │ str        ┆ str                ┆ str    ┆ ---                 ┆ str            ┆ str            │
+    │            ┆                    ┆        ┆ str                 ┆                ┆                │
+    ╞════════════╪════════════════════╪════════╪═════════════════════╪════════════════╪════════════════╡
+    │ 5311737    ┆ Carley Barrett     ┆ 24     ┆ G                   ┆ 5' 7"          ┆ null           │
+    │ 5106182    ┆ Tara Daye          ┆ 44     ┆ G                   ┆ 5' 10"         ┆ null           │
+    │ 5107710    ┆ Taylor Feldman     ┆ 5      ┆ G                   ┆ 5' 8"          ┆ null           │
+    │ 5311739    ┆ Avery Gordon       ┆ 55     ┆ F                   ┆ 6' 7"          ┆ null           │
+    │ 5108895    ┆ Taylor Henderson   ┆ 2      ┆ G                   ┆ 5' 11"         ┆ null           │
+    │ …          ┆ …                  ┆ …      ┆ …                   ┆ …              ┆ …              │
+    │ 4433438    ┆ Madison Layden-Zay ┆ 33     ┆ G                   ┆ 6' 1"          ┆ null           │
+    │ 5240041    ┆ Lana McCarthy      ┆ 35     ┆ F                   ┆ 6' 4"          ┆ null           │
+    │ 5240040    ┆ Kendall Puryear    ┆ 22     ┆ F                   ┆ 6' 3"          ┆ null           │
+    │ 5239064    ┆ Kiki Smith         ┆ 23     ┆ G                   ┆ 5' 7"          ┆ null           │
+    │ 5243531    ┆ Nya Smith          ┆ 3      ┆ G                   ┆ 5' 9"          ┆ null           │
+    └────────────┴────────────────────┴────────┴─────────────────────┴────────────────┴────────────────┘
+
+
 
 ## 📅 Schedule & scoreboard
 
@@ -118,6 +175,28 @@ final_four = safe('Final Four schedule', lambda: wbb.espn_wbb_schedule(dates=202
  if has_rows(final_four) else 'schedule unavailable')
 ```
 
+    ✅ Final Four schedule
+
+
+
+
+
+    shape: (2, 7)
+    ┌───────────┬───────────────┬──────────────┬────────────┬──────────────┬────────────┬──────────────┐
+    │ id        ┆ date          ┆ away_display ┆ away_score ┆ home_display ┆ home_score ┆ status_type_ │
+    │ ---       ┆ ---           ┆ _name        ┆ ---        ┆ _name        ┆ ---        ┆ completed    │
+    │ str       ┆ str           ┆ ---          ┆ str        ┆ ---          ┆ str        ┆ ---          │
+    │           ┆               ┆ str          ┆            ┆ str          ┆            ┆ bool         │
+    ╞═══════════╪═══════════════╪══════════════╪════════════╪══════════════╪════════════╪══════════════╡
+    │ 401746073 ┆ 2025-04-04T23 ┆ Texas        ┆ 57         ┆ South        ┆ 74         ┆ true         │
+    │           ┆ :00Z          ┆ Longhorns    ┆            ┆ Carolina     ┆            ┆              │
+    │           ┆               ┆              ┆            ┆ Gamecocks    ┆            ┆              │
+    │ 401746074 ┆ 2025-04-05T01 ┆ UConn        ┆ 85         ┆ UCLA Bruins  ┆ 51         ┆ true         │
+    │           ┆ :30Z          ┆ Huskies      ┆            ┆              ┆            ┆              │
+    └───────────┴───────────────┴──────────────┴────────────┴──────────────┴────────────┴──────────────┘
+
+
+
 
 ```python
 # ⭐ The scoreboard view of the same date — richer game-state columns
@@ -127,6 +206,24 @@ keep = ['game_id', 'short_name', 'status_type_completed', 'home_team_short_displ
 (board.select([c for c in keep if c in board.columns])
  if has_rows(board) else 'scoreboard unavailable')
 ```
+
+    ✅ Final Four scoreboard
+
+
+
+
+
+    shape: (2, 3)
+    ┌───────────┬──────────────┬───────────────────────┐
+    │ game_id   ┆ short_name   ┆ status_type_completed │
+    │ ---       ┆ ---          ┆ ---                   │
+    │ str       ┆ str          ┆ bool                  │
+    ╞═══════════╪══════════════╪═══════════════════════╡
+    │ 401746073 ┆ TEX VS SC    ┆ true                  │
+    │ 401746074 ┆ CONN VS UCLA ┆ true                  │
+    └───────────┴──────────────┴───────────────────────┘
+
+
 
 ## 🎬 Play-by-play
 
@@ -145,6 +242,31 @@ if pbp is not None and isinstance(pbp, dict) and pbp.get('plays'):
  if plays is not None else 'pbp unavailable')
 ```
 
+    ✅ championship pbp
+    plays shape: (443, 58) | components: ['gameId', 'plays', 'winprobability', 'boxscore', 'header', 'format', 'broadcasts', 'videos']
+
+
+
+
+
+    shape: (5, 5)
+    ┌───────────────┬────────────────────┬───────────────────┬─────────────┬───────────────────────────┐
+    │ period.number ┆ clock.displayValue ┆ type.text         ┆ scoringPlay ┆ text                      │
+    │ ---           ┆ ---                ┆ ---               ┆ ---         ┆ ---                       │
+    │ i64           ┆ str                ┆ str               ┆ bool        ┆ str                       │
+    ╞═══════════════╪════════════════════╪═══════════════════╪═════════════╪═══════════════════════════╡
+    │ 1             ┆ 10:00              ┆ Jumpball          ┆ false       ┆ Start game                │
+    │ 1             ┆ 9:57               ┆ Jumpball          ┆ false       ┆ Jump Ball won by UConn    │
+    │ 1             ┆ 9:57               ┆ Jumpball          ┆ false       ┆ Jump Ball lost by South   │
+    │               ┆                    ┆                   ┆             ┆ Caroli…                   │
+    │ 1             ┆ 9:40               ┆ JumpShot          ┆ false       ┆ Kaitlyn Chen missed Three │
+    │               ┆                    ┆                   ┆             ┆ Poin…                     │
+    │ 1             ┆ 9:33               ┆ Offensive Rebound ┆ false       ┆ Paige Bueckers Offensive  │
+    │               ┆                    ┆                   ┆             ┆ Rebou…                    │
+    └───────────────┴────────────────────┴───────────────────┴─────────────┴───────────────────────────┘
+
+
+
 
 ```python
 # Scoring plays only, with the running score
@@ -152,6 +274,27 @@ if pbp is not None and isinstance(pbp, dict) and pbp.get('plays'):
       .select(['period.number', 'clock.displayValue', 'awayScore', 'homeScore', 'text']).head(8)
  if plays is not None else 'pbp unavailable')
 ```
+
+
+
+
+    shape: (8, 5)
+    ┌───────────────┬────────────────────┬───────────┬───────────┬─────────────────────────────────┐
+    │ period.number ┆ clock.displayValue ┆ awayScore ┆ homeScore ┆ text                            │
+    │ ---           ┆ ---                ┆ ---       ┆ ---       ┆ ---                             │
+    │ i64           ┆ str                ┆ i64       ┆ i64       ┆ str                             │
+    ╞═══════════════╪════════════════════╪═══════════╪═══════════╪═════════════════════════════════╡
+    │ 1             ┆ 9:18               ┆ 0         ┆ 3         ┆ Te-Hina Paopao made Three Poin… │
+    │ 1             ┆ 8:58               ┆ 2         ┆ 3         ┆ Sarah Strong made Jumper.       │
+    │ 1             ┆ 8:36               ┆ 2         ┆ 5         ┆ Chloe Kitts made Jumper.        │
+    │ 1             ┆ 8:13               ┆ 4         ┆ 5         ┆ Paige Bueckers made Jumper.     │
+    │ 1             ┆ 7:24               ┆ 6         ┆ 5         ┆ Azzi Fudd made Jumper. Assiste… │
+    │ 1             ┆ 7:00               ┆ 6         ┆ 7         ┆ Raven Johnson made Layup. Assi… │
+    │ 1             ┆ 6:40               ┆ 8         ┆ 7         ┆ Kaitlyn Chen made Jumper.       │
+    │ 1             ┆ 6:23               ┆ 8         ┆ 9         ┆ Bree Hall made Jumper.          │
+    └───────────────┴────────────────────┴───────────┴───────────┴─────────────────────────────────┘
+
+
 
 ## ⭐ Premium ESPN analytics
 
@@ -172,12 +315,32 @@ rankings = safe('rankings (AP/Coaches poll)', wbb.espn_wbb_rankings)
  else 'no poll published right now (offseason) — try during the season')
 ```
 
+    🟡 rankings (AP/Coaches poll) (no rows right now)
+
+
+
+
+
+    'no poll published right now (offseason) — try during the season'
+
+
+
 
 ```python
 injuries = safe('injury report', wbb.espn_wbb_injuries)
 (injuries.head(10) if has_rows(injuries)
  else 'no active injuries posted right now (offseason)')
 ```
+
+    🟡 injury report (no rows right now)
+
+
+
+
+
+    'no active injuries posted right now (offseason)'
+
+
 
 ## 📊 Basketball Power Index (BPI)
 
@@ -219,6 +382,33 @@ else:
 out
 ```
 
+    ✅ season BPI
+
+
+
+
+
+    shape: (12, 4)
+    ┌──────────┬─────────┬───────────────┬─────────────────────────────────┐
+    │ bpi_rank ┆ bpi     ┆ conference_id ┆ team_ref                        │
+    │ ---      ┆ ---     ┆ ---           ┆ ---                             │
+    │ f64      ┆ f64     ┆ i64           ┆ str                             │
+    ╞══════════╪═════════╪═══════════════╪═════════════════════════════════╡
+    │ 1.0      ┆ 38.1724 ┆ 4             ┆ http://sports.core.api.espn.co… │
+    │ 2.0      ┆ 36.4436 ┆ 23            ┆ http://sports.core.api.espn.co… │
+    │ 3.0      ┆ 33.1668 ┆ 23            ┆ http://sports.core.api.espn.co… │
+    │ 4.0      ┆ 32.1685 ┆ 2             ┆ http://sports.core.api.espn.co… │
+    │ 5.0      ┆ 31.8751 ┆ 7             ┆ http://sports.core.api.espn.co… │
+    │ …        ┆ …       ┆ …             ┆ …                               │
+    │ 8.0      ┆ 28.45   ┆ 23            ┆ http://sports.core.api.espn.co… │
+    │ 9.0      ┆ 26.9175 ┆ 8             ┆ http://sports.core.api.espn.co… │
+    │ 10.0     ┆ 26.1062 ┆ 23            ┆ http://sports.core.api.espn.co… │
+    │ 11.0     ┆ 25.8556 ┆ 23            ┆ http://sports.core.api.espn.co… │
+    │ 12.0     ┆ 25.5795 ┆ 8             ┆ http://sports.core.api.espn.co… │
+    └──────────┴─────────┴───────────────┴─────────────────────────────────┘
+
+
+
 And [`espn_wbb_season_powerindex_leaders`](../wbb/reference/core.md#espn_wbb_season_powerindex_leaders) lists the category leaders — who tops BPI, strength-of-schedule, strength-of-record, and more.
 
 
@@ -227,6 +417,31 @@ spi_leaders = safe('BPI category leaders', lambda: wbb.espn_wbb_season_powerinde
 (spi_leaders.select(['name', 'display_name']).head(10)
  if has_rows(spi_leaders) else 'BPI leaders unavailable')
 ```
+
+    ✅ BPI category leaders
+
+
+
+
+
+    shape: (9, 2)
+    ┌───────────────────────┬─────────────────────┐
+    │ name                  ┆ display_name        │
+    │ ---                   ┆ ---                 │
+    │ str                   ┆ str                 │
+    ╞═══════════════════════╪═════════════════════╡
+    │ bpi                   ┆ BPI Leader          │
+    │ rpirank               ┆ NCAAM RPI Leader    │
+    │ sospast               ┆ SOS Leader          │
+    │ sor                   ┆ SOR Leader          │
+    │ bpioffense            ┆ BPI Off Leader      │
+    │ bpidefense            ┆ BPI Def Leader      │
+    │ bpisevendaychangerank ┆ 7-Day RK CHG Leader │
+    │ top50bpiwins          ┆ Most Quality Wins   │
+    │ sosoutofconfpast      ┆ Non-Conf SOS Leader │
+    └───────────────────────┴─────────────────────┘
+
+
 
 ## 🏆 Standings & conferences
 
@@ -240,12 +455,73 @@ standings = safe('2025 standings', lambda: wbb.espn_wbb_standings(season=SEASON)
  if has_rows(standings) else 'standings unavailable')
 ```
 
+    ✅ 2025 standings
+
+
+
+
+
+    shape: (10, 7)
+    ┌───────────────────┬──────────────────┬──────┬────────┬─────────────┬────────────┬────────────────┐
+    │ team_display_name ┆ conference_abbre ┆ wins ┆ losses ┆ win_percent ┆ points_for ┆ points_against │
+    │ ---               ┆ viation          ┆ ---  ┆ ---    ┆ ---         ┆ ---        ┆ ---            │
+    │ str               ┆ ---              ┆ i64  ┆ i64    ┆ f64         ┆ f64        ┆ f64            │
+    │                   ┆ str              ┆      ┆        ┆             ┆            ┆                │
+    ╞═══════════════════╪══════════════════╪══════╪════════╪═════════════╪════════════╪════════════════╡
+    │ Florida Gulf      ┆ ASUN             ┆ 18   ┆ 0      ┆ 1.0         ┆ 1367.0     ┆ 983.0          │
+    │ Coast Eagles      ┆                  ┆      ┆        ┆             ┆            ┆                │
+    │ UConn Huskies     ┆ bige             ┆ 18   ┆ 0      ┆ 1.0         ┆ 1480.0     ┆ 866.0          │
+    │ Norfolk State     ┆ meac             ┆ 14   ┆ 0      ┆ 1.0         ┆ 1145.0     ┆ 747.0          │
+    │ Spartans          ┆                  ┆      ┆        ┆             ┆            ┆                │
+    │ Fairleigh         ┆ neast            ┆ 16   ┆ 0      ┆ 1.0         ┆ 1086.0     ┆ 805.0          │
+    │ Dickinson Knights ┆                  ┆      ┆        ┆             ┆            ┆                │
+    │ South Dakota      ┆ summ             ┆ 16   ┆ 0      ┆ 1.0         ┆ 1258.0     ┆ 933.0          │
+    │ State Jackrabbits ┆                  ┆      ┆        ┆             ┆            ┆                │
+    │ James Madison     ┆ belt             ┆ 18   ┆ 0      ┆ 1.0         ┆ 1358.0     ┆ 1072.0         │
+    │ Dukes             ┆                  ┆      ┆        ┆             ┆            ┆                │
+    │ Grand Canyon      ┆ wac              ┆ 16   ┆ 0      ┆ 1.0         ┆ 1219.0     ┆ 894.0          │
+    │ Lopes             ┆                  ┆      ┆        ┆             ┆            ┆                │
+    │ Green Bay Phoenix ┆ hor              ┆ 19   ┆ 1      ┆ 0.95        ┆ 1408.0     ┆ 1037.0         │
+    │ Fairfield Stags   ┆ maac             ┆ 19   ┆ 1      ┆ 0.95        ┆ 1498.0     ┆ 1034.0         │
+    │ SE Louisiana Lady ┆ land             ┆ 19   ┆ 1      ┆ 0.95        ┆ 1330.0     ┆ 1013.0         │
+    │ Lions             ┆                  ┆      ┆        ┆             ┆            ┆                │
+    └───────────────────┴──────────────────┴──────┴────────┴─────────────┴────────────┴────────────────┘
+
+
+
 
 ```python
 conferences = safe('conferences', wbb.espn_wbb_conferences)
 (conferences.select(['group_id', 'name', 'abbreviation', 'short_name']).head(12)
  if has_rows(conferences) else 'conferences unavailable')
 ```
+
+    ✅ conferences
+
+
+
+
+
+    shape: (12, 4)
+    ┌──────────┬───────────────────────────┬──────────────┬────────────┐
+    │ group_id ┆ name                      ┆ abbreviation ┆ short_name │
+    │ ---      ┆ ---                       ┆ ---          ┆ ---        │
+    │ str      ┆ str                       ┆ str          ┆ str        │
+    ╞══════════╪═══════════════════════════╪══════════════╪════════════╡
+    │ null     ┆ NCAA Division I           ┆ NCAA         ┆ null       │
+    │ null     ┆ America East Conference   ┆ aeast        ┆ null       │
+    │ null     ┆ American Conference       ┆ American     ┆ null       │
+    │ null     ┆ Atlantic 10 Conference    ┆ atl10        ┆ null       │
+    │ null     ┆ Atlantic Coast Conference ┆ acc          ┆ null       │
+    │ …        ┆ …                         ┆ …            ┆ …          │
+    │ null     ┆ Big East Conference       ┆ bige         ┆ null       │
+    │ null     ┆ Big Sky Conference        ┆ bsky         ┆ null       │
+    │ null     ┆ Big South Conference      ┆ bsou         ┆ null       │
+    │ null     ┆ Big Ten Conference        ┆ big10        ┆ null       │
+    │ null     ┆ Big West Conference       ┆ bigw         ┆ null       │
+    └──────────┴───────────────────────────┴──────────────┴────────────┘
+
+
 
 ## 🍳 Cookbook: common WBB tasks
 
@@ -262,6 +538,9 @@ team_box = wbb.load_wbb_team_boxscore(seasons=[2024])
 season_pbp = wbb.load_wbb_pbp(seasons=[2024])
 print('player_box:', player_box.shape, '| team_box:', team_box.shape, '| pbp:', season_pbp.shape)
 ```
+
+    player_box: (167412, 55) | team_box: (11796, 56) | pbp: (1908679, 61)
+
 
 ### Recipe 1 — Win-probability ride of a championship 📈
 
@@ -280,6 +559,29 @@ else:
     out = 'win probability unavailable'
 out
 ```
+
+    ✅ win probability
+    snapshots: 300 | opening home win%: 42.9 | final home win%: 2.1
+
+
+
+
+
+    shape: (6, 4)
+    ┌─────────────────┬─────────────────────┬─────────────────────┬────────────────┐
+    │ sequence_number ┆ home_win_percentage ┆ away_win_percentage ┆ tie_percentage │
+    │ ---             ┆ ---                 ┆ ---                 ┆ ---            │
+    │ str             ┆ f64                 ┆ f64                 ┆ f64            │
+    ╞═════════════════╪═════════════════════╪═════════════════════╪════════════════╡
+    │ 113521784       ┆ 0.429               ┆ 0.571               ┆ 0.0            │
+    │ 113521785       ┆ 0.416               ┆ 0.584               ┆ 0.0            │
+    │ 113521801       ┆ 0.468               ┆ 0.532               ┆ 0.0            │
+    │ 113521802       ┆ 0.473               ┆ 0.527               ┆ 0.0            │
+    │ 113521803       ┆ 0.514               ┆ 0.486               ┆ 0.0            │
+    │ 113521804       ┆ 0.474               ┆ 0.526               ┆ 0.0            │
+    └─────────────────┴─────────────────────┴─────────────────────┴────────────────┘
+
+
 
 ### Recipe 2 — BPI matchup preview for a game 🔮
 
@@ -302,6 +604,30 @@ else:
 out
 ```
 
+    ✅ game predictor (BPI)
+
+
+
+
+
+    shape: (8, 2)
+    ┌───────────────────┬───────┐
+    │ stat              ┆ value │
+    │ ---               ┆ ---   │
+    │ str               ┆ str   │
+    ╞═══════════════════╪═══════╡
+    │ MATCHUP QUALITY   ┆ 99.0  │
+    │ GAME SCORE        ┆       │
+    │ WIN PROB          ┆ 42.9% │
+    │ PRED PT DIFF      ┆ -1.9  │
+    │ OPPONENT WIN PROB ┆ 57.1% │
+    │ WIN PROB          ┆ 42.9  │
+    │ OPPONENT WIN PROB ┆ 57.1  │
+    │ null              ┆ 0.0   │
+    └───────────────────┴───────┘
+
+
+
 ### Recipe 3 — Top scorers of a full season 🥇
 
 Take the season-long player boxscore and aggregate with polars to find the highest per-game scorers (min. 20 games).
@@ -323,6 +649,29 @@ top_scorers = (
 top_scorers
 ```
 
+
+
+
+    shape: (10, 6)
+    ┌────────────┬──────────────────────┬─────────────────────────┬───────┬──────────────┬──────┐
+    │ athlete_id ┆ athlete_display_name ┆ team_short_display_name ┆ games ┆ total_points ┆ ppg  │
+    │ ---        ┆ ---                  ┆ ---                     ┆ ---   ┆ ---          ┆ ---  │
+    │ i32        ┆ str                  ┆ str                     ┆ u32   ┆ i32          ┆ f64  │
+    ╞════════════╪══════════════════════╪═════════════════════════╪═══════╪══════════════╪══════╡
+    │ 5108957    ┆ Lilah Grubman        ┆ Yale                    ┆ 27    ┆ 0            ┆ null │
+    │ 5125264    ┆ Jana El Alfy         ┆ UConn                   ┆ 39    ┆ 0            ┆ null │
+    │ 4594876    ┆ Vicky Parra          ┆ Weber St                ┆ 33    ┆ 0            ┆ null │
+    │ 4899599    ┆ Mya Meredith         ┆ N Kentucky              ┆ 31    ┆ 0            ┆ null │
+    │ 5106098    ┆ Jade Campbell        ┆ St Francis PA           ┆ 30    ┆ 0            ┆ null │
+    │ 5110093    ┆ Marie' Perdew        ┆ Morehead St             ┆ 30    ┆ 0            ┆ null │
+    │ 4898993    ┆ Nadira Eltayeb       ┆ Kansas                  ┆ 33    ┆ 0            ┆ null │
+    │ 5177057    ┆ Fantasia James       ┆ FIU                     ┆ 33    ┆ 0            ┆ null │
+    │ 5178483    ┆ Hilary Behrens       ┆ S Dakota St             ┆ 33    ┆ 0            ┆ null │
+    │ 5178591    ┆ Anastasia Drosouni   ┆ California              ┆ 34    ┆ 0            ┆ null │
+    └────────────┴──────────────────────┴─────────────────────────┴───────┴──────────────┴──────┘
+
+
+
 ### Recipe 4 — Best scoring offenses, joined to records 🤝
 
 Aggregate the team boxscore to rank programs by points per game, then attach each team's W-L from the live standings.
@@ -343,6 +692,29 @@ if has_rows(standings):
 offense
 ```
 
+
+
+
+    shape: (10, 6)
+    ┌─────────┬────────────────────────────┬───────┬──────┬──────┬────────┐
+    │ team_id ┆ team_display_name          ┆ games ┆ ppg  ┆ wins ┆ losses │
+    │ ---     ┆ ---                        ┆ ---   ┆ ---  ┆ ---  ┆ ---    │
+    │ i64     ┆ str                        ┆ u32   ┆ f64  ┆ i64  ┆ i64    │
+    ╞═════════╪════════════════════════════╪═══════╪══════╪══════╪════════╡
+    │ 2294    ┆ Iowa Hawkeyes              ┆ 39    ┆ 91.0 ┆ 10   ┆ 8      │
+    │ 99      ┆ LSU Tigers                 ┆ 37    ┆ 85.9 ┆ 12   ┆ 4      │
+    │ 2579    ┆ South Carolina Gamecocks   ┆ 38    ┆ 85.4 ┆ 15   ┆ 1      │
+    │ 276     ┆ Marshall Thundering Herd   ┆ 33    ┆ 85.3 ┆ 6    ┆ 12     │
+    │ 93      ┆ Murray State Racers        ┆ 32    ┆ 84.5 ┆ 16   ┆ 4      │
+    │ 127     ┆ Michigan State Spartans    ┆ 31    ┆ 82.8 ┆ 11   ┆ 7      │
+    │ 213     ┆ Penn State Lady Lions      ┆ 35    ┆ 82.7 ┆ 1    ┆ 17     │
+    │ 198     ┆ Oral Roberts Golden Eagles ┆ 32    ┆ 82.1 ┆ 12   ┆ 4      │
+    │ 2181    ┆ Drake Bulldogs             ┆ 35    ┆ 81.2 ┆ 15   ┆ 5      │
+    │ 2653    ┆ Troy Trojans               ┆ 34    ┆ 80.9 ┆ 13   ┆ 5      │
+    └─────────┴────────────────────────────┴───────┴──────┴──────┴────────┘
+
+
+
 ### Recipe 5 — A program's full season slate 🗓️
 
 [`espn_wbb_team_schedule`](../wbb/reference/site.md#espn_wbb_team_schedule) returns one program's complete season — every game with its date, matchup short name, and season type. Here's UConn's 2024-25 road to the title (`team_id=2509`).
@@ -358,6 +730,34 @@ else:
     out = 'team schedule unavailable (offseason) — try during the season'
 out
 ```
+
+    ✅ UConn team schedule
+    games on the slate: 29
+
+
+
+
+
+    shape: (12, 5)
+    ┌───────────┬───────────────────┬────────────┬──────────────────┬───────────┐
+    │ id        ┆ date              ┆ short_name ┆ season_type_name ┆ week_text │
+    │ ---       ┆ ---               ┆ ---        ┆ ---              ┆ ---       │
+    │ str       ┆ str               ┆ str        ┆ str              ┆ str       │
+    ╞═══════════╪═══════════════════╪════════════╪══════════════════╪═══════════╡
+    │ 401713616 ┆ 2024-11-07T00:00Z ┆ PFW @ PUR  ┆ Regular Season   ┆ Week 1    │
+    │ 401703046 ┆ 2024-11-11T00:00Z ┆ ND @ PUR   ┆ Regular Season   ┆ Week 1    │
+    │ 401713617 ┆ 2024-11-15T00:30Z ┆ IUIN @ PUR ┆ Regular Season   ┆ Week 2    │
+    │ 401713618 ┆ 2024-11-19T00:00Z ┆ BELL @ PUR ┆ Regular Season   ┆ Week 3    │
+    │ 401713619 ┆ 2024-11-24T18:00Z ┆ UTA @ PUR  ┆ Regular Season   ┆ Week 3    │
+    │ …         ┆ …                 ┆ …          ┆ …                ┆ …         │
+    │ 401713620 ┆ 2024-12-05T00:00Z ┆ ME @ PUR   ┆ Regular Season   ┆ Week 5    │
+    │ 401721485 ┆ 2024-12-07T19:00Z ┆ MD @ PUR   ┆ Regular Season   ┆ Week 5    │
+    │ 401703049 ┆ 2024-12-14T22:00Z ┆ UK @ PUR   ┆ Regular Season   ┆ Week 6    │
+    │ 401713615 ┆ 2024-12-18T00:00Z ┆ PUR @ M-OH ┆ Regular Season   ┆ Week 7    │
+    │ 401713621 ┆ 2024-12-21T19:00Z ┆ INST @ PUR ┆ Regular Season   ┆ Week 7    │
+    └───────────┴───────────────────┴────────────┴──────────────────┴───────────┘
+
+
 
 ### Recipe 6 — Deadliest three-point shooting teams 🎯
 
@@ -380,6 +780,29 @@ three_pt = (
 )
 three_pt
 ```
+
+
+
+
+    shape: (10, 6)
+    ┌─────────┬────────────────────────────────┬───────┬─────┬──────┬───────────┐
+    │ team_id ┆ team_display_name              ┆ games ┆ tpm ┆ tpa  ┆ three_pct │
+    │ ---     ┆ ---                            ┆ ---   ┆ --- ┆ ---  ┆ ---       │
+    │ i32     ┆ str                            ┆ u32   ┆ i32 ┆ i32  ┆ f64       │
+    ╞═════════╪════════════════════════════════╪═══════╪═════╪══════╪═══════════╡
+    │ 2250    ┆ Gonzaga Bulldogs               ┆ 36    ┆ 336 ┆ 849  ┆ 39.6      │
+    │ 84      ┆ Indiana Hoosiers               ┆ 32    ┆ 268 ┆ 677  ┆ 39.6      │
+    │ 2579    ┆ South Carolina Gamecocks       ┆ 38    ┆ 253 ┆ 640  ┆ 39.5      │
+    │ 149     ┆ Montana Lady Griz              ┆ 33    ┆ 357 ┆ 927  ┆ 38.5      │
+    │ 66      ┆ Iowa State Cyclones            ┆ 33    ┆ 285 ┆ 745  ┆ 38.3      │
+    │ 2086    ┆ Butler Bulldogs                ┆ 32    ┆ 266 ┆ 694  ┆ 38.3      │
+    │ 2571    ┆ South Dakota State Jackrabbits ┆ 33    ┆ 223 ┆ 586  ┆ 38.1      │
+    │ 257     ┆ Richmond Spiders               ┆ 35    ┆ 320 ┆ 840  ┆ 38.1      │
+    │ 2294    ┆ Iowa Hawkeyes                  ┆ 39    ┆ 426 ┆ 1132 ┆ 37.6      │
+    │ 127     ┆ Michigan State Spartans        ┆ 31    ┆ 283 ┆ 757  ┆ 37.4      │
+    └─────────┴────────────────────────────────┴───────┴─────┴──────┴───────────┘
+
+
 
 ### Recipe 7 — Clutch shot-makers ⏱️
 
@@ -410,6 +833,29 @@ clutch = (
 clutch
 ```
 
+
+
+
+    shape: (10, 4)
+    ┌──────────────────────┬─────────────────────────┬──────────────┬───────────────┐
+    │ athlete_display_name ┆ team_short_display_name ┆ clutch_plays ┆ clutch_points │
+    │ ---                  ┆ ---                     ┆ ---          ┆ ---           │
+    │ str                  ┆ str                     ┆ u32          ┆ i32           │
+    ╞══════════════════════╪═════════════════════════╪══════════════╪═══════════════╡
+    │ Maya Wong            ┆ Illinois St             ┆ 63           ┆ 81            │
+    │ Dyaisha Fair         ┆ Syracuse                ┆ 59           ┆ 80            │
+    │ Jada Guinn           ┆ Chattanooga             ┆ 63           ┆ 77            │
+    │ Alyssa Fisher        ┆ Loyola Chicago          ┆ 38           ┆ 71            │
+    │ Daisha Bradford      ┆ UL Monroe               ┆ 51           ┆ 68            │
+    │ Ta'Niya Latson       ┆ Florida St              ┆ 47           ┆ 65            │
+    │ Cheyenne Stubbs      ┆ Utah State              ┆ 36           ┆ 62            │
+    │ Chellia Watson       ┆ Buffalo                 ┆ 38           ┆ 61            │
+    │ Deja Kelly           ┆ North Carolina          ┆ 51           ┆ 59            │
+    │ Lucy Olsen           ┆ Villanova               ┆ 39           ┆ 59            │
+    └──────────────────────┴─────────────────────────┴──────────────┴───────────────┘
+
+
+
 ### Recipe 8 — Where the buckets come from (shot-zone mix) 🗺️
 
 The play-by-play carries `coordinate_x` / `coordinate_y` for shots and a `score_value` (2 or 3). Bucket every made field goal into a zone and see how a season's points break down by shot location.
@@ -438,6 +884,22 @@ shot_zones = (
 shot_zones
 ```
 
+
+
+
+    shape: (3, 4)
+    ┌──────────────────┬──────────────────┬────────┬───────────┐
+    │ shot_zone        ┆ made_field_goals ┆ points ┆ share_pct │
+    │ ---              ┆ ---              ┆ ---    ┆ ---       │
+    │ str              ┆ u32              ┆ i32    ┆ f64       │
+    ╞══════════════════╪══════════════════╪════════╪═══════════╡
+    │ 2pt — at the rim ┆ 9108             ┆ 18216  ┆ 70.6      │
+    │ 3-pointer        ┆ 3314             ┆ 9942   ┆ 25.7      │
+    │ 2pt — jumper     ┆ 471              ┆ 942    ┆ 3.7       │
+    └──────────────────┴──────────────────┴────────┴───────────┘
+
+
+
 ### Recipe 9 — Double-double machines 🔄
 
 Flag every player-game with at least two double-digit categories (points / rebounds / assists), then count who racked up the most double-doubles across the season.
@@ -462,6 +924,29 @@ dd = (
 dd
 ```
 
+
+
+
+    shape: (10, 4)
+    ┌────────────┬──────────────────────┬─────────────────────────┬────────────────┐
+    │ athlete_id ┆ athlete_display_name ┆ team_short_display_name ┆ double_doubles │
+    │ ---        ┆ ---                  ┆ ---                     ┆ ---            │
+    │ i32        ┆ str                  ┆ str                     ┆ u32            │
+    ╞════════════╪══════════════════════╪═════════════════════════╪════════════════╡
+    │ 4595746    ┆ Lauren Gustin        ┆ BYU                     ┆ 30             │
+    │ 4433402    ┆ Angel Reese          ┆ LSU                     ┆ 27             │
+    │ 4705101    ┆ Macy McGlone         ┆ E Illinois              ┆ 26             │
+    │ 4433403    ┆ Caitlin Clark        ┆ Iowa                    ┆ 24             │
+    │ 4898966    ┆ Adrianna Smith       ┆ Maine                   ┆ 22             │
+    │ 4684384    ┆ Aneesah Morrow       ┆ LSU                     ┆ 22             │
+    │ 4899516    ┆ Akasha Davis         ┆ Lamar                   ┆ 20             │
+    │ 4433404    ┆ Cameron Brink        ┆ Stanford                ┆ 20             │
+    │ 5108550    ┆ Serah Williams       ┆ Wisconsin               ┆ 20             │
+    │ 4898391    ┆ Phillipina Kyei      ┆ Oregon                  ┆ 20             │
+    └────────────┴──────────────────────┴─────────────────────────┴────────────────┘
+
+
+
 ### Recipe 10 — Find the best defenses (fewest points allowed) 🛡️
 
 Every team boxscore row carries the **opponent's** score, so a single group-by yields points allowed per game. Lowest-scoring opponents = stingiest defenses.
@@ -484,6 +969,29 @@ defense = (
 defense
 ```
 
+
+
+
+    shape: (10, 6)
+    ┌─────────┬───────────────────────────┬───────┬─────────┬─────────┬─────────┐
+    │ team_id ┆ team_display_name         ┆ games ┆ opp_ppg ┆ own_ppg ┆ net_ppg │
+    │ ---     ┆ ---                       ┆ ---   ┆ ---     ┆ ---     ┆ ---     │
+    │ i32     ┆ str                       ┆ u32   ┆ f64     ┆ f64     ┆ f64     │
+    ╞═════════╪═══════════════════════════╪═══════╪═════════╪═════════╪═════════╡
+    │ 399     ┆ UAlbany Great Danes       ┆ 32    ┆ 51.3    ┆ 60.9    ┆ 9.6     │
+    │ 261     ┆ Vermont Catamounts        ┆ 37    ┆ 52.8    ┆ 59.4    ┆ 6.6     │
+    │ 2450    ┆ Norfolk State Spartans    ┆ 33    ┆ 53.1    ┆ 67.0    ┆ 13.9    │
+    │ 2670    ┆ VCU Rams                  ┆ 32    ┆ 53.2    ┆ 63.3    ┆ 10.1    │
+    │ 2603    ┆ Saint Joseph's Hawks      ┆ 34    ┆ 54.5    ┆ 65.3    ┆ 10.8    │
+    │ 236     ┆ Chattanooga Mocs          ┆ 33    ┆ 54.5    ┆ 64.2    ┆ 9.7     │
+    │ 526     ┆ Florida Gulf Coast Eagles ┆ 34    ┆ 55.0    ┆ 74.9    ┆ 19.9    │
+    │ 2097    ┆ Campbell Fighting Camels  ┆ 31    ┆ 55.1    ┆ 60.8    ┆ 5.7     │
+    │ 46      ┆ Georgetown Hoyas          ┆ 35    ┆ 55.1    ┆ 57.9    ┆ 2.8     │
+    │ 2217    ┆ Fairfield Stags           ┆ 33    ┆ 55.2    ┆ 72.5    ┆ 17.3    │
+    └─────────┴───────────────────────────┴───────┴─────────┴─────────┴─────────┘
+
+
+
 ### Recipe 11 — Rolling form: a team's last 10 games 📊
 
 Filter the team boxscore to one program, sort by date, and take the tail — a quick "how did they finish the year?" view with the scoring margin per game. Here's UConn (`team_id=2509`).
@@ -501,6 +1009,32 @@ last10 = (
 print('average margin over last 10:', round(last10['margin'].mean(), 1) if last10.height else 'n/a')
 last10
 ```
+
+    average margin over last 10: 1.6
+
+
+
+
+
+    shape: (10, 5)
+    ┌────────────┬─────────────────────────────────┬────────────┬─────────────────────┬────────┐
+    │ game_date  ┆ opponent_team_short_display_na… ┆ team_score ┆ opponent_team_score ┆ margin │
+    │ ---        ┆ ---                             ┆ ---        ┆ ---                 ┆ ---    │
+    │ date       ┆ str                             ┆ i32        ┆ i32                 ┆ i32    │
+    ╞════════════╪═════════════════════════════════╪════════════╪═════════════════════╪════════╡
+    │ 2024-02-17 ┆ Nebraska                        ┆ 65         ┆ 77                  ┆ -12    │
+    │ 2024-02-21 ┆ Michigan St                     ┆ 59         ┆ 68                  ┆ -9     │
+    │ 2024-02-25 ┆ Wisconsin                       ┆ 79         ┆ 55                  ┆ 24     │
+    │ 2024-02-28 ┆ Penn State                      ┆ 88         ┆ 93                  ┆ -5     │
+    │ 2024-03-03 ┆ Michigan                        ┆ 60         ┆ 64                  ┆ -4     │
+    │ 2024-03-06 ┆ Northwestern                    ┆ 78         ┆ 72                  ┆ 6      │
+    │ 2024-03-07 ┆ Nebraska                        ┆ 56         ┆ 64                  ┆ -8     │
+    │ 2024-03-25 ┆ Butler                          ┆ 62         ┆ 51                  ┆ 11     │
+    │ 2024-03-28 ┆ Duquesne                        ┆ 71         ┆ 50                  ┆ 21     │
+    │ 2024-04-01 ┆ Vermont                         ┆ 59         ┆ 67                  ┆ -8     │
+    └────────────┴─────────────────────────────────┴────────────┴─────────────────────┴────────┘
+
+
 
 ### Recipe 12 — Pandas interop: a season's play-type mix 🐼
 
@@ -520,6 +1054,23 @@ play_mix = (
 )
 play_mix
 ```
+
+
+
+
+                play_type   count
+    0            JumpShot  427608
+    1   Defensive Rebound  293368
+    2           LayUpShot  250960
+    3        PersonalFoul  192322
+    4       MadeFreeThrow  188762
+    5  Lost Ball Turnover  183859
+    6   Offensive Rebound  151143
+    7               Steal   89517
+    8          Block Shot   36019
+    9   OfficialTVTimeOut   24582
+
+
 
 ## 🎉 Where to go next
 

--- a/docs/docs/tutorials/06_mbb_intro.md
+++ b/docs/docs/tutorials/06_mbb_intro.md
@@ -74,6 +74,9 @@ pl.Config.set_tbl_rows(10)
 print("most recent MBB season:", sdv.mbb.most_recent_mbb_season())
 ```
 
+    most recent MBB season: 2026
+
+
 ESPN's *live* endpoints (scoreboard, rankings, standings, a single game's
 play-by-play) are seasonal — in the offseason a poll or scoreboard can come
 back empty. So we use a tiny `safe()` helper: you get the frame when the feed
@@ -107,6 +110,27 @@ print("teams:", teams.shape)
 teams.select(["team_id", "team_location", "team_name", "team_abbreviation", "team_is_active"]).head()
 ```
 
+    teams: (362, 14)
+
+
+
+
+
+    shape: (5, 5)
+    ┌─────────┬───────────────────┬──────────────┬───────────────────┬────────────────┐
+    │ team_id ┆ team_location     ┆ team_name    ┆ team_abbreviation ┆ team_is_active │
+    │ ---     ┆ ---               ┆ ---          ┆ ---               ┆ ---            │
+    │ str     ┆ str               ┆ str          ┆ str               ┆ bool           │
+    ╞═════════╪═══════════════════╪══════════════╪═══════════════════╪════════════════╡
+    │ 2000    ┆ Abilene Christian ┆ Wildcats     ┆ ACU               ┆ true           │
+    │ 2005    ┆ Air Force         ┆ Falcons      ┆ AF                ┆ true           │
+    │ 2006    ┆ Akron             ┆ Zips         ┆ AKR               ┆ true           │
+    │ 2010    ┆ Alabama A&M       ┆ Bulldogs     ┆ AAMU              ┆ true           │
+    │ 333     ┆ Alabama           ┆ Crimson Tide ┆ ALA               ┆ true           │
+    └─────────┴───────────────────┴──────────────┴───────────────────┴────────────────┘
+
+
+
 ## 📅 Schedule & scores for a date window
 
 [`espn_mbb_schedule`](../mbb/reference/additional.md#espn_mbb_schedule) takes a
@@ -122,6 +146,23 @@ sched = safe(
 (sched.select(["id", "home_display_name", "away_display_name", "home_score", "away_score"]).head()
  if sched is not None and sched.height else "schedule unavailable")
 ```
+
+    ✅ schedule 2024-04-08
+
+
+
+
+
+    shape: (1, 5)
+    ┌───────────┬───────────────────┬─────────────────────┬────────────┬────────────┐
+    │ id        ┆ home_display_name ┆ away_display_name   ┆ home_score ┆ away_score │
+    │ ---       ┆ ---               ┆ ---                 ┆ ---        ┆ ---        │
+    │ str       ┆ str               ┆ str                 ┆ str        ┆ str        │
+    ╞═══════════╪═══════════════════╪═════════════════════╪════════════╪════════════╡
+    │ 401638645 ┆ UConn Huskies     ┆ Purdue Boilermakers ┆ 75         ┆ 60         │
+    └───────────┴───────────────────┴─────────────────────┴────────────┴────────────┘
+
+
 
 ## 📊 The rich scoreboard
 
@@ -144,6 +185,23 @@ else:
 out
 ```
 
+    ✅ scoreboard 2024-04-08
+
+
+
+
+
+    shape: (1, 3)
+    ┌───────────┬─────────────┬─────────────────────────┐
+    │ game_id   ┆ short_name  ┆ status_type_description │
+    │ ---       ┆ ---         ┆ ---                     │
+    │ str       ┆ str         ┆ str                     │
+    ╞═══════════╪═════════════╪═════════════════════════╡
+    │ 401638645 ┆ PUR VS CONN ┆ Final                   │
+    └───────────┴─────────────┴─────────────────────────┘
+
+
+
 ## 🏆 Conference standings
 
 [`espn_mbb_standings`](../mbb/reference/site.md#espn_mbb_standings) returns one
@@ -165,6 +223,35 @@ else:
     out = "standings unavailable"
 out
 ```
+
+    ✅ standings 2024
+
+
+
+
+
+    shape: (10, 6)
+    ┌───────────────────────┬───────────────────────┬──────┬────────┬─────────────┬────────────────────┐
+    │ team_display_name     ┆ group_name            ┆ wins ┆ losses ┆ win_percent ┆ point_differential │
+    │ ---                   ┆ ---                   ┆ ---  ┆ ---    ┆ ---         ┆ ---                │
+    │ str                   ┆ str                   ┆ f64  ┆ f64    ┆ f64         ┆ f64                │
+    ╞═══════════════════════╪═══════════════════════╪══════╪════════╪═════════════╪════════════════════╡
+    │ McNeese Cowboys       ┆ Southland Conference  ┆ 17.0 ┆ 1.0    ┆ 0.9444444   ┆ 308.0              │
+    │ Vermont Catamounts    ┆ America East          ┆ 15.0 ┆ 1.0    ┆ 0.9375      ┆ 179.0              │
+    │                       ┆ Conference            ┆      ┆        ┆             ┆                    │
+    │ Saint Mary's Gaels    ┆ West Coast Conference ┆ 15.0 ┆ 1.0    ┆ 0.9375      ┆ 312.0              │
+    │ UConn Huskies         ┆ Big East Conference   ┆ 18.0 ┆ 2.0    ┆ 0.9         ┆ 277.0              │
+    │ South Florida Bulls   ┆ American Conference   ┆ 16.0 ┆ 2.0    ┆ 0.8888889   ┆ 124.0              │
+    │ Colgate Raiders       ┆ Patriot League        ┆ 16.0 ┆ 2.0    ┆ 0.8888889   ┆ 217.0              │
+    │ App State             ┆ Sun Belt Conference   ┆ 16.0 ┆ 2.0    ┆ 0.8888889   ┆ 198.0              │
+    │ Mountaineers          ┆                       ┆      ┆        ┆             ┆                    │
+    │ Gonzaga Bulldogs      ┆ West Coast Conference ┆ 14.0 ┆ 2.0    ┆ 0.875       ┆ 305.0              │
+    │ Princeton Tigers      ┆ Ivy League            ┆ 12.0 ┆ 2.0    ┆ 0.857143    ┆ 136.0              │
+    │ North Carolina Tar    ┆ Atlantic Coast        ┆ 17.0 ┆ 3.0    ┆ 0.85        ┆ 210.0              │
+    │ Heels                 ┆ Conference            ┆      ┆        ┆             ┆                    │
+    └───────────────────────┴───────────────────────┴──────┴────────┴─────────────┴────────────────────┘
+
+
 
 ## 🍳 Cookbook: common MBB tasks
 
@@ -192,6 +279,32 @@ else:
 out
 ```
 
+    ✅ fox scoring leaders
+
+
+
+
+
+    shape: (10, 5)
+    ┌─────────┬─────┬──────┬──────┬──────┐
+    │ players ┆ gp  ┆ mpg  ┆ ppg  ┆ pts  │
+    │ ---     ┆ --- ┆ ---  ┆ ---  ┆ ---  │
+    │ str     ┆ str ┆ str  ┆ str  ┆ str  │
+    ╞═════════╪═════╪══════╪══════╪══════╡
+    │ 1       ┆ 37  ┆ null ┆ null ┆ null │
+    │ 2       ┆ 37  ┆ null ┆ null ┆ null │
+    │ 3       ┆ 37  ┆ null ┆ null ┆ null │
+    │ 4       ┆ 36  ┆ null ┆ null ┆ null │
+    │ 5       ┆ 36  ┆ null ┆ null ┆ null │
+    │ 6       ┆ 35  ┆ null ┆ null ┆ null │
+    │ 7       ┆ 35  ┆ null ┆ null ┆ null │
+    │ 8       ┆ 35  ┆ null ┆ null ┆ null │
+    │ 9       ┆ 35  ┆ null ┆ null ┆ null │
+    │ 10      ┆ 35  ┆ null ┆ null ┆ null │
+    └─────────┴─────┴──────┴──────┴──────┘
+
+
+
 ### Recipe 2 — Look up a team's roster 👥 (ESPN)
 
 Grab a `team_id` from `espn_mbb_teams`, then
@@ -214,6 +327,33 @@ else:
     out = "roster unavailable right now"
 out
 ```
+
+    ✅ roster team_id=41
+
+
+
+
+
+    shape: (12, 4)
+    ┌──────────────────┬────────┬────────────────┬────────────────┐
+    │ full_name        ┆ jersey ┆ display_height ┆ display_weight │
+    │ ---              ┆ ---    ┆ ---            ┆ ---            │
+    │ str              ┆ str    ┆ str            ┆ str            │
+    ╞══════════════════╪════════╪════════════════╪════════════════╡
+    │ Solo Ball        ┆ 1      ┆ 6' 4"          ┆ 200 lbs        │
+    │ Silas Demary Jr. ┆ 2      ┆ 6' 4"          ┆ 195 lbs        │
+    │ Rrezon Elezaj    ┆ 10     ┆ 7' 1"          ┆ 225 lbs        │
+    │ Jacob Furphy     ┆ 7      ┆ 6' 6"          ┆ 205 lbs        │
+    │ Alex Karaban     ┆ 11     ┆ 6' 8"          ┆ 230 lbs        │
+    │ …                ┆ …      ┆ …              ┆ …              │
+    │ Braylon Mullins  ┆ 24     ┆ 6' 6"          ┆ 196 lbs        │
+    │ Uroš Paunovic    ┆ 77     ┆ 6' 3"          ┆ 190 lbs        │
+    │ Tarris Reed Jr.  ┆ 5      ┆ 6' 11"         ┆ 265 lbs        │
+    │ Eric Reibe       ┆ 12     ┆ 7' 1"          ┆ 260 lbs        │
+    │ Jacob Ross       ┆ 13     ┆ 6' 5"          ┆ 195 lbs        │
+    └──────────────────┴────────┴────────────────┴────────────────┘
+
+
 
 ### Recipe 3 — Season scoring leaderboard from parquet 📦
 
@@ -238,6 +378,32 @@ print("player box rows:", pbox.shape)
     .head(10))
 ```
 
+    player box rows: (198586, 55)
+
+
+
+
+
+    shape: (10, 4)
+    ┌──────────────────────┬─────────────────────────┬─────┬──────┐
+    │ athlete_display_name ┆ team_short_display_name ┆ g   ┆ ppg  │
+    │ ---                  ┆ ---                     ┆ --- ┆ ---  │
+    │ str                  ┆ str                     ┆ u32 ┆ f64  │
+    ╞══════════════════════╪═════════════════════════╪═════╪══════╡
+    │ Zach Edey            ┆ Purdue                  ┆ 39  ┆ 25.2 │
+    │ Tommy Bruner         ┆ Denver                  ┆ 34  ┆ 24.0 │
+    │ Terrence Shannon Jr. ┆ Illinois                ┆ 32  ┆ 23.0 │
+    │ Tyler Thomas         ┆ Hofstra                 ┆ 33  ┆ 22.5 │
+    │ Xavier Johnson       ┆ S Illinois              ┆ 32  ┆ 22.2 │
+    │ David Jones          ┆ Memphis                 ┆ 32  ┆ 21.8 │
+    │ Tyson Acuff          ┆ E Michigan              ┆ 27  ┆ 21.7 │
+    │ Dalton Knecht        ┆ Tennessee               ┆ 36  ┆ 21.7 │
+    │ Jordan Sears         ┆ UT Martin               ┆ 32  ┆ 21.6 │
+    │ Tucker DeVries       ┆ Drake                   ┆ 34  ┆ 21.6 │
+    └──────────────────────┴─────────────────────────┴─────┴──────┘
+
+
+
 ### Recipe 4 — Play-by-play slice for one game 🎬 (ESPN)
 
 [`espn_mbb_pbp`](../mbb/reference/additional.md#espn_mbb_pbp) returns a dict;
@@ -258,6 +424,42 @@ else:
     out = "play-by-play unavailable right now"
 out
 ```
+
+    ✅ pbp 401638636
+
+
+
+
+
+    shape: (10, 6)
+    ┌───────────────┬────────────────────┬───────────────────────┬─────────────┬───────────┬───────────┐
+    │ period.number ┆ clock.displayValue ┆ text                  ┆ scoringPlay ┆ homeScore ┆ awayScore │
+    │ ---           ┆ ---                ┆ ---                   ┆ ---         ┆ ---       ┆ ---       │
+    │ i64           ┆ str                ┆ str                   ┆ bool        ┆ i64       ┆ i64       │
+    ╞═══════════════╪════════════════════╪═══════════════════════╪═════════════╪═══════════╪═══════════╡
+    │ 1             ┆ 19:27              ┆ Ryan Kalkbrenner made ┆ true        ┆ 0         ┆ 2         │
+    │               ┆                    ┆ Layup. A…             ┆             ┆           ┆           │
+    │ 1             ┆ 18:24              ┆ Dalton Knecht made    ┆ true        ┆ 2         ┆ 2         │
+    │               ┆                    ┆ Jumper.               ┆             ┆           ┆           │
+    │ 1             ┆ 17:04              ┆ Mason Miller made     ┆ true        ┆ 2         ┆ 5         │
+    │               ┆                    ┆ Three Point …         ┆             ┆           ┆           │
+    │ 1             ┆ 16:48              ┆ Dalton Knecht made    ┆ true        ┆ 3         ┆ 5         │
+    │               ┆                    ┆ Free Throw.           ┆             ┆           ┆           │
+    │ 1             ┆ 16:34              ┆ Baylor Scheierman     ┆ true        ┆ 3         ┆ 7         │
+    │               ┆                    ┆ made Jumper.          ┆             ┆           ┆           │
+    │ 1             ┆ 15:34              ┆ Josiah-Jordan James   ┆ true        ┆ 6         ┆ 7         │
+    │               ┆                    ┆ made Three…           ┆             ┆           ┆           │
+    │ 1             ┆ 14:45              ┆ Josiah-Jordan James   ┆ true        ┆ 9         ┆ 7         │
+    │               ┆                    ┆ made Three…           ┆             ┆           ┆           │
+    │ 1             ┆ 14:19              ┆ Baylor Scheierman     ┆ true        ┆ 9         ┆ 9         │
+    │               ┆                    ┆ made Jumper.          ┆             ┆           ┆           │
+    │ 1             ┆ 14:07              ┆ Jordan Gainey made    ┆ true        ┆ 11        ┆ 9         │
+    │               ┆                    ┆ Jumper. Ass…          ┆             ┆           ┆           │
+    │ 1             ┆ 13:39              ┆ Baylor Scheierman     ┆ true        ┆ 11        ┆ 12        │
+    │               ┆                    ┆ made Three P…         ┆             ┆           ┆           │
+    └───────────────┴────────────────────┴───────────────────────┴─────────────┴───────────┴───────────┘
+
+
 
 ### Recipe 5 — Best net scoring margin 📊 (parquet)
 
@@ -280,6 +482,32 @@ print("team box rows:", tbox.shape)
     .head(10))
 ```
 
+    team box rows: (12480, 57)
+
+
+
+
+
+    shape: (10, 5)
+    ┌─────────────────────┬─────┬──────┬─────────┬────────────┐
+    │ team_display_name   ┆ g   ┆ ppg  ┆ opp_ppg ┆ net_margin │
+    │ ---                 ┆ --- ┆ ---  ┆ ---     ┆ ---        │
+    │ str                 ┆ u32 ┆ f64  ┆ f64     ┆ f64        │
+    ╞═════════════════════╪═════╪══════╪═════════╪════════════╡
+    │ UConn Huskies       ┆ 40  ┆ 81.4 ┆ 63.4    ┆ 18.0       │
+    │ McNeese Cowboys     ┆ 34  ┆ 80.0 ┆ 62.2    ┆ 17.8       │
+    │ Houston Cougars     ┆ 37  ┆ 73.5 ┆ 57.6    ┆ 15.9       │
+    │ Gonzaga Bulldogs    ┆ 35  ┆ 84.5 ┆ 69.1    ┆ 15.4       │
+    │ Arizona Wildcats    ┆ 36  ┆ 87.1 ┆ 72.1    ┆ 15.0       │
+    │ Auburn Tigers       ┆ 35  ┆ 83.1 ┆ 68.3    ┆ 14.8       │
+    │ Saint Mary's Gaels  ┆ 34  ┆ 74.0 ┆ 59.2    ┆ 14.8       │
+    │ Iowa State Cyclones ┆ 37  ┆ 75.3 ┆ 61.5    ┆ 13.8       │
+    │ James Madison Dukes ┆ 36  ┆ 83.2 ┆ 69.6    ┆ 13.6       │
+    │ Purdue Boilermakers ┆ 39  ┆ 82.3 ┆ 69.0    ┆ 13.3       │
+    └─────────────────────┴─────┴──────┴─────────┴────────────┘
+
+
+
 ### Recipe 6 — Best 3-point shooting teams 🎯 (parquet)
 
 Same team-box parquet, different question: sum makes and attempts across the season, then divide. A `min attempts` filter keeps small-sample flukes off the board so the leaders are real volume shooters.
@@ -300,6 +528,29 @@ Same team-box parquet, different question: sum makes and attempts across the sea
     .select(["team_display_name", "tpm", "tpa", "three_pct"])
     .head(10))
 ```
+
+
+
+
+    shape: (10, 4)
+    ┌─────────────────────────┬───────┬───────┬───────────┐
+    │ team_display_name       ┆ tpm   ┆ tpa   ┆ three_pct │
+    │ ---                     ┆ ---   ┆ ---   ┆ ---       │
+    │ str                     ┆ f64   ┆ f64   ┆ f64       │
+    ╞═════════════════════════╪═══════╪═══════╪═══════════╡
+    │ Kentucky Wildcats       ┆ 327.0 ┆ 800.0 ┆ 40.9      │
+    │ Purdue Boilermakers     ┆ 318.0 ┆ 788.0 ┆ 40.4      │
+    │ Dayton Flyers           ┆ 310.0 ┆ 777.0 ┆ 39.9      │
+    │ UNC Greensboro Spartans ┆ 322.0 ┆ 812.0 ┆ 39.7      │
+    │ Samford Bulldogs        ┆ 351.0 ┆ 889.0 ┆ 39.5      │
+    │ Colorado Buffaloes      ┆ 254.0 ┆ 649.0 ┆ 39.1      │
+    │ Northwestern Wildcats   ┆ 278.0 ┆ 713.0 ┆ 39.0      │
+    │ Baylor Bears            ┆ 301.0 ┆ 773.0 ┆ 38.9      │
+    │ Wright State Raiders    ┆ 218.0 ┆ 569.0 ┆ 38.3      │
+    │ McNeese Cowboys         ┆ 257.0 ┆ 671.0 ┆ 38.3      │
+    └─────────────────────────┴───────┴───────┴───────────┘
+
+
 
 ### Recipe 7 — Most efficient scorers ⚡ (true shooting %)
 
@@ -326,6 +577,29 @@ pbox = sdv.mbb.load_mbb_player_boxscore(seasons=[2024])
     .head(10))
 ```
 
+
+
+
+    shape: (10, 5)
+    ┌──────────────────────┬───────────────────┬─────┬───────┬────────┐
+    │ athlete_display_name ┆ team_abbreviation ┆ g   ┆ pts   ┆ ts_pct │
+    │ ---                  ┆ ---               ┆ --- ┆ ---   ┆ ---    │
+    │ str                  ┆ str               ┆ u32 ┆ f64   ┆ f64    │
+    ╞══════════════════════╪═══════════════════╪═════╪═══════╪════════╡
+    │ Jayson Kent          ┆ INST              ┆ 38  ┆ 514.0 ┆ 73.3   │
+    │ Aubin Gateretse      ┆ STET              ┆ 35  ┆ 407.0 ┆ 71.2   │
+    │ Lynn Kidd            ┆ VT                ┆ 33  ┆ 434.0 ┆ 70.7   │
+    │ Reed Sheppard        ┆ UK                ┆ 33  ┆ 411.0 ┆ 70.5   │
+    │ Vladislav Goldin     ┆ FAU               ┆ 34  ┆ 534.0 ┆ 69.1   │
+    │ Ryan Kalkbrenner     ┆ CREI              ┆ 35  ┆ 604.0 ┆ 68.9   │
+    │ Cedric Coward        ┆ EWU               ┆ 32  ┆ 494.0 ┆ 68.3   │
+    │ Jaylin Williams      ┆ AUB               ┆ 34  ┆ 422.0 ┆ 68.2   │
+    │ Zach Edey            ┆ PUR               ┆ 39  ┆ 983.0 ┆ 67.3   │
+    │ Chaz Lanier          ┆ UNF               ┆ 32  ┆ 629.0 ┆ 67.3   │
+    └──────────────────────┴───────────────────┴─────┴───────┴────────┘
+
+
+
 ### Recipe 8 — One conference's power board 🏟️ (ESPN, join)
 
 [`espn_mbb_conferences`](../mbb/reference/additional.md#espn_mbb_conferences) is the group catalog; [`espn_mbb_standings`](../mbb/reference/site.md#espn_mbb_standings) carries a `group_name` per team. Filter standings to a single league — here the Big 12 — to get a clean intra-conference pecking order.
@@ -351,6 +625,37 @@ else:
 out
 ```
 
+    ✅ conferences
+    some conferences: ['NCAA Division I', 'Non-NCAA Division I']
+
+
+    ✅ standings 2024
+
+
+
+
+
+    shape: (12, 5)
+    ┌────────────────────────┬──────┬────────┬─────────────┬────────────────────┐
+    │ team_display_name      ┆ wins ┆ losses ┆ win_percent ┆ point_differential │
+    │ ---                    ┆ ---  ┆ ---    ┆ ---         ┆ ---                │
+    │ str                    ┆ f64  ┆ f64    ┆ f64         ┆ f64                │
+    ╞════════════════════════╪══════╪════════╪═════════════╪════════════════════╡
+    │ Houston Cougars        ┆ 15.0 ┆ 3.0    ┆ 0.8333333   ┆ 191.0              │
+    │ Iowa State Cyclones    ┆ 13.0 ┆ 5.0    ┆ 0.7222222   ┆ 71.0               │
+    │ Baylor Bears           ┆ 11.0 ┆ 7.0    ┆ 0.6111111   ┆ 52.0               │
+    │ Texas Tech Red Raiders ┆ 11.0 ┆ 7.0    ┆ 0.6111111   ┆ 39.0               │
+    │ BYU Cougars            ┆ 10.0 ┆ 8.0    ┆ 0.5555556   ┆ 19.0               │
+    │ …                      ┆ …    ┆ …      ┆ …           ┆ …                  │
+    │ TCU Horned Frogs       ┆ 9.0  ┆ 9.0    ┆ 0.5         ┆ 21.0               │
+    │ Oklahoma Sooners       ┆ 8.0  ┆ 10.0   ┆ 0.444444    ┆ -33.0              │
+    │ Kansas State Wildcats  ┆ 8.0  ┆ 10.0   ┆ 0.444444    ┆ -23.0              │
+    │ Cincinnati Bearcats    ┆ 7.0  ┆ 11.0   ┆ 0.3888889   ┆ 5.0                │
+    │ UCF Knights            ┆ 7.0  ┆ 11.0   ┆ 0.3888889   ┆ -44.0              │
+    └────────────────────────┴──────┴────────┴─────────────┴────────────────────┘
+
+
+
 ### Recipe 9 — A team's full season schedule 🗓️ (ESPN)
 
 [`espn_mbb_team_schedule`](../mbb/reference/additional.md#espn_mbb_team_schedule) returns every game on one team's slate for a season — matchup name, week and season type — perfect for building an opponent list. We use UConn's 2024 championship run.
@@ -370,6 +675,33 @@ else:
 out
 ```
 
+    ✅ team schedule 41
+
+
+
+
+
+    shape: (12, 4)
+    ┌───────────┬──────────────┬──────────────────┬───────────┐
+    │ id        ┆ short_name   ┆ season_type_name ┆ week_text │
+    │ ---       ┆ ---          ┆ ---              ┆ ---       │
+    │ str       ┆ str          ┆ str              ┆ str       │
+    ╞═══════════╪══════════════╪══════════════════╪═══════════╡
+    │ 401584359 ┆ NAU @ CONN   ┆ Regular Season   ┆ Week 1    │
+    │ 401589296 ┆ STO @ CONN   ┆ Regular Season   ┆ Week 1    │
+    │ 401591369 ┆ MVSU @ CONN  ┆ Regular Season   ┆ Week 2    │
+    │ 401591374 ┆ CONN VS IU   ┆ Regular Season   ┆ Week 2    │
+    │ 401601491 ┆ CONN VS TEX  ┆ Regular Season   ┆ Week 3    │
+    │ …         ┆ …            ┆ …                ┆ …         │
+    │ 401574563 ┆ CONN @ KU    ┆ Regular Season   ┆ Week 4    │
+    │ 401580309 ┆ UNC VS CONN  ┆ Regular Season   ┆ Week 5    │
+    │ 401591372 ┆ UAPB @ CONN  ┆ Regular Season   ┆ Week 5    │
+    │ 401591373 ┆ CONN VS GONZ ┆ Regular Season   ┆ Week 6    │
+    │ 401599441 ┆ CONN @ HALL  ┆ Regular Season   ┆ Week 7    │
+    └───────────┴──────────────┴──────────────────┴───────────┘
+
+
+
 ### Recipe 10 — Top rebounding teams 🧲 (FoxSports)
 
 [`fox_mbb_league_leaders`](../mbb/reference/additional.md#fox_mbb_league_leaders) isn't just a player board — flip `who="team"` and pick `category="rebounds"` to rank programs on the glass straight from FoxSports. No IDs needed.
@@ -387,6 +719,32 @@ else:
     out = "Fox team leaders unavailable right now"
 out
 ```
+
+    ✅ fox team rebounds
+
+
+
+
+
+    shape: (10, 6)
+    ┌───────┬─────┬─────┬─────┬──────┬──────────┐
+    │ teams ┆ gp  ┆ w   ┆ l   ┆ ppg  ┆ ppg_diff │
+    │ ---   ┆ --- ┆ --- ┆ --- ┆ ---  ┆ ---      │
+    │ str   ┆ str ┆ str ┆ str ┆ str  ┆ str      │
+    ╞═══════╪═════╪═════╪═════╪══════╪══════════╡
+    │ 1     ┆ 37  ┆ 21  ┆ 16  ┆ null ┆ null     │
+    │ 2     ┆ 35  ┆ 21  ┆ 15  ┆ null ┆ null     │
+    │ 3     ┆ 35  ┆ 18  ┆ 17  ┆ null ┆ null     │
+    │ 4     ┆ 35  ┆ 23  ┆ 13  ┆ null ┆ null     │
+    │ 5     ┆ 35  ┆ 15  ┆ 20  ┆ null ┆ null     │
+    │ 6     ┆ 35  ┆ 19  ┆ 18  ┆ null ┆ null     │
+    │ 7     ┆ 35  ┆ 30  ┆ 9   ┆ null ┆ null     │
+    │ 8     ┆ 35  ┆ 19  ┆ 16  ┆ null ┆ null     │
+    │ 9     ┆ 34  ┆ 29  ┆ 6   ┆ null ┆ null     │
+    │ 10    ┆ 34  ┆ 36  ┆ 3   ┆ null ┆ null     │
+    └───────┴─────┴─────┴─────┴──────┴──────────┘
+
+
 
 ### Recipe 11 — Crunch-time buckets 🔥 (parquet PBP)
 
@@ -406,6 +764,43 @@ print("season pbp rows:", season_pbp.shape)
              "text", "home_score", "away_score"])
     .head(10))
 ```
+
+    season pbp rows: (2004997, 56)
+
+
+
+
+
+    shape: (10, 6)
+    ┌───────────┬────────────────────┬───────────────────┬───────────────────┬────────────┬────────────┐
+    │ game_id   ┆ period_display_val ┆ clock_display_val ┆ text              ┆ home_score ┆ away_score │
+    │ ---       ┆ ue                 ┆ ue                ┆ ---               ┆ ---        ┆ ---        │
+    │ i32       ┆ ---                ┆ ---               ┆ str               ┆ i32        ┆ i32        │
+    │           ┆ str                ┆ str               ┆                   ┆            ┆            │
+    ╞═══════════╪════════════════════╪═══════════════════╪═══════════════════╪════════════╪════════════╡
+    │ 401638645 ┆ 2nd Half           ┆ 1:22              ┆ Zach Edey made    ┆ 73         ┆ 60         │
+    │           ┆                    ┆                   ┆ Dunk. Assisted …  ┆            ┆            │
+    │ 401638645 ┆ 2nd Half           ┆ 0:45              ┆ Donovan Clingan   ┆ 75         ┆ 60         │
+    │           ┆                    ┆                   ┆ made Layup. As…   ┆            ┆            │
+    │ 401638643 ┆ 2nd Half           ┆ 1:27              ┆ Jayden Taylor     ┆ 63         ┆ 47         │
+    │           ┆                    ┆                   ┆ made Layup.       ┆            ┆            │
+    │ 401638643 ┆ 2nd Half           ┆ 0:45              ┆ Jayden Taylor     ┆ 63         ┆ 50         │
+    │           ┆                    ┆                   ┆ made Three Point… ┆            ┆            │
+    │ 401638644 ┆ 2nd Half           ┆ 1:07              ┆ Tristen Newton    ┆ 83         ┆ 68         │
+    │           ┆                    ┆                   ┆ made Three Poin…  ┆            ┆            │
+    │ 401638644 ┆ 2nd Half           ┆ 0:55              ┆ Grant Nelson made ┆ 83         ┆ 70         │
+    │           ┆                    ┆                   ┆ Layup.            ┆            ┆            │
+    │ 401638644 ┆ 2nd Half           ┆ 0:33              ┆ Cam Spencer made  ┆ 86         ┆ 70         │
+    │           ┆                    ┆                   ┆ Three Point J…    ┆            ┆            │
+    │ 401638644 ┆ 2nd Half           ┆ 0:20              ┆ Grant Nelson made ┆ 86         ┆ 72         │
+    │           ┆                    ┆                   ┆ Two Point Ti…     ┆            ┆            │
+    │ 401641124 ┆ 2nd Half           ┆ 1:07              ┆ Al-Amir Dawes     ┆ 77         ┆ 77         │
+    │           ┆                    ┆                   ┆ made Three Point… ┆            ┆            │
+    │ 401641124 ┆ 2nd Half           ┆ 0:20              ┆ Dre Davis made    ┆ 79         ┆ 77         │
+    │           ┆                    ┆                   ┆ Layup.            ┆            ┆            │
+    └───────────┴────────────────────┴───────────────────┴───────────────────┴────────────┴────────────┘
+
+
 
 ### Recipe 12 — Double-double leaders 🐼 (pandas interop)
 
@@ -428,6 +823,23 @@ pbox_pd["is_dd"] = (pbox_pd[["points", "rebounds", "assists"]] >= 10).sum(axis=1
     .reset_index(drop=True))
 ```
 
+
+
+
+       athlete_display_name team_abbreviation  double_doubles
+    0       Enrique Freeman               AKR              31
+    1             Zach Edey               PUR              30
+    2  Vonterius Woolbright               WCU              27
+    3              DJ Burns               YSU              22
+    4           Oumar Ballo              ARIZ              20
+    5         Armando Bacot               UNC              19
+    6         Fardaws Aimaq               CAL              19
+    7       Yaxel Lendeborg               UAB              19
+    8          Saint Thomas              UNCO              19
+    9           Riley Minix              MORE              19
+
+
+
 ## 🧾 One call, the whole game: `espn_mbb_summary`
 
 [`espn_mbb_summary`](../mbb/reference/site.md#espn_mbb_summary) is the Swiss
@@ -448,6 +860,41 @@ else:
 out
 ```
 
+    ✅ summary 401638636
+    box score sections available: ['boxscore_player', 'boxscore_team', 'plays', 'winprobability', 'leaders', 'game_info', 'officials', 'header']
+
+
+
+
+
+    shape: (5, 9)
+    ┌─────────┬────────────┬───────────┬───────────┬───┬───────────┬───────────┬───────────┬───────────┐
+    │ team_id ┆ team_abbre ┆ team_disp ┆ home_away ┆ … ┆ stat_name ┆ stat_labe ┆ stat_disp ┆ stat_valu │
+    │ ---     ┆ viation    ┆ lay_name  ┆ ---       ┆   ┆ ---       ┆ l         ┆ lay_value ┆ e         │
+    │ str     ┆ ---        ┆ ---       ┆ str       ┆   ┆ str       ┆ ---       ┆ ---       ┆ ---       │
+    │         ┆ str        ┆ str       ┆           ┆   ┆           ┆ str       ┆ str       ┆ str       │
+    ╞═════════╪════════════╪═══════════╪═══════════╪═══╪═══════════╪═══════════╪═══════════╪═══════════╡
+    │ 156     ┆ CREI       ┆ Creighton ┆ away      ┆ … ┆ fieldGoal ┆ FG        ┆ 26-58     ┆ null      │
+    │         ┆            ┆ Bluejays  ┆           ┆   ┆ sMade-fie ┆           ┆           ┆           │
+    │         ┆            ┆           ┆           ┆   ┆ ldGoalsAt ┆           ┆           ┆           │
+    │         ┆            ┆           ┆           ┆   ┆ tem…      ┆           ┆           ┆           │
+    │ 156     ┆ CREI       ┆ Creighton ┆ away      ┆ … ┆ fieldGoal ┆ Field     ┆ 45        ┆ null      │
+    │         ┆            ┆ Bluejays  ┆           ┆   ┆ Pct       ┆ Goal %    ┆           ┆           │
+    │ 156     ┆ CREI       ┆ Creighton ┆ away      ┆ … ┆ threePoin ┆ 3PT       ┆ 11-23     ┆ null      │
+    │         ┆            ┆ Bluejays  ┆           ┆   ┆ tFieldGoa ┆           ┆           ┆           │
+    │         ┆            ┆           ┆           ┆   ┆ lsMade-th ┆           ┆           ┆           │
+    │         ┆            ┆           ┆           ┆   ┆ ree…      ┆           ┆           ┆           │
+    │ 156     ┆ CREI       ┆ Creighton ┆ away      ┆ … ┆ threePoin ┆ Three     ┆ 48        ┆ null      │
+    │         ┆            ┆ Bluejays  ┆           ┆   ┆ tFieldGoa ┆ Point %   ┆           ┆           │
+    │         ┆            ┆           ┆           ┆   ┆ lPct      ┆           ┆           ┆           │
+    │ 156     ┆ CREI       ┆ Creighton ┆ away      ┆ … ┆ freeThrow ┆ FT        ┆ 12-13     ┆ null      │
+    │         ┆            ┆ Bluejays  ┆           ┆   ┆ sMade-fre ┆           ┆           ┆           │
+    │         ┆            ┆           ┆           ┆   ┆ eThrowsAt ┆           ┆           ┆           │
+    │         ┆            ┆           ┆           ┆   ┆ tem…      ┆           ┆           ┆           │
+    └─────────┴────────────┴───────────┴───────────┴───┴───────────┴───────────┴───────────┴───────────┘
+
+
+
 ## 🙌 Who suited up: game rosters
 
 [`espn_mbb_game_rosters`](../mbb/reference/additional.md#espn_mbb_game_rosters)
@@ -464,6 +911,32 @@ else:
     out = "game rosters unavailable right now"
 out
 ```
+
+    ✅ game rosters 401638636
+
+
+
+
+
+    shape: (10, 3)
+    ┌──────────────────────┬───────────────────┬─────────┐
+    │ athlete_display_name ┆ team_abbreviation ┆ starter │
+    │ ---                  ┆ ---               ┆ ---     │
+    │ str                  ┆ str               ┆ bool    │
+    ╞══════════════════════╪═══════════════════╪═════════╡
+    │ Jonas Aidoo          ┆ TENN              ┆ true    │
+    │ Dalton Knecht        ┆ TENN              ┆ true    │
+    │ Zakai Zeigler        ┆ TENN              ┆ true    │
+    │ Jahmai Mashack       ┆ TENN              ┆ true    │
+    │ Josiah-Jordan James  ┆ TENN              ┆ true    │
+    │ Tobe Awaka           ┆ TENN              ┆ false   │
+    │ J.P. Estrella        ┆ TENN              ┆ false   │
+    │ Freddie Dilione V    ┆ TENN              ┆ false   │
+    │ Cameron Carr         ┆ TENN              ┆ false   │
+    │ Jordan Gainey        ┆ TENN              ┆ false   │
+    └──────────────────────┴───────────────────┴─────────┘
+
+
 
 ## 🔧 A multi-season pipeline: highest-scoring tournament games
 
@@ -485,6 +958,34 @@ print("season schedule rows:", schedule_2024.shape)
              "home_score", "away_score", "total"])
     .head(10))
 ```
+
+    season schedule rows: (6249, 84)
+
+
+
+
+
+    shape: (10, 6)
+    ┌────────────┬───────────────────────────┬───────────────────────┬────────────┬────────────┬───────┐
+    │ game_date  ┆ home_display_name         ┆ away_display_name     ┆ home_score ┆ away_score ┆ total │
+    │ ---        ┆ ---                       ┆ ---                   ┆ ---        ┆ ---        ┆ ---   │
+    │ date       ┆ str                       ┆ str                   ┆ i32        ┆ i32        ┆ i64   │
+    ╞════════════╪═══════════════════════════╪═══════════════════════╪════════════╪════════════╪═══════╡
+    │ 2024-01-03 ┆ George Washington         ┆ Fordham Rams          ┆ 113        ┆ 119        ┆ 232   │
+    │            ┆ Revolutionar…             ┆                       ┆            ┆            ┆       │
+    │ 2024-01-13 ┆ Samford Bulldogs          ┆ VMI Keydets           ┆ 134        ┆ 96         ┆ 230   │
+    │ 2023-12-14 ┆ Tulane Green Wave         ┆ Furman Paladins       ┆ 117        ┆ 110        ┆ 227   │
+    │ 2024-01-25 ┆ Denver Pioneers           ┆ South Dakota Coyotes  ┆ 111        ┆ 110        ┆ 221   │
+    │ 2023-11-09 ┆ Kent State Golden Flashes ┆ James Madison Dukes   ┆ 108        ┆ 113        ┆ 221   │
+    │ 2023-11-08 ┆ Bryant Bulldogs           ┆ Fisher College Eagles ┆ 140        ┆ 79         ┆ 219   │
+    │ 2024-02-03 ┆ UAlbany Great Danes       ┆ UMBC Retrievers       ┆ 102        ┆ 114        ┆ 216   │
+    │ 2024-01-21 ┆ UTSA Roadrunners          ┆ Florida Atlantic Owls ┆ 103        ┆ 112        ┆ 215   │
+    │ 2024-03-02 ┆ Kentucky Wildcats         ┆ Arkansas Razorbacks   ┆ 111        ┆ 102        ┆ 213   │
+    │ 2024-02-10 ┆ Appalachian State         ┆ Toledo Rockets        ┆ 109        ┆ 104        ┆ 213   │
+    │            ┆ Mountaineers              ┆                       ┆            ┆            ┆       │
+    └────────────┴───────────────────────────┴───────────────────────┴────────────┴────────────┴───────┘
+
+
 
 ## 🎉 Where to next
 

--- a/docs/docs/tutorials/07_nhl_intro.md
+++ b/docs/docs/tutorials/07_nhl_intro.md
@@ -121,6 +121,24 @@ cols = ['id', 'game_state', 'home_team_abbrev', 'home_team_score',
  if sched is not None else 'schedule unavailable')
 ```
 
+    ✅ native schedule
+
+
+
+
+
+    shape: (1, 6)
+    ┌────────────┬────────────┬──────────────────┬─────────────────┬─────────────────┬─────────────────┐
+    │ id         ┆ game_state ┆ home_team_abbrev ┆ home_team_score ┆ away_team_abbre ┆ away_team_score │
+    │ ---        ┆ ---        ┆ ---              ┆ ---             ┆ v               ┆ ---             │
+    │ i64        ┆ str        ┆ str              ┆ i64             ┆ ---             ┆ i64             │
+    │            ┆            ┆                  ┆                 ┆ str             ┆                 │
+    ╞════════════╪════════════╪══════════════════╪═════════════════╪═════════════════╪═════════════════╡
+    │ 2023030417 ┆ OFF        ┆ FLA              ┆ 2               ┆ EDM             ┆ 1               │
+    └────────────┴────────────┴──────────────────┴─────────────────┴─────────────────┴─────────────────┘
+
+
+
 ### 🥅 Play-by-play
 
 [`nhl_web_pbp(game_id=...)`](../nhl/reference/nhl_api_web.md#nhl_web_pbp) returns
@@ -141,6 +159,29 @@ else:
 out
 ```
 
+    ✅ native pbp
+    pbp shape: (331, 48)
+
+
+
+
+
+    shape: (5, 6)
+    ┌────────────────┬────────────────┬───────────────┬────────────────┬───────────────┬───────────────┐
+    │ period_descrip ┆ time_in_period ┆ type_desc_key ┆ details_event_ ┆ details_x_coo ┆ details_y_coo │
+    │ tor_number     ┆ ---            ┆ ---           ┆ owner_team_id  ┆ rd            ┆ rd            │
+    │ ---            ┆ str            ┆ str           ┆ ---            ┆ ---           ┆ ---           │
+    │ i64            ┆                ┆               ┆ f64            ┆ f64           ┆ f64           │
+    ╞════════════════╪════════════════╪═══════════════╪════════════════╪═══════════════╪═══════════════╡
+    │ 1              ┆ 00:00          ┆ period-start  ┆ null           ┆ null          ┆ null          │
+    │ 1              ┆ 00:00          ┆ faceoff       ┆ 22.0           ┆ 0.0           ┆ 0.0           │
+    │ 1              ┆ 00:21          ┆ shot-on-goal  ┆ 22.0           ┆ 82.0          ┆ -3.0          │
+    │ 1              ┆ 00:31          ┆ missed-shot   ┆ 13.0           ┆ -81.0         ┆ 30.0          │
+    │ 1              ┆ 00:40          ┆ blocked-shot  ┆ 13.0           ┆ -64.0         ┆ -36.0         │
+    └────────────────┴────────────────┴───────────────┴────────────────┴───────────────┴───────────────┘
+
+
+
 
 ```python
 # Event-type mix for the game — native uses `type_desc_key`
@@ -148,6 +189,29 @@ out
     .sort('events', descending=True).head(10)
  if pbp is not None else 'pbp unavailable')
 ```
+
+
+
+
+    shape: (10, 2)
+    ┌───────────────┬────────┐
+    │ type_desc_key ┆ events │
+    │ ---           ┆ ---    │
+    │ str           ┆ u32    │
+    ╞═══════════════╪════════╡
+    │ faceoff       ┆ 59     │
+    │ hit           ┆ 53     │
+    │ stoppage      ┆ 52     │
+    │ shot-on-goal  ┆ 42     │
+    │ missed-shot   ┆ 36     │
+    │ blocked-shot  ┆ 32     │
+    │ giveaway      ┆ 22     │
+    │ takeaway      ┆ 19     │
+    │ goal          ┆ 3      │
+    │ period-end    ┆ 3      │
+    └───────────────┴────────┘
+
+
 
 ### 📊 Boxscore
 
@@ -168,6 +232,27 @@ else:
 out
 ```
 
+    ✅ native boxscore
+
+
+
+
+
+    shape: (5, 8)
+    ┌──────────────┬───────────┬──────────┬───────┬─────────┬────────┬─────┬───────┐
+    │ name_default ┆ home_away ┆ position ┆ goals ┆ assists ┆ points ┆ sog ┆ toi   │
+    │ ---          ┆ ---       ┆ ---      ┆ ---   ┆ ---     ┆ ---    ┆ --- ┆ ---   │
+    │ str          ┆ str       ┆ str      ┆ f64   ┆ f64     ┆ f64    ┆ f64 ┆ str   │
+    ╞══════════════╪═══════════╪══════════╪═══════╪═════════╪════════╪═════╪═══════╡
+    │ C. Verhaeghe ┆ home      ┆ C        ┆ 1.0   ┆ 1.0     ┆ 2.0    ┆ 3.0 ┆ 19:23 │
+    │ M. Janmark   ┆ away      ┆ C        ┆ 1.0   ┆ 0.0     ┆ 1.0    ┆ 1.0 ┆ 12:40 │
+    │ C. Ceci      ┆ away      ┆ D        ┆ 0.0   ┆ 1.0     ┆ 1.0    ┆ 1.0 ┆ 18:35 │
+    │ S. Reinhart  ┆ home      ┆ C        ┆ 1.0   ┆ 0.0     ┆ 1.0    ┆ 2.0 ┆ 21:42 │
+    │ A. Lundell   ┆ home      ┆ C        ┆ 0.0   ┆ 1.0     ┆ 1.0    ┆ 0.0 ┆ 14:39 │
+    └──────────────┴───────────┴──────────┴───────┴─────────┴────────┴─────┴───────┘
+
+
+
 ### 🏆 Standings
 
 [`nhl_standings(date='YYYY-MM-DD')`](../nhl/reference/nhl_api_web.md#nhl_standings)
@@ -185,6 +270,27 @@ else:
     out = 'standings unavailable'
 out
 ```
+
+    ✅ native standings
+
+
+
+
+
+    shape: (5, 7)
+    ┌─────────────────────┬─────────────────┬───────────────┬──────────────┬──────┬────────┬────────┐
+    │ team_name_default   ┆ conference_name ┆ division_name ┆ games_played ┆ wins ┆ losses ┆ points │
+    │ ---                 ┆ ---             ┆ ---           ┆ ---          ┆ ---  ┆ ---    ┆ ---    │
+    │ str                 ┆ str             ┆ str           ┆ i64          ┆ i64  ┆ i64    ┆ i64    │
+    ╞═════════════════════╪═════════════════╪═══════════════╪══════════════╪══════╪════════╪════════╡
+    │ New York Rangers    ┆ Eastern         ┆ Metropolitan  ┆ 82           ┆ 55   ┆ 23     ┆ 114    │
+    │ Carolina Hurricanes ┆ Eastern         ┆ Metropolitan  ┆ 81           ┆ 52   ┆ 22     ┆ 111    │
+    │ Dallas Stars        ┆ Western         ┆ Central       ┆ 81           ┆ 51   ┆ 21     ┆ 111    │
+    │ Boston Bruins       ┆ Eastern         ┆ Atlantic      ┆ 81           ┆ 47   ┆ 19     ┆ 109    │
+    │ Florida Panthers    ┆ Eastern         ┆ Atlantic      ┆ 81           ┆ 51   ┆ 24     ┆ 108    │
+    └─────────────────────┴─────────────────┴───────────────┴──────────────┴──────┴────────┴────────┘
+
+
 
 ## 🛰️ NHL EDGE — player & puck tracking
 
@@ -220,6 +326,24 @@ else:
 out
 ```
 
+    ✅ EDGE skating speed
+
+
+
+
+
+    shape: (1, 5)
+    ┌───────────────────┬───────────────────┬───────────────────┬───────────────────┬──────────────────┐
+    │ skating_speed_det ┆ skating_speed_det ┆ skating_speed_det ┆ skating_speed_det ┆ skating_speed_de │
+    │ ails_max_skat…    ┆ ails_max_skat…    ┆ ails_max_skat…    ┆ ails_bursts_o…    ┆ tails_bursts_o…  │
+    │ ---               ┆ ---               ┆ ---               ┆ ---               ┆ ---              │
+    │ f64               ┆ f64               ┆ f64               ┆ i64               ┆ f64              │
+    ╞═══════════════════╪═══════════════════╪═══════════════════╪═══════════════════╪══════════════════╡
+    │ 24.191            ┆ 22.0904           ┆ 0.9984            ┆ 66                ┆ 0.9984           │
+    └───────────────────┴───────────────────┴───────────────────┴───────────────────┴──────────────────┘
+
+
+
 ## 📈 Stats-REST & Records flat APIs
 
 Two more first-party surfaces round out the kit:
@@ -243,6 +367,32 @@ else:
     out = 'leaders unavailable'
 out
 ```
+
+    ✅ stats-rest goal leaders
+
+
+
+
+
+    shape: (10, 4)
+    ┌───────────────────┬──────────────────────┬───────────────┬───────┐
+    │ player_full_name  ┆ player_position_code ┆ team_tri_code ┆ goals │
+    │ ---               ┆ ---                  ┆ ---           ┆ ---   │
+    │ str               ┆ str                  ┆ str           ┆ i64   │
+    ╞═══════════════════╪══════════════════════╪═══════════════╪═══════╡
+    │ Wayne Gretzky     ┆ C                    ┆ EDM           ┆ 92    │
+    │ Wayne Gretzky     ┆ C                    ┆ EDM           ┆ 87    │
+    │ Brett Hull        ┆ R                    ┆ STL           ┆ 86    │
+    │ Mario Lemieux     ┆ C                    ┆ PIT           ┆ 85    │
+    │ Phil Esposito     ┆ C                    ┆ BOS           ┆ 76    │
+    │ Teemu Selanne     ┆ R                    ┆ WIN           ┆ 76    │
+    │ Alexander Mogilny ┆ R                    ┆ BUF           ┆ 76    │
+    │ Wayne Gretzky     ┆ C                    ┆ EDM           ┆ 73    │
+    │ Brett Hull        ┆ R                    ┆ STL           ┆ 72    │
+    │ Wayne Gretzky     ┆ C                    ┆ EDM           ┆ 71    │
+    └───────────────────┴──────────────────────┴───────────────┴───────┘
+
+
 
 ## 🍳 Cookbook: common NHL tasks
 
@@ -272,6 +422,11 @@ else:
     print('no schedule rows to pick a game_id from')
 ```
 
+    ✅ boxscore 2023030417
+    ✅ pbp 2023030417
+    players in box: 40 | pbp events: 331
+
+
 ### Recipe 2 — A team, its schedule & its roster 👥
 
 Use the team tri-code (e.g. `FLA`) with
@@ -296,6 +451,32 @@ else:
 out
 ```
 
+    ✅ FLA schedule
+
+
+    ✅ FLA roster
+    games: 114 | roster size: 22
+
+
+
+
+
+    shape: (5, 6)
+    ┌─────────┬───────────────────┬──────────────────┬────────────────┬───────────────┬────────────────┐
+    │ id      ┆ first_name_defaul ┆ last_name_defaul ┆ sweater_number ┆ position_code ┆ shoots_catches │
+    │ ---     ┆ t                 ┆ t                ┆ ---            ┆ ---           ┆ ---            │
+    │ i64     ┆ ---               ┆ ---              ┆ i64            ┆ str           ┆ str            │
+    │         ┆ str               ┆ str              ┆                ┆               ┆                │
+    ╞═════════╪═══════════════════╪══════════════════╪════════════════╪═══════════════╪════════════════╡
+    │ 8477493 ┆ Aleksander        ┆ Barkov           ┆ 16             ┆ C             ┆ L              │
+    │ 8477935 ┆ Sam               ┆ Bennett          ┆ 9              ┆ C             ┆ L              │
+    │ 8479981 ┆ Jonah             ┆ Gadjovich        ┆ 12             ┆ L             ┆ L              │
+    │ 8480825 ┆ Patrick           ┆ Giles            ┆ 36             ┆ R             ┆ R              │
+    │ 8479367 ┆ William           ┆ Lockwood         ┆ 67             ┆ R             ┆ R              │
+    └─────────┴───────────────────┴──────────────────┴────────────────┴───────────────┴────────────────┘
+
+
+
 ### Recipe 3 — A player's game log + the league leaderboard ⚡
 
 Pair a single player's [`nhl_player_game_log`](../nhl/reference/nhl_api_web.md#nhl_player_game_log)
@@ -315,6 +496,27 @@ else:
 out
 ```
 
+    ✅ McDavid game log
+
+
+
+
+
+    shape: (5, 7)
+    ┌────────────┬─────────────────┬───────┬─────────┬────────┬───────┬───────┐
+    │ game_date  ┆ opponent_abbrev ┆ goals ┆ assists ┆ points ┆ shots ┆ toi   │
+    │ ---        ┆ ---             ┆ ---   ┆ ---     ┆ ---    ┆ ---   ┆ ---   │
+    │ str        ┆ str             ┆ i64   ┆ i64     ┆ i64    ┆ i64   ┆ str   │
+    ╞════════════╪═════════════════╪═══════╪═════════╪════════╪═══════╪═══════╡
+    │ 2024-04-17 ┆ ARI             ┆ 0     ┆ 0       ┆ 0      ┆ 2     ┆ 18:10 │
+    │ 2024-04-15 ┆ SJS             ┆ 1     ┆ 1       ┆ 2      ┆ 3     ┆ 15:45 │
+    │ 2024-04-06 ┆ CGY             ┆ 0     ┆ 2       ┆ 2      ┆ 3     ┆ 20:39 │
+    │ 2024-04-05 ┆ COL             ┆ 2     ┆ 0       ┆ 2      ┆ 9     ┆ 20:11 │
+    │ 2024-04-03 ┆ DAL             ┆ 0     ┆ 0       ┆ 0      ┆ 8     ┆ 20:05 │
+    └────────────┴─────────────────┴───────┴─────────┴────────┴───────┴───────┘
+
+
+
 
 ```python
 board = safe('skater leaders', lambda: nhl.nhl_skater_leaders(season=SEASON))
@@ -325,6 +527,32 @@ else:
     out = 'leaders unavailable'
 out
 ```
+
+    ✅ skater leaders
+
+
+
+
+
+    shape: (10, 5)
+    ┌───────────┬────────────────────┬───────────────────┬─────────────┬───────┐
+    │ category  ┆ first_name_default ┆ last_name_default ┆ team_abbrev ┆ value │
+    │ ---       ┆ ---                ┆ ---               ┆ ---         ┆ ---   │
+    │ str       ┆ str                ┆ str               ┆ str         ┆ f64   │
+    ╞═══════════╪════════════════════╪═══════════════════╪═════════════╪═══════╡
+    │ goalsSh   ┆ Travis             ┆ Konecny           ┆ PHI         ┆ 6.0   │
+    │ goalsSh   ┆ Sam                ┆ Reinhart          ┆ FLA         ┆ 5.0   │
+    │ goalsSh   ┆ Simon              ┆ Holmstrom         ┆ NYI         ┆ 5.0   │
+    │ goalsSh   ┆ Blake              ┆ Coleman           ┆ CGY         ┆ 4.0   │
+    │ goalsSh   ┆ Colton             ┆ Sissons           ┆ NSH         ┆ 3.0   │
+    │ plusMinus ┆ Gustav             ┆ Forsling          ┆ FLA         ┆ 56.0  │
+    │ plusMinus ┆ Dylan              ┆ DeMelo            ┆ WPG         ┆ 46.0  │
+    │ plusMinus ┆ Mattias            ┆ Ekholm            ┆ EDM         ┆ 44.0  │
+    │ plusMinus ┆ Quinn              ┆ Hughes            ┆ VAN         ┆ 38.0  │
+    │ plusMinus ┆ Zach               ┆ Hyman             ┆ EDM         ┆ 36.0  │
+    └───────────┴────────────────────┴───────────────────┴─────────────┴───────┘
+
+
 
 ### Recipe 4 — An EDGE tracking leaderboard 🛰️
 
@@ -345,6 +573,24 @@ else:
 out
 ```
 
+    ✅ EDGE skater leaders
+
+
+
+
+
+    shape: (1, 4)
+    ┌────────────────────────┬────────────────────────┬────────────────────────┬───────────────────────┐
+    │ leaders_hardest_shot_p ┆ leaders_hardest_shot_p ┆ leaders_hardest_shot_p ┆ leaders_hardest_shot_ │
+    │ layer_fi…              ┆ layer_la…              ┆ layer_po…              ┆ player_te…            │
+    │ ---                    ┆ ---                    ┆ ---                    ┆ ---                   │
+    │ str                    ┆ str                    ┆ str                    ┆ str                   │
+    ╞════════════════════════╪════════════════════════╪════════════════════════╪═══════════════════════╡
+    │ Colin                  ┆ Miller                 ┆ D                      ┆ WPG                   │
+    └────────────────────────┴────────────────────────┴────────────────────────┴───────────────────────┘
+
+
+
 ### Recipe 5 — Who's hot? Standings by last-10 form 🔥
 
 The native [`nhl_standings`](../nhl/reference/nhl_api_web.md#nhl_standings)
@@ -364,6 +610,39 @@ else:
     out = 'standings unavailable'
 out
 ```
+
+    ✅ standings as-of date
+
+
+
+
+
+    shape: (8, 8)
+    ┌─────────────┬──────────┬────────────┬────────────┬────────────┬────────────┬────────────┬────────┐
+    │ team_name_d ┆ l10_wins ┆ l10_losses ┆ l10_ot_los ┆ l10_points ┆ streak_cod ┆ streak_cou ┆ points │
+    │ efault      ┆ ---      ┆ ---        ┆ ses        ┆ ---        ┆ e          ┆ nt         ┆ ---    │
+    │ ---         ┆ i64      ┆ i64        ┆ ---        ┆ i64        ┆ ---        ┆ ---        ┆ i64    │
+    │ str         ┆          ┆            ┆ i64        ┆            ┆ str        ┆ i64        ┆        │
+    ╞═════════════╪══════════╪════════════╪════════════╪════════════╪════════════╪════════════╪════════╡
+    │ New York    ┆ 8        ┆ 1          ┆ 1          ┆ 17         ┆ W          ┆ 1          ┆ 92     │
+    │ Islanders   ┆          ┆            ┆            ┆            ┆            ┆            ┆        │
+    │ Carolina    ┆ 8        ┆ 2          ┆ 0          ┆ 16         ┆ W          ┆ 5          ┆ 111    │
+    │ Hurricanes  ┆          ┆            ┆            ┆            ┆            ┆            ┆        │
+    │ Dallas      ┆ 8        ┆ 2          ┆ 0          ┆ 16         ┆ W          ┆ 1          ┆ 111    │
+    │ Stars       ┆          ┆            ┆            ┆            ┆            ┆            ┆        │
+    │ Pittsburgh  ┆ 7        ┆ 1          ┆ 2          ┆ 16         ┆ W          ┆ 1          ┆ 88     │
+    │ Penguins    ┆          ┆            ┆            ┆            ┆            ┆            ┆        │
+    │ New York    ┆ 7        ┆ 3          ┆ 0          ┆ 14         ┆ W          ┆ 2          ┆ 114    │
+    │ Rangers     ┆          ┆            ┆            ┆            ┆            ┆            ┆        │
+    │ Edmonton    ┆ 6        ┆ 2          ┆ 2          ┆ 14         ┆ W          ┆ 1          ┆ 104    │
+    │ Oilers      ┆          ┆            ┆            ┆            ┆            ┆            ┆        │
+    │ Winnipeg    ┆ 6        ┆ 3          ┆ 1          ┆ 13         ┆ W          ┆ 6          ┆ 106    │
+    │ Jets        ┆          ┆            ┆            ┆            ┆            ┆            ┆        │
+    │ Toronto     ┆ 6        ┆ 3          ┆ 1          ┆ 13         ┆ OT         ┆ 1          ┆ 102    │
+    │ Maple Leafs ┆          ┆            ┆            ┆            ┆            ┆            ┆        │
+    └─────────────┴──────────┴────────────┴────────────┴────────────┴────────────┴────────────┴────────┘
+
+
 
 ### Recipe 6 — A whole team's stat lines in one call 📋
 
@@ -386,6 +665,32 @@ else:
     out = 'club stats unavailable'
 out
 ```
+
+    ✅ FLA club stats
+
+
+
+
+
+    shape: (8, 9)
+    ┌─────────────┬─────────────┬─────────────┬────────────┬───┬─────────┬────────┬───────┬────────────┐
+    │ first_name_ ┆ last_name_d ┆ position_co ┆ games_play ┆ … ┆ assists ┆ points ┆ shots ┆ avg_time_o │
+    │ default     ┆ efault      ┆ de          ┆ ed         ┆   ┆ ---     ┆ ---    ┆ ---   ┆ n_ice_per_ │
+    │ ---         ┆ ---         ┆ ---         ┆ ---        ┆   ┆ i64     ┆ i64    ┆ i64   ┆ game       │
+    │ str         ┆ str         ┆ str         ┆ i64        ┆   ┆         ┆        ┆       ┆ ---        │
+    │             ┆             ┆             ┆            ┆   ┆         ┆        ┆       ┆ f64        │
+    ╞═════════════╪═════════════╪═════════════╪════════════╪═══╪═════════╪════════╪═══════╪════════════╡
+    │ Sam         ┆ Reinhart    ┆ C           ┆ 82         ┆ … ┆ 37      ┆ 94     ┆ 233   ┆ 1217.9878  │
+    │ Matthew     ┆ Tkachuk     ┆ L           ┆ 80         ┆ … ┆ 62      ┆ 88     ┆ 280   ┆ 1118.4     │
+    │ Aleksander  ┆ Barkov      ┆ C           ┆ 73         ┆ … ┆ 57      ┆ 80     ┆ 193   ┆ 1178.2055  │
+    │ Carter      ┆ Verhaeghe   ┆ C           ┆ 76         ┆ … ┆ 38      ┆ 72     ┆ 246   ┆ 1077.75    │
+    │ Sam         ┆ Bennett     ┆ C           ┆ 69         ┆ … ┆ 21      ┆ 41     ┆ 171   ┆ 996.5942   │
+    │ Gustav      ┆ Forsling    ┆ D           ┆ 79         ┆ … ┆ 29      ┆ 39     ┆ 160   ┆ 1328.519   │
+    │ Evan        ┆ Rodrigues   ┆ C           ┆ 80         ┆ … ┆ 27      ┆ 39     ┆ 186   ┆ 910.0375   │
+    │ Anton       ┆ Lundell     ┆ C           ┆ 78         ┆ … ┆ 22      ┆ 35     ┆ 166   ┆ 922.5769   │
+    └─────────────┴─────────────┴─────────────┴────────────┴───┴─────────┴────────┴───────┴────────────┘
+
+
 
 ### Recipe 7 — Goalie leaderboard + a netminder's bio 🥅
 
@@ -411,6 +716,27 @@ else:
 out
 ```
 
+    ✅ goalie leaders
+
+
+
+
+
+    shape: (5, 5)
+    ┌──────────┬────────────────────┬───────────────────┬─────────────┬───────┐
+    │ category ┆ first_name_default ┆ last_name_default ┆ team_abbrev ┆ value │
+    │ ---      ┆ ---                ┆ ---               ┆ ---         ┆ ---   │
+    │ str      ┆ str                ┆ str               ┆ str         ┆ f64   │
+    ╞══════════╪════════════════════╪═══════════════════╪═════════════╪═══════╡
+    │ wins     ┆ Alexandar          ┆ Georgiev          ┆ COL         ┆ 38.0  │
+    │ wins     ┆ Connor             ┆ Hellebuyck        ┆ WPG         ┆ 37.0  │
+    │ wins     ┆ Stuart             ┆ Skinner           ┆ EDM         ┆ 36.0  │
+    │ wins     ┆ Sergei             ┆ Bobrovsky         ┆ FLA         ┆ 36.0  │
+    │ wins     ┆ Igor               ┆ Shesterkin        ┆ NYR         ┆ 36.0  │
+    └──────────┴────────────────────┴───────────────────┴─────────────┴───────┘
+
+
+
 
 ```python
 # Bobrovsky's bio card (player_id 8475683) — one wide row
@@ -425,6 +751,25 @@ else:
     out = 'player landing unavailable'
 out
 ```
+
+    ✅ goalie landing
+
+
+
+
+
+    shape: (1, 8)
+    ┌────────────┬────────────┬──────────┬────────────┬────────────┬───────────┬───────────┬───────────┐
+    │ first_name ┆ last_name_ ┆ position ┆ current_te ┆ height_in_ ┆ weight_in ┆ birth_cit ┆ birth_cou │
+    │ _default   ┆ default    ┆ ---      ┆ am_abbrev  ┆ inches     ┆ _pounds   ┆ y_default ┆ ntry      │
+    │ ---        ┆ ---        ┆ str      ┆ ---        ┆ ---        ┆ ---       ┆ ---       ┆ ---       │
+    │ str        ┆ str        ┆          ┆ str        ┆ i64        ┆ i64       ┆ str       ┆ str       │
+    ╞════════════╪════════════╪══════════╪════════════╪════════════╪═══════════╪═══════════╪═══════════╡
+    │ Sergei     ┆ Bobrovsky  ┆ G        ┆ FLA        ┆ 74         ┆ 180       ┆ Novokuzne ┆ RUS       │
+    │            ┆            ┆          ┆            ┆            ┆           ┆ tsk       ┆           │
+    └────────────┴────────────┴──────────┴────────────┴────────────┴───────────┴───────────┴───────────┘
+
+
 
 ### Recipe 8 — Home vs road splits, derived from a schedule 🏠✈️
 
@@ -462,6 +807,24 @@ else:
 out
 ```
 
+    ✅ FLA season schedule
+
+
+
+
+
+    shape: (2, 5)
+    ┌───────┬─────┬──────┬─────────────┬─────────────┐
+    │ venue ┆ gp  ┆ wins ┆ gf_per_game ┆ ga_per_game │
+    │ ---   ┆ --- ┆ ---  ┆ ---         ┆ ---         │
+    │ str   ┆ u32 ┆ u32  ┆ f64         ┆ f64         │
+    ╞═══════╪═════╪══════╪═════════════╪═════════════╡
+    │ home  ┆ 41  ┆ 26   ┆ 3.15        ┆ 2.56        │
+    │ road  ┆ 41  ┆ 26   ┆ 3.39        ┆ 2.32        │
+    └───────┴─────┴──────┴─────────────┴─────────────┘
+
+
+
 ### Recipe 9 — Pull a draft board 🎟️
 
 [`nhl_draft_picks`](../nhl/reference/nhl_api_web.md#nhl_draft_picks) returns one
@@ -482,6 +845,35 @@ else:
     out = 'draft board unavailable'
 out
 ```
+
+    ✅ 2023 draft round 1
+
+
+
+
+
+    shape: (10, 7)
+    ┌──────────────┬─────────────┬─────────────┬─────────────┬─────────────┬─────────────┬─────────────┐
+    │ overall_pick ┆ team_abbrev ┆ first_name_ ┆ last_name_d ┆ position_co ┆ amateur_clu ┆ amateur_lea │
+    │ ---          ┆ ---         ┆ default     ┆ efault      ┆ de          ┆ b_name      ┆ gue         │
+    │ i64          ┆ str         ┆ ---         ┆ ---         ┆ ---         ┆ ---         ┆ ---         │
+    │              ┆             ┆ str         ┆ str         ┆ str         ┆ str         ┆ str         │
+    ╞══════════════╪═════════════╪═════════════╪═════════════╪═════════════╪═════════════╪═════════════╡
+    │ 1            ┆ CHI         ┆ Connor      ┆ Bedard      ┆ C           ┆ Regina      ┆ WHL         │
+    │ 2            ┆ ANA         ┆ Leo         ┆ Carlsson    ┆ C           ┆ Orebro      ┆ SWEDEN      │
+    │ 3            ┆ CBJ         ┆ Adam        ┆ Fantilli    ┆ C           ┆ Michigan    ┆ BIG10       │
+    │ 4            ┆ SJS         ┆ Will        ┆ Smith       ┆ C           ┆ USA U-18    ┆ NTDP        │
+    │ 5            ┆ MTL         ┆ David       ┆ Reinbacher  ┆ D           ┆ Kloten      ┆ SWISS       │
+    │ 6            ┆ ARI         ┆ Dmitriy     ┆ Simashev    ┆ D           ┆ Yaroslavl   ┆ RUSSIA-JR.  │
+    │              ┆             ┆             ┆             ┆             ┆ Jr.         ┆             │
+    │ 7            ┆ PHI         ┆ Matvei      ┆ Michkov     ┆ RW          ┆ SKA St.     ┆ RUSSIA      │
+    │              ┆             ┆             ┆             ┆             ┆ Petersburg  ┆             │
+    │ 8            ┆ WSH         ┆ Ryan        ┆ Leonard     ┆ RW          ┆ USA U-18    ┆ NTDP        │
+    │ 9            ┆ DET         ┆ Nate        ┆ Danielson   ┆ C           ┆ Brandon     ┆ WHL         │
+    │ 10           ┆ STL         ┆ Dalibor     ┆ Dvorsky     ┆ C           ┆ AIK         ┆ SWEDEN-2    │
+    └──────────────┴─────────────┴─────────────┴─────────────┴─────────────┴─────────────┴─────────────┘
+
+
 
 ### Recipe 10 — Season-to-date team aggregates (loader + pandas) 📦🐼
 
@@ -507,6 +899,16 @@ else:
     out = 'team box loader unavailable'
 out
 ```
+
+    ✅ team box 2024
+
+
+
+
+
+    'team box loader unavailable'
+
+
 
 ### Recipe 11 — All-time franchise standings (Records API join) 🏛️
 
@@ -535,6 +937,33 @@ else:
 out
 ```
 
+    ✅ franchise team totals
+    ✅ franchises
+
+
+
+
+
+    shape: (10, 6)
+    ┌─────────────────────┬──────────────┬────────┬────────┬────────┬──────┐
+    │ full_name           ┆ games_played ┆ wins   ┆ losses ┆ points ┆ cups │
+    │ ---                 ┆ ---          ┆ ---    ┆ ---    ┆ ---    ┆ ---  │
+    │ str                 ┆ f64          ┆ f64    ┆ f64    ┆ f64    ┆ i64  │
+    ╞═════════════════════╪══════════════╪════════╪════════╪════════╪══════╡
+    │ Montréal Canadiens  ┆ 7197.0       ┆ 3644.0 ┆ 2487.0 ┆ 8354.0 ┆ 23   │
+    │ Boston Bruins       ┆ 7036.0       ┆ 3482.0 ┆ 2527.0 ┆ 7991.0 ┆ 6    │
+    │ New York Rangers    ┆ 6970.0       ┆ 3110.0 ┆ 2860.0 ┆ 7220.0 ┆ 4    │
+    │ Toronto Maple Leafs ┆ 6926.0       ┆ 3107.0 ┆ 2826.0 ┆ 7207.0 ┆ 11   │
+    │ Detroit Red Wings   ┆ 6703.0       ┆ 3079.0 ┆ 2621.0 ┆ 7161.0 ┆ 11   │
+    │ Chicago Blackhawks  ┆ 6970.0       ┆ 2943.0 ┆ 2990.0 ┆ 6923.0 ┆ 6    │
+    │ Philadelphia Flyers ┆ 4581.0       ┆ 2249.0 ┆ 1635.0 ┆ 5195.0 ┆ 2    │
+    │ St. Louis Blues     ┆ 4583.0       ┆ 2139.0 ┆ 1801.0 ┆ 4921.0 ┆ 1    │
+    │ Pittsburgh Penguins ┆ 4581.0       ┆ 2102.0 ┆ 1883.0 ┆ 4800.0 ┆ 5    │
+    │ Buffalo Sabres      ┆ 4355.0       ┆ 2004.0 ┆ 1735.0 ┆ 4624.0 ┆ 0    │
+    └─────────────────────┴──────────────┴────────┴────────┴────────┴──────┘
+
+
+
 ### Recipe 12 — EDGE tracking leaders: team & goalie 🛰️
 
 Round out the tour with two more EDGE *landing* boards. Each is a wide
@@ -556,6 +985,24 @@ else:
 out
 ```
 
+    ✅ EDGE team leaders
+
+
+
+
+
+    shape: (1, 3)
+    ┌────────────────────────────────┬────────────────────────────────┬────────────────────────────────┐
+    │ leaders_shot_attempts_over90_t ┆ leaders_shot_attempts_over90_t ┆ leaders_shot_attempts_over90_a │
+    │ …                              ┆ …                              ┆ …                              │
+    │ ---                            ┆ ---                            ┆ ---                            │
+    │ str                            ┆ str                            ┆ i64                            │
+    ╞════════════════════════════════╪════════════════════════════════╪════════════════════════════════╡
+    │ Oilers                         ┆ EDM                            ┆ 167                            │
+    └────────────────────────────────┴────────────────────────────────┴────────────────────────────────┘
+
+
+
 
 ```python
 gl = safe('EDGE goalie leaders', lambda: nhl.nhl_edge_goalie_landing(season=SEASON))
@@ -571,6 +1018,24 @@ else:
     out = 'EDGE goalie leaders unavailable'
 out
 ```
+
+    ✅ EDGE goalie leaders
+
+
+
+
+
+    shape: (1, 4)
+    ┌────────────────────────┬────────────────────────┬────────────────────────┬───────────────────────┐
+    │ leaders_high_danger_sa ┆ leaders_high_danger_sa ┆ leaders_high_danger_sa ┆ leaders_high_danger_s │
+    │ ve_pctg_…              ┆ ve_pctg_…              ┆ ve_pctg_…              ┆ ave_pctg_…            │
+    │ ---                    ┆ ---                    ┆ ---                    ┆ ---                   │
+    │ str                    ┆ str                    ┆ str                    ┆ f64                   │
+    ╞════════════════════════╪════════════════════════╪════════════════════════╪═══════════════════════╡
+    │ Anthony                ┆ Stolarz                ┆ FLA                    ┆ 0.860697              │
+    └────────────────────────┴────────────────────────┴────────────────────────┴───────────────────────┘
+
+
 
 ## 🛟 ESPN NHL (`espn_nhl_*`) — the secondary path
 
@@ -600,6 +1065,27 @@ else:
 out
 ```
 
+    ✅ ESPN teams
+
+
+
+
+
+    shape: (5, 5)
+    ┌─────────┬───────────────┬────────────┬───────────────────┬─────────────────────┐
+    │ team_id ┆ team_location ┆ team_name  ┆ team_abbreviation ┆ team_display_name   │
+    │ ---     ┆ ---           ┆ ---        ┆ ---               ┆ ---                 │
+    │ str     ┆ str           ┆ str        ┆ str               ┆ str                 │
+    ╞═════════╪═══════════════╪════════════╪═══════════════════╪═════════════════════╡
+    │ 25      ┆ Anaheim       ┆ Ducks      ┆ ANA               ┆ Anaheim Ducks       │
+    │ 1       ┆ Boston        ┆ Bruins     ┆ BOS               ┆ Boston Bruins       │
+    │ 2       ┆ Buffalo       ┆ Sabres     ┆ BUF               ┆ Buffalo Sabres      │
+    │ 3       ┆ Calgary       ┆ Flames     ┆ CGY               ┆ Calgary Flames      │
+    │ 7       ┆ Carolina      ┆ Hurricanes ┆ CAR               ┆ Carolina Hurricanes │
+    └─────────┴───────────────┴────────────┴───────────────────┴─────────────────────┘
+
+
+
 
 ```python
 espn_pbp = safe(f'ESPN pbp {ESPN_GAME}', lambda: nhl.espn_nhl_pbp(game_id=ESPN_GAME))
@@ -613,6 +1099,32 @@ else:
     out = 'ESPN pbp unavailable'
 out
 ```
+
+    ✅ ESPN pbp 401675111
+    ESPN plays: 328
+
+
+
+
+
+    shape: (5, 5)
+    ┌───────────────┬────────────────────┬────────────────────────────────┬──────────────┬─────────────┐
+    │ period.number ┆ clock.displayValue ┆ text                           ┆ type.text    ┆ scoringPlay │
+    │ ---           ┆ ---                ┆ ---                            ┆ ---          ┆ ---         │
+    │ i64           ┆ str                ┆ str                            ┆ str          ┆ bool        │
+    ╞═══════════════╪════════════════════╪════════════════════════════════╪══════════════╪═════════════╡
+    │ 1             ┆ 0:00               ┆ Start of 1st Period            ┆ Period Start ┆ false       │
+    │ 1             ┆ 0:00               ┆ Adam Henrique faceoff won      ┆ Face Off     ┆ false       │
+    │               ┆                    ┆ agai…                          ┆              ┆             │
+    │ 1             ┆ 0:21               ┆ Adam Henrique Tip-In saved by  ┆ Shot         ┆ false       │
+    │               ┆                    ┆ …                              ┆              ┆             │
+    │ 1             ┆ 0:31               ┆ Anton Lundell Backhand Wide    ┆ Missed       ┆ false       │
+    │               ┆                    ┆ Le…                            ┆              ┆             │
+    │ 1             ┆ 0:40               ┆ Matthew Tkachuk shot blocked   ┆ Blocked      ┆ false       │
+    │               ┆                    ┆ b…                             ┆              ┆             │
+    └───────────────┴────────────────────┴────────────────────────────────┴──────────────┴─────────────┘
+
+
 
 ## 📦 Parquet loaders (`load_nhl_*`)
 
@@ -639,6 +1151,28 @@ else:
     out = 'release loader unavailable'
 out
 ```
+
+    ✅ load schedule 2024
+    release schedule shape: (1400, 35)
+
+
+
+
+
+    shape: (5, 6)
+    ┌────────────┬────────────┬────────────────┬────────────────┬────────────┬────────────┐
+    │ game_id    ┆ game_date  ┆ home_team_name ┆ away_team_name ┆ home_score ┆ away_score │
+    │ ---        ┆ ---        ┆ ---            ┆ ---            ┆ ---        ┆ ---        │
+    │ i32        ┆ str        ┆ str            ┆ str            ┆ i32        ┆ i32        │
+    ╞════════════╪════════════╪════════════════╪════════════════╪════════════╪════════════╡
+    │ 2023030417 ┆ 2024-06-25 ┆ Florida        ┆ Edmonton       ┆ 2          ┆ 1          │
+    │ 2023030416 ┆ 2024-06-22 ┆ Edmonton       ┆ Florida        ┆ 5          ┆ 1          │
+    │ 2023030415 ┆ 2024-06-19 ┆ Florida        ┆ Edmonton       ┆ 3          ┆ 5          │
+    │ 2023030414 ┆ 2024-06-16 ┆ Edmonton       ┆ Florida        ┆ 8          ┆ 1          │
+    │ 2023030413 ┆ 2024-06-14 ┆ Edmonton       ┆ Florida        ┆ 3          ┆ 4          │
+    └────────────┴────────────┴────────────────┴────────────────┴────────────┴────────────┘
+
+
 
 ## 🎉 Where to next
 

--- a/docs/docs/tutorials/08_wnba_intro.md
+++ b/docs/docs/tutorials/08_wnba_intro.md
@@ -58,6 +58,9 @@ SEASON = 2024  # a complete season, so every cell has data to show
 print('most recent WNBA season:', wnba.most_recent_wnba_season())
 ```
 
+    most recent WNBA season: 2026
+
+
 ESPN's live endpoints are seasonal and occasionally rate-limited, so a tiny `safe()` helper runs each risky call defensively — you get the frame when the feed is up, and a friendly one-liner when it isn't (never a scary traceback). The `load_wnba_*` loaders read static parquet releases and are rock-solid, so we let those run bare. 🛟
 
 
@@ -86,6 +89,34 @@ print('shape:', None if teams is None else teams.shape)
  if teams is not None else 'teams unavailable')
 ```
 
+    ✅ WNBA teams
+    shape: (15, 14)
+
+
+
+
+
+    shape: (15, 5)
+    ┌─────────┬───────────────┬───────────┬───────────────────┬────────────────────────┐
+    │ team_id ┆ team_location ┆ team_name ┆ team_abbreviation ┆ team_display_name      │
+    │ ---     ┆ ---           ┆ ---       ┆ ---               ┆ ---                    │
+    │ str     ┆ str           ┆ str       ┆ str               ┆ str                    │
+    ╞═════════╪═══════════════╪═══════════╪═══════════════════╪════════════════════════╡
+    │ 20      ┆ Atlanta       ┆ Dream     ┆ ATL               ┆ Atlanta Dream          │
+    │ 19      ┆ Chicago       ┆ Sky       ┆ CHI               ┆ Chicago Sky            │
+    │ 18      ┆ Connecticut   ┆ Sun       ┆ CON               ┆ Connecticut Sun        │
+    │ 3       ┆ Dallas        ┆ Wings     ┆ DAL               ┆ Dallas Wings           │
+    │ 129689  ┆ Golden State  ┆ Valkyries ┆ GS                ┆ Golden State Valkyries │
+    │ …       ┆ …             ┆ …         ┆ …                 ┆ …                      │
+    │ 11      ┆ Phoenix       ┆ Mercury   ┆ PHX               ┆ Phoenix Mercury        │
+    │ 132052  ┆ Portland      ┆ Fire      ┆ POR               ┆ Portland Fire          │
+    │ 14      ┆ Seattle       ┆ Storm     ┆ SEA               ┆ Seattle Storm          │
+    │ 131935  ┆ Toronto       ┆ Tempo     ┆ TOR               ┆ Toronto Tempo          │
+    │ 16      ┆ Washington    ┆ Mystics   ┆ WSH               ┆ Washington Mystics     │
+    └─────────┴───────────────┴───────────┴───────────────────┴────────────────────────┘
+
+
+
 ## 👥 Team roster — Las Vegas Aces
 
 [`espn_wnba_team_roster`](../wnba/reference/site.md#espn_wnba_team_roster) lists active players for one team in a season. The back-to-back champion Aces are `team_id=17`. Player columns are unprefixed (`athlete_id`, `full_name`, `jersey`, `position_abbreviation`).
@@ -97,6 +128,33 @@ aces = safe('Aces roster', lambda: wnba.espn_wnba_team_roster(team_id=17, season
               'position_abbreviation', 'display_height', 'age']).head(12)
  if aces is not None else 'roster unavailable')
 ```
+
+    ✅ Aces roster
+
+
+
+
+
+    shape: (12, 6)
+    ┌────────────┬──────────────────┬────────┬───────────────────────┬────────────────┬─────┐
+    │ athlete_id ┆ full_name        ┆ jersey ┆ position_abbreviation ┆ display_height ┆ age │
+    │ ---        ┆ ---              ┆ ---    ┆ ---                   ┆ ---            ┆ --- │
+    │ str        ┆ str              ┆ str    ┆ str                   ┆ str            ┆ i64 │
+    ╞════════════╪══════════════════╪════════╪═══════════════════════╪════════════════╪═════╡
+    │ 4565501    ┆ Janiah Barker    ┆ 2      ┆ F                     ┆ 6' 4"          ┆ 22  │
+    │ 4433633    ┆ Kierstan Bell    ┆ 1      ┆ F                     ┆ 6' 1"          ┆ 26  │
+    │ 4280892    ┆ Chennedy Carter  ┆ 23     ┆ G                     ┆ 5' 9"          ┆ 27  │
+    │ 4281190    ┆ Dana Evans       ┆ 11     ┆ G                     ┆ 5' 6"          ┆ 27  │
+    │ 2529122    ┆ Chelsea Gray     ┆ 12     ┆ G                     ┆ 5' 11"         ┆ 33  │
+    │ …          ┆ …                ┆ …      ┆ …                     ┆ …              ┆ …   │
+    │ 4398776    ┆ NaLyssa Smith    ┆ 3      ┆ F                     ┆ 6' 4"          ┆ 25  │
+    │ 3099736    ┆ Stephanie Talbot ┆ 7      ┆ F                     ┆ 6' 2"          ┆ 31  │
+    │ 3142086    ┆ Brianna Turner   ┆ 21     ┆ F                     ┆ 6' 3"          ┆ 29  │
+    │ 3149391    ┆ A'ja Wilson      ┆ 22     ┆ C                     ┆ 6' 4"          ┆ 29  │
+    │ 4065870    ┆ Jackie Young     ┆ 0      ┆ G                     ┆ 6' 0"          ┆ 28  │
+    └────────────┴──────────────────┴────────┴───────────────────────┴────────────────┴─────┘
+
+
 
 ## 📅 Schedule
 
@@ -122,6 +180,30 @@ else:
 out
 ```
 
+    ✅ 2024 Finals schedule
+
+
+
+
+
+    shape: (3, 9)
+    ┌───────────┬────────────┬────────────┬────────────┬───┬────────────┬──────────┬──────────┬────────┐
+    │ id        ┆ home_displ ┆ away_displ ┆ home_score ┆ … ┆ status_typ ┆ home_pts ┆ away_pts ┆ margin │
+    │ ---       ┆ ay_name    ┆ ay_name    ┆ ---        ┆   ┆ e_descript ┆ ---      ┆ ---      ┆ ---    │
+    │ str       ┆ ---        ┆ ---        ┆ str        ┆   ┆ ion        ┆ i64      ┆ i64      ┆ i64    │
+    │           ┆ str        ┆ str        ┆            ┆   ┆ ---        ┆          ┆          ┆        │
+    │           ┆            ┆            ┆            ┆   ┆ str        ┆          ┆          ┆        │
+    ╞═══════════╪════════════╪════════════╪════════════╪═══╪════════════╪══════════╪══════════╪════════╡
+    │ 401726990 ┆ Minnesota  ┆ New York   ┆ 77         ┆ … ┆ Final      ┆ 77       ┆ 80       ┆ 3      │
+    │           ┆ Lynx       ┆ Liberty    ┆            ┆   ┆            ┆          ┆          ┆        │
+    │ 401726991 ┆ Minnesota  ┆ New York   ┆ 82         ┆ … ┆ Final      ┆ 82       ┆ 80       ┆ 2      │
+    │           ┆ Lynx       ┆ Liberty    ┆            ┆   ┆            ┆          ┆          ┆        │
+    │ 401726992 ┆ New York   ┆ Minnesota  ┆ 67         ┆ … ┆ Final      ┆ 67       ┆ 62       ┆ 5      │
+    │           ┆ Liberty    ┆ Lynx       ┆            ┆   ┆            ┆          ┆          ┆        │
+    └───────────┴────────────┴────────────┴────────────┴───┴────────────┴──────────┴──────────┴────────┘
+
+
+
 ## 🎬 Play-by-play — 2024 Finals Game 5
 
 [`espn_wnba_pbp`](../wnba/reference/additional.md#play-by-play-schedule--rosters) returns a **dict** of component pieces (`plays`, `boxscore`, `header`, `winprobability`, …). The `plays` entry is a list of raw ESPN dicts; build a frame with `pl.DataFrame(..., infer_schema_length=None)`. Its columns use raw **dot-notation** (`period.number`, `clock.displayValue`, `scoringPlay`, `type.text`).
@@ -140,6 +222,44 @@ else:
 out
 ```
 
+    ✅ Game 5 pbp
+    dict keys: ['gameId', 'plays', 'winprobability', 'boxscore', 'header', 'format', 'broadcasts', 'videos']
+
+
+
+
+
+    shape: (10, 5)
+    ┌───────────────┬────────────────────┬───────────────────────┬───────────────────────┬─────────────┐
+    │ period.number ┆ clock.displayValue ┆ type.text             ┆ text                  ┆ scoringPlay │
+    │ ---           ┆ ---                ┆ ---                   ┆ ---                   ┆ ---         │
+    │ i64           ┆ str                ┆ str                   ┆ str                   ┆ bool        │
+    ╞═══════════════╪════════════════════╪═══════════════════════╪═══════════════════════╪═════════════╡
+    │ 1             ┆ 10:00              ┆ Jumpball              ┆ Napheesa Collier vs.  ┆ false       │
+    │               ┆                    ┆                       ┆ Jonquel J…            ┆             │
+    │ 1             ┆ 9:35               ┆ Cutting Layup Shot    ┆ Napheesa Collier      ┆ true        │
+    │               ┆                    ┆                       ┆ makes 3-foot …        ┆             │
+    │ 1             ┆ 9:12               ┆ Pullup Jump Shot      ┆ Sabrina Ionescu       ┆ false       │
+    │               ┆                    ┆                       ┆ misses 24-foot…       ┆             │
+    │ 1             ┆ 9:09               ┆ Defensive Rebound     ┆ Bridget Carleton      ┆ false       │
+    │               ┆                    ┆                       ┆ defensive reb…        ┆             │
+    │ 1             ┆ 8:55               ┆ Personal Foul         ┆ Betnijah              ┆ false       │
+    │               ┆                    ┆                       ┆ Laney-Hamilton        ┆             │
+    │               ┆                    ┆                       ┆ person…               ┆             │
+    │ 1             ┆ 8:50               ┆ Out of Bounds - Lost  ┆ Courtney Williams out ┆ false       │
+    │               ┆                    ┆ Ball Turn…            ┆ of bound…             ┆             │
+    │ 1             ┆ 8:31               ┆ Jump Shot             ┆ Breanna Stewart       ┆ false       │
+    │               ┆                    ┆                       ┆ misses 13-foot…       ┆             │
+    │ 1             ┆ 8:28               ┆ Defensive Rebound     ┆ Napheesa Collier      ┆ false       │
+    │               ┆                    ┆                       ┆ defensive reb…        ┆             │
+    │ 1             ┆ 8:07               ┆ Cutting Layup Shot    ┆ Napheesa Collier      ┆ true        │
+    │               ┆                    ┆                       ┆ makes 3-foot …        ┆             │
+    │ 1             ┆ 8:00               ┆ Lost Ball Turnover    ┆ Breanna Stewart lost  ┆ false       │
+    │               ┆                    ┆                       ┆ ball turn…            ┆             │
+    └───────────────┴────────────────────┴───────────────────────┴───────────────────────┴─────────────┘
+
+
+
 Filter to scoring plays only to watch the lead change down the stretch.
 
 
@@ -150,6 +270,27 @@ Filter to scoring plays only to watch the lead change down the stretch.
     .tail(8)
  if plays is not None else 'pbp unavailable')
 ```
+
+
+
+
+    shape: (8, 5)
+    ┌───────────────┬────────────────────┬───────────┬───────────┬─────────────────────────────────┐
+    │ period.number ┆ clock.displayValue ┆ homeScore ┆ awayScore ┆ text                            │
+    │ ---           ┆ ---                ┆ ---       ┆ ---       ┆ ---                             │
+    │ i64           ┆ str                ┆ i64       ┆ i64       ┆ str                             │
+    ╞═══════════════╪════════════════════╪═══════════╪═══════════╪═════════════════════════════════╡
+    │ 4             ┆ 0:5.0              ┆ 59        ┆ 60        ┆ Breanna Stewart makes free thr… │
+    │ 4             ┆ 0:5.0              ┆ 60        ┆ 60        ┆ Breanna Stewart makes free thr… │
+    │ 5             ┆ 4:52               ┆ 63        ┆ 60        ┆ Leonie Fiebich makes 23-foot t… │
+    │ 5             ┆ 3:14               ┆ 65        ┆ 60        ┆ Nyara Sabally makes two point … │
+    │ 5             ┆ 1:51               ┆ 65        ┆ 61        ┆ Kayla McBride makes free throw… │
+    │ 5             ┆ 1:51               ┆ 65        ┆ 62        ┆ Kayla McBride makes free throw… │
+    │ 5             ┆ 0:10.0             ┆ 66        ┆ 62        ┆ Breanna Stewart makes free thr… │
+    │ 5             ┆ 0:10.0             ┆ 67        ┆ 62        ┆ Breanna Stewart makes free thr… │
+    └───────────────┴────────────────────┴───────────┴───────────┴─────────────────────────────────┘
+
+
 
 ## 🌟 Player season stats — Caitlin Clark
 
@@ -165,6 +306,26 @@ cc = safe('Caitlin Clark stats',
  if cc is not None else 'player stats unavailable')
 ```
 
+    ✅ Caitlin Clark stats
+
+
+
+
+
+    shape: (1, 7)
+    ┌──────────────┬─────────────┬─────────────┬─────────────┬─────────────┬─────────────┬─────────────┐
+    │ full_name    ┆ team_abbrev ┆ general_gam ┆ offensive_a ┆ offensive_a ┆ general_avg ┆ offensive_t │
+    │ ---          ┆ iation      ┆ es_played   ┆ vg_points   ┆ vg_assists  ┆ _rebounds   ┆ hree_point_ │
+    │ str          ┆ ---         ┆ ---         ┆ ---         ┆ ---         ┆ ---         ┆ field_go…   │
+    │              ┆ str         ┆ f64         ┆ f64         ┆ f64         ┆ f64         ┆ ---         │
+    │              ┆             ┆             ┆             ┆             ┆             ┆ f64         │
+    ╞══════════════╪═════════════╪═════════════╪═════════════╪═════════════╪═════════════╪═════════════╡
+    │ Caitlin      ┆ IND         ┆ 40.0        ┆ 19.225      ┆ 8.425       ┆ 5.675       ┆ 34.366196   │
+    │ Clark        ┆             ┆             ┆             ┆             ┆             ┆             │
+    └──────────────┴─────────────┴─────────────┴─────────────┴─────────────┴─────────────┴─────────────┘
+
+
+
 ## 📊 Team season stats
 
 [`espn_wnba_team_stats`](../wnba/reference/additional.md#espn_wnba_team_stats) returns a **dict** keyed by category — `{'Averages', 'Totals', 'Misc'}`. Each value is a long frame of `stat_name` / `display_value` rows, so index into the dict rather than calling `.head()` on the return directly.
@@ -177,6 +338,31 @@ print('categories:', list(aces_stats.keys()) if aces_stats is not None else None
 (aces_stats['Averages'].select(['stat_name', 'abbreviation', 'display_value']).head(10)
  if aces_stats is not None else 'team stats unavailable')
 ```
+
+    ✅ Aces team stats
+    categories: ['Averages', 'Totals', 'Misc']
+
+
+
+
+
+    shape: (8, 3)
+    ┌──────────────────────────┬──────────────┬───────────────┐
+    │ stat_name                ┆ abbreviation ┆ display_value │
+    │ ---                      ┆ ---          ┆ ---           │
+    │ str                      ┆ str          ┆ str           │
+    ╞══════════════════════════╪══════════════╪═══════════════╡
+    │ Rebounds Per Game        ┆ REB          ┆ 34.1          │
+    │ Assist To Turnover Ratio ┆ AST/TO       ┆ 1.9           │
+    │ Fouls Per Game           ┆ PF           ┆ 16.5          │
+    │ Games Played             ┆ GP           ┆ 40            │
+    │ Games Started            ┆ GS           ┆ 0             │
+    │ Minutes Per Game         ┆ MIN          ┆ 0.0           │
+    │ Rebounds                 ┆ REB          ┆ 1364          │
+    │ Rebounds                 ┆ REB          ┆ 1364          │
+    └──────────────────────────┴──────────────┴───────────────┘
+
+
 
 ## 🍳 Cookbook: common WNBA tasks
 
@@ -196,6 +382,30 @@ standings = safe('2024 standings', lambda: wnba.espn_wnba_standings(season=SEASO
  if standings is not None else 'standings unavailable')
 ```
 
+    ✅ 2024 standings
+
+
+
+
+
+    shape: (8, 5)
+    ┌───────────────────┬──────┬────────┬─────────────┬────────────────────┐
+    │ team_display_name ┆ wins ┆ losses ┆ win_percent ┆ point_differential │
+    │ ---               ┆ ---  ┆ ---    ┆ ---         ┆ ---                │
+    │ str               ┆ i64  ┆ i64    ┆ f64         ┆ f64                │
+    ╞═══════════════════╪══════╪════════╪═════════════╪════════════════════╡
+    │ New York Liberty  ┆ 32   ┆ 8      ┆ 0.8         ┆ 366.0              │
+    │ Minnesota Lynx    ┆ 30   ┆ 10     ┆ 0.75        ┆ 255.0              │
+    │ Connecticut Sun   ┆ 28   ┆ 12     ┆ 0.7         ┆ 260.0              │
+    │ Las Vegas Aces    ┆ 27   ┆ 13     ┆ 0.675       ┆ 219.0              │
+    │ Seattle Storm     ┆ 25   ┆ 15     ┆ 0.625       ┆ 179.0              │
+    │ Indiana Fever     ┆ 20   ┆ 20     ┆ 0.5         ┆ -107.0             │
+    │ Phoenix Mercury   ┆ 19   ┆ 21     ┆ 0.475       ┆ -132.0             │
+    │ Atlanta Dream     ┆ 15   ┆ 25     ┆ 0.375       ┆ -110.0             │
+    └───────────────────┴──────┴────────┴─────────────┴────────────────────┘
+
+
+
 ### Recipe 2 — Draft board 🎓
 
 [`espn_wnba_draft`](../wnba/reference/site.md#espn_wnba_draft) lists every pick for a season. The 2024 draft headlined with Caitlin Clark going first overall to the Indiana Fever.
@@ -207,6 +417,33 @@ draft = safe('2024 draft', lambda: wnba.espn_wnba_draft(season=SEASON))
                'athlete_position_abbreviation', 'school_name']).head(10)
  if draft is not None else 'draft unavailable')
 ```
+
+    ✅ 2024 draft
+
+
+
+
+
+    shape: (10, 5)
+    ┌──────────────┬───────────────────┬──────────────────────┬──────────────────────┬─────────────────┐
+    │ overall_pick ┆ team_display_name ┆ athlete_display_name ┆ athlete_position_abb ┆ school_name     │
+    │ ---          ┆ ---               ┆ ---                  ┆ reviation            ┆ ---             │
+    │ i64          ┆ str               ┆ str                  ┆ ---                  ┆ str             │
+    │              ┆                   ┆                      ┆ str                  ┆                 │
+    ╞══════════════╪═══════════════════╪══════════════════════╪══════════════════════╪═════════════════╡
+    │ 1            ┆ null              ┆ Caitlin Clark        ┆ null                 ┆ Hawkeyes        │
+    │ 2            ┆ null              ┆ Cameron Brink        ┆ null                 ┆ Cardinal        │
+    │ 3            ┆ null              ┆ Kamilla Cardoso      ┆ null                 ┆ Gamecocks       │
+    │ 4            ┆ null              ┆ Rickea Jackson       ┆ null                 ┆ Lady Volunteers │
+    │ 5            ┆ null              ┆ Jacy Sheldon         ┆ null                 ┆ Buckeyes        │
+    │ 6            ┆ null              ┆ Aaliyah Edwards      ┆ null                 ┆ Huskies         │
+    │ 7            ┆ null              ┆ Angel Reese          ┆ null                 ┆ Tigers          │
+    │ 8            ┆ null              ┆ Alissa Pili          ┆ null                 ┆ Utes            │
+    │ 9            ┆ null              ┆ Carla Leite          ┆ null                 ┆ France          │
+    │ 10           ┆ null              ┆ Leila Lacan          ┆ null                 ┆ France          │
+    └──────────────┴───────────────────┴──────────────────────┴──────────────────────┴─────────────────┘
+
+
 
 ### Recipe 3 — Top 10 scorers of the season 📈
 
@@ -232,6 +469,29 @@ top_scorers = (
 top_scorers
 ```
 
+
+
+
+    shape: (10, 6)
+    ┌──────────────────────┬───────────────────┬───────┬──────────────┬──────┬─────┐
+    │ athlete_display_name ┆ team_abbreviation ┆ games ┆ total_points ┆ ppg  ┆ apg │
+    │ ---                  ┆ ---               ┆ ---   ┆ ---          ┆ ---  ┆ --- │
+    │ str                  ┆ str               ┆ u32   ┆ i32          ┆ f64  ┆ f64 │
+    ╞══════════════════════╪═══════════════════╪═══════╪══════════════╪══════╪═════╡
+    │ A'ja Wilson          ┆ LV                ┆ 44    ┆ 1149         ┆ 26.1 ┆ 2.4 │
+    │ Arike Ogunbowale     ┆ DAL               ┆ 38    ┆ 845          ┆ 22.2 ┆ 5.1 │
+    │ Napheesa Collier     ┆ MIN               ┆ 47    ┆ 1000         ┆ 21.3 ┆ 3.4 │
+    │ Kahleah Copper       ┆ PHX               ┆ 39    ┆ 811          ┆ 20.8 ┆ 2.3 │
+    │ Breanna Stewart      ┆ NY                ┆ 50    ┆ 1014         ┆ 20.3 ┆ 3.5 │
+    │ Kelsey Mitchell      ┆ IND               ┆ 42    ┆ 805          ┆ 19.2 ┆ 1.9 │
+    │ Caitlin Clark        ┆ IND               ┆ 42    ┆ 805          ┆ 19.2 ┆ 8.4 │
+    │ Jewell Loyd          ┆ SEA               ┆ 39    ┆ 744          ┆ 19.1 ┆ 3.6 │
+    │ Sabrina Ionescu      ┆ NY                ┆ 50    ┆ 900          ┆ 18.0 ┆ 5.9 │
+    │ Brittney Griner      ┆ PHX               ┆ 32    ┆ 568          ┆ 17.8 ┆ 2.2 │
+    └──────────────────────┴───────────────────┴───────┴──────────────┴──────┴─────┘
+
+
+
 ### Recipe 4 — Who worked the whistle? 👀
 
 [`espn_wnba_game_officials`](../wnba/reference/additional.md#espn_wnba_game_officials) returns the referees assigned to a game — handy for officiating studies. Pair a `game_id` from the schedule with this call.
@@ -247,6 +507,26 @@ else:
     out = 'officials unavailable'
 out
 ```
+
+    ✅ Game 5 officials
+
+
+
+
+
+    shape: (4, 3)
+    ┌───────────────┬───────────────┬───────┐
+    │ full_name     ┆ display_name  ┆ order │
+    │ ---           ┆ ---           ┆ ---   │
+    │ str           ┆ str           ┆ i32   │
+    ╞═══════════════╪═══════════════╪═══════╡
+    │ Roy Gulbeyan  ┆ Roy Gulbeyan  ┆ 1     │
+    │ Maj Forsberg  ┆ Maj Forsberg  ┆ 2     │
+    │ Tim Greene    ┆ Tim Greene    ┆ 3     │
+    │ Isaac Barnett ┆ Isaac Barnett ┆ 4     │
+    └───────────────┴───────────────┴───────┘
+
+
 
 ### Recipe 5 — Best net rating in the league ⚖️
 
@@ -269,6 +549,30 @@ net_rating = (
 )
 net_rating
 ```
+
+
+
+
+    shape: (12, 6)
+    ┌───────────────────┬────────────────────┬───────┬─────────┬─────────────┬──────┐
+    │ team_abbreviation ┆ team_display_name  ┆ games ┆ pts_for ┆ pts_against ┆ net  │
+    │ ---               ┆ ---                ┆ ---   ┆ ---     ┆ ---         ┆ ---  │
+    │ str               ┆ str                ┆ u32   ┆ f64     ┆ f64         ┆ f64  │
+    ╞═══════════════════╪════════════════════╪═══════╪═════════╪═════════════╪══════╡
+    │ NY                ┆ New York Liberty   ┆ 52    ┆ 85.0    ┆ 77.0        ┆ 8.0  │
+    │ CON               ┆ Connecticut Sun    ┆ 47    ┆ 80.4    ┆ 74.5        ┆ 5.9  │
+    │ MIN               ┆ Minnesota Lynx     ┆ 53    ┆ 82.4    ┆ 77.2        ┆ 5.2  │
+    │ LV                ┆ Las Vegas Aces     ┆ 46    ┆ 85.5    ┆ 80.7        ┆ 4.8  │
+    │ SEA               ┆ Seattle Storm      ┆ 42    ┆ 82.7    ┆ 78.8        ┆ 3.9  │
+    │ …                 ┆ …                  ┆ …     ┆ …       ┆ …           ┆ …    │
+    │ IND               ┆ Indiana Fever      ┆ 42    ┆ 84.5    ┆ 87.8        ┆ -3.3 │
+    │ PHX               ┆ Phoenix Mercury    ┆ 42    ┆ 81.9    ┆ 85.5        ┆ -3.6 │
+    │ CHI               ┆ Chicago Sky        ┆ 40    ┆ 77.4    ┆ 82.5        ┆ -5.1 │
+    │ LA                ┆ Los Angeles Sparks ┆ 40    ┆ 78.4    ┆ 85.6        ┆ -7.2 │
+    │ DAL               ┆ Dallas Wings       ┆ 40    ┆ 84.2    ┆ 92.1        ┆ -7.9 │
+    └───────────────────┴────────────────────┴───────┴─────────┴─────────────┴──────┘
+
+
 
 ### Recipe 6 — Double-double machines 🏅
 
@@ -298,6 +602,29 @@ double_doubles = (
 double_doubles
 ```
 
+
+
+
+    shape: (10, 4)
+    ┌──────────────────────┬───────────────────┬────────────────┬────────────────┐
+    │ athlete_display_name ┆ team_abbreviation ┆ double_doubles ┆ triple_doubles │
+    │ ---                  ┆ ---               ┆ ---            ┆ ---            │
+    │ str                  ┆ str               ┆ u32            ┆ u32            │
+    ╞══════════════════════╪═══════════════════╪════════════════╪════════════════╡
+    │ Angel Reese          ┆ CHI               ┆ 26             ┆ 0              │
+    │ A'ja Wilson          ┆ LV                ┆ 26             ┆ 0              │
+    │ Breanna Stewart      ┆ NY                ┆ 22             ┆ 0              │
+    │ Tina Charles         ┆ ATL               ┆ 21             ┆ 1              │
+    │ Napheesa Collier     ┆ MIN               ┆ 21             ┆ 0              │
+    │ Alyssa Thomas        ┆ CON               ┆ 19             ┆ 4              │
+    │ Dearica Hamby        ┆ LA                ┆ 16             ┆ 0              │
+    │ Aliyah Boston        ┆ IND               ┆ 15             ┆ 0              │
+    │ Caitlin Clark        ┆ IND               ┆ 14             ┆ 2              │
+    │ Jonquel Jones        ┆ NY                ┆ 14             ┆ 0              │
+    └──────────────────────┴───────────────────┴────────────────┴────────────────┘
+
+
+
 ### Recipe 7 — Most efficient high-volume scorers 🎯
 
 Raw points reward volume; **true shooting %** rewards efficiency. TS% = points / (2 × (FGA + 0.44 × FTA)). Aggregate the makes/attempts from the box-score loader, keep players with real workloads, and you've got the league's most efficient buckets.
@@ -324,6 +651,29 @@ true_shooting = (
 )
 true_shooting
 ```
+
+
+
+
+    shape: (10, 7)
+    ┌──────────────────────┬───────────────────┬───────┬──────┬─────┬─────┬────────┐
+    │ athlete_display_name ┆ team_abbreviation ┆ games ┆ pts  ┆ fga ┆ fta ┆ ts_pct │
+    │ ---                  ┆ ---               ┆ ---   ┆ ---  ┆ --- ┆ --- ┆ ---    │
+    │ str                  ┆ str               ┆ u32   ┆ i32  ┆ i32 ┆ i32 ┆ f64    │
+    ╞══════════════════════╪═══════════════════╪═══════╪══════╪═════╪═════╪════════╡
+    │ Leonie Fiebich       ┆ NY                ┆ 52    ┆ 395  ┆ 287 ┆ 38  ┆ 65.0   │
+    │ Jonquel Jones        ┆ NY                ┆ 51    ┆ 726  ┆ 497 ┆ 145 ┆ 64.7   │
+    │ Bridget Carleton     ┆ MIN               ┆ 52    ┆ 508  ┆ 379 ┆ 58  ┆ 62.8   │
+    │ Brittney Griner      ┆ PHX               ┆ 32    ┆ 568  ┆ 403 ┆ 122 ┆ 62.2   │
+    │ Stefanie Dolson      ┆ WSH               ┆ 39    ┆ 371  ┆ 280 ┆ 42  ┆ 62.1   │
+    │ Sophie Cunningham    ┆ PHX               ┆ 42    ┆ 347  ┆ 250 ┆ 69  ┆ 61.9   │
+    │ Tiffany Hayes        ┆ LV                ┆ 39    ┆ 376  ┆ 263 ┆ 100 ┆ 61.2   │
+    │ Teaira McCowan       ┆ DAL               ┆ 39    ┆ 458  ┆ 323 ┆ 124 ┆ 60.7   │
+    │ Kayla McBride        ┆ MIN               ┆ 52    ┆ 782  ┆ 572 ┆ 183 ┆ 59.9   │
+    │ A'ja Wilson          ┆ LV                ┆ 44    ┆ 1149 ┆ 842 ┆ 299 ┆ 59.0   │
+    └──────────────────────┴───────────────────┴───────┴──────┴─────┴─────┴────────┘
+
+
 
 ### Recipe 8 — Where do the threes come from? 🎯
 
@@ -353,6 +703,30 @@ threes.join(team_names, on='team_id', how='left').select(
 ).head(12)
 ```
 
+
+
+
+    shape: (12, 4)
+    ┌───────────────────┬───────────────────┬────────────────┬──────────────┐
+    │ team_abbreviation ┆ three_pt_attempts ┆ three_pt_makes ┆ three_pt_pct │
+    │ ---               ┆ ---               ┆ ---            ┆ ---          │
+    │ str               ┆ u32               ┆ u32            ┆ f64          │
+    ╞═══════════════════╪═══════════════════╪════════════════╪══════════════╡
+    │ NY                ┆ 517               ┆ 517            ┆ 100.0        │
+    │ MIN               ┆ 488               ┆ 488            ┆ 100.0        │
+    │ LV                ┆ 429               ┆ 429            ┆ 100.0        │
+    │ WSH               ┆ 389               ┆ 389            ┆ 100.0        │
+    │ IND               ┆ 382               ┆ 382            ┆ 100.0        │
+    │ …                 ┆ …                 ┆ …              ┆ …            │
+    │ CON               ┆ 282               ┆ 282            ┆ 100.0        │
+    │ SEA               ┆ 254               ┆ 254            ┆ 100.0        │
+    │ DAL               ┆ 250               ┆ 250            ┆ 100.0        │
+    │ ATL               ┆ 249               ┆ 249            ┆ 100.0        │
+    │ CHI               ┆ 193               ┆ 193            ┆ 100.0        │
+    └───────────────────┴───────────────────┴────────────────┴──────────────┘
+
+
+
 ### Recipe 9 — Head-to-head series ⚔️
 
 Want every meeting between two clubs? Filter the team box-score loader on team + opponent abbreviations and you get the full season series — scores, dates and who won. Here's New York vs. Minnesota, the eventual 2024 Finals matchup.
@@ -378,6 +752,31 @@ print('NY series record vs MIN:',
 head_to_head
 ```
 
+    NY series record vs MIN: 4 - 5
+
+
+
+
+
+    shape: (9, 5)
+    ┌────────────┬────────────┬─────────────────────┬─────────────┬────────┐
+    │ game_date  ┆ team_score ┆ opponent_team_score ┆ team_winner ┆ winner │
+    │ ---        ┆ ---        ┆ ---                 ┆ ---         ┆ ---    │
+    │ date       ┆ i32        ┆ i32                 ┆ bool        ┆ str    │
+    ╞════════════╪════════════╪═════════════════════╪═════════════╪════════╡
+    │ 2024-05-25 ┆ 67         ┆ 84                  ┆ false       ┆ MIN    │
+    │ 2024-06-25 ┆ 89         ┆ 94                  ┆ false       ┆ MIN    │
+    │ 2024-07-02 ┆ 76         ┆ 67                  ┆ true        ┆ NY     │
+    │ 2024-09-15 ┆ 79         ┆ 88                  ┆ false       ┆ MIN    │
+    │ 2024-10-10 ┆ 93         ┆ 95                  ┆ false       ┆ MIN    │
+    │ 2024-10-13 ┆ 80         ┆ 66                  ┆ true        ┆ NY     │
+    │ 2024-10-16 ┆ 80         ┆ 77                  ┆ true        ┆ NY     │
+    │ 2024-10-18 ┆ 80         ┆ 82                  ┆ false       ┆ MIN    │
+    │ 2024-10-20 ┆ 67         ┆ 62                  ┆ true        ┆ NY     │
+    └────────────┴────────────┴─────────────────────┴─────────────┴────────┘
+
+
+
 ### Recipe 10 — Rolling form: hot and cold streaks 🔥
 
 A team's last-5 record tells you who's surging into the playoffs. Sort one team's games by date, then a `rolling_sum` over the win flag gives a running 5-game window — polars makes the time-series slice a one-liner.
@@ -399,6 +798,30 @@ form = (
 form
 ```
 
+
+
+
+    shape: (12, 6)
+    ┌────────────┬────────────────────────────┬────────────┬─────────────────────┬─────┬────────────┐
+    │ game_date  ┆ opponent_team_abbreviation ┆ team_score ┆ opponent_team_score ┆ won ┆ wins_last5 │
+    │ ---        ┆ ---                        ┆ ---        ┆ ---                 ┆ --- ┆ ---        │
+    │ date       ┆ str                        ┆ i32        ┆ i32                 ┆ i8  ┆ i64        │
+    ╞════════════╪════════════════════════════╪════════════╪═════════════════════╪═════╪════════════╡
+    │ 2024-09-19 ┆ ATL                        ┆ 67         ┆ 78                  ┆ 0   ┆ 3          │
+    │ 2024-09-22 ┆ ATL                        ┆ 83         ┆ 69                  ┆ 1   ┆ 3          │
+    │ 2024-09-24 ┆ ATL                        ┆ 91         ┆ 82                  ┆ 1   ┆ 3          │
+    │ 2024-09-29 ┆ LV                         ┆ 87         ┆ 77                  ┆ 1   ┆ 4          │
+    │ 2024-10-01 ┆ LV                         ┆ 88         ┆ 84                  ┆ 1   ┆ 4          │
+    │ …          ┆ …                          ┆ …          ┆ …                   ┆ …   ┆ …          │
+    │ 2024-10-10 ┆ MIN                        ┆ 93         ┆ 95                  ┆ 0   ┆ 3          │
+    │ 2024-10-13 ┆ MIN                        ┆ 80         ┆ 66                  ┆ 1   ┆ 3          │
+    │ 2024-10-16 ┆ MIN                        ┆ 80         ┆ 77                  ┆ 1   ┆ 3          │
+    │ 2024-10-18 ┆ MIN                        ┆ 80         ┆ 82                  ┆ 0   ┆ 3          │
+    │ 2024-10-20 ┆ MIN                        ┆ 67         ┆ 62                  ┆ 1   ┆ 3          │
+    └────────────┴────────────────────────────┴────────────┴─────────────────────┴─────┴────────────┘
+
+
+
 ### Recipe 11 — Roster construction by position 👥
 
 [`load_wnba_rosters`](../wnba/reference/loaders.md#load_wnba_rosters) hands you every team's full roster. Pivot guards / forwards / centers per team to see how each front office balances its lineup — a clean join-free `pivot`.
@@ -416,6 +839,30 @@ position_mix = (
 )
 position_mix
 ```
+
+
+
+
+    shape: (12, 4)
+    ┌───────────────────┬─────┬─────┬─────┐
+    │ team_abbreviation ┆ F   ┆ G   ┆ C   │
+    │ ---               ┆ --- ┆ --- ┆ --- │
+    │ str               ┆ u32 ┆ u32 ┆ u32 │
+    ╞═══════════════════╪═════╪═════╪═════╡
+    │ ATL               ┆ 4   ┆ 7   ┆ 1   │
+    │ CHI               ┆ 3   ┆ 9   ┆ 2   │
+    │ CONNECTICU        ┆ 5   ┆ 8   ┆ 2   │
+    │ DALLAS            ┆ 6   ┆ 7   ┆ 1   │
+    │ IND               ┆ 3   ┆ 8   ┆ 2   │
+    │ …                 ┆ …   ┆ …   ┆ …   │
+    │ MIN               ┆ 8   ┆ 5   ┆ 1   │
+    │ NY                ┆ 5   ┆ 8   ┆ 2   │
+    │ PHX               ┆ 7   ┆ 7   ┆ 1   │
+    │ SEA               ┆ 5   ┆ 6   ┆ 3   │
+    │ WSH               ┆ 3   ┆ 9   ┆ 2   │
+    └───────────────────┴─────┴─────┴─────┘
+
+
 
 ### Recipe 12 — Season scoring leaders, the pre-aggregated way 📐
 
@@ -438,6 +885,29 @@ scoring_leaders = (
 )
 scoring_leaders
 ```
+
+
+
+
+    shape: (10, 4)
+    ┌──────────────────────┬───────────────────┬───────────────────────────────┬──────┐
+    │ athlete_display_name ┆ team_display_name ┆ athlete_position_abbreviation ┆ ppg  │
+    │ ---                  ┆ ---               ┆ ---                           ┆ ---  │
+    │ str                  ┆ str               ┆ str                           ┆ f64  │
+    ╞══════════════════════╪═══════════════════╪═══════════════════════════════╪══════╡
+    │ A'ja Wilson          ┆ Las Vegas Aces    ┆ C                             ┆ 21.4 │
+    │ Olivia Miles         ┆ Minnesota Lynx    ┆ G                             ┆ 21.0 │
+    │ Breanna Stewart      ┆ Seattle Storm     ┆ F                             ┆ 20.5 │
+    │ Arike Ogunbowale     ┆ Dallas Wings      ┆ G                             ┆ 19.9 │
+    │ Paige Bueckers       ┆ Dallas Wings      ┆ G                             ┆ 19.2 │
+    │ Caitlin Clark        ┆ Indiana Fever     ┆ G                             ┆ 18.6 │
+    │ Napheesa Collier     ┆ Minnesota Lynx    ┆ F                             ┆ 18.4 │
+    │ Jovana Nogic         ┆ Phoenix Mercury   ┆ G                             ┆ 17.5 │
+    │ Kelsey Mitchell      ┆ Indiana Fever     ┆ G                             ┆ 17.4 │
+    │ Rhyne Howard         ┆ Atlanta Dream     ┆ G                             ┆ 17.1 │
+    └──────────────────────┴───────────────────┴───────────────────────────────┴──────┘
+
+
 
 ## 📦 Bulk loaders (`load_wnba_*`)
 
@@ -463,6 +933,31 @@ box_2024.select(['game_id', 'game_date', 'athlete_display_name',
                  'team_abbreviation', 'minutes', 'points',
                  'rebounds', 'assists']).head()
 ```
+
+    schedule rows: (264, 77)
+
+
+
+
+
+    shape: (5, 8)
+    ┌───────────┬────────────┬────────────────┬────────────────┬─────────┬────────┬──────────┬─────────┐
+    │ game_id   ┆ game_date  ┆ athlete_displa ┆ team_abbreviat ┆ minutes ┆ points ┆ rebounds ┆ assists │
+    │ ---       ┆ ---        ┆ y_name         ┆ ion            ┆ ---     ┆ ---    ┆ ---      ┆ ---     │
+    │ i32       ┆ date       ┆ ---            ┆ ---            ┆ f64     ┆ i32    ┆ i32      ┆ i32     │
+    │           ┆            ┆ str            ┆ str            ┆         ┆        ┆          ┆         │
+    ╞═══════════╪════════════╪════════════════╪════════════════╪═════════╪════════╪══════════╪═════════╡
+    │ 401726992 ┆ 2024-10-20 ┆ Bridget        ┆ MIN            ┆ 41.0    ┆ 3      ┆ 6        ┆ 2       │
+    │           ┆            ┆ Carleton       ┆                ┆         ┆        ┆          ┆         │
+    │ 401726992 ┆ 2024-10-20 ┆ Alanna Smith   ┆ MIN            ┆ 36.0    ┆ 6      ┆ 8        ┆ 2       │
+    │ 401726992 ┆ 2024-10-20 ┆ Napheesa       ┆ MIN            ┆ 44.0    ┆ 22     ┆ 7        ┆ 2       │
+    │           ┆            ┆ Collier        ┆                ┆         ┆        ┆          ┆         │
+    │ 401726992 ┆ 2024-10-20 ┆ Kayla McBride  ┆ MIN            ┆ 43.0    ┆ 21     ┆ 5        ┆ 5       │
+    │ 401726992 ┆ 2024-10-20 ┆ Courtney       ┆ MIN            ┆ 30.0    ┆ 4      ┆ 4        ┆ 3       │
+    │           ┆            ┆ Williams       ┆                ┆         ┆        ┆          ┆         │
+    └───────────┴────────────┴────────────────┴────────────────┴─────────┴────────┴──────────┴─────────┘
+
+
 
 ## 🎉 Where to next
 

--- a/docs/docs/tutorials/09_mlb_intro.md
+++ b/docs/docs/tutorials/09_mlb_intro.md
@@ -65,6 +65,9 @@ pl.Config.set_tbl_rows(12)
 print("most recent MLB season:", mlb.most_recent_mlb_season())
 ```
 
+    most recent MLB season: 2026
+
+
 The MLB Stats API and Savant are public and reliable, but they're still
 **live network calls** — a date with no games, an offseason day, or a blip can
 make a call come back empty. So we use a tiny `safe()` helper: you get the
@@ -115,6 +118,29 @@ cols = ["game_pk", "status_detailed_state",
  if schedule is not None else "schedule unavailable right now")
 ```
 
+    ✅ schedule
+
+
+
+
+
+    shape: (3, 6)
+    ┌─────────┬─────────────────┬─────────────────┬─────────────────┬─────────────────┬────────────────┐
+    │ game_pk ┆ status_detailed ┆ teams_away_team ┆ teams_away_scor ┆ teams_home_team ┆ teams_home_sco │
+    │ ---     ┆ _state          ┆ _name           ┆ e               ┆ _name           ┆ re             │
+    │ i64     ┆ ---             ┆ ---             ┆ ---             ┆ ---             ┆ ---            │
+    │         ┆ str             ┆ str             ┆ i64             ┆ str             ┆ i64            │
+    ╞═════════╪═════════════════╪═════════════════╪═════════════════╪═════════════════╪════════════════╡
+    │ 744914  ┆ Final           ┆ Houston Astros  ┆ 3               ┆ Toronto Blue    ┆ 1              │
+    │         ┆                 ┆                 ┆                 ┆ Jays            ┆                │
+    │ 744840  ┆ Final           ┆ New York Mets   ┆ 9               ┆ Washington      ┆ 7              │
+    │         ┆                 ┆                 ┆                 ┆ Nationals       ┆                │
+    │ 746535  ┆ Final           ┆ Milwaukee       ┆ 7               ┆ Colorado        ┆ 8              │
+    │         ┆                 ┆ Brewers         ┆                 ┆ Rockies         ┆                │
+    └─────────┴─────────────────┴─────────────────┴─────────────────┴─────────────────┴────────────────┘
+
+
+
 ## 🏆 Standings (MLB Stats API)
 
 [`mlb_api_standings`](../mlb/reference/additional.md#mlb_api_standings) covers
@@ -136,6 +162,32 @@ keep = ["team_name", "standings_division_name", "wins", "losses",
  if standings is not None else "standings unavailable right now")
 ```
 
+    ✅ standings
+
+
+
+
+
+    shape: (10, 6)
+    ┌───────────┬─────────────────────────┬──────┬────────┬────────────────────┬───────────────┐
+    │ team_name ┆ standings_division_name ┆ wins ┆ losses ┆ winning_percentage ┆ division_rank │
+    │ ---       ┆ ---                     ┆ ---  ┆ ---    ┆ ---                ┆ ---           │
+    │ str       ┆ str                     ┆ i64  ┆ i64    ┆ str                ┆ str           │
+    ╞═══════════╪═════════════════════════╪══════╪════════╪════════════════════╪═══════════════╡
+    │ Dodgers   ┆ null                    ┆ 98   ┆ 64     ┆ .605               ┆ 1             │
+    │ Phillies  ┆ null                    ┆ 95   ┆ 67     ┆ .586               ┆ 1             │
+    │ Yankees   ┆ null                    ┆ 94   ┆ 68     ┆ .580               ┆ 1             │
+    │ Brewers   ┆ null                    ┆ 93   ┆ 69     ┆ .574               ┆ 1             │
+    │ Padres    ┆ null                    ┆ 93   ┆ 69     ┆ .574               ┆ 2             │
+    │ Guardians ┆ null                    ┆ 92   ┆ 69     ┆ .571               ┆ 1             │
+    │ Orioles   ┆ null                    ┆ 91   ┆ 71     ┆ .562               ┆ 2             │
+    │ Braves    ┆ null                    ┆ 89   ┆ 73     ┆ .549               ┆ 2             │
+    │ Mets      ┆ null                    ┆ 89   ┆ 73     ┆ .549               ┆ 3             │
+    │ D-backs   ┆ null                    ┆ 89   ┆ 73     ┆ .549               ┆ 3             │
+    └───────────┴─────────────────────────┴──────┴────────┴────────────────────┴───────────────┘
+
+
+
 ## 🧢 Teams & rosters (MLB Stats API)
 
 [`mlb_api_teams`](../mlb/reference/additional.md#mlb_api_teams) +
@@ -154,6 +206,29 @@ teams = safe(
  if teams is not None else "teams unavailable right now")
 ```
 
+    ✅ teams
+
+
+
+
+
+
+
+    shape: (5, 5)
+    ┌─────┬──────────────────────┬──────────────┬───────────────┬───────────┐
+    │ id  ┆ name                 ┆ abbreviation ┆ location_name ┆ team_name │
+    │ --- ┆ ---                  ┆ ---          ┆ ---           ┆ ---       │
+    │ i64 ┆ str                  ┆ str          ┆ str           ┆ str       │
+    ╞═════╪══════════════════════╪══════════════╪═══════════════╪═══════════╡
+    │ 133 ┆ Oakland Athletics    ┆ OAK          ┆ Oakland       ┆ Athletics │
+    │ 134 ┆ Pittsburgh Pirates   ┆ PIT          ┆ Pittsburgh    ┆ Pirates   │
+    │ 135 ┆ San Diego Padres     ┆ SD           ┆ San Diego     ┆ Padres    │
+    │ 136 ┆ Seattle Mariners     ┆ SEA          ┆ Seattle       ┆ Mariners  │
+    │ 137 ┆ San Francisco Giants ┆ SF           ┆ San Francisco ┆ Giants    │
+    └─────┴──────────────────────┴──────────────┴───────────────┴───────────┘
+
+
+
 
 ```python
 roster = safe(
@@ -165,6 +240,27 @@ rcols = ["jersey_number", "person_id", "person_full_name",
 (roster.select([c for c in rcols if c in roster.columns]).head()
  if roster is not None else "roster unavailable right now")
 ```
+
+    ✅ Yankees roster
+
+
+
+
+
+    shape: (5, 5)
+    ┌───────────────┬───────────┬──────────────────┬───────────────────────┬───────────────────────┐
+    │ jersey_number ┆ person_id ┆ person_full_name ┆ position_abbreviation ┆ status_description    │
+    │ ---           ┆ ---       ┆ ---              ┆ ---                   ┆ ---                   │
+    │ str           ┆ i64       ┆ str              ┆ str                   ┆ str                   │
+    ╞═══════════════╪═══════════╪══════════════════╪═══════════════════════╪═══════════════════════╡
+    │ 74            ┆ 677076    ┆ Clayton Andrews  ┆ P                     ┆ Minor League Contract │
+    │ 85            ┆ 690925    ┆ Clayton Beeter   ┆ P                     ┆ Forty Man             │
+    │ 19            ┆ 542932    ┆ Jon Berti        ┆ 3B                    ┆ Forty Man             │
+    │ 53            ┆ 641360    ┆ Phil Bickford    ┆ P                     ┆ Minor League Contract │
+    │ 57            ┆ 595897    ┆ Nick Burdi       ┆ P                     ┆ Minor League Contract │
+    └───────────────┴───────────┴──────────────────┴───────────────────────┴───────────────────────┘
+
+
 
 ## 🧍 Player bio & season stats (MLB Stats API)
 
@@ -183,6 +279,23 @@ bcols = ["id", "full_name", "primary_number", "birth_date",
  if bio is not None else "bio unavailable right now")
 ```
 
+    ✅ Judge bio
+
+
+
+
+
+    shape: (1, 7)
+    ┌────────┬─────────────┬────────────────┬────────────┬────────┬────────┬────────────────┐
+    │ id     ┆ full_name   ┆ primary_number ┆ birth_date ┆ height ┆ weight ┆ mlb_debut_date │
+    │ ---    ┆ ---         ┆ ---            ┆ ---        ┆ ---    ┆ ---    ┆ ---            │
+    │ i64    ┆ str         ┆ str            ┆ str        ┆ str    ┆ i64    ┆ str            │
+    ╞════════╪═════════════╪════════════════╪════════════╪════════╪════════╪════════════════╡
+    │ 592450 ┆ Aaron Judge ┆ 99             ┆ 1992-04-26 ┆ 6' 7"  ┆ 282    ┆ 2016-08-13     │
+    └────────┴─────────────┴────────────────┴────────────┴────────┴────────┴────────────────┘
+
+
+
 
 ```python
 hitting = safe(
@@ -197,6 +310,24 @@ scols = ["season", "stat_games_played", "stat_home_runs", "stat_rbi",
 (hitting.select([c for c in scols if c in hitting.columns])
  if hitting is not None else "stats unavailable right now")
 ```
+
+    ✅ Judge 2024 hitting
+
+
+
+
+
+    shape: (1, 8)
+    ┌────────┬─────────────────┬────────────────┬──────────┬──────────┬──────────┬──────────┬──────────┐
+    │ season ┆ stat_games_play ┆ stat_home_runs ┆ stat_rbi ┆ stat_avg ┆ stat_obp ┆ stat_slg ┆ stat_ops │
+    │ ---    ┆ ed              ┆ ---            ┆ ---      ┆ ---      ┆ ---      ┆ ---      ┆ ---      │
+    │ str    ┆ ---             ┆ i64            ┆ i64      ┆ str      ┆ str      ┆ str      ┆ str      │
+    │        ┆ i64             ┆                ┆          ┆          ┆          ┆          ┆          │
+    ╞════════╪═════════════════╪════════════════╪══════════╪══════════╪══════════╪══════════╪══════════╡
+    │ 2024   ┆ 158             ┆ 58             ┆ 144      ┆ .322     ┆ .458     ┆ .701     ┆ 1.159    │
+    └────────┴─────────────────┴────────────────┴──────────┴──────────┴──────────┴──────────┴──────────┘
+
+
 
 ## 🎯 Pitch-level Statcast (Baseball Savant)
 
@@ -222,6 +353,34 @@ else:
     out = "no pitches in that window right now"
 out
 ```
+
+    ✅ Judge pitches (2-day)
+    shape: (11, 119)
+
+
+
+
+
+    shape: (5, 8)
+    ┌────────────┬────────────┬────────────┬───────────┬───────────┬───────────┬───────────┬───────────┐
+    │ game_date  ┆ player_nam ┆ pitch_type ┆ release_s ┆ launch_sp ┆ launch_an ┆ events    ┆ descripti │
+    │ ---        ┆ e          ┆ ---        ┆ peed      ┆ eed       ┆ gle       ┆ ---       ┆ on        │
+    │ str        ┆ ---        ┆ str        ┆ ---       ┆ ---       ┆ ---       ┆ str       ┆ ---       │
+    │            ┆ str        ┆            ┆ f64       ┆ f64       ┆ i64       ┆           ┆ str       │
+    ╞════════════╪════════════╪════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
+    │ 2024-07-02 ┆ Judge,     ┆ FC         ┆ 97.1      ┆ 91.0      ┆ 19        ┆ single    ┆ hit_into_ │
+    │            ┆ Aaron      ┆            ┆           ┆           ┆           ┆           ┆ play      │
+    │ 2024-07-02 ┆ Judge,     ┆ FC         ┆ 97.2      ┆ null      ┆ null      ┆ null      ┆ swinging_ │
+    │            ┆ Aaron      ┆            ┆           ┆           ┆           ┆           ┆ strike    │
+    │ 2024-07-02 ┆ Judge,     ┆ SL         ┆ 87.5      ┆ 94.3      ┆ 42        ┆ field_out ┆ hit_into_ │
+    │            ┆ Aaron      ┆            ┆           ┆           ┆           ┆           ┆ play      │
+    │ 2024-07-02 ┆ Judge,     ┆ FC         ┆ 96.3      ┆ null      ┆ null      ┆ null      ┆ ball      │
+    │            ┆ Aaron      ┆            ┆           ┆           ┆           ┆           ┆           │
+    │ 2024-07-02 ┆ Judge,     ┆ SL         ┆ 90.1      ┆ null      ┆ null      ┆ null      ┆ foul      │
+    │            ┆ Aaron      ┆            ┆           ┆           ┆           ┆           ┆           │
+    └────────────┴────────────┴────────────┴───────────┴───────────┴───────────┴───────────┴───────────┘
+
+
 
 ## 🍳 Cookbook: common baseball tasks
 
@@ -259,6 +418,43 @@ print(rank)
 games
 ```
 
+    ✅ Yankees July schedule
+    shape: (1, 4)
+    ┌───────────┬──────┬────────┬───────────────┐
+    │ team_name ┆ wins ┆ losses ┆ division_rank │
+    │ ---       ┆ ---  ┆ ---    ┆ ---           │
+    │ str       ┆ i64  ┆ i64    ┆ str           │
+    ╞═══════════╪══════╪════════╪═══════════════╡
+    │ Yankees   ┆ 94   ┆ 68     ┆ 1             │
+    └───────────┴──────┴────────┴───────────────┘
+
+
+
+
+
+    shape: (6, 6)
+    ┌─────────┬───────────────┬──────────────────┬─────────────────┬─────────────────┬─────────────────┐
+    │ game_pk ┆ official_date ┆ teams_away_team_ ┆ teams_home_team ┆ teams_away_scor ┆ teams_home_scor │
+    │ ---     ┆ ---           ┆ name             ┆ _name           ┆ e               ┆ e               │
+    │ i64     ┆ str           ┆ ---              ┆ ---             ┆ ---             ┆ ---             │
+    │         ┆               ┆ str              ┆ str             ┆ i64             ┆ i64             │
+    ╞═════════╪═══════════════╪══════════════════╪═════════════════╪═════════════════╪═════════════════╡
+    │ 745730  ┆ 2024-07-02    ┆ Cincinnati Reds  ┆ New York        ┆ 5               ┆ 4               │
+    │         ┆               ┆                  ┆ Yankees         ┆                 ┆                 │
+    │ 745728  ┆ 2024-07-03    ┆ Cincinnati Reds  ┆ New York        ┆ 3               ┆ 2               │
+    │         ┆               ┆                  ┆ Yankees         ┆                 ┆                 │
+    │ 745726  ┆ 2024-07-04    ┆ Cincinnati Reds  ┆ New York        ┆ 8               ┆ 4               │
+    │         ┆               ┆                  ┆ Yankees         ┆                 ┆                 │
+    │ 745725  ┆ 2024-07-05    ┆ Boston Red Sox   ┆ New York        ┆ 5               ┆ 3               │
+    │         ┆               ┆                  ┆ Yankees         ┆                 ┆                 │
+    │ 745724  ┆ 2024-07-06    ┆ Boston Red Sox   ┆ New York        ┆ 4               ┆ 14              │
+    │         ┆               ┆                  ┆ Yankees         ┆                 ┆                 │
+    │ 745723  ┆ 2024-07-07    ┆ Boston Red Sox   ┆ New York        ┆ 3               ┆ 0               │
+    │         ┆               ┆                  ┆ Yankees         ┆                 ┆                 │
+    └─────────┴───────────────┴──────────────────┴─────────────────┴─────────────────┴─────────────────┘
+
+
+
 ### Recipe 2 — A Statcast leaderboard 🏃
 
 The `statcast_leaderboard_*` family wraps Savant's *pre-aggregated* season
@@ -276,6 +472,32 @@ spcols = ["last_name, first_name", "team", "position", "competitive_runs", "spri
        .sort("sprint_speed", descending=True).head(10)
  if sprint is not None and sprint.height else "leaderboard unavailable right now")
 ```
+
+    ✅ sprint speed leaderboard
+
+
+
+
+
+    shape: (10, 5)
+    ┌───────────────────────┬──────┬──────────┬──────────────────┬──────────────┐
+    │ last_name, first_name ┆ team ┆ position ┆ competitive_runs ┆ sprint_speed │
+    │ ---                   ┆ ---  ┆ ---      ┆ ---              ┆ ---          │
+    │ str                   ┆ str  ┆ str      ┆ i64              ┆ f64          │
+    ╞═══════════════════════╪══════╪══════════╪══════════════════╪══════════════╡
+    │ Witt Jr., Bobby       ┆ KC   ┆ SS       ┆ 298              ┆ 30.5         │
+    │ Rojas, Johan          ┆ PHI  ┆ CF       ┆ 176              ┆ 30.1         │
+    │ De La Cruz, Elly      ┆ CIN  ┆ SS       ┆ 249              ┆ 30.0         │
+    │ Fitzgerald, Tyler     ┆ SF   ┆ SS       ┆ 99               ┆ 30.0         │
+    │ Clase, Jonatan        ┆ TOR  ┆ LF       ┆ 20               ┆ 30.0         │
+    │ Crow-Armstrong, Pete  ┆ CHC  ┆ CF       ┆ 149              ┆ 30.0         │
+    │ Scott II, Victor      ┆ STL  ┆ CF       ┆ 62               ┆ 30.0         │
+    │ Mateo, Jorge          ┆ BAL  ┆ 2B       ┆ 77               ┆ 29.9         │
+    │ Siri, Jose            ┆ TB   ┆ CF       ┆ 116              ┆ 29.9         │
+    │ Hampson, Garrett      ┆ KC   ┆ CF       ┆ 89               ┆ 29.8         │
+    └───────────────────────┴──────┴──────────┴──────────────────┴──────────────┘
+
+
 
 ### Recipe 3 — Box score for one game 📊
 
@@ -304,6 +526,24 @@ out = box_df if box_df is not None else "boxscore unavailable right now"
 out
 ```
 
+    ✅ boxscore 744914
+
+
+
+
+
+    shape: (2, 7)
+    ┌──────┬───────────────────┬──────┬──────┬───────────┬─────┬──────┐
+    │ side ┆ team              ┆ runs ┆ hits ┆ home_runs ┆ rbi ┆ avg  │
+    │ ---  ┆ ---               ┆ ---  ┆ ---  ┆ ---       ┆ --- ┆ ---  │
+    │ str  ┆ str               ┆ i64  ┆ i64  ┆ i64       ┆ i64 ┆ str  │
+    ╞══════╪═══════════════════╪══════╪══════╪═══════════╪═════╪══════╡
+    │ away ┆ Houston Astros    ┆ 3    ┆ 4    ┆ 2         ┆ 3   ┆ .264 │
+    │ home ┆ Toronto Blue Jays ┆ 1    ┆ 4    ┆ 1         ┆ 1   ┆ .234 │
+    └──────┴───────────────────┴──────┴──────┴───────────┴─────┴──────┘
+
+
+
 ### Recipe 4 — Plate-appearance play-by-play + outcome mix ⚾
 
 [`mlb_api_play_by_play`](../mlb/reference/mlb_api.md#mlb_api_play_by_play)
@@ -327,6 +567,28 @@ else:
 out
 ```
 
+    ✅ play-by-play 744914
+
+
+
+
+
+    shape: (5, 5)
+    ┌──────────────┬──────────────────┬────────────────────────┬────────────────────────┬──────────────┐
+    │ about.inning ┆ about.halfInning ┆ matchup.batter.fullNam ┆ matchup.pitcher.fullNa ┆ result.event │
+    │ ---          ┆ ---              ┆ e                      ┆ me                     ┆ ---          │
+    │ i64          ┆ str              ┆ ---                    ┆ ---                    ┆ str          │
+    │              ┆                  ┆ str                    ┆ str                    ┆              │
+    ╞══════════════╪══════════════════╪════════════════════════╪════════════════════════╪══════════════╡
+    │ 1            ┆ top              ┆ Alex Bregman           ┆ Yariel Rodríguez       ┆ Flyout       │
+    │ 1            ┆ top              ┆ Jake Meyers            ┆ Yariel Rodríguez       ┆ Strikeout    │
+    │ 1            ┆ top              ┆ Yordan Alvarez         ┆ Yariel Rodríguez       ┆ Groundout    │
+    │ 1            ┆ bottom           ┆ Bo Bichette            ┆ Hunter Brown           ┆ Groundout    │
+    │ 1            ┆ bottom           ┆ Spencer Horwitz        ┆ Hunter Brown           ┆ Lineout      │
+    └──────────────┴──────────────────┴────────────────────────┴────────────────────────┴──────────────┘
+
+
+
 
 ```python
 # Outcome mix for the game — the shape of every plate appearance.
@@ -338,6 +600,29 @@ else:
     out = "no play-by-play to summarize right now"
 out
 ```
+
+
+
+
+    shape: (10, 2)
+    ┌──────────────┬───────┐
+    │ result.event ┆ count │
+    │ ---          ┆ ---   │
+    │ str          ┆ u32   │
+    ╞══════════════╪═══════╡
+    │ Strikeout    ┆ 16    │
+    │ Groundout    ┆ 14    │
+    │ Pop Out      ┆ 10    │
+    │ Flyout       ┆ 7     │
+    │ Walk         ┆ 6     │
+    │ Lineout      ┆ 4     │
+    │ Home Run     ┆ 3     │
+    │ Single       ┆ 3     │
+    │ Double       ┆ 2     │
+    │ Hit By Pitch ┆ 1     │
+    └──────────────┴───────┘
+
+
 
 ### Recipe 5 — League leaders for any stat 🥇
 
@@ -362,6 +647,32 @@ leaders = safe("2024 HR leaders",
                lambda: hr_leaders(SAMPLE_SEASON, "homeRuns", "hitting", 10))
 leaders if leaders is not None else "leaders unavailable right now"
 ```
+
+    ✅ 2024 HR leaders
+
+
+
+
+
+    shape: (10, 4)
+    ┌──────┬───────────────────┬───────────────────────┬───────┐
+    │ rank ┆ player            ┆ team                  ┆ value │
+    │ ---  ┆ ---               ┆ ---                   ┆ ---   │
+    │ i64  ┆ str               ┆ str                   ┆ str   │
+    ╞══════╪═══════════════════╪═══════════════════════╪═══════╡
+    │ 1    ┆ Aaron Judge       ┆ New York Yankees      ┆ 58    │
+    │ 2    ┆ Shohei Ohtani     ┆ Los Angeles Dodgers   ┆ 54    │
+    │ 3    ┆ Anthony Santander ┆ Baltimore Orioles     ┆ 44    │
+    │ 4    ┆ Juan Soto         ┆ New York Yankees      ┆ 41    │
+    │ 5    ┆ Marcell Ozuna     ┆ Atlanta Braves        ┆ 39    │
+    │ 5    ┆ José Ramírez      ┆ Cleveland Guardians   ┆ 39    │
+    │ 5    ┆ Brent Rooker      ┆ Oakland Athletics     ┆ 39    │
+    │ 8    ┆ Kyle Schwarber    ┆ Philadelphia Phillies ┆ 38    │
+    │ 9    ┆ Gunnar Henderson  ┆ Baltimore Orioles     ┆ 37    │
+    │ 10   ┆ Ketel Marte       ┆ Arizona Diamondbacks  ┆ 36    │
+    └──────┴───────────────────┴───────────────────────┴───────┘
+
+
 
 ### Recipe 6 — Who's beating their expected stats? 🎲
 
@@ -389,6 +700,32 @@ else:
 out
 ```
 
+    ✅ expected stats
+
+
+
+
+
+    shape: (10, 5)
+    ┌───────────────────────┬─────┬───────┬──────────┬──────────────────────────┐
+    │ last_name, first_name ┆ pa  ┆ woba  ┆ est_woba ┆ est_woba_minus_woba_diff │
+    │ ---                   ┆ --- ┆ ---   ┆ ---      ┆ ---                      │
+    │ str                   ┆ i64 ┆ f64   ┆ f64      ┆ f64                      │
+    ╞═══════════════════════╪═════╪═══════╪══════════╪══════════════════════════╡
+    │ Drury, Brandon        ┆ 360 ┆ 0.217 ┆ 0.264    ┆ -0.047                   │
+    │ Soto, Juan            ┆ 713 ┆ 0.421 ┆ 0.463    ┆ -0.042                   │
+    │ Bailey, Patrick       ┆ 448 ┆ 0.281 ┆ 0.322    ┆ -0.041                   │
+    │ Sosa, Lenyn           ┆ 369 ┆ 0.28  ┆ 0.321    ┆ -0.041                   │
+    │ Morel, Christopher    ┆ 611 ┆ 0.28  ┆ 0.316    ┆ -0.036                   │
+    │ Garcia, Maikel        ┆ 626 ┆ 0.27  ┆ 0.305    ┆ -0.035                   │
+    │ Martinez, J.D.        ┆ 495 ┆ 0.318 ┆ 0.353    ┆ -0.035                   │
+    │ Harris II, Michael    ┆ 470 ┆ 0.312 ┆ 0.346    ┆ -0.034                   │
+    │ Margot, Manuel        ┆ 343 ┆ 0.276 ┆ 0.31     ┆ -0.034                   │
+    │ Kirk, Alejandro       ┆ 386 ┆ 0.297 ┆ 0.329    ┆ -0.032                   │
+    └───────────────────────┴─────┴───────┴──────────┴──────────────────────────┘
+
+
+
 ### Recipe 7 — The fastest bats in baseball 💨
 
 Bat tracking is one of Statcast's newest toys.
@@ -411,6 +748,32 @@ else:
     out = "bat-tracking leaderboard unavailable right now"
 out
 ```
+
+    ✅ bat tracking
+
+
+
+
+
+    shape: (10, 5)
+    ┌────────────────────┬────────────────────┬───────────────┬─────────────────┬──────────────┐
+    │ name               ┆ swings_competitive ┆ avg_bat_speed ┆ hard_swing_rate ┆ swing_length │
+    │ ---                ┆ ---                ┆ ---           ┆ ---             ┆ ---          │
+    │ str                ┆ i64                ┆ f64           ┆ f64             ┆ f64          │
+    ╞════════════════════╪════════════════════╪═══════════════╪═════════════════╪══════════════╡
+    │ Caminero, Junior   ┆ 406                ┆ 79.947173     ┆ 0.891626        ┆ 8.55445      │
+    │ Stanton, Giancarlo ┆ 155                ┆ 79.335078     ┆ 0.929032        ┆ 8.440819     │
+    │ Walker, Jordan     ┆ 471                ┆ 79.051274     ┆ 0.857749        ┆ 8.310408     │
+    │ Cruz, Oneil        ┆ 447                ┆ 78.461902     ┆ 0.780761        ┆ 7.622225     │
+    │ Kurtz, Nick        ┆ 451                ┆ 78.099293     ┆ 0.802661        ┆ 7.770633     │
+    │ Jones, Spencer     ┆ 89                 ┆ 77.835442     ┆ 0.797753        ┆ 7.768163     │
+    │ Adell, Jo          ┆ 541                ┆ 77.258055     ┆ 0.698706        ┆ 7.744954     │
+    │ Clarke, Denzel     ┆ 88                 ┆ 77.159528     ┆ 0.738636        ┆ 7.621649     │
+    │ Smith, Cam         ┆ 436                ┆ 77.064606     ┆ 0.724771        ┆ 7.703723     │
+    │ Bolte, Henry       ┆ 126                ┆ 77.04431      ┆ 0.753968        ┆ 7.871587     │
+    └────────────────────┴────────────────────┴───────────────┴─────────────────┴──────────────┘
+
+
 
 ### Recipe 8 — The best gloves: Outs Above Average 🧤
 
@@ -435,6 +798,33 @@ else:
     out = "OAA leaderboard unavailable right now"
 out
 ```
+
+    ✅ outs above average
+
+
+
+
+
+    shape: (10, 5)
+    ┌───────────────────┬───────────────────┬───────────────────┬───────────────────┬──────────────────┐
+    │ last_name,        ┆ display_team_name ┆ primary_pos_forma ┆ outs_above_averag ┆ fielding_runs_pr │
+    │ first_name        ┆ ---               ┆ tted              ┆ e                 ┆ evented          │
+    │ ---               ┆ str               ┆ ---               ┆ ---               ┆ ---              │
+    │ str               ┆                   ┆ str               ┆ i64               ┆ i64              │
+    ╞═══════════════════╪═══════════════════╪═══════════════════╪═══════════════════╪══════════════════╡
+    │ Giménez, Andrés   ┆ Guardians         ┆ 2B                ┆ 20                ┆ 15               │
+    │ Young, Jacob      ┆ Nationals         ┆ CF                ┆ 20                ┆ 18               │
+    │ Semien, Marcus    ┆ Rangers           ┆ 2B                ┆ 19                ┆ 14               │
+    │ Swanson, Dansby   ┆ Cubs              ┆ SS                ┆ 17                ┆ 13               │
+    │ Siani, Michael    ┆ Cardinals         ┆ CF                ┆ 16                ┆ 14               │
+    │ Siri, Jose        ┆ Rays              ┆ CF                ┆ 16                ┆ 14               │
+    │ Witt Jr., Bobby   ┆ Royals            ┆ SS                ┆ 16                ┆ 12               │
+    │ Lindor, Francisco ┆ Mets              ┆ SS                ┆ 15                ┆ 11               │
+    │ Santana, Carlos   ┆ Twins             ┆ 1B                ┆ 15                ┆ 11               │
+    │ Tovar, Ezequiel   ┆ Rockies           ┆ SS                ┆ 15                ┆ 11               │
+    └───────────────────┴───────────────────┴───────────────────┴───────────────────┴──────────────────┘
+
+
 
 ### Recipe 9 — Find the X: the hardest-hit homers 🚀
 
@@ -461,6 +851,33 @@ else:
 out
 ```
 
+    ✅ home runs (2-day)
+    homers in window: 51
+
+
+
+
+
+    shape: (10, 5)
+    ┌────────────┬────────────────────┬──────────────┬──────────────┬─────────────────┐
+    │ game_date  ┆ player_name        ┆ launch_speed ┆ launch_angle ┆ hit_distance_sc │
+    │ ---        ┆ ---                ┆ ---          ┆ ---          ┆ ---             │
+    │ str        ┆ str                ┆ f64          ┆ i64          ┆ i64             │
+    ╞════════════╪════════════════════╪══════════════╪══════════════╪═════════════════╡
+    │ 2024-07-02 ┆ De La Cruz, Elly   ┆ 114.1        ┆ 21           ┆ 425             │
+    │ 2024-07-02 ┆ Judge, Aaron       ┆ 112.5        ┆ 25           ┆ 381             │
+    │ 2024-07-02 ┆ Sánchez, Jesús     ┆ 112.5        ┆ 24           ┆ 448             │
+    │ 2024-07-02 ┆ Ohtani, Shohei     ┆ 112.0        ┆ 37           ┆ 433             │
+    │ 2024-07-02 ┆ Soler, Jorge       ┆ 109.0        ┆ 21           ┆ 394             │
+    │ 2024-07-02 ┆ Rooker, Brent      ┆ 108.7        ┆ 34           ┆ 405             │
+    │ 2024-07-02 ┆ Turner, Trea       ┆ 108.5        ┆ 20           ┆ 422             │
+    │ 2024-07-02 ┆ Schneemann, Daniel ┆ 108.3        ┆ 28           ┆ 408             │
+    │ 2024-07-02 ┆ Riley, Austin      ┆ 108.3        ┆ 36           ┆ 407             │
+    │ 2024-07-02 ┆ Witt Jr., Bobby    ┆ 108.0        ┆ 24           ┆ 399             │
+    └────────────┴────────────────────┴──────────────┴──────────────┴─────────────────┘
+
+
+
 ### Recipe 10 — The biggest swings of a game (WPA) 📈
 
 [`mlb_api_win_probability`](../mlb/reference/mlb_api.md#mlb_api_win_probability)
@@ -486,6 +903,39 @@ def wpa_swings(game_pk, n=8):
 wpa = safe(f"WPA swings {gid}", lambda: wpa_swings(gid))
 wpa if wpa is not None else "win-probability unavailable right now"
 ```
+
+    ✅ WPA swings 744914
+
+
+
+
+
+    shape: (8, 5)
+    ┌──────────────┬──────────────────┬──────────────────┬──────────────────────┬──────────────────────┐
+    │ about.inning ┆ about.halfInning ┆ result.event     ┆ result.description   ┆ homeTeamWinProbabili │
+    │ ---          ┆ ---              ┆ ---              ┆ ---                  ┆ tyAdded              │
+    │ i64          ┆ str              ┆ str              ┆ str                  ┆ ---                  │
+    │              ┆                  ┆                  ┆                      ┆ f64                  │
+    ╞══════════════╪══════════════════╪══════════════════╪══════════════════════╪══════════════════════╡
+    │ 8            ┆ bottom           ┆ Double           ┆ Spencer Horwitz      ┆ 23.7                 │
+    │              ┆                  ┆                  ┆ doubles (3) on…      ┆                      │
+    │ 8            ┆ bottom           ┆ Groundout        ┆ Daulton Varsho       ┆ -20.4                │
+    │              ┆                  ┆                  ┆ grounds out sha…     ┆                      │
+    │ 8            ┆ bottom           ┆ Lineout          ┆ George Springer      ┆ -19.3                │
+    │              ┆                  ┆                  ┆ lines out to t…      ┆                      │
+    │ 5            ┆ top              ┆ Home Run         ┆ Jeremy Peña homers   ┆ -14.8                │
+    │              ┆                  ┆                  ┆ (6) on a fl…         ┆                      │
+    │ 9            ┆ top              ┆ Home Run         ┆ Yordan Alvarez       ┆ -12.6                │
+    │              ┆                  ┆                  ┆ homers (17) on …     ┆                      │
+    │ 8            ┆ bottom           ┆ Walk             ┆ Addison Barger       ┆ 9.8                  │
+    │              ┆                  ┆                  ┆ walks.               ┆                      │
+    │ 8            ┆ bottom           ┆ Strikeout        ┆ Bo Bichette strikes  ┆ -9.0                 │
+    │              ┆                  ┆                  ┆ out swingi…          ┆                      │
+    │ 7            ┆ top              ┆ Grounded Into DP ┆ Yainer Diaz grounds  ┆ 8.1                  │
+    │              ┆                  ┆                  ┆ into a dou…          ┆                      │
+    └──────────────┴──────────────────┴──────────────────┴──────────────────────┴──────────────────────┘
+
+
 
 ### Recipe 11 — Season award winners (MVP, Cy Young) 🏅
 
@@ -516,6 +966,26 @@ board = safe("2024 award winners", lambda: award_board(SAMPLE_SEASON, AWARDS))
 board if (board is not None and board.height) else "awards unavailable right now"
 ```
 
+    ✅ 2024 award winners
+
+
+
+
+
+    shape: (4, 3)
+    ┌─────────────┬────────┬───────────────┐
+    │ award       ┆ season ┆ winner        │
+    │ ---         ┆ ---    ┆ ---           │
+    │ str         ┆ str    ┆ str           │
+    ╞═════════════╪════════╪═══════════════╡
+    │ AL MVP      ┆ 2024   ┆ Aaron Judge   │
+    │ NL MVP      ┆ 2024   ┆ Shohei Ohtani │
+    │ AL Cy Young ┆ 2024   ┆ Tarik Skubal  │
+    │ NL Cy Young ┆ 2024   ┆ Chris Sale    │
+    └─────────────┴────────┴───────────────┘
+
+
+
 ### Recipe 12 — The first-round draft board 🎓
 
 [`mlb_api_draft`](../mlb/reference/mlb_api.md#mlb_api_draft) returns the amateur
@@ -538,6 +1008,34 @@ def draft_board(year, round_=1):
 draft = safe("2024 first round", lambda: draft_board(2024, round_=1))
 draft.head(12) if (draft is not None and draft.height) else "draft unavailable right now"
 ```
+
+    ✅ 2024 first round
+
+
+
+
+
+    shape: (12, 4)
+    ┌──────┬───────────────────┬──────────────────────┬─────────────────────┐
+    │ pick ┆ player            ┆ team                 ┆ school              │
+    │ ---  ┆ ---               ┆ ---                  ┆ ---                 │
+    │ i64  ┆ str               ┆ str                  ┆ str                 │
+    ╞══════╪═══════════════════╪══════════════════════╪═════════════════════╡
+    │ 1    ┆ Travis Bazzana    ┆ Cleveland Guardians  ┆ Oregon State        │
+    │ 2    ┆ Chase Burns       ┆ Cincinnati Reds      ┆ Wake Forest         │
+    │ 3    ┆ Charlie Condon    ┆ Colorado Rockies     ┆ Georgia             │
+    │ 4    ┆ Nick Kurtz        ┆ Athletics            ┆ Wake Forest         │
+    │ 5    ┆ Hagen Smith       ┆ Chicago White Sox    ┆ Arkansas            │
+    │ 6    ┆ Jac Caglianone    ┆ Kansas City Royals   ┆ Florida             │
+    │ 7    ┆ JJ Wetherholt     ┆ St. Louis Cardinals  ┆ West Virginia       │
+    │ 8    ┆ Christian Moore   ┆ Los Angeles Angels   ┆ Tennessee           │
+    │ 9    ┆ Konnor Griffin    ┆ Pittsburgh Pirates   ┆ Jackson Prep School │
+    │ 10   ┆ Seaver King       ┆ Washington Nationals ┆ Wake Forest         │
+    │ 11   ┆ Bryce Rainer      ┆ Detroit Tigers       ┆ Harvard-Westlake HS │
+    │ 12   ┆ Braden Montgomery ┆ Boston Red Sox       ┆ Texas A&M           │
+    └──────┴───────────────────┴──────────────────────┴─────────────────────┘
+
+
 
 ## 📅 A whole season's schedule via ESPN
 
@@ -564,6 +1062,32 @@ else:
 out
 ```
 
+    ✅ ESPN 2024 season schedule
+    games: 500
+
+
+
+
+
+    shape: (5, 6)
+    ┌───────────┬────────────────────┬────────────┬───────────────────┬────────────┬───────────────────┐
+    │ game_id   ┆ away_display_name  ┆ away_score ┆ home_display_name ┆ home_score ┆ status_type_compl │
+    │ ---       ┆ ---                ┆ ---        ┆ ---               ┆ ---        ┆ eted              │
+    │ str       ┆ str                ┆ str        ┆ str               ┆ str        ┆ ---               │
+    │           ┆                    ┆            ┆                   ┆            ┆ bool              │
+    ╞═══════════╪════════════════════╪════════════╪═══════════════════╪════════════╪═══════════════════╡
+    │ 401576167 ┆ Los Angeles        ┆ 14         ┆ San Diego Padres  ┆ 1          ┆ true              │
+    │           ┆ Dodgers            ┆            ┆                   ┆            ┆                   │
+    │ 401576169 ┆ Kansas City Royals ┆ 4          ┆ Texas Rangers     ┆ 5          ┆ true              │
+    │ 401576643 ┆ Chicago White Sox  ┆ 1          ┆ Chicago Cubs      ┆ 8          ┆ true              │
+    │ 401576170 ┆ San Diego Padres   ┆ 1          ┆ Los Angeles       ┆ 4          ┆ true              │
+    │           ┆                    ┆            ┆ Dodgers           ┆            ┆                   │
+    │ 401576168 ┆ Arizona            ┆ 0          ┆ Colorado Rockies  ┆ 3          ┆ true              │
+    │           ┆ Diamondbacks       ┆            ┆                   ┆            ┆                   │
+    └───────────┴────────────────────┴────────────┴───────────────────┴────────────┴───────────────────┘
+
+
+
 ## ⚪ Secondary path: ESPN teams (`espn_mlb_*`)
 
 [`espn_mlb_teams`](../mlb/reference/additional.md#espn_mlb_teams) returns one
@@ -577,6 +1101,27 @@ ecols = ["team_id", "team_location", "team_name", "team_abbreviation", "team_dis
 (espn_teams.select([c for c in ecols if c in espn_teams.columns]).head()
  if espn_teams is not None else "ESPN teams unavailable right now")
 ```
+
+    ✅ ESPN teams
+
+
+
+
+
+    shape: (5, 5)
+    ┌─────────┬───────────────┬──────────────┬───────────────────┬──────────────────────┐
+    │ team_id ┆ team_location ┆ team_name    ┆ team_abbreviation ┆ team_display_name    │
+    │ ---     ┆ ---           ┆ ---          ┆ ---               ┆ ---                  │
+    │ str     ┆ str           ┆ str          ┆ str               ┆ str                  │
+    ╞═════════╪═══════════════╪══════════════╪═══════════════════╪══════════════════════╡
+    │ 29      ┆ Arizona       ┆ Diamondbacks ┆ ARI               ┆ Arizona Diamondbacks │
+    │ 11      ┆ Athletics     ┆ Athletics    ┆ ATH               ┆ Athletics            │
+    │ 15      ┆ Atlanta       ┆ Braves       ┆ ATL               ┆ Atlanta Braves       │
+    │ 1       ┆ Baltimore     ┆ Orioles      ┆ BAL               ┆ Baltimore Orioles    │
+    │ 2       ┆ Boston        ┆ Red Sox      ┆ BOS               ┆ Boston Red Sox       │
+    └─────────┴───────────────┴──────────────┴───────────────────┴──────────────────────┘
+
+
 
 ## 🎉 Where to next
 

--- a/docs/docs/tutorials/10_pwhl_intro.md
+++ b/docs/docs/tutorials/10_pwhl_intro.md
@@ -63,6 +63,9 @@ import sportsdataverse.pwhl as pwhl
 print("most recent PWHL season:", pwhl.most_recent_pwhl_season())
 ```
 
+    most recent PWHL season: 2027
+
+
 The 🛰️ **live** HockeyTech feed is seasonal and occasionally rate-limited, so a tiny `safe()` helper runs those calls defensively — you get the frame when the feed is up, and a friendly one-liner when it isn't (never a scary traceback). The 📦 **loaders** read release parquets and are rock-solid, so they don't need the wrapper. 🛟
 
 
@@ -88,12 +91,37 @@ schedule.shape
 ```
 
 
+
+
+    (85, 29)
+
+
+
+
 ```python
 schedule.select([
     'game_id', 'game_date', 'home_team', 'away_team',
     'home_score', 'away_score', 'winner', 'game_type',
 ]).head()
 ```
+
+
+
+
+    shape: (5, 8)
+    ┌─────────┬─────────────┬───────────┬───────────┬────────────┬────────────┬───────────┬───────────┐
+    │ game_id ┆ game_date   ┆ home_team ┆ away_team ┆ home_score ┆ away_score ┆ winner    ┆ game_type │
+    │ ---     ┆ ---         ┆ ---       ┆ ---       ┆ ---        ┆ ---        ┆ ---       ┆ ---       │
+    │ str     ┆ str         ┆ str       ┆ str       ┆ str        ┆ str        ┆ str       ┆ str       │
+    ╞═════════╪═════════════╪═══════════╪═══════════╪════════════╪════════════╪═══════════╪═══════════╡
+    │ 84      ┆ Wed, May 8  ┆ Toronto   ┆ Minnesota ┆ 4          ┆ 0          ┆ Toronto   ┆ playoffs  │
+    │ 98      ┆ Wed, May 29 ┆ Boston    ┆ Minnesota ┆ 0          ┆ 3          ┆ Minnesota ┆ playoffs  │
+    │ 90      ┆ Wed, May 15 ┆ Minnesota ┆ Toronto   ┆ 1          ┆ 0          ┆ Minnesota ┆ playoffs  │
+    │ 63      ┆ Wed, May 1  ┆ Toronto   ┆ Minnesota ┆ 4          ┆ 1          ┆ Toronto   ┆ regular   │
+    │ 45      ┆ Wed, Mar 6  ┆ Toronto   ┆ Boston    ┆ 3          ┆ 1          ┆ Toronto   ┆ regular   │
+    └─────────┴─────────────┴───────────┴───────────┴────────────┴────────────┴───────────┴───────────┘
+
+
 
 ## 👥 Rosters (loader)
 
@@ -107,6 +135,24 @@ rosters.select([
     'jersey_number', 'position',
 ]).head()
 ```
+
+
+
+
+    shape: (5, 7)
+    ┌──────────────┬───────────┬─────────────┬────────────┬───────────┬───────────────┬──────────┐
+    │ team         ┆ team_abbr ┆ player_type ┆ first_name ┆ last_name ┆ jersey_number ┆ position │
+    │ ---          ┆ ---       ┆ ---         ┆ ---        ┆ ---       ┆ ---           ┆ ---      │
+    │ str          ┆ str       ┆ str         ┆ str        ┆ str       ┆ i32           ┆ str      │
+    ╞══════════════╪═══════════╪═════════════╪════════════╪═══════════╪═══════════════╪══════════╡
+    │ PWHL Toronto ┆ TOR       ┆ skater      ┆ Jocelyne   ┆ Larocque  ┆ 3             ┆ LD       │
+    │ PWHL Toronto ┆ TOR       ┆ skater      ┆ Lauriane   ┆ Rougeau   ┆ 5             ┆ LD       │
+    │ PWHL Toronto ┆ TOR       ┆ skater      ┆ Kali       ┆ Flanagan  ┆ 6             ┆ RD       │
+    │ PWHL Toronto ┆ TOR       ┆ skater      ┆ Olivia     ┆ Knowles   ┆ 7             ┆ RD       │
+    │ PWHL Toronto ┆ TOR       ┆ skater      ┆ Alexa      ┆ Vasko     ┆ 10            ┆ C        │
+    └──────────────┴───────────┴─────────────┴────────────┴───────────┴───────────────┴──────────┘
+
+
 
 ## 📊 Boxscores (loader)
 
@@ -129,6 +175,24 @@ skater_box.select([
 ```
 
 
+
+
+    shape: (5, 10)
+    ┌─────────┬────────────┬───────────┬──────────┬───┬────────┬───────┬────────────┬─────────────┐
+    │ game_id ┆ first_name ┆ last_name ┆ position ┆ … ┆ points ┆ shots ┆ plus_minus ┆ time_on_ice │
+    │ ---     ┆ ---        ┆ ---       ┆ ---      ┆   ┆ ---    ┆ ---   ┆ ---        ┆ ---         │
+    │ i32     ┆ str        ┆ str       ┆ str      ┆   ┆ i32    ┆ i32   ┆ i32        ┆ f64         │
+    ╞═════════╪════════════╪═══════════╪══════════╪═══╪════════╪═══════╪════════════╪═════════════╡
+    │ 2       ┆ Jocelyne   ┆ Larocque  ┆ LD       ┆ … ┆ 0      ┆ 2     ┆ -2         ┆ 26.7        │
+    │ 2       ┆ Lauriane   ┆ Rougeau   ┆ LD       ┆ … ┆ 0      ┆ 0     ┆ 0          ┆ 12.1        │
+    │ 2       ┆ Kali       ┆ Flanagan  ┆ RD       ┆ … ┆ 0      ┆ 1     ┆ -1         ┆ 21.6        │
+    │ 2       ┆ Olivia     ┆ Knowles   ┆ RD       ┆ … ┆ 0      ┆ 0     ┆ 0          ┆ 9.7         │
+    │ 2       ┆ Alexa      ┆ Vasko     ┆ C        ┆ … ┆ 0      ┆ 3     ┆ 0          ┆ 10.5        │
+    └─────────┴────────────┴───────────┴──────────┴───┴────────┴───────┴────────────┴─────────────┘
+
+
+
+
 ```python
 goalie_box = pwhl.load_pwhl_goalie_box(seasons=[2024])
 goalie_box.select([
@@ -136,6 +200,24 @@ goalie_box.select([
     'saves', 'shots_against', 'goals_against', 'time_on_ice',
 ]).head()
 ```
+
+
+
+
+    shape: (5, 7)
+    ┌─────────┬────────────┬────────────┬───────┬───────────────┬───────────────┬─────────────┐
+    │ game_id ┆ first_name ┆ last_name  ┆ saves ┆ shots_against ┆ goals_against ┆ time_on_ice │
+    │ ---     ┆ ---        ┆ ---        ┆ ---   ┆ ---           ┆ ---           ┆ ---         │
+    │ i32     ┆ str        ┆ str        ┆ i32   ┆ i32           ┆ i32           ┆ f64         │
+    ╞═════════╪════════════╪════════════╪═══════╪═══════════════╪═══════════════╪═════════════╡
+    │ 2       ┆ Erica      ┆ Howe       ┆ 0     ┆ 0             ┆ 0             ┆ null        │
+    │ 2       ┆ Kristen    ┆ Campbell   ┆ 24    ┆ 28            ┆ 4             ┆ 60.0        │
+    │ 2       ┆ Corinne    ┆ Schroeder  ┆ 29    ┆ 29            ┆ 0             ┆ 60.0        │
+    │ 2       ┆ Abbey      ┆ Levy       ┆ 0     ┆ 0             ┆ 0             ┆ null        │
+    │ 3       ┆ Sandra     ┆ Abstreiter ┆ 0     ┆ 0             ┆ 0             ┆ null        │
+    └─────────┴────────────┴────────────┴───────┴───────────────┴───────────────┴─────────────┘
+
+
 
 ## 🎬 Play-by-play (loader)
 
@@ -148,12 +230,36 @@ pbp.shape
 ```
 
 
+
+
+    (10456, 95)
+
+
+
+
 ```python
 (pbp
     .group_by('event')
     .agg(pl.len().alias('events'))
     .sort('events', descending=True))
 ```
+
+
+
+
+    shape: (4, 2)
+    ┌─────────┬────────┐
+    │ event   ┆ events │
+    │ ---     ┆ ---    │
+    │ str     ┆ u32    │
+    ╞═════════╪════════╡
+    │ shot    ┆ 4922   │
+    │ faceoff ┆ 4631   │
+    │ penalty ┆ 518    │
+    │ goal    ┆ 385    │
+    └─────────┴────────┘
+
+
 
 ## 🍳 Cookbook: common PWHL tasks
 
@@ -172,6 +278,25 @@ No loader is needed for a quick standings table: the schedule's `winner` column 
     .sort('wins', descending=True))
 ```
 
+
+
+
+    shape: (6, 2)
+    ┌───────────┬──────┐
+    │ winner    ┆ wins │
+    │ ---       ┆ ---  │
+    │ str       ┆ u32  │
+    ╞═══════════╪══════╡
+    │ Toronto   ┆ 17   │
+    │ Montreal  ┆ 13   │
+    │ Boston    ┆ 12   │
+    │ Minnesota ┆ 12   │
+    │ New York  ┆ 9    │
+    │ Ottawa    ┆ 9    │
+    └───────────┴──────┘
+
+
+
 ### Recipe 2 — Season scoring leaders 🥇
 
 Aggregate the skater boxscore across every game to build a points leaderboard — the inaugural-season top of the table.
@@ -189,6 +314,29 @@ Aggregate the skater boxscore across every game to build a points leaderboard �
     .select(['first_name', 'last_name', 'goals', 'assists', 'points'])
     .head(10))
 ```
+
+
+
+
+    shape: (10, 5)
+    ┌──────────────┬───────────┬───────┬─────────┬────────┐
+    │ first_name   ┆ last_name ┆ goals ┆ assists ┆ points │
+    │ ---          ┆ ---       ┆ ---   ┆ ---     ┆ ---    │
+    │ str          ┆ str       ┆ i32   ┆ i32     ┆ i32    │
+    ╞══════════════╪═══════════╪═══════╪═════════╪════════╡
+    │ Natalie      ┆ Spooner   ┆ 21    ┆ 8       ┆ 29     │
+    │ Marie-Philip ┆ Poulin    ┆ 11    ┆ 14      ┆ 25     │
+    │ Sarah        ┆ Nurse     ┆ 11    ┆ 13      ┆ 24     │
+    │ Alex         ┆ Carpenter ┆ 8     ┆ 15      ┆ 23     │
+    │ Emma         ┆ Maltais   ┆ 5     ┆ 16      ┆ 21     │
+    │ Taylor       ┆ Heise     ┆ 9     ┆ 12      ┆ 21     │
+    │ Ella         ┆ Shelton   ┆ 7     ┆ 14      ┆ 21     │
+    │ Brianne      ┆ Jenner    ┆ 9     ┆ 11      ┆ 20     │
+    │ Erin         ┆ Ambrose   ┆ 4     ┆ 16      ┆ 20     │
+    │ Grace        ┆ Zumwinkle ┆ 12    ┆ 8       ┆ 20     │
+    └──────────────┴───────────┴───────┴─────────┴────────┘
+
+
 
 ### Recipe 3 — Goalie save-percentage leaders 🧤
 
@@ -212,6 +360,29 @@ Sum saves and shots-against from the goalie boxscore, then compute a season save
     .head(10))
 ```
 
+
+
+
+    shape: (10, 5)
+    ┌────────────┬────────────┬───────────────┬───────────────┬──────────┐
+    │ first_name ┆ last_name  ┆ shots_against ┆ goals_against ┆ save_pct │
+    │ ---        ┆ ---        ┆ ---           ┆ ---           ┆ ---      │
+    │ str        ┆ str        ┆ i32           ┆ i32           ┆ f64      │
+    ╞════════════╪════════════╪═══════════════╪═══════════════╪══════════╡
+    │ Elaine     ┆ Chuli      ┆ 253           ┆ 13            ┆ 0.949    │
+    │ Aerin      ┆ Frankel    ┆ 790           ┆ 49            ┆ 0.938    │
+    │ Kristen    ┆ Campbell   ┆ 718           ┆ 48            ┆ 0.933    │
+    │ Corinne    ┆ Schroeder  ┆ 511           ┆ 36            ┆ 0.93     │
+    │ Nicole     ┆ Hensley    ┆ 492           ┆ 37            ┆ 0.925    │
+    │ Maddie     ┆ Rooney     ┆ 362           ┆ 27            ┆ 0.925    │
+    │ Ann-Renée  ┆ Desbiens   ┆ 580           ┆ 44            ┆ 0.924    │
+    │ Emerance   ┆ Maschmeyer ┆ 599           ┆ 51            ┆ 0.915    │
+    │ Abbey      ┆ Levy       ┆ 254           ┆ 24            ┆ 0.906    │
+    │ Emma       ┆ Söderberg  ┆ 170           ┆ 17            ┆ 0.9      │
+    └────────────┴────────────┴───────────────┴───────────────┴──────────┘
+
+
+
 ### Recipe 4 — Biggest blowouts of the season 💥
 
 Cast the string scores to integers, compute the margin, and sort — the season's most lopsided games fall right out.
@@ -231,6 +402,29 @@ Cast the string scores to integers, compute the margin, and sort — the season'
              'away_score', 'away_team', 'winner', 'margin'])
     .head(10))
 ```
+
+
+
+
+    shape: (10, 7)
+    ┌─────────────┬───────────┬────────────┬────────────┬───────────┬───────────┬────────┐
+    │ game_date   ┆ home_team ┆ home_score ┆ away_score ┆ away_team ┆ winner    ┆ margin │
+    │ ---         ┆ ---       ┆ ---        ┆ ---        ┆ ---       ┆ ---       ┆ ---    │
+    │ str         ┆ str       ┆ i32        ┆ i32        ┆ str       ┆ str       ┆ i32    │
+    ╞═════════════╪═══════════╪════════════╪════════════╪═══════════╪═══════════╪════════╡
+    │ Wed, May 8  ┆ Toronto   ┆ 4          ┆ 0          ┆ Minnesota ┆ Toronto   ┆ 4      │
+    │ Wed, Mar 13 ┆ Minnesota ┆ 4          ┆ 0          ┆ Boston    ┆ Minnesota ┆ 4      │
+    │ Sun, Apr 28 ┆ New York  ┆ 2          ┆ 6          ┆ Toronto   ┆ Toronto   ┆ 4      │
+    │ Sat, Mar 16 ┆ Minnesota ┆ 5          ┆ 1          ┆ New York  ┆ Minnesota ┆ 4      │
+    │ Sat, Jan 13 ┆ Toronto   ┆ 1          ┆ 5          ┆ Ottawa    ┆ Ottawa    ┆ 4      │
+    │ Sat, Apr 20 ┆ Ottawa    ┆ 4          ┆ 0          ┆ Minnesota ┆ Ottawa    ┆ 4      │
+    │ Mon, Jan 1  ┆ Toronto   ┆ 0          ┆ 4          ┆ New York  ┆ New York  ┆ 4      │
+    │ Wed, May 29 ┆ Boston    ┆ 0          ┆ 3          ┆ Minnesota ┆ Minnesota ┆ 3      │
+    │ Wed, May 1  ┆ Toronto   ┆ 4          ┆ 1          ┆ Minnesota ┆ Toronto   ┆ 3      │
+    │ Wed, Mar 20 ┆ New York  ┆ 0          ┆ 3          ┆ Ottawa    ┆ Ottawa    ┆ 3      │
+    └─────────────┴───────────┴────────────┴────────────┴───────────┴───────────┴────────┘
+
+
 
 ### Recipe 5 — Team offense: shots & shooting % ⚡
 
@@ -257,6 +451,25 @@ team_lookup = (pwhl.load_pwhl_team_box(seasons=[2024])
     .sort('goals', descending=True))
 ```
 
+
+
+
+    shape: (6, 4)
+    ┌───────────┬───────┬───────┬──────────────┐
+    │ team_abbr ┆ goals ┆ shots ┆ shooting_pct │
+    │ ---       ┆ ---   ┆ ---   ┆ ---          │
+    │ str       ┆ i32   ┆ i32   ┆ f64          │
+    ╞═══════════╪═══════╪═══════╪══════════════╡
+    │ TOR       ┆ 74    ┆ 790   ┆ 9.4          │
+    │ MIN       ┆ 72    ┆ 1025  ┆ 7.0          │
+    │ MTL       ┆ 64    ┆ 814   ┆ 7.9          │
+    │ BOS       ┆ 62    ┆ 907   ┆ 6.8          │
+    │ OTT       ┆ 61    ┆ 721   ┆ 8.5          │
+    │ NY        ┆ 52    ┆ 667   ┆ 7.8          │
+    └───────────┴───────┴───────┴──────────────┘
+
+
+
 ### Recipe 6 — Power-play conversion leaders 🔌
 
 The team boxscore carries `pp_goals` and `pp_opportunities`, so a season power-play percentage is a single division.
@@ -276,6 +489,25 @@ team_box = pwhl.load_pwhl_team_box(seasons=[2024])
     )
     .sort('pp_pct', descending=True))
 ```
+
+
+
+
+    shape: (6, 4)
+    ┌───────────┬──────────┬──────────────────┬────────┐
+    │ team_abbr ┆ pp_goals ┆ pp_opportunities ┆ pp_pct │
+    │ ---       ┆ ---      ┆ ---              ┆ ---    │
+    │ str       ┆ i32      ┆ i32              ┆ f64    │
+    ╞═══════════╪══════════╪══════════════════╪════════╡
+    │ OTT       ┆ 16       ┆ 64               ┆ 25.0   │
+    │ NY        ┆ 19       ┆ 78               ┆ 24.4   │
+    │ MTL       ┆ 16       ┆ 94               ┆ 17.0   │
+    │ TOR       ┆ 11       ┆ 80               ┆ 13.8   │
+    │ MIN       ┆ 7        ┆ 87               ┆ 8.0    │
+    │ BOS       ┆ 4        ┆ 68               ┆ 5.9    │
+    └───────────┴──────────┴──────────────────┴────────┘
+
+
 
 ### Recipe 7 — Faceoff specialists 🎯
 
@@ -297,6 +529,29 @@ The skater boxscore tracks faceoff wins and attempts. Aggregate, gate on a minim
     .head(10))
 ```
 
+
+
+
+    shape: (10, 5)
+    ┌──────────────┬───────────────┬─────────┬─────────────┬────────┐
+    │ first_name   ┆ last_name     ┆ fo_wins ┆ fo_attempts ┆ fo_pct │
+    │ ---          ┆ ---           ┆ ---     ┆ ---         ┆ ---    │
+    │ str          ┆ str           ┆ i32     ┆ i32         ┆ f64    │
+    ╞══════════════╪═══════════════╪═════════╪═════════════╪════════╡
+    │ Abby         ┆ Roque         ┆ 205     ┆ 339         ┆ 60.5   │
+    │ Marie-Philip ┆ Poulin        ┆ 326     ┆ 546         ┆ 59.7   │
+    │ Alex         ┆ Carpenter     ┆ 245     ┆ 415         ┆ 59.0   │
+    │ Kelly        ┆ Pannek        ┆ 344     ┆ 630         ┆ 54.6   │
+    │ Brianne      ┆ Jenner        ┆ 125     ┆ 230         ┆ 54.3   │
+    │ Taylor       ┆ Heise         ┆ 264     ┆ 495         ┆ 53.3   │
+    │ Hannah       ┆ Brandt        ┆ 270     ┆ 510         ┆ 52.9   │
+    │ Kristin      ┆ O'Neill       ┆ 240     ┆ 460         ┆ 52.2   │
+    │ Jade         ┆ Downie-Landry ┆ 116     ┆ 225         ┆ 51.6   │
+    │ Jesse        ┆ Compher       ┆ 119     ┆ 233         ┆ 51.1   │
+    └──────────────┴───────────────┴─────────┴─────────────┴────────┘
+
+
+
 ### Recipe 8 — Two-way workhorses: hits + blocks 🧱
 
 Not every contribution shows up on the scoresheet. Sum hits and blocked shots from the skater box to surface the players doing the dirty work — defenders usually own this list.
@@ -316,6 +571,29 @@ Not every contribution shows up on the scoresheet. Sum hits and blocked shots fr
     .head(10))
 ```
 
+
+
+
+    shape: (10, 6)
+    ┌────────────┬────────────┬──────────┬──────┬────────┬──────────────────┐
+    │ first_name ┆ last_name  ┆ position ┆ hits ┆ blocks ┆ hits_plus_blocks │
+    │ ---        ┆ ---        ┆ ---      ┆ ---  ┆ ---    ┆ ---              │
+    │ str        ┆ str        ┆ str      ┆ i32  ┆ i32    ┆ i32              │
+    ╞════════════╪════════════╪══════════╪══════╪════════╪══════════════════╡
+    │ Renata     ┆ Fast       ┆ RD       ┆ 77   ┆ 23     ┆ 100              │
+    │ Megan      ┆ Keller     ┆ LD       ┆ 64   ┆ 33     ┆ 97               │
+    │ Kaleigh    ┆ Fratkin    ┆ RD       ┆ 65   ┆ 19     ┆ 84               │
+    │ Blayre     ┆ Turnbull   ┆ C        ┆ 62   ┆ 14     ┆ 76               │
+    │ Allie      ┆ Munroe     ┆ LD       ┆ 44   ┆ 25     ┆ 69               │
+    │ Jessica    ┆ DiGirolamo ┆ LD       ┆ 36   ┆ 31     ┆ 67               │
+    │ Lee        ┆ Stecklein  ┆ LD       ┆ 36   ┆ 25     ┆ 61               │
+    │ Emma       ┆ Greco      ┆ LD       ┆ 32   ┆ 29     ┆ 61               │
+    │ Emma       ┆ Maltais    ┆ LW       ┆ 53   ┆ 8      ┆ 61               │
+    │ Kelly      ┆ Pannek     ┆ C        ┆ 28   ┆ 30     ┆ 58               │
+    └────────────┴────────────┴──────────┴──────┴────────┴──────────────────┘
+
+
+
 ### Recipe 9 — The penalty box 🚨
 
 [`load_pwhl_penalty_summary`](../pwhl/reference/loaders.md#load_pwhl_penalty_summary) is a tidy per-infraction log. Two quick cuts: the most common infractions league-wide, and the players spending the most time in the box.
@@ -334,6 +612,27 @@ top_infractions
 ```
 
 
+
+
+    shape: (8, 2)
+    ┌────────────────┬───────┐
+    │ description    ┆ count │
+    │ ---            ┆ ---   │
+    │ str            ┆ u32   │
+    ╞════════════════╪═══════╡
+    │ Tripping       ┆ 106   │
+    │ Hooking        ┆ 91    │
+    │ Roughing       ┆ 64    │
+    │ Interference   ┆ 53    │
+    │ Slashing       ┆ 35    │
+    │ Boarding       ┆ 30    │
+    │ Cross Checking ┆ 26    │
+    │ Holding        ┆ 26    │
+    └────────────────┴───────┘
+
+
+
+
 ```python
 # PIM leaders (players who actually took the penalty)
 (penalties
@@ -346,6 +645,29 @@ top_infractions
     .sort('pim', descending=True)
     .head(10))
 ```
+
+
+
+
+    shape: (10, 4)
+    ┌────────────────┬───────────────┬─────┬───────────┐
+    │ taken_by_first ┆ taken_by_last ┆ pim ┆ penalties │
+    │ ---            ┆ ---           ┆ --- ┆ ---       │
+    │ str            ┆ str           ┆ i32 ┆ u32       │
+    ╞════════════════╪═══════════════╪═════╪═══════════╡
+    │ Tereza         ┆ Vanišová      ┆ 37  ┆ 13        │
+    │ Kaleigh        ┆ Fratkin       ┆ 36  ┆ 18        │
+    │ Abby           ┆ Roque         ┆ 31  ┆ 10        │
+    │ Jesse          ┆ Compher       ┆ 25  ┆ 7         │
+    │ Megan          ┆ Keller        ┆ 22  ┆ 11        │
+    │ Allie          ┆ Munroe        ┆ 20  ┆ 10        │
+    │ Gabbie         ┆ Hughes        ┆ 20  ┆ 10        │
+    │ Sarah          ┆ Nurse         ┆ 18  ┆ 9         │
+    │ Jade           ┆ Downie-Landry ┆ 18  ┆ 9         │
+    │ Lee            ┆ Stecklein     ┆ 18  ┆ 9         │
+    └────────────────┴───────────────┴─────┴───────────┘
+
+
 
 ### Recipe 10 — When do goals get scored? ⏱️
 
@@ -364,6 +686,25 @@ goals_by_period
 ```
 
 
+
+
+    shape: (6, 2)
+    ┌────────────────┬───────┐
+    │ period_of_game ┆ goals │
+    │ ---            ┆ ---   │
+    │ str            ┆ u32   │
+    ╞════════════════╪═══════╡
+    │ 1              ┆ 109   │
+    │ 2              ┆ 120   │
+    │ 3              ┆ 138   │
+    │ 4              ┆ 15    │
+    │ 5              ┆ 2     │
+    │ 6              ┆ 1     │
+    └────────────────┴───────┘
+
+
+
+
 ```python
 # Top goal-scorers from the play-by-play feed
 (goal_events
@@ -373,6 +714,29 @@ goals_by_period
     .sort('goals', descending=True)
     .head(10))
 ```
+
+
+
+
+    shape: (10, 3)
+    ┌───────────────────┬──────────────────┬───────┐
+    │ player_name_first ┆ player_name_last ┆ goals │
+    │ ---               ┆ ---              ┆ ---   │
+    │ str               ┆ str              ┆ u32   │
+    ╞═══════════════════╪══════════════════╪═══════╡
+    │ Natalie           ┆ Spooner          ┆ 21    │
+    │ Grace             ┆ Zumwinkle        ┆ 12    │
+    │ Sarah             ┆ Nurse            ┆ 11    │
+    │ Marie-Philip      ┆ Poulin           ┆ 11    │
+    │ Daryl             ┆ Watts            ┆ 10    │
+    │ Laura             ┆ Stacey           ┆ 10    │
+    │ Michela           ┆ Cava             ┆ 9     │
+    │ Gabbie            ┆ Hughes           ┆ 9     │
+    │ Taylor            ┆ Heise            ┆ 9     │
+    │ Brianne           ┆ Jenner           ┆ 9     │
+    └───────────────────┴──────────────────┴───────┘
+
+
 
 ### Recipe 11 — Three-stars honour roll ⭐ and a head-to-head series
 
@@ -392,6 +756,29 @@ three_stars = pwhl.load_pwhl_three_stars(seasons=[2024])
 ```
 
 
+
+
+    shape: (10, 3)
+    ┌──────────────┬───────────┬─────────────┐
+    │ first_name   ┆ last_name ┆ first_stars │
+    │ ---          ┆ ---       ┆ ---         │
+    │ str          ┆ str       ┆ u32         │
+    ╞══════════════╪═══════════╪═════════════╡
+    │ Natalie      ┆ Spooner   ┆ 7           │
+    │ Kristen      ┆ Campbell  ┆ 4           │
+    │ Nicole       ┆ Hensley   ┆ 4           │
+    │ Sarah        ┆ Nurse     ┆ 3           │
+    │ Marie-Philip ┆ Poulin    ┆ 3           │
+    │ Gabbie       ┆ Hughes    ┆ 3           │
+    │ Hilary       ┆ Knight    ┆ 3           │
+    │ Susanna      ┆ Tapani    ┆ 3           │
+    │ Alex         ┆ Carpenter ┆ 3           │
+    │ Michela      ┆ Cava      ┆ 2           │
+    └──────────────┴───────────┴─────────────┘
+
+
+
+
 ```python
 # Head-to-head: Boston vs. Montreal, every meeting in 2024
 A, B = 'Boston', 'Montreal'
@@ -403,6 +790,26 @@ A, B = 'Boston', 'Montreal'
     .select(['game_date', 'home_team', 'home_score',
              'away_score', 'away_team', 'winner', 'game_status']))
 ```
+
+
+
+
+    shape: (7, 7)
+    ┌─────────────┬───────────┬────────────┬────────────┬───────────┬──────────┬─────────────┐
+    │ game_date   ┆ home_team ┆ home_score ┆ away_score ┆ away_team ┆ winner   ┆ game_status │
+    │ ---         ┆ ---       ┆ ---        ┆ ---        ┆ ---       ┆ ---      ┆ ---         │
+    │ str         ┆ str       ┆ str        ┆ str        ┆ str       ┆ str      ┆ str         │
+    ╞═════════════╪═══════════╪════════════╪════════════╪═══════════╪══════════╪═════════════╡
+    │ Tue, May 14 ┆ Boston    ┆ 3          ┆ 2          ┆ Montreal  ┆ Boston   ┆ Final OT    │
+    │ Thu, May 9  ┆ Montreal  ┆ 1          ┆ 2          ┆ Boston    ┆ Boston   ┆ Final OT    │
+    │ Sun, Feb 4  ┆ Boston    ┆ 1          ┆ 2          ┆ Montreal  ┆ Montreal ┆ Final OT    │
+    │ Sat, May 4  ┆ Boston    ┆ 4          ┆ 3          ┆ Montreal  ┆ Boston   ┆ Final       │
+    │ Sat, May 11 ┆ Montreal  ┆ 1          ┆ 2          ┆ Boston    ┆ Boston   ┆ Final OT3   │
+    │ Sat, Mar 2  ┆ Montreal  ┆ 3          ┆ 1          ┆ Boston    ┆ Montreal ┆ Final       │
+    │ Sat, Jan 13 ┆ Montreal  ┆ 2          ┆ 3          ┆ Boston    ┆ Boston   ┆ Final OT    │
+    └─────────────┴───────────┴────────────┴────────────┴───────────┴──────────┴─────────────┘
+
+
 
 ### Recipe 12 — Find a player, then pull her career lines 🛰️🔎
 
@@ -426,6 +833,35 @@ else:
 out
 ```
 
+    ✅ player search: Spooner
+
+
+    ✅ player stats 100
+
+
+
+
+
+    shape: (10, 7)
+    ┌────────────────────────┬───────────┬──────────────┬───────┬─────────┬────────┬─────────────────┐
+    │ season_name            ┆ team_code ┆ games_played ┆ goals ┆ assists ┆ points ┆ points_per_game │
+    │ ---                    ┆ ---       ┆ ---          ┆ ---   ┆ ---     ┆ ---    ┆ ---             │
+    │ str                    ┆ str       ┆ str          ┆ str   ┆ str     ┆ str    ┆ str             │
+    ╞════════════════════════╪═══════════╪══════════════╪═══════╪═════════╪════════╪═════════════════╡
+    │ 2025-26 Regular Season ┆ TOR       ┆ 30           ┆ 3     ┆ 5       ┆ 8      ┆ 0.27            │
+    │ 2024-25 Regular Season ┆ TOR       ┆ 14           ┆ 3     ┆ 2       ┆ 5      ┆ 0.36            │
+    │ 2024 Regular Season    ┆ TOR       ┆ 24           ┆ 20    ┆ 7       ┆ 27     ┆ 1.13            │
+    │ Total                  ┆ null      ┆ 68           ┆ 26    ┆ 14      ┆ 40     ┆ 0.59            │
+    │ 2025-26 Preseason      ┆ TOR       ┆ 1            ┆ 0     ┆ 1       ┆ 1      ┆ 1.00            │
+    │ 2024 Preseason         ┆ TOR       ┆ 1            ┆ 0     ┆ 0       ┆ 0      ┆ 0.00            │
+    │ Total                  ┆ null      ┆ 2            ┆ 0     ┆ 1       ┆ 1      ┆ 0.50            │
+    │ 2025 Playoffs          ┆ TOR       ┆ 4            ┆ 0     ┆ 1       ┆ 1      ┆ 0.25            │
+    │ 2024 Playoffs          ┆ TOR       ┆ 3            ┆ 1     ┆ 1       ┆ 2      ┆ 0.67            │
+    │ Total                  ┆ null      ┆ 7            ┆ 1     ┆ 2       ┆ 3      ┆ 0.43            │
+    └────────────────────────┴───────────┴──────────────┴───────┴─────────┴────────┴─────────────────┘
+
+
+
 ### Recipe 13 — A team, its roster, and a game's PBP + Corsi 🛰️📈
 
 The full live tour. List teams with [`pwhl_teams`](../pwhl/reference/additional.md#pwhl_teams), grab a `team_id`, pull the roster with [`pwhl_team_roster`](../pwhl/reference/additional.md#pwhl_team_roster), take a `game_id` from the loader schedule, then fetch enriched events with [`pwhl_pbp`](../pwhl/reference/additional.md#pwhl_pbp) and shot-attempt share with [`pwhl_game_corsi`](../pwhl/reference/additional.md#pwhl_game_corsi) — all from the same feed. Everything is `safe()`-wrapped, so offline this prints a friendly note instead of raising.
@@ -444,6 +880,30 @@ else:
 out
 ```
 
+    ✅ PWHL teams
+
+
+    ✅ PWHL roster 1
+
+
+
+
+
+    shape: (5, 3)
+    ┌────────────┬───────────┬──────────┐
+    │ first_name ┆ last_name ┆ position │
+    │ ---        ┆ ---       ┆ ---      │
+    │ str        ┆ str       ┆ str      │
+    ╞════════════╪═══════════╪══════════╡
+    │ Emily      ┆ Brown     ┆ D        │
+    │ Megan      ┆ Keller    ┆ D        │
+    │ Sidney     ┆ Morin     ┆ D        │
+    │ Lexie      ┆ Adzija    ┆ F        │
+    │ Sophie     ┆ Shirley   ┆ F        │
+    └────────────┴───────────┴──────────┘
+
+
+
 
 ```python
 # A game_id from the loader schedule (offline-safe), then enrich it live.
@@ -453,6 +913,13 @@ corsi = safe(f'PWHL corsi {gid}', lambda: pwhl.pwhl_game_corsi(game_id=gid))
 print('live pbp rows:', None if pbp_live is None else pbp_live.height,
       '| corsi rows:', None if corsi is None else corsi.height)
 ```
+
+    ✅ PWHL pbp 84
+
+
+    ✅ PWHL corsi 84
+    live pbp rows: 188 | corsi rows: 39
+
 
 ## 🛰️ Live standings & leaders
 
@@ -470,6 +937,28 @@ else:
 out
 ```
 
+    ✅ PWHL standings
+
+
+
+
+
+    shape: (6, 6)
+    ┌────────────────────┬───────────┬──────────────┬──────┬────────┬────────┐
+    │ team               ┆ team_code ┆ games_played ┆ wins ┆ losses ┆ points │
+    │ ---                ┆ ---       ┆ ---          ┆ ---  ┆ ---    ┆ ---    │
+    │ str                ┆ str       ┆ str          ┆ i64  ┆ str    ┆ i64    │
+    ╞════════════════════╪═══════════╪══════════════╪══════╪════════╪════════╡
+    │ x - PWHL Toronto   ┆ x - TOR   ┆ 24           ┆ 17   ┆ 7      ┆ 47     │
+    │ x - PWHL Montreal  ┆ x - MTL   ┆ 24           ┆ 13   ┆ 6      ┆ 41     │
+    │ x - PWHL Boston    ┆ x - BOS   ┆ 24           ┆ 12   ┆ 9      ┆ 35     │
+    │ x - PWHL Minnesota ┆ x - MIN   ┆ 24           ┆ 12   ┆ 9      ┆ 35     │
+    │ e - PWHL Ottawa    ┆ e - OTT   ┆ 24           ┆ 9    ┆ 9      ┆ 32     │
+    │ e - PWHL New York  ┆ e - NY    ┆ 24           ┆ 9    ┆ 12     ┆ 26     │
+    └────────────────────┴───────────┴──────────────┴──────┴────────┴────────┘
+
+
+
 
 ```python
 leaders = safe('PWHL leaders', lambda: pwhl.pwhl_leaders(season=2024))
@@ -481,6 +970,32 @@ else:
     out = 'leaders feed unavailable right now'
 out
 ```
+
+    ✅ PWHL leaders
+
+
+
+
+
+    shape: (10, 5)
+    ┌──────┬─────────────────────┬───────────┬────────────────┬────────────────┐
+    │ rank ┆ name                ┆ team_code ┆ stat_formatted ┆ type_formatted │
+    │ ---  ┆ ---                 ┆ ---       ┆ ---            ┆ ---            │
+    │ i64  ┆ str                 ┆ str       ┆ str            ┆ str            │
+    ╞══════╪═════════════════════╪═══════════╪════════════════╪════════════════╡
+    │ 1    ┆ Natalie Spooner     ┆ TOR       ┆ 27             ┆ Points         │
+    │ 2    ┆ Sarah Nurse         ┆ TOR       ┆ 23             ┆ Points         │
+    │ 3    ┆ Marie-Philip Poulin ┆ MTL       ┆ 23             ┆ Points         │
+    │ 4    ┆ Alex Carpenter      ┆ NY        ┆ 23             ┆ Points         │
+    │ 5    ┆ Ella Shelton        ┆ NY        ┆ 21             ┆ Points         │
+    │ 1    ┆ Natalie Spooner     ┆ TOR       ┆ 20             ┆ Goals          │
+    │ 2    ┆ Sarah Nurse         ┆ TOR       ┆ 11             ┆ Goals          │
+    │ 3    ┆ Grace Zumwinkle     ┆ MIN       ┆ 11             ┆ Goals          │
+    │ 4    ┆ Marie-Philip Poulin ┆ MTL       ┆ 10             ┆ Goals          │
+    │ 5    ┆ Laura Stacey        ┆ MTL       ┆ 10             ┆ Goals          │
+    └──────┴─────────────────────┴───────────┴────────────────┴────────────────┘
+
+
 
 ## 🥅 On-ice analytics
 
@@ -506,6 +1021,27 @@ else:
 out
 ```
 
+    ✅ PWHL TOI 84
+
+
+
+
+
+    shape: (5, 4)
+    ┌────────────┬───────────┬─────────────┬────────────┐
+    │ first_name ┆ last_name ┆ toi_seconds ┆ num_shifts │
+    │ ---        ┆ ---       ┆ ---         ┆ ---        │
+    │ str        ┆ str       ┆ i64         ┆ u32        │
+    ╞════════════╪═══════════╪═════════════╪════════════╡
+    │ Kristen    ┆ Campbell  ┆ 3600        ┆ 3          │
+    │ Nicole     ┆ Hensley   ┆ 3600        ┆ 3          │
+    │ Jocelyne   ┆ Larocque  ┆ 1677        ┆ 29         │
+    │ Renata     ┆ Fast      ┆ 1674        ┆ 28         │
+    │ Sophie     ┆ Jaques    ┆ 1402        ┆ 26         │
+    └────────────┴───────────┴─────────────┴────────────┘
+
+
+
 
 ```python
 if corsi is not None and corsi.height:
@@ -519,6 +1055,24 @@ else:
     out = 'corsi feed unavailable right now'
 out
 ```
+
+
+
+
+    shape: (5, 4)
+    ┌───────────┬───────────┬───────────────┬─────────────────┐
+    │ player_id ┆ corsi_for ┆ corsi_against ┆ corsi_for_per60 │
+    │ ---       ┆ ---       ┆ ---           ┆ ---             │
+    │ str       ┆ i64       ┆ i64           ┆ f64             │
+    ╞═══════════╪═══════════╪═══════════════╪═════════════════╡
+    │ 115       ┆ 18        ┆ 5             ┆ 84.155844       │
+    │ 76        ┆ 20        ┆ 5             ┆ 78.26087        │
+    │ 89        ┆ 17        ┆ 7             ┆ 72.943981       │
+    │ 100       ┆ 19        ┆ 10            ┆ 66.86217        │
+    │ 20        ┆ 20        ┆ 17            ┆ 64.228368       │
+    └───────────┴───────────┴───────────────┴─────────────────┘
+
+
 
 ## ✨ Bonus: tidy goal log + pandas interop
 
@@ -534,6 +1088,25 @@ scoring.select([
 ```
 
 
+
+
+    shape: (5, 8)
+    ┌─────────┬────────┬───────┬───────────┬──────────────┬─────────────┬───────────────┬──────────────┐
+    │ game_id ┆ period ┆ time  ┆ team_abbr ┆ scorer_first ┆ scorer_last ┆ is_power_play ┆ is_game_winn │
+    │ ---     ┆ ---    ┆ ---   ┆ ---       ┆ ---          ┆ ---         ┆ ---           ┆ ing          │
+    │ i32     ┆ str    ┆ str   ┆ str       ┆ str          ┆ str         ┆ i32           ┆ ---          │
+    │         ┆        ┆       ┆           ┆              ┆             ┆               ┆ i32          │
+    ╞═════════╪════════╪═══════╪═══════════╪══════════════╪═════════════╪═══════════════╪══════════════╡
+    │ 2       ┆ 1st    ┆ 10:43 ┆ NY        ┆ Ella         ┆ Shelton     ┆ 0             ┆ 1            │
+    │ 2       ┆ 3rd    ┆ 2:53  ┆ NY        ┆ Alex         ┆ Carpenter   ┆ 0             ┆ 0            │
+    │ 2       ┆ 3rd    ┆ 4:57  ┆ NY        ┆ Jill         ┆ Saulnier    ┆ 0             ┆ 0            │
+    │ 2       ┆ 3rd    ┆ 7:42  ┆ NY        ┆ Kayla        ┆ Vespa       ┆ 0             ┆ 0            │
+    │ 3       ┆ 2nd    ┆ 16:24 ┆ OTT       ┆ Hayley       ┆ Scamurra    ┆ 1             ┆ 0            │
+    └─────────┴────────┴───────┴───────────┴──────────────┴─────────────┴───────────────┴──────────────┘
+
+
+
+
 ```python
 # Same skater box, but as a pandas DataFrame — group with the pandas API.
 skater_pd = pwhl.load_pwhl_skater_box(seasons=[2024], return_as_pandas=True)
@@ -543,6 +1116,26 @@ print('type:', type(skater_pd).__name__, '| shape:', skater_pd.shape)
     .sort_values('points', ascending=False)
     .head(10))
 ```
+
+    type: DataFrame | shape: (3205, 22)
+
+
+
+
+
+           first_name  last_name  points
+    101       Natalie    Spooner      29
+    90   Marie-Philip     Poulin      25
+    114         Sarah      Nurse      24
+    4            Alex  Carpenter      23
+    35           Ella    Shelton      21
+    40           Emma    Maltais      21
+    126        Taylor      Heise      21
+    18        Brianne     Jenner      20
+    42           Erin    Ambrose      20
+    47          Grace  Zumwinkle      20
+
+
 
 ## 🎉 Where to next
 

--- a/docs/docs/tutorials/11_junior_hockey_intro.md
+++ b/docs/docs/tutorials/11_junior_hockey_intro.md
@@ -86,12 +86,45 @@ sched = safe("AHL schedule", lambda: ahl.ahl_schedule(season=ahl.most_recent_ahl
 sched.shape if sched is not None else None
 ```
 
+    ✅ AHL schedule
+
+
+
+
+
+    (10000, 12)
+
+
+
 
 ```python
 cols = ["game_id", "game_date", "home_team", "away_team", "home_score", "away_score"]
 (sched.select([c for c in cols if c in sched.columns]).head()
  if sched is not None else "schedule unavailable")
 ```
+
+
+
+
+    shape: (5, 6)
+    ┌─────────┬──────────────────────────┬────────────────────┬──────────────┬────────────┬────────────┐
+    │ game_id ┆ game_date                ┆ home_team          ┆ away_team    ┆ home_score ┆ away_score │
+    │ ---     ┆ ---                      ┆ ---                ┆ ---          ┆ ---        ┆ ---        │
+    │ str     ┆ str                      ┆ str                ┆ str          ┆ str        ┆ str        │
+    ╞═════════╪══════════════════════════╪════════════════════╪══════════════╪════════════╪════════════╡
+    │ 1005950 ┆ 1995-01-17T20:00:00-05:0 ┆ U.S. AHL All-Stars ┆ Canadian AHL ┆ 4          ┆ 6          │
+    │         ┆ 0                        ┆                    ┆ All-Stars    ┆            ┆            │
+    │ 1005949 ┆ 1996-01-16T19:30:00-05:0 ┆ U.S. AHL All-Stars ┆ Canadian AHL ┆ 6          ┆ 5          │
+    │         ┆ 0                        ┆                    ┆ All-Stars    ┆            ┆            │
+    │ 1005948 ┆ 1997-01-16T20:30:00-04:0 ┆ Canadian AHL       ┆ World AHL    ┆ 2          ┆ 3          │
+    │         ┆ 0                        ┆ All-Stars          ┆ All-Stars    ┆            ┆            │
+    │ 1005947 ┆ 1998-02-11T19:30:00-05:0 ┆ PlanetUSA AHL      ┆ Canadian AHL ┆ 10         ┆ 11         │
+    │         ┆ 0                        ┆ All-Stars          ┆ All-Stars    ┆            ┆            │
+    │ 1005946 ┆ 1999-01-25T20:00:00-05:0 ┆ PlanetUSA AHL      ┆ Canadian AHL ┆ 5          ┆ 4          │
+    │         ┆ 0                        ┆ All-Stars          ┆ All-Stars    ┆            ┆            │
+    └─────────┴──────────────────────────┴────────────────────┴──────────────┴────────────┴────────────┘
+
+
 
 ## 🍳 Cookbook: common hockey tasks
 
@@ -111,6 +144,26 @@ cols = ["team", "games_played", "wins", "losses", "ot_losses", "points", "goals_
  if standings is not None and standings.height else "standings unavailable")
 ```
 
+    ✅ OHL standings
+
+
+
+
+
+    shape: (2, 8)
+    ┌───────────────┬──────────────┬──────┬────────┬───────────┬────────┬───────────┬───────────────┐
+    │ team          ┆ games_played ┆ wins ┆ losses ┆ ot_losses ┆ points ┆ goals_for ┆ goals_against │
+    │ ---           ┆ ---          ┆ ---  ┆ ---    ┆ ---       ┆ ---    ┆ ---       ┆ ---           │
+    │ str           ┆ str          ┆ str  ┆ str    ┆ str       ┆ i64    ┆ str       ┆ str           │
+    ╞═══════════════╪══════════════╪══════╪════════╪═══════════╪════════╪═══════════╪═══════════════╡
+    │ Top Prospects ┆ 1            ┆ 1    ┆ 0      ┆ 0         ┆ 2      ┆ 4         ┆ 3             │
+    │ West          ┆              ┆      ┆        ┆           ┆        ┆           ┆               │
+    │ Top Prospects ┆ 1            ┆ 0    ┆ 1      ┆ 0         ┆ 0      ┆ 3         ┆ 4             │
+    │ East          ┆              ┆      ┆        ┆           ┆        ┆           ┆               │
+    └───────────────┴──────────────┴──────┴────────┴───────────┴────────┴───────────┴───────────────┘
+
+
+
 ### Recipe 2 — A team and its roster 👥
 
 List teams with [`whl_teams`](../ahl/reference/additional.md#ahl_teams), grab a `team_id`, then pull the
@@ -128,6 +181,40 @@ else:
     out = "teams unavailable"
 out
 ```
+
+    ✅ WHL teams
+
+
+    ✅ WHL roster 201
+
+
+
+
+
+    shape: (5, 7)
+    ┌──────────────────┬─────────┬───────────┬───────────────┬────────────┬──────────┬─────────────────┐
+    │ team_name        ┆ team_id ┆ team_code ┆ team_nickname ┆ team_label ┆ division ┆ team_logo       │
+    │ ---              ┆ ---     ┆ ---       ┆ ---           ┆ ---        ┆ ---      ┆ ---             │
+    │ str              ┆ str     ┆ str       ┆ str           ┆ str        ┆ str      ┆ str             │
+    ╞══════════════════╪═════════╪═══════════╪═══════════════╪════════════╪══════════╪═════════════════╡
+    │ Brandon Wheat    ┆ 201     ┆ BDN       ┆ Wheat Kings   ┆ Brandon    ┆ 1        ┆ https://assets. │
+    │ Kings            ┆         ┆           ┆               ┆            ┆          ┆ leaguestat.com/ │
+    │                  ┆         ┆           ┆               ┆            ┆          ┆ …               │
+    │ Calgary Hitmen   ┆ 202     ┆ CGY       ┆ Hitmen        ┆ Calgary    ┆ 3        ┆ https://assets. │
+    │                  ┆         ┆           ┆               ┆            ┆          ┆ leaguestat.com/ │
+    │                  ┆         ┆           ┆               ┆            ┆          ┆ …               │
+    │ Edmonton Oil     ┆ 228     ┆ EDM       ┆ Oil Kings     ┆ Edmonton   ┆ 3        ┆ https://assets. │
+    │ Kings            ┆         ┆           ┆               ┆            ┆          ┆ leaguestat.com/ │
+    │                  ┆         ┆           ┆               ┆            ┆          ┆ …               │
+    │ Everett          ┆ 226     ┆ EVT       ┆ Silvertips    ┆ Everett    ┆ 6        ┆ https://assets. │
+    │ Silvertips       ┆         ┆           ┆               ┆            ┆          ┆ leaguestat.com/ │
+    │                  ┆         ┆           ┆               ┆            ┆          ┆ …               │
+    │ Kamloops Blazers ┆ 203     ┆ KAM       ┆ Blazers       ┆ Kamloops   ┆ 2        ┆ https://assets. │
+    │                  ┆         ┆           ┆               ┆            ┆          ┆ leaguestat.com/ │
+    │                  ┆         ┆           ┆               ┆            ┆          ┆ …               │
+    └──────────────────┴─────────┴───────────┴───────────────┴────────────┴──────────┴─────────────────┘
+
+
 
 ### Recipe 3 — A game's play-by-play + shot attempts 📈
 
@@ -154,6 +241,13 @@ else:
     print("no schedule rows to pick a game_id from")
 ```
 
+    ✅ AHL pbp 1020900
+
+
+    ✅ AHL corsi 1020900
+    pbp rows: 37 | corsi rows: 0
+
+
 ### Recipe 4 — Compare all four leagues at once 🔁
 
 Because the surface is identical, one loop tours every league.
@@ -167,6 +261,47 @@ for lg, mod in LEAGUES.items():
     rows.append({"league": lg.upper(), "season": season, "games": None if sch is None else sch.height})
 pl.DataFrame(rows)
 ```
+
+    ✅ ahl season
+
+
+    ✅ ahl schedule
+
+
+    ✅ ohl season
+
+
+    ✅ ohl schedule
+
+
+    ✅ whl season
+
+
+    ✅ whl schedule
+
+
+    ✅ qmjhl season
+
+
+    ✅ qmjhl schedule
+
+
+
+
+
+    shape: (4, 3)
+    ┌────────┬────────┬───────┐
+    │ league ┆ season ┆ games │
+    │ ---    ┆ ---    ┆ ---   │
+    │ str    ┆ i64    ┆ i64   │
+    ╞════════╪════════╪═══════╡
+    │ AHL    ┆ 2026   ┆ 10000 │
+    │ OHL    ┆ 2026   ┆ 10000 │
+    │ WHL    ┆ 2026   ┆ 10000 │
+    │ QMJHL  ┆ 2027   ┆ 10000 │
+    └────────┴────────┴───────┘
+
+
 
 ### Recipe 5 — The scoring race 🥇
 
@@ -182,6 +317,16 @@ cols = ["rank", "name", "team_code", "position", "stat_formatted", "type_formatt
 (leaders.select([c for c in cols if c in leaders.columns]).head(10)
  if leaders is not None and leaders.height else "leaders unavailable (offseason?)")
 ```
+
+    ✅ QMJHL leaders
+
+
+
+
+
+    'leaders unavailable (offseason?)'
+
+
 
 ### Recipe 6 — Who's hot, who's not 🌡️
 
@@ -208,6 +353,26 @@ else:
 out
 ```
 
+    ✅ AHL standings
+
+
+
+
+
+    shape: (4, 5)
+    ┌─────────────────────────────┬────────┬───────────┬───────────────┬───────────┐
+    │ team                        ┆ points ┆ goals_for ┆ goals_against ┆ goal_diff │
+    │ ---                         ┆ ---    ┆ ---       ┆ ---           ┆ ---       │
+    │ str                         ┆ i64    ┆ str       ┆ str           ┆ i64       │
+    ╞═════════════════════════════╪════════╪═══════════╪═══════════════╪═══════════╡
+    │ Pacific Division All-Stars  ┆ 6      ┆ 10        ┆ 8             ┆ 2         │
+    │ Atlantic Division All-Stars ┆ 3      ┆ 7         ┆ 4             ┆ 3         │
+    │ Central Division All-Stars  ┆ 3      ┆ 8         ┆ 7             ┆ 1         │
+    │ North Division All-Stars    ┆ 2      ┆ 4         ┆ 10            ┆ -6        │
+    └─────────────────────────────┴────────┴───────────┴───────────────┴───────────┘
+
+
+
 ### Recipe 7 — A player's career stat line 📊
 
 Grab any `player_id` (the leaderboard is a handy source) and
@@ -228,6 +393,33 @@ else:
     out = "leaders unavailable to source a player_id"
 out
 ```
+
+    ✅ WHL leaders
+
+
+    ✅ WHL stats for Carson Carels
+
+
+
+
+
+    shape: (5, 7)
+    ┌───────────────────────────┬───────────────┬──────────────┬───────┬─────────┬────────┬────────────┐
+    │ season_name               ┆ team_name     ┆ games_played ┆ goals ┆ assists ┆ points ┆ stat_type  │
+    │ ---                       ┆ ---           ┆ ---          ┆ ---   ┆ ---     ┆ ---    ┆ ---        │
+    │ str                       ┆ str           ┆ str          ┆ str   ┆ str     ┆ str    ┆ str        │
+    ╞═══════════════════════════╪═══════════════╪══════════════╪═══════╪═════════╪════════╪════════════╡
+    │ 2025 - 26 Regular Season  ┆ Prince George ┆ 58           ┆ 20    ┆ 53      ┆ 73     ┆ regular    │
+    │                           ┆ Cougars       ┆              ┆       ┆         ┆        ┆            │
+    │ 2024 - 25 Regular Season  ┆ Prince George ┆ 60           ┆ 6     ┆ 29      ┆ 35     ┆ regular    │
+    │                           ┆ Cougars       ┆              ┆       ┆         ┆        ┆            │
+    │ 2023 - 24 Regular Season  ┆ Prince George ┆ 7            ┆ 0     ┆ 3       ┆ 3      ┆ regular    │
+    │                           ┆ Cougars       ┆              ┆       ┆         ┆        ┆            │
+    │ Total                     ┆ null          ┆ 125          ┆ 26    ┆ 85      ┆ 111    ┆ regular    │
+    │ WHL Prospects Game 2026   ┆ West          ┆ 1            ┆ 0     ┆ 4       ┆ 4      ┆ exhibition │
+    └───────────────────────────┴───────────────┴──────────────┴───────┴─────────┴────────┴────────────┘
+
+
 
 ### Recipe 8 — The box score: goals & three stars 🌟
 
@@ -254,6 +446,31 @@ else:
 out
 ```
 
+    ✅ OHL schedule
+
+
+    ✅ OHL game summary 16968
+
+
+
+
+
+    shape: (5, 7)
+    ┌───────────┬───────┬─────────────────┬─────────────────┬─────────────────┬────────────┬───────────┐
+    │ period_id ┆ time  ┆ goal_scorer_tea ┆ goal_scorer_fir ┆ goal_scorer_las ┆ power_play ┆ empty_net │
+    │ ---       ┆ ---   ┆ m_code          ┆ st_name         ┆ t_name          ┆ ---        ┆ ---       │
+    │ str       ┆ str   ┆ ---             ┆ ---             ┆ ---             ┆ str        ┆ str       │
+    │           ┆       ┆ str             ┆ str             ┆ str             ┆            ┆           │
+    ╞═══════════╪═══════╪═════════════════╪═════════════════╪═════════════════╪════════════╪═══════════╡
+    │ 1         ┆ 4:33  ┆ SAG             ┆ Brandon         ┆ Saad            ┆ 0          ┆ 0         │
+    │ 1         ┆ 15:47 ┆ SAG             ┆ Brad            ┆ Walch           ┆ 1          ┆ 0         │
+    │ 2         ┆ 2:02  ┆ SAR             ┆ Craig           ┆ Hottot          ┆ 0          ┆ 0         │
+    │ 2         ┆ 15:44 ┆ SAG             ┆ Michael         ┆ Sgarbossa       ┆ 0          ┆ 0         │
+    │ 3         ┆ 10:05 ┆ SAR             ┆ Brett           ┆ Ritchie         ┆ 0          ┆ 0         │
+    └───────────┴───────┴─────────────────┴─────────────────┴─────────────────┴────────────┴───────────┘
+
+
+
 And the three-star selections from the same dict — no extra call needed:
 
 
@@ -267,6 +484,22 @@ else:
     out = "summary unavailable"
 out
 ```
+
+
+
+
+    shape: (3, 4)
+    ┌────────────┬────────────┬───────────────┬──────┐
+    │ first_name ┆ last_name  ┆ jersey_number ┆ home │
+    │ ---        ┆ ---        ┆ ---           ┆ ---  │
+    │ str        ┆ str        ┆ str           ┆ i64  │
+    ╞════════════╪════════════╪═══════════════╪══════╡
+    │ Craig      ┆ Hottot     ┆ 16            ┆ 1    │
+    │ Michael    ┆ Sgarbossa  ┆ 93            ┆ 0    │
+    │ Alex       ┆ Galchenyuk ┆ 94            ┆ 1    │
+    └────────────┴────────────┴───────────────┴──────┘
+
+
 
 ### Recipe 9 — Slice the play-by-play: just the goals ⛳
 
@@ -290,6 +523,29 @@ else:
 out
 ```
 
+    ✅ AHL pbp 1020900
+
+
+
+
+
+    shape: (7, 5)
+    ┌────────────────┬───────┬─────────┬───────────────────┬──────────────────┐
+    │ period_of_game ┆ clock ┆ team_id ┆ player_name_first ┆ player_name_last │
+    │ ---            ┆ ---   ┆ ---     ┆ ---               ┆ ---              │
+    │ str            ┆ str   ┆ str     ┆ str               ┆ str              │
+    ╞════════════════╪═══════╪═════════╪═══════════════════╪══════════════════╡
+    │ 2              ┆ 14:28 ┆ 313     ┆ Patrick           ┆ Sharp            │
+    │ 2              ┆ 7:18  ┆ 313     ┆ Jon               ┆ Sim              │
+    │ 2              ┆ 1:55  ┆ 313     ┆ Ben               ┆ Stafford         │
+    │ 2              ┆ 0:13  ┆ 313     ┆ Jon               ┆ Sim              │
+    │ 3              ┆ 15:23 ┆ 330     ┆ Steve             ┆ Maltais          │
+    │ 3              ┆ 11:11 ┆ 313     ┆ Patrick           ┆ Sharp            │
+    │ 3              ┆ 3:53  ┆ 330     ┆ Lonny             ┆ Bohonos          │
+    └────────────────┴───────┴─────────┴───────────────────┴──────────────────┘
+
+
+
 ### Recipe 10 — Head-to-head history 🤝
 
 The schedule is just a frame, so a rivalry view is two `str.contains` filters.
@@ -310,6 +566,32 @@ else:
     out = "schedule unavailable"
 out
 ```
+
+    Wilkes-Barre/Scranton Penguins hosting Hershey Bears:
+
+
+
+
+
+    shape: (5, 5)
+    ┌───────────────────────────┬───────────────────────┬───────────────┬────────────┬────────────┐
+    │ game_date                 ┆ home_team             ┆ away_team     ┆ home_score ┆ away_score │
+    │ ---                       ┆ ---                   ┆ ---           ┆ ---        ┆ ---        │
+    │ str                       ┆ str                   ┆ str           ┆ str        ┆ str        │
+    ╞═══════════════════════════╪═══════════════════════╪═══════════════╪════════════╪════════════╡
+    │ 2005-01-28T19:05:00-05:00 ┆ Wilkes-Barre/Scranton ┆ Hershey Bears ┆ 2          ┆ 4          │
+    │                           ┆ Penguins              ┆               ┆            ┆            │
+    │ 2005-02-04T19:05:00-05:00 ┆ Wilkes-Barre/Scranton ┆ Hershey Bears ┆ 8          ┆ 2          │
+    │                           ┆ Penguins              ┆               ┆            ┆            │
+    │ 2005-02-11T19:05:00-05:00 ┆ Wilkes-Barre/Scranton ┆ Hershey Bears ┆ 0          ┆ 2          │
+    │                           ┆ Penguins              ┆               ┆            ┆            │
+    │ 2005-03-30T19:05:00-05:00 ┆ Wilkes-Barre/Scranton ┆ Hershey Bears ┆ 2          ┆ 3          │
+    │                           ┆ Penguins              ┆               ┆            ┆            │
+    │ 2005-04-08T19:05:00-04:00 ┆ Wilkes-Barre/Scranton ┆ Hershey Bears ┆ 3          ┆ 2          │
+    │                           ┆ Penguins              ┆               ┆            ┆            │
+    └───────────────────────────┴───────────────────────┴───────────────┴────────────┴────────────┘
+
+
 
 ### Recipe 11 — Scout the roster: shooters & positions 🔍
 
@@ -334,6 +616,19 @@ else:
 out
 ```
 
+    ✅ WHL teams
+
+
+    ✅ WHL roster 201
+
+
+
+
+
+    'roster empty for this team/season'
+
+
+
 ### Recipe 12 — Hand off to pandas 🐼
 
 Every accessor takes `return_as_pandas=True`, so the whole toolkit drops
@@ -354,6 +649,22 @@ else:
     out = "season list unavailable"
 out
 ```
+
+    ✅ AHL season_id
+    pandas
+
+
+
+
+
+       season_id               season_name  season_yr game_type_label
+    0         92  2026 Calder Cup Playoffs       2026        playoffs
+    1         91   2026 All-Star Challenge       2026         regular
+    2         90    2025-26 Regular Season       2026         regular
+    3         88  2025 Calder Cup Playoffs       2025        playoffs
+    4         87   2025 All-Star Challenge       2025         regular
+
+
 
 ## 🥅 On-ice analytics
 

--- a/docs/docs/tutorials/12_odds_intro.md
+++ b/docs/docs/tutorials/12_odds_intro.md
@@ -57,6 +57,9 @@ HAS_KEY = bool(os.environ.get("ODDS_API_KEY"))
 print("ODDS_API_KEY set:", HAS_KEY, "— live cells will" + ("" if HAS_KEY else " NOT") + " run")
 ```
 
+    ODDS_API_KEY set: False — live cells will NOT run
+
+
 ## 🗂️ What's on the board?
 
 Start with [`toa_sports`](../odds/reference/additional.md#toa_sports) — it lists every sport/league key,
@@ -72,6 +75,13 @@ else:
     out = "set ODDS_API_KEY to run: odds.toa_sports(all_sports=True)"
 out
 ```
+
+
+
+
+    'set ODDS_API_KEY to run: odds.toa_sports(all_sports=True)'
+
+
 
 ## 💰 The main event: live odds
 
@@ -95,6 +105,13 @@ else:
     out = "set ODDS_API_KEY to run: odds.toa_sports_odds(sport='americanfootball_nfl', regions='us')"
 out
 ```
+
+
+
+
+    "set ODDS_API_KEY to run: odds.toa_sports_odds(sport='americanfootball_nfl', regions='us')"
+
+
 
 ## 🍳 Cookbook: common odds tasks
 
@@ -122,6 +139,13 @@ else:
 out
 ```
 
+
+
+
+    'needs ODDS_API_KEY'
+
+
+
 ### Recipe 2 — Spreads & totals for a slate 📋
 
 Ask for `markets="spreads,totals"` and the `outcome_point` column carries the
@@ -142,6 +166,13 @@ else:
 out
 ```
 
+
+
+
+    'needs ODDS_API_KEY'
+
+
+
 ### Recipe 3 — Just one book 🎯
 
 Pin a single sportsbook with `bookmakers=`. Great for tracking *your* book's
@@ -156,6 +187,13 @@ else:
     out = "needs ODDS_API_KEY"
 out
 ```
+
+
+
+
+    'needs ODDS_API_KEY'
+
+
 
 ### Recipe 4 — Implied probability & the hold 🧮
 
@@ -185,6 +223,13 @@ else:
 out
 ```
 
+
+
+
+    'needs ODDS_API_KEY'
+
+
+
 ### Recipe 5 — Find the biggest favorite on the board 🐻
 
 Sort the moneyline outcomes by price ascending — the most negative number is
@@ -204,6 +249,13 @@ else:
     out = "needs ODDS_API_KEY"
 out
 ```
+
+
+
+
+    'needs ODDS_API_KEY'
+
+
 
 ### Recipe 6 — Consensus over/under per game 📊
 
@@ -231,6 +283,13 @@ else:
     out = "needs ODDS_API_KEY"
 out
 ```
+
+
+
+
+    'needs ODDS_API_KEY'
+
+
 
 ### Recipe 7 — Just today's slate ⏰
 
@@ -260,6 +319,13 @@ else:
 out
 ```
 
+
+
+
+    'set ODDS_API_KEY to run the commence-time filter recipe'
+
+
+
 ### Recipe 8 — Player props for one game 🎯
 
 Event-level markets (player props!) live on [`toa_event_odds`](../odds/reference/additional.md#toa_event_odds).
@@ -281,6 +347,13 @@ else:
     out = "set ODDS_API_KEY to run the player-props recipe"
 out
 ```
+
+
+
+
+    'set ODDS_API_KEY to run the player-props recipe'
+
+
 
 ### Recipe 9 — Which markets does a game offer? 🗃️
 
@@ -307,6 +380,13 @@ else:
 out
 ```
 
+
+
+
+    'set ODDS_API_KEY to run the event-markets recipe'
+
+
+
 ### Recipe 10 — Recent finals & margin of victory 🏁
 
 [`toa_sports_scores`](../odds/reference/additional.md#toa_sports_scores) returns live + recently
@@ -326,6 +406,13 @@ else:
     out = "set ODDS_API_KEY to run: odds.toa_sports_scores(sport='americanfootball_nfl', days_from=3)"
 out
 ```
+
+
+
+
+    "set ODDS_API_KEY to run: odds.toa_sports_scores(sport='americanfootball_nfl', days_from=3)"
+
+
 
 ### Recipe 11 — Tour several leagues at once 🔁
 
@@ -347,6 +434,13 @@ else:
 out
 ```
 
+
+
+
+    'set ODDS_API_KEY to tour leagues with odds.toa_sports_events(sport=...)'
+
+
+
 ### Recipe 12 — Who's in the league? (participants 👥)
 
 [`toa_sports_participants`](../odds/reference/additional.md#toa_sports_participants) lists every team /
@@ -364,6 +458,13 @@ else:
 out
 ```
 
+
+
+
+    "set ODDS_API_KEY to run: odds.toa_sports_participants(sport='americanfootball_nfl')"
+
+
+
 ## ⛽ Mind your quota
 
 Paid calls cost credits (every 10 bookmakers × market ≈ 1 credit). After any
@@ -375,6 +476,13 @@ request** — handy to drop at the end of a script.
 ```python
 odds.toa_usage() if HAS_KEY else "set ODDS_API_KEY to track quota with odds.toa_usage()"
 ```
+
+
+
+
+    'set ODDS_API_KEY to track quota with odds.toa_usage()'
+
+
 
 ## ⏳ Time travel: historical odds
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -7,12 +7,18 @@ import type * as Preset from '@docusaurus/preset-classic';
 // Cap which doc versions are BUILT to keep each deploy under the Vercel build
 // container's memory budget. Every `yarn version:docs x.y.z` adds a full doc
 // copy; building all of them (6+) OOMs the build. We build the rolling
-// `current` tree plus the latest 3 release snapshots, derived from
+// `current` tree plus the latest N release snapshots, derived from
 // versions.json (which Docusaurus maintains newest-first) so this list never
 // needs manual editing at release time. Older snapshots stay under
 // versioned_docs/ in git and can be re-added by bumping the slice if the build
 // budget grows.
-const VERSIONS_TO_KEEP = 3;
+//
+// Dropped 3 -> 2: each release tree keeps growing (0.0.58 carries the full Fox /
+// Yahoo / NFL-native / odds surface), and `current` now ships executed tutorial
+// outputs, so `current + latest 3` OOMed the Vercel build. `current + latest 2`
+// (0.0.58 + 0.0.56) restores headroom; 0.0.55 stays archived in git, re-buildable
+// by bumping this back if the budget allows.
+const VERSIONS_TO_KEEP = 2;
 const allReleasedVersions: string[] = JSON.parse(
   fs.readFileSync(path.join(__dirname, 'versions.json'), 'utf-8'),
 );


### PR DESCRIPTION
One-time manual run of `render_notebooks.py` (the weekly cron's job) now that the
`pipefail` bug suppressing it is fixed (#104). Re-executes `examples/notebooks/`
against the live APIs and renders **code + outputs** to `docs/docs/tutorials/`,
so the website tutorials show real results (DataFrame previews, function output)
instead of code-only pages.

- All 12 notebooks executed cleanly; **5,743 lines** of outputs added.
- Odds page used its key-guarded fallback (no `ODDS_API_KEY` in the render env) —
  scrubbed: no API key or 32-hex secret in any rendered page.
- LF line endings (the `newline="\n"` fix from #104).

Holding for the Vercel preview build to confirm the executed outputs are
MDX-safe before merge (these pages have never been through a Docusaurus build).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all tutorial example outputs across 12 sports modules to show current API results and demonstration data for quickstart, CFB, NFL, NBA, WBB, MBB, NHL, WNBA, MLB, PWHL, junior hockey, and odds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->