### PR TITLE
feat(nfl): ESPN-athletes players builder (build_nfl_players) + crosswalk + load_nfl_players docs

### DIFF
--- a/docs/docs/nfl/index.md
+++ b/docs/docs/nfl/index.md
@@ -11,7 +11,7 @@ sidebar_label: NFL
 | [ESPN core API (v2)](reference/core) | 83 | `https://sports.core.api.espn.com/v2/sports` |
 | [NFL.com API](reference/nfl_api) | 11 | `https://api.nfl.com` |
 | [Dataset loaders](reference/loaders) | 8 | nflverse data releases |
-| [Additional functions](reference/additional) | 93 | hand-written wrappers, loaders & helpers |
+| [Additional functions](reference/additional) | 95 | hand-written wrappers, loaders & helpers |
 
 ## Examples
 

--- a/docs/docs/nfl/reference/additional.md
+++ b/docs/docs/nfl/reference/additional.md
@@ -2581,71 +2581,90 @@ stats_2024 = load_nfl_player_stats().filter(pl.col("season") == 2024)
 
 ### `load_nfl_players(return_as_pandas=False) -> 'pl.DataFrame'` {#load_nfl_players}
 
-Load NFL Player ID information
+Load the nflverse NFL player-identity master.
+
+Reads nflverse's published `players.parquet` — a one-row-per-player
+identity master that is the union of **seven** upstream systems (GSIS, ESPN,
+NGS roster, Pro-Football-Reference, OverTheCap, PFF, and the Sleeper / Yahoo
+cross-walk). It is the canonical source for cross-system identifier
+columns (`gsis_id`, `espn_id`, `pfr_id`, `pff_id`, `otc_id`,
+`smart_id`, `esb_id`, `nfl_id`) plus name, position, physical, draft,
+and status fields.
+
+This is the **full identity master**. For an SDV-native, public-source-only
+alternative that does not depend on the nflverse release, see
+`sportsdataverse.nfl.build_nfl_players` (ESPN-athletes tier only) and
+`sportsdataverse.nfl.nfl_players_crosswalk` (a thin ID-only slice of
+this same parquet).
 
 **Parameters**
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `return_as_pandas` | `bool` | `False` | If True, returns a pandas dataframe. If False, returns a polars dataframe. |
+| `return_as_pandas` | `bool` | `False` | If `True`, return a `pandas.DataFrame`; otherwise a `polars.DataFrame` (default). |
 
 **Returns**
 
-Polars dataframe containing players available.
+One-row-per-player identity master. `return_as_pandas` narrows the return to a `pandas.DataFrame`.
 
 | col_name | type | description |
 |---|---|---|
-| `gsis_id` | character | Game Stats and Info Service ID: the primary ID for play-by-play data. |
-| `display_name` | character | Full name of player |
-| `common_first_name` | character | Common first name of player |
-| `first_name` | character | First name of player |
-| `last_name` | character | Last name of player |
-| `short_name` | character | Player short name (i.e. "F.Last") |
-| `football_name` | character | Common player name (i.e. in most cases common_first_name last_name) |
-| `suffix` | character | Name suffix of player |
-| `esb_id` | character | Player ID for Elias Sports Bureau |
-| `nfl_id` | character | NFL ID of player (this is used in Big Data Bowl Data) |
-| `pfr_id` | character | Pro-Football-Reference ID for player |
-| `pff_id` | character | Pro Football Focus ID - usually an integer with between 3 and 6 digits. |
-| `otc_id` | character | Over the Cap ID for player |
-| `espn_id` | character | ESPN ID - usual format is an integer with ~5 digits |
-| `smart_id` | character | SMART ID for player (that's in raw pbp. It includes a hashed ESB_ID) |
-| `birth_date` | character | Player birth date (sourced from NFL. Other sources may differ) |
-| `position_group` | character | Postion group of player as listed by NFL |
-| `position` | character | Primary position as reported by NFL.com |
-| `ngs_position_group` | character | Position group of player as listed by Next Gen Stats |
-| `ngs_position` | character | Primary position as reported by the NextGen stats API. |
-| `height` | integer | Official height, in inches |
-| `weight` | integer | Official weight, in pounds |
-| `headshot` | character | NFL headshot url for player |
-| `college_name` | character | Official college (usually the last one attended) |
-| `college_conference` | character | Conference of college |
-| `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
-| `rookie_season` | integer | 4 digit number indicating which season the player was a rookie |
-| `last_season` | integer | 4 digit number indicating which season the player was active the last time |
-| `latest_team` | character | Latest team the player was listed in |
-| `status` | character | Status label. |
-| `ngs_status` | character | Next Gen Stats variant of status |
-| `ngs_status_short_description` | character | Next Gen Stats status description |
-| `years_of_experience` | integer | Years played in league |
-| `pff_position` | character | Position of player as listed by PFF |
-| `pff_status` | character | Roster status as listed by PFF |
-| `draft_year` | integer | Year that player was drafted |
-| `draft_round` | integer | Round that player was drafted in |
-| `draft_pick` | integer | Draft pick within round, i.e. 32nd pick of second round. |
-| `draft_team` | character | Team that drafted player |
+| `gsis_id` | character | NFL Game Statistics & Information System player identifier, the canonical nflverse player key. |
+| `display_name` | character | Player's full display name as published by nflverse. |
+| `common_first_name` | character | Player's commonly used first name (the name they go by, which may differ from their legal first name). |
+| `first_name` | character | Player's legal first name. |
+| `last_name` | character | Player's last name. |
+| `short_name` | character | Abbreviated name (typically first initial plus last name). |
+| `football_name` | character | Player's preferred on-field name as used in broadcast and box-score contexts. |
+| `suffix` | character | Generational or honorific name suffix (e.g., Jr., Sr., III), when present. |
+| `esb_id` | character | Elias Sports Bureau player identifier. |
+| `nfl_id` | character | NFL.com / Shield player identifier. |
+| `pfr_id` | character | Pro-Football-Reference player identifier. |
+| `pff_id` | character | Pro Football Focus player identifier. |
+| `otc_id` | character | OverTheCap player identifier (salary-cap data source). |
+| `espn_id` | character | ESPN athlete identifier. |
+| `smart_id` | character | NFL SMART (Standard Media and Reference Table) globally unique player identifier. |
+| `birth_date` | character | Player's date of birth (ISO YYYY-MM-DD). |
+| `position_group` | character | Broad positional grouping the player belongs to (e.g., QB, RB, WR, DL). |
+| `position` | character | Player's specific listed position abbreviation. |
+| `ngs_position_group` | character | Positional grouping as classified by NFL Next Gen Stats. |
+| `ngs_position` | character | Specific position as classified by NFL Next Gen Stats. |
+| `height` | integer | Player's height in inches. |
+| `weight` | integer | Player's listed weight in pounds. |
+| `headshot` | character | URL to the player's official headshot image. |
+| `college_name` | character | Name of the college the player attended. |
+| `college_conference` | character | Athletic conference of the player's college. |
+| `jersey_number` | character | Player's uniform / jersey number. |
+| `rookie_season` | integer | Season (year) the player entered the league as a rookie. |
+| `last_season` | integer | Most recent season (year) the player appeared on an NFL roster. |
+| `latest_team` | character | Abbreviation of the most recent team the player was rostered on. |
+| `status` | character | Player's current roster status (e.g., active, retired, free agent). |
+| `ngs_status` | character | Player status as reported by NFL Next Gen Stats. |
+| `ngs_status_short_description` | character | Short human-readable description of the NFL Next Gen Stats status. |
+| `years_of_experience` | integer | Number of accrued NFL seasons of experience. |
+| `pff_position` | character | Player's position as classified by Pro Football Focus. |
+| `pff_status` | character | Player's status as classified by Pro Football Focus. |
+| `draft_year` | integer | Year the player was selected in the NFL Draft (null if undrafted). |
+| `draft_round` | integer | Round in which the player was drafted (null if undrafted). |
+| `draft_pick` | integer | Overall pick number at which the player was drafted (null if undrafted). |
+| `draft_team` | character | Abbreviation of the team that drafted the player (null if undrafted). |
 
 **Example**
 
 ```python
 from sportsdataverse.nfl import load_nfl_players
 players = load_nfl_players()
-players.shape
+print(players.shape)
 
 # Pandas round-trip
 
 players_pd = load_nfl_players(return_as_pandas=True)
 players_pd.head()
+
+# Pipeline next step (one line)
+
+import polars as pl
+load_nfl_players().select(["gsis_id", "display_name", "position"]).head()
 ```
 
 ### `load_nfl_schedule(seasons: 'List[int]', return_as_pandas=False) -> 'pl.DataFrame'` {#load_nfl_schedule}
@@ -3641,71 +3660,90 @@ stats_2024 = load_nfl_player_stats().filter(pl.col("season") == 2024)
 
 ### `load_players(return_as_pandas=False) -> 'pl.DataFrame'` {#load_players}
 
-Load NFL Player ID information
+Load the nflverse NFL player-identity master.
+
+Reads nflverse's published `players.parquet` — a one-row-per-player
+identity master that is the union of **seven** upstream systems (GSIS, ESPN,
+NGS roster, Pro-Football-Reference, OverTheCap, PFF, and the Sleeper / Yahoo
+cross-walk). It is the canonical source for cross-system identifier
+columns (`gsis_id`, `espn_id`, `pfr_id`, `pff_id`, `otc_id`,
+`smart_id`, `esb_id`, `nfl_id`) plus name, position, physical, draft,
+and status fields.
+
+This is the **full identity master**. For an SDV-native, public-source-only
+alternative that does not depend on the nflverse release, see
+`sportsdataverse.nfl.build_nfl_players` (ESPN-athletes tier only) and
+`sportsdataverse.nfl.nfl_players_crosswalk` (a thin ID-only slice of
+this same parquet).
 
 **Parameters**
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `return_as_pandas` | `bool` | `False` | If True, returns a pandas dataframe. If False, returns a polars dataframe. |
+| `return_as_pandas` | `bool` | `False` | If `True`, return a `pandas.DataFrame`; otherwise a `polars.DataFrame` (default). |
 
 **Returns**
 
-Polars dataframe containing players available.
+One-row-per-player identity master. `return_as_pandas` narrows the return to a `pandas.DataFrame`.
 
 | col_name | type | description |
 |---|---|---|
-| `gsis_id` | character | Game Stats and Info Service ID: the primary ID for play-by-play data. |
-| `display_name` | character | Full name of player |
-| `common_first_name` | character | Common first name of player |
-| `first_name` | character | First name of player |
-| `last_name` | character | Last name of player |
-| `short_name` | character | Player short name (i.e. "F.Last") |
-| `football_name` | character | Common player name (i.e. in most cases common_first_name last_name) |
-| `suffix` | character | Name suffix of player |
-| `esb_id` | character | Player ID for Elias Sports Bureau |
-| `nfl_id` | character | NFL ID of player (this is used in Big Data Bowl Data) |
-| `pfr_id` | character | Pro-Football-Reference ID for player |
-| `pff_id` | character | Pro Football Focus ID - usually an integer with between 3 and 6 digits. |
-| `otc_id` | character | Over the Cap ID for player |
-| `espn_id` | character | ESPN ID - usual format is an integer with ~5 digits |
-| `smart_id` | character | SMART ID for player (that's in raw pbp. It includes a hashed ESB_ID) |
-| `birth_date` | character | Player birth date (sourced from NFL. Other sources may differ) |
-| `position_group` | character | Postion group of player as listed by NFL |
-| `position` | character | Primary position as reported by NFL.com |
-| `ngs_position_group` | character | Position group of player as listed by Next Gen Stats |
-| `ngs_position` | character | Primary position as reported by the NextGen stats API. |
-| `height` | integer | Official height, in inches |
-| `weight` | integer | Official weight, in pounds |
-| `headshot` | character | NFL headshot url for player |
-| `college_name` | character | Official college (usually the last one attended) |
-| `college_conference` | character | Conference of college |
-| `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
-| `rookie_season` | integer | 4 digit number indicating which season the player was a rookie |
-| `last_season` | integer | 4 digit number indicating which season the player was active the last time |
-| `latest_team` | character | Latest team the player was listed in |
-| `status` | character | Status label. |
-| `ngs_status` | character | Next Gen Stats variant of status |
-| `ngs_status_short_description` | character | Next Gen Stats status description |
-| `years_of_experience` | integer | Years played in league |
-| `pff_position` | character | Position of player as listed by PFF |
-| `pff_status` | character | Roster status as listed by PFF |
-| `draft_year` | integer | Year that player was drafted |
-| `draft_round` | integer | Round that player was drafted in |
-| `draft_pick` | integer | Draft pick within round, i.e. 32nd pick of second round. |
-| `draft_team` | character | Team that drafted player |
+| `gsis_id` | character | NFL Game Statistics & Information System player identifier, the canonical nflverse player key. |
+| `display_name` | character | Player's full display name as published by nflverse. |
+| `common_first_name` | character | Player's commonly used first name (the name they go by, which may differ from their legal first name). |
+| `first_name` | character | Player's legal first name. |
+| `last_name` | character | Player's last name. |
+| `short_name` | character | Abbreviated name (typically first initial plus last name). |
+| `football_name` | character | Player's preferred on-field name as used in broadcast and box-score contexts. |
+| `suffix` | character | Generational or honorific name suffix (e.g., Jr., Sr., III), when present. |
+| `esb_id` | character | Elias Sports Bureau player identifier. |
+| `nfl_id` | character | NFL.com / Shield player identifier. |
+| `pfr_id` | character | Pro-Football-Reference player identifier. |
+| `pff_id` | character | Pro Football Focus player identifier. |
+| `otc_id` | character | OverTheCap player identifier (salary-cap data source). |
+| `espn_id` | character | ESPN athlete identifier. |
+| `smart_id` | character | NFL SMART (Standard Media and Reference Table) globally unique player identifier. |
+| `birth_date` | character | Player's date of birth (ISO YYYY-MM-DD). |
+| `position_group` | character | Broad positional grouping the player belongs to (e.g., QB, RB, WR, DL). |
+| `position` | character | Player's specific listed position abbreviation. |
+| `ngs_position_group` | character | Positional grouping as classified by NFL Next Gen Stats. |
+| `ngs_position` | character | Specific position as classified by NFL Next Gen Stats. |
+| `height` | integer | Player's height in inches. |
+| `weight` | integer | Player's listed weight in pounds. |
+| `headshot` | character | URL to the player's official headshot image. |
+| `college_name` | character | Name of the college the player attended. |
+| `college_conference` | character | Athletic conference of the player's college. |
+| `jersey_number` | character | Player's uniform / jersey number. |
+| `rookie_season` | integer | Season (year) the player entered the league as a rookie. |
+| `last_season` | integer | Most recent season (year) the player appeared on an NFL roster. |
+| `latest_team` | character | Abbreviation of the most recent team the player was rostered on. |
+| `status` | character | Player's current roster status (e.g., active, retired, free agent). |
+| `ngs_status` | character | Player status as reported by NFL Next Gen Stats. |
+| `ngs_status_short_description` | character | Short human-readable description of the NFL Next Gen Stats status. |
+| `years_of_experience` | integer | Number of accrued NFL seasons of experience. |
+| `pff_position` | character | Player's position as classified by Pro Football Focus. |
+| `pff_status` | character | Player's status as classified by Pro Football Focus. |
+| `draft_year` | integer | Year the player was selected in the NFL Draft (null if undrafted). |
+| `draft_round` | integer | Round in which the player was drafted (null if undrafted). |
+| `draft_pick` | integer | Overall pick number at which the player was drafted (null if undrafted). |
+| `draft_team` | character | Abbreviation of the team that drafted the player (null if undrafted). |
 
 **Example**
 
 ```python
 from sportsdataverse.nfl import load_nfl_players
 players = load_nfl_players()
-players.shape
+print(players.shape)
 
 # Pandas round-trip
 
 players_pd = load_nfl_players(return_as_pandas=True)
 players_pd.head()
+
+# Pipeline next step (one line)
+
+import polars as pl
+load_nfl_players().select(["gsis_id", "display_name", "position"]).head()
 ```
 
 ### `load_rosters(seasons: 'List[int]', return_as_pandas=False) -> 'pl.DataFrame'` {#load_rosters}
@@ -4654,6 +4692,54 @@ cfg.timeout         # 30 (seconds)
 
 from sportsdataverse.nfl import NflConfig
 cfg = NflConfig(cache_mode="off", timeout=10)
+```
+
+### `build_nfl_players(*, return_as_pandas: 'bool' = False) -> "Union[pl.DataFrame, 'pd.DataFrame']"` {#build_nfl_players}
+
+Build an SDV-native NFL players frame from ESPN's public athletes endpoint.
+
+Walks ESPN's public NFL athletes index
+(`sports.core.api.espn.com/v2/sports/football/leagues/nfl/athletes`),
+resolves each athlete's detail resource, flattens it onto the SDV-native
+players schema, **dedups to the highest numeric `espn_id` per
+`(full_name, birth_date)`** (the ESPN ~2007 4-digit -> 7-digit id
+migration left some players with two ids), and enriches `gsis_id` +
+other cross-IDs by a best-effort join against
+`sportsdataverse.nfl.load_nfl_players`.
+
+This is the **public ESPN-athletes tier only** — a partial mirror of
+nflverse's full seven-source `players.parquet` (three of those sources,
+PFR / OTC / PFF, require private credentials). ESPN-native rows with no
+nflverse match keep only their ESPN fields (cross-IDs left null). For the
+full identity master prefer `sportsdataverse.nfl.load_nfl_players`;
+use `build_nfl_players` when you need an SDV-native frame that depends
+only on the live public ESPN API.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `return_as_pandas` | `bool` | `False` | If `True`, return a `pandas.DataFrame`; otherwise a `polars.DataFrame` (default). |
+
+**Returns**
+
+A one-row-per-player `DataFrame` with the documented schema (`espn_id`, `full_name`, `first_name`, `last_name`, `position`, `team`, `jersey`, `height`, `weight`, `birth_date`, `status`, `headshot_url`, `gsis_id`, `esb_id`, `pfr_id`, `pff_id`, `smart_id`, `college`). An empty / failed fetch yields a zero-row frame carrying the same column set (never a raise).
+
+**Example**
+
+```python
+from sportsdataverse.nfl import build_nfl_players
+players = build_nfl_players()
+print(players.shape)
+
+# Pandas output
+
+df = build_nfl_players(return_as_pandas=True)
+
+# Pipeline next step (one line)
+
+import polars as pl
+build_nfl_players().filter(pl.col("position") == "QB").head()
 ```
 
 ### `build_nfl_rosters(seasons: 'List[int]', *, return_as_pandas: 'bool' = False) -> "Union[pl.DataFrame, 'pd.DataFrame']"` {#build_nfl_rosters}
@@ -6196,6 +6282,39 @@ A polars (or pandas) `DataFrame` stacking every leader list, with a `category` c
 from sportsdataverse.nfl import nfl_ngs_statboard_leaders
 bd = nfl_ngs_statboard_leaders(season=2024, season_type="REG")
 bd["category"].unique().to_list()
+```
+
+### `nfl_players_crosswalk(*, return_as_pandas: 'bool' = False) -> "Union[pl.DataFrame, 'pd.DataFrame']"` {#nfl_players_crosswalk}
+
+Pure-consumer ID crosswalk sliced from `load_nfl_players`.
+
+Reads nflverse's published players master and projects it down to just the
+cross-system identifier columns it carries (`gsis_id`, `esb_id`,
+`espn_id`, `pfr_id`, `pff_id`, `otc_id`, `nfl_id`, `smart_id` —
+whichever the parquet exposes) plus `full_name` and `position`, deduped
+on `gsis_id`. It is a convenience for joining nflverse identity IDs onto
+PBP / rosters / stats frames without carrying the full ~40-column master.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `return_as_pandas` | `bool` | `False` | If `True`, return a `pandas.DataFrame`; otherwise a `polars.DataFrame` (default). |
+
+**Returns**
+
+A one-row-per-`gsis_id` `DataFrame` of cross-system IDs + `full_name` / `position`. A failed / empty players load yields a zero-row frame carrying the same column set (never a raise).
+
+**Example**
+
+```python
+from sportsdataverse.nfl import nfl_players_crosswalk
+xwalk = nfl_players_crosswalk()
+print(xwalk.columns)
+
+# Join nflverse IDs onto a PBP frame (one line)
+
+pbp.join(nfl_players_crosswalk(), left_on="passer_player_id", right_on="gsis_id", how="left")
 ```
 
 ### `nfl_token_gen(client_key: 'Optional[str]' = None, client_secret: 'Optional[str]' = None, force_refresh: 'bool' = False) -> 'str'` {#nfl_token_gen}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -284,6 +284,7 @@ files = [
     "sportsdataverse/nfl/config.py",
     "sportsdataverse/nfl/model_vars.py",
     "sportsdataverse/nfl/nfl_build.py",
+    "sportsdataverse/nfl/nfl_players.py",
     "sportsdataverse/nfl/nfl_roster_builder.py",
     "sportsdataverse/nfl/utils_date.py",
     "sportsdataverse/mlb/mlb_statcast_runtime.py",

--- a/sportsdataverse/nfl/__init__.py
+++ b/sportsdataverse/nfl/__init__.py
@@ -102,4 +102,5 @@ from sportsdataverse.nfl.utils_date import *
 from sportsdataverse.nfl.utils_date import get_current_nfl_season as get_current_season
 from sportsdataverse.nfl.utils_date import get_current_nfl_week as get_current_week
 from sportsdataverse.nfl.nfl_build import build_nfl_season
+from sportsdataverse.nfl.nfl_players import build_nfl_players, nfl_players_crosswalk
 from sportsdataverse.nfl.nfl_roster_builder import build_nfl_rosters

--- a/sportsdataverse/nfl/nfl_loaders.py
+++ b/sportsdataverse/nfl/nfl_loaders.py
@@ -867,29 +867,54 @@ def load_nfl_teams(return_as_pandas=False) -> pl.DataFrame:
 
 @cached_loader
 def load_nfl_players(return_as_pandas=False) -> pl.DataFrame:
-    """Load NFL Player ID information
+    """Load the nflverse NFL player-identity master.
+
+    Reads nflverse's published ``players.parquet`` — a one-row-per-player
+    identity master that is the union of **seven** upstream systems (GSIS, ESPN,
+    NGS roster, Pro-Football-Reference, OverTheCap, PFF, and the Sleeper / Yahoo
+    cross-walk). It is the canonical source for cross-system identifier
+    columns (``gsis_id``, ``espn_id``, ``pfr_id``, ``pff_id``, ``otc_id``,
+    ``smart_id``, ``esb_id``, ``nfl_id``) plus name, position, physical, draft,
+    and status fields.
+
+    This is the **full identity master**. For an SDV-native, public-source-only
+    alternative that does not depend on the nflverse release, see
+    :func:`sportsdataverse.nfl.build_nfl_players` (ESPN-athletes tier only) and
+    :func:`sportsdataverse.nfl.nfl_players_crosswalk` (a thin ID-only slice of
+    this same parquet).
 
     Args:
-        return_as_pandas (bool): If True, returns a pandas dataframe. If False, returns a polars dataframe.
+        return_as_pandas (bool): If ``True``, return a ``pandas.DataFrame``;
+            otherwise a ``polars.DataFrame`` (default).
 
     Returns:
-        pl.DataFrame: Polars dataframe containing players available.
+        pl.DataFrame: One-row-per-player identity master. ``return_as_pandas``
+        narrows the return to a ``pandas.DataFrame``.
+
+    Raises:
+        Exception: Propagates any network / parquet-read error from the
+            underlying ``pl.read_parquet`` against the nflverse release URL.
 
     Example:
         Quick start::
 
             from sportsdataverse.nfl import load_nfl_players
             players = load_nfl_players()
-            players.shape
+            print(players.shape)
 
         Pandas round-trip::
 
             players_pd = load_nfl_players(return_as_pandas=True)
             players_pd.head()
 
+        Pipeline next step (one line)::
+
+            import polars as pl
+            load_nfl_players().select(["gsis_id", "display_name", "position"]).head()
+
         See Also:
             * `nflverse`_ -- full data ecosystem (R + Python)
-            * `nflreadpy`_ -- direct nflverse Python bindings
+            * `nflreadpy`_ -- direct nflverse Python bindings (load_players)
 
         .. _nflverse: https://nflverse.nflverse.com
         .. _nflreadpy: https://github.com/nflverse/nflreadpy

--- a/sportsdataverse/nfl/nfl_players.py
+++ b/sportsdataverse/nfl/nfl_players.py
@@ -1,0 +1,432 @@
+"""SDV-native NFL players builder (public ESPN-athletes tier only) + crosswalk.
+
+This module is the *self-sufficient* half of sdv-py's player-identity story. It
+pairs an SDV-native **builder** (reached only through public ESPN endpoints) with
+a pure-**consumer** crosswalk over nflverse's published players master:
+
+* :func:`sportsdataverse.nfl.load_nfl_players` reads nflverse's **published**
+  ``players.parquet`` — the union of **seven** upstream identity systems (GSIS,
+  ESPN, NGS roster, PFR, OTC, PFF, Sleeper/Yahoo cross-walk). Three of those
+  (PFR, OTC, PFF) require **private credentials** sdv-py does not hold, so that
+  parquet is the only place the full seven-source master is available. Prefer it
+  as the **identity master** whenever a round trip to nflverse is acceptable.
+* :func:`build_nfl_players` rebuilds a players frame from **only the public
+  ESPN NFL athletes endpoint** (``sports.core.api.espn.com/.../athletes``), which
+  sdv-py can reach without credentials. It is therefore a *partial* mirror: it
+  carries the dense ESPN-native identity fields (``espn_id``, name, position,
+  jersey, height, weight, ``birth_date``, ``status``, ``headshot_url``) and a
+  best-effort ``gsis_id`` (+ other cross-IDs) enriched from
+  :func:`load_nfl_players`. ESPN-native rows with no nflverse match keep only
+  their ESPN fields. Use it for **SDV-native self-sufficiency** (no nflverse
+  release dependency).
+* :func:`nfl_players_crosswalk` is a pure consumer of
+  :func:`load_nfl_players` — it slices the published parquet down to just the
+  ID-crosswalk columns (``gsis_id``, ``espn_id``, ``pfr_id``, …) plus
+  ``full_name`` / ``position``, deduped on ``gsis_id``, as a convenience for
+  joining nflverse IDs onto PBP / rosters / stats frames.
+
+ESPN-ID dedup (critical): ESPN migrated ~4-digit -> ~7-digit athlete ids around
+2007, so a handful of players carry two ESPN ids. :func:`build_nfl_players`
+replicates nflverse's rule and keeps the **highest numeric ``espn_id`` per
+``(full_name, birth_date)``** so downstream joins never duplicate.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Dict, List, Optional, Union, overload
+
+import polars as pl
+
+from sportsdataverse.dl_utils import download
+
+if TYPE_CHECKING:  # pragma: no cover -- annotation-only import (PEP 563 defers eval)
+    import pandas as pd
+
+__all__ = ["build_nfl_players", "nfl_players_crosswalk"]
+
+# ESPN public NFL athletes listing (paginated ``$ref`` index) + per-athlete detail.
+_ATHLETES_URL = "https://sports.core.api.espn.com/v2/sports/football/leagues/nfl/athletes"
+_PAGE_LIMIT = 1000
+
+# ---------------------------------------------------------------------------
+# SDV-native players schema. ESPN supplies the identity + physical fields
+# densely; the cross-system IDs are best-effort enrichments joined from
+# load_nfl_players() on (full_name, birth_date). Columns ESPN does not supply
+# are still emitted (null / enriched) so the frame carries a stable, documented
+# column set even when a fetch is empty.
+# ---------------------------------------------------------------------------
+_SCHEMA: Dict[str, pl.DataType] = {
+    "espn_id": pl.Utf8,
+    "full_name": pl.Utf8,
+    "first_name": pl.Utf8,
+    "last_name": pl.Utf8,
+    "position": pl.Utf8,
+    "team": pl.Utf8,
+    "jersey": pl.Utf8,
+    "height": pl.Float64,
+    "weight": pl.Float64,
+    "birth_date": pl.Utf8,
+    "status": pl.Utf8,
+    "headshot_url": pl.Utf8,
+    "gsis_id": pl.Utf8,
+    "esb_id": pl.Utf8,
+    "pfr_id": pl.Utf8,
+    "pff_id": pl.Utf8,
+    "smart_id": pl.Utf8,
+    "college": pl.Utf8,
+}
+
+# Cross-system ID + enrichment columns sourced from load_nfl_players() (joined
+# on espn_id first, then a name+dob fallback). ESPN itself supplies none of
+# these; left-null when unmatched. {target_col: players_table_col}.
+_PLAYER_ENRICH: Dict[str, str] = {
+    "gsis_id": "gsis_id",
+    "esb_id": "esb_id",
+    "pfr_id": "pfr_id",
+    "pff_id": "pff_id",
+    "smart_id": "smart_id",
+    "college": "college_name",
+}
+
+
+def _empty_frame(return_as_pandas: bool) -> Union[pl.DataFrame, "pd.DataFrame"]:
+    """Zero-row frame carrying the full documented schema (never raises)."""
+    frame = pl.DataFrame(schema=_SCHEMA)
+    return frame.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else frame
+
+
+def _athlete_row(athlete: Dict) -> Optional[Dict]:
+    """Map one ESPN athlete-detail payload onto the SDV-native players schema.
+
+    Cross-system IDs (``gsis_id`` etc.) are left ``None`` here; they are filled
+    by the :func:`load_nfl_players` enrichment join. Returns ``None`` for a
+    payload with no usable ``id`` so the caller can skip it.
+    """
+    espn_id = athlete.get("id")
+    if espn_id is None:
+        return None
+    position = athlete.get("position") or {}
+    status = athlete.get("status") or {}
+    headshot = athlete.get("headshot") or {}
+    return {
+        "espn_id": str(espn_id),
+        "full_name": athlete.get("fullName") or athlete.get("displayName"),
+        "first_name": athlete.get("firstName"),
+        "last_name": athlete.get("lastName"),
+        "position": position.get("abbreviation") if isinstance(position, dict) else None,
+        # The ESPN core-v2 athlete detail exposes ``team`` only as a ``$ref`` URL;
+        # the team abbreviation is not inlined, so ``team`` is left null here
+        # (best-effort field — populate via a roster join if needed).
+        "team": None,
+        "jersey": athlete.get("jersey"),
+        "height": athlete.get("height"),
+        "weight": athlete.get("weight"),
+        "birth_date": athlete.get("dateOfBirth"),
+        "status": status.get("name") if isinstance(status, dict) else (status or None),
+        "headshot_url": headshot.get("href") if isinstance(headshot, dict) else None,
+        "gsis_id": None,
+        "esb_id": None,
+        "pfr_id": None,
+        "pff_id": None,
+        "smart_id": None,
+        "college": None,
+    }
+
+
+def _fetch_athletes(limit: Optional[int] = None) -> List[Dict]:
+    """Fetch ESPN's public NFL athletes and return a list of detail payloads.
+
+    Walks the paginated ``$ref`` index at :data:`_ATHLETES_URL`, then resolves
+    each athlete's detail resource (one round trip per athlete). ``limit`` caps
+    the number of athletes resolved (``None`` = all). All HTTP goes through the
+    package gateway :func:`sportsdataverse.dl_utils.download`; a failed page /
+    athlete is skipped rather than raising, so a partial/empty fetch degrades to
+    a smaller (or zero-row) frame.
+    """
+    refs: List[str] = []
+    page = 1
+    while True:
+        resp = download(url=_ATHLETES_URL, params={"limit": _PAGE_LIMIT, "page": page, "active": "true"})
+        payload = {}
+        if resp is not None:
+            try:
+                payload = resp.json()
+            except Exception:  # noqa: BLE001 -- malformed page degrades to empty
+                payload = {}
+        items = payload.get("items") or []
+        for item in items:
+            ref = item.get("$ref") if isinstance(item, dict) else None
+            if ref:
+                refs.append(ref)
+                if limit is not None and len(refs) >= limit:
+                    break
+        page_count = payload.get("pageCount") or 0
+        if (limit is not None and len(refs) >= limit) or page >= page_count or not items:
+            break
+        page += 1
+
+    athletes: List[Dict] = []
+    for ref in refs:
+        resp = download(url=ref)
+        if resp is None:
+            continue
+        try:
+            detail = resp.json()
+        except Exception:  # noqa: BLE001 -- malformed athlete degrades to skip
+            continue
+        if isinstance(detail, dict):
+            athletes.append(detail)
+    return athletes
+
+
+def _dedup_espn_id(frame: pl.DataFrame) -> pl.DataFrame:
+    """Keep the HIGHEST numeric ``espn_id`` per ``(full_name, birth_date)``.
+
+    Replicates nflverse's ESPN-id reconciliation: ESPN's ~2007 migration from
+    ~4-digit to ~7-digit athlete ids left some players with two ``espn_id``
+    rows. Sorting by the numeric id descending and keeping the first row per
+    ``(full_name, birth_date)`` selects the modern (higher) id so downstream
+    joins never duplicate.
+    """
+    if frame.is_empty():
+        return frame
+    return (
+        frame.with_columns(pl.col("espn_id").cast(pl.Int64, strict=False).alias("_espn_id_num"))
+        .sort("_espn_id_num", descending=True, nulls_last=True)
+        .unique(subset=["full_name", "birth_date"], keep="first", maintain_order=True)
+        .drop("_espn_id_num")
+    )
+
+
+def _enrich_cross_ids(frame: pl.DataFrame) -> pl.DataFrame:
+    """Left-join :func:`load_nfl_players` cross-system IDs + college.
+
+    Best-effort: a failed players load (or a players frame missing the join
+    keys) leaves the enrichment columns untouched (ESPN-native / null). The
+    join only *fills* columns ESPN left null — it never overwrites an
+    ESPN-supplied value. Matching is by ``espn_id`` first, then a
+    ``(full_name, birth_date)`` fallback for rows the espn_id join missed.
+    """
+    from sportsdataverse.nfl.nfl_loaders import load_nfl_players
+
+    try:
+        players = load_nfl_players()
+    except Exception:  # noqa: BLE001 -- enrichment is strictly best-effort
+        return frame
+    if players.is_empty():
+        return frame
+
+    have = [src for src in set(_PLAYER_ENRICH.values()) if src in players.columns]
+    if not have:
+        return frame
+
+    # Normalise the players-table birth_date to a bare YYYY-MM-DD string so the
+    # name+dob fallback lines up with ESPN's ``dateOfBirth`` (also normalised).
+    name_col = "display_name" if "display_name" in players.columns else None
+
+    def _norm_dob(col: str) -> pl.Expr:
+        return pl.col(col).cast(pl.Utf8).str.slice(0, 10)
+
+    frame = frame.with_columns(_norm_dob("birth_date").alias("_dob"))
+
+    # --- Pass 1: join on espn_id (dense + unambiguous when present). ---
+    if "espn_id" in players.columns:
+        p1 = players.select(["espn_id", *have]).filter(pl.col("espn_id").is_not_null())
+        p1 = p1.with_columns(pl.col("espn_id").cast(pl.Utf8)).unique(subset=["espn_id"], keep="first")
+        p1 = p1.rename({src: f"_p1_{src}" for src in have})
+        frame = frame.join(p1, on="espn_id", how="left")
+    else:
+        for src in have:
+            frame = frame.with_columns(pl.lit(None, dtype=pl.Utf8).alias(f"_p1_{src}"))
+
+    # --- Pass 2: name+dob fallback for rows pass 1 missed. ---
+    if name_col is not None and "birth_date" in players.columns:
+        p2 = players.select([name_col, "birth_date", *have])
+        p2 = p2.with_columns(_norm_dob("birth_date").alias("_dob")).drop("birth_date")
+        p2 = p2.rename({name_col: "full_name"})
+        p2 = p2.unique(subset=["full_name", "_dob"], keep="first")
+        p2 = p2.rename({src: f"_p2_{src}" for src in have})
+        frame = frame.join(p2, on=["full_name", "_dob"], how="left")
+    else:
+        for src in have:
+            frame = frame.with_columns(pl.lit(None, dtype=pl.Utf8).alias(f"_p2_{src}"))
+
+    fills = []
+    for target, src in _PLAYER_ENRICH.items():
+        p1c, p2c = f"_p1_{src}", f"_p2_{src}"
+        if p1c in frame.columns or p2c in frame.columns:
+            parts = [pl.col(target)]
+            if p1c in frame.columns:
+                parts.append(pl.col(p1c).cast(pl.Utf8))
+            if p2c in frame.columns:
+                parts.append(pl.col(p2c).cast(pl.Utf8))
+            fills.append(pl.coalesce(parts).alias(target))
+    if fills:
+        frame = frame.with_columns(fills)
+    drop = [c for c in frame.columns if c.startswith("_p1_") or c.startswith("_p2_") or c == "_dob"]
+    return frame.drop(drop)
+
+
+@overload
+def build_nfl_players() -> pl.DataFrame: ...
+@overload
+def build_nfl_players(*, return_as_pandas: bool = ...) -> Union[pl.DataFrame, "pd.DataFrame"]: ...
+
+
+def build_nfl_players(
+    *,
+    return_as_pandas: bool = False,
+) -> Union[pl.DataFrame, "pd.DataFrame"]:
+    """Build an SDV-native NFL players frame from ESPN's public athletes endpoint.
+
+    Walks ESPN's public NFL athletes index
+    (``sports.core.api.espn.com/v2/sports/football/leagues/nfl/athletes``),
+    resolves each athlete's detail resource, flattens it onto the SDV-native
+    players schema, **dedups to the highest numeric ``espn_id`` per
+    ``(full_name, birth_date)``** (the ESPN ~2007 4-digit -> 7-digit id
+    migration left some players with two ids), and enriches ``gsis_id`` +
+    other cross-IDs by a best-effort join against
+    :func:`sportsdataverse.nfl.load_nfl_players`.
+
+    This is the **public ESPN-athletes tier only** — a partial mirror of
+    nflverse's full seven-source ``players.parquet`` (three of those sources,
+    PFR / OTC / PFF, require private credentials). ESPN-native rows with no
+    nflverse match keep only their ESPN fields (cross-IDs left null). For the
+    full identity master prefer :func:`sportsdataverse.nfl.load_nfl_players`;
+    use :func:`build_nfl_players` when you need an SDV-native frame that depends
+    only on the live public ESPN API.
+
+    Args:
+        return_as_pandas: If ``True``, return a ``pandas.DataFrame``; otherwise a
+            ``polars.DataFrame`` (default).
+
+    Returns:
+        A one-row-per-player ``DataFrame`` with the documented schema
+        (``espn_id``, ``full_name``, ``first_name``, ``last_name``,
+        ``position``, ``team``, ``jersey``, ``height``, ``weight``,
+        ``birth_date``, ``status``, ``headshot_url``, ``gsis_id``, ``esb_id``,
+        ``pfr_id``, ``pff_id``, ``smart_id``, ``college``). An empty / failed
+        fetch yields a zero-row frame carrying the same column set (never a
+        raise).
+
+    Example:
+        Quick start::
+
+            from sportsdataverse.nfl import build_nfl_players
+            players = build_nfl_players()
+            print(players.shape)
+
+        Pandas output::
+
+            df = build_nfl_players(return_as_pandas=True)
+
+        Pipeline next step (one line)::
+
+            import polars as pl
+            build_nfl_players().filter(pl.col("position") == "QB").head()
+
+        See Also:
+            * `nflverse`_ -- full seven-source identity master (R + Python)
+            * `nflreadpy`_ -- direct nflverse Python bindings (load_players)
+
+        .. _nflverse: https://nflverse.nflverse.com
+        .. _nflreadpy: https://github.com/nflverse/nflreadpy
+    """
+    athletes = _fetch_athletes()
+    rows = [row for athlete in athletes if (row := _athlete_row(athlete)) is not None]
+    if not rows:
+        return _empty_frame(return_as_pandas)
+
+    frame = pl.DataFrame(rows, schema=_SCHEMA)
+    frame = _dedup_espn_id(frame)
+    frame = _enrich_cross_ids(frame)
+    # Re-assert column order (the enrichment join can reorder).
+    frame = frame.select(list(_SCHEMA.keys()))
+    return frame.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else frame
+
+
+# ID-crosswalk columns sliced from load_nfl_players(). Only the subset the
+# published parquet actually carries is retained (whatever is missing is
+# dropped), plus full_name + position for human-readable joins.
+_CROSSWALK_IDS: List[str] = [
+    "gsis_id",
+    "esb_id",
+    "espn_id",
+    "pfr_id",
+    "pff_id",
+    "otc_id",
+    "nfl_id",
+    "smart_id",
+]
+
+
+@overload
+def nfl_players_crosswalk() -> pl.DataFrame: ...
+@overload
+def nfl_players_crosswalk(*, return_as_pandas: bool = ...) -> Union[pl.DataFrame, "pd.DataFrame"]: ...
+
+
+def nfl_players_crosswalk(
+    *,
+    return_as_pandas: bool = False,
+) -> Union[pl.DataFrame, "pd.DataFrame"]:
+    """Pure-consumer ID crosswalk sliced from :func:`load_nfl_players`.
+
+    Reads nflverse's published players master and projects it down to just the
+    cross-system identifier columns it carries (``gsis_id``, ``esb_id``,
+    ``espn_id``, ``pfr_id``, ``pff_id``, ``otc_id``, ``nfl_id``, ``smart_id`` —
+    whichever the parquet exposes) plus ``full_name`` and ``position``, deduped
+    on ``gsis_id``. It is a convenience for joining nflverse identity IDs onto
+    PBP / rosters / stats frames without carrying the full ~40-column master.
+
+    Args:
+        return_as_pandas: If ``True``, return a ``pandas.DataFrame``; otherwise a
+            ``polars.DataFrame`` (default).
+
+    Returns:
+        A one-row-per-``gsis_id`` ``DataFrame`` of cross-system IDs +
+        ``full_name`` / ``position``. A failed / empty players load yields a
+        zero-row frame carrying the same column set (never a raise).
+
+    Example:
+        Quick start::
+
+            from sportsdataverse.nfl import nfl_players_crosswalk
+            xwalk = nfl_players_crosswalk()
+            print(xwalk.columns)
+
+        Join nflverse IDs onto a PBP frame (one line)::
+
+            pbp.join(nfl_players_crosswalk(), left_on="passer_player_id", right_on="gsis_id", how="left")
+
+        See Also:
+            * `nflverse`_ -- full seven-source identity master (R + Python)
+            * `nflreadpy`_ -- direct nflverse Python bindings (load_players)
+
+        .. _nflverse: https://nflverse.nflverse.com
+        .. _nflreadpy: https://github.com/nflverse/nflreadpy
+    """
+    from sportsdataverse.nfl.nfl_loaders import load_nfl_players
+
+    name_aliases = ["full_name", "display_name"]
+    base_cols = ["full_name", "position", *_CROSSWALK_IDS]
+
+    try:
+        players = load_nfl_players()
+    except Exception:  # noqa: BLE001 -- pure consumer; degrade to empty on failure
+        players = pl.DataFrame()
+
+    if players.is_empty():
+        empty = pl.DataFrame(schema={c: pl.Utf8 for c in base_cols})
+        return empty.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else empty
+
+    # Resolve a full_name column (the parquet uses display_name).
+    name_src = next((c for c in name_aliases if c in players.columns), None)
+    if name_src is not None and name_src != "full_name":
+        players = players.rename({name_src: "full_name"})
+
+    keep = [c for c in base_cols if c in players.columns]
+    frame = players.select(keep)
+    if "gsis_id" in frame.columns:
+        frame = frame.unique(subset=["gsis_id"], keep="first", maintain_order=True)
+    return frame.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else frame

--- a/sportsdataverse/parsed/nfl.py
+++ b/sportsdataverse/parsed/nfl.py
@@ -147,6 +147,7 @@ from sportsdataverse.nfl import nfl_weeks as _raw_nfl_weeks
 from sportsdataverse.nfl import nfl_weeks_by_date as _raw_nfl_weeks_by_date
 from sportsdataverse.nfl import NFLPlayProcess as NFLPlayProcess  # noqa: F401
 from sportsdataverse.nfl import NflConfig as NflConfig  # noqa: F401
+from sportsdataverse.nfl import build_nfl_players as build_nfl_players  # noqa: F401
 from sportsdataverse.nfl import build_nfl_rosters as build_nfl_rosters  # noqa: F401
 from sportsdataverse.nfl import build_nfl_season as build_nfl_season  # noqa: F401
 from sportsdataverse.nfl import cached_loader as cached_loader  # noqa: F401
@@ -245,6 +246,7 @@ from sportsdataverse.nfl import nfl_ngs_microsite_chart_players as nfl_ngs_micro
 from sportsdataverse.nfl import nfl_ngs_play_is_highlight as nfl_ngs_play_is_highlight  # noqa: F401
 from sportsdataverse.nfl import nfl_ngs_statboard as nfl_ngs_statboard  # noqa: F401
 from sportsdataverse.nfl import nfl_ngs_statboard_leaders as nfl_ngs_statboard_leaders  # noqa: F401
+from sportsdataverse.nfl import nfl_players_crosswalk as nfl_players_crosswalk  # noqa: F401
 from sportsdataverse.nfl import nfl_token_gen as nfl_token_gen  # noqa: F401
 from sportsdataverse.nfl import nfl_week_games as nfl_week_games  # noqa: F401
 from sportsdataverse.nfl import normalize_team_roster_columns as normalize_team_roster_columns  # noqa: F401
@@ -259,6 +261,7 @@ from sportsdataverse.nfl import update_config as update_config  # noqa: F401
 __all__ = [
     "NFLPlayProcess",
     "NflConfig",
+    "build_nfl_players",
     "build_nfl_rosters",
     "build_nfl_season",
     "cached_loader",
@@ -472,6 +475,7 @@ __all__ = [
     "nfl_ngs_play_is_highlight",
     "nfl_ngs_statboard",
     "nfl_ngs_statboard_leaders",
+    "nfl_players_crosswalk",
     "nfl_rosters",
     "nfl_standings",
     "nfl_team",

--- a/tests/nfl/test_nfl_players.py
+++ b/tests/nfl/test_nfl_players.py
@@ -1,0 +1,200 @@
+"""Tests for the public-ESPN NFL players builder (``build_nfl_players``) and
+the pure-consumer ID crosswalk (``nfl_players_crosswalk``).
+
+The offline tests monkeypatch the ESPN athlete fetch to a synthetic payload and
+assert the SDV-native schema + the highest-espn_id dedup rule. The live tests
+(gated by ``SDV_PY_LIVE_TESTS=1``) hit the real public ESPN / nflverse surfaces
+and assert non-empty frames with the documented invariants.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+import sportsdataverse.nfl.nfl_players as players_mod
+from sportsdataverse.nfl import build_nfl_players, nfl_players_crosswalk
+from tests.conftest import skip_if_no_live
+
+# Minimal columns the players frame must carry.
+_CORE_COLS = {
+    "espn_id",
+    "full_name",
+    "first_name",
+    "last_name",
+    "position",
+    "jersey",
+    "height",
+    "weight",
+    "birth_date",
+    "status",
+    "headshot_url",
+    "gsis_id",
+}
+
+
+def _athlete(athlete_id, full_name, dob, position="QB"):
+    """One ESPN core-v2 athlete-detail payload (shape mirrors the live API)."""
+    first, _, last = full_name.partition(" ")
+    return {
+        "id": str(athlete_id),
+        "firstName": first,
+        "lastName": last or first,
+        "fullName": full_name,
+        "displayName": full_name,
+        "weight": 225.0,
+        "height": 74.0,
+        "dateOfBirth": dob,
+        "jersey": "15",
+        "status": {"id": "1", "name": "Active", "type": "active"},
+        "headshot": {"href": f"https://a.espncdn.com/i/headshots/nfl/players/full/{athlete_id}.png"},
+        "position": {"id": "8", "name": "Quarterback", "abbreviation": position},
+        "team": {"$ref": "http://sports.core.api.espn.com/.../teams/12?lang=en"},
+    }
+
+
+def _fake_athletes():
+    """Two distinct players, plus a duplicate-id pair for the same player.
+
+    "Old Player" appears with both a legacy 4-digit espn_id (1234) and a modern
+    7-digit espn_id (3139477) for the SAME (full_name, birth_date) — the dedup
+    rule must keep the higher (modern) id.
+    """
+    return [
+        _athlete(1234, "Old Player", "1990-01-01T07:00Z"),
+        _athlete(3139477, "Old Player", "1990-01-01T07:00Z"),
+        _athlete(4242, "Solo Receiver", "1995-05-05T07:00Z", position="WR"),
+    ]
+
+
+def test_build_nfl_players_parses_schema(monkeypatch):
+    # Disable the players-table enrichment so the unit test is fully offline.
+    monkeypatch.setattr(players_mod, "_enrich_cross_ids", lambda frame: frame)
+    monkeypatch.setattr(players_mod, "_fetch_athletes", lambda limit=None: _fake_athletes())
+
+    df = build_nfl_players()
+    assert isinstance(df, pl.DataFrame)
+    # Two distinct players after the duplicate "Old Player" rows collapse.
+    assert df.height == 2
+    # Full documented schema, in order.
+    assert list(df.columns) == list(players_mod._SCHEMA.keys())
+    assert _CORE_COLS.issubset(set(df.columns))
+    # espn_id present + unique per player.
+    assert df["espn_id"].null_count() == 0
+    assert df["espn_id"].n_unique() == df.height
+    # Field-mapping spot-checks.
+    wr = df.filter(pl.col("full_name") == "Solo Receiver").row(0, named=True)
+    assert wr["position"] == "WR"
+    assert wr["first_name"] == "Solo"
+    assert wr["status"] == "Active"
+    assert wr["headshot_url"].endswith("4242.png")
+
+
+def test_build_nfl_players_espn_id_dedup_keeps_highest(monkeypatch):
+    monkeypatch.setattr(players_mod, "_enrich_cross_ids", lambda frame: frame)
+    monkeypatch.setattr(players_mod, "_fetch_athletes", lambda limit=None: _fake_athletes())
+
+    df = build_nfl_players()
+    old = df.filter(pl.col("full_name") == "Old Player")
+    # Exactly one row survives and it carries the HIGHER (modern) espn_id.
+    assert old.height == 1
+    assert old.row(0, named=True)["espn_id"] == "3139477"
+
+
+def test_build_nfl_players_empty_fetch(monkeypatch):
+    monkeypatch.setattr(players_mod, "_enrich_cross_ids", lambda frame: frame)
+    monkeypatch.setattr(players_mod, "_fetch_athletes", lambda limit=None: [])
+
+    df = build_nfl_players()
+    assert isinstance(df, pl.DataFrame)
+    assert df.height == 0
+    # Empty frame still carries the full documented schema.
+    assert list(df.columns) == list(players_mod._SCHEMA.keys())
+
+
+def test_build_nfl_players_pandas(monkeypatch):
+    import pandas as pd
+
+    monkeypatch.setattr(players_mod, "_enrich_cross_ids", lambda frame: frame)
+    monkeypatch.setattr(players_mod, "_fetch_athletes", lambda limit=None: _fake_athletes())
+
+    df = build_nfl_players(return_as_pandas=True)
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) == 2
+
+
+def test_build_nfl_players_enrichment(monkeypatch):
+    """The cross-id enrichment fills gsis_id from the players table by espn_id."""
+    monkeypatch.setattr(players_mod, "_fetch_athletes", lambda limit=None: _fake_athletes())
+
+    fake_players = pl.DataFrame(
+        {
+            "espn_id": ["3139477"],
+            "display_name": ["Old Player"],
+            "birth_date": ["1990-01-01"],
+            "gsis_id": ["00-0033333"],
+            "college_name": ["State U"],
+        }
+    )
+    monkeypatch.setattr(
+        "sportsdataverse.nfl.nfl_loaders.load_nfl_players",
+        lambda *a, **k: fake_players,
+    )
+
+    df = build_nfl_players()
+    old = df.filter(pl.col("full_name") == "Old Player").row(0, named=True)
+    assert old["gsis_id"] == "00-0033333"
+    assert old["college"] == "State U"
+
+
+def test_nfl_players_crosswalk_empty(monkeypatch):
+    monkeypatch.setattr(
+        "sportsdataverse.nfl.nfl_loaders.load_nfl_players",
+        lambda *a, **k: pl.DataFrame(),
+    )
+    xwalk = nfl_players_crosswalk()
+    assert isinstance(xwalk, pl.DataFrame)
+    assert xwalk.height == 0
+    assert "gsis_id" in xwalk.columns and "espn_id" in xwalk.columns
+
+
+def test_nfl_players_crosswalk_slices_and_dedups(monkeypatch):
+    fake_players = pl.DataFrame(
+        {
+            "gsis_id": ["00-0011111", "00-0011111", "00-0022222"],
+            "display_name": ["A Player", "A Player", "B Player"],
+            "position": ["QB", "QB", "WR"],
+            "espn_id": ["111", "111", "222"],
+            "pfr_id": ["Aaaa01", "Aaaa01", "Bbbb02"],
+            "height": [74, 74, 70],  # non-crosswalk column should be dropped
+        }
+    )
+    monkeypatch.setattr(
+        "sportsdataverse.nfl.nfl_loaders.load_nfl_players",
+        lambda *a, **k: fake_players,
+    )
+    xwalk = nfl_players_crosswalk()
+    assert xwalk.height == 2  # deduped on gsis_id
+    assert "full_name" in xwalk.columns and "position" in xwalk.columns
+    assert "height" not in xwalk.columns  # non-crosswalk column dropped
+    assert set(xwalk["gsis_id"].to_list()) == {"00-0011111", "00-0022222"}
+
+
+@skip_if_no_live
+def test_build_nfl_players_live():
+    df = build_nfl_players()
+    assert isinstance(df, pl.DataFrame)
+    assert df.height > 0
+    assert _CORE_COLS.issubset(set(df.columns))
+    # espn_id present + unique per player (the dedup invariant).
+    assert df["espn_id"].null_count() == 0
+    assert df["espn_id"].n_unique() == df.height
+
+
+@skip_if_no_live
+def test_nfl_players_crosswalk_live():
+    xwalk = nfl_players_crosswalk()
+    assert isinstance(xwalk, pl.DataFrame)
+    assert xwalk.height > 0
+    assert "gsis_id" in xwalk.columns and "espn_id" in xwalk.columns
+    # gsis_id is the dedup key — densely populated.
+    assert xwalk["gsis_id"].null_count() == 0

--- a/tools/codegen/manual_column_descriptions.yaml
+++ b/tools/codegen/manual_column_descriptions.yaml
@@ -1627,6 +1627,46 @@ load_nfl_pfr_weekly_rush:
   rushing_yards_before_contact_avg: Average rushing yards gained before first contact per rushing attempt in this weekly game log.
 load_nfl_player_stats:
   opponent_team: Abbreviation or name of the opposing team faced by the player in a given game or week.
+load_nfl_players:
+  gsis_id: NFL Game Statistics & Information System player identifier, the canonical nflverse player key.
+  display_name: Player's full display name as published by nflverse.
+  common_first_name: Player's commonly used first name (the name they go by, which may differ from their legal first name).
+  first_name: Player's legal first name.
+  last_name: Player's last name.
+  short_name: Abbreviated name (typically first initial plus last name).
+  football_name: Player's preferred on-field name as used in broadcast and box-score contexts.
+  suffix: Generational or honorific name suffix (e.g., Jr., Sr., III), when present.
+  esb_id: Elias Sports Bureau player identifier.
+  nfl_id: NFL.com / Shield player identifier.
+  pfr_id: Pro-Football-Reference player identifier.
+  pff_id: Pro Football Focus player identifier.
+  otc_id: OverTheCap player identifier (salary-cap data source).
+  espn_id: ESPN athlete identifier.
+  smart_id: NFL SMART (Standard Media and Reference Table) globally unique player identifier.
+  birth_date: Player's date of birth (ISO YYYY-MM-DD).
+  position_group: Broad positional grouping the player belongs to (e.g., QB, RB, WR, DL).
+  position: Player's specific listed position abbreviation.
+  ngs_position_group: Positional grouping as classified by NFL Next Gen Stats.
+  ngs_position: Specific position as classified by NFL Next Gen Stats.
+  height: Player's height in inches.
+  weight: Player's listed weight in pounds.
+  headshot: URL to the player's official headshot image.
+  college_name: Name of the college the player attended.
+  college_conference: Athletic conference of the player's college.
+  jersey_number: Player's uniform / jersey number.
+  rookie_season: Season (year) the player entered the league as a rookie.
+  last_season: Most recent season (year) the player appeared on an NFL roster.
+  latest_team: Abbreviation of the most recent team the player was rostered on.
+  status: Player's current roster status (e.g., active, retired, free agent).
+  ngs_status: Player status as reported by NFL Next Gen Stats.
+  ngs_status_short_description: Short human-readable description of the NFL Next Gen Stats status.
+  years_of_experience: Number of accrued NFL seasons of experience.
+  pff_position: Player's position as classified by Pro Football Focus.
+  pff_status: Player's status as classified by Pro Football Focus.
+  draft_year: Year the player was selected in the NFL Draft (null if undrafted).
+  draft_round: Round in which the player was drafted (null if undrafted).
+  draft_pick: Overall pick number at which the player was drafted (null if undrafted).
+  draft_team: Abbreviation of the team that drafted the player (null if undrafted).
 load_nfl_rosters:
   season: NFL season (year) the roster entry applies to.
   team: Team abbreviation in the nflverse standard (relocations folded, e.g. 'OAK' -> 'LV', 'SD' -> 'LAC', 'STL' -> 'LA').
@@ -1784,6 +1824,46 @@ load_pfr_advstats:
   times_sacked: Total number of times the defensive player recorded a sack of the quarterback, from Pro Football Reference.
 load_player_stats:
   opponent_team: Abbreviation of the opposing team the player faced in the game or week represented by this row.
+load_players:
+  gsis_id: NFL Game Statistics & Information System player identifier, the canonical nflverse player key.
+  display_name: Player's full display name as published by nflverse.
+  common_first_name: Player's commonly used first name (the name they go by, which may differ from their legal first name).
+  first_name: Player's legal first name.
+  last_name: Player's last name.
+  short_name: Abbreviated name (typically first initial plus last name).
+  football_name: Player's preferred on-field name as used in broadcast and box-score contexts.
+  suffix: Generational or honorific name suffix (e.g., Jr., Sr., III), when present.
+  esb_id: Elias Sports Bureau player identifier.
+  nfl_id: NFL.com / Shield player identifier.
+  pfr_id: Pro-Football-Reference player identifier.
+  pff_id: Pro Football Focus player identifier.
+  otc_id: OverTheCap player identifier (salary-cap data source).
+  espn_id: ESPN athlete identifier.
+  smart_id: NFL SMART (Standard Media and Reference Table) globally unique player identifier.
+  birth_date: Player's date of birth (ISO YYYY-MM-DD).
+  position_group: Broad positional grouping the player belongs to (e.g., QB, RB, WR, DL).
+  position: Player's specific listed position abbreviation.
+  ngs_position_group: Positional grouping as classified by NFL Next Gen Stats.
+  ngs_position: Specific position as classified by NFL Next Gen Stats.
+  height: Player's height in inches.
+  weight: Player's listed weight in pounds.
+  headshot: URL to the player's official headshot image.
+  college_name: Name of the college the player attended.
+  college_conference: Athletic conference of the player's college.
+  jersey_number: Player's uniform / jersey number.
+  rookie_season: Season (year) the player entered the league as a rookie.
+  last_season: Most recent season (year) the player appeared on an NFL roster.
+  latest_team: Abbreviation of the most recent team the player was rostered on.
+  status: Player's current roster status (e.g., active, retired, free agent).
+  ngs_status: Player status as reported by NFL Next Gen Stats.
+  ngs_status_short_description: Short human-readable description of the NFL Next Gen Stats status.
+  years_of_experience: Number of accrued NFL seasons of experience.
+  pff_position: Player's position as classified by Pro Football Focus.
+  pff_status: Player's status as classified by Pro Football Focus.
+  draft_year: Year the player was selected in the NFL Draft (null if undrafted).
+  draft_round: Round in which the player was drafted (null if undrafted).
+  draft_pick: Overall pick number at which the player was drafted (null if undrafted).
+  draft_team: Abbreviation of the team that drafted the player (null if undrafted).
 load_rosters:
   season: NFL season (year) the roster entry applies to.
   team: Team abbreviation in the nflverse standard (relocations folded, e.g. 'OAK' -> 'LV', 'SD' -> 'LAC', 'STL' -> 'LA').


### PR DESCRIPTION
PR4b (final) of the NFL data-expansion program — a **public-source (ESPN-athletes) players builder** + ID-crosswalk helper + `load_nfl_players` doc upgrade.

## Added (`sportsdataverse/nfl/nfl_players.py`)
- **`build_nfl_players()`** — builds an SDV-native players dataset from ESPN's public core-v2 athletes endpoint (`sports.core.api.espn.com/v2/.../nfl/athletes`, paginated `$ref` walk via `dl_utils.download`). 18-col schema (espn_id, names, position, jersey, height, weight, birth_date, status, headshot_url, gsis_id, esb_id, pfr_id, pff_id, smart_id, college). 
  - **ESPN-ID dedup**: keeps the highest numeric `espn_id` per `(full_name, birth_date)` — handles ESPN's ~2007 4→7-digit ID migration so joins don't duplicate.
  - `gsis_id` + cross-ids enriched best-effort from `load_nfl_players()` (espn_id then name+dob fallback). Empty/failed fetch → zero-row frame (no raise).
  - **Public ESPN tier only** — partial vs nflverse's 7-source `players.parquet` (3 sources need private PFR/OTC/PFF creds). `load_nfl_players` serves the full identity master; `build_nfl_players` is for SDV-native self-sufficiency.
- **`nfl_players_crosswalk()`** — pure-consumer convenience: `load_nfl_players()` reduced to the ID-crosswalk columns (gsis_id/esb_id/espn_id/pfr_id/pff_id/otc_id/nfl_id/smart_id + name/position), deduped on gsis_id, for joining onto PBP/rosters/stats.

## Consumer upgrade
`load_nfl_players` docstring → full Google-style with runnable Example; **all** column descriptions filled (residual blank count **0**).

## Notes
`build_nfl_players` resolves ~7,455 athlete `$ref`s sequentially → minutes per full run (correct; future: bounded parallel). `team` is null by design (ESPN inlines it only as a `$ref`).

## Tests
Unit (mock athletes → schema + the highest-espn_id dedup) + live-gated (real API). codegen `--check` clean (full regen); tests/nfl + tests/codegen 406 passed; ruff clean; `nfl_players.py` in the mypy ratchet (clean).
