### PR TITLE
feat(nfl): nfl_model_pbp dataset — load_nfl_pbp(source="sdv") + air_epa self-compute fix

### DIFF
--- a/docs/docs/nfl/reference/additional.md
+++ b/docs/docs/nfl/reference/additional.md
@@ -3051,7 +3051,7 @@ participation = load_nfl_pbp_participation(seasons=[2022])
 participation = load_nfl_pbp_participation(seasons=range(2018, 2023))
 ```
 
-### `load_pbp(seasons: 'List[int]', return_as_pandas=False) -> 'pl.DataFrame'` {#load_pbp}
+### `load_pbp(seasons: 'List[int]', source: 'str' = 'nflverse', return_as_pandas=False) -> 'pl.DataFrame'` {#load_pbp}
 
 Load NFL play by play data going back to 1999
 
@@ -3060,6 +3060,7 @@ Load NFL play by play data going back to 1999
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `seasons` | `list` |  | Used to define different seasons. 1999 is the earliest available season. |
+| `source` | `str` | `'nflverse'` | Which enriched play-by-play release to read. `"nflverse"` (the default, also accepts `None`) returns the nflverse/nflfastR `play_by_play_{season}.parquet` releases — full history from 1999, unchanged behavior. `"sportsdataverse"` / `"sdv"` returns the SDV-native `nfl_model_pbp` release: a Python-built, nflfastR-faithful enriched frame (ep/epa, wp/wpa/vegas_wp, cp/cpoe, xyac_*/air_epa) that covers the published seasons (2023+) and drops administrative / timeout rows for a clean modeling subset. Any other value raises `ValueError`. |
 | `return_as_pandas` | `bool` | `False` | If True, returns a pandas dataframe. If False, returns a polars dataframe. |
 
 **Returns**
@@ -3451,6 +3452,11 @@ print(pbp.shape)
 # Multi-season range
 
 pbp = load_nfl_pbp(seasons=range(2020, 2025))
+
+# SDV-native enriched play-by-play (Python-built, nflfastR-faithful EP/WP/CP/xYAC; published seasons only; admin/timeout rows dropped)
+
+pbp_sdv = load_nfl_pbp(seasons=[2024], source="sdv")
+pbp_sdv.select(["ep", "epa", "wp", "wpa", "cp", "cpoe", "xyac_epa"]).head()
 
 # With cache off (development workflow)
 
@@ -4977,8 +4983,14 @@ regressor, xYAC is **one** `multi:softprob` model (`num_class=76`) that
 predicts a distribution over YAC buckets (`yac = -5..70`); the five output
 columns are *derived* from that distribution by re-scoring expected points on
 every outcome.  `ep` is **not** required on the input — it is recomputed on
-the outcome rows via `calculate_expected_points` — but `air_epa` and
-the play's pre-snap `ep` (`original_ep`) are read for the EPA baseline.
+the outcome rows via `calculate_expected_points`.  The play's pre-snap
+`ep` (`original_ep`) is the EPA baseline; `air_epa` is also part of the
+baseline (`xyac_epa = Σ((ep − original_ep)·prob) − air_epa`).  `air_epa`
+is **optional**: when present (the nflverse path) it is used verbatim so
+parity is byte-for-byte preserved; when absent (the Shield-native / ESPN
+path) it is computed from the already-scored `yac == 0` (catch-spot)
+outcome — `air_epa = ep(yac == 0) − original_ep` — and, since it was
+genuinely missing, surfaced as an extra `air_epa` output column.
 
 Inference filter (nflfastR `valid_pass` ∧ `distance_to_goal != 0`):
 `complete_pass == 1` OR `incomplete_pass == 1` OR `interception == 1`,
@@ -5001,13 +5013,13 @@ network) the underlying loader raises `FileNotFoundError`.
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `pbp_data` | `DataFrame` |  | nflverse-format play-by-play DataFrame. Required: `air_yards`, `season`, `half_seconds_remaining`, `yardline_100`, `ydstogo`, `down`, `posteam`, `home_team`, `roof`, `ep`, `air_epa`, `posteam_timeouts_remaining`, `defteam_timeouts_remaining`, `complete_pass`, `incomplete_pass`, `interception`, `pass_location`, `receiver_player_name`. Optional: `qb_hit`. |
+| `pbp_data` | `DataFrame` |  | nflverse-format play-by-play DataFrame. Required: `air_yards`, `season`, `half_seconds_remaining`, `yardline_100`, `ydstogo`, `down`, `posteam`, `home_team`, `roof`, `ep`, `posteam_timeouts_remaining`, `defteam_timeouts_remaining`, `complete_pass`, `incomplete_pass`, `interception`, `pass_location`, `receiver_player_name`. Optional: `air_epa` (used verbatim when present for byte-for-byte nflverse parity; computed from the `yac == 0` outcome and added as an output column when absent), `qb_hit`. |
 | `models_dir` | `Optional[Union[str, Path]]` | `None` | Optional directory to load `xyac_model.ubj` from instead of downloading/caching it (offline use or a custom-trained model). When `None` (default) the model is resolved bundled → cache → downloaded-from-release. |
 | `return_as_pandas` | `bool` | `False` | When `True`, return a `pandas.DataFrame`. |
 
 **Returns**
 
-DataFrame with the original columns plus the five nflfastR xYAC columns (`Float64`, null on non-qualifying rows): `xyac_epa`, `xyac_mean_yardage`, `xyac_median_yardage`, `xyac_success`, `xyac_fd`.
+DataFrame with the original columns plus the five nflfastR xYAC columns (`Float64`, null on non-qualifying rows): `xyac_epa`, `xyac_mean_yardage`, `xyac_median_yardage`, `xyac_success`, `xyac_fd`. When the input lacked `air_epa` and at least one qualifying pass was scored, a computed `air_epa` column (catch-spot air EPA) is also added.
 
 **Example**
 

--- a/sportsdataverse/config.py
+++ b/sportsdataverse/config.py
@@ -58,6 +58,7 @@ NFLVERSEGITHUBPBP = "https://raw.githubusercontent.com/nflverse/"
 DYNASTYPROCESSGITHUB = "https://github.com/dynastyprocess/data/raw/master/files/"
 FFOPPORTUNITYGITHUB = "https://github.com/ffverse/ffopportunity/releases/download/"
 NFL_BASE_URL = NFLVERSEGITHUB + "pbp/play_by_play_{season}.parquet"  # done
+NFL_MODEL_PBP_URL = SDVRELEASES + "nfl_model_pbp/model_pbp_{season}.parquet"
 NFL_PLAYER_URL = f"{NFLVERSEGITHUB}players/players.parquet"
 NFL_PLAYER_STATS_URL = f"{NFLVERSEGITHUB}player_stats/player_stats.parquet"
 NFL_PLAYER_KICKING_STATS_URL = f"{NFLVERSEGITHUB}player_stats/player_stats_kicking.parquet"

--- a/sportsdataverse/nfl/ep_wp.py
+++ b/sportsdataverse/nfl/ep_wp.py
@@ -1037,6 +1037,8 @@ _XYAC_MODEL_FILE: str = "xyac_model.ubj"
 def _derive_xyac(
     pass_df: pl.DataFrame,
     probs: np.ndarray,
+    *,
+    compute_air_epa: bool = False,
 ) -> pl.DataFrame:
     """Derive the 5 nflfastR xYAC columns from the 76-class outcome distribution.
 
@@ -1047,18 +1049,35 @@ def _derive_xyac(
     half clock by 6 seconds, re-scores expected points on every outcome row via
     :func:`calculate_expected_points`, and reduces back to one row per play.
 
+    The ``xyac_epa`` baseline is ``Σ((ep − original_ep)·prob) − air_epa``.  When
+    the caller supplies ``air_epa`` (the nflverse path — it carries the column
+    computed by nflfastR's ``add_air_yac_ep_variables``), that value is used
+    verbatim so the output is byte-for-byte preserved.  When ``air_epa`` is
+    absent (the Shield-native / ESPN path — see :func:`calculate_xyac`), pass
+    ``compute_air_epa=True`` to derive it from the already-scored ``yac == 0``
+    (catch-spot) outcome row: ``air_epa = ep(yac == 0) − original_ep``.  That
+    row's ``ep`` carries the same TD (``yardline_100 == 0 → 7``) and
+    turnover-on-downs (``ep → −ep``) handling as nflfastR's ``airEPA``, so the
+    derived value is faithful to the R definition.
+
     Args:
         pass_df: Qualifying (``valid_pass``) plays, one row each, carrying the
             join columns (``_xyac_index``, ``distance_to_goal``, ``original_spot``
             = pre-play ``yardline_100``, ``original_ep``, ``original_ydstogo``,
-            ``air_epa``, ``air_yards``, ``down``, ``ydstogo`` plus the EP inputs
+            ``air_yards``, ``down``, ``ydstogo`` plus the EP inputs
             ``season``/``week``/``home_team``/``posteam``/``roof``/
             ``half_seconds_remaining``/``posteam_timeouts_remaining``/
-            ``defteam_timeouts_remaining``).
+            ``defteam_timeouts_remaining``).  Must also carry ``air_epa`` unless
+            ``compute_air_epa`` is ``True``.
         probs: ``(n_plays, 76)`` float prob matrix from the multinomial model.
+        compute_air_epa: When ``True``, derive ``air_epa`` from the ``yac == 0``
+            outcome row instead of reading it from ``pass_df``.  The derived
+            value is surfaced as an extra ``air_epa`` column on the returned
+            frame so callers can fold it into the native dataset.
 
     Returns:
-        One row per play keyed on ``_xyac_index`` with the 5 ``xyac_*`` columns.
+        One row per play keyed on ``_xyac_index`` with the 5 ``xyac_*`` columns
+        (plus ``air_epa`` when ``compute_air_epa`` is ``True``).
     """
     n_plays = pass_df.height
     # yac outcome grid: -5..70 (76 buckets) repeated per play.
@@ -1176,11 +1195,20 @@ def _derive_xyac(
     )
     long = long.with_columns(
         # epa = ep - original_ep; wt_epa = epa * prob  (nflfastR)
+        (pl.col("ep") - pl.col("original_ep")).alias("_epa"),
         ((pl.col("ep") - pl.col("original_ep")) * pl.col("prob")).alias("_wt_epa"),
         (pl.col("yardline_100_noflip") * pl.col("prob")).alias("_wt_yardln"),
         ((pl.col("ep") > pl.col("original_ep")).cast(pl.Float64) * pl.col("prob")).alias("_wt_success"),
         ((pl.col("gain") >= pl.col("original_ydstogo")).cast(pl.Float64) * pl.col("prob")).alias("_wt_fd"),
     )
+    if compute_air_epa:
+        # Native path: air_epa = ep(yac == 0) - original_ep (catch-spot air EPA,
+        # faithful to nflfastR's airEPA — the yac == 0 ep already carries the TD
+        # and turnover-on-downs adjustments applied above).  Captured per play as
+        # a single non-null value so .min() over the play group recovers it.
+        long = long.with_columns(
+            pl.when(pl.col("yac") == 0).then(pl.col("_epa")).otherwise(None).alias("air_epa"),
+        )
     # median: first yac whose cumulative prob crosses 0.5
     long = long.with_columns(
         pl.col("prob").cum_sum().over("_xyac_index").alias("_cum2"),
@@ -1192,15 +1220,31 @@ def _derive_xyac(
         .alias("_med"),
     )
 
-    return long.group_by("_xyac_index").agg(
-        (pl.col("_wt_epa").sum() - pl.col("air_epa").first()).alias("xyac_epa"),
-        ((pl.col("original_spot").first() - pl.col("air_yards").first()) - pl.col("_wt_yardln").sum()).alias(
-            "xyac_mean_yardage"
-        ),
-        pl.col("_med").max().cast(pl.Float64).alias("xyac_median_yardage"),
-        pl.col("_wt_success").sum().alias("xyac_success"),
-        pl.col("_wt_fd").sum().alias("xyac_fd"),
+    # air_epa baseline: the supplied (nflverse) column, or the yac == 0 derived
+    # value when compute_air_epa is set.  ``.min()`` ignores the per-row nulls
+    # introduced for the non-(yac == 0) rows in the computed case; in the supplied
+    # case every row carries the same value so ``.first()``-equivalent semantics
+    # hold either way.
+    air_epa_expr = pl.col("air_epa").min().alias("_air_epa_base")
+    agg = (
+        long.group_by("_xyac_index")
+        .agg(
+            air_epa_expr,
+            pl.col("_wt_epa").sum().alias("_sum_wt_epa"),
+            ((pl.col("original_spot").first() - pl.col("air_yards").first()) - pl.col("_wt_yardln").sum()).alias(
+                "xyac_mean_yardage"
+            ),
+            pl.col("_med").max().cast(pl.Float64).alias("xyac_median_yardage"),
+            pl.col("_wt_success").sum().alias("xyac_success"),
+            pl.col("_wt_fd").sum().alias("xyac_fd"),
+        )
+        .with_columns(
+            (pl.col("_sum_wt_epa") - pl.col("_air_epa_base")).alias("xyac_epa"),
+        )
     )
+    if compute_air_epa:
+        agg = agg.with_columns(pl.col("_air_epa_base").alias("air_epa"))
+    return agg.drop("_sum_wt_epa", "_air_epa_base")
 
 
 def calculate_xyac(
@@ -1216,8 +1260,14 @@ def calculate_xyac(
     predicts a distribution over YAC buckets (``yac = -5..70``); the five output
     columns are *derived* from that distribution by re-scoring expected points on
     every outcome.  ``ep`` is **not** required on the input — it is recomputed on
-    the outcome rows via :func:`calculate_expected_points` — but ``air_epa`` and
-    the play's pre-snap ``ep`` (``original_ep``) are read for the EPA baseline.
+    the outcome rows via :func:`calculate_expected_points`.  The play's pre-snap
+    ``ep`` (``original_ep``) is the EPA baseline; ``air_epa`` is also part of the
+    baseline (``xyac_epa = Σ((ep − original_ep)·prob) − air_epa``).  ``air_epa``
+    is **optional**: when present (the nflverse path) it is used verbatim so
+    parity is byte-for-byte preserved; when absent (the Shield-native / ESPN
+    path) it is computed from the already-scored ``yac == 0`` (catch-spot)
+    outcome — ``air_epa = ep(yac == 0) − original_ep`` — and, since it was
+    genuinely missing, surfaced as an extra ``air_epa`` output column.
 
     Inference filter (nflfastR ``valid_pass`` ∧ ``distance_to_goal != 0``):
     ``complete_pass == 1`` OR ``incomplete_pass == 1`` OR ``interception == 1``,
@@ -1240,10 +1290,13 @@ def calculate_xyac(
         pbp_data: nflverse-format play-by-play DataFrame.  Required:
             ``air_yards``, ``season``, ``half_seconds_remaining``,
             ``yardline_100``, ``ydstogo``, ``down``, ``posteam``, ``home_team``,
-            ``roof``, ``ep``, ``air_epa``, ``posteam_timeouts_remaining``,
+            ``roof``, ``ep``, ``posteam_timeouts_remaining``,
             ``defteam_timeouts_remaining``, ``complete_pass``,
             ``incomplete_pass``, ``interception``, ``pass_location``,
-            ``receiver_player_name``.  Optional: ``qb_hit``.
+            ``receiver_player_name``.  Optional: ``air_epa`` (used verbatim when
+            present for byte-for-byte nflverse parity; computed from the
+            ``yac == 0`` outcome and added as an output column when absent),
+            ``qb_hit``.
         models_dir: Optional directory to load ``xyac_model.ubj`` from instead
             of downloading/caching it (offline use or a custom-trained model).
             When ``None`` (default) the model is resolved bundled → cache →
@@ -1254,7 +1307,9 @@ def calculate_xyac(
         DataFrame with the original columns plus the five nflfastR xYAC columns
         (``Float64``, null on non-qualifying rows):
         ``xyac_epa``, ``xyac_mean_yardage``, ``xyac_median_yardage``,
-        ``xyac_success``, ``xyac_fd``.
+        ``xyac_success``, ``xyac_fd``.  When the input lacked ``air_epa`` and at
+        least one qualifying pass was scored, a computed ``air_epa`` column
+        (catch-spot air EPA) is also added.
 
     Example:
         Quick start::
@@ -1314,26 +1369,42 @@ def calculate_xyac(
         # Only the columns the EP re-score + derivation actually read are kept
         # (``calculate_expected_points`` needs season/posteam/home_team/roof/
         # half_seconds_remaining/yardline_100/down/ydstogo/timeouts).
-        join_df = pass_df.select(
-            "_xyac_index",
-            "season",
-            "home_team",
-            "posteam",
-            "roof",
-            "half_seconds_remaining",
-            "posteam_timeouts_remaining",
-            "defteam_timeouts_remaining",
-            "air_epa",
-            "air_yards",
+        #
+        # ``air_epa`` is an EPA *input*, not a passthrough: the nflverse path
+        # carries it (computed by nflfastR's add_air_yac_ep_variables) and we use
+        # it verbatim to preserve byte-for-byte parity.  The Shield-native / ESPN
+        # path does NOT produce air_epa, so when it is absent we ask _derive_xyac
+        # to compute it from the yac == 0 outcome (catch-spot air EPA) — this is
+        # what unblocks xYAC on that path (previously a ColumnNotFoundError).
+        has_air_epa = "air_epa" in pass_df.columns
+        join_cols = [
+            pl.col("_xyac_index"),
+            pl.col("season"),
+            pl.col("home_team"),
+            pl.col("posteam"),
+            pl.col("roof"),
+            pl.col("half_seconds_remaining"),
+            pl.col("posteam_timeouts_remaining"),
+            pl.col("defteam_timeouts_remaining"),
+            pl.col("air_yards"),
             (pl.col("yardline_100") - pl.col("air_yards")).alias("distance_to_goal"),
             pl.col("yardline_100").alias("original_spot"),
             pl.col("ep").alias("original_ep"),
             pl.col("down").cast(pl.Int64),
             pl.col("ydstogo").cast(pl.Int64),
             pl.col("ydstogo").cast(pl.Int64).alias("original_ydstogo"),
-        )
+        ]
+        if has_air_epa:
+            join_cols.append(pl.col("air_epa"))
+        join_df = pass_df.select(join_cols)
 
-        xyac_frame = _derive_xyac(join_df, probs).select("_xyac_index", *_XYAC_OUT_COLS)
+        derived = _derive_xyac(join_df, probs, compute_air_epa=not has_air_epa)
+        # Surface the computed air_epa as an output column only when it was
+        # genuinely absent from the input (never overwrite nflverse's column).
+        out_cols = list(_XYAC_OUT_COLS)
+        if not has_air_epa and "air_epa" not in df.columns:
+            out_cols.append("air_epa")
+        xyac_frame = derived.select("_xyac_index", *out_cols)
     else:
         xyac_frame = empty
 
@@ -2502,11 +2573,17 @@ def enrich_nfl_pbp(
     # a RuntimeWarning rather than failing the whole enrichment.
     try:
         raw = _self.calculate_xyac(raw, models_dir=models_dir)
-    except FileNotFoundError as exc:
+    except (FileNotFoundError, pl.exceptions.ColumnNotFoundError) as exc:
         import warnings
 
+        # FileNotFoundError → xyac_model.ubj genuinely unavailable (offline,
+        # no cache).  ColumnNotFoundError is a defensive catch: calculate_xyac
+        # now derives air_epa from the yac == 0 outcome when it is absent, so a
+        # missing-column failure should no longer fire on the Shield-native
+        # path — but if some other required input column is genuinely missing
+        # we degrade gracefully rather than failing the whole enrichment.
         warnings.warn(
-            f"enrich_nfl_pbp: skipping xYAC step — model unavailable ({exc}).",
+            f"enrich_nfl_pbp: skipping xYAC step — {type(exc).__name__}: {exc}.",
             RuntimeWarning,
             stacklevel=2,
         )

--- a/sportsdataverse/nfl/nfl_loaders.py
+++ b/sportsdataverse/nfl/nfl_loaders.py
@@ -19,6 +19,7 @@ from sportsdataverse.config import (
     NFL_FF_RANKINGS_WEEK_URL,
     NFL_FTN_CHARTING_URL,
     NFL_INJURIES_URL,
+    NFL_MODEL_PBP_URL,
     NFL_NGS_PASSING_URL,
     NFL_NGS_RECEIVING_URL,
     NFL_NGS_RUSHING_URL,
@@ -48,18 +49,27 @@ from sportsdataverse.nfl.cache import cached_loader
 
 
 @cached_loader
-def load_nfl_pbp(seasons: List[int], return_as_pandas=False) -> pl.DataFrame:
+def load_nfl_pbp(seasons: List[int], source: str = "nflverse", return_as_pandas=False) -> pl.DataFrame:
     """Load NFL play by play data going back to 1999
 
     Args:
         seasons (list): Used to define different seasons. 1999 is the earliest available season.
+        source (str): Which enriched play-by-play release to read. ``"nflverse"`` (the
+            default, also accepts ``None``) returns the nflverse/nflfastR
+            ``play_by_play_{season}.parquet`` releases — full history from 1999,
+            unchanged behavior. ``"sportsdataverse"`` / ``"sdv"`` returns the
+            SDV-native ``nfl_model_pbp`` release: a Python-built, nflfastR-faithful
+            enriched frame (ep/epa, wp/wpa/vegas_wp, cp/cpoe, xyac_*/air_epa) that
+            covers the published seasons (2023+) and drops administrative / timeout
+            rows for a clean modeling subset. Any other value raises ``ValueError``.
         return_as_pandas (bool): If True, returns a pandas dataframe. If False, returns a polars dataframe.
 
     Returns:
         pl.DataFrame: Polars dataframe containing the play-by-plays available for the requested seasons.
 
     Raises:
-        ValueError: If `season` is less than 1999.
+        ValueError: If `season` is less than 1999, or `source` is not one of
+            ``"nflverse"``, ``None``, ``"sportsdataverse"``, or ``"sdv"``.
 
     Example:
         Quick start::
@@ -71,6 +81,12 @@ def load_nfl_pbp(seasons: List[int], return_as_pandas=False) -> pl.DataFrame:
         Multi-season range::
 
             pbp = load_nfl_pbp(seasons=range(2020, 2025))
+
+        SDV-native enriched play-by-play (Python-built, nflfastR-faithful
+        EP/WP/CP/xYAC; published seasons only; admin/timeout rows dropped)::
+
+            pbp_sdv = load_nfl_pbp(seasons=[2024], source="sdv")
+            pbp_sdv.select(["ep", "epa", "wp", "wpa", "cp", "cpoe", "xyac_epa"]).head()
 
         With cache off (development workflow)::
 
@@ -92,12 +108,18 @@ def load_nfl_pbp(seasons: List[int], return_as_pandas=False) -> pl.DataFrame:
         .. _nflreadpy: https://github.com/nflverse/nflreadpy
         .. _nflfastR: https://www.nflfastr.com
     """
+    if source in ("nflverse", None):
+        base_url = NFL_BASE_URL
+    elif source in ("sportsdataverse", "sdv"):
+        base_url = NFL_MODEL_PBP_URL
+    else:
+        raise ValueError(f"Invalid source {source!r}; expected one of 'nflverse', None, 'sportsdataverse', or 'sdv'.")
     data = pl.DataFrame()
     if type(seasons) is int:
         seasons = [seasons]
     for i in tqdm(seasons):
         season_not_found_error(int(i), 1999)
-        i_data = pl.read_parquet(NFL_BASE_URL.format(season=i), use_pyarrow=True, columns=None)
+        i_data = pl.read_parquet(base_url.format(season=i), use_pyarrow=True, columns=None)
         data = pl.concat([data, i_data], how="vertical")
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 

--- a/tests/nfl/test_nfl_ep_wp.py
+++ b/tests/nfl/test_nfl_ep_wp.py
@@ -999,6 +999,70 @@ class TestCalculateXyac:
 
 
 # ---------------------------------------------------------------------------
+# Public API: calculate_xyac — air_epa absent (Shield-native / ESPN) path
+# ---------------------------------------------------------------------------
+
+
+class TestCalculateXyacAirEpaAbsent:
+    """When air_epa is absent (native path), calculate_xyac computes it.
+
+    Previously this raised polars.ColumnNotFoundError because _derive_xyac read
+    pl.col("air_epa"); the fix derives air_epa from the yac == 0 outcome.
+    """
+
+    _OUT = ("xyac_epa", "xyac_mean_yardage", "xyac_median_yardage", "xyac_success", "xyac_fd")
+
+    def test_no_crash_when_air_epa_absent(self, mock_xyac_model):
+        df = _nflverse_pass_row().drop("air_epa")
+        assert "air_epa" not in df.columns
+        # Must not raise ColumnNotFoundError.
+        result = calculate_xyac(df)
+        for col in self._OUT:
+            assert col in result.columns
+
+    def test_xyac_epa_non_null_on_qualifying_pass(self, mock_xyac_model):
+        df = _nflverse_pass_row().drop("air_epa")
+        result = calculate_xyac(df)
+        assert result["xyac_epa"][0] is not None
+
+    def test_air_epa_surfaced_as_output_when_absent(self, mock_xyac_model):
+        df = _nflverse_pass_row().drop("air_epa")
+        result = calculate_xyac(df)
+        assert "air_epa" in result.columns
+        assert result["air_epa"][0] is not None
+
+    def test_air_epa_not_added_when_present(self, mock_xyac_model):
+        """Supplied air_epa is kept verbatim and not duplicated/overwritten."""
+        df = _nflverse_pass_row()  # carries air_epa = 0.5
+        result = calculate_xyac(df)
+        # Single air_epa column, value preserved exactly.
+        assert result.columns.count("air_epa") == 1
+        assert result["air_epa"][0] == pytest.approx(0.5)
+
+    def test_computed_air_epa_matches_yac0_outcome_identity(self, mock_xyac_model):
+        """xyac_epa(no air_epa) == Σ((ep-orig)·prob) - air_epa_computed.
+
+        Equivalently: feeding the computed air_epa back in as the supplied
+        column reproduces the same xyac_epa, proving the two paths share the
+        identical Σ((ep-original_ep)·prob) term and differ only by which
+        air_epa baseline is subtracted.
+        """
+        df = _nflverse_pass_row().drop("air_epa")
+        out_native = calculate_xyac(df)
+        computed_air = out_native["air_epa"][0]
+        # Supply the computed air_epa back -> xyac_epa must be byte-identical.
+        df_supplied = df.with_columns(pl.lit(computed_air).alias("air_epa"))
+        out_supplied = calculate_xyac(df_supplied)
+        assert out_supplied["xyac_epa"][0] == pytest.approx(out_native["xyac_epa"][0])
+
+    def test_air_epa_absent_with_nonpass_row(self, mock_xyac_model):
+        """Non-qualifying rows stay null; no crash without air_epa."""
+        df = _nflverse_pass_row(air_yards=None).drop("air_epa")
+        result = calculate_xyac(df)
+        assert result["xyac_epa"][0] is None
+
+
+# ---------------------------------------------------------------------------
 # Download-on-demand + cache resolution for the large xYAC model.
 #
 # These exercise ``_load_model``'s resolution order (override → bundled →

--- a/tools/codegen/endpoints/releases.yaml
+++ b/tools/codegen/endpoints/releases.yaml
@@ -841,6 +841,9 @@ loaders:
 # per-season loaders are listed; season-less / extra-param / alias loaders
 # (player_stats, nextgen_stats, pfr_advstats, teams, players, ff_*, ...) stay
 # under "Additional functions". ---
+# load_nfl_pbp also accepts source="sdv" to read the SDV-native nfl_model_pbp
+# release (Python-built, nflfastR-faithful EP/WP/CP/xYAC; published seasons only).
+# The default source="nflverse" maps to the asset below and is documented here.
 - fn: load_nfl_pbp
   league: nfl
   base: nflverse


### PR DESCRIPTION
PR2 of the NFL data-expansion program — the SDV-native enriched PBP dataset (`nfl_model_pbp`) consumer side.

The dataset is **published** at `sportsdataverse/sportsdataverse-data@nfl_model_pbp` (2023+2024 live; cron + backfill follow), built by nfl-data's `native_pbp --enrich` (Shield → `enrich_nfl_pbp`). Companion PR: nfl-data.

## Changes
- **`air_epa` self-compute fix** (`calculate_xyac`) — sdv-py's xYAC silently required `air_epa` as an *input* column (present in nflverse PBP, never produced by our own EPA derivation), so it crashed (`ColumnNotFoundError`) on any non-nflverse frame. Now computed from the 0-YAC catch-spot outcome (faithful to nflfastR's `airEPA`); the nflverse path is byte-for-byte preserved (xyac_epa parity stays 0.976), and the Shield-native path now produces real `xyac_epa`. `air_epa` is surfaced as an output column when computed. `enrich`'s xYAC guard widened to also catch the column-missing case.
- **`load_nfl_pbp(source=...)`** — `source="nflverse"` (default, unchanged → nflreadpy parity preserved), `source="sportsdataverse"|"sdv"` reads the SDV-native enriched dataset, else `ValueError`. `NFL_MODEL_PBP_URL` added to config. Docstring + runnable Example updated.

## Parity (Shield-native vs nflverse 2023)
ep 0.975, wp 0.994, cp 0.991, cpoe 0.9985, xyac_mean 0.980, xyac_epa works; native is a clean subset (drops admin/timeout rows). `air_yards` is present in Shield (92.6% on passes) so CP/xYAC are real.

## Tests
codegen `--check` clean; tests/codegen 105, tests/nfl 281; ruff clean. Full suite green locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `source` parameter to `load_nfl_pbp()` enabling selection between nflverse and SDV-native enriched play-by-play datasets.

* **Documentation**
  * Clarified `air_epa` as optional in xYAC calculations, with auto-computation when absent.
  * Updated documentation for data source selection and column requirements.

* **Tests**
  * Added comprehensive tests for xYAC calculations with optional air_epa inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->