### PR TITLE
docs(nfl): add nfl_api returns-schema tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [0.0.64 Release: June 17, 2026](#0064-release-june-17-2026)
   - [MLB — comprehensive Baseball Savant / Statcast surface (`mlb_statcast_*`, 43 endpoints)](#mlb--comprehensive-baseball-savant--statcast-surface-mlb_statcast_-43-endpoints)
+  - [Documentation — `nfl_api` (NFL.com Shield) returns-schema tables](#documentation--nfl_api-nflcom-shield-returns-schema-tables)
 - [0.0.63 Release: June 16, 2026](#0063-release-june-16-2026)
   - [All sports — `espn_*_game_rosters` diagonal per-team concat (fixes silent roster loss)](#all-sports--espn__game_rosters-diagonal-per-team-concat-fixes-silent-roster-loss)
   - [HTTP — `download()` no longer retries a definitive 404](#http--download-no-longer-retries-a-definitive-404)
@@ -127,6 +128,10 @@ Expanded the Baseball Savant integration from a 12-endpoint representative slice
 - **Hand-written search** — `mlb_statcast_search` (+ `_minors`, `_wbc`) auto-chunks the 25,000-row Savant cap and translates friendly filters (`season`, `pitch_type`, `at_bat_result`, `batters_lookup`, …) to Savant's `hf*` params. `mlb_statcast_player` parses a player page's `serverVals` section (default `statcast`, ~260 metrics) to a tidy frame (`section=` for others, `raw=True` for HTML).
 - **Returns-schemas** (`col_name | type | description`) for every frame-returning function, and `examples/notebooks/09_mlb_intro.ipynb` modernized to the new surface.
 - The pre-0.0.64 `statcast_*` names were **renamed (no aliases)** to the `mlb_statcast_*` convention.
+
+### Documentation — `nfl_api` (NFL.com Shield) returns-schema tables
+
+Added live-captured `col_name | type | description` returns-schemas for all 11 `api.nfl.com` endpoints (`standings`, `rosters`, `teams_history`, `team`, `weeks`, `weeks_by_date`, `combine_profiles`, `draft_picks`, `injuries`, `game_summaries`, `weekly_game_details`), wired via `returns_schema:` into `nfl_api.yaml` and rendered into the reference docs — bringing `nfl_api` to parity with the other six native API families (mlb_api, nhl_*). Docs/codegen-metadata only; no runtime change.
 
 ## 0.0.63 Release: June 16, 2026
 

--- a/docs/docs/nfl/reference/nfl_api.md
+++ b/docs/docs/nfl/reference/nfl_api.md
@@ -24,7 +24,63 @@ GET /football/v2/standings — one row per team standing across the returned wee
 
 ### Returns
 
-**`return_parsed=True`** (default) — a tidy `polars.DataFrame` (parser: `parse_nfl_standings`); pass `return_as_pandas=True` for a `pandas.DataFrame`.
+**`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
+| col_name | type | description |
+|---|---|---|
+| `team_id` | character | NFL.com Shield GUID for the team. |
+| `team_current_logo` | character | Templated URL of the team's current logo. |
+| `team_full_name` | character | Full team name (e.g. "Arizona Cardinals"). |
+| `clinched_bye` | logical | Whether the team has clinched a first-round playoff bye. |
+| `clinched_division` | logical | Whether the team has clinched its division. |
+| `clinched_eliminated` | logical | Whether the team has been mathematically eliminated from playoff contention. |
+| `clinched_home_field` | logical | Whether the team has clinched home-field advantage throughout the playoffs. |
+| `clinched_playoff` | logical | Whether the team has clinched a playoff berth. |
+| `clinched_wild_card` | logical | Whether the team has clinched a wild-card playoff berth. |
+| `close_games_wins` | integer | Wins in close games (decided by one score / 8 points or fewer). |
+| `close_games_losses` | integer | Losses in close games (decided by one score / 8 points or fewer). |
+| `close_games_ties` | integer | Ties in close games. |
+| `conference_wins` | integer | Wins against conference (AFC/NFC) opponents. |
+| `conference_win_pct` | numeric | Win percentage against conference opponents. |
+| `conference_losses` | integer | Losses against conference opponents. |
+| `conference_ties` | integer | Ties against conference opponents. |
+| `conference_rank` | integer | Standings rank within the conference. |
+| `conference_points_for` | integer | Points scored in conference games. |
+| `conference_points_against` | integer | Points allowed in conference games. |
+| `division_wins` | integer | Wins against division opponents. |
+| `division_win_pct` | numeric | Win percentage against division opponents. |
+| `division_losses` | integer | Losses against division opponents. |
+| `division_ties` | integer | Ties against division opponents. |
+| `division_rank` | integer | Standings rank within the division. |
+| `division_points_for` | integer | Points scored in division games. |
+| `division_points_against` | integer | Points allowed in division games. |
+| `home_wins` | integer | Wins in home games. |
+| `home_win_pct` | numeric | Win percentage in home games. |
+| `home_losses` | integer | Losses in home games. |
+| `home_ties` | integer | Ties in home games. |
+| `home_points_for` | integer | Points scored in home games. |
+| `home_points_against` | integer | Points allowed in home games. |
+| `last5_wins` | integer | Wins over the last five games. |
+| `last5_win_pct` | numeric | Win percentage over the last five games. |
+| `last5_losses` | integer | Losses over the last five games. |
+| `last5_ties` | integer | Ties over the last five games. |
+| `last5_points_for` | integer | Points scored over the last five games. |
+| `last5_points_against` | integer | Points allowed over the last five games. |
+| `overall_games` | integer | Total games played. |
+| `overall_wins` | integer | Total wins. |
+| `overall_win_pct` | numeric | Overall win percentage. |
+| `overall_losses` | integer | Total losses. |
+| `overall_ties` | integer | Total ties. |
+| `overall_points_for` | integer | Total points scored. |
+| `overall_points_against` | integer | Total points allowed. |
+| `overall_streak_type` | character | Current streak type ("W" for winning, "L" for losing). |
+| `overall_streak_length` | integer | Length of the current win/loss streak. |
+| `road_wins` | integer | Wins in road (away) games. |
+| `road_win_pct` | numeric | Win percentage in road games. |
+| `road_losses` | integer | Losses in road games. |
+| `road_ties` | integer | Ties in road games. |
+| `road_points_for` | integer | Points scored in road games. |
+| `road_points_against` | integer | Points allowed in road games. |
+
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
 ### Example
@@ -50,7 +106,24 @@ GET /football/v2/rosters — one row per team roster for the season.
 
 ### Returns
 
-**`return_parsed=True`** (default) — a tidy `polars.DataFrame` (parser: `parse_nfl_rosters`); pass `return_as_pandas=True` for a `pandas.DataFrame`.
+**`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
+| col_name | type | description |
+|---|---|---|
+| `season` | integer | Season (year) of the roster. |
+| `season_type` | character | Season type code (PRE, REG, or POST). |
+| `team_id` | character | NFL.com Shield GUID for the team. |
+| `team_abbreviation` | character | Team abbreviation (e.g. "ARI"). |
+| `team_full_name` | character | Full team name (e.g. "Arizona Cardinals"). |
+| `team_conference_abbr` | character | Conference abbreviation (AFC or NFC). |
+| `team_conference_full_name` | character | Full conference name (e.g. "National Football Conference"). |
+| `team_current_logo` | character | Templated URL of the team's current logo. |
+| `team_division_full_name` | character | Full division name (e.g. "NFC West"). |
+| `team_league` | character | League name ("National Football League"). |
+| `team_location` | character | Team location / city (e.g. "Arizona"). |
+| `team_nick_name` | character | Team nickname (e.g. "Cardinals"). |
+| `team_venues` | character | JSON-stringified array of the team's venue objects (id, name, etc.). |
+| `persons` | character | JSON-stringified array of roster player objects for the team. |
+
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
 ### Example
@@ -76,7 +149,23 @@ GET /football/v2/teams/history — one row per team for a season.
 
 ### Returns
 
-**`return_parsed=True`** (default) — a tidy `polars.DataFrame` (parser: `parse_nfl_teams_history`); pass `return_as_pandas=True` for a `pandas.DataFrame`.
+**`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
+| col_name | type | description |
+|---|---|---|
+| `id` | character | NFL.com Shield GUID for the team (or Pro Bowl team entry). |
+| `season` | integer | Season (year) the team record applies to. |
+| `abbreviation` | character | Team abbreviation (e.g. "AFC", "ARI"). |
+| `full_name` | character | Full team name (e.g. "AFC Pro Bowl Team", "Arizona Cardinals"). |
+| `team_type` | character | Team type classification (e.g. "TEAM", "PRO" for Pro Bowl teams). |
+| `conference_abbr` | character | Conference abbreviation (AFC or NFC). |
+| `conference_full_name` | character | Full conference name (e.g. "American Football Conference"). |
+| `current_logo` | character | Templated URL of the team's current logo. |
+| `division_full_name` | character | Full division name (e.g. "NFC West"). |
+| `league` | character | League name ("National Football League"). |
+| `location` | character | Team location / city. |
+| `nick_name` | character | Team nickname. |
+| `venues` | character | JSON-stringified array of the team's venue objects (empty for non-club entries). |
+
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
 ### Example
@@ -101,7 +190,25 @@ GET /football/v2/teams/{team_id} — single-team detail (one row).
 
 ### Returns
 
-**`return_parsed=True`** (default) — a tidy `polars.DataFrame` (parser: `parse_nfl_team`); pass `return_as_pandas=True` for a `pandas.DataFrame`.
+**`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
+| col_name | type | description |
+|---|---|---|
+| `id` | character | NFL.com Shield GUID for the team. |
+| `bio` | character | Team biography / description text (may be null). |
+| `current_background` | character | Templated URL of the team's current background image. |
+| `current_coach` | character | Name of the team's current head coach. |
+| `current_logo` | character | Templated URL of the team's current logo. |
+| `primary_color` | character | Team primary color (hex code). |
+| `secondary_color` | character | Team secondary color (hex code). |
+| `year_established` | integer | Year the franchise was established. |
+| `full_name` | character | Full team name (e.g. "Arizona Cardinals"). |
+| `nfl_shop_url` | character | URL to the team's NFL Shop storefront. |
+| `official_website_url` | character | URL of the team's official website. |
+| `owners` | character | Name(s) of the team's owner(s). |
+| `team_type` | character | Team type classification (e.g. "TEAM"). |
+| `socials` | character | JSON-stringified array of the team's social-media links (platform, link). |
+| `vll_channel_callsign` | character | Verizon Live League (VLL) channel call sign for the team. |
+
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
 ### Example
@@ -127,7 +234,17 @@ GET /football/v2/weeks/season/{season}/seasonType/{season_type} — week calenda
 
 ### Returns
 
-**`return_parsed=True`** (default) — a tidy `polars.DataFrame` (parser: `parse_nfl_weeks`); pass `return_as_pandas=True` for a `pandas.DataFrame`.
+**`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
+| col_name | type | description |
+|---|---|---|
+| `season` | integer | Season (year) of the week. |
+| `season_type` | character | Season type code (PRE, REG, or POST). |
+| `week` | integer | Week number within the season type. |
+| `bye_teams` | character | JSON-stringified array of teams on bye during the week (empty when none). |
+| `date_begin` | character | Start date of the week (YYYY-MM-DD). |
+| `date_end` | character | End date of the week (YYYY-MM-DD). |
+| `week_type` | character | Week type code (e.g. PRE, REG, WC, DIV, CONF, SB). |
+
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
 ### Example
@@ -152,7 +269,17 @@ GET /football/v2/weeks/date/{YYYY-MM-DD} — the week containing a date (one row
 
 ### Returns
 
-**`return_parsed=True`** (default) — a tidy `polars.DataFrame` (parser: `parse_nfl_weeks_by_date`); pass `return_as_pandas=True` for a `pandas.DataFrame`.
+**`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
+| col_name | type | description |
+|---|---|---|
+| `season` | integer | Season (year) the date falls in. |
+| `season_type` | character | Season type code (PRE, REG, or POST). |
+| `week` | integer | Week number that the queried date falls within. |
+| `bye_teams` | character | JSON-stringified array of teams on bye during the week (empty when none). |
+| `date_begin` | character | Start date of the week (YYYY-MM-DD). |
+| `date_end` | character | End date of the week (YYYY-MM-DD). |
+| `week_type` | character | Week type code (e.g. PRE, REG, WC, DIV, CONF, SB). |
+
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
 ### Example
@@ -178,7 +305,66 @@ GET /football/v2/combine/profiles — one row per combine prospect.
 
 ### Returns
 
-**`return_parsed=True`** (default) — a tidy `polars.DataFrame` (parser: `parse_nfl_combine_profiles`); pass `return_as_pandas=True` for a `pandas.DataFrame`.
+**`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
+| col_name | type | description |
+|---|---|---|
+| `id` | character | NFL.com Shield GUID for the combine profile. |
+| `year` | integer | Combine / draft class year. |
+| `person_id` | character | NFL.com Shield GUID of the prospect. |
+| `person_display_name` | character | Prospect's full display name. |
+| `person_esb_id` | character | Prospect's Elias Sports Bureau (ESB) identifier. |
+| `person_first_name` | character | Prospect's first name. |
+| `person_last_name` | character | Prospect's last name. |
+| `person_hometown` | character | Prospect's hometown (city, state). |
+| `person_college_names` | character | JSON-stringified array of the prospect's college(s). |
+| `arm_length` | numeric | Arm length measured at the combine, in inches. |
+| `athleticism_score` | numeric | Composite athleticism score. |
+| `bench_press` | numeric | Bench-press measurement object (flattened; null when no measurement). |
+| `broad_jump` | numeric | Broad-jump measurement object (flattened; null when no measurement). |
+| `bio` | character | HTML biography / career summary for the prospect. |
+| `college_class` | character | Prospect's college class (e.g. Senior, Junior). |
+| `draft_grade` | numeric | Numeric draft grade assigned to the prospect. |
+| `draft_projection` | character | Draft projection text (e.g. "Priority free agent"). |
+| `forty_yard_dash` | numeric | 40-yard-dash measurement object (flattened; null when no measurement). |
+| `grade` | numeric | Overall prospect grade. |
+| `hand_size` | integer | Hand size measured at the combine, in inches. |
+| `headshot` | character | Templated URL of the prospect's headshot image. |
+| `height` | integer | Prospect height, in inches. |
+| `nfl_comparison` | character | Player the prospect is most comparable to. |
+| `overview` | character | HTML scouting overview of the prospect. |
+| `production_score` | numeric | Composite college-production score. |
+| `profile_author` | character | Author of the scouting profile (e.g. "Lance Zierlein"). |
+| `pro_forty_yard_dash` | numeric | Pro-day 40-yard-dash measurement object (flattened; null when no measurement). |
+| `sixty_yard_shuttle` | numeric | 60-yard-shuttle measurement object (flattened; null when no measurement). |
+| `size_score` | numeric | Composite size score (flattened; null when not scored). |
+| `sources_tell_us` | character | "Sources tell us" scouting commentary text. |
+| `strengths` | character | HTML list of the prospect's strengths. |
+| `ten_yard_split` | numeric | 10-yard-split measurement object (flattened; null when no measurement). |
+| `three_cone_drill` | numeric | Three-cone-drill measurement object (flattened; null when no measurement). |
+| `twenty_yard_shuttle` | numeric | 20-yard-shuttle measurement object (flattened; null when no measurement). |
+| `weaknesses` | character | HTML list of the prospect's weaknesses. |
+| `combine_attendance` | logical | Whether the prospect attended the combine. |
+| `position` | character | Prospect's position abbreviation (e.g. "CB"). |
+| `position_group` | character | Prospect's position group (e.g. "DB"). |
+| `vertical_jump` | numeric | Vertical-jump measurement object (flattened; null when no measurement). |
+| `weight` | integer | Prospect weight, in pounds. |
+| `pro_forty_yard_dash_designation` | character | Designation for the pro-day 40-yard dash (OFFICIAL or UNOFFICIAL). |
+| `pro_forty_yard_dash_seconds` | numeric | Pro-day 40-yard-dash time, in seconds. |
+| `bench_press_designation` | character | Designation for the bench-press result (OFFICIAL or UNOFFICIAL). |
+| `bench_press_repetitions` | integer | Number of 225 lb bench-press repetitions. |
+| `broad_jump_designation` | character | Designation for the broad-jump result (OFFICIAL or UNOFFICIAL). |
+| `broad_jump_inches` | integer | Broad-jump distance, in inches. |
+| `forty_yard_dash_designation` | character | Designation for the 40-yard-dash result (OFFICIAL or UNOFFICIAL). |
+| `forty_yard_dash_seconds` | numeric | 40-yard-dash time, in seconds. |
+| `ten_yard_split_designation` | character | Designation for the 10-yard-split result (OFFICIAL or UNOFFICIAL). |
+| `ten_yard_split_seconds` | numeric | 10-yard-split time, in seconds. |
+| `vertical_jump_designation` | character | Designation for the vertical-jump result (OFFICIAL or UNOFFICIAL). |
+| `vertical_jump_inches` | integer | Vertical-jump height, in inches. |
+| `three_cone_drill_designation` | character | Designation for the three-cone-drill result (OFFICIAL or UNOFFICIAL). |
+| `three_cone_drill_seconds` | numeric | Three-cone-drill time, in seconds. |
+| `twenty_yard_shuttle_designation` | character | Designation for the 20-yard-shuttle result (OFFICIAL or UNOFFICIAL). |
+| `twenty_yard_shuttle_seconds` | numeric | 20-yard-shuttle time, in seconds. |
+
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
 ### Example
@@ -204,7 +390,20 @@ GET /football/v2/draft/picks/report — one row per draft pick.
 
 ### Returns
 
-**`return_parsed=True`** (default) — a tidy `polars.DataFrame` (parser: `parse_nfl_draft_picks`); pass `return_as_pandas=True` for a `pandas.DataFrame`.
+**`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
+| col_name | type | description |
+|---|---|---|
+| `year` | integer | Draft year. |
+| `draft_round` | integer | Round of the draft in which the pick was made. |
+| `draft_position` | integer | Pick position within the round. |
+| `draft_number_overall` | integer | Overall pick number across the entire draft. |
+| `person_id` | character | NFL.com Shield GUID of the drafted player (may be empty until the pick is announced). |
+| `pick_is_in` | logical | Whether the pick has officially been submitted / announced. |
+| `team_id` | character | NFL.com Shield GUID of the team making the pick. |
+| `trade_note` | character | Trade annotation for the pick (e.g. "CAR>CHI" denoting a traded selection). |
+| `tweet_sent` | logical | Whether the announcement tweet has been sent for the pick. |
+| `tweets_sent` | character | JSON-stringified array of per-account tweet-sent status objects. |
+
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
 ### Example
@@ -231,7 +430,29 @@ GET /football/v2/injuries — one row per injured player.
 
 ### Returns
 
-**`return_parsed=True`** (default) — a tidy `polars.DataFrame` (parser: `parse_nfl_injuries`); pass `return_as_pandas=True` for a `pandas.DataFrame`.
+**`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
+| col_name | type | description |
+|---|---|---|
+| `season` | integer | Season (year) of the injury report. |
+| `season_type` | character | Season type code (PRE, REG, or POST). |
+| `week` | integer | Week number of the injury report. |
+| `team_id` | character | NFL.com Shield GUID of the player's team. |
+| `team_current_logo` | character | Templated URL of the team's current logo. |
+| `team_full_name` | character | Full team name (e.g. "Atlanta Falcons"). |
+| `person_id` | character | NFL.com Shield GUID of the injured player. |
+| `person_first_name` | character | Player's first name. |
+| `person_common_first_name` | character | Player's common / preferred first name. |
+| `person_last_name` | character | Player's last name. |
+| `person_display_name` | character | Player's full display name. |
+| `person_gsis_id` | character | Player's NFL GSIS identifier (e.g. "00-0036948"). |
+| `person_headshot` | character | Templated URL of the player's headshot image. |
+| `injuries` | character | JSON-stringified array of detailed injury objects (empty when not specified). |
+| `injury_status` | character | Game-status designation (e.g. OUT, DOUBTFUL, QUESTIONABLE). |
+| `practices` | character | JSON-stringified array of practice-participation notes. |
+| `practice_days` | character | JSON-stringified array of per-day practice status objects (date, status). |
+| `practice_status` | character | Most recent practice-participation status (e.g. FULL, LIMITED, DNP). |
+| `position` | character | Player's position abbreviation (e.g. "DE"). |
+
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
 ### Example
@@ -258,7 +479,44 @@ GET /football/v2/stats/live/game-summaries — one row per game (live state).
 
 ### Returns
 
-**`return_parsed=True`** (default) — a tidy `polars.DataFrame` (parser: `parse_nfl_game_summaries`); pass `return_as_pandas=True` for a `pandas.DataFrame`.
+**`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
+| col_name | type | description |
+|---|---|---|
+| `game_id` | character | NFL.com Shield GUID for the game. |
+| `offset` | integer | Live-feed sequence offset for the summary snapshot. |
+| `attendance` | integer | Announced game attendance. |
+| `clock` | character | Game clock at the snapshot (MM:SS). |
+| `distance` | integer | Yards to gain for a first down at the snapshot. |
+| `down` | integer | Current down (1-4) at the snapshot. |
+| `game_book_url` | character | URL of the official game book image. |
+| `is_goal_to_go` | logical | Whether the current situation is goal-to-go. |
+| `is_red_zone` | logical | Whether the ball is in the red zone. |
+| `phase` | character | Game phase (e.g. PREGAME, INGAME, HALFTIME, FINAL). |
+| `quarter` | character | Current period descriptor (e.g. Q1, HALFTIME, END_OF_GAME). |
+| `start_time` | character | ISO 8601 kickoff timestamp. |
+| `weather` | character | Weather summary string (temperature, humidity, wind). |
+| `yard_line` | character | Current line of scrimmage (e.g. "KC 10"). |
+| `away_team_team_id` | character | NFL.com Shield GUID of the away team. |
+| `away_team_has_possession` | logical | Whether the away team has possession at the snapshot. |
+| `away_team_score_q1` | integer | Away team points scored in the first quarter. |
+| `away_team_score_q2` | integer | Away team points scored in the second quarter. |
+| `away_team_score_q3` | integer | Away team points scored in the third quarter. |
+| `away_team_score_q4` | integer | Away team points scored in the fourth quarter. |
+| `away_team_score_ot` | integer | Away team points scored in overtime. |
+| `away_team_score_total` | integer | Away team total points. |
+| `away_team_timeouts_remaining` | integer | Away team timeouts remaining at the snapshot. |
+| `away_team_timeouts_used` | integer | Away team timeouts used at the snapshot. |
+| `home_team_team_id` | character | NFL.com Shield GUID of the home team. |
+| `home_team_has_possession` | logical | Whether the home team has possession at the snapshot. |
+| `home_team_score_q1` | integer | Home team points scored in the first quarter. |
+| `home_team_score_q2` | integer | Home team points scored in the second quarter. |
+| `home_team_score_q3` | integer | Home team points scored in the third quarter. |
+| `home_team_score_q4` | integer | Home team points scored in the fourth quarter. |
+| `home_team_score_ot` | integer | Home team points scored in overtime. |
+| `home_team_score_total` | integer | Home team total points. |
+| `home_team_timeouts_remaining` | integer | Home team timeouts remaining at the snapshot. |
+| `home_team_timeouts_used` | integer | Home team timeouts used at the snapshot. |
+
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
 ### Example
@@ -289,7 +547,86 @@ GET /football/v2/experience/weekly-game-details — one row per game (bare list)
 
 ### Returns
 
-**`return_parsed=True`** (default) — a tidy `polars.DataFrame` (parser: `parse_nfl_weekly_game_details`); pass `return_as_pandas=True` for a `pandas.DataFrame`.
+**`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
+| col_name | type | description |
+|---|---|---|
+| `id` | character | NFL.com Shield GUID for the game. |
+| `home_team_id` | character | NFL.com Shield GUID of the home team. |
+| `home_team_current_logo` | character | Templated URL of the home team's current logo. |
+| `home_team_full_name` | character | Full home-team name (e.g. "Kansas City Chiefs"). |
+| `away_team_id` | character | NFL.com Shield GUID of the away team. |
+| `away_team_current_logo` | character | Templated URL of the away team's current logo. |
+| `away_team_full_name` | character | Full away-team name (e.g. "Baltimore Ravens"). |
+| `category` | character | Game category / window (e.g. SNF, MNF, TNF). |
+| `date` | character | Game date (YYYY-MM-DD). |
+| `time` | character | ISO 8601 kickoff timestamp. |
+| `broadcast_info_home_network_channels` | character | JSON-stringified array of broadcast channels in the home market. |
+| `broadcast_info_away_network_channels` | character | JSON-stringified array of broadcast channels in the away market. |
+| `broadcast_info_international_watch_options` | character | JSON-stringified array of international broadcaster options by country. |
+| `broadcast_info_streaming_networks` | character | JSON-stringified array of streaming-network objects. |
+| `broadcast_info_territory` | character | Broadcast territory designation (e.g. NATIONAL, REGIONAL). |
+| `broadcast_info_audio_networks` | character | JSON-stringified array of audio-broadcast network objects. |
+| `game_type` | character | Game type classification (e.g. UNSPECIFIED, REG, WC). |
+| `international` | logical | Whether the game is played at an international venue. |
+| `neutral_site` | logical | Whether the game is played at a neutral site. |
+| `venue_id` | character | NFL.com Shield GUID of the venue. |
+| `venue_name` | character | Venue name (e.g. "GEHA Field at Arrowhead Stadium"). |
+| `venue_city` | character | Venue city. |
+| `venue_country` | character | Venue country. |
+| `season` | integer | Season (year) of the game. |
+| `season_type` | character | Season type code (PRE, REG, or POST). |
+| `status` | character | Game status (e.g. SCHEDULED, INGAME, FINAL). |
+| `week` | integer | Week number of the game. |
+| `week_type` | character | Week type code (e.g. PRE, REG, WC, DIV, CONF, SB). |
+| `external_ids` | character | JSON-stringified array of external game identifiers (elias, gsis, etc.). |
+| `ticket_url` | character | Primary ticket-purchase URL for the game. |
+| `ticket_vendors` | character | JSON-stringified array of ticket-vendor objects (vendor name, URL). |
+| `extensions` | character | JSON-stringified array of extension objects (empty when none). |
+| `version` | integer | Record version number. |
+| `summary_game_id` | character | NFL.com Shield GUID for the game (from the embedded live summary). |
+| `summary_offset` | integer | Live-feed sequence offset for the embedded summary snapshot. |
+| `summary_attendance` | integer | Announced game attendance (from the embedded summary). |
+| `summary_clock` | character | Game clock at the summary snapshot (MM:SS). |
+| `summary_distance` | integer | Yards to gain for a first down at the summary snapshot. |
+| `summary_down` | integer | Current down (1-4) at the summary snapshot. |
+| `summary_game_book_url` | character | URL of the official game book image (from the embedded summary). |
+| `summary_is_goal_to_go` | logical | Whether the situation is goal-to-go at the summary snapshot. |
+| `summary_is_red_zone` | logical | Whether the ball is in the red zone at the summary snapshot. |
+| `summary_phase` | character | Game phase (e.g. PREGAME, INGAME, HALFTIME, FINAL). |
+| `summary_quarter` | character | Current period descriptor (e.g. Q1, HALFTIME, END_OF_GAME). |
+| `summary_start_time` | character | ISO 8601 kickoff timestamp (from the embedded summary). |
+| `summary_weather` | character | Weather summary string (temperature, humidity, wind). |
+| `summary_yard_line` | character | Current line of scrimmage at the summary snapshot (e.g. "KC 10"). |
+| `summary_away_team_team_id` | character | NFL.com Shield GUID of the away team (from the embedded summary). |
+| `summary_away_team_has_possession` | logical | Whether the away team has possession at the summary snapshot. |
+| `summary_away_team_score_q1` | integer | Away team points scored in the first quarter. |
+| `summary_away_team_score_q2` | integer | Away team points scored in the second quarter. |
+| `summary_away_team_score_q3` | integer | Away team points scored in the third quarter. |
+| `summary_away_team_score_q4` | integer | Away team points scored in the fourth quarter. |
+| `summary_away_team_score_ot` | integer | Away team points scored in overtime. |
+| `summary_away_team_score_total` | integer | Away team total points. |
+| `summary_away_team_timeouts_remaining` | integer | Away team timeouts remaining at the summary snapshot. |
+| `summary_away_team_timeouts_used` | integer | Away team timeouts used at the summary snapshot. |
+| `summary_home_team_team_id` | character | NFL.com Shield GUID of the home team (from the embedded summary). |
+| `summary_home_team_has_possession` | logical | Whether the home team has possession at the summary snapshot. |
+| `summary_home_team_score_q1` | integer | Home team points scored in the first quarter. |
+| `summary_home_team_score_q2` | integer | Home team points scored in the second quarter. |
+| `summary_home_team_score_q3` | integer | Home team points scored in the third quarter. |
+| `summary_home_team_score_q4` | integer | Home team points scored in the fourth quarter. |
+| `summary_home_team_score_ot` | integer | Home team points scored in overtime. |
+| `summary_home_team_score_total` | integer | Home team total points. |
+| `summary_home_team_timeouts_remaining` | integer | Home team timeouts remaining at the summary snapshot. |
+| `summary_home_team_timeouts_used` | integer | Home team timeouts used at the summary snapshot. |
+| `drive_chart_game_id` | character | NFL.com Shield GUID for the game (from the drive chart, present when include_drive_chart=true). |
+| `drive_chart_offset` | integer | Live-feed sequence offset for the drive-chart snapshot. |
+| `drive_chart_drives` | character | JSON-stringified array of drive objects (sequence, team, result, etc.). |
+| `drive_chart_plays` | character | JSON-stringified array of play objects within the drive chart. |
+| `drive_chart_scoring_summaries` | character | JSON-stringified array of scoring-summary objects (sequence, scores, clock). |
+| `replays` | character | JSON-stringified array of replay objects (populated only when include_replays=true). |
+| `tagged_videos` | character | JSON-stringified array of tagged-video objects (populated only when include_tagged_videos=true). |
+| `away_team_standings` | character | JSON-stringified away-team standings object (populated only when include_standings=true). |
+| `home_team_standings` | character | JSON-stringified home-team standings object (populated only when include_standings=true). |
+
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
 ### Example

--- a/docs/src/pages/CHANGELOG.md
+++ b/docs/src/pages/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [0.0.64 Release: June 17, 2026](#0064-release-june-17-2026)
   - [MLB — comprehensive Baseball Savant / Statcast surface (`mlb_statcast_*`, 43 endpoints)](#mlb--comprehensive-baseball-savant--statcast-surface-mlb_statcast_-43-endpoints)
+  - [Documentation — `nfl_api` (NFL.com Shield) returns-schema tables](#documentation--nfl_api-nflcom-shield-returns-schema-tables)
 - [0.0.63 Release: June 16, 2026](#0063-release-june-16-2026)
   - [All sports — `espn_*_game_rosters` diagonal per-team concat (fixes silent roster loss)](#all-sports--espn__game_rosters-diagonal-per-team-concat-fixes-silent-roster-loss)
   - [HTTP — `download()` no longer retries a definitive 404](#http--download-no-longer-retries-a-definitive-404)
@@ -127,6 +128,10 @@ Expanded the Baseball Savant integration from a 12-endpoint representative slice
 - **Hand-written search** — `mlb_statcast_search` (+ `_minors`, `_wbc`) auto-chunks the 25,000-row Savant cap and translates friendly filters (`season`, `pitch_type`, `at_bat_result`, `batters_lookup`, …) to Savant's `hf*` params. `mlb_statcast_player` parses a player page's `serverVals` section (default `statcast`, ~260 metrics) to a tidy frame (`section=` for others, `raw=True` for HTML).
 - **Returns-schemas** (`col_name | type | description`) for every frame-returning function, and `examples/notebooks/09_mlb_intro.ipynb` modernized to the new surface.
 - The pre-0.0.64 `statcast_*` names were **renamed (no aliases)** to the `mlb_statcast_*` convention.
+
+### Documentation — `nfl_api` (NFL.com Shield) returns-schema tables
+
+Added live-captured `col_name | type | description` returns-schemas for all 11 `api.nfl.com` endpoints (`standings`, `rosters`, `teams_history`, `team`, `weeks`, `weeks_by_date`, `combine_profiles`, `draft_picks`, `injuries`, `game_summaries`, `weekly_game_details`), wired via `returns_schema:` into `nfl_api.yaml` and rendered into the reference docs — bringing `nfl_api` to parity with the other six native API families (mlb_api, nhl_*). Docs/codegen-metadata only; no runtime change.
 
 ## 0.0.63 Release: June 16, 2026
 

--- a/tools/codegen/endpoints/nfl_api.yaml
+++ b/tools/codegen/endpoints/nfl_api.yaml
@@ -18,6 +18,7 @@ endpoints:
   summary: "GET /football/v2/standings — one row per team standing across the returned week(s)."
   path: /football/v2/standings
   parser: parse_nfl_standings
+  returns_schema: native/nfl_api/standings
   extra_params:
   - {name: season, query_key: season, type: int, default: 2024}
   - {name: season_type, query_key: seasonType, type: str, default: REG, description: "Season type code (string): PRE, REG, or POST -- not ESPN's numeric 1/2/3."}
@@ -28,6 +29,7 @@ endpoints:
   summary: "GET /football/v2/rosters — one row per team roster for the season."
   path: /football/v2/rosters
   parser: parse_nfl_rosters
+  returns_schema: native/nfl_api/rosters
   extra_params:
   - {name: season, query_key: season, type: int, default: 2024}
   - {name: limit, query_key: limit, type: int, default: 40}
@@ -36,6 +38,7 @@ endpoints:
   summary: "GET /football/v2/teams/history — one row per team for a season."
   path: /football/v2/teams/history
   parser: parse_nfl_teams_history
+  returns_schema: native/nfl_api/teams_history
   extra_params:
   - {name: season, query_key: season, type: int, default: 2024}
   - {name: limit, query_key: limit, type: int, default: 40}
@@ -44,6 +47,7 @@ endpoints:
   summary: "GET /football/v2/teams/{team_id} — single-team detail (one row)."
   path: /football/v2/teams/{team_id}
   parser: parse_nfl_team
+  returns_schema: native/nfl_api/team
   path_params:
   - {name: team_id, type: str, required: true}
   example_args: {team_id: 10403800-517c-7b8c-65a3-c61b95d86123}
@@ -51,6 +55,7 @@ endpoints:
   summary: "GET /football/v2/weeks/season/{season}/seasonType/{season_type} — week calendar (one row per week)."
   path: /football/v2/weeks/season/{season}/seasonType/{season_type}
   parser: parse_nfl_weeks
+  returns_schema: native/nfl_api/weeks
   path_params:
   - {name: season, type: int, required: false, default: 2024}
   - {name: season_type, type: str, required: false, default: REG, description: "Season type code (string): PRE, REG, or POST -- not ESPN's numeric 1/2/3."}
@@ -59,6 +64,7 @@ endpoints:
   summary: "GET /football/v2/weeks/date/{YYYY-MM-DD} — the week containing a date (one row)."
   path: /football/v2/weeks/date/{date}
   parser: parse_nfl_weeks_by_date
+  returns_schema: native/nfl_api/weeks_by_date
   path_params:
   - {name: date, type: str, required: true}
   example_args: {date: '2024-09-08'}
@@ -66,6 +72,7 @@ endpoints:
   summary: "GET /football/v2/combine/profiles — one row per combine prospect."
   path: /football/v2/combine/profiles
   parser: parse_nfl_combine_profiles
+  returns_schema: native/nfl_api/combine_profiles
   extra_params:
   - {name: year, query_key: year, type: int, default: 2024}
   - {name: limit, query_key: limit, type: int, default: 40}
@@ -74,6 +81,7 @@ endpoints:
   summary: "GET /football/v2/draft/picks/report — one row per draft pick."
   path: /football/v2/draft/picks/report
   parser: parse_nfl_draft_picks
+  returns_schema: native/nfl_api/draft_picks
   extra_params:
   - {name: year, query_key: year, type: int, default: 2024}
   - {name: limit, query_key: limit, type: int, default: 40}
@@ -82,6 +90,7 @@ endpoints:
   summary: "GET /football/v2/injuries — one row per injured player."
   path: /football/v2/injuries
   parser: parse_nfl_injuries
+  returns_schema: native/nfl_api/injuries
   extra_params:
   - {name: season, query_key: season, type: int, default: 2024}
   - {name: season_type, query_key: seasonType, type: str, default: REG, description: "Season type code (string): PRE, REG, or POST -- not ESPN's numeric 1/2/3."}
@@ -91,6 +100,7 @@ endpoints:
   summary: "GET /football/v2/stats/live/game-summaries — one row per game (live state)."
   path: /football/v2/stats/live/game-summaries
   parser: parse_nfl_game_summaries
+  returns_schema: native/nfl_api/game_summaries
   extra_params:
   - {name: season, query_key: season, type: int, default: 2024}
   - {name: season_type, query_key: seasonType, type: str, default: REG, description: "Season type code (string): PRE, REG, or POST -- not ESPN's numeric 1/2/3."}
@@ -100,6 +110,7 @@ endpoints:
   summary: "GET /football/v2/experience/weekly-game-details — one row per game (bare list)."
   path: /football/v2/experience/weekly-game-details
   parser: parse_nfl_weekly_game_details
+  returns_schema: native/nfl_api/weekly_game_details
   extra_params:
   - {name: season, query_key: season, type: int, default: 2024}
   - {name: season_type, query_key: type, type: str, default: REG, description: "Season type code (string): PRE, REG, or POST (sent as the `type` query param) -- not ESPN's numeric 1/2/3."}

--- a/tools/codegen/schemas/native/nfl_api/combine_profiles.yaml
+++ b/tools/codegen/schemas/native/nfl_api/combine_profiles.yaml
@@ -1,0 +1,171 @@
+schema: combine_profiles
+kind: dataframe
+columns:
+- name: id
+  type: character
+  description: NFL.com Shield GUID for the combine profile.
+- name: year
+  type: integer
+  description: Combine / draft class year.
+- name: person_id
+  type: character
+  description: NFL.com Shield GUID of the prospect.
+- name: person_display_name
+  type: character
+  description: Prospect's full display name.
+- name: person_esb_id
+  type: character
+  description: Prospect's Elias Sports Bureau (ESB) identifier.
+- name: person_first_name
+  type: character
+  description: Prospect's first name.
+- name: person_last_name
+  type: character
+  description: Prospect's last name.
+- name: person_hometown
+  type: character
+  description: Prospect's hometown (city, state).
+- name: person_college_names
+  type: character
+  description: JSON-stringified array of the prospect's college(s).
+- name: arm_length
+  type: numeric
+  description: Arm length measured at the combine, in inches.
+- name: athleticism_score
+  type: numeric
+  description: Composite athleticism score.
+- name: bench_press
+  type: numeric
+  description: Bench-press measurement object (flattened; null when no measurement).
+- name: broad_jump
+  type: numeric
+  description: Broad-jump measurement object (flattened; null when no measurement).
+- name: bio
+  type: character
+  description: HTML biography / career summary for the prospect.
+- name: college_class
+  type: character
+  description: Prospect's college class (e.g. Senior, Junior).
+- name: draft_grade
+  type: numeric
+  description: Numeric draft grade assigned to the prospect.
+- name: draft_projection
+  type: character
+  description: Draft projection text (e.g. "Priority free agent").
+- name: forty_yard_dash
+  type: numeric
+  description: 40-yard-dash measurement object (flattened; null when no measurement).
+- name: grade
+  type: numeric
+  description: Overall prospect grade.
+- name: hand_size
+  type: integer
+  description: Hand size measured at the combine, in inches.
+- name: headshot
+  type: character
+  description: Templated URL of the prospect's headshot image.
+- name: height
+  type: integer
+  description: Prospect height, in inches.
+- name: nfl_comparison
+  type: character
+  description: Player the prospect is most comparable to.
+- name: overview
+  type: character
+  description: HTML scouting overview of the prospect.
+- name: production_score
+  type: numeric
+  description: Composite college-production score.
+- name: profile_author
+  type: character
+  description: Author of the scouting profile (e.g. "Lance Zierlein").
+- name: pro_forty_yard_dash
+  type: numeric
+  description: Pro-day 40-yard-dash measurement object (flattened; null when no measurement).
+- name: sixty_yard_shuttle
+  type: numeric
+  description: 60-yard-shuttle measurement object (flattened; null when no measurement).
+- name: size_score
+  type: numeric
+  description: Composite size score (flattened; null when not scored).
+- name: sources_tell_us
+  type: character
+  description: "\"Sources tell us\" scouting commentary text."
+- name: strengths
+  type: character
+  description: HTML list of the prospect's strengths.
+- name: ten_yard_split
+  type: numeric
+  description: 10-yard-split measurement object (flattened; null when no measurement).
+- name: three_cone_drill
+  type: numeric
+  description: Three-cone-drill measurement object (flattened; null when no measurement).
+- name: twenty_yard_shuttle
+  type: numeric
+  description: 20-yard-shuttle measurement object (flattened; null when no measurement).
+- name: weaknesses
+  type: character
+  description: HTML list of the prospect's weaknesses.
+- name: combine_attendance
+  type: logical
+  description: Whether the prospect attended the combine.
+- name: position
+  type: character
+  description: Prospect's position abbreviation (e.g. "CB").
+- name: position_group
+  type: character
+  description: Prospect's position group (e.g. "DB").
+- name: vertical_jump
+  type: numeric
+  description: Vertical-jump measurement object (flattened; null when no measurement).
+- name: weight
+  type: integer
+  description: Prospect weight, in pounds.
+- name: pro_forty_yard_dash_designation
+  type: character
+  description: Designation for the pro-day 40-yard dash (OFFICIAL or UNOFFICIAL).
+- name: pro_forty_yard_dash_seconds
+  type: numeric
+  description: Pro-day 40-yard-dash time, in seconds.
+- name: bench_press_designation
+  type: character
+  description: Designation for the bench-press result (OFFICIAL or UNOFFICIAL).
+- name: bench_press_repetitions
+  type: integer
+  description: Number of 225 lb bench-press repetitions.
+- name: broad_jump_designation
+  type: character
+  description: Designation for the broad-jump result (OFFICIAL or UNOFFICIAL).
+- name: broad_jump_inches
+  type: integer
+  description: Broad-jump distance, in inches.
+- name: forty_yard_dash_designation
+  type: character
+  description: Designation for the 40-yard-dash result (OFFICIAL or UNOFFICIAL).
+- name: forty_yard_dash_seconds
+  type: numeric
+  description: 40-yard-dash time, in seconds.
+- name: ten_yard_split_designation
+  type: character
+  description: Designation for the 10-yard-split result (OFFICIAL or UNOFFICIAL).
+- name: ten_yard_split_seconds
+  type: numeric
+  description: 10-yard-split time, in seconds.
+- name: vertical_jump_designation
+  type: character
+  description: Designation for the vertical-jump result (OFFICIAL or UNOFFICIAL).
+- name: vertical_jump_inches
+  type: integer
+  description: Vertical-jump height, in inches.
+- name: three_cone_drill_designation
+  type: character
+  description: Designation for the three-cone-drill result (OFFICIAL or UNOFFICIAL).
+- name: three_cone_drill_seconds
+  type: numeric
+  description: Three-cone-drill time, in seconds.
+- name: twenty_yard_shuttle_designation
+  type: character
+  description: Designation for the 20-yard-shuttle result (OFFICIAL or UNOFFICIAL).
+- name: twenty_yard_shuttle_seconds
+  type: numeric
+  description: 20-yard-shuttle time, in seconds.

--- a/tools/codegen/schemas/native/nfl_api/draft_picks.yaml
+++ b/tools/codegen/schemas/native/nfl_api/draft_picks.yaml
@@ -1,0 +1,33 @@
+schema: draft_picks
+kind: dataframe
+columns:
+- name: year
+  type: integer
+  description: Draft year.
+- name: draft_round
+  type: integer
+  description: Round of the draft in which the pick was made.
+- name: draft_position
+  type: integer
+  description: Pick position within the round.
+- name: draft_number_overall
+  type: integer
+  description: Overall pick number across the entire draft.
+- name: person_id
+  type: character
+  description: NFL.com Shield GUID of the drafted player (may be empty until the pick is announced).
+- name: pick_is_in
+  type: logical
+  description: Whether the pick has officially been submitted / announced.
+- name: team_id
+  type: character
+  description: NFL.com Shield GUID of the team making the pick.
+- name: trade_note
+  type: character
+  description: Trade annotation for the pick (e.g. "CAR>CHI" denoting a traded selection).
+- name: tweet_sent
+  type: logical
+  description: Whether the announcement tweet has been sent for the pick.
+- name: tweets_sent
+  type: character
+  description: JSON-stringified array of per-account tweet-sent status objects.

--- a/tools/codegen/schemas/native/nfl_api/game_summaries.yaml
+++ b/tools/codegen/schemas/native/nfl_api/game_summaries.yaml
@@ -1,0 +1,105 @@
+schema: game_summaries
+kind: dataframe
+columns:
+- name: game_id
+  type: character
+  description: NFL.com Shield GUID for the game.
+- name: offset
+  type: integer
+  description: Live-feed sequence offset for the summary snapshot.
+- name: attendance
+  type: integer
+  description: Announced game attendance.
+- name: clock
+  type: character
+  description: Game clock at the snapshot (MM:SS).
+- name: distance
+  type: integer
+  description: Yards to gain for a first down at the snapshot.
+- name: down
+  type: integer
+  description: Current down (1-4) at the snapshot.
+- name: game_book_url
+  type: character
+  description: URL of the official game book image.
+- name: is_goal_to_go
+  type: logical
+  description: Whether the current situation is goal-to-go.
+- name: is_red_zone
+  type: logical
+  description: Whether the ball is in the red zone.
+- name: phase
+  type: character
+  description: Game phase (e.g. PREGAME, INGAME, HALFTIME, FINAL).
+- name: quarter
+  type: character
+  description: Current period descriptor (e.g. Q1, HALFTIME, END_OF_GAME).
+- name: start_time
+  type: character
+  description: ISO 8601 kickoff timestamp.
+- name: weather
+  type: character
+  description: Weather summary string (temperature, humidity, wind).
+- name: yard_line
+  type: character
+  description: Current line of scrimmage (e.g. "KC 10").
+- name: away_team_team_id
+  type: character
+  description: NFL.com Shield GUID of the away team.
+- name: away_team_has_possession
+  type: logical
+  description: Whether the away team has possession at the snapshot.
+- name: away_team_score_q1
+  type: integer
+  description: Away team points scored in the first quarter.
+- name: away_team_score_q2
+  type: integer
+  description: Away team points scored in the second quarter.
+- name: away_team_score_q3
+  type: integer
+  description: Away team points scored in the third quarter.
+- name: away_team_score_q4
+  type: integer
+  description: Away team points scored in the fourth quarter.
+- name: away_team_score_ot
+  type: integer
+  description: Away team points scored in overtime.
+- name: away_team_score_total
+  type: integer
+  description: Away team total points.
+- name: away_team_timeouts_remaining
+  type: integer
+  description: Away team timeouts remaining at the snapshot.
+- name: away_team_timeouts_used
+  type: integer
+  description: Away team timeouts used at the snapshot.
+- name: home_team_team_id
+  type: character
+  description: NFL.com Shield GUID of the home team.
+- name: home_team_has_possession
+  type: logical
+  description: Whether the home team has possession at the snapshot.
+- name: home_team_score_q1
+  type: integer
+  description: Home team points scored in the first quarter.
+- name: home_team_score_q2
+  type: integer
+  description: Home team points scored in the second quarter.
+- name: home_team_score_q3
+  type: integer
+  description: Home team points scored in the third quarter.
+- name: home_team_score_q4
+  type: integer
+  description: Home team points scored in the fourth quarter.
+- name: home_team_score_ot
+  type: integer
+  description: Home team points scored in overtime.
+- name: home_team_score_total
+  type: integer
+  description: Home team total points.
+- name: home_team_timeouts_remaining
+  type: integer
+  description: Home team timeouts remaining at the snapshot.
+- name: home_team_timeouts_used
+  type: integer
+  description: Home team timeouts used at the snapshot.

--- a/tools/codegen/schemas/native/nfl_api/injuries.yaml
+++ b/tools/codegen/schemas/native/nfl_api/injuries.yaml
@@ -1,0 +1,60 @@
+schema: injuries
+kind: dataframe
+columns:
+- name: season
+  type: integer
+  description: Season (year) of the injury report.
+- name: season_type
+  type: character
+  description: Season type code (PRE, REG, or POST).
+- name: week
+  type: integer
+  description: Week number of the injury report.
+- name: team_id
+  type: character
+  description: NFL.com Shield GUID of the player's team.
+- name: team_current_logo
+  type: character
+  description: Templated URL of the team's current logo.
+- name: team_full_name
+  type: character
+  description: Full team name (e.g. "Atlanta Falcons").
+- name: person_id
+  type: character
+  description: NFL.com Shield GUID of the injured player.
+- name: person_first_name
+  type: character
+  description: Player's first name.
+- name: person_common_first_name
+  type: character
+  description: Player's common / preferred first name.
+- name: person_last_name
+  type: character
+  description: Player's last name.
+- name: person_display_name
+  type: character
+  description: Player's full display name.
+- name: person_gsis_id
+  type: character
+  description: Player's NFL GSIS identifier (e.g. "00-0036948").
+- name: person_headshot
+  type: character
+  description: Templated URL of the player's headshot image.
+- name: injuries
+  type: character
+  description: JSON-stringified array of detailed injury objects (empty when not specified).
+- name: injury_status
+  type: character
+  description: Game-status designation (e.g. OUT, DOUBTFUL, QUESTIONABLE).
+- name: practices
+  type: character
+  description: JSON-stringified array of practice-participation notes.
+- name: practice_days
+  type: character
+  description: JSON-stringified array of per-day practice status objects (date, status).
+- name: practice_status
+  type: character
+  description: Most recent practice-participation status (e.g. FULL, LIMITED, DNP).
+- name: position
+  type: character
+  description: Player's position abbreviation (e.g. "DE").

--- a/tools/codegen/schemas/native/nfl_api/rosters.yaml
+++ b/tools/codegen/schemas/native/nfl_api/rosters.yaml
@@ -1,0 +1,45 @@
+schema: rosters
+kind: dataframe
+columns:
+- name: season
+  type: integer
+  description: Season (year) of the roster.
+- name: season_type
+  type: character
+  description: Season type code (PRE, REG, or POST).
+- name: team_id
+  type: character
+  description: NFL.com Shield GUID for the team.
+- name: team_abbreviation
+  type: character
+  description: Team abbreviation (e.g. "ARI").
+- name: team_full_name
+  type: character
+  description: Full team name (e.g. "Arizona Cardinals").
+- name: team_conference_abbr
+  type: character
+  description: Conference abbreviation (AFC or NFC).
+- name: team_conference_full_name
+  type: character
+  description: Full conference name (e.g. "National Football Conference").
+- name: team_current_logo
+  type: character
+  description: Templated URL of the team's current logo.
+- name: team_division_full_name
+  type: character
+  description: Full division name (e.g. "NFC West").
+- name: team_league
+  type: character
+  description: League name ("National Football League").
+- name: team_location
+  type: character
+  description: Team location / city (e.g. "Arizona").
+- name: team_nick_name
+  type: character
+  description: Team nickname (e.g. "Cardinals").
+- name: team_venues
+  type: character
+  description: JSON-stringified array of the team's venue objects (id, name, etc.).
+- name: persons
+  type: character
+  description: JSON-stringified array of roster player objects for the team.

--- a/tools/codegen/schemas/native/nfl_api/standings.yaml
+++ b/tools/codegen/schemas/native/nfl_api/standings.yaml
@@ -1,0 +1,162 @@
+schema: standings
+kind: dataframe
+columns:
+- name: team_id
+  type: character
+  description: NFL.com Shield GUID for the team.
+- name: team_current_logo
+  type: character
+  description: Templated URL of the team's current logo.
+- name: team_full_name
+  type: character
+  description: Full team name (e.g. "Arizona Cardinals").
+- name: clinched_bye
+  type: logical
+  description: Whether the team has clinched a first-round playoff bye.
+- name: clinched_division
+  type: logical
+  description: Whether the team has clinched its division.
+- name: clinched_eliminated
+  type: logical
+  description: Whether the team has been mathematically eliminated from playoff contention.
+- name: clinched_home_field
+  type: logical
+  description: Whether the team has clinched home-field advantage throughout the playoffs.
+- name: clinched_playoff
+  type: logical
+  description: Whether the team has clinched a playoff berth.
+- name: clinched_wild_card
+  type: logical
+  description: Whether the team has clinched a wild-card playoff berth.
+- name: close_games_wins
+  type: integer
+  description: Wins in close games (decided by one score / 8 points or fewer).
+- name: close_games_losses
+  type: integer
+  description: Losses in close games (decided by one score / 8 points or fewer).
+- name: close_games_ties
+  type: integer
+  description: Ties in close games.
+- name: conference_wins
+  type: integer
+  description: Wins against conference (AFC/NFC) opponents.
+- name: conference_win_pct
+  type: numeric
+  description: Win percentage against conference opponents.
+- name: conference_losses
+  type: integer
+  description: Losses against conference opponents.
+- name: conference_ties
+  type: integer
+  description: Ties against conference opponents.
+- name: conference_rank
+  type: integer
+  description: Standings rank within the conference.
+- name: conference_points_for
+  type: integer
+  description: Points scored in conference games.
+- name: conference_points_against
+  type: integer
+  description: Points allowed in conference games.
+- name: division_wins
+  type: integer
+  description: Wins against division opponents.
+- name: division_win_pct
+  type: numeric
+  description: Win percentage against division opponents.
+- name: division_losses
+  type: integer
+  description: Losses against division opponents.
+- name: division_ties
+  type: integer
+  description: Ties against division opponents.
+- name: division_rank
+  type: integer
+  description: Standings rank within the division.
+- name: division_points_for
+  type: integer
+  description: Points scored in division games.
+- name: division_points_against
+  type: integer
+  description: Points allowed in division games.
+- name: home_wins
+  type: integer
+  description: Wins in home games.
+- name: home_win_pct
+  type: numeric
+  description: Win percentage in home games.
+- name: home_losses
+  type: integer
+  description: Losses in home games.
+- name: home_ties
+  type: integer
+  description: Ties in home games.
+- name: home_points_for
+  type: integer
+  description: Points scored in home games.
+- name: home_points_against
+  type: integer
+  description: Points allowed in home games.
+- name: last5_wins
+  type: integer
+  description: Wins over the last five games.
+- name: last5_win_pct
+  type: numeric
+  description: Win percentage over the last five games.
+- name: last5_losses
+  type: integer
+  description: Losses over the last five games.
+- name: last5_ties
+  type: integer
+  description: Ties over the last five games.
+- name: last5_points_for
+  type: integer
+  description: Points scored over the last five games.
+- name: last5_points_against
+  type: integer
+  description: Points allowed over the last five games.
+- name: overall_games
+  type: integer
+  description: Total games played.
+- name: overall_wins
+  type: integer
+  description: Total wins.
+- name: overall_win_pct
+  type: numeric
+  description: Overall win percentage.
+- name: overall_losses
+  type: integer
+  description: Total losses.
+- name: overall_ties
+  type: integer
+  description: Total ties.
+- name: overall_points_for
+  type: integer
+  description: Total points scored.
+- name: overall_points_against
+  type: integer
+  description: Total points allowed.
+- name: overall_streak_type
+  type: character
+  description: Current streak type ("W" for winning, "L" for losing).
+- name: overall_streak_length
+  type: integer
+  description: Length of the current win/loss streak.
+- name: road_wins
+  type: integer
+  description: Wins in road (away) games.
+- name: road_win_pct
+  type: numeric
+  description: Win percentage in road games.
+- name: road_losses
+  type: integer
+  description: Losses in road games.
+- name: road_ties
+  type: integer
+  description: Ties in road games.
+- name: road_points_for
+  type: integer
+  description: Points scored in road games.
+- name: road_points_against
+  type: integer
+  description: Points allowed in road games.

--- a/tools/codegen/schemas/native/nfl_api/team.yaml
+++ b/tools/codegen/schemas/native/nfl_api/team.yaml
@@ -1,0 +1,48 @@
+schema: team
+kind: dataframe
+columns:
+- name: id
+  type: character
+  description: NFL.com Shield GUID for the team.
+- name: bio
+  type: character
+  description: Team biography / description text (may be null).
+- name: current_background
+  type: character
+  description: Templated URL of the team's current background image.
+- name: current_coach
+  type: character
+  description: Name of the team's current head coach.
+- name: current_logo
+  type: character
+  description: Templated URL of the team's current logo.
+- name: primary_color
+  type: character
+  description: Team primary color (hex code).
+- name: secondary_color
+  type: character
+  description: Team secondary color (hex code).
+- name: year_established
+  type: integer
+  description: Year the franchise was established.
+- name: full_name
+  type: character
+  description: Full team name (e.g. "Arizona Cardinals").
+- name: nfl_shop_url
+  type: character
+  description: URL to the team's NFL Shop storefront.
+- name: official_website_url
+  type: character
+  description: URL of the team's official website.
+- name: owners
+  type: character
+  description: Name(s) of the team's owner(s).
+- name: team_type
+  type: character
+  description: Team type classification (e.g. "TEAM").
+- name: socials
+  type: character
+  description: JSON-stringified array of the team's social-media links (platform, link).
+- name: vll_channel_callsign
+  type: character
+  description: Verizon Live League (VLL) channel call sign for the team.

--- a/tools/codegen/schemas/native/nfl_api/teams_history.yaml
+++ b/tools/codegen/schemas/native/nfl_api/teams_history.yaml
@@ -1,0 +1,42 @@
+schema: teams_history
+kind: dataframe
+columns:
+- name: id
+  type: character
+  description: NFL.com Shield GUID for the team (or Pro Bowl team entry).
+- name: season
+  type: integer
+  description: Season (year) the team record applies to.
+- name: abbreviation
+  type: character
+  description: Team abbreviation (e.g. "AFC", "ARI").
+- name: full_name
+  type: character
+  description: Full team name (e.g. "AFC Pro Bowl Team", "Arizona Cardinals").
+- name: team_type
+  type: character
+  description: Team type classification (e.g. "TEAM", "PRO" for Pro Bowl teams).
+- name: conference_abbr
+  type: character
+  description: Conference abbreviation (AFC or NFC).
+- name: conference_full_name
+  type: character
+  description: Full conference name (e.g. "American Football Conference").
+- name: current_logo
+  type: character
+  description: Templated URL of the team's current logo.
+- name: division_full_name
+  type: character
+  description: Full division name (e.g. "NFC West").
+- name: league
+  type: character
+  description: League name ("National Football League").
+- name: location
+  type: character
+  description: Team location / city.
+- name: nick_name
+  type: character
+  description: Team nickname.
+- name: venues
+  type: character
+  description: JSON-stringified array of the team's venue objects (empty for non-club entries).

--- a/tools/codegen/schemas/native/nfl_api/weekly_game_details.yaml
+++ b/tools/codegen/schemas/native/nfl_api/weekly_game_details.yaml
@@ -1,0 +1,231 @@
+schema: weekly_game_details
+kind: dataframe
+columns:
+- name: id
+  type: character
+  description: NFL.com Shield GUID for the game.
+- name: home_team_id
+  type: character
+  description: NFL.com Shield GUID of the home team.
+- name: home_team_current_logo
+  type: character
+  description: Templated URL of the home team's current logo.
+- name: home_team_full_name
+  type: character
+  description: Full home-team name (e.g. "Kansas City Chiefs").
+- name: away_team_id
+  type: character
+  description: NFL.com Shield GUID of the away team.
+- name: away_team_current_logo
+  type: character
+  description: Templated URL of the away team's current logo.
+- name: away_team_full_name
+  type: character
+  description: Full away-team name (e.g. "Baltimore Ravens").
+- name: category
+  type: character
+  description: Game category / window (e.g. SNF, MNF, TNF).
+- name: date
+  type: character
+  description: Game date (YYYY-MM-DD).
+- name: time
+  type: character
+  description: ISO 8601 kickoff timestamp.
+- name: broadcast_info_home_network_channels
+  type: character
+  description: JSON-stringified array of broadcast channels in the home market.
+- name: broadcast_info_away_network_channels
+  type: character
+  description: JSON-stringified array of broadcast channels in the away market.
+- name: broadcast_info_international_watch_options
+  type: character
+  description: JSON-stringified array of international broadcaster options by country.
+- name: broadcast_info_streaming_networks
+  type: character
+  description: JSON-stringified array of streaming-network objects.
+- name: broadcast_info_territory
+  type: character
+  description: Broadcast territory designation (e.g. NATIONAL, REGIONAL).
+- name: broadcast_info_audio_networks
+  type: character
+  description: JSON-stringified array of audio-broadcast network objects.
+- name: game_type
+  type: character
+  description: Game type classification (e.g. UNSPECIFIED, REG, WC).
+- name: international
+  type: logical
+  description: Whether the game is played at an international venue.
+- name: neutral_site
+  type: logical
+  description: Whether the game is played at a neutral site.
+- name: venue_id
+  type: character
+  description: NFL.com Shield GUID of the venue.
+- name: venue_name
+  type: character
+  description: Venue name (e.g. "GEHA Field at Arrowhead Stadium").
+- name: venue_city
+  type: character
+  description: Venue city.
+- name: venue_country
+  type: character
+  description: Venue country.
+- name: season
+  type: integer
+  description: Season (year) of the game.
+- name: season_type
+  type: character
+  description: Season type code (PRE, REG, or POST).
+- name: status
+  type: character
+  description: Game status (e.g. SCHEDULED, INGAME, FINAL).
+- name: week
+  type: integer
+  description: Week number of the game.
+- name: week_type
+  type: character
+  description: Week type code (e.g. PRE, REG, WC, DIV, CONF, SB).
+- name: external_ids
+  type: character
+  description: JSON-stringified array of external game identifiers (elias, gsis, etc.).
+- name: ticket_url
+  type: character
+  description: Primary ticket-purchase URL for the game.
+- name: ticket_vendors
+  type: character
+  description: JSON-stringified array of ticket-vendor objects (vendor name, URL).
+- name: extensions
+  type: character
+  description: JSON-stringified array of extension objects (empty when none).
+- name: version
+  type: integer
+  description: Record version number.
+- name: summary_game_id
+  type: character
+  description: NFL.com Shield GUID for the game (from the embedded live summary).
+- name: summary_offset
+  type: integer
+  description: Live-feed sequence offset for the embedded summary snapshot.
+- name: summary_attendance
+  type: integer
+  description: Announced game attendance (from the embedded summary).
+- name: summary_clock
+  type: character
+  description: Game clock at the summary snapshot (MM:SS).
+- name: summary_distance
+  type: integer
+  description: Yards to gain for a first down at the summary snapshot.
+- name: summary_down
+  type: integer
+  description: Current down (1-4) at the summary snapshot.
+- name: summary_game_book_url
+  type: character
+  description: URL of the official game book image (from the embedded summary).
+- name: summary_is_goal_to_go
+  type: logical
+  description: Whether the situation is goal-to-go at the summary snapshot.
+- name: summary_is_red_zone
+  type: logical
+  description: Whether the ball is in the red zone at the summary snapshot.
+- name: summary_phase
+  type: character
+  description: Game phase (e.g. PREGAME, INGAME, HALFTIME, FINAL).
+- name: summary_quarter
+  type: character
+  description: Current period descriptor (e.g. Q1, HALFTIME, END_OF_GAME).
+- name: summary_start_time
+  type: character
+  description: ISO 8601 kickoff timestamp (from the embedded summary).
+- name: summary_weather
+  type: character
+  description: Weather summary string (temperature, humidity, wind).
+- name: summary_yard_line
+  type: character
+  description: Current line of scrimmage at the summary snapshot (e.g. "KC 10").
+- name: summary_away_team_team_id
+  type: character
+  description: NFL.com Shield GUID of the away team (from the embedded summary).
+- name: summary_away_team_has_possession
+  type: logical
+  description: Whether the away team has possession at the summary snapshot.
+- name: summary_away_team_score_q1
+  type: integer
+  description: Away team points scored in the first quarter.
+- name: summary_away_team_score_q2
+  type: integer
+  description: Away team points scored in the second quarter.
+- name: summary_away_team_score_q3
+  type: integer
+  description: Away team points scored in the third quarter.
+- name: summary_away_team_score_q4
+  type: integer
+  description: Away team points scored in the fourth quarter.
+- name: summary_away_team_score_ot
+  type: integer
+  description: Away team points scored in overtime.
+- name: summary_away_team_score_total
+  type: integer
+  description: Away team total points.
+- name: summary_away_team_timeouts_remaining
+  type: integer
+  description: Away team timeouts remaining at the summary snapshot.
+- name: summary_away_team_timeouts_used
+  type: integer
+  description: Away team timeouts used at the summary snapshot.
+- name: summary_home_team_team_id
+  type: character
+  description: NFL.com Shield GUID of the home team (from the embedded summary).
+- name: summary_home_team_has_possession
+  type: logical
+  description: Whether the home team has possession at the summary snapshot.
+- name: summary_home_team_score_q1
+  type: integer
+  description: Home team points scored in the first quarter.
+- name: summary_home_team_score_q2
+  type: integer
+  description: Home team points scored in the second quarter.
+- name: summary_home_team_score_q3
+  type: integer
+  description: Home team points scored in the third quarter.
+- name: summary_home_team_score_q4
+  type: integer
+  description: Home team points scored in the fourth quarter.
+- name: summary_home_team_score_ot
+  type: integer
+  description: Home team points scored in overtime.
+- name: summary_home_team_score_total
+  type: integer
+  description: Home team total points.
+- name: summary_home_team_timeouts_remaining
+  type: integer
+  description: Home team timeouts remaining at the summary snapshot.
+- name: summary_home_team_timeouts_used
+  type: integer
+  description: Home team timeouts used at the summary snapshot.
+- name: drive_chart_game_id
+  type: character
+  description: NFL.com Shield GUID for the game (from the drive chart, present when include_drive_chart=true).
+- name: drive_chart_offset
+  type: integer
+  description: Live-feed sequence offset for the drive-chart snapshot.
+- name: drive_chart_drives
+  type: character
+  description: JSON-stringified array of drive objects (sequence, team, result, etc.).
+- name: drive_chart_plays
+  type: character
+  description: JSON-stringified array of play objects within the drive chart.
+- name: drive_chart_scoring_summaries
+  type: character
+  description: JSON-stringified array of scoring-summary objects (sequence, scores, clock).
+- name: replays
+  type: character
+  description: JSON-stringified array of replay objects (populated only when include_replays=true).
+- name: tagged_videos
+  type: character
+  description: JSON-stringified array of tagged-video objects (populated only when include_tagged_videos=true).
+- name: away_team_standings
+  type: character
+  description: JSON-stringified away-team standings object (populated only when include_standings=true).
+- name: home_team_standings
+  type: character
+  description: JSON-stringified home-team standings object (populated only when include_standings=true).

--- a/tools/codegen/schemas/native/nfl_api/weeks.yaml
+++ b/tools/codegen/schemas/native/nfl_api/weeks.yaml
@@ -1,0 +1,24 @@
+schema: weeks
+kind: dataframe
+columns:
+- name: season
+  type: integer
+  description: Season (year) of the week.
+- name: season_type
+  type: character
+  description: Season type code (PRE, REG, or POST).
+- name: week
+  type: integer
+  description: Week number within the season type.
+- name: bye_teams
+  type: character
+  description: JSON-stringified array of teams on bye during the week (empty when none).
+- name: date_begin
+  type: character
+  description: Start date of the week (YYYY-MM-DD).
+- name: date_end
+  type: character
+  description: End date of the week (YYYY-MM-DD).
+- name: week_type
+  type: character
+  description: Week type code (e.g. PRE, REG, WC, DIV, CONF, SB).

--- a/tools/codegen/schemas/native/nfl_api/weeks_by_date.yaml
+++ b/tools/codegen/schemas/native/nfl_api/weeks_by_date.yaml
@@ -1,0 +1,24 @@
+schema: weeks_by_date
+kind: dataframe
+columns:
+- name: season
+  type: integer
+  description: Season (year) the date falls in.
+- name: season_type
+  type: character
+  description: Season type code (PRE, REG, or POST).
+- name: week
+  type: integer
+  description: Week number that the queried date falls within.
+- name: bye_teams
+  type: character
+  description: JSON-stringified array of teams on bye during the week (empty when none).
+- name: date_begin
+  type: character
+  description: Start date of the week (YYYY-MM-DD).
+- name: date_end
+  type: character
+  description: End date of the week (YYYY-MM-DD).
+- name: week_type
+  type: character
+  description: Week type code (e.g. PRE, REG, WC, DIV, CONF, SB).


### PR DESCRIPTION
## Summary

Adds live-captured **returns-schema tables** (`col_name | type | description`) for all **11 `api.nfl.com` (NFL.com "Shield") endpoints**, bringing the `nfl_api` native API family to parity with the other six native families (mlb_api, nhl_api_web, nhl_edge, nhl_stats_rest, nhl_records, mlb_statcast), which already render per-endpoint **Returns** tables on their reference pages.

Before this change, `nfl_api` was the only native flat-API family with parsers but **no returns schemas and no `returns_schema:` wiring**, so its reference page's `### Returns` sections showed only the generic "tidy polars.DataFrame (parser: ...)" line with no column table.

## What changed

- **11 schema files** added under `tools/codegen/schemas/native/nfl_api/` — `standings`, `rosters`, `teams_history`, `team`, `weeks`, `weeks_by_date`, `combine_profiles`, `draft_picks`, `injuries`, `game_summaries`, `weekly_game_details`. Ported **verbatim** from the sibling JS repo (`sportsdataverse-js`) where they were first live-captured; same `schema:` / `kind: dataframe` / `columns: [{name,type,description}]` format as the existing `mlb_api` schemas.
- **`tools/codegen/endpoints/nfl_api.yaml`** — each of the 11 endpoint blocks gains a `returns_schema: native/nfl_api/<short>` line (placed right after its `parser:`, matching the `mlb_api.yaml` convention).
- **`docs/docs/nfl/reference/nfl_api.md`** regenerated via `python tools/codegen/generate.py --docs` — all 11 `### Returns` sections now render full column tables.
- **`CHANGELOG.md`** (+ synced `docs/src/pages/CHANGELOG.md` mirror) — one docs bullet under 0.0.64.

## Notes

- **Docs / codegen-metadata only — no runtime change.** No parser, wrapper, or loader code was touched.
- Split out from the JS native-API work, where these schemas were originally captured.
- Drift gate is green: `python tools/codegen/generate.py --check` exits 0, and the `codegen drift check` pre-commit hook passed.