### PR TITLE
docs(build): build all 6 doc versions again after Vercel memory upgrade

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -4,21 +4,16 @@ import {themes as prismThemes} from 'prism-react-renderer';
 import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 
-// Cap which doc versions are BUILT to keep each deploy under the Vercel build
-// container's memory budget. Every `yarn version:docs x.y.z` adds a full doc
-// copy; building all of them (6+) OOMs the build. We build the rolling
-// `current` tree plus the latest N release snapshots, derived from
-// versions.json (which Docusaurus maintains newest-first) so this list never
-// needs manual editing at release time. Older snapshots stay under
-// versioned_docs/ in git and can be re-added by bumping the slice if the build
-// budget grows.
+// Cap which doc versions are BUILT, derived from versions.json (which Docusaurus
+// maintains newest-first) so the list never needs manual editing at release time:
+// the rolling `current` tree plus the latest N release snapshots. Older snapshots
+// always stay under versioned_docs/ in git; this only controls what's built/served.
 //
-// Dropped 3 -> 2: each release tree keeps growing (0.0.58 carries the full Fox /
-// Yahoo / NFL-native / odds surface), and `current` now ships executed tutorial
-// outputs, so `current + latest 3` OOMed the Vercel build. `current + latest 2`
-// (0.0.58 + 0.0.56) restores headroom; 0.0.55 stays archived in git, re-buildable
-// by bumping this back if the budget allows.
-const VERSIONS_TO_KEEP = 2;
+// Raised to 6 after the Vercel build container's memory was upgraded — every
+// released snapshot in versions.json is built again (was temporarily dropped to 2
+// when `current + latest 3` OOMed the smaller container). Still a rolling cap, so
+// once versions.json grows past 6 the oldest stop building; revisit then.
+const VERSIONS_TO_KEEP = 6;
 const allReleasedVersions: string[] = JSON.parse(
   fs.readFileSync(path.join(__dirname, 'versions.json'), 'utf-8'),
 );


### PR DESCRIPTION
Raise `VERSIONS_TO_KEEP` 2 → 6 now that the Vercel build container's memory was
upgraded, restoring `/docs/0.0.54`, `/docs/0.0.53`, `/docs/0.0.50` (and keeping
0.0.58/0.0.56/0.0.55). The drop to 2 was a temporary OOM mitigation on the
smaller container (#105).

Holding for the Vercel preview to confirm `current + 6` fits the upgraded budget
before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation configuration to retain and rebuild a greater number of recent documentation versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->