### PR TITLE
refactor(nfl): drop the enrich_nfl_pbp method="snapshot" vestige

### DIFF
--- a/sportsdataverse/nfl/ep_wp.py
+++ b/sportsdataverse/nfl/ep_wp.py
@@ -2447,10 +2447,9 @@ def enrich_nfl_pbp(
             WP inputs ``score_differential`` / ``game_seconds_remaining`` /
             ``spread_line`` / ``receive_2h_ko``).
         method: ``"lead_diff"`` (default) — the native, nflfastR-faithful
-            EPA/WPA derivation and the canonical parity path; it is the only
-            implemented method.  ``"snapshot"`` is accepted for API stability
-            but is **not implemented** (it has no nflfastR-parity reference) and
-            raises ``NotImplementedError``; pass ``"lead_diff"`` instead.
+            EPA/WPA derivation and the canonical parity path. It is the only
+            supported method; any other value raises ``ValueError``. (The param
+            is retained for forward extensibility / API stability.)
         models_dir: Optional directory to load the xYAC model
             (``xyac_model.ubj``) from instead of downloading/caching it —
             for offline use or a custom-trained model.  When ``None``
@@ -2490,10 +2489,8 @@ def enrich_nfl_pbp(
           null while the rest of the enrichment proceeds.
 
     Raises:
-        ValueError: when ``method`` is unrecognised, or required contract
-            columns are absent from ``df``.
-        NotImplementedError: when ``method="snapshot"`` — that method is not
-            implemented (no nflfastR-parity reference); use ``"lead_diff"``.
+        ValueError: when ``method`` is not ``"lead_diff"``, or required
+            contract columns are absent from ``df``.
 
     Example:
         Quick start::
@@ -2525,16 +2522,10 @@ def enrich_nfl_pbp(
         .. _nflfastR: https://www.nflfastr.com
         .. _nflreadpy: https://github.com/nflverse/nflreadpy
     """
-    if method == "snapshot":
-        raise NotImplementedError(
-            "enrich_nfl_pbp(method='snapshot') is not implemented. The 'snapshot' "
-            "(model-snapshot) derivation has no nflfastR-parity reference, so it is "
-            "intentionally not provided; the parameter is retained only for API "
-            "stability. Use method='lead_diff' (the default) — the native, "
-            "nflfastR-faithful EPA/WPA derivation."
-        )
     if method != "lead_diff":
-        raise ValueError(f"enrich_nfl_pbp: unknown method {method!r}; expected 'lead_diff' or 'snapshot'.")
+        raise ValueError(
+            f"enrich_nfl_pbp: unknown method {method!r}; expected 'lead_diff' (the only supported method)."
+        )
 
     _validate_enrich_input(df)
 

--- a/tests/nfl/test_enrich.py
+++ b/tests/nfl/test_enrich.py
@@ -25,7 +25,7 @@ assertions target the ORCHESTRATION WIRING (not model numerics):
   scoring,
 * ``ep`` is the start-of-play estimate,
 * idempotency (enrich twice == enrich once),
-* method dispatch (``snapshot`` -> NotImplementedError, invalid -> ValueError),
+* method dispatch (any non-``lead_diff`` value, incl. ``snapshot``, -> ValueError),
 * input-column validation against the frame contract.
 
 The stub EP score is a deterministic function of ``yardline_100`` so that the
@@ -317,9 +317,11 @@ def patched(monkeypatch):  # noqa: ANN001
 
 
 class TestDispatch:
-    def test_snapshot_not_implemented(self) -> None:
+    def test_snapshot_method_raises_valueerror(self) -> None:
+        # "snapshot" was a removed design vestige; it is now just an
+        # unsupported method value (ValueError), not a NotImplementedError.
         df = _synthetic_frame()
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(ValueError):
             enrich_nfl_pbp(df, method="snapshot")
 
     def test_invalid_method_raises_valueerror(self) -> None:


### PR DESCRIPTION
Removes the dead `method="snapshot"` branch from `enrich_nfl_pbp` — an early design-fork value never implemented (the default `"lead_diff"` already achieves nflfastR parity).

- Dedicated `NotImplementedError` branch + docstring/Raises mentions removed.
- Any non-`lead_diff` value (incl. `snapshot`) now raises a plain `ValueError`.
- `method=` param retained for forward extensibility.
- Test updated (`snapshot` -> `ValueError`).

ruff + mypy clean; enrich tests 15 passed; codegen `--check` clean.

Not included: 2a (ESPN-path xYAC) — blocked by the deferred `air_yards` gap (needs FTN-charting air_yards, 2022+), a separate decision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the `enrich_nfl_pbp()` method validation. The API now supports only `method="lead_diff"`; previously supported methods are no longer accepted and will raise an error.

* **Tests**
  * Updated test suite to reflect new validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->