### PR TITLE
feat(nfl): NFL ETL convergence — delegate EPA/WPA to ep_wp, add fixed_drive/series + build_nfl_season

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,6 +12,7 @@
   - [Module Naming](#module-naming)
   - [NFL — nflreadpy Parity](#nfl--nflreadpy-parity)
     - [NFL Cache + Config](#nfl-cache--config)
+    - [NFL — `ep_wp` model application + EPA/WPA](#nfl--ep_wp-model-application--epawpa)
   - [CFB — `cfb_play_participants`](#cfb--cfb_play_participants)
   - [CFB — offline reprocess (`CFBPlayProcess`, 0.0.52+)](#cfb--offline-reprocess-cfbplayprocess-0052)
   - [Module Pattern (NEW modules)](#module-pattern-new-modules)
@@ -208,6 +209,20 @@ clear_cache()  # wipes both memory + filesystem
 Call `clear_cache()` after modifying a loader's underlying URL — the
 key does NOT hash the URL or function body, so a renamed-URL/same-name
 change yields stale data until invalidated.
+
+### NFL — `ep_wp` model application + EPA/WPA
+
+`sportsdataverse/nfl/ep_wp.py` is the **single owner of NFL model
+application and EPA/WPA derivation**. Construction modules (`NFLPlayProcess`,
+`native_pbp`, `load_nfl_pbp`) must never add EPA/WPA inline — they emit a
+frame and `ep_wp.enrich_nfl_pbp` / `calculate_epa` / `calculate_wpa` apply
+it. `NFLPlayProcess.__process_epa` / `__process_wpa` delegate to those shared
+functions (byte-identical output verified — one engine across both the
+ESPN and nflverse `lead_diff` paths). `build_nfl_season(game_ids, *, source=...)`
+compiles a full season: per-game construct→enrich→`diagonal_relaxed` concat,
+with a per-game parquet cache keyed `(game_id, PIPELINE_VERSION)` via
+`nfl/cache.py`. `method="snapshot"` on `enrich_nfl_pbp` is intentionally
+`NotImplementedError` — the cross-era comparison was validated without it.
 
 ## CFB — `cfb_play_participants`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@
   - [Key Coding Conventions](#key-coding-conventions)
     - [Module pattern (NEW modules)](#module-pattern-new-modules)
     - [NFL — nflreadpy parity](#nfl--nflreadpy-parity)
+    - [NFL — `ep_wp` model application + EPA/WPA (nflfastR alignment, 0.0.67+)](#nfl--ep_wp-model-application--epawpa-nflfastr-alignment-0067)
     - [CFB — `cfb_play_participants` and the 0.36-live reconciliation](#cfb--cfb_play_participants-and-the-036-live-reconciliation)
     - [CFB — offline reprocess (`odds_override`, raw allowlist, `odds_source`) (0.0.52+)](#cfb--offline-reprocess-odds_override-raw-allowlist-odds_source-0052)
     - [MLB — Statcast (Baseball Savant) comprehensive surface (0.0.64+)](#mlb--statcast-baseball-savant-comprehensive-surface-0064)
@@ -458,6 +459,54 @@ inline-bundled (not separate JSON files) because the
 When in doubt about the upstream API surface, check
 `gh repo view nflverse/nflreadpy` — sdv-py mirrors nflreadpy's signatures
 where practical.
+
+### NFL — `ep_wp` model application + EPA/WPA (nflfastR alignment, 0.0.67+)
+
+`sportsdataverse/nfl/ep_wp.py` is the **single owner of NFL model application
+and EPA/WPA derivation**. The canonical rule: **construction modules
+(`nfl_pbp.py` / native_pbp / `load_nfl_pbp`) must never re-add EPA/WPA inline —
+they emit a frame and `ep_wp` applies the models.** EPA/WPA logic lives in
+exactly one place.
+
+- **Scorers** mirror nflfastR's `calculate_*()`: `calculate_expected_points`
+  (single start-of-play `ep` + 7 class probs), `calculate_win_probability`
+  (`wp` naive + `vegas_wp` spread), `calculate_completion_probability`
+  (`cp` + `cpoe`, percentage-point scale `100*(complete_pass-cp)`),
+  `calculate_xyac`. Outputs are `Float64` (cast explicitly — the models emit
+  float32; do NOT let a `pl.Series(numpy_f32)` silently downcast the public
+  columns).
+- **Derivations** `calculate_epa(df)` / `calculate_wpa(df)` were lifted verbatim
+  from `NFLPlayProcess.__process_epa/__process_wpa` (scoring overlays, half-end
+  `-ep`, penalty `EP_between`, kickoff touchback, turnover/onside, OT two-path,
+  posteam→home flip). **Every `shift`/lead is `.over("game_id")`** — no
+  cross-game leak when frames are concatenated.
+- **`enrich_nfl_pbp(df, *, method=...)`** orchestrates EP→EPA→WP→WPA→CP→CPOE→xYAC
+  in nflfastR order. `method="lead_diff"` (default, **shipped + parity-validated**)
+  is a nflverse-native faithful port of nflfastR `helper_add_ep_wp.R`: scores one
+  `ep`, derives the rest natively on nflverse columns, applies the **kickoff/PAT
+  feature substitution** (touchback yardline `TOUCHBACK_YARDLINE_PRE/POST_2016` =
+  80 pre-2016 / 75 from 2016, `down`→1, `ydstogo`→10 — the parity lever), and
+  exposes `ep` as **start-of-play** EP. `method="snapshot"` (ESPN `start.*`/`end.*`
+  via `calculate_epa`/`calculate_wpa`) is **planned** — currently
+  `NotImplementedError`; it pairs with delegating `NFLPlayProcess.__process_*` to
+  `ep_wp` (the de-triplication is not yet landed — until then the inline
+  `__process_epa/wpa` math is an intentional temporary duplicate of the shared
+  functions).
+- **Constants** are centralized in `model_vars.py`: `NFLVERSE_FRAME_CONTRACT`,
+  `_EP_POINT_VALUES`, `ERA_SEASON_CUTS` (cuts 2001/2005/2013/2017),
+  `TOUCHBACK_YARDLINE_PRE/POST_2016`, `SPREAD_TIME_DECAY_EXPONENT` (`-4.0`).
+  `receive_2h_ko` is derived in `_add_wp_aux` when absent (per game: 1st-half
+  posteam == opening defense).
+- **Models** `nfl/models/*.ubj` are the **faithful** `nfl_model_artifacts`
+  (EP 18-feat / wp_spread 12 / wp_naive 11 / cp 18) from `sportsdataverse-data`,
+  not the old CFB-shape placeholders. Refresh by downloading that release and
+  verifying `Booster.feature_names == *_FEATURES`.
+- **Parity** (`lead_diff` vs nflverse, model domain): `ep` 0.996, `epa` 0.994,
+  `wp` 0.997, `vegas_wp` 0.998, `cpoe` scale-correct; `wpa` ≈0.89 is an SNR
+  ceiling (the derivation is exact — corr 1.0 when fed nflverse's own `wp`; the
+  residual is WP-model per-play noise amplified by first-differencing, not a
+  bug). The track6 EP/WP/CP recipe + this surface are validated against the
+  nflfastR source in the workspace (`nflverse-dev/nflfastR/R/helper_add_ep_wp.R`).
 
 ### CFB — `cfb_play_participants` and the 0.36-live reconciliation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -486,12 +486,24 @@ exactly one place.
   `ep`, derives the rest natively on nflverse columns, applies the **kickoff/PAT
   feature substitution** (touchback yardline `TOUCHBACK_YARDLINE_PRE/POST_2016` =
   80 pre-2016 / 75 from 2016, `down`→1, `ydstogo`→10 — the parity lever), and
-  exposes `ep` as **start-of-play** EP. `method="snapshot"` (ESPN `start.*`/`end.*`
-  via `calculate_epa`/`calculate_wpa`) is **planned** — currently
-  `NotImplementedError`; it pairs with delegating `NFLPlayProcess.__process_*` to
-  `ep_wp` (the de-triplication is not yet landed — until then the inline
-  `__process_epa/wpa` math is an intentional temporary duplicate of the shared
-  functions).
+  exposes `ep` as **start-of-play** EP. `method="snapshot"` remains
+  `NotImplementedError` — it was the intended vehicle for a
+  lead_diff-vs-snapshot cross-era comparison, which was instead validated
+  directly; the comparison confirmed correctness without needing a second
+  live path, so `"snapshot"` is intentionally left unimplemented.
+- **`NFLPlayProcess.__process_epa` / `__process_wpa` now delegate** their
+  derivation to the shared `calculate_epa` / `calculate_wpa` — the ESPN
+  construction path and the nflverse lead_diff path share one derivation
+  engine (byte-identical output verified). There is no inline duplicate.
+- **`fixed_drive` / `series` columns** — nflfastR
+  `helper_add_fixed_drives.R` + `helper_add_series_data.R` are ported into
+  the ESPN `NFLPlayProcess` construction path (including lag-2/3
+  timeout-interleave and onside-recovery handling); they are additive
+  columns appended during `run_processing_pipeline()`.
+- **`build_nfl_season(game_ids, *, source=...)`** — season-compile helper:
+  iterates game IDs, calls construct→enrich→appends, joins via
+  `diagonal_relaxed`, and caches each game's enriched parquet keyed by
+  `(game_id, PIPELINE_VERSION)` reusing `nfl/cache.py`.
 - **Constants** are centralized in `model_vars.py`: `NFLVERSE_FRAME_CONTRACT`,
   `_EP_POINT_VALUES`, `ERA_SEASON_CUTS` (cuts 2001/2005/2013/2017),
   `TOUCHBACK_YARDLINE_PRE/POST_2016`, `SPREAD_TIME_DECAY_EXPONENT` (`-4.0`).

--- a/docs/docs/nfl/index.md
+++ b/docs/docs/nfl/index.md
@@ -11,7 +11,7 @@ sidebar_label: NFL
 | [ESPN core API (v2)](reference/core) | 83 | `https://sports.core.api.espn.com/v2/sports` |
 | [NFL.com API](reference/nfl_api) | 11 | `https://api.nfl.com` |
 | [Dataset loaders](reference/loaders) | 8 | nflverse data releases |
-| [Additional functions](reference/additional) | 87 | hand-written wrappers, loaders & helpers |
+| [Additional functions](reference/additional) | 90 | hand-written wrappers, loaders & helpers |
 
 ## Examples
 

--- a/docs/docs/nfl/reference/additional.md
+++ b/docs/docs/nfl/reference/additional.md
@@ -4634,6 +4634,62 @@ from sportsdataverse.nfl import NflConfig
 cfg = NflConfig(cache_mode="off", timeout=10)
 ```
 
+### `build_nfl_season(game_ids: 'list[int] | None' = None, *, seasons: 'list[int] | None' = None, source: 'str' = 'espn', return_as_pandas: 'bool' = False) -> "'pl.DataFrame | pd.DataFrame'"` {#build_nfl_season}
+
+Compile play-by-play for multiple NFL games into one tidy frame.
+
+The `source` parameter determines which input parameter is required:
+
+- `source="espn"` — requires *game_ids*; *seasons* must be `None`.
+- `source="nflverse"` — requires *seasons*; *game_ids* must be `None`.
+
+For ESPN games the function either loads a previously cached plays frame or
+processes the game fresh via `NFLPlayProcess`.  Individual game failures
+are logged and skipped so a single bad game does not abort the whole season
+build.  The per-game frames are concatenated with `how="diagonal_relaxed"`
+(schema union, missing columns filled with `null`) so games with slightly
+different column sets merge cleanly.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_ids` | `list[int] \| None` | `None` | ESPN event IDs to compile (e.g. `[401671801, 401671802]`). Required when `source="espn"`; must be `None` for other sources. |
+| `seasons` | `list[int] \| None` | `None` | Season years to compile (e.g. `[2023, 2024]`). Required when `source="nflverse"`; must be `None` for other sources. |
+| `source` | `str` | `'espn'` | Data source. - `"espn"` *(default)*: each game is processed via `NFLPlayProcess(gameId=gid).espn_nfl_pbp()` + `run_processing_pipeline()`. Pass *game_ids*. - `"nflverse"`: delegates to `sportsdataverse.nfl.load_nfl_pbp` for the requested seasons. Pass *seasons*. Returns the full pre-enriched season frame as-is. - `"shield"`: raises `NotImplementedError` — Shield (api.nfl.com) play-by-play lives in the native-pipeline (`nfl-data`) repository, not sdv-py. |
+| `return_as_pandas` | `bool` | `False` | If `True`, return a `pandas.DataFrame` instead of polars. |
+
+**Returns**
+
+All plays from the requested games/seasons, concatenated with schema-union semantics (missing columns are `null`). Returns a zero-row frame if every game failed (ESPN source only). When *return_as_pandas* is `True`, returns a `pandas.DataFrame` instead.
+
+**Example**
+
+```python
+from sportsdataverse.nfl import build_nfl_season
+df = build_nfl_season(game_ids=[401671801, 401671802])
+print(df.shape)
+
+# nflverse season compile (pass season years)
+
+from sportsdataverse.nfl import build_nfl_season
+df = build_nfl_season(seasons=[2023], source="nflverse")
+print(df.shape)
+
+# With filesystem cache enabled (ESPN)
+
+from sportsdataverse.nfl import build_nfl_season, update_config
+update_config(cache_mode="filesystem")
+df = build_nfl_season(game_ids=[401671801, 401671802])  # processes + caches
+df2 = build_nfl_season(game_ids=[401671801, 401671802]) # served from cache
+
+# Pandas output
+
+from sportsdataverse.nfl import build_nfl_season
+df_pd = build_nfl_season(game_ids=[401671801], return_as_pandas=True)
+print(df_pd.shape)
+```
+
 ### `cached_loader(func: 'F') -> 'F'` {#cached_loader}
 
 Decorator that adds caching to a `load_nfl_*` function.
@@ -4716,6 +4772,68 @@ pbp_cp = calculate_completion_probability(pbp)
 print(pbp_cp.select("cp", "cpoe").head())
 ```
 
+### `calculate_epa(df: 'pl.DataFrame') -> 'pl.DataFrame'` {#calculate_epa}
+
+Derive expected points added (EPA) from pre-scored EP point estimates.
+
+This is the **derivation half** of `NFLPlayProcess.__process_epa` lifted
+into a shared, model-free function so the same nflfastR-faithful EPA logic
+can be reused by the streaming `enrich_nfl_pbp` pipeline and by
+process_epa` itself.  It performs **no** model inference — the caller
+must already have scored the per-play EP point estimates.
+
+Derivation rules (mirror nflfastR / the original process_epa`):
+
+* Scoring overlays rewrite `EP_end` to the realized point value
+  (offense TD `+7` / `+6.92` / 2pt variants, made FG `+3`,
+  defensive scores, extra points, etc.) using the same `type.text` /
+  `text` classification as process_epa`.
+* Turnovers (`end_change_vec` / `downs_turnover`), kickoff turnovers
+  and recovered onside kicks flip `EP_end` to the opponent's
+  perspective (`EP_end * -1`).
+* `lag_EP_end` is the previous play's `EP_end`; `EP_between` flips
+  its sign on a prior-play possession change.
+* Kickoffs use `EP_start_touchback` as `EP_start`.
+* `EPA = EP_end - EP_start` normally; `-EP_start` on a non-scoring
+  end-of-half play; `0` on a timeout; `EP_end - EP_start + EP_between`
+  on a (non-kickoff, non-`Penalty`) penalty-in-text play.
+
+**Every** `shift` is grouped `.over("game_id")` so a concatenated
+multi-game frame never leaks EP across game boundaries — this differs from
+process_epa` (which runs one game per instance and therefore needs no
+grouping).
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `df` | `DataFrame` |  | Play-by-play DataFrame that already carries the EP point estimates under the ESPN-internal names `EP_start`, `EP_end` and `EP_start_touchback` (e.g. as produced by the EP-scoring half of process_epa`), plus the play-classification / flag columns: `game_id`, `type.text`, `text`, `change_of_pos_team`, `downs_turnover`, `kickoff_onside`, `scoring_play`, `end_of_half` and `penalty_in_text`. See EPA_REQUIRED_COLUMNS`. This function does **not** score EP itself — score it first via the EP feature pipeline (the `EP_*` triple is the ESPN-internal naming, distinct from `calculate_expected_points`'s lowercase `ep`). |
+
+**Returns**
+
+The input frame with the EPA derivation applied. `EP_start` is rewritten to `0.92` for scoring-attempt play types (`Extra Point Good`, `Extra Point Missed`, `Two-Point Conversion Good`, `Two-Point Conversion Missed`, `Two Point Pass`, `Two Point Rush`, `Blocked PAT`) before any other overlays fire. `EP_start` / `EP_end` are then rewritten in place (overlays, sign flips, touchback), `EP_between`, `lag_EP_end` and `lag_change_of_pos_team` are added, `EPA` is added, and lowercase nflverse aliases `ep` (`= EP_end`), `epa` (`= EPA`), `ep_start` (`= EP_start`) and `ep_end` (`= EP_end`) are added for downstream contract parity.
+
+**Example**
+
+```python
+# For most use cases, call the high-level entry point instead. ``enrich_nfl_pbp`` scores EP, derives EPA, and adds WP/WPA/CP/CPOE in one shot on any nflverse-shape frame
+
+    from sportsdataverse.nfl import load_nfl_pbp
+    from sportsdataverse.nfl.ep_wp import enrich_nfl_pbp
+
+    pbp = load_nfl_pbp([2023])
+    enriched = enrich_nfl_pbp(pbp)
+    print(enriched.select("game_id", "ep", "epa").head())
+
+``calculate_epa`` directly requires ESPN-internal columns
+(``EP_start``, ``EP_end``, ``EP_start_touchback``, ``type.text``,
+etc.) produced by ``NFLPlayProcess``.  It is called internally by
+``NFLPlayProcess.__process_epa`` and by the ``enrich_nfl_pbp``
+orchestrator — a naked ``calculate_epa(load_nfl_pbp([2023]))``
+will raise ``KeyError`` because those columns are absent from a
+nflverse frame.
+```
+
 ### `calculate_expected_points(pbp_data: 'pl.DataFrame', *, return_as_pandas: 'bool' = False) -> "Union[pl.DataFrame, 'pd.DataFrame']"` {#calculate_expected_points}
 
 Compute expected points for provided plays.
@@ -4775,6 +4893,79 @@ from sportsdataverse.nfl.ep_wp import calculate_win_probability
 pbp = load_nfl_pbp([2023])
 pbp_wp = calculate_win_probability(pbp)
 print(pbp_wp.select("wp", "vegas_wp").head())
+```
+
+### `calculate_wpa(df: 'pl.DataFrame') -> 'pl.DataFrame'` {#calculate_wpa}
+
+Derive win probability added (WPA) from pre-scored WP point estimates.
+
+This is the **derivation half** of `NFLPlayProcess.__process_wpa` lifted
+into a shared, model-free function so the same nflfastR-faithful WPA logic
+can be reused by the streaming `enrich_nfl_pbp` pipeline and by
+process_wpa` itself.  It performs **no** model inference — the caller
+must already have scored the per-play WP point estimates
+(`wp_spread.ubj`) for the start / touchback / end feature views and
+attached them as `wp_before` / `wp_touchback` / `wp_after`.  This
+mirrors `calculate_epa`, which likewise consumes pre-scored EP point
+estimates and leaves prediction to the orchestrator.
+
+Derivation rules (mirror the original process_wpa`):
+
+* **Leading overlay (do not drop):** on a kickoff (`type.text` in
+  `kickoff_vec`) `wp_before` is replaced by `wp_touchback` — the
+  win-probability scored from the touchback feature view — before any
+  other column derives.  This is the WP analogue of the EPA `0.92`
+  scoring-attempt overlay and must fire first.
+* `def_wp_before = 1 - wp_before`; `home_wp_before` / `away_wp_before`
+  are the posteam->home perspective columns (the offense's `wp_before`
+  flows to home when the start possession team is the home team, otherwise
+  to the defense `def_wp_before`).
+* `wp_after` is rewritten by the end-of-half / end-of-game / OT two-path:
+  timeouts hold `wp_before`; a completed final play resolves to `1.0` /
+  `0.0` by the winner; end-of-half and `End Period` / `End of Half`
+  lead plays take `lead_wp_before` (or `1 - lead_wp_before` on a
+  possession change); a possession change otherwise flips the lead;
+  everything else keeps the model `wp_after`.
+* `def_wp_after = 1 - wp_after`; `home_wp_after` / `away_wp_after`
+  use the **end** possession team for the perspective flip.
+* `wpa = wp_after - wp_before`.
+
+**Every** `shift` / forward reference is grouped `.over("game_id")` so a
+concatenated multi-game frame never leaks WP across game boundaries — the
+`lead_wp_before` / `lead_wp_before2` shifts and the end-of-game
+`game_play_number == max()` lookup are all per-game.  This differs from
+process_wpa` (which runs one game per instance and therefore needs no
+grouping).
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `df` | `DataFrame` |  | Play-by-play DataFrame that already carries the WP point estimates `wp_before` (start feature view), `wp_touchback` (touchback feature view) and `wp_after` (end feature view), plus the play-classification / perspective columns `game_id`, `type.text`, `homeTeamId`, `start.pos_team.id`, `end.pos_team.id`, `start.pos_team_receives_2H_kickoff`, `change_of_pos_team`, `scoringPlay`, `kickoff_onside`, `end_of_half`, `status_type_completed`, `pos_score_diff_end`, `lead_play_type`, `lead_pos_team` and `game_play_number`. See WPA_REQUIRED_COLUMNS`. This function does **not** score WP itself — score it first via `calculate_win_probability` / the `wp_spread` feature pipeline. |
+
+**Returns**
+
+The input frame with the WPA derivation applied: `wp_before` rewritten by the kickoff-touchback overlay; `def_wp_before`, `home_wp_before`, `away_wp_before`, `lead_wp_before`, `lead_wp_before2`, the rewritten `wp_after`, `def_wp_after`, `home_wp_after`, `away_wp_after` and `wpa` added; plus first-class lowercase aliases `wp` (`= wp_before`), `def_wp` (`= def_wp_before`), `home_wp` (`= home_wp_before`) and `away_wp` (`= away_wp_before`) for downstream contract parity (the per-play offense win probability is the pre-snap `wp_before`, matching nflfastR's `wp` semantics).
+
+**Example**
+
+```python
+# For most use cases, call the high-level entry point instead. ``enrich_nfl_pbp`` scores WP, derives WPA, and adds EP/EPA/CP/CPOE in one shot on any nflverse-shape frame
+
+    from sportsdataverse.nfl import load_nfl_pbp
+    from sportsdataverse.nfl.ep_wp import enrich_nfl_pbp
+
+    pbp = load_nfl_pbp([2023])
+    enriched = enrich_nfl_pbp(pbp)
+    print(enriched.select("game_id", "wp", "def_wp", "home_wp", "away_wp", "wpa").head())
+
+``calculate_wpa`` directly requires ESPN-internal columns
+(``wp_before``, ``wp_touchback``, ``wp_after``, ``homeTeamId``,
+``start.pos_team.id``, etc.) produced by ``NFLPlayProcess``.  It is
+called internally by ``NFLPlayProcess.__process_wpa`` and by the
+``enrich_nfl_pbp`` orchestrator — a naked
+``calculate_wpa(load_nfl_pbp([2023]))`` will raise ``KeyError``
+because those columns are absent from a nflverse frame.
 ```
 
 ### `calculate_xyac(pbp_data: 'pl.DataFrame', *, return_as_pandas: 'bool' = False) -> "Union[pl.DataFrame, 'pd.DataFrame']"` {#calculate_xyac}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -283,6 +283,7 @@ files = [
     "sportsdataverse/cfb/cfb_yahoo_ext.py",
     "sportsdataverse/nfl/config.py",
     "sportsdataverse/nfl/model_vars.py",
+    "sportsdataverse/nfl/nfl_build.py",
     "sportsdataverse/nfl/utils_date.py",
     "sportsdataverse/mlb/mlb_statcast_runtime.py",
     "sportsdataverse/mlb/mlb_statcast_parsers.py",

--- a/sportsdataverse/nfl/__init__.py
+++ b/sportsdataverse/nfl/__init__.py
@@ -101,3 +101,4 @@ from sportsdataverse.nfl.nfl_teams import *
 from sportsdataverse.nfl.utils_date import *
 from sportsdataverse.nfl.utils_date import get_current_nfl_season as get_current_season
 from sportsdataverse.nfl.utils_date import get_current_nfl_week as get_current_week
+from sportsdataverse.nfl.nfl_build import build_nfl_season

--- a/sportsdataverse/nfl/cache.py
+++ b/sportsdataverse/nfl/cache.py
@@ -71,8 +71,11 @@ def cache_get(key: str) -> pl.DataFrame | None:
     """Return a cached frame for *key*, or ``None`` on miss or expiry.
 
     Honors the active :class:`~sportsdataverse.nfl.config.NflConfig` cache
-    mode (``memory``, ``filesystem``, ``off``).  Expired entries are evicted
-    automatically.
+    mode (``memory``, ``filesystem``, ``off``).  An expired entry is treated
+    as a MISS (returns ``None``).  In ``memory`` mode the expired key is
+    dropped from the in-process dict on read; in ``filesystem`` mode the
+    stale parquet file is NOT auto-deleted from disk — call
+    :func:`clear_cache` to reclaim it.
 
     Args:
         key: Cache key string (e.g. from ``_game_cache_key()``).
@@ -95,7 +98,14 @@ def cache_get(key: str) -> pl.DataFrame | None:
             try:
                 return pl.read_parquet(path)
             except Exception:
-                path.unlink(missing_ok=True)
+                # Corrupt / unreadable parquet: best-effort cleanup. ``unlink``
+                # can itself raise (permissions, Windows file lock), but
+                # ``cache_get`` is opaque infra and must return ``None`` on any
+                # cache issue rather than propagate.
+                try:
+                    path.unlink(missing_ok=True)
+                except Exception:
+                    pass
     return None
 
 

--- a/sportsdataverse/nfl/cache.py
+++ b/sportsdataverse/nfl/cache.py
@@ -67,6 +67,62 @@ def _is_expired(timestamp: float) -> bool:
     return (time.time() - timestamp) > get_config().cache_duration
 
 
+def cache_get(key: str) -> pl.DataFrame | None:
+    """Return a cached frame for *key*, or ``None`` on miss or expiry.
+
+    Honors the active :class:`~sportsdataverse.nfl.config.NflConfig` cache
+    mode (``memory``, ``filesystem``, ``off``).  Expired entries are evicted
+    automatically.
+
+    Args:
+        key: Cache key string (e.g. from ``_game_cache_key()``).
+
+    Returns:
+        polars.DataFrame if the key is present and unexpired; ``None``
+        otherwise.
+    """
+    cfg = get_config()
+    if cfg.cache_mode == "memory":
+        entry = _MEMORY.get(key)
+        if entry is not None:
+            ts, frame = entry
+            if not _is_expired(ts):
+                return frame
+            del _MEMORY[key]
+    elif cfg.cache_mode == "filesystem":
+        path = _filesystem_path(key)
+        if path.exists() and not _is_expired(path.stat().st_mtime):
+            try:
+                return pl.read_parquet(path)
+            except Exception:
+                path.unlink(missing_ok=True)
+    return None
+
+
+def cache_put(key: str, frame: pl.DataFrame) -> None:
+    """Persist *frame* to the active cache backend under *key*.
+
+    Honors the active :class:`~sportsdataverse.nfl.config.NflConfig` cache
+    mode.  Write failures on the filesystem backend are silently swallowed —
+    the data is still returned to the caller; the cache is opaque infra.
+
+    Args:
+        key: Cache key string.
+        frame: polars DataFrame to store.
+    """
+    cfg = get_config()
+    if cfg.cache_mode == "memory":
+        _MEMORY[key] = (time.time(), frame)
+    elif cfg.cache_mode == "filesystem":
+        cache_dir = cfg.cache_dir
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        path = _filesystem_path(key)
+        try:
+            frame.write_parquet(path)
+        except Exception:
+            pass  # Cache write failure is non-fatal; data still returned.
+
+
 def cached_loader(func: F) -> F:
     """Decorator that adds caching to a ``load_nfl_*`` function.
 

--- a/sportsdataverse/nfl/ep_wp.py
+++ b/sportsdataverse/nfl/ep_wp.py
@@ -738,9 +738,9 @@ def calculate_expected_points(
 
     ep = np.clip(probs @ _EP_POINT_VALUES, -10.0, 10.0)
 
-    prob_frame = pl.DataFrame({name: probs[:, i].tolist() for i, name in enumerate(_EP_CLASS_NAMES)}).with_columns(
-        ep=pl.Series("ep", ep.tolist())
-    )
+    prob_frame = pl.DataFrame(
+        {name: pl.Series(name, probs[:, i]) for i, name in enumerate(_EP_CLASS_NAMES)}
+    ).with_columns(ep=pl.Series("ep", ep))
 
     result = pl.concat([df, prob_frame], how="horizontal")
 
@@ -805,14 +805,21 @@ def calculate_win_probability(
 
     if "spread_line" in df.columns:
         # Where spread_line is null, fall back to naive wp for vegas_wp
-        has_spread = np.array(df["spread_line"].is_not_null().to_list(), dtype=bool)
+        has_spread = df["spread_line"].is_not_null().to_numpy()
         vegas_wp = np.where(has_spread, wp_spread, wp_naive)
     else:
         vegas_wp = wp_naive
 
+    # NOTE: wp_naive is NOT gated to null-spread_line rows even though
+    # vegas_wp already handles the spread/naive merge.  The `wp` column
+    # intentionally exposes the naive model output for *every* row so
+    # callers can compare naive vs spread-adjusted WP side-by-side
+    # (mirroring nflfastR's calculate_win_probability which always
+    # emits both).  Gating the predict to null-spread rows would silently
+    # drop `wp` for all spread rows and break that contract.
     result = df.with_columns(
-        wp=pl.Series("wp", wp_naive.tolist()),
-        vegas_wp=pl.Series("vegas_wp", vegas_wp.tolist()),
+        wp=pl.Series("wp", wp_naive),
+        vegas_wp=pl.Series("vegas_wp", vegas_wp),
     )
 
     if return_as_pandas:

--- a/sportsdataverse/nfl/ep_wp.py
+++ b/sportsdataverse/nfl/ep_wp.py
@@ -739,8 +739,8 @@ def calculate_expected_points(
     ep = np.clip(probs @ _EP_POINT_VALUES, -10.0, 10.0)
 
     prob_frame = pl.DataFrame(
-        {name: pl.Series(name, probs[:, i]) for i, name in enumerate(_EP_CLASS_NAMES)}
-    ).with_columns(ep=pl.Series("ep", ep))
+        {name: pl.Series(name, probs[:, i], dtype=pl.Float64) for i, name in enumerate(_EP_CLASS_NAMES)}
+    ).with_columns(ep=pl.Series("ep", ep, dtype=pl.Float64))
 
     result = pl.concat([df, prob_frame], how="horizontal")
 
@@ -818,8 +818,8 @@ def calculate_win_probability(
     # emits both).  Gating the predict to null-spread rows would silently
     # drop `wp` for all spread rows and break that contract.
     result = df.with_columns(
-        wp=pl.Series("wp", wp_naive),
-        vegas_wp=pl.Series("vegas_wp", vegas_wp),
+        wp=pl.Series("wp", wp_naive, dtype=pl.Float64),
+        vegas_wp=pl.Series("vegas_wp", vegas_wp, dtype=pl.Float64),
     )
 
     if return_as_pandas:

--- a/sportsdataverse/nfl/ep_wp.py
+++ b/sportsdataverse/nfl/ep_wp.py
@@ -1078,14 +1078,31 @@ def calculate_epa(df: pl.DataFrame) -> pl.DataFrame:
         KeyError: If any column in :data:`_EPA_REQUIRED_COLUMNS` is absent.
 
     Example:
-        Derive EPA from a pre-scored frame::
+        For most use cases, call the high-level entry point instead.
+        ``enrich_nfl_pbp`` scores EP, derives EPA, and adds WP/WPA/CP/CPOE
+        in one shot on any nflverse-shape frame::
 
-            import polars as pl
-            from sportsdataverse.nfl.ep_wp import calculate_epa
+            from sportsdataverse.nfl import load_nfl_pbp
+            from sportsdataverse.nfl.ep_wp import enrich_nfl_pbp
 
-            # `scored` already has EP_start / EP_end / EP_start_touchback
-            out = calculate_epa(scored)
-            print(out.select("game_id", "ep", "epa").head())
+            pbp = load_nfl_pbp([2023])
+            enriched = enrich_nfl_pbp(pbp)
+            print(enriched.select("game_id", "ep", "epa").head())
+
+        ``calculate_epa`` directly requires ESPN-internal columns
+        (``EP_start``, ``EP_end``, ``EP_start_touchback``, ``type.text``,
+        etc.) produced by ``NFLPlayProcess``.  It is called internally by
+        ``NFLPlayProcess.__process_epa`` and by the ``enrich_nfl_pbp``
+        orchestrator — a naked ``calculate_epa(load_nfl_pbp([2023]))``
+        will raise ``KeyError`` because those columns are absent from a
+        nflverse frame.
+
+        See Also:
+            * `nflfastR`_ -- R package whose EPA derivation this mirrors.
+            * `nflreadpy`_ -- Python parity loader for nflverse frames.
+
+        .. _nflfastR: https://www.nflfastr.com
+        .. _nflreadpy: https://github.com/nflverse/nflreadpy
     """
     missing = [c for c in _EPA_REQUIRED_COLUMNS if c not in df.columns]
     if missing:
@@ -1407,14 +1424,31 @@ def calculate_wpa(df: pl.DataFrame) -> pl.DataFrame:
         KeyError: If any column in :data:`_WPA_REQUIRED_COLUMNS` is absent.
 
     Example:
-        Derive WPA from a pre-scored frame::
+        For most use cases, call the high-level entry point instead.
+        ``enrich_nfl_pbp`` scores WP, derives WPA, and adds EP/EPA/CP/CPOE
+        in one shot on any nflverse-shape frame::
 
-            import polars as pl
-            from sportsdataverse.nfl.ep_wp import calculate_wpa
+            from sportsdataverse.nfl import load_nfl_pbp
+            from sportsdataverse.nfl.ep_wp import enrich_nfl_pbp
 
-            # `scored` already has wp_before / wp_touchback / wp_after
-            out = calculate_wpa(scored)
-            print(out.select("game_id", "wp", "wpa").head())
+            pbp = load_nfl_pbp([2023])
+            enriched = enrich_nfl_pbp(pbp)
+            print(enriched.select("game_id", "wp", "def_wp", "home_wp", "away_wp", "wpa").head())
+
+        ``calculate_wpa`` directly requires ESPN-internal columns
+        (``wp_before``, ``wp_touchback``, ``wp_after``, ``homeTeamId``,
+        ``start.pos_team.id``, etc.) produced by ``NFLPlayProcess``.  It is
+        called internally by ``NFLPlayProcess.__process_wpa`` and by the
+        ``enrich_nfl_pbp`` orchestrator — a naked
+        ``calculate_wpa(load_nfl_pbp([2023]))`` will raise ``KeyError``
+        because those columns are absent from a nflverse frame.
+
+        See Also:
+            * `nflfastR`_ -- R package whose WPA derivation this mirrors.
+            * `nflreadpy`_ -- Python parity loader for nflverse frames.
+
+        .. _nflfastR: https://www.nflfastr.com
+        .. _nflreadpy: https://github.com/nflverse/nflreadpy
     """
     missing = [c for c in _WPA_REQUIRED_COLUMNS if c not in df.columns]
     if missing:
@@ -2001,10 +2035,28 @@ def enrich_nfl_pbp(
         return_as_pandas: When ``True``, return a ``pandas.DataFrame``.
 
     Returns:
-        The input frame plus ``ep`` (start-of-play expected points), ``epa``,
-        ``wp`` (naive WP), ``vegas_wp`` (spread-adjusted WP), ``def_wp`` /
-        ``home_wp`` / ``away_wp``, ``wpa`` / ``vegas_wpa``, ``cp`` / ``cpoe``,
-        and the four ``xyac_*`` columns.
+        polars.DataFrame (or pandas.DataFrame when *return_as_pandas* is
+        ``True``) — the input frame with the following columns added or
+        recomputed:
+
+        * ``ep`` — start-of-play expected points (float64, clipped to [-10, 10]).
+        * ``epa`` — expected points added (float64; null on terminal/timeout rows).
+        * ``wp`` — naive win probability from the ``wp_naive`` model (float64).
+        * ``vegas_wp`` — spread-adjusted win probability from ``wp_spread``
+          (falls back to ``wp`` when ``spread_line`` is null).
+        * ``def_wp`` — defensive team win probability (``1 - wp``).
+        * ``home_wp`` — home-team win probability (possession-team frame flip).
+        * ``away_wp`` — away-team win probability (``1 - home_wp``).
+        * ``wpa`` — win probability added (float64; null on kneel/terminal rows).
+        * ``vegas_wpa`` — spread-adjusted WPA.
+        * ``cp`` — completion probability for intended pass plays (null
+          otherwise; float64).
+        * ``cpoe`` — completion probability over expected, percentage-point
+          scale (null when ``complete_pass`` absent; float64).
+        * ``xyac_mean_yardage``, ``xyac_median_yardage``, ``xyac_sd_yardage``,
+          ``xyac_prob_complete`` — expected yards after catch sub-models (null
+          on non-pass plays; omitted with a ``RuntimeWarning`` if the xYAC
+          model files are absent).
 
     Raises:
         ValueError: when ``method`` is unrecognised, or required contract
@@ -2021,9 +2073,17 @@ def enrich_nfl_pbp(
             enriched = enrich_nfl_pbp(pbp)
             print(enriched.select("ep", "epa", "wp", "wpa").head())
 
-        Pandas next step (one line)::
+        Pandas output::
 
-            enrich_nfl_pbp(pbp, return_as_pandas=True).head()
+            from sportsdataverse.nfl import load_nfl_pbp
+            from sportsdataverse.nfl.ep_wp import enrich_nfl_pbp
+
+            enriched_pd = enrich_nfl_pbp(load_nfl_pbp([2023]), return_as_pandas=True)
+            print(enriched_pd[["ep", "epa", "wp", "wpa"]].head())
+
+        Pipeline next step::
+
+            enriched.filter(pl.col("play_type") == "pass").select("posteam", "epa", "cp", "cpoe").head()
 
         See Also:
             * `nflfastR`_ -- the R package whose ``helper_add_ep_wp.R`` this

--- a/sportsdataverse/nfl/nfl_build.py
+++ b/sportsdataverse/nfl/nfl_build.py
@@ -178,7 +178,9 @@ def build_nfl_season(
 
         Pandas output::
 
+            from sportsdataverse.nfl import build_nfl_season
             df_pd = build_nfl_season(game_ids=[401671801], return_as_pandas=True)
+            print(df_pd.shape)
 
         See Also:
             * `nflverse`_ -- full NFL data ecosystem

--- a/sportsdataverse/nfl/nfl_build.py
+++ b/sportsdataverse/nfl/nfl_build.py
@@ -1,0 +1,253 @@
+"""Season-compile helper for ESPN NFL play-by-play.
+
+Provides :func:`build_nfl_season` which processes a list of game IDs through
+``NFLPlayProcess`` and concatenates the resulting plays frames into a single
+polars ``DataFrame``. A per-game parquet cache (keyed by game id +
+``PIPELINE_VERSION``) avoids re-processing on repeated calls.
+
+Cache behavior mirrors the existing :mod:`sportsdataverse.nfl.cache` layer:
+
+- ``memory`` — per-process dict; survives within a Python session until
+  :func:`sportsdataverse.nfl.clear_cache` is called or the process exits.
+- ``filesystem`` — parquet file under ``NflConfig.cache_dir``.
+- ``off`` — no cache; every game is always re-processed.
+
+Bump ``PIPELINE_VERSION`` whenever the processing pipeline changes in a way
+that would produce different output columns or values, so stale cached frames
+are automatically invalidated.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+import warnings
+from pathlib import Path
+from typing import Union
+
+import polars as pl
+
+from sportsdataverse.nfl.cache import _MEMORY, _is_expired, get_config
+
+# ---------------------------------------------------------------------------
+# Pipeline version — bump to invalidate all per-game caches.
+# ---------------------------------------------------------------------------
+PIPELINE_VERSION: int = 1
+
+logger = logging.getLogger("sdv.nfl_build")
+logger.addHandler(logging.NullHandler())
+
+# ---------------------------------------------------------------------------
+# Internal per-game cache helpers (separate key namespace from cached_loader)
+# ---------------------------------------------------------------------------
+
+
+def _game_cache_key(game_id: int, pipeline_version: int) -> str:
+    """Stable sha256 key for a single processed game frame."""
+    payload = {"game_id": game_id, "pipeline_version": pipeline_version}
+    return "nfl_build__" + hashlib.sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest()
+
+
+def _game_cache_path(key: str) -> Path:
+    """Resolve the on-disk parquet path for a given per-game cache key."""
+    cache_dir = get_config().cache_dir
+    return cache_dir / f"{key}.parquet"
+
+
+def _game_cache_read(key: str) -> pl.DataFrame | None:
+    """Return cached frame for *key* or ``None`` on miss/expiry."""
+    cfg = get_config()
+    if cfg.cache_mode == "memory":
+        entry = _MEMORY.get(key)
+        if entry is not None:
+            ts, frame = entry
+            if not _is_expired(ts):
+                return frame
+            del _MEMORY[key]
+    elif cfg.cache_mode == "filesystem":
+        path = _game_cache_path(key)
+        if path.exists() and not _is_expired(path.stat().st_mtime):
+            try:
+                return pl.read_parquet(path)
+            except Exception:
+                path.unlink(missing_ok=True)
+    return None
+
+
+def _game_cache_write(key: str, frame: pl.DataFrame) -> None:
+    """Persist *frame* to the active cache backend."""
+    cfg = get_config()
+    if cfg.cache_mode == "memory":
+        _MEMORY[key] = (time.time(), frame)
+    elif cfg.cache_mode == "filesystem":
+        cache_dir = get_config().cache_dir
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        path = _game_cache_path(key)
+        try:
+            frame.write_parquet(path)
+        except Exception:
+            pass  # Cache write failure is non-fatal; data still returned.
+
+
+# ---------------------------------------------------------------------------
+# Per-game builder (ESPN source)
+# ---------------------------------------------------------------------------
+
+
+def _build_game_espn(game_id: int) -> pl.DataFrame:
+    """Process one ESPN game and return its plays as a polars ``DataFrame``."""
+    # Import lazily to keep module-level imports light and to allow tests to
+    # monkeypatch the function before the first call.
+    from sportsdataverse.nfl.nfl_pbp import NFLPlayProcess  # noqa: PLC0415
+
+    proc = NFLPlayProcess(gameId=game_id)
+    proc.espn_nfl_pbp()
+    result: dict = proc.run_processing_pipeline()
+    plays = result.get("plays", [])
+    return pl.DataFrame(plays, infer_schema_length=None)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def build_nfl_season(
+    game_ids: list[int],
+    *,
+    source: str = "espn",
+    return_as_pandas: bool = False,
+) -> Union[pl.DataFrame, object]:
+    """Compile play-by-play for multiple NFL games into one tidy frame.
+
+    For each *game_id* the function either loads a previously cached plays
+    frame or processes the game fresh via ``NFLPlayProcess``.  Individual
+    game failures are logged and skipped so a single bad game does not abort
+    the whole season build.  The per-game frames are concatenated with
+    ``how="diagonal_relaxed"`` (schema union, missing columns filled with
+    ``null``) so games with slightly different column sets merge cleanly.
+
+    Args:
+        game_ids: ESPN event IDs to compile (e.g. ``[401671801, 401671802]``).
+        source: Data source.
+
+            - ``"espn"`` *(default)*: each game is processed via
+              ``NFLPlayProcess(gameId=gid).espn_nfl_pbp()`` +
+              ``run_processing_pipeline()``.
+            - ``"nflverse"``: delegates to :func:`sportsdataverse.nfl.load_nfl_pbp`
+              for the seasons implied by *game_ids*.  **Note:** the nflverse
+              loader is season-oriented (not game-id-oriented); use it when
+              you want a full pre-enriched season frame rather than ESPN-
+              processed individual games.
+            - ``"shield"``: raises :class:`NotImplementedError` — Shield
+              (api.nfl.com) play-by-play lives in the native-pipeline
+              (`nfl-data`) repository, not sdv-py.
+
+        return_as_pandas: If ``True``, return a ``pandas.DataFrame`` instead
+            of polars.
+
+    Returns:
+        polars.DataFrame: All plays from the requested games, concatenated
+        with schema-union semantics (missing columns are ``null``).  Returns
+        a zero-row frame if every game failed.  When *return_as_pandas* is
+        ``True``, returns a ``pandas.DataFrame`` instead.
+
+    Raises:
+        ValueError: If *source* is not one of ``"espn"``, ``"nflverse"``,
+            ``"shield"``.
+        NotImplementedError: If ``source="shield"``.
+
+    Example:
+        Basic ESPN season compile::
+
+            from sportsdataverse.nfl import build_nfl_season
+            df = build_nfl_season([401671801, 401671802])
+            print(df.shape)
+
+        With filesystem cache enabled::
+
+            from sportsdataverse.nfl import build_nfl_season, update_config
+            update_config(cache_mode="filesystem")
+            df = build_nfl_season([401671801, 401671802])  # processes + caches
+            df2 = build_nfl_season([401671801, 401671802]) # served from cache
+
+        Pandas output::
+
+            df_pd = build_nfl_season([401671801], return_as_pandas=True)
+
+        See Also:
+            * `nflverse`_ -- full NFL data ecosystem
+            * `nflfastR`_ -- R sister package for NFL PBP
+
+        .. _nflverse: https://nflverse.nflverse.com
+        .. _nflfastR: https://www.nflfastr.com
+    """
+    _VALID_SOURCES = {"espn", "nflverse", "shield"}
+
+    if source not in _VALID_SOURCES:
+        raise ValueError(f"Unknown source {source!r}. Expected one of: {sorted(_VALID_SOURCES)!r}")
+
+    if source == "shield":
+        raise NotImplementedError(
+            "source='shield' is not supported in sdv-py. "
+            "Shield (api.nfl.com) play-by-play lives in the native-pipeline "
+            "(nfl-data) repository."
+        )
+
+    if source == "nflverse":
+        from sportsdataverse.nfl.nfl_loaders import load_nfl_pbp  # noqa: PLC0415
+
+        # nflverse loader is season-oriented; derive unique seasons from ids.
+        # game_ids here are treated as season years for nflverse parity
+        # (the caller should pass seasons, not ESPN game IDs, for this source).
+        warnings.warn(
+            "source='nflverse' treats game_ids as season years "
+            "(e.g. [2024]) rather than ESPN event IDs.  "
+            "Use source='espn' for per-game processing.",
+            UserWarning,
+            stacklevel=2,
+        )
+        frame = load_nfl_pbp(seasons=game_ids, return_as_pandas=False)
+        assert isinstance(frame, pl.DataFrame)
+        if return_as_pandas:
+            return frame.to_pandas()
+        return frame
+
+    # ---- source == "espn" ------------------------------------------------
+    frames: list[pl.DataFrame] = []
+    skipped: list[int] = []
+
+    for gid in game_ids:
+        key = _game_cache_key(gid, PIPELINE_VERSION)
+        cached = _game_cache_read(key)
+        if cached is not None:
+            frames.append(cached)
+            continue
+
+        try:
+            frame = _build_game_espn(gid)
+        except Exception as exc:
+            warnings.warn(
+                f"build_nfl_season: skipping game_id={gid} after error: {exc}",
+                UserWarning,
+                stacklevel=2,
+            )
+            skipped.append(gid)
+            continue
+
+        _game_cache_write(key, frame)
+        frames.append(frame)
+
+    if skipped:
+        logger.warning("build_nfl_season: skipped %d game(s): %s", len(skipped), skipped)
+
+    if not frames:
+        return pl.DataFrame()
+
+    result = pl.concat(frames, how="diagonal_relaxed")
+
+    if return_as_pandas:
+        return result.to_pandas()
+    return result

--- a/sportsdataverse/nfl/nfl_build.py
+++ b/sportsdataverse/nfl/nfl_build.py
@@ -86,80 +86,99 @@ def _build_game_espn(game_id: int) -> pl.DataFrame:
 
 @overload
 def build_nfl_season(
-    game_ids: list[int],
+    game_ids: list[int] | None = ...,
     *,
+    seasons: list[int] | None = ...,
     source: str = ...,
     return_as_pandas: Literal[False] = ...,
 ) -> pl.DataFrame: ...
 @overload
 def build_nfl_season(
-    game_ids: list[int],
+    game_ids: list[int] | None = ...,
     *,
+    seasons: list[int] | None = ...,
     source: str = ...,
     return_as_pandas: Literal[True],
 ) -> "pd.DataFrame": ...
 def build_nfl_season(
-    game_ids: list[int],
+    game_ids: list[int] | None = None,
     *,
+    seasons: list[int] | None = None,
     source: str = "espn",
     return_as_pandas: bool = False,
 ) -> "pl.DataFrame | pd.DataFrame":
     """Compile play-by-play for multiple NFL games into one tidy frame.
 
-    For each *game_id* the function either loads a previously cached plays
-    frame or processes the game fresh via ``NFLPlayProcess``.  Individual
-    game failures are logged and skipped so a single bad game does not abort
-    the whole season build.  The per-game frames are concatenated with
-    ``how="diagonal_relaxed"`` (schema union, missing columns filled with
-    ``null``) so games with slightly different column sets merge cleanly.
+    The ``source`` parameter determines which input parameter is required:
+
+    - ``source="espn"`` — requires *game_ids*; *seasons* must be ``None``.
+    - ``source="nflverse"`` — requires *seasons*; *game_ids* must be ``None``.
+
+    For ESPN games the function either loads a previously cached plays frame or
+    processes the game fresh via ``NFLPlayProcess``.  Individual game failures
+    are logged and skipped so a single bad game does not abort the whole season
+    build.  The per-game frames are concatenated with ``how="diagonal_relaxed"``
+    (schema union, missing columns filled with ``null``) so games with slightly
+    different column sets merge cleanly.
 
     Args:
         game_ids: ESPN event IDs to compile (e.g. ``[401671801, 401671802]``).
+            Required when ``source="espn"``; must be ``None`` for other sources.
+        seasons: Season years to compile (e.g. ``[2023, 2024]``).
+            Required when ``source="nflverse"``; must be ``None`` for other sources.
         source: Data source.
 
             - ``"espn"`` *(default)*: each game is processed via
               ``NFLPlayProcess(gameId=gid).espn_nfl_pbp()`` +
-              ``run_processing_pipeline()``.
+              ``run_processing_pipeline()``.  Pass *game_ids*.
             - ``"nflverse"``: delegates to :func:`sportsdataverse.nfl.load_nfl_pbp`
-              for the seasons implied by *game_ids*.  **Note:** the nflverse
-              loader is season-oriented (not game-id-oriented); use it when
-              you want a full pre-enriched season frame rather than ESPN-
-              processed individual games.
+              for the requested seasons.  Pass *seasons*.  Returns the full
+              pre-enriched season frame as-is.
             - ``"shield"``: raises :class:`NotImplementedError` — Shield
               (api.nfl.com) play-by-play lives in the native-pipeline
-              (`nfl-data`) repository, not sdv-py.
+              (``nfl-data``) repository, not sdv-py.
 
         return_as_pandas: If ``True``, return a ``pandas.DataFrame`` instead
             of polars.
 
     Returns:
-        polars.DataFrame: All plays from the requested games, concatenated
-        with schema-union semantics (missing columns are ``null``).  Returns
-        a zero-row frame if every game failed.  When *return_as_pandas* is
-        ``True``, returns a ``pandas.DataFrame`` instead.
+        polars.DataFrame: All plays from the requested games/seasons,
+        concatenated with schema-union semantics (missing columns are ``null``).
+        Returns a zero-row frame if every game failed (ESPN source only).
+        When *return_as_pandas* is ``True``, returns a ``pandas.DataFrame``
+        instead.
 
     Raises:
         ValueError: If *source* is not one of ``"espn"``, ``"nflverse"``,
-            ``"shield"``.
+            ``"shield"``; or if the wrong input parameter is supplied for the
+            chosen source (e.g. passing *seasons* to ``source="espn"`` or
+            *game_ids* to ``source="nflverse"``); or if the required parameter
+            is missing or empty.
         NotImplementedError: If ``source="shield"``.
 
     Example:
-        Basic ESPN season compile::
+        ESPN season compile (pass ESPN event IDs)::
 
             from sportsdataverse.nfl import build_nfl_season
-            df = build_nfl_season([401671801, 401671802])
+            df = build_nfl_season(game_ids=[401671801, 401671802])
             print(df.shape)
 
-        With filesystem cache enabled::
+        nflverse season compile (pass season years)::
+
+            from sportsdataverse.nfl import build_nfl_season
+            df = build_nfl_season(seasons=[2023], source="nflverse")
+            print(df.shape)
+
+        With filesystem cache enabled (ESPN)::
 
             from sportsdataverse.nfl import build_nfl_season, update_config
             update_config(cache_mode="filesystem")
-            df = build_nfl_season([401671801, 401671802])  # processes + caches
-            df2 = build_nfl_season([401671801, 401671802]) # served from cache
+            df = build_nfl_season(game_ids=[401671801, 401671802])  # processes + caches
+            df2 = build_nfl_season(game_ids=[401671801, 401671802]) # served from cache
 
         Pandas output::
 
-            df_pd = build_nfl_season([401671801], return_as_pandas=True)
+            df_pd = build_nfl_season(game_ids=[401671801], return_as_pandas=True)
 
         See Also:
             * `nflverse`_ -- full NFL data ecosystem
@@ -181,24 +200,27 @@ def build_nfl_season(
         )
 
     if source == "nflverse":
+        if game_ids is not None:
+            raise ValueError("source='nflverse' takes seasons, not game_ids. Pass seasons=[year, ...] instead.")
+        if not seasons:
+            raise ValueError(
+                "source='nflverse' requires seasons to be a non-empty list of season years (e.g. seasons=[2023])."
+            )
         from sportsdataverse.nfl.nfl_loaders import load_nfl_pbp  # noqa: PLC0415
 
-        # nflverse loader is season-oriented; derive unique seasons from ids.
-        # game_ids here are treated as season years for nflverse parity
-        # (the caller should pass seasons, not ESPN game IDs, for this source).
-        warnings.warn(
-            "source='nflverse' treats game_ids as season years "
-            "(e.g. [2024]) rather than ESPN event IDs.  "
-            "Use source='espn' for per-game processing.",
-            UserWarning,
-            stacklevel=2,
-        )
-        frame = load_nfl_pbp(seasons=game_ids, return_as_pandas=False)
+        frame = load_nfl_pbp(seasons=seasons, return_as_pandas=False)
         if return_as_pandas:
             return frame.to_pandas()
         return frame
 
     # ---- source == "espn" ------------------------------------------------
+    if seasons is not None:
+        raise ValueError("source='espn' takes game_ids, not seasons. Pass game_ids=[espn_event_id, ...] instead.")
+    if not game_ids:
+        raise ValueError(
+            "source='espn' requires game_ids to be a non-empty list of ESPN event IDs (e.g. game_ids=[401671801])."
+        )
+
     frames: list[pl.DataFrame] = []
     skipped: list[int] = []
 

--- a/sportsdataverse/nfl/nfl_build.py
+++ b/sportsdataverse/nfl/nfl_build.py
@@ -22,19 +22,20 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-import time
 import warnings
-from pathlib import Path
-from typing import Union
+from typing import TYPE_CHECKING, Literal, overload
 
 import polars as pl
 
-from sportsdataverse.nfl.cache import _MEMORY, _is_expired, get_config
+from sportsdataverse.nfl.cache import cache_get, cache_put
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 # ---------------------------------------------------------------------------
 # Pipeline version — bump to invalidate all per-game caches.
 # ---------------------------------------------------------------------------
-PIPELINE_VERSION: int = 1
+PIPELINE_VERSION: int = 1  # 1 -> initial release
 
 logger = logging.getLogger("sdv.nfl_build")
 logger.addHandler(logging.NullHandler())
@@ -50,45 +51,14 @@ def _game_cache_key(game_id: int, pipeline_version: int) -> str:
     return "nfl_build__" + hashlib.sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest()
 
 
-def _game_cache_path(key: str) -> Path:
-    """Resolve the on-disk parquet path for a given per-game cache key."""
-    cache_dir = get_config().cache_dir
-    return cache_dir / f"{key}.parquet"
-
-
 def _game_cache_read(key: str) -> pl.DataFrame | None:
     """Return cached frame for *key* or ``None`` on miss/expiry."""
-    cfg = get_config()
-    if cfg.cache_mode == "memory":
-        entry = _MEMORY.get(key)
-        if entry is not None:
-            ts, frame = entry
-            if not _is_expired(ts):
-                return frame
-            del _MEMORY[key]
-    elif cfg.cache_mode == "filesystem":
-        path = _game_cache_path(key)
-        if path.exists() and not _is_expired(path.stat().st_mtime):
-            try:
-                return pl.read_parquet(path)
-            except Exception:
-                path.unlink(missing_ok=True)
-    return None
+    return cache_get(key)
 
 
 def _game_cache_write(key: str, frame: pl.DataFrame) -> None:
     """Persist *frame* to the active cache backend."""
-    cfg = get_config()
-    if cfg.cache_mode == "memory":
-        _MEMORY[key] = (time.time(), frame)
-    elif cfg.cache_mode == "filesystem":
-        cache_dir = get_config().cache_dir
-        cache_dir.mkdir(parents=True, exist_ok=True)
-        path = _game_cache_path(key)
-        try:
-            frame.write_parquet(path)
-        except Exception:
-            pass  # Cache write failure is non-fatal; data still returned.
+    cache_put(key, frame)
 
 
 # ---------------------------------------------------------------------------
@@ -114,12 +84,26 @@ def _build_game_espn(game_id: int) -> pl.DataFrame:
 # ---------------------------------------------------------------------------
 
 
+@overload
+def build_nfl_season(
+    game_ids: list[int],
+    *,
+    source: str = ...,
+    return_as_pandas: Literal[False] = ...,
+) -> pl.DataFrame: ...
+@overload
+def build_nfl_season(
+    game_ids: list[int],
+    *,
+    source: str = ...,
+    return_as_pandas: Literal[True],
+) -> "pd.DataFrame": ...
 def build_nfl_season(
     game_ids: list[int],
     *,
     source: str = "espn",
     return_as_pandas: bool = False,
-) -> Union[pl.DataFrame, object]:
+) -> "pl.DataFrame | pd.DataFrame":
     """Compile play-by-play for multiple NFL games into one tidy frame.
 
     For each *game_id* the function either loads a previously cached plays
@@ -210,7 +194,6 @@ def build_nfl_season(
             stacklevel=2,
         )
         frame = load_nfl_pbp(seasons=game_ids, return_as_pandas=False)
-        assert isinstance(frame, pl.DataFrame)
         if return_as_pandas:
             return frame.to_pandas()
         return frame

--- a/sportsdataverse/nfl/nfl_pbp.py
+++ b/sportsdataverse/nfl/nfl_pbp.py
@@ -3488,9 +3488,9 @@ class NFLPlayProcess(object):
         EP_end = np.clip(_probs_end @ _EP_POINT_VALUES, -10.0, 10.0)
 
         play_df = play_df.with_columns(
-            EP_start_touchback=pl.lit(EP_start_touchback),
-            EP_start=pl.lit(EP_start),
-            EP_end=pl.lit(EP_end),
+            pl.Series("EP_start_touchback", EP_start_touchback, dtype=pl.Float64),
+            pl.Series("EP_start", EP_start, dtype=pl.Float64),
+            pl.Series("EP_end", EP_end, dtype=pl.Float64),
         )
 
         # --- Derivation half delegated to the shared, model-free calculate_epa ---
@@ -3776,10 +3776,17 @@ class NFLPlayProcess(object):
         # on, leaving output identical. calculate_wpa also emits lowercase nflverse
         # aliases (wp / def_wp / home_wp / away_wp) the legacy __process_wpa output
         # never carried, so drop them to keep the plays schema byte-identical.
+        # NOTE: the XGBoost ``predict`` arrays are native float32 (unlike the EP
+        # arrays, which are float64 after the ``np.clip(probs @ point_values)``
+        # matmul). ``pl.Series`` is given the array's native float32 dtype here so
+        # the downstream ``calculate_wpa`` arithmetic runs at the exact same
+        # precision the prior ``pl.lit(<f32 array>)`` produced -- forcing Float64
+        # would widen the inputs and shift the WP cascade by ~1e-8. This is an
+        # explicitness change only, byte-identical to the prior ``pl.lit`` form.
         play_df = play_df.with_columns(
-            wp_before=pl.lit(WP_start),
-            wp_touchback=pl.lit(WP_start_touchback),
-            wp_after=pl.lit(WP_end),
+            pl.Series("wp_before", WP_start, dtype=pl.Float32),
+            pl.Series("wp_touchback", WP_start_touchback, dtype=pl.Float32),
+            pl.Series("wp_after", WP_end, dtype=pl.Float32),
         )
         play_df = calculate_wpa(play_df).drop("wp", "def_wp", "home_wp", "away_wp")
         return play_df
@@ -3991,7 +3998,10 @@ class NFLPlayProcess(object):
                 (
                     (pl.col("kickoff_play") == True)
                     & ((pl.col("kickoff_onside") == True) | (pl.col("kickoff_downed") == True))
-                    & (pl.col("fumble_recovered") == True)
+                    & (
+                        (pl.col("fumble_recovered") == True)
+                        | (pl.col("end.pos_team.id") == pl.col("start.def_pos_team.id"))
+                    )
                 )
                 .cast(pl.Int8)
                 .alias("_ff_own_kick_rec"),

--- a/sportsdataverse/nfl/nfl_pbp.py
+++ b/sportsdataverse/nfl/nfl_pbp.py
@@ -3916,6 +3916,350 @@ class NFLPlayProcess(object):
         )
         return play_df
 
+    def __add_fixed_drives_series(self, play_df: pl.DataFrame) -> pl.DataFrame:
+        """Add nflfastR-parity ``fixed_drive`` and ``series`` columns.
+
+        Reconstructs nflverse/nflfastR's drive- and series-numbering scheme on
+        top of the ESPN ``NFLPlayProcess`` frame so the ESPN-constructed output
+        reaches parity with ``load_nfl_pbp`` on these columns. Ported faithfully
+        from nflfastR ``R/helper_add_fixed_drives.R`` (``add_drive_results``)
+        and ``R/helper_add_series_data.R`` (``add_series_data``); dplyr/
+        ``data.table`` idioms are translated to polars 1.x.
+
+        Adds five columns -- ``fixed_drive`` (int, shared across both teams,
+        increments on a real possession change with nflfastR's PAT / onside /
+        safety special cases), ``fixed_drive_result`` (str), ``series`` (int,
+        increments on a new set of downs / first down / possession change),
+        ``series_success`` (int 0/1), and ``series_result`` (str). The method is
+        strictly additive -- every pre-existing column is left untouched and the
+        ``_ff_*`` working columns are dropped before returning.
+
+        nflfastR is keyed on its own column vocabulary; the ESPN frame uses
+        different names, so the inputs are mapped first: ``pos_team`` ->
+        posteam, ``def_pos_team`` -> defteam, ``half`` -> game_half,
+        ``start.distance`` -> ydstogo, ``statYardage`` -> yards_gained,
+        ``text`` -> desc. nflfastR signals absent from the ESPN frame
+        (``play_type``, ``td_team``, ``first_down_*``, ``own_kickoff_recovery``,
+        ``qb_kneel``, ``interception``) are derived from ESPN columns.
+
+        Args:
+            play_df (pl.DataFrame): The plays frame after ``__add_drive_data``,
+                where ``pos_team`` / ``def_pos_team`` / down / yardage / scoring
+                flags / ``end_of_half`` are all populated.
+
+        Returns:
+            pl.DataFrame: The same frame plus the five drive/series columns.
+        """
+        cols = play_df.columns
+        txt = pl.col("text") if "text" in cols else pl.col("desc")
+        type_txt = pl.col("type.text") if "type.text" in cols else pl.lit("")
+        eoh = pl.col("end_of_half").cast(pl.Boolean) if "end_of_half" in cols else pl.lit(False)
+
+        # ---- map nflfastR inputs from ESPN columns + derive missing signals ----
+        play_df = (
+            play_df.with_columns(
+                pl.col("pos_team").alias("_ff_posteam"),
+                pl.col("def_pos_team").alias("_ff_defteam"),
+                pl.col("half").alias("_ff_half"),
+                pl.col("down").alias("_ff_down"),
+                pl.col("start.distance").alias("_ff_ydstogo"),
+                pl.col("statYardage").alias("_ff_ygained"),
+                txt.alias("_ff_desc"),
+                pl.col("touchdown").cast(pl.Int8).alias("_ff_td"),
+                pl.col("safety").cast(pl.Int8).alias("_ff_safety"),
+                pl.col("fumble_lost").cast(pl.Int8).alias("_ff_fumlost"),
+                pl.col("field_goal_result").alias("_ff_fgr"),
+                pl.col("kickoff_play").cast(pl.Int8).alias("_ff_kick_att"),
+                (pl.col("punt") | pl.col("punt_play")).cast(pl.Int8).alias("_ff_punt_att"),
+                pl.col("fg_attempt").cast(pl.Int8).alias("_ff_fg"),
+            )
+            .with_columns(
+                # nflfastR play_type, collapsed from ESPN type.text / rush / pass flags
+                pl.when(pl.col("_ff_kick_att") == 1)
+                .then(pl.lit("kickoff"))
+                .when(pl.col("_ff_punt_att") == 1)
+                .then(pl.lit("punt"))
+                .when(pl.col("_ff_fg") == 1)
+                .then(pl.lit("field_goal"))
+                .when(pl.col("pass") == True)
+                .then(pl.lit("pass"))
+                .when(pl.col("rush") == True)
+                .then(pl.lit("run"))
+                .otherwise(pl.lit("no_play"))
+                .alias("_ff_play_type"),
+                # own_kickoff_recovery: kicking team retains a recovered kick
+                (
+                    (pl.col("kickoff_play") == True)
+                    & ((pl.col("kickoff_onside") == True) | (pl.col("kickoff_downed") == True))
+                    & (pl.col("fumble_recovered") == True)
+                )
+                .cast(pl.Int8)
+                .alias("_ff_own_kick_rec"),
+            )
+            .with_columns(
+                # td_team: defense on return / interception TDs, else offense
+                pl.when(pl.col("_ff_td") == 0)
+                .then(None)
+                .when(type_txt.str.contains(r"(?i)return touchdown") | pl.col("int_td"))
+                .then(pl.col("def_pos_team"))
+                .when(
+                    txt.str.contains(r"(?i)intercept(ed)?.*touchdown|fumble.*return.*touchdown|return(ed)?.*touchdown")
+                )
+                .then(pl.col("def_pos_team"))
+                .otherwise(pl.col("pos_team"))
+                .alias("_ff_tdteam"),
+                (pl.col("int_td") | txt.str.contains(r"(?i)intercept")).cast(pl.Int8).alias("_ff_int"),
+                (txt.str.contains(r"(?i)kneel") & (pl.col("rush") == True)).cast(pl.Int8).alias("_ff_qbkneel"),
+                # ESPN omits nflfastR's "END QUARTER 2/4 / END GAME" desc markers; the
+                # end_of_half boolean is the 1:1 ESPN analog for "End of half".
+                (eoh | txt.str.contains(r"(END QUARTER 2)|(END QUARTER 4)|(END GAME)")).cast(pl.Int8).alias("_ff_eoh"),
+            )
+        )
+
+        # per-play first down: non-scoring scrimmage play that advanced the chain
+        # (same possession, end down resets to 1, yards gained >= distance) or a
+        # penalty that converted a first down. This strips the post-touchdown /
+        # dead-ball end.down==1 bookkeeping artifacts the raw flags carry.
+        fd_gain = (
+            (pl.col("scrimmage_play") == True)
+            & (pl.col("end.down") == 1)
+            & (pl.col("start.pos_team.id") == pl.col("end.pos_team.id"))
+            & (pl.col("touchdown") == False)
+            & (pl.col("statYardage") >= pl.col("start.distance"))
+        )
+        fd_pen = (
+            (pl.col("penalty_1st_conv") == True)
+            & (pl.col("touchdown") == False)
+            & (pl.col("start.pos_team.id") == pl.col("end.pos_team.id"))
+            if "penalty_1st_conv" in cols
+            else pl.lit(False)
+        )
+        play_df = play_df.with_columns(
+            (fd_gain & (pl.col("rush") == True)).cast(pl.Int8).alias("_ff_fd_rush"),
+            (fd_gain & (pl.col("pass") == True)).cast(pl.Int8).alias("_ff_fd_pass"),
+            (fd_pen | (fd_gain & (pl.col("pass") == False) & (pl.col("rush") == False)))
+            .cast(pl.Int8)
+            .alias("_ff_fd_pen"),
+        )
+
+        # ===================== fixed_drive (add_drive_results) =====================
+        # posteam swap: on a recovered kickoff the kicking team (defteam) owns the
+        # drive (helper_add_fixed_drives.R L15-27).
+        play_df = play_df.with_columns(
+            pl.when(
+                (pl.col("_ff_kick_att") == 1) & ((pl.col("_ff_own_kick_rec") == 1) | (pl.col("_ff_fumlost") == 1)),
+            )
+            .then(pl.col("_ff_defteam"))
+            .otherwise(pl.col("_ff_posteam"))
+            .alias("_ff_pt"),
+        ).with_columns(
+            pl.int_range(pl.len()).over(["game_id", "_ff_half"]).alias("_ff_row"),
+        )
+        lag_pt = pl.col("_ff_pt").shift(1).over(["game_id", "_ff_half"])
+        lag_pt2 = pl.col("_ff_pt").shift(2).over(["game_id", "_ff_half"])
+        lag_pt3 = pl.col("_ff_pt").shift(3).over(["game_id", "_ff_half"])
+        lag_td = pl.col("_ff_td").shift(1).over(["game_id", "_ff_half"])
+        lag_td2 = pl.col("_ff_td").shift(2).over(["game_id", "_ff_half"])
+        lag_tdteam = pl.col("_ff_tdteam").shift(1).over(["game_id", "_ff_half"])
+        lag_fum = pl.col("_ff_fumlost").shift(1).over(["game_id", "_ff_half"])
+        lag_fum2 = pl.col("_ff_fumlost").shift(2).over(["game_id", "_ff_half"])
+        lag_ptype = pl.col("_ff_play_type").shift(1).over(["game_id", "_ff_half"])
+        lag_ptype2 = pl.col("_ff_play_type").shift(2).over(["game_id", "_ff_half"])
+        lag_safety = pl.col("_ff_safety").shift(1).over(["game_id", "_ff_half"])
+        lag_safety2 = pl.col("_ff_safety").shift(2).over(["game_id", "_ff_half"])
+
+        play_df = (
+            play_df.with_columns(
+                # change in posteam, incl. the t-2 / t-3 NA-posteam variants (L32-44)
+                pl.when(
+                    (pl.col("_ff_pt") != lag_pt)
+                    | ((pl.col("_ff_pt") != lag_pt2) & lag_pt.is_null())
+                    | ((pl.col("_ff_pt") != lag_pt3) & lag_pt2.is_null() & lag_pt.is_null()),
+                )
+                .then(1)
+                .otherwise(0)
+                .alias("_ff_nd"),
+            )
+            .with_columns(
+                # PAT after a defensive TD is not a new drive (L45-54)
+                pl.when((lag_td == 1) & (lag_pt != lag_tdteam) & lag_pt.is_not_null())
+                .then(0)
+                .otherwise(pl.col("_ff_nd"))
+                .alias("_ff_nd"),
+            )
+            .with_columns(
+                # same team retains after a lost fumble on a punt/fg/pass/run that did
+                # not score: it's a new drive (L83-113).
+                pl.when(
+                    (pl.col("_ff_nd") != 1)
+                    & (
+                        (
+                            (pl.col("_ff_pt") == lag_pt)
+                            & (lag_fum == 1)
+                            & lag_ptype.is_in(["punt", "pass", "run", "field_goal"])
+                            & (lag_td == 0)
+                        )
+                        | (
+                            lag_pt.is_null()
+                            & (pl.col("_ff_pt") == lag_pt2)
+                            & (lag_fum2 == 1)
+                            & lag_ptype2.is_in(["punt", "pass", "run", "field_goal"])
+                            & (lag_td2 == 0)
+                        )
+                    ),
+                )
+                .then(1)
+                .otherwise(pl.col("_ff_nd"))
+                .alias("_ff_nd"),
+            )
+            .with_columns(
+                # first observation of a half is a new drive (L114-115)
+                pl.when(pl.col("_ff_row") == 0).then(1).otherwise(pl.col("_ff_nd")).alias("_ff_nd"),
+            )
+            .with_columns(
+                # recovered onside / muffed kick is a new drive (L117-122)
+                pl.when(
+                    (pl.col("_ff_play_type") == "kickoff")
+                    & ((pl.col("_ff_own_kick_rec") == 1) | (pl.col("_ff_fumlost") == 1)),
+                )
+                .then(1)
+                .otherwise(pl.col("_ff_nd"))
+                .alias("_ff_nd"),
+            )
+            .with_columns(
+                # kickoff after a safety is a new drive (L124-134)
+                pl.when(
+                    ((pl.col("_ff_kick_att") == 1) & (lag_safety == 1))
+                    | (
+                        (pl.col("_ff_kick_att") == 1)
+                        & (lag_safety2 == 1)
+                        & (lag_ptype.is_null() | (lag_ptype == "no_play"))
+                    ),
+                )
+                .then(1)
+                .otherwise(pl.col("_ff_nd"))
+                .alias("_ff_nd"),
+            )
+            .with_columns(
+                pl.col("_ff_nd").fill_null(0).alias("_ff_nd"),
+            )
+            .with_columns(
+                fixed_drive=pl.col("_ff_nd").cum_sum().over("game_id"),
+            )
+        )
+
+        play_df = play_df.with_columns(
+            # per-play candidate drive result (L142-158)
+            pl.when((pl.col("_ff_td") == 1) & (pl.col("_ff_pt") == pl.col("_ff_tdteam")))
+            .then(pl.lit("Touchdown"))
+            .when((pl.col("_ff_td") == 1) & (pl.col("_ff_pt") != pl.col("_ff_tdteam")))
+            .then(pl.lit("Opp touchdown"))
+            .when(pl.col("_ff_fgr") == "made")
+            .then(pl.lit("Field goal"))
+            .when(pl.col("_ff_fgr").is_in(["blocked", "missed"]))
+            .then(pl.lit("Missed field goal"))
+            .when(pl.col("_ff_safety") == 1)
+            .then(pl.lit("Safety"))
+            .when((pl.col("_ff_play_type") == "punt") | (pl.col("_ff_punt_att") == 1))
+            .then(pl.lit("Punt"))
+            .when((pl.col("_ff_int") == 1) | (pl.col("_ff_fumlost") == 1))
+            .then(pl.lit("Turnover"))
+            .when(
+                (pl.col("_ff_down") == 4)
+                & (pl.col("_ff_ygained") < pl.col("_ff_ydstogo"))
+                & (pl.col("_ff_play_type") != "no_play"),
+            )
+            .then(pl.lit("Turnover on downs"))
+            .when(pl.col("_ff_eoh") == 1)
+            .then(pl.lit("End of half"))
+            .otherwise(None)
+            .alias("_ff_tmp"),
+        )
+        last_tmp = pl.col("_ff_tmp").drop_nulls().last().over(["game_id", "fixed_drive"])
+        first_tmp = pl.col("_ff_tmp").drop_nulls().first().over(["game_id", "fixed_drive"])
+        play_df = play_df.with_columns(
+            # end-of-half drives take the first result seen, else the last (L162-168)
+            fixed_drive_result=pl.when(last_tmp == "End of half").then(first_tmp).otherwise(last_tmp),
+        )
+
+        # ======================= series (add_series_data) ========================
+        play_df = play_df.with_columns(
+            pl.int_range(pl.len()).over(["game_id", "_ff_half"]).alias("_ff_srow"),
+        )
+        lag_fd = pl.col("fixed_drive").shift(1).over(["game_id", "_ff_half"])
+        lag_fdr = pl.col("_ff_fd_rush").shift(1).over(["game_id", "_ff_half"])
+        lag_fdp = pl.col("_ff_fd_pass").shift(1).over(["game_id", "_ff_half"])
+        lag_fdn = pl.col("_ff_fd_pen").shift(1).over(["game_id", "_ff_half"])
+        lag_td_s = pl.col("_ff_td").shift(1).over(["game_id", "_ff_half"])
+        play_df = (
+            play_df.with_columns(
+                # new series: a new drive, a non-TD first down on the prior play, or the
+                # first play of the half (L35-47)
+                pl.when(
+                    (pl.col("fixed_drive") != lag_fd)
+                    | (((lag_fdr == 1) | (lag_fdp == 1) | (lag_fdn == 1)) & (lag_td_s == 0))
+                    | (pl.col("_ff_srow") == 0),
+                )
+                .then(1)
+                .otherwise(0)
+                .alias("_ff_ns"),
+            )
+            .with_columns(
+                pl.col("_ff_ns").fill_null(0).alias("_ff_ns"),
+            )
+            .with_columns(
+                series=pl.col("_ff_ns").cum_sum().over("game_id"),
+            )
+        )
+        play_df = play_df.with_columns(
+            # per-play candidate series result (L54-75): note "First down" and
+            # "QB kneel" precede the scoring branches, unlike the drive result.
+            pl.when(
+                ((pl.col("_ff_fd_pen") == 1) | (pl.col("_ff_fd_rush") == 1) | (pl.col("_ff_fd_pass") == 1))
+                & (pl.col("_ff_td") == 0),
+            )
+            .then(pl.lit("First down"))
+            .when((pl.col("_ff_td") == 1) & (pl.col("_ff_pt") == pl.col("_ff_tdteam")))
+            .then(pl.lit("Touchdown"))
+            .when((pl.col("_ff_td") == 1) & (pl.col("_ff_pt") != pl.col("_ff_tdteam")))
+            .then(pl.lit("Opp touchdown"))
+            .when(pl.col("_ff_fgr") == "made")
+            .then(pl.lit("Field goal"))
+            .when(pl.col("_ff_fgr").is_in(["blocked", "missed"]))
+            .then(pl.lit("Missed field goal"))
+            .when(pl.col("_ff_safety") == 1)
+            .then(pl.lit("Safety"))
+            .when((pl.col("_ff_play_type") == "punt") | (pl.col("_ff_punt_att") == 1))
+            .then(pl.lit("Punt"))
+            .when((pl.col("_ff_int") == 1) | (pl.col("_ff_fumlost") == 1))
+            .then(pl.lit("Turnover"))
+            .when(
+                (pl.col("_ff_down") == 4)
+                & (pl.col("_ff_ygained") < pl.col("_ff_ydstogo"))
+                & (pl.col("_ff_play_type") != "no_play"),
+            )
+            .then(pl.lit("Turnover on downs"))
+            .when(pl.col("_ff_qbkneel") == 1)
+            .then(pl.lit("QB kneel"))
+            .when(pl.col("_ff_eoh") == 1)
+            .then(pl.lit("End of half"))
+            .otherwise(None)
+            .alias("_ff_stmp"),
+        )
+        last_stmp = pl.col("_ff_stmp").drop_nulls().last().over(["game_id", "series"])
+        first_stmp = pl.col("_ff_stmp").drop_nulls().first().over(["game_id", "series"])
+        play_df = play_df.with_columns(
+            series_result=pl.when(last_stmp == "End of half").then(first_stmp).otherwise(last_stmp),
+        ).with_columns(
+            # series_success: 1 if the series ended in a TD or first down (L86-90)
+            series_success=pl.when(pl.col("series_result").is_in(["Touchdown", "First down"])).then(1).otherwise(0),
+        )
+
+        # drop all working columns -- strictly additive output
+        drop_cols = [c for c in play_df.columns if c.startswith("_ff_")]
+        play_df = play_df.drop(drop_cols)
+        return play_df
+
     def __cast_box_score_column(self, play_df, column, target_type):
         if column in play_df.columns:
             play_df = play_df.with_columns(pl.col(column).cast(target_type).alias(column))
@@ -4781,6 +5125,7 @@ class NFLPlayProcess(object):
                     .pipe(self.__process_cp)
                     .pipe(self.__process_xyac)
                     .pipe(self.__add_drive_data)
+                    .pipe(self.__add_fixed_drives_series)
                     .pipe(self.__process_qbr)
                 )
                 self.ran_pipeline = True

--- a/sportsdataverse/nfl/nfl_pbp.py
+++ b/sportsdataverse/nfl/nfl_pbp.py
@@ -37,6 +37,8 @@ from sportsdataverse.nfl.ep_wp import (
     _espn_wp_features,
     _espn_xyac_features,
     _load_model as _ep_wp_load_model,
+    calculate_epa,
+    calculate_wpa,
 )
 from sportsdataverse.nfl.model_vars import (
     defense_score_vec,
@@ -3491,307 +3493,118 @@ class NFLPlayProcess(object):
             EP_end=pl.lit(EP_end),
         )
 
-        play_df = (
-            play_df.with_columns(
-                EP_start=pl.when(
-                    pl.col("type.text").is_in(
-                        [
-                            "Extra Point Good",
-                            "Extra Point Missed",
-                            "Two-Point Conversion Good",
-                            "Two-Point Conversion Missed",
-                            "Two Point Pass",
-                            "Two Point Rush",
-                            "Blocked PAT",
-                        ],
-                    ),
-                )
-                .then(0.92)
-                .otherwise(pl.col("EP_start")),
+        # --- Derivation half delegated to the shared, model-free calculate_epa ---
+        # The EP point estimates (EP_start / EP_end / EP_start_touchback) have been
+        # scored above; calculate_epa is the verbatim lift of the scoring-overlay /
+        # lead-lag / EP_between / kickoff-touchback / turnover-flip / EPA derivation
+        # that used to live inline here. NFLPlayProcess always operates on a single
+        # game, so calculate_epa's ``.over("game_id")`` window guards collapse to the
+        # plain ``.shift`` semantics this method relied on, leaving output identical.
+        # calculate_epa also emits lowercase nflverse aliases (ep / epa / ep_start /
+        # ep_end) the legacy __process_epa output never carried, so drop them to keep
+        # the plays schema byte-identical; the EPA_* summary flags below stay inline.
+        play_df = calculate_epa(play_df).drop("ep", "epa", "ep_start", "ep_end")
+
+        play_df = play_df.with_columns(
+            def_EPA=pl.col("EPA") * -1,
+            # --- EPA Summary flags ----
+            EPA_scrimmage=pl.when(pl.col("scrimmage_play") == True).then(pl.col("EPA")).otherwise(None),
+            EPA_rush=pl.when((pl.col("rush") == True).and_(pl.col("penalty_in_text") == True))
+            .then(pl.col("EPA"))
+            .when((pl.col("rush") == True).and_(pl.col("penalty_in_text") == False))
+            .then(pl.col("EPA"))
+            .otherwise(None),
+            EPA_pass=pl.when(pl.col("pass") == True).then(pl.col("EPA")).otherwise(None),
+            EPA_explosive=pl.when((pl.col("pass") == True).and_(pl.col("EPA") >= 2.4))
+            .then(True)
+            .when(((pl.col("rush") == True).and_(pl.col("EPA") >= 1.8)))
+            .then(True)
+            .otherwise(False),
+        ).with_columns(
+            EPA_non_explosive=pl.when(pl.col("EPA_explosive") == False).then(pl.col("EPA")).otherwise(None),
+            EPA_explosive_pass=pl.when((pl.col("pass") == True).and_(pl.col("EPA") >= 2.4)).then(True).otherwise(False),
+            EPA_explosive_rush=pl.when((pl.col("rush") == True).and_(pl.col("EPA") >= 1.8)).then(True).otherwise(False),
+            first_down_created=pl.when(
+                (pl.col("scrimmage_play") == True)
+                .and_(pl.col("end.down") == 1)
+                .and_(pl.col("start.pos_team.id") == pl.col("end.pos_team.id")),
             )
-            .with_columns(
-                # End of Half
-                EP_end=pl.when(
-                    (pl.col("type.text").str.to_lowercase().str.contains(r"end of game")).or_(
-                        pl.col("type.text").str.to_lowercase().str.contains(r"end of half"),
-                    ),
-                )
-                .then(0)
-                # Defensive 2pt Conversion
-                .when(pl.col("type.text").is_in(["Defensive 2pt Conversion"]))
-                .then(-2)
-                # Safeties
-                .when(
-                    (pl.col("type.text").is_in(defense_score_vec)).and_(
-                        pl.col("text").str.to_lowercase().str.contains(r"(?i)safety"),
-                    ),
-                )
-                .then(-2)
-                # Defense TD + Successful Two-Point Conversion
-                .when(
-                    (pl.col("type.text").is_in(defense_score_vec))
-                    .and_(pl.col("text").str.to_lowercase().str.contains(r"(?i)conversion"))
-                    .and_(pl.col("text").str.to_lowercase().str.contains(r"(?i)failed") == False),
-                )
-                .then(-8)
-                # Defense TD + Failed Two-Point Conversion
-                .when(
-                    (pl.col("type.text").is_in(defense_score_vec))
-                    .and_(pl.col("text").str.to_lowercase().str.contains(r"(?i)conversion"))
-                    .and_(pl.col("text").str.to_lowercase().str.contains(r"(?i)failed")),
-                )
-                .then(-6)
-                # Defense TD + Kick/PAT Missed
-                .when(
-                    (pl.col("type.text").is_in(defense_score_vec))
-                    .and_(pl.col("text").str.to_lowercase().str.contains(r"PAT"))
-                    .and_(pl.col("text").str.to_lowercase().str.contains(r"(?i)missed")),
-                )
-                .then(-6)
-                # Defense TD + Kick/PAT Good
-                .when(
-                    (pl.col("type.text").is_in(defense_score_vec)).and_(
-                        pl.col("text").str.to_lowercase().str.contains(r"kick\)"),
-                    ),
-                )
-                .then(-7)
-                # Defense TD
-                .when(pl.col("type.text").is_in(defense_score_vec))
-                .then(-6.92)
-                # Offense TD + Failed Two-Point Conversion
-                .when(
-                    (pl.col("type.text").is_in(offense_score_vec))
-                    .and_(pl.col("text").str.to_lowercase().str.contains(r"(?i)conversion"))
-                    .and_(pl.col("text").str.to_lowercase().str.contains(r"(?i)failed")),
-                )
-                .then(6)
-                # Offense TD + Successful Two-Point Conversion
-                .when(
-                    (pl.col("type.text").is_in(offense_score_vec))
-                    .and_(pl.col("text").str.to_lowercase().str.contains(r"(?i)conversion"))
-                    .and_(pl.col("text").str.to_lowercase().str.contains(r"(?i)failed") == False),
-                )
-                .then(8)
-                # Offense Made FG
-                .when(
-                    (pl.col("type.text").is_in(offense_score_vec))
-                    .and_(pl.col("type.text").str.to_lowercase().str.contains(r"(?i)field goal"))
-                    .and_(pl.col("type.text").str.to_lowercase().str.contains(r"(?i)good")),
-                )
-                .then(3)
-                # Offense TD + Kick/PAT Missed
-                .when(
-                    (pl.col("type.text").is_in(offense_score_vec))
-                    .and_(pl.col("text").str.to_lowercase().str.contains(r"PAT"))
-                    .and_(pl.col("text").str.to_lowercase().str.contains(r"(?i)missed")),
-                )
-                .then(6)
-                # Offense TD + Kick/PAT Good
-                .when(
-                    (pl.col("type.text").is_in(offense_score_vec)).and_(
-                        pl.col("text").str.to_lowercase().str.contains(r"kick\)"),
-                    ),
-                )
-                .then(7)
-                # Offense TD
-                .when(pl.col("type.text").is_in(offense_score_vec))
-                .then(6.92)
-                # Extra Point Good
-                .when(pl.col("type.text").is_in(["Extra Point Good"]))
-                .then(1)
-                # Extra Point Missed
-                .when(pl.col("type.text").is_in(["Extra Point Missed"]))
-                .then(0)
-                # Two-Point Conversion Good
-                .when(pl.col("type.text").is_in(["Two-Point Conversion Good"]))
-                .then(2)
-                # Two-Point Conversion Missed
-                .when(pl.col("type.text").is_in(["Two-Point Conversion Missed"]))
-                .then(0)
-                # Two Point Pass/Rush Missed (Pre-2014 Data)
-                .when(
-                    (pl.col("type.text").is_in(["Two Point Pass", "Two Point Rush"])).and_(
-                        pl.col("text").str.to_lowercase().str.contains(r"(?i)no good"),
-                    ),
-                )
-                .then(0)
-                # Two Point Pass/Rush Good (Pre-2014 Data)
-                .when(
-                    (pl.col("type.text").is_in(["Two Point Pass", "Two Point Rush"])).and_(
-                        pl.col("text").str.to_lowercase().str.contains(r"(?i)no good") == False,
-                    ),
-                )
-                .then(2)
-                # Blocked PAT
-                .when(pl.col("type.text").is_in(["Blocked PAT"]))
-                .then(0)
-                # Flips for Turnovers that aren't kickoffs
-                .when(
-                    ((pl.col("type.text").is_in(end_change_vec)).or_(pl.col("downs_turnover") == True)).and_(
-                        pl.col("type.text").is_in(kickoff_vec) == False,
-                    ),
-                )
-                .then(pl.col("EP_end") * -1)
-                # Flips for Turnovers that are kickoffs
-                .when(pl.col("type.text").is_in(kickoff_turnovers))
-                .then(pl.col("EP_end") * -1)
-                # Onside kicks
-                .when((pl.col("kickoff_onside") == True).and_(pl.col("change_of_pos_team") == True))
-                .then(pl.col("EP_end") * -1)
-                .otherwise(pl.col("EP_end")),
+            .then(True)
+            .otherwise(False),
+            EPA_success=pl.when(pl.col("EPA") > 0).then(True).otherwise(False),
+            EPA_success_early_down=pl.when((pl.col("EPA") > 0).and_(pl.col("early_down") == True))
+            .then(True)
+            .otherwise(False),
+            EPA_success_early_down_pass=pl.when(
+                (pl.col("pass") == True).and_(pl.col("EPA") > 0).and_(pl.col("early_down") == True),
             )
-            .with_columns(
-                lag_EP_end=pl.col("EP_end").shift(1),
-                lag_change_of_pos_team=pl.col("change_of_pos_team").shift(1),
+            .then(True)
+            .otherwise(False),
+            EPA_success_early_down_rush=pl.when(
+                (pl.col("rush") == True).and_(pl.col("EPA") > 0).and_(pl.col("early_down") == True),
             )
-            .with_columns(
-                lag_change_of_pos_team=pl.when(pl.col("lag_change_of_pos_team").is_null())
-                .then(False)
-                .otherwise(pl.col("lag_change_of_pos_team")),
+            .then(True)
+            .otherwise(False),
+            EPA_success_late_down=pl.when((pl.col("EPA") > 0).and_(pl.col("late_down") == True))
+            .then(True)
+            .otherwise(False),
+            EPA_success_late_down_pass=pl.when(
+                (pl.col("pass") == True).and_(pl.col("EPA") > 0).and_(pl.col("late_down") == True),
             )
-            .with_columns(
-                EP_between=pl.when(pl.col("lag_change_of_pos_team") == True)
-                .then(pl.col("EP_start") + pl.col("lag_EP_end"))
-                .otherwise(pl.col("EP_start") - pl.col("lag_EP_end")),
-                EP_start=pl.when(
-                    (pl.col("type.text").is_in(["Timeout", "End Period"])).and_(
-                        pl.col("lag_change_of_pos_team") == False,
-                    ),
-                )
-                .then(pl.col("lag_EP_end"))
-                .otherwise(pl.col("EP_start")),
+            .then(True)
+            .otherwise(False),
+            EPA_success_late_down_rush=pl.when(
+                (pl.col("rush") == True).and_(pl.col("EPA") > 0).and_(pl.col("late_down") == True),
             )
-            .with_columns(
-                EP_start=pl.when(pl.col("type.text").is_in(kickoff_vec))
-                .then(pl.col("EP_start_touchback"))
-                .otherwise(pl.col("EP_start")),
+            .then(True)
+            .otherwise(False),
+            EPA_success_standard_down=pl.when((pl.col("EPA") > 0).and_(pl.col("standard_down") == True))
+            .then(True)
+            .otherwise(False),
+            EPA_success_passing_down=pl.when((pl.col("EPA") > 0).and_(pl.col("passing_down") == True))
+            .then(True)
+            .otherwise(False),
+            EPA_success_pass=pl.when((pl.col("EPA") > 0).and_(pl.col("pass") == True)).then(True).otherwise(False),
+            EPA_success_rush=pl.when((pl.col("EPA") > 0).and_(pl.col("rush") == True)).then(True).otherwise(False),
+            EPA_success_EPA=pl.when(pl.col("EPA") > 0).then(pl.col("EPA")).otherwise(None),
+            EPA_success_standard_down_EPA=pl.when((pl.col("EPA") > 0).and_(pl.col("standard_down") == True))
+            .then(pl.col("EPA"))
+            .otherwise(None),
+            EPA_success_passing_down_EPA=pl.when((pl.col("EPA") > 0).and_(pl.col("passing_down") == True))
+            .then(pl.col("EPA"))
+            .otherwise(None),
+            EPA_success_pass_EPA=pl.when((pl.col("EPA") > 0).and_(pl.col("pass") == True))
+            .then(pl.col("EPA"))
+            .otherwise(None),
+            EPA_success_rush_EPA=pl.when((pl.col("EPA") > 0).and_(pl.col("rush") == True))
+            .then(pl.col("EPA"))
+            .otherwise(None),
+            EPA_middle_8_success=pl.when((pl.col("EPA") > 0).and_(pl.col("middle_8") == True))
+            .then(True)
+            .otherwise(False),
+            EPA_middle_8_success_pass=pl.when(
+                (pl.col("pass") == True).and_(pl.col("EPA") > 0).and_(pl.col("middle_8") == True),
             )
-            .with_columns(
-                EP_end=pl.when(pl.col("type.text").is_in(["Timeout"]))
-                .then(pl.col("EP_start"))
-                .otherwise(pl.col("EP_end")),
+            .then(True)
+            .otherwise(False),
+            EPA_middle_8_success_rush=pl.when(
+                (pl.col("rush") == True).and_(pl.col("EPA") > 0).and_(pl.col("middle_8") == True),
             )
-            .with_columns(
-                EPA=pl.when(pl.col("type.text").is_in(["Timeout"]))
-                .then(0)
-                .when((pl.col("scoring_play") == False).and_(pl.col("end_of_half") == True))
-                .then(-1 * pl.col("EP_start"))
-                .when((pl.col("type.text").is_in(kickoff_vec)).and_(pl.col("penalty_in_text") == True))
-                .then(pl.col("EP_end") - pl.col("EP_start"))
-                .when(
-                    (pl.col("penalty_in_text") == True)
-                    .and_(pl.col("type.text").is_in(["Penalty"]) == False)
-                    .and_(pl.col("type.text").is_in(kickoff_vec) == False),
-                )
-                .then(pl.col("EP_end") - pl.col("EP_start") + pl.col("EP_between"))
-                .otherwise(pl.col("EP_end") - pl.col("EP_start")),
+            .then(True)
+            .otherwise(False),
+            EPA_penalty=pl.when(pl.col("type.text").is_in(["Penalty", "Penalty (Kickoff)"]))
+            .then(pl.col("EPA"))
+            .when(pl.col("penalty_in_text") == True)
+            .then(pl.col("EP_end") - pl.col("EP_start"))
+            .otherwise(None),
+            EPA_sp=pl.when(
+                (pl.col("fg_attempt") == True).or_(pl.col("punt") == True).or_(pl.col("kickoff_play") == True),
             )
-            .with_columns(
-                def_EPA=pl.col("EPA") * -1,
-                # --- EPA Summary flags ----
-                EPA_scrimmage=pl.when(pl.col("scrimmage_play") == True).then(pl.col("EPA")).otherwise(None),
-                EPA_rush=pl.when((pl.col("rush") == True).and_(pl.col("penalty_in_text") == True))
-                .then(pl.col("EPA"))
-                .when((pl.col("rush") == True).and_(pl.col("penalty_in_text") == False))
-                .then(pl.col("EPA"))
-                .otherwise(None),
-                EPA_pass=pl.when(pl.col("pass") == True).then(pl.col("EPA")).otherwise(None),
-                EPA_explosive=pl.when((pl.col("pass") == True).and_(pl.col("EPA") >= 2.4))
-                .then(True)
-                .when(((pl.col("rush") == True).and_(pl.col("EPA") >= 1.8)))
-                .then(True)
-                .otherwise(False),
-            )
-            .with_columns(
-                EPA_non_explosive=pl.when(pl.col("EPA_explosive") == False).then(pl.col("EPA")).otherwise(None),
-                EPA_explosive_pass=pl.when((pl.col("pass") == True).and_(pl.col("EPA") >= 2.4))
-                .then(True)
-                .otherwise(False),
-                EPA_explosive_rush=pl.when((pl.col("rush") == True).and_(pl.col("EPA") >= 1.8))
-                .then(True)
-                .otherwise(False),
-                first_down_created=pl.when(
-                    (pl.col("scrimmage_play") == True)
-                    .and_(pl.col("end.down") == 1)
-                    .and_(pl.col("start.pos_team.id") == pl.col("end.pos_team.id")),
-                )
-                .then(True)
-                .otherwise(False),
-                EPA_success=pl.when(pl.col("EPA") > 0).then(True).otherwise(False),
-                EPA_success_early_down=pl.when((pl.col("EPA") > 0).and_(pl.col("early_down") == True))
-                .then(True)
-                .otherwise(False),
-                EPA_success_early_down_pass=pl.when(
-                    (pl.col("pass") == True).and_(pl.col("EPA") > 0).and_(pl.col("early_down") == True),
-                )
-                .then(True)
-                .otherwise(False),
-                EPA_success_early_down_rush=pl.when(
-                    (pl.col("rush") == True).and_(pl.col("EPA") > 0).and_(pl.col("early_down") == True),
-                )
-                .then(True)
-                .otherwise(False),
-                EPA_success_late_down=pl.when((pl.col("EPA") > 0).and_(pl.col("late_down") == True))
-                .then(True)
-                .otherwise(False),
-                EPA_success_late_down_pass=pl.when(
-                    (pl.col("pass") == True).and_(pl.col("EPA") > 0).and_(pl.col("late_down") == True),
-                )
-                .then(True)
-                .otherwise(False),
-                EPA_success_late_down_rush=pl.when(
-                    (pl.col("rush") == True).and_(pl.col("EPA") > 0).and_(pl.col("late_down") == True),
-                )
-                .then(True)
-                .otherwise(False),
-                EPA_success_standard_down=pl.when((pl.col("EPA") > 0).and_(pl.col("standard_down") == True))
-                .then(True)
-                .otherwise(False),
-                EPA_success_passing_down=pl.when((pl.col("EPA") > 0).and_(pl.col("passing_down") == True))
-                .then(True)
-                .otherwise(False),
-                EPA_success_pass=pl.when((pl.col("EPA") > 0).and_(pl.col("pass") == True)).then(True).otherwise(False),
-                EPA_success_rush=pl.when((pl.col("EPA") > 0).and_(pl.col("rush") == True)).then(True).otherwise(False),
-                EPA_success_EPA=pl.when(pl.col("EPA") > 0).then(pl.col("EPA")).otherwise(None),
-                EPA_success_standard_down_EPA=pl.when((pl.col("EPA") > 0).and_(pl.col("standard_down") == True))
-                .then(pl.col("EPA"))
-                .otherwise(None),
-                EPA_success_passing_down_EPA=pl.when((pl.col("EPA") > 0).and_(pl.col("passing_down") == True))
-                .then(pl.col("EPA"))
-                .otherwise(None),
-                EPA_success_pass_EPA=pl.when((pl.col("EPA") > 0).and_(pl.col("pass") == True))
-                .then(pl.col("EPA"))
-                .otherwise(None),
-                EPA_success_rush_EPA=pl.when((pl.col("EPA") > 0).and_(pl.col("rush") == True))
-                .then(pl.col("EPA"))
-                .otherwise(None),
-                EPA_middle_8_success=pl.when((pl.col("EPA") > 0).and_(pl.col("middle_8") == True))
-                .then(True)
-                .otherwise(False),
-                EPA_middle_8_success_pass=pl.when(
-                    (pl.col("pass") == True).and_(pl.col("EPA") > 0).and_(pl.col("middle_8") == True),
-                )
-                .then(True)
-                .otherwise(False),
-                EPA_middle_8_success_rush=pl.when(
-                    (pl.col("rush") == True).and_(pl.col("EPA") > 0).and_(pl.col("middle_8") == True),
-                )
-                .then(True)
-                .otherwise(False),
-                EPA_penalty=pl.when(pl.col("type.text").is_in(["Penalty", "Penalty (Kickoff)"]))
-                .then(pl.col("EPA"))
-                .when(pl.col("penalty_in_text") == True)
-                .then(pl.col("EP_end") - pl.col("EP_start"))
-                .otherwise(None),
-                EPA_sp=pl.when(
-                    (pl.col("fg_attempt") == True).or_(pl.col("punt") == True).or_(pl.col("kickoff_play") == True),
-                )
-                .then(pl.col("EPA"))
-                .otherwise(False),
-                EPA_fg=pl.when(pl.col("fg_attempt") == True).then(pl.col("EPA")).otherwise(None),
-                EPA_punt=pl.when(pl.col("punt") == True).then(pl.col("EPA")).otherwise(None),
-                EPA_kickoff=pl.when(pl.col("kickoff_play") == True).then(pl.col("EPA")).otherwise(None),
-            )
+            .then(pl.col("EPA"))
+            .otherwise(False),
+            EPA_fg=pl.when(pl.col("fg_attempt") == True).then(pl.col("EPA")).otherwise(None),
+            EPA_punt=pl.when(pl.col("punt") == True).then(pl.col("EPA")).otherwise(None),
+            EPA_kickoff=pl.when(pl.col("kickoff_play") == True).then(pl.col("EPA")).otherwise(None),
         )
         return play_df
 
@@ -3954,108 +3767,21 @@ class NFLPlayProcess(object):
         )
         WP_end = _wp_model.predict(DMatrix(X_wp_end, feature_names=WP_SPREAD_FEATURES))
 
-        play_df = (
-            play_df.with_columns(
-                wp_before=pl.lit(WP_start),
-                wp_touchback=pl.lit(WP_start_touchback),
-                wp_after=pl.lit(WP_end),
-            )
-            .with_columns(
-                wp_before=pl.when(pl.col("type.text").is_in(kickoff_vec))
-                .then(pl.col("wp_touchback"))
-                .otherwise(pl.col("wp_before")),
-            )
-            .with_columns(
-                def_wp_before=1 - pl.col("wp_before"),
-            )
-            .with_columns(
-                home_wp_before=pl.when(pl.col("start.pos_team.id") == pl.col("homeTeamId"))
-                .then(pl.col("wp_before"))
-                .otherwise(pl.col("def_wp_before")),
-                away_wp_before=pl.when(pl.col("start.pos_team.id") != pl.col("homeTeamId"))
-                .then(pl.col("wp_before"))
-                .otherwise(pl.col("def_wp_before")),
-            )
-            .with_columns(
-                lead_wp_before=pl.col("wp_before").shift(-1),
-                lead_wp_before2=pl.col("wp_before").shift(-2),
-            )
-            .with_columns(
-                wp_after=pl.when(pl.col("type.text").is_in(["Timeout"]))
-                .then(pl.col("wp_before"))
-                .when(
-                    (pl.col("status_type_completed") == True)
-                    .and_(
-                        (pl.col("lead_play_type").is_null()).or_(
-                            pl.col("game_play_number") == pl.col("game_play_number").max(),
-                        ),
-                    )
-                    .and_(pl.col("pos_score_diff_end") > 0),
-                )
-                .then(1.0)
-                .when(
-                    (pl.col("status_type_completed") == True)
-                    .and_(
-                        (pl.col("lead_play_type").is_null()).or_(
-                            pl.col("game_play_number") == pl.col("game_play_number").max(),
-                        ),
-                    )
-                    .and_(pl.col("pos_score_diff_end") < 0),
-                )
-                .then(0.0)
-                .when(
-                    (pl.col("end_of_half") == True)
-                    .and_(pl.col("start.pos_team.id") == pl.col("lead_pos_team"))
-                    .and_(pl.col("type.text") != "Timeout"),
-                )
-                .then(pl.col("lead_wp_before"))
-                .when(
-                    (pl.col("end_of_half") == True)
-                    .and_(pl.col("start.pos_team.id") != pl.col("end.pos_team.id"))
-                    .and_(pl.col("type.text") != "Timeout"),
-                )
-                .then(1 - pl.col("lead_wp_before"))
-                .when(
-                    (pl.col("end_of_half") == True)
-                    .and_(pl.col("start.pos_team_receives_2H_kickoff") == False)
-                    .and_(pl.col("type.text") == "Timeout"),
-                )
-                .then(pl.col("wp_after"))
-                .when(
-                    (pl.col("lead_play_type").is_in(["End Period", "End of Half"])).and_(
-                        pl.col("change_of_pos_team") == False,
-                    ),
-                )
-                .then(pl.col("lead_wp_before"))
-                .when(
-                    (pl.col("lead_play_type").is_in(["End Period", "End of Half"])).and_(
-                        pl.col("change_of_pos_team") == True,
-                    ),
-                )
-                .then(1 - pl.col("lead_wp_before"))
-                .when((pl.col("kickoff_onside") == True).and_(pl.col("change_of_pos_team") == True))
-                .then(pl.col("wp_after"))
-                .when((pl.col("start.pos_team.id") != pl.col("end.pos_team.id")).and_(pl.col("scoringPlay") == False))
-                .then(1 - pl.col("lead_wp_before"))
-                .when((pl.col("start.pos_team.id") != pl.col("end.pos_team.id")).and_(pl.col("scoringPlay") == True))
-                .then(pl.col("lead_wp_before"))
-                .otherwise(pl.col("wp_after")),
-            )
-            .with_columns(
-                def_wp_after=1 - pl.col("wp_after"),
-            )
-            .with_columns(
-                home_wp_after=pl.when(pl.col("end.pos_team.id") == pl.col("homeTeamId"))
-                .then(pl.col("wp_after"))
-                .otherwise(pl.col("def_wp_after")),
-                away_wp_after=pl.when(pl.col("end.pos_team.id") != pl.col("homeTeamId"))
-                .then(pl.col("wp_after"))
-                .otherwise(pl.col("def_wp_after")),
-            )
-            .with_columns(
-                wpa=pl.col("wp_after") - pl.col("wp_before"),
-            )
+        # Attach the scored WP point estimates, then delegate the derivation half to
+        # the shared, model-free calculate_wpa. calculate_wpa is the verbatim lift of
+        # the kickoff-touchback overlay / posteam->home flip / lead_wp / end-of-game /
+        # OT derivation that used to live inline here. NFLPlayProcess always operates
+        # on a single game, so calculate_wpa's ``.over("game_id")`` window guards
+        # collapse to the plain ``.shift`` / ``.max()`` semantics this method relied
+        # on, leaving output identical. calculate_wpa also emits lowercase nflverse
+        # aliases (wp / def_wp / home_wp / away_wp) the legacy __process_wpa output
+        # never carried, so drop them to keep the plays schema byte-identical.
+        play_df = play_df.with_columns(
+            wp_before=pl.lit(WP_start),
+            wp_touchback=pl.lit(WP_start_touchback),
+            wp_after=pl.lit(WP_end),
         )
+        play_df = calculate_wpa(play_df).drop("wp", "def_wp", "home_wp", "away_wp")
         return play_df
 
     def __process_cp(self, play_df):

--- a/sportsdataverse/nfl/nfl_pbp.py
+++ b/sportsdataverse/nfl/nfl_pbp.py
@@ -4010,6 +4010,17 @@ class NFLPlayProcess(object):
                 .alias("_ff_tdteam"),
                 (pl.col("int_td") | txt.str.contains(r"(?i)intercept")).cast(pl.Int8).alias("_ff_int"),
                 (txt.str.contains(r"(?i)kneel") & (pl.col("rush") == True)).cast(pl.Int8).alias("_ff_qbkneel"),
+                # standalone timeout / two-minute-warning row detector. nflfastR keys
+                # the L55-82 PAT-after-defensive-TD interleave on desc matching
+                # "(Timeout)|(Two-Minute Warning)"; the ESPN analog is the play-type
+                # label, which carries "Timeout" / "Official Timeout" / "Two-minute
+                # warning". Match type.text (and the description as a fallback).
+                (
+                    type_txt.str.contains(r"(?i)timeout|two-minute warning")
+                    | txt.str.contains(r"(?i)timeout|two-minute warning")
+                )
+                .cast(pl.Int8)
+                .alias("_ff_to"),
                 # ESPN omits nflfastR's "END QUARTER 2/4 / END GAME" desc markers; the
                 # end_of_half boolean is the 1:1 ESPN analog for "End of half".
                 (eoh | txt.str.contains(r"(END QUARTER 2)|(END QUARTER 4)|(END GAME)")).cast(pl.Int8).alias("_ff_eoh"),
@@ -4060,7 +4071,12 @@ class NFLPlayProcess(object):
         lag_pt3 = pl.col("_ff_pt").shift(3).over(["game_id", "_ff_half"])
         lag_td = pl.col("_ff_td").shift(1).over(["game_id", "_ff_half"])
         lag_td2 = pl.col("_ff_td").shift(2).over(["game_id", "_ff_half"])
+        lag_td3 = pl.col("_ff_td").shift(3).over(["game_id", "_ff_half"])
         lag_tdteam = pl.col("_ff_tdteam").shift(1).over(["game_id", "_ff_half"])
+        lag_tdteam2 = pl.col("_ff_tdteam").shift(2).over(["game_id", "_ff_half"])
+        lag_tdteam3 = pl.col("_ff_tdteam").shift(3).over(["game_id", "_ff_half"])
+        lag_to = pl.col("_ff_to").shift(1).over(["game_id", "_ff_half"])
+        lag_to2 = pl.col("_ff_to").shift(2).over(["game_id", "_ff_half"])
         lag_fum = pl.col("_ff_fumlost").shift(1).over(["game_id", "_ff_half"])
         lag_fum2 = pl.col("_ff_fumlost").shift(2).over(["game_id", "_ff_half"])
         lag_ptype = pl.col("_ff_play_type").shift(1).over(["game_id", "_ff_half"])
@@ -4083,6 +4099,32 @@ class NFLPlayProcess(object):
             .with_columns(
                 # PAT after a defensive TD is not a new drive (L45-54)
                 pl.when((lag_td == 1) & (lag_pt != lag_tdteam) & lag_pt.is_not_null())
+                .then(0)
+                .otherwise(pl.col("_ff_nd"))
+                .alias("_ff_nd"),
+            )
+            .with_columns(
+                # PAT after a defensive TD is not a new drive even if a single
+                # standalone Timeout / Two-minute-warning row follows the TD
+                # (L55-67). The prior row is a timeout, the TD was 2 rows back, and
+                # that TD was scored by the defense. A null lag => keep _ff_nd
+                # (the R `missing = new_drive` clause): the `&` chain is null when any
+                # lag is out of range, and pl.when treats null as the else branch.
+                pl.when(
+                    (lag_to == 1) & (lag_td2 == 1) & (lag_pt2 != lag_tdteam2),
+                )
+                .then(0)
+                .otherwise(pl.col("_ff_nd"))
+                .alias("_ff_nd"),
+            )
+            .with_columns(
+                # PAT after a defensive TD is not a new drive even if TWO standalone
+                # Timeout / Two-minute-warning rows follow the TD (L68-82). The prior
+                # two rows are timeouts, the TD was 3 rows back, and that TD was
+                # scored by the defense. Same null-keeps-_ff_nd semantics as above.
+                pl.when(
+                    (lag_to == 1) & (lag_to2 == 1) & (lag_td3 == 1) & (lag_pt3 != lag_tdteam3),
+                )
                 .then(0)
                 .otherwise(pl.col("_ff_nd"))
                 .alias("_ff_nd"),

--- a/sportsdataverse/parsed/nfl.py
+++ b/sportsdataverse/parsed/nfl.py
@@ -147,10 +147,13 @@ from sportsdataverse.nfl import nfl_weeks as _raw_nfl_weeks
 from sportsdataverse.nfl import nfl_weeks_by_date as _raw_nfl_weeks_by_date
 from sportsdataverse.nfl import NFLPlayProcess as NFLPlayProcess  # noqa: F401
 from sportsdataverse.nfl import NflConfig as NflConfig  # noqa: F401
+from sportsdataverse.nfl import build_nfl_season as build_nfl_season  # noqa: F401
 from sportsdataverse.nfl import cached_loader as cached_loader  # noqa: F401
 from sportsdataverse.nfl import calculate_completion_probability as calculate_completion_probability  # noqa: F401
+from sportsdataverse.nfl import calculate_epa as calculate_epa  # noqa: F401
 from sportsdataverse.nfl import calculate_expected_points as calculate_expected_points  # noqa: F401
 from sportsdataverse.nfl import calculate_win_probability as calculate_win_probability  # noqa: F401
+from sportsdataverse.nfl import calculate_wpa as calculate_wpa  # noqa: F401
 from sportsdataverse.nfl import calculate_xyac as calculate_xyac  # noqa: F401
 from sportsdataverse.nfl import clear_cache as clear_cache  # noqa: F401
 from sportsdataverse.nfl import download as download  # noqa: F401
@@ -253,10 +256,13 @@ from sportsdataverse.nfl import update_config as update_config  # noqa: F401
 __all__ = [
     "NFLPlayProcess",
     "NflConfig",
+    "build_nfl_season",
     "cached_loader",
     "calculate_completion_probability",
+    "calculate_epa",
     "calculate_expected_points",
     "calculate_win_probability",
+    "calculate_wpa",
     "calculate_xyac",
     "clear_cache",
     "download",

--- a/tests/nfl/test_fixed_drives_series.py
+++ b/tests/nfl/test_fixed_drives_series.py
@@ -1,0 +1,419 @@
+"""Offline synthetic tests for ``NFLPlayProcess.__add_fixed_drives_series``.
+
+The method ports nflfastR's drive- and series-numbering scheme onto the ESPN
+``NFLPlayProcess`` frame so the ESPN-constructed output reaches nflverse parity
+on ``fixed_drive`` / ``fixed_drive_result`` / ``series`` / ``series_success`` /
+``series_result``.  The rules are translated from:
+
+* ``nflfastR/R/helper_add_fixed_drives.R`` (``add_drive_results``) -- a new
+  ``fixed_drive`` increments on a real possession change, with the special
+  cases: a PAT/2pt after a *defensive* touchdown stays in the SAME drive
+  (L45-54), a recovered onside/muffed kick is a NEW drive (L117-122), and a
+  kickoff after a safety is a NEW drive (L124-134).
+* ``nflfastR/R/helper_add_series_data.R`` (``add_series_data``) -- ``series``
+  increments on a new drive, a non-touchdown first down on the prior play, or
+  the first play of the half (L35-47); ``series_success`` is 1 iff the series
+  ended in a touchdown or first down (L86-90).
+
+Each scenario below is a hand-built play sequence with possession / down /
+flags set so the expected ``fixed_drive`` / ``series`` values can be computed
+directly from those R rules (cited inline).  The frames carry only the ~29
+input columns the method reads; everything else is irrelevant to the logic.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+from sportsdataverse.nfl.nfl_pbp import NFLPlayProcess
+
+# Two synthetic team ids used throughout.
+A = 1  # "offense first"
+B = 2
+
+# The exact input columns the method consumes.
+_DEFAULT = {
+    "game_id": 1,
+    "half": 1,
+    "pos_team": A,
+    "def_pos_team": B,
+    "start.pos_team.id": A,
+    "end.pos_team.id": A,
+    "down": 1,
+    "end.down": 2,
+    "start.distance": 10,
+    "statYardage": 3,
+    "text": "play.",
+    "type.text": "Rush",
+    "touchdown": False,
+    "safety": False,
+    "fumble_lost": False,
+    "fumble_recovered": False,
+    "field_goal_result": None,
+    "kickoff_play": False,
+    "kickoff_onside": False,
+    "kickoff_downed": False,
+    "punt": False,
+    "punt_play": False,
+    "fg_attempt": False,
+    "scrimmage_play": True,
+    "int_td": False,
+    "penalty_1st_conv": False,
+    "pass": False,
+    "rush": True,
+}
+
+# Explicit dtypes so empty / boolean columns are never inferred as Null.
+_SCHEMA = {
+    "game_id": pl.Int64,
+    "half": pl.Int64,
+    "pos_team": pl.Int64,
+    "def_pos_team": pl.Int64,
+    "start.pos_team.id": pl.Int64,
+    "end.pos_team.id": pl.Int64,
+    "down": pl.Int64,
+    "end.down": pl.Int64,
+    "start.distance": pl.Int64,
+    "statYardage": pl.Int64,
+    "text": pl.Utf8,
+    "type.text": pl.Utf8,
+    "touchdown": pl.Boolean,
+    "safety": pl.Boolean,
+    "fumble_lost": pl.Boolean,
+    "fumble_recovered": pl.Boolean,
+    "field_goal_result": pl.Utf8,
+    "kickoff_play": pl.Boolean,
+    "kickoff_onside": pl.Boolean,
+    "kickoff_downed": pl.Boolean,
+    "punt": pl.Boolean,
+    "punt_play": pl.Boolean,
+    "fg_attempt": pl.Boolean,
+    "scrimmage_play": pl.Boolean,
+    "int_td": pl.Boolean,
+    "penalty_1st_conv": pl.Boolean,
+    "pass": pl.Boolean,
+    "rush": pl.Boolean,
+}
+
+
+def _frame(rows: list[dict]) -> pl.DataFrame:
+    """Build a play frame from partial rows, filling defaults + dtypes."""
+    full = [{**_DEFAULT, **r} for r in rows]
+    return pl.DataFrame(full, schema=_SCHEMA)
+
+
+def _run(df: pl.DataFrame) -> pl.DataFrame:
+    proc = NFLPlayProcess(gameId=1)
+    method = getattr(proc, "_NFLPlayProcess__add_fixed_drives_series")
+    return method(df)
+
+
+# --------------------------------------------------------------------------- #
+# fixed_drive                                                                  #
+# --------------------------------------------------------------------------- #
+def test_fixed_drive_increments_on_possession_change_and_is_additive():
+    """A simply alternating possession sequence: each posteam flip is a new
+    drive (helper_add_fixed_drives.R L32-44).  First play of the half is a new
+    drive (L114-115).  Frame must be strictly additive (5 new cols only)."""
+    df = _frame(
+        [
+            {"pos_team": A, "def_pos_team": B, "rush": True},  # drive 1
+            {"pos_team": A, "def_pos_team": B, "pass": True, "rush": False},
+            {
+                "pos_team": A,
+                "def_pos_team": B,
+                "punt": True,
+                "punt_play": True,
+                "rush": False,
+                "type.text": "Punt",
+                "scrimmage_play": False,
+            },
+            {"pos_team": B, "def_pos_team": A, "rush": True},  # drive 2 (poss flip)
+            {"pos_team": B, "def_pos_team": A, "rush": True},
+            {"pos_team": A, "def_pos_team": B, "rush": True},  # drive 3 (poss flip)
+        ]
+    )
+    before = df.width
+    out = _run(df)
+    assert out.width == before + 5
+    assert [c for c in out.columns if c.startswith("_ff_")] == []
+    assert out["fixed_drive"].to_list() == [1, 1, 1, 2, 2, 3]
+    # monotonic non-decreasing
+    fd = out["fixed_drive"].to_list()
+    assert all(fd[i] <= fd[i + 1] for i in range(len(fd) - 1))
+    # drive 1 ended on a punt
+    assert out["fixed_drive_result"].to_list()[0] == "Punt"
+
+
+def test_pat_after_defensive_td_stays_in_same_drive():
+    """Team A is on offense and B returns an interception for a TD; the ensuing
+    2pt try is run by B (posteam flips to B) but is NOT a new drive
+    (helper_add_fixed_drives.R L45-54: PAT after a defensive TD).  The kickoff
+    afterward, run by A, IS a new drive."""
+    df = _frame(
+        [
+            {"pos_team": A, "def_pos_team": B, "rush": True},  # drive 1
+            {
+                "pos_team": A,
+                "def_pos_team": B,
+                "pass": True,
+                "rush": False,  # B returns INT for TD
+                "touchdown": True,
+                "int_td": True,
+                "type.text": "Interception Return Touchdown",
+                "text": "intercepted and returned for a touchdown.",
+                "end.pos_team.id": A,
+                "end.down": 1,
+            },
+            {
+                "pos_team": B,
+                "def_pos_team": A,
+                "rush": True,  # B's 2pt try -> same drive
+                "type.text": "Two Point Rush",
+                "scrimmage_play": False,
+                "down": 1,
+            },
+            {
+                "pos_team": A,
+                "def_pos_team": B,
+                "kickoff_play": True,
+                "rush": False,  # kickoff by A -> new drive
+                "type.text": "Kickoff",
+                "scrimmage_play": False,
+            },
+            {"pos_team": A, "def_pos_team": B, "rush": True},
+        ]
+    )
+    out = _run(df)
+    # rows 0,1 = drive 1 (A had the ball, B scored the def TD on a play A possessed,
+    # 2pt try by B folds into drive 1); kickoff by A starts drive 2.
+    assert out["fixed_drive"].to_list() == [1, 1, 1, 2, 2]
+    # drive 1 result is the defensive (opponent) touchdown
+    assert out["fixed_drive_result"].to_list()[0] == "Opp touchdown"
+
+
+def test_onside_kick_recovery_is_new_drive():
+    """A recovered onside kick (kicking team retains) is a NEW drive
+    (helper_add_fixed_drives.R L117-122).  ``own_kickoff_recovery`` is derived
+    from kickoff_onside + fumble_recovered."""
+    df = _frame(
+        [
+            {"pos_team": A, "def_pos_team": B, "rush": True},  # drive 1
+            {
+                "pos_team": A,
+                "def_pos_team": B,
+                "field_goal_result": "made",  # FG -> drive 1 ends
+                "fg_attempt": True,
+                "rush": False,
+                "type.text": "Field Goal Good",
+                "scrimmage_play": False,
+            },
+            {
+                "pos_team": A,
+                "def_pos_team": B,
+                "kickoff_play": True,
+                "rush": False,  # onside recovery by A
+                "kickoff_onside": True,
+                "fumble_recovered": True,
+                "type.text": "Kickoff",
+                "scrimmage_play": False,
+                "text": "A kicks onside, recovered by A.",
+            },
+            {"pos_team": A, "def_pos_team": B, "rush": True},  # A keeps ball
+        ]
+    )
+    out = _run(df)
+    # The onside-recovery row opens a NEW drive (L117-122) -- this is the rule
+    # under test.  Per the L18-20 posteam swap, a recovered kick's posteam is
+    # flipped to the (kicking) team's defteam, so the following scrimmage play
+    # by A registers as a possession change and a further new drive -- matching
+    # nflfastR exactly.
+    fd = out["fixed_drive"].to_list()
+    assert fd == [1, 1, 2, 3]
+    assert fd[2] == 2  # onside recovery is its own new drive boundary
+    assert out["fixed_drive_result"].to_list()[0] == "Field goal"
+
+
+def test_safety_then_kickoff_is_new_drive_and_result_is_safety():
+    """A safety ends the drive with result "Safety" (L148); the kickoff on the
+    following play is a NEW drive (L124-134)."""
+    df = _frame(
+        [
+            {"pos_team": A, "def_pos_team": B, "rush": True},  # drive 1
+            {
+                "pos_team": A,
+                "def_pos_team": B,
+                "rush": True,
+                "safety": True,  # safety -> drive 1 ends
+                "type.text": "Safety",
+            },
+            # free kick after safety; ESPN labels the kickoff row with the RECEIVING
+            # team's possession (B).  It opens a new drive (L124-134) and B's
+            # ensuing possession continues that drive.
+            {
+                "pos_team": B,
+                "def_pos_team": A,
+                "kickoff_play": True,
+                "rush": False,
+                "type.text": "Kickoff",
+                "scrimmage_play": False,
+            },
+            {"pos_team": B, "def_pos_team": A, "rush": True},  # B receives
+        ]
+    )
+    out = _run(df)
+    assert out["fixed_drive"].to_list() == [1, 1, 2, 2]
+    assert out["fixed_drive_result"].to_list()[0] == "Safety"
+
+
+# --------------------------------------------------------------------------- #
+# series / series_success / series_result                                      #
+# --------------------------------------------------------------------------- #
+def test_series_first_down_conversion_increments_and_succeeds():
+    """A 3rd-down rush that gains enough for a first down ends the series with
+    "First down" (series_result), series_success=1, and the NEXT play opens a
+    new series (helper_add_series_data.R L35-47, L86-90)."""
+    df = _frame(
+        [
+            # 1st & 10, gain 4 -> 2nd & 6 (same series 1)
+            {"down": 1, "start.distance": 10, "statYardage": 4, "end.down": 2, "rush": True},
+            # 3rd & 6, gain 8 -> first down (end.down resets to 1, yards>=togo)
+            {"down": 3, "start.distance": 6, "statYardage": 8, "end.down": 1, "rush": True},
+            # next play is a new series (1st & 10)
+            {"down": 1, "start.distance": 10, "statYardage": 2, "end.down": 2, "rush": True},
+        ]
+    )
+    out = _run(df)
+    # series increments after the converting play (the prior-play first down rule)
+    assert out["series"].to_list() == [1, 1, 2]
+    # series 1 ended in a first down -> success
+    s1 = out.filter(pl.col("series") == 1)
+    assert s1["series_result"].to_list()[0] == "First down"
+    assert s1["series_success"].to_list()[0] == 1
+
+
+def test_series_turnover_on_downs_fails():
+    """A 4th-down play short of the sticks is a turnover on downs:
+    series_result="Turnover on downs", series_success=0 (L67-69)."""
+    df = _frame(
+        [
+            {
+                "down": 3,
+                "start.distance": 8,
+                "statYardage": 2,
+                "end.down": 4,
+                "rush": True,
+                "pos_team": A,
+                "def_pos_team": B,
+            },
+            # 4th & 6, gain 2 (< togo) -> turnover on downs; possession flips next
+            {
+                "down": 4,
+                "start.distance": 6,
+                "statYardage": 2,
+                "end.down": 1,
+                "rush": True,
+                "pos_team": A,
+                "def_pos_team": B,
+                "start.pos_team.id": A,
+                "end.pos_team.id": B,
+            },
+            {
+                "down": 1,
+                "start.distance": 10,
+                "statYardage": 3,
+                "end.down": 2,
+                "rush": True,
+                "pos_team": B,
+                "def_pos_team": A,
+                "start.pos_team.id": B,
+                "end.pos_team.id": B,
+            },
+        ]
+    )
+    out = _run(df)
+    s1 = out.filter(pl.col("series") == 1)
+    assert s1["series_result"].to_list()[-1] == "Turnover on downs"
+    assert s1["series_success"].to_list()[-1] == 0
+
+
+def test_series_punt_fails():
+    """A punt ends the series with "Punt" and series_success=0 (L65)."""
+    df = _frame(
+        [
+            {
+                "down": 3,
+                "start.distance": 9,
+                "statYardage": 1,
+                "end.down": 4,
+                "rush": True,
+                "pos_team": A,
+                "def_pos_team": B,
+            },
+            # 4th & 8 punt
+            {
+                "down": 4,
+                "start.distance": 8,
+                "statYardage": 0,
+                "end.down": 1,
+                "rush": False,
+                "punt": True,
+                "punt_play": True,
+                "type.text": "Punt",
+                "scrimmage_play": False,
+                "pos_team": A,
+                "def_pos_team": B,
+                "start.pos_team.id": A,
+                "end.pos_team.id": B,
+            },
+            {
+                "down": 1,
+                "start.distance": 10,
+                "statYardage": 5,
+                "end.down": 2,
+                "rush": True,
+                "pos_team": B,
+                "def_pos_team": A,
+                "start.pos_team.id": B,
+                "end.pos_team.id": B,
+            },
+        ]
+    )
+    out = _run(df)
+    s1 = out.filter(pl.col("series") == 1)
+    assert s1["series_result"].to_list()[-1] == "Punt"
+    assert s1["series_success"].to_list()[-1] == 0
+
+
+def test_offensive_touchdown_drive_and_series_results():
+    """An offensive rushing touchdown -> drive result "Touchdown" and the
+    scoring series ends "Touchdown" with success=1 (L143, L59, L86-90)."""
+    df = _frame(
+        [
+            {
+                "down": 1,
+                "start.distance": 10,
+                "statYardage": 6,
+                "end.down": 2,
+                "rush": True,
+                "pos_team": A,
+                "def_pos_team": B,
+            },
+            {
+                "down": 2,
+                "start.distance": 4,
+                "statYardage": 4,
+                "end.down": 1,
+                "rush": True,
+                "touchdown": True,
+                "type.text": "Rushing Touchdown",
+                "text": "rushes for a touchdown.",
+                "pos_team": A,
+                "def_pos_team": B,
+            },
+        ]
+    )
+    out = _run(df)
+    assert out["fixed_drive_result"].to_list()[0] == "Touchdown"
+    assert out["series_result"].to_list()[-1] == "Touchdown"
+    assert out["series_success"].to_list()[-1] == 1

--- a/tests/nfl/test_fixed_drives_series.py
+++ b/tests/nfl/test_fixed_drives_series.py
@@ -192,6 +192,131 @@ def test_pat_after_defensive_td_stays_in_same_drive():
     assert out["fixed_drive_result"].to_list()[0] == "Opp touchdown"
 
 
+def test_pat_after_defensive_td_with_one_timeout_stays_in_same_drive():
+    """nflfastR L55-67: a PAT/2pt after a *defensive* TD is NOT a new drive even
+    when a single standalone Timeout row is interleaved between the scoring play
+    and the try.  ESPN (unlike the assumption the first port made) DOES retain
+    standalone timeout rows, so the boundary must be suppressed via the
+    ``lag(...,2L)`` variant -- the prior row is a timeout, the TD was 2 rows back,
+    and that TD was defensive.  The result MUST equal the no-timeout case
+    ``[1, 1, 1, 2, 2]`` (see ``test_pat_after_defensive_td_stays_in_same_drive``):
+    the timeout must not manufacture a spurious drive increment that then
+    cascades into ``series``."""
+    df = _frame(
+        [
+            {"pos_team": A, "def_pos_team": B, "rush": True},  # drive 1
+            {
+                "pos_team": A,
+                "def_pos_team": B,
+                "pass": True,
+                "rush": False,  # B returns INT for TD
+                "touchdown": True,
+                "int_td": True,
+                "type.text": "Interception Return Touchdown",
+                "text": "intercepted and returned for a touchdown.",
+                "end.pos_team.id": A,
+                "end.down": 1,
+            },
+            {
+                "pos_team": A,  # standalone Official Timeout, possession unchanged
+                "def_pos_team": B,
+                "rush": False,
+                "type.text": "Official Timeout",
+                "text": "Timeout.",
+                "scrimmage_play": False,
+            },
+            {
+                "pos_team": B,
+                "def_pos_team": A,
+                "rush": True,  # B's 2pt try -> same drive (lag-2 suppression)
+                "type.text": "Two Point Rush",
+                "scrimmage_play": False,
+                "down": 1,
+            },
+            {
+                "pos_team": A,
+                "def_pos_team": B,
+                "kickoff_play": True,
+                "rush": False,  # kickoff by A -> new drive
+                "type.text": "Kickoff",
+                "scrimmage_play": False,
+            },
+            {"pos_team": A, "def_pos_team": B, "rush": True},
+        ]
+    )
+    out = _run(df)
+    # The interleaved Official Timeout must NOT manufacture an extra drive: the
+    # 2pt try still folds into drive 1, identical to the no-timeout case.
+    assert out["fixed_drive"].to_list() == [1, 1, 1, 1, 2, 2]
+    # series tracks the drive boundaries; no spurious cascade.
+    assert out["series"].to_list() == [1, 1, 1, 1, 2, 2]
+    assert out["fixed_drive_result"].to_list()[0] == "Opp touchdown"
+
+
+def test_pat_after_defensive_td_with_two_timeouts_stays_in_same_drive():
+    """nflfastR L68-82: a PAT/2pt after a *defensive* TD is NOT a new drive even
+    when TWO standalone timeout rows (e.g. an Official Timeout then the
+    Two-minute warning) are interleaved -- the ``lag(...,3L)`` variant.  The
+    prior two rows are timeouts, the TD was 3 rows back, and that TD was
+    defensive.  The 2pt try must fold into drive 1, never incrementing the
+    drive/series across the two interleaved rows."""
+    df = _frame(
+        [
+            {"pos_team": A, "def_pos_team": B, "rush": True},  # drive 1
+            {
+                "pos_team": A,
+                "def_pos_team": B,
+                "pass": True,
+                "rush": False,  # B returns INT for TD
+                "touchdown": True,
+                "int_td": True,
+                "type.text": "Interception Return Touchdown",
+                "text": "intercepted and returned for a touchdown.",
+                "end.pos_team.id": A,
+                "end.down": 1,
+            },
+            {
+                "pos_team": A,  # 1st interleaved timeout
+                "def_pos_team": B,
+                "rush": False,
+                "type.text": "Official Timeout",
+                "text": "Timeout.",
+                "scrimmage_play": False,
+            },
+            {
+                "pos_team": A,  # 2nd interleaved timeout (two-minute warning)
+                "def_pos_team": B,
+                "rush": False,
+                "type.text": "Two-minute warning",
+                "text": "Two-minute warning.",
+                "scrimmage_play": False,
+            },
+            {
+                "pos_team": B,
+                "def_pos_team": A,
+                "rush": True,  # B's 2pt try -> same drive (lag-3 suppression)
+                "type.text": "Two Point Rush",
+                "scrimmage_play": False,
+                "down": 1,
+            },
+            {
+                "pos_team": A,
+                "def_pos_team": B,
+                "kickoff_play": True,
+                "rush": False,  # kickoff by A -> new drive
+                "type.text": "Kickoff",
+                "scrimmage_play": False,
+            },
+            {"pos_team": A, "def_pos_team": B, "rush": True},
+        ]
+    )
+    out = _run(df)
+    # Two interleaved timeout rows must still not manufacture a spurious drive.
+    assert out["fixed_drive"].to_list() == [1, 1, 1, 1, 1, 2, 2]
+    assert out["series"].to_list() == [1, 1, 1, 1, 1, 2, 2]
+    assert out["fixed_drive_result"].to_list()[0] == "Opp touchdown"
+
+
 def test_onside_kick_recovery_is_new_drive():
     """A recovered onside kick (kicking team retains) is a NEW drive
     (helper_add_fixed_drives.R L117-122).  ``own_kickoff_recovery`` is derived

--- a/tests/nfl/test_fixed_drives_series.py
+++ b/tests/nfl/test_fixed_drives_series.py
@@ -39,6 +39,7 @@ _DEFAULT = {
     "def_pos_team": B,
     "start.pos_team.id": A,
     "end.pos_team.id": A,
+    "start.def_pos_team.id": B,
     "down": 1,
     "end.down": 2,
     "start.distance": 10,
@@ -71,6 +72,7 @@ _SCHEMA = {
     "def_pos_team": pl.Int64,
     "start.pos_team.id": pl.Int64,
     "end.pos_team.id": pl.Int64,
+    "start.def_pos_team.id": pl.Int64,
     "down": pl.Int64,
     "end.down": pl.Int64,
     "start.distance": pl.Int64,
@@ -353,6 +355,55 @@ def test_onside_kick_recovery_is_new_drive():
     # flipped to the (kicking) team's defteam, so the following scrimmage play
     # by A registers as a possession change and a further new drive -- matching
     # nflfastR exactly.
+    fd = out["fixed_drive"].to_list()
+    assert fd == [1, 1, 2, 3]
+    assert fd[2] == 2  # onside recovery is its own new drive boundary
+    assert out["fixed_drive_result"].to_list()[0] == "Field goal"
+
+
+def test_onside_recovery_via_possession_change_without_fumble_flag_is_new_drive():
+    """A recovered onside kick can be represented by the END possession changing
+    to the kicking team WITHOUT a ``fumble_recovered`` flag.  ``_ff_own_kick_rec``
+    must still fire so the drive/series metadata follows the (recovering) kicking
+    team (helper_add_fixed_drives.R L15-27, L117-122).
+
+    Identical to ``test_onside_kick_recovery_is_new_drive`` except the recovery is
+    signalled purely by ``end.pos_team.id == start.def_pos_team.id`` (possession
+    change) rather than ``fumble_recovered=True``.  Before the fix the second OR
+    branch did not exist, so ``_ff_own_kick_rec`` stayed 0 and the onside row was
+    NOT promoted to a new drive (the whole sequence collapsed to ``[1, 1, 1, 1]``).
+    """
+    df = _frame(
+        [
+            {"pos_team": A, "def_pos_team": B, "rush": True},  # drive 1
+            {
+                "pos_team": A,
+                "def_pos_team": B,
+                "field_goal_result": "made",  # FG -> drive 1 ends
+                "fg_attempt": True,
+                "rush": False,
+                "type.text": "Field Goal Good",
+                "scrimmage_play": False,
+            },
+            {
+                "pos_team": A,
+                "def_pos_team": B,
+                "kickoff_play": True,
+                "rush": False,  # onside recovery by A, NO fumble_recovered flag
+                "kickoff_onside": True,
+                "fumble_recovered": False,
+                "start.def_pos_team.id": B,
+                "end.pos_team.id": B,  # END possession changed -> own-kick recovery
+                "type.text": "Kickoff",
+                "scrimmage_play": False,
+                "text": "A kicks onside, recovered by A.",
+            },
+            {"pos_team": A, "def_pos_team": B, "rush": True},  # A keeps ball
+        ]
+    )
+    out = _run(df)
+    # Same outcome as the fumble-flagged onside test: the recovery row opens a new
+    # drive and A's ensuing scrimmage play registers as a further possession change.
     fd = out["fixed_drive"].to_list()
     assert fd == [1, 1, 2, 3]
     assert fd[2] == 2  # onside recovery is its own new drive boundary

--- a/tests/nfl/test_nfl_build.py
+++ b/tests/nfl/test_nfl_build.py
@@ -219,3 +219,33 @@ def test_empty_game_ids(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_pipeline_version_is_positive_int() -> None:
     assert isinstance(PIPELINE_VERSION, int)
     assert PIPELINE_VERSION >= 1
+
+
+# ---------------------------------------------------------------------------
+# Test 11: source="nflverse" emits UserWarning and passes frame through
+# ---------------------------------------------------------------------------
+
+
+def test_nflverse_source_warns_and_passes_frame(monkeypatch: pytest.MonkeyPatch) -> None:
+    """source='nflverse' emits a UserWarning and returns the loader's frame."""
+    import sportsdataverse.nfl.nfl_build as nfl_build_mod2  # same module, different alias
+
+    fake_frame = pl.DataFrame({"season": [2024, 2024], "play_id": [1, 2]})
+
+    def fake_load_nfl_pbp(seasons: list[int], return_as_pandas: bool = False) -> pl.DataFrame:
+        return fake_frame
+
+    monkeypatch.setattr(nfl_build_mod2, "load_nfl_pbp", fake_load_nfl_pbp, raising=False)
+    # The loader is imported lazily inside the function; patch at module level
+    # by injecting into nfl_build's namespace so the lazy import resolves to our stub.
+    import sportsdataverse.nfl.nfl_loaders as nfl_loaders_mod
+
+    monkeypatch.setattr(nfl_loaders_mod, "load_nfl_pbp", fake_load_nfl_pbp)
+
+    update_config(cache_mode="off")
+
+    with pytest.warns(UserWarning, match="source='nflverse' treats game_ids as season years"):
+        result = build_nfl_season([2024], source="nflverse")
+
+    assert isinstance(result, pl.DataFrame)
+    assert result.shape == fake_frame.shape

--- a/tests/nfl/test_nfl_build.py
+++ b/tests/nfl/test_nfl_build.py
@@ -1,0 +1,221 @@
+"""Offline tests for sportsdataverse.nfl.nfl_build.
+
+All tests are network-free: they monkeypatch ``nfl_build._build_game_espn``
+so no ESPN requests are made.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Generator
+
+import polars as pl
+import pytest
+
+import sportsdataverse.nfl.nfl_build as nfl_build_mod
+from sportsdataverse.nfl import clear_cache, reset_config, update_config
+from sportsdataverse.nfl.nfl_build import PIPELINE_VERSION, build_nfl_season
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FRAME_A = pl.DataFrame({"game_id": [1, 1], "play_id": [101, 102], "yards": [5, 10]})
+_FRAME_B = pl.DataFrame({"game_id": [2, 2], "play_id": [201, 202], "epa": [0.1, -0.2]})
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache() -> Generator[None, None, None]:
+    """Reset config + clear cache before and after each test."""
+    reset_config()
+    clear_cache()
+    yield
+    reset_config()
+    clear_cache()
+
+
+# ---------------------------------------------------------------------------
+# Test 1: compile + concat with diagonal_relaxed (schema union)
+# ---------------------------------------------------------------------------
+
+
+def test_compile_concat_diagonal_relaxed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """build_nfl_season merges games with different column sets via schema union."""
+    call_map = {1: _FRAME_A, 2: _FRAME_B}
+
+    def fake_build(game_id: int) -> pl.DataFrame:
+        return call_map[game_id]
+
+    monkeypatch.setattr(nfl_build_mod, "_build_game_espn", fake_build)
+    update_config(cache_mode="off")
+
+    result = build_nfl_season([1, 2])
+
+    assert isinstance(result, pl.DataFrame)
+    assert result.shape[0] == _FRAME_A.shape[0] + _FRAME_B.shape[0]
+    # Columns must be the union of both frames
+    assert "yards" in result.columns
+    assert "epa" in result.columns
+    assert "game_id" in result.columns
+    # Missing cells are null, not erroring
+    assert result.filter(pl.col("game_id") == 1)["epa"].is_null().all()
+    assert result.filter(pl.col("game_id") == 2)["yards"].is_null().all()
+
+
+# ---------------------------------------------------------------------------
+# Test 2: cache hit skips builder (memory mode)
+# ---------------------------------------------------------------------------
+
+
+def test_cache_hit_memory_skips_builder(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Second call with cache_mode='memory' does not invoke _build_game_espn again."""
+    call_count = {"n": 0}
+
+    def counting_build(game_id: int) -> pl.DataFrame:
+        call_count["n"] += 1
+        return _FRAME_A
+
+    monkeypatch.setattr(nfl_build_mod, "_build_game_espn", counting_build)
+    update_config(cache_mode="memory", cache_duration=3600)
+
+    build_nfl_season([1])
+    assert call_count["n"] == 1, "builder should run once on first call"
+
+    build_nfl_season([1])
+    assert call_count["n"] == 1, "builder should NOT run on cache hit"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: cache hit skips builder (filesystem mode)
+# ---------------------------------------------------------------------------
+
+
+def test_cache_hit_filesystem_skips_builder(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Second call with cache_mode='filesystem' does not invoke _build_game_espn again."""
+    call_count = {"n": 0}
+
+    def counting_build(game_id: int) -> pl.DataFrame:
+        call_count["n"] += 1
+        return _FRAME_A
+
+    monkeypatch.setattr(nfl_build_mod, "_build_game_espn", counting_build)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        update_config(cache_mode="filesystem", cache_dir=Path(tmp), cache_duration=3600)
+
+        build_nfl_season([1])
+        assert call_count["n"] == 1
+
+        build_nfl_season([1])
+        assert call_count["n"] == 1, "builder should NOT run on filesystem cache hit"
+
+
+# ---------------------------------------------------------------------------
+# Test 4: PIPELINE_VERSION bump forces recompute
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_version_bump_invalidates_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Changing PIPELINE_VERSION causes a cache miss, forcing the builder to run again."""
+    call_count = {"n": 0}
+
+    def counting_build(game_id: int) -> pl.DataFrame:
+        call_count["n"] += 1
+        return _FRAME_A
+
+    monkeypatch.setattr(nfl_build_mod, "_build_game_espn", counting_build)
+    update_config(cache_mode="memory", cache_duration=3600)
+
+    # Prime the cache with the current version
+    build_nfl_season([1])
+    assert call_count["n"] == 1
+
+    # Simulate a pipeline bump by patching PIPELINE_VERSION
+    old_version = nfl_build_mod.PIPELINE_VERSION
+    monkeypatch.setattr(nfl_build_mod, "PIPELINE_VERSION", old_version + 1)
+
+    build_nfl_season([1])
+    assert call_count["n"] == 2, "bumped PIPELINE_VERSION must invalidate cache"
+
+
+# ---------------------------------------------------------------------------
+# Test 5: source="shield" raises NotImplementedError
+# ---------------------------------------------------------------------------
+
+
+def test_shield_source_raises_not_implemented() -> None:
+    with pytest.raises(NotImplementedError):
+        build_nfl_season([1], source="shield")
+
+
+# ---------------------------------------------------------------------------
+# Test 6: invalid source raises ValueError
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_source_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="Unknown source"):
+        build_nfl_season([1], source="invalid_source")
+
+
+# ---------------------------------------------------------------------------
+# Test 7: failed game is skipped, result is partial
+# ---------------------------------------------------------------------------
+
+
+def test_failed_game_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A game that raises an exception is skipped; the rest still compile."""
+
+    def flaky_build(game_id: int) -> pl.DataFrame:
+        if game_id == 999:
+            raise RuntimeError("ESPN 500")
+        return _FRAME_A
+
+    monkeypatch.setattr(nfl_build_mod, "_build_game_espn", flaky_build)
+    update_config(cache_mode="off")
+
+    with pytest.warns(UserWarning, match="skipping game_id=999"):
+        result = build_nfl_season([1, 999])
+
+    assert result.shape[0] == _FRAME_A.shape[0]
+
+
+# ---------------------------------------------------------------------------
+# Test 8: return_as_pandas=True returns a pandas DataFrame
+# ---------------------------------------------------------------------------
+
+
+def test_return_as_pandas(monkeypatch: pytest.MonkeyPatch) -> None:
+    import pandas as pd
+
+    monkeypatch.setattr(nfl_build_mod, "_build_game_espn", lambda gid: _FRAME_A)
+    update_config(cache_mode="off")
+
+    result = build_nfl_season([1], return_as_pandas=True)
+    assert isinstance(result, pd.DataFrame)
+
+
+# ---------------------------------------------------------------------------
+# Test 9: empty game_ids returns empty DataFrame
+# ---------------------------------------------------------------------------
+
+
+def test_empty_game_ids(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(nfl_build_mod, "_build_game_espn", lambda gid: _FRAME_A)
+    update_config(cache_mode="off")
+
+    result = build_nfl_season([])
+    assert isinstance(result, pl.DataFrame)
+    assert result.shape[0] == 0
+
+
+# ---------------------------------------------------------------------------
+# Test 10: PIPELINE_VERSION is a positive integer constant
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_version_is_positive_int() -> None:
+    assert isinstance(PIPELINE_VERSION, int)
+    assert PIPELINE_VERSION >= 1

--- a/tests/nfl/test_nfl_build.py
+++ b/tests/nfl/test_nfl_build.py
@@ -198,17 +198,16 @@ def test_return_as_pandas(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Test 9: empty game_ids returns empty DataFrame
+# Test 9: empty game_ids raises ValueError for espn source
 # ---------------------------------------------------------------------------
 
 
-def test_empty_game_ids(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_empty_game_ids_raises_value_error(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(nfl_build_mod, "_build_game_espn", lambda gid: _FRAME_A)
     update_config(cache_mode="off")
 
-    result = build_nfl_season([])
-    assert isinstance(result, pl.DataFrame)
-    assert result.shape[0] == 0
+    with pytest.raises(ValueError, match="non-empty list of ESPN event IDs"):
+        build_nfl_season([])
 
 
 # ---------------------------------------------------------------------------
@@ -222,30 +221,61 @@ def test_pipeline_version_is_positive_int() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Test 11: source="nflverse" emits UserWarning and passes frame through
+# Test 11: source="nflverse" passes frame through (no warning)
 # ---------------------------------------------------------------------------
 
 
-def test_nflverse_source_warns_and_passes_frame(monkeypatch: pytest.MonkeyPatch) -> None:
-    """source='nflverse' emits a UserWarning and returns the loader's frame."""
-    import sportsdataverse.nfl.nfl_build as nfl_build_mod2  # same module, different alias
-
+def test_nflverse_source_passes_frame_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    """source='nflverse' delegates to load_nfl_pbp and returns the frame without warning."""
     fake_frame = pl.DataFrame({"season": [2024, 2024], "play_id": [1, 2]})
+    received_seasons: list[list[int]] = []
 
     def fake_load_nfl_pbp(seasons: list[int], return_as_pandas: bool = False) -> pl.DataFrame:
+        received_seasons.append(seasons)
         return fake_frame
 
-    monkeypatch.setattr(nfl_build_mod2, "load_nfl_pbp", fake_load_nfl_pbp, raising=False)
-    # The loader is imported lazily inside the function; patch at module level
-    # by injecting into nfl_build's namespace so the lazy import resolves to our stub.
     import sportsdataverse.nfl.nfl_loaders as nfl_loaders_mod
 
     monkeypatch.setattr(nfl_loaders_mod, "load_nfl_pbp", fake_load_nfl_pbp)
 
     update_config(cache_mode="off")
 
-    with pytest.warns(UserWarning, match="source='nflverse' treats game_ids as season years"):
-        result = build_nfl_season([2024], source="nflverse")
+    # No warning should be emitted — the API is explicit now
+    result = build_nfl_season(seasons=[2024], source="nflverse")
 
     assert isinstance(result, pl.DataFrame)
     assert result.shape == fake_frame.shape
+    assert received_seasons == [[2024]], "load_nfl_pbp must be called with the provided seasons"
+
+
+# ---------------------------------------------------------------------------
+# Test 12: source="espn" with seasons= raises ValueError
+# ---------------------------------------------------------------------------
+
+
+def test_espn_source_rejects_seasons() -> None:
+    """source='espn' must reject seasons= kwarg with a clear ValueError."""
+    with pytest.raises(ValueError, match="source='espn' takes game_ids, not seasons"):
+        build_nfl_season(seasons=[2023], source="espn")
+
+
+# ---------------------------------------------------------------------------
+# Test 13: source="nflverse" with game_ids= raises ValueError
+# ---------------------------------------------------------------------------
+
+
+def test_nflverse_source_rejects_game_ids() -> None:
+    """source='nflverse' must reject game_ids= with a clear ValueError."""
+    with pytest.raises(ValueError, match="source='nflverse' takes seasons, not game_ids"):
+        build_nfl_season(game_ids=[401671801], source="nflverse")
+
+
+# ---------------------------------------------------------------------------
+# Test 14: source="nflverse" with neither raises ValueError
+# ---------------------------------------------------------------------------
+
+
+def test_nflverse_source_requires_seasons() -> None:
+    """source='nflverse' with neither game_ids nor seasons raises ValueError."""
+    with pytest.raises(ValueError, match="requires seasons"):
+        build_nfl_season(source="nflverse")


### PR DESCRIPTION
## Summary
ESPN-construction + efficiency + docs convergence follow-up to the shipped `lead_diff` enrich increment. Brings `NFLPlayProcess` onto the shared `ep_wp` model-application engine, adds the missing nflfastR `fixed_drive`/`series` construction, and adds a season-compile helper.

## What's in it (9 commits)
- **perf / dtype** — `tolist()`→`pl.Series(numpy)` in the EP/WP scorers + an f64-dtype-preservation fix (the perf change had silently downcast the probability / wp columns to f32).
- **docs** — `ep_wp` canonical model-application flow in `CLAUDE.md` (construction never re-adds EPA inline; scorers / derivations / `enrich_nfl_pbp`; faithful models; the parity table + WPA SNR-ceiling note).
- **de-triplication** — `NFLPlayProcess.__process_epa` / `__process_wpa` now delegate their derivation to the shared `calculate_epa` / `calculate_wpa` (−267 duplicated lines). Verified **byte-identical** 392-column output on a real game.
- **fixed_drive / series** — ported nflfastR `helper_add_fixed_drives.R` + `helper_add_series_data.R` to the ESPN path (incl. the lag-2/3 timeout-interleave suppression for PAT-after-defensive-TD). Additive; existing columns unchanged.
- **build_nfl_season** — `build_nfl_season(game_ids, *, source=...)` compile helper + per-game parquet cache (keyed `(game_id, PIPELINE_VERSION)`).

## Verification
- `tests/nfl/` — 263 passed, 37 skipped.
- Byte-identical de-triplication (proven against a real-game baseline).
- Live end-to-end: `build_nfl_season` on 3 real 2024 games → 539 rows × 397 cols, EPA/WPA/fixed_drive/series populated, per-game cache turns a 4.9s rebuild into 0.00s identical.
- Final whole-branch review: ready to merge, 0 Critical / 0 Important.

## Context
Builds on the `lead_diff` `enrich_nfl_pbp` (in `main` as part of 0.0.67) — a nflverse-native faithful port of nflfastR `helper_add_ep_wp.R`, cross-era parity-validated (EP/EPA/WP 0.99+ every era 2000–2023). The WPA parity ceiling (~0.89) is root-caused as intrinsic first-difference model-input noise — the calculation is exact (reproduces nflverse `wpa` to corr 1.0 when fed nflverse's own WP), not a derivation bug.

## Deferred (intentional, not gaps)
- `enrich_nfl_pbp(method="snapshot")` remains `NotImplementedError` — the de-triplication met the single-engine goal via delegation; the comparison was validated cross-era.
- `cp` / `cpoe` are null on the ESPN path (the ESPN feed lacks `air_yards`) — a pre-existing ESPN-source limitation, not introduced here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `build_nfl_season` function to compile NFL play-by-play data across multiple games into a single dataset with optional formats.
  * Introduced cache functions for improved data retrieval efficiency across memory and filesystem backends.

* **Bug Fixes**
  * Improved EPA/WPA calculation precision and reliability through enhanced data type handling.

* **Documentation**
  * Expanded development guide with comprehensive EPA/WPA modeling standards and best practices.

* **Tests**
  * Added extensive test coverage for season building, drive/series numbering, and data caching functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->