### PR TITLE
feat(cfb): opponent-adjusted EPA (ridge) — season + walk-forward per-game

### DIFF
--- a/docs/docs/cfb/index.md
+++ b/docs/docs/cfb/index.md
@@ -10,7 +10,7 @@ sidebar_label: CFB
 | [ESPN web API (v3)](reference/web) | 5 | `https://site.web.api.espn.com/apis/common/v3/sports` |
 | [ESPN core API (v2)](reference/core) | 85 | `https://sports.core.api.espn.com/v2/sports` |
 | [Dataset loaders](reference/loaders) | 6 | sportsdataverse raw data / sportsdataverse-data releases |
-| [Additional functions](reference/additional) | 39 | hand-written wrappers, loaders & helpers |
+| [Additional functions](reference/additional) | 41 | hand-written wrappers, loaders & helpers |
 
 ## Examples
 

--- a/docs/docs/cfb/reference/additional.md
+++ b/docs/docs/cfb/reference/additional.md
@@ -937,6 +937,69 @@ sched = load_cfb_schedule(seasons=[most_recent_cfb_season()])
 
 ## Other
 
+### `cfb_adjusted_epa(plays: 'pl.DataFrame | pd.DataFrame', *, ridge_lambda: 'float' = 325.0, return_as_pandas: 'bool' = False) -> 'pl.DataFrame | pd.DataFrame'` {#cfb_adjusted_epa}
+
+Season opponent-adjusted per-team EPA from a season's play-by-play.
+
+Fits one ridge of per-play `EPA` on offense-team, defense-team, and
+home-field indicators over the competitive (`0.1 <= wp_before <= 0.9`) pass
+and rush plays, nets each team's per-game raw EPA against the opponent's
+fitted strength, and averages to a season figure. In-sample/descriptive (the
+fit uses the whole season); for leak-free per-game values use
+`cfb_adjusted_epa_by_game`.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `plays` | `DataFrame \| DataFrame` |  | A cfbfastR-schema play-by-play frame (polars or pandas) with the columns listed in the module docstring. One season at a time. |
+| `ridge_lambda` | `float` | `325.0` | Ridge penalty (glmnet-scale; default 325). |
+| `return_as_pandas` | `bool` | `False` | Return a pandas `DataFrame` instead of polars. |
+
+**Returns**
+
+One row per team (>= 2 valid games): `team_id`, `pos_team`, `valid_games`, `adj_off_epa`, `adj_def_epa`, `off_strength_faced`, `def_strength_faced`, `net_adj_epa` and their `*_rank` columns.
+
+**Example**
+
+```python
+import sportsdataverse.cfb as cfb
+pbp = cfb.load_cfb_pbp(seasons=[2023])
+cfb.cfb_adjusted_epa(pbp).sort("net_adj_epa_rank").head()
+```
+
+### `cfb_adjusted_epa_by_game(plays: 'pl.DataFrame | pd.DataFrame', *, ridge_lambda: 'float' = 325.0, return_as_pandas: 'bool' = False) -> 'pl.DataFrame | pd.DataFrame'` {#cfb_adjusted_epa_by_game}
+
+Walk-forward (point-in-time) opponent-adjusted EPA, one row per team-game.
+
+For each week `w` the opponent-strength ridge is fit on competitive plays
+from **weeks before `w` only**, then that week's games are adjusted with
+those as-of strengths -- so the value uses no future information and is valid
+as an in-season power-rating / model feature. Week 1 (no prior) yields null
+adjustments; not-yet-seen opponents fall back to the league baseline (with the
+heavy ridge penalty this is the intended early-season shrinkage to average).
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `plays` | `DataFrame \| DataFrame` |  | A cfbfastR-schema play-by-play frame (polars or pandas) with the module-docstring columns **plus** `week`. One season at a time. |
+| `ridge_lambda` | `float` | `325.0` | Ridge penalty (glmnet-scale; default 325). |
+| `return_as_pandas` | `bool` | `False` | Return a pandas `DataFrame` instead of polars. |
+
+**Returns**
+
+One row per (game, team), sorted by `week` then `team_id`: `game_id`, `week`, `team_id`, `opponent_id`, `pos_team`, `raw_off_epa`, `adj_off_epa`, `raw_def_epa`, `adj_def_epa`, `off_strength_faced` (opponent offense), `def_strength_faced` (opponent defense), `net_adj_epa`. The `adj_*` / `net` columns are null for week 1 (and any week with no prior fit).
+
+**Example**
+
+```python
+import sportsdataverse.cfb as cfb
+pbp = cfb.load_cfb_pbp(seasons=[2023])
+tg = cfb.cfb_adjusted_epa_by_game(pbp)
+tg.filter(pl.col("week") >= 5).sort("net_adj_epa", descending=True).head()
+```
+
 ### `cfb_odds_events_crosswalk(season: 'Optional[int]' = None, week: 'Optional[int]' = None, *, sport: 'str' = 'americanfootball_ncaaf', api_key: 'Optional[str]' = None, season_type: 'int' = 2, return_as_pandas: 'bool' = False, **kwargs: 'Any') -> 'DataFrameT'` {#cfb_odds_events_crosswalk}
 
 Match The Odds API CFB events to ESPN game ids.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ dependencies = [
     "requests>=2.28.0",
     "scipy>=1.10.0",
     "tqdm>=4.50.0",
+    "scikit-learn>=1.0.0",
     "xgboost>=2.0.0",
 ]
 
@@ -99,6 +100,7 @@ models = [
     "matplotlib>=3.5.0",
     "tqdm>=4.50.0",
     "attrs>=20.3.0",
+    "scikit-learn>=1.0.0",
     "xgboost>=2.0.0",
 ]
 all = [
@@ -126,6 +128,7 @@ all = [
     "matplotlib>=3.5.0",
     "tqdm>=4.50.0",
     "attrs>=20.3.0",
+    "scikit-learn>=1.0.0",
     "xgboost>=2.0.0",
 ]
 
@@ -278,6 +281,7 @@ warn_redundant_casts = true
 files = [
     "sportsdataverse/_deprecation.py",
     "sportsdataverse/errors.py",
+    "sportsdataverse/cfb/cfb_adjusted_epa.py",
     "sportsdataverse/cfb/cfb_crosswalk.py",
     "sportsdataverse/cfb/cfb_fox_ext.py",
     "sportsdataverse/cfb/cfb_yahoo_ext.py",

--- a/sportsdataverse/cfb/__init__.py
+++ b/sportsdataverse/cfb/__init__.py
@@ -6,6 +6,7 @@ from sportsdataverse.cfb.cfb_game_rosters import *
 from sportsdataverse.cfb.cfb_loaders import *
 from sportsdataverse.cfb.cfb_loaders_extra import *
 from sportsdataverse.cfb.cfb_pbp import *
+from sportsdataverse.cfb.cfb_adjusted_epa import *
 from sportsdataverse.cfb.cfb_fourth_down import *
 from sportsdataverse.cfb.cfb_two_point import *
 from sportsdataverse.cfb.cfb_pbp_fox import *

--- a/sportsdataverse/cfb/cfb_adjusted_epa.py
+++ b/sportsdataverse/cfb/cfb_adjusted_epa.py
@@ -1,0 +1,368 @@
+"""Opponent-adjusted EPA (ridge / RAPM-style) for college football play-by-play.
+
+Reusable estimation primitives that separate a team's per-play EPA from its
+schedule with a ridge regression on offense/defense team indicators (plus
+home-field) -- the "Binion Box Score" opponent adjustment, lifted out of the
+data-build layer so any caller can run it on a supplied frame.
+
+Two entry points:
+
+* :func:`cfb_adjusted_epa` -- one row per team for a whole season (the season
+  figure used by the team-summary tables). The ridge is fit on the full season,
+  so per-team values are in-sample/descriptive.
+* :func:`cfb_adjusted_epa_by_game` -- one row per team-game, **walk-forward /
+  point-in-time**: each week is adjusted using opponent strengths fit only on
+  *prior* weeks. Leak-free, so the values are valid as in-season power-rating or
+  model inputs (week 1 has no prior, so its adjustments are null; not-yet-seen
+  opponents fall back to the league baseline, which with the heavy ridge penalty
+  is the intended early-season shrinkage toward average).
+
+Neither is a bundled model artifact (unlike the EP/WP/QBR ``.ubj`` files): the
+ridge is fit *in-sample on team dummies*, so the coefficients *are* that window's
+team strengths -- nothing to persist or apply to a different season. Faithful
+port of cfbfastR's ``adjust_epa`` / ``cfbfastR-cfb-data`` ``espn_cfb_15``.
+
+Required input columns (a cfbfastR-schema pbp frame): ``game_id``, ``pos_team``,
+``pos_team_id``, ``def_pos_team_id``, ``home``, ``neutral_site``, ``EPA``,
+``pass``, ``rush``, ``wp_before`` (plus ``week`` for the by-game variant).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, overload
+
+import numpy as np
+import polars as pl
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+__all__ = ["cfb_adjusted_epa", "cfb_adjusted_epa_by_game"]
+
+# Ridge penalty: cfbfastR uses glmnet at the grid's largest lambda (cv$lambda[[1]]).
+_RIDGE_LAMBDA = 325.0
+
+_REQUIRED_COLUMNS = (
+    "game_id",
+    "pos_team",
+    "pos_team_id",
+    "def_pos_team_id",
+    "home",
+    "neutral_site",
+    "EPA",
+    "pass",
+    "rush",
+    "wp_before",
+)
+_BY_GAME_REQUIRED = (*_REQUIRED_COLUMNS, "week")
+
+_EMPTY_OFFENSE = pl.DataFrame(schema={"team_id": pl.Utf8, "adjmodelOff": pl.Float64})
+_EMPTY_DEFENSE = pl.DataFrame(schema={"team_id": pl.Utf8, "adjmodelDef": pl.Float64})
+
+
+def _rank(col: str, *, descending: bool) -> pl.Expr:
+    """R ``rank()`` -- average ties, ``na.last=TRUE`` (NA rows get trailing ranks)."""
+    c = pl.col(col)
+    base = c.rank(method="average", descending=descending)
+    n_nonnull = c.is_not_null().sum()
+    null_trail = (n_nonnull + c.is_null().cum_sum()).cast(pl.Float64)
+    return pl.when(c.is_null()).then(null_trail).otherwise(base)
+
+
+def _prepare(plays: pl.DataFrame | pd.DataFrame, required: tuple[str, ...]) -> tuple[pl.DataFrame, pl.DataFrame]:
+    """Validate + build the ``base`` (EPA pass/rush) and ``clean`` (competitive + hfa) frames."""
+    df = pl.from_pandas(plays) if not isinstance(plays, pl.DataFrame) else plays
+    missing = [c for c in required if c not in df.columns]
+    if missing:
+        raise KeyError(f"cfb_adjusted_epa: plays is missing required columns {missing}")
+    base = df.filter(pl.col("EPA").is_not_null() & ((pl.col("pass") == 1) | (pl.col("rush") == 1))).with_columns(
+        pos_team_id=pl.col("pos_team_id").cast(pl.Utf8),
+        def_pos_team_id=pl.col("def_pos_team_id").cast(pl.Utf8),
+        game_id=pl.col("game_id").cast(pl.Utf8),
+    )
+    clean = base.filter((pl.col("wp_before") >= 0.1) & (pl.col("wp_before") <= 0.9)).with_columns(
+        hfa=pl.when(pl.col("neutral_site") == True)  # noqa: E712
+        .then(pl.lit(0))
+        .when(pl.col("pos_team") == pl.col("home"))
+        .then(pl.lit(1))
+        .otherwise(pl.lit(-1))
+    )
+    return base, clean
+
+
+def _fit_opponent_ridge(clean: pl.DataFrame, ridge_lambda: float) -> tuple[pl.DataFrame, pl.DataFrame, float]:
+    """Fit the offense/defense ridge on competitive plays -> (offense, defense, intercept).
+
+    ``offense``/``defense`` carry one row per *non-reference* team (``model.matrix``
+    drops the first factor level); ``intercept`` is the league baseline used as the
+    fallback strength for not-yet-seen teams in the walk-forward variant.
+    """
+    try:
+        from sklearn.linear_model import Ridge
+    except ImportError as exc:  # pragma: no cover - optional dep guidance
+        raise ImportError(
+            "cfb_adjusted_epa requires scikit-learn. Install it with "
+            "`pip install sportsdataverse[models]` (or `pip install scikit-learn`)."
+        ) from exc
+
+    off_ids = sorted(clean["pos_team_id"].drop_nulls().unique().to_list())
+    def_ids = sorted(clean["def_pos_team_id"].drop_nulls().unique().to_list())
+    off_dummy, def_dummy = off_ids[1:], def_ids[1:]
+
+    pos = clean["pos_team_id"].to_numpy()
+    dfn = clean["def_pos_team_id"].to_numpy()
+    feats = [clean["hfa"].cast(pl.Float64).to_numpy().reshape(-1, 1)]
+    feats += [(pos == t).astype(float).reshape(-1, 1) for t in off_dummy]
+    feats += [(dfn == t).astype(float).reshape(-1, 1) for t in def_dummy]
+    x_mat = np.hstack(feats)
+    y = clean["EPA"].cast(pl.Float64).to_numpy()
+
+    # glmnet (1/2n)RSS + lambda/2||b||^2 with internal standardization vs sklearn
+    # RSS + alpha||b||^2: standardize X and scale alpha by n. Coefficients won't
+    # byte-match glmnet, but the relative team strengths correlate closely.
+    mu, sd = x_mat.mean(axis=0), x_mat.std(axis=0)
+    sd[sd == 0] = 1.0
+    model = Ridge(alpha=ridge_lambda * len(y), fit_intercept=True)
+    model.fit((x_mat - mu) / sd, y)
+    coef_std = model.coef_ / sd
+    intercept = float(model.intercept_ - (coef_std * mu).sum())
+    names = ["hfa"] + [f"pos_team_id{t}" for t in off_dummy] + [f"def_pos_team_id{t}" for t in def_dummy]
+    coef = dict(zip(names, coef_std))
+    offense = pl.DataFrame(
+        {"team_id": off_dummy, "adjmodelOff": [coef[f"pos_team_id{t}"] + intercept for t in off_dummy]}
+    )
+    defense = pl.DataFrame(
+        {"team_id": def_dummy, "adjmodelDef": [coef[f"def_pos_team_id{t}"] + intercept for t in def_dummy]}
+    )
+    return offense, defense, intercept
+
+
+def _adjust_games(
+    base: pl.DataFrame,
+    offense: pl.DataFrame,
+    defense: pl.DataFrame,
+    *,
+    fill_strength: float | None,
+) -> pl.DataFrame:
+    """Per-(game, pos_team) raw + opponent-adjusted EPA from given strength tables.
+
+    ``fill_strength`` (the league baseline) replaces missing opponent strengths
+    when set -- used by the walk-forward variant so not-yet-seen opponents shrink
+    to average; the season variant passes ``None`` (reference-team opponents stay
+    null and are excluded by the valid-games filter).
+    """
+    off_aggs = [pl.col("pos_team").last().alias("pos_team"), pl.col("EPA").mean().alias("raw_off_epa")]
+    if "week" in base.columns:
+        off_aggs.append(pl.col("week").first().alias("week"))
+    off_game = (
+        base.group_by(["game_id", "pos_team_id", "def_pos_team_id"])
+        .agg(off_aggs)
+        .join(defense, left_on="def_pos_team_id", right_on="team_id", how="left")
+    )
+    def_game = (
+        base.group_by(["game_id", "def_pos_team_id", "pos_team_id"])
+        .agg(raw_def_epa=pl.col("EPA").mean())
+        .join(offense, left_on="pos_team_id", right_on="team_id", how="left")
+        .select("game_id", "def_pos_team_id", "raw_def_epa", "adjmodelOff")
+    )
+    opp = off_game.join(
+        def_game,
+        left_on=["game_id", "pos_team_id"],
+        right_on=["game_id", "def_pos_team_id"],
+        how="left",
+    )
+    if fill_strength is not None:
+        opp = opp.with_columns(
+            pl.col("adjmodelDef").fill_null(fill_strength),
+            pl.col("adjmodelOff").fill_null(fill_strength),
+        )
+    return opp.with_columns(
+        adj_off_epa=pl.col("raw_off_epa") - pl.col("adjmodelDef"),
+        adj_def_epa=pl.col("raw_def_epa") - pl.col("adjmodelOff"),
+    )
+
+
+@overload
+def cfb_adjusted_epa(
+    plays: pl.DataFrame | pd.DataFrame, *, ridge_lambda: float = ..., return_as_pandas: Literal[False] = ...
+) -> pl.DataFrame: ...
+
+
+@overload
+def cfb_adjusted_epa(
+    plays: pl.DataFrame | pd.DataFrame, *, ridge_lambda: float = ..., return_as_pandas: Literal[True]
+) -> pd.DataFrame: ...
+
+
+def cfb_adjusted_epa(
+    plays: pl.DataFrame | pd.DataFrame,
+    *,
+    ridge_lambda: float = _RIDGE_LAMBDA,
+    return_as_pandas: bool = False,
+) -> pl.DataFrame | pd.DataFrame:
+    """Season opponent-adjusted per-team EPA from a season's play-by-play.
+
+    Fits one ridge of per-play ``EPA`` on offense-team, defense-team, and
+    home-field indicators over the competitive (``0.1 <= wp_before <= 0.9``) pass
+    and rush plays, nets each team's per-game raw EPA against the opponent's
+    fitted strength, and averages to a season figure. In-sample/descriptive (the
+    fit uses the whole season); for leak-free per-game values use
+    :func:`cfb_adjusted_epa_by_game`.
+
+    Args:
+        plays: A cfbfastR-schema play-by-play frame (polars or pandas) with the
+            columns listed in the module docstring. One season at a time.
+        ridge_lambda: Ridge penalty (glmnet-scale; default 325).
+        return_as_pandas: Return a pandas ``DataFrame`` instead of polars.
+
+    Returns:
+        One row per team (>= 2 valid games): ``team_id``, ``pos_team``,
+        ``valid_games``, ``adj_off_epa``, ``adj_def_epa``, ``off_strength_faced``,
+        ``def_strength_faced``, ``net_adj_epa`` and their ``*_rank`` columns.
+
+    Raises:
+        ImportError: If ``scikit-learn`` is not installed.
+        KeyError: If ``plays`` is missing a required column.
+
+    Example:
+        Quick start::
+
+            import sportsdataverse.cfb as cfb
+            pbp = cfb.load_cfb_pbp(seasons=[2023])
+            cfb.cfb_adjusted_epa(pbp).sort("net_adj_epa_rank").head()
+
+    See Also:
+        * `cfbfastR`_ -- the R implementation this ports (``adjust_epa``).
+
+    .. _cfbfastR: https://cfbfastR.sportsdataverse.org
+    """
+    base, clean = _prepare(plays, _REQUIRED_COLUMNS)
+    offense, defense, _ = _fit_opponent_ridge(clean, ridge_lambda)
+    opp = _adjust_games(base, offense, defense, fill_strength=None)
+    team = (
+        opp.group_by("pos_team_id")
+        .agg(
+            pos_team=pl.col("pos_team").last(),
+            valid_games=(pl.col("adj_off_epa").is_not_null() & pl.col("adj_def_epa").is_not_null()).sum(),
+            adj_off_epa=pl.col("adj_off_epa").mean(),
+            adj_def_epa=pl.col("adj_def_epa").mean(),
+            off_strength_faced=pl.col("adjmodelOff").mean(),
+            def_strength_faced=pl.col("adjmodelDef").mean(),
+        )
+        .filter(
+            pl.col("adj_off_epa").is_not_null() & pl.col("adj_def_epa").is_not_null() & (pl.col("valid_games") >= 2)
+        )
+        .with_columns(net_adj_epa=pl.col("adj_off_epa") - pl.col("adj_def_epa"))
+        .sort("pos_team_id")
+    )
+    out = team.with_columns(
+        adj_off_epa_rank=_rank("adj_off_epa", descending=True),
+        adj_def_epa_rank=_rank("adj_def_epa", descending=False),
+        net_adj_epa_rank=_rank("net_adj_epa", descending=True),
+    ).rename({"pos_team_id": "team_id"})
+    return out.to_pandas() if return_as_pandas else out
+
+
+@overload
+def cfb_adjusted_epa_by_game(
+    plays: pl.DataFrame | pd.DataFrame, *, ridge_lambda: float = ..., return_as_pandas: Literal[False] = ...
+) -> pl.DataFrame: ...
+
+
+@overload
+def cfb_adjusted_epa_by_game(
+    plays: pl.DataFrame | pd.DataFrame, *, ridge_lambda: float = ..., return_as_pandas: Literal[True]
+) -> pd.DataFrame: ...
+
+
+def cfb_adjusted_epa_by_game(
+    plays: pl.DataFrame | pd.DataFrame,
+    *,
+    ridge_lambda: float = _RIDGE_LAMBDA,
+    return_as_pandas: bool = False,
+) -> pl.DataFrame | pd.DataFrame:
+    """Walk-forward (point-in-time) opponent-adjusted EPA, one row per team-game.
+
+    For each week ``w`` the opponent-strength ridge is fit on competitive plays
+    from **weeks before ``w`` only**, then that week's games are adjusted with
+    those as-of strengths -- so the value uses no future information and is valid
+    as an in-season power-rating / model feature. Week 1 (no prior) yields null
+    adjustments; not-yet-seen opponents fall back to the league baseline (with the
+    heavy ridge penalty this is the intended early-season shrinkage to average).
+
+    Args:
+        plays: A cfbfastR-schema play-by-play frame (polars or pandas) with the
+            module-docstring columns **plus** ``week``. One season at a time.
+        ridge_lambda: Ridge penalty (glmnet-scale; default 325).
+        return_as_pandas: Return a pandas ``DataFrame`` instead of polars.
+
+    Returns:
+        One row per (game, team), sorted by ``week`` then ``team_id``:
+        ``game_id``, ``week``, ``team_id``, ``opponent_id``, ``pos_team``,
+        ``raw_off_epa``, ``adj_off_epa``, ``raw_def_epa``, ``adj_def_epa``,
+        ``off_strength_faced`` (opponent offense), ``def_strength_faced``
+        (opponent defense), ``net_adj_epa``. The ``adj_*`` / ``net`` columns are
+        null for week 1 (and any week with no prior fit).
+
+    Raises:
+        ImportError: If ``scikit-learn`` is not installed.
+        KeyError: If ``plays`` is missing a required column (incl. ``week``).
+
+    Example:
+        Quick start::
+
+            import sportsdataverse.cfb as cfb
+            pbp = cfb.load_cfb_pbp(seasons=[2023])
+            tg = cfb.cfb_adjusted_epa_by_game(pbp)
+            tg.filter(pl.col("week") >= 5).sort("net_adj_epa", descending=True).head()
+
+    See Also:
+        * `cfbfastR`_ -- the season implementation this extends (``adjust_epa``).
+
+    .. _cfbfastR: https://cfbfastR.sportsdataverse.org
+    """
+    base, clean = _prepare(plays, _BY_GAME_REQUIRED)
+    weeks = sorted(base.filter(pl.col("week").is_not_null())["week"].unique().to_list())
+
+    parts: list[pl.DataFrame] = []
+    for week in weeks:
+        prior = clean.filter(pl.col("week") < week)
+        if prior.height > 0 and prior["pos_team_id"].n_unique() >= 2 and prior["def_pos_team_id"].n_unique() >= 2:
+            offense, defense, intercept = _fit_opponent_ridge(prior, ridge_lambda)
+        else:
+            offense, defense, intercept = _EMPTY_OFFENSE, _EMPTY_DEFENSE, None
+        wk = base.filter(pl.col("week") == week)
+        parts.append(_adjust_games(wk, offense, defense, fill_strength=intercept))
+
+    if parts:
+        out = pl.concat(parts, how="vertical_relaxed")
+    else:
+        out = _adjust_games(base.head(0), _EMPTY_OFFENSE, _EMPTY_DEFENSE, fill_strength=None)
+
+    out = (
+        out.with_columns(net_adj_epa=pl.col("adj_off_epa") - pl.col("adj_def_epa"))
+        .rename(
+            {
+                "pos_team_id": "team_id",
+                "def_pos_team_id": "opponent_id",
+                "adjmodelDef": "def_strength_faced",
+                "adjmodelOff": "off_strength_faced",
+            }
+        )
+        .select(
+            "game_id",
+            "week",
+            "team_id",
+            "opponent_id",
+            "pos_team",
+            "raw_off_epa",
+            "adj_off_epa",
+            "raw_def_epa",
+            "adj_def_epa",
+            "off_strength_faced",
+            "def_strength_faced",
+            "net_adj_epa",
+        )
+        .sort(["week", "team_id"])
+    )
+    return out.to_pandas() if return_as_pandas else out

--- a/sportsdataverse/parsed/cfb.py
+++ b/sportsdataverse/parsed/cfb.py
@@ -155,6 +155,8 @@ from sportsdataverse.cfb import yahoo_cfb_team_season_stats as _raw_yahoo_cfb_te
 from sportsdataverse.cfb import yahoo_cfb_team_season_stats_legacy as _raw_yahoo_cfb_team_season_stats_legacy
 from sportsdataverse.cfb import yahoo_cfb_teams as _raw_yahoo_cfb_teams
 from sportsdataverse.cfb import CFBPlayProcess as CFBPlayProcess  # noqa: F401
+from sportsdataverse.cfb import cfb_adjusted_epa as cfb_adjusted_epa  # noqa: F401
+from sportsdataverse.cfb import cfb_adjusted_epa_by_game as cfb_adjusted_epa_by_game  # noqa: F401
 from sportsdataverse.cfb import cfb_odds_events_crosswalk as cfb_odds_events_crosswalk  # noqa: F401
 from sportsdataverse.cfb import cfb_rosters_crosswalk as cfb_rosters_crosswalk  # noqa: F401
 from sportsdataverse.cfb import cfb_schedule_crosswalk as cfb_schedule_crosswalk  # noqa: F401
@@ -193,6 +195,8 @@ from sportsdataverse.cfb import underscore as underscore  # noqa: F401
 
 __all__ = [
     "CFBPlayProcess",
+    "cfb_adjusted_epa",
+    "cfb_adjusted_epa_by_game",
     "cfb_odds_events_crosswalk",
     "cfb_rosters_crosswalk",
     "cfb_schedule_crosswalk",

--- a/tests/cfb/test_cfb_adjusted_epa.py
+++ b/tests/cfb/test_cfb_adjusted_epa.py
@@ -1,0 +1,165 @@
+"""Unit tests for sportsdataverse.cfb.cfb_adjusted_epa.
+
+Structural / contract tests on a small synthetic league (offline, deterministic).
+Full byte-for-value parity against the R ``adjust_epa`` is validated in the
+cfbfastR-cfb-data ``team_summaries`` integration suite; here we lock the public
+contract: output schema, the net = off - def identity, the valid-games filter,
+clean rankings, the pandas option, and the missing-column guard.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import pytest
+
+from sportsdataverse.cfb import cfb_adjusted_epa, cfb_adjusted_epa_by_game
+
+_EXPECTED_COLUMNS = {
+    "team_id",
+    "pos_team",
+    "valid_games",
+    "adj_off_epa",
+    "adj_def_epa",
+    "off_strength_faced",
+    "def_strength_faced",
+    "net_adj_epa",
+    "adj_off_epa_rank",
+    "adj_def_epa_rank",
+    "net_adj_epa_rank",
+}
+
+
+def _synthetic_pbp() -> pl.DataFrame:
+    """A deterministic 4-team league: every ordered pairing is a game in which
+    both teams take offensive snaps, so each team has plenty of valid games."""
+    teams = ["1", "2", "3", "4"]
+    names = {t: f"T{t}" for t in teams}
+    rng = np.random.default_rng(0)
+    rows: list[dict[str, object]] = []
+    gid = 0
+    for home in teams:
+        for away in teams:
+            if home == away:
+                continue
+            gid += 1
+            week = (gid - 1) // 2 + 1  # 2 games per week
+            for off, dfn in ((home, away), (away, home)):
+                for _ in range(20):
+                    rows.append(
+                        {
+                            "game_id": gid,
+                            "week": week,
+                            "pos_team": names[off],
+                            "pos_team_id": off,
+                            "def_pos_team_id": dfn,
+                            "home": names[home],
+                            "neutral_site": False,
+                            "EPA": float(rng.normal()),
+                            "pass": 1,
+                            "rush": 0,
+                            "wp_before": 0.5,
+                        }
+                    )
+    return pl.DataFrame(rows)
+
+
+def test_schema_and_net_identity() -> None:
+    df = cfb_adjusted_epa(_synthetic_pbp())
+    assert isinstance(df, pl.DataFrame)
+    assert set(df.columns) == _EXPECTED_COLUMNS
+    assert df.height == 4
+    net = df["adj_off_epa"] - df["adj_def_epa"]
+    assert (net - df["net_adj_epa"]).abs().max() < 1e-9
+    assert df["valid_games"].min() >= 2
+
+
+def test_rankings_are_permutations() -> None:
+    df = cfb_adjusted_epa(_synthetic_pbp())
+    for rank_col in ("adj_off_epa_rank", "adj_def_epa_rank", "net_adj_epa_rank"):
+        assert sorted(df[rank_col].to_list()) == [1.0, 2.0, 3.0, 4.0]
+
+
+def test_return_as_pandas() -> None:
+    import pandas as pd
+
+    out = cfb_adjusted_epa(_synthetic_pbp(), return_as_pandas=True)
+    assert isinstance(out, pd.DataFrame)
+    assert set(out.columns) == _EXPECTED_COLUMNS
+
+
+def test_accepts_pandas_input() -> None:
+    out = cfb_adjusted_epa(_synthetic_pbp().to_pandas())
+    assert isinstance(out, pl.DataFrame)
+    assert out.height == 4
+
+
+def test_missing_required_column_raises() -> None:
+    with pytest.raises(KeyError):
+        cfb_adjusted_epa(_synthetic_pbp().drop("EPA"))
+
+
+def test_stable_across_runs() -> None:
+    # Stable within float tolerance (polars' threaded group-by reductions can
+    # differ by a last-ULP across runs, so exact equality is too strict).
+    a = cfb_adjusted_epa(_synthetic_pbp()).sort("team_id")
+    b = cfb_adjusted_epa(_synthetic_pbp()).sort("team_id")
+    assert a.columns == b.columns
+    for col in a.columns:
+        if a.schema[col].is_numeric():
+            assert (a[col] - b[col]).abs().max() < 1e-9
+        else:
+            assert a[col].to_list() == b[col].to_list()
+
+
+_BY_GAME_COLUMNS = {
+    "game_id",
+    "week",
+    "team_id",
+    "opponent_id",
+    "pos_team",
+    "raw_off_epa",
+    "adj_off_epa",
+    "raw_def_epa",
+    "adj_def_epa",
+    "off_strength_faced",
+    "def_strength_faced",
+    "net_adj_epa",
+}
+
+
+def test_by_game_schema_and_grain() -> None:
+    df = cfb_adjusted_epa_by_game(_synthetic_pbp())
+    assert isinstance(df, pl.DataFrame)
+    assert set(df.columns) == _BY_GAME_COLUMNS
+    # one row per (game, team): 12 games x 2 teams
+    assert df.height == 24
+    assert df.select(["game_id", "team_id"]).unique().height == 24
+    assert df["raw_off_epa"].is_not_null().all()
+
+
+def test_by_game_is_walk_forward() -> None:
+    df = cfb_adjusted_epa_by_game(_synthetic_pbp())
+    # week 1 has no prior weeks -> no opponent model -> null adjustments (leak-free)
+    wk1 = df.filter(pl.col("week") == 1)
+    assert wk1.height > 0
+    assert wk1["adj_off_epa"].is_null().all()
+    assert wk1["adj_def_epa"].is_null().all()
+    # later weeks have a prior fit -> adjusted values present
+    assert df.filter(pl.col("week") >= 2)["adj_off_epa"].is_not_null().any()
+    # net = off - def where both present
+    both = df.filter(pl.col("adj_off_epa").is_not_null() & pl.col("adj_def_epa").is_not_null())
+    assert ((both["adj_off_epa"] - both["adj_def_epa"]) - both["net_adj_epa"]).abs().max() < 1e-9
+
+
+def test_by_game_return_as_pandas() -> None:
+    import pandas as pd
+
+    out = cfb_adjusted_epa_by_game(_synthetic_pbp(), return_as_pandas=True)
+    assert isinstance(out, pd.DataFrame)
+    assert set(out.columns) == _BY_GAME_COLUMNS
+
+
+def test_by_game_requires_week() -> None:
+    with pytest.raises(KeyError):
+        cfb_adjusted_epa_by_game(_synthetic_pbp().drop("week"))

--- a/uv.lock
+++ b/uv.lock
@@ -2244,6 +2244,15 @@ wheels = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.25.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3526,6 +3535,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "narwhals"
+version = "2.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/3c/c4ef2164a71c1a63d7f1ae411c4082c5fa872405106db60a4b7114989ad7/narwhals-2.22.1.tar.gz", hash = "sha256:d62920805a0a43b7ff8b54b0c0d3142d796f8a9301836ada37e573d6a33cbcd9", size = 647493, upload-time = "2026-06-05T12:34:34.051Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/ca/36339329c4604adbcc99c899b7eb1ce1a555c499b6a6860757dc9bfed36d/narwhals-2.22.1-py3-none-any.whl", hash = "sha256:60567d774edf77db53906f89d9fbd164e66e56d66d388e1e6990f17ac33cfb53", size = 454815, upload-time = "2026-06-05T12:34:32.289Z" },
 ]
 
 [[package]]
@@ -5879,6 +5897,162 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-learn"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version > '3.9' and python_full_version < '3.10'",
+    "python_full_version <= '3.9'",
+]
+dependencies = [
+    { name = "joblib", marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "threadpoolctl", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/a5/4ae3b3a0755f7b35a280ac90b28817d1f380318973cff14075ab41ef50d9/scikit_learn-1.6.1.tar.gz", hash = "sha256:b4fc2525eca2c69a59260f583c56a7557c6ccdf8deafdba6e060f94c1c59738e", size = 7068312, upload-time = "2025-01-10T08:07:55.348Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/3a/f4597eb41049110b21ebcbb0bcb43e4035017545daa5eedcfeb45c08b9c5/scikit_learn-1.6.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d056391530ccd1e501056160e3c9673b4da4805eb67eb2bdf4e983e1f9c9204e", size = 12067702, upload-time = "2025-01-10T08:05:56.515Z" },
+    { url = "https://files.pythonhosted.org/packages/37/19/0423e5e1fd1c6ec5be2352ba05a537a473c1677f8188b9306097d684b327/scikit_learn-1.6.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:0c8d036eb937dbb568c6242fa598d551d88fb4399c0344d95c001980ec1c7d36", size = 11112765, upload-time = "2025-01-10T08:06:00.272Z" },
+    { url = "https://files.pythonhosted.org/packages/70/95/d5cb2297a835b0f5fc9a77042b0a2d029866379091ab8b3f52cc62277808/scikit_learn-1.6.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8634c4bd21a2a813e0a7e3900464e6d593162a29dd35d25bdf0103b3fce60ed5", size = 12643991, upload-time = "2025-01-10T08:06:04.813Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/91/ab3c697188f224d658969f678be86b0968ccc52774c8ab4a86a07be13c25/scikit_learn-1.6.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:775da975a471c4f6f467725dff0ced5c7ac7bda5e9316b260225b48475279a1b", size = 13497182, upload-time = "2025-01-10T08:06:08.42Z" },
+    { url = "https://files.pythonhosted.org/packages/17/04/d5d556b6c88886c092cc989433b2bab62488e0f0dafe616a1d5c9cb0efb1/scikit_learn-1.6.1-cp310-cp310-win_amd64.whl", hash = "sha256:8a600c31592bd7dab31e1c61b9bbd6dea1b3433e67d264d17ce1017dbdce8002", size = 11125517, upload-time = "2025-01-10T08:06:12.783Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/2a/e291c29670795406a824567d1dfc91db7b699799a002fdaa452bceea8f6e/scikit_learn-1.6.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:72abc587c75234935e97d09aa4913a82f7b03ee0b74111dcc2881cba3c5a7b33", size = 12102620, upload-time = "2025-01-10T08:06:16.675Z" },
+    { url = "https://files.pythonhosted.org/packages/25/92/ee1d7a00bb6b8c55755d4984fd82608603a3cc59959245068ce32e7fb808/scikit_learn-1.6.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:b3b00cdc8f1317b5f33191df1386c0befd16625f49d979fe77a8d44cae82410d", size = 11116234, upload-time = "2025-01-10T08:06:21.83Z" },
+    { url = "https://files.pythonhosted.org/packages/30/cd/ed4399485ef364bb25f388ab438e3724e60dc218c547a407b6e90ccccaef/scikit_learn-1.6.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dc4765af3386811c3ca21638f63b9cf5ecf66261cc4815c1db3f1e7dc7b79db2", size = 12592155, upload-time = "2025-01-10T08:06:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/f3/62fc9a5a659bb58a03cdd7e258956a5824bdc9b4bb3c5d932f55880be569/scikit_learn-1.6.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:25fc636bdaf1cc2f4a124a116312d837148b5e10872147bdaf4887926b8c03d8", size = 13497069, upload-time = "2025-01-10T08:06:32.515Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/a6/c5b78606743a1f28eae8f11973de6613a5ee87366796583fb74c67d54939/scikit_learn-1.6.1-cp311-cp311-win_amd64.whl", hash = "sha256:fa909b1a36e000a03c382aade0bd2063fd5680ff8b8e501660c0f59f021a6415", size = 11139809, upload-time = "2025-01-10T08:06:35.514Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/18/c797c9b8c10380d05616db3bfb48e2a3358c767affd0857d56c2eb501caa/scikit_learn-1.6.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:926f207c804104677af4857b2c609940b743d04c4c35ce0ddc8ff4f053cddc1b", size = 12104516, upload-time = "2025-01-10T08:06:40.009Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b7/2e35f8e289ab70108f8cbb2e7a2208f0575dc704749721286519dcf35f6f/scikit_learn-1.6.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:2c2cae262064e6a9b77eee1c8e768fc46aa0b8338c6a8297b9b6759720ec0ff2", size = 11167837, upload-time = "2025-01-10T08:06:43.305Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/f6/ff7beaeb644bcad72bcfd5a03ff36d32ee4e53a8b29a639f11bcb65d06cd/scikit_learn-1.6.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1061b7c028a8663fb9a1a1baf9317b64a257fcb036dae5c8752b2abef31d136f", size = 12253728, upload-time = "2025-01-10T08:06:47.618Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7a/8bce8968883e9465de20be15542f4c7e221952441727c4dad24d534c6d99/scikit_learn-1.6.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2e69fab4ebfc9c9b580a7a80111b43d214ab06250f8a7ef590a4edf72464dd86", size = 13147700, upload-time = "2025-01-10T08:06:50.888Z" },
+    { url = "https://files.pythonhosted.org/packages/62/27/585859e72e117fe861c2079bcba35591a84f801e21bc1ab85bce6ce60305/scikit_learn-1.6.1-cp312-cp312-win_amd64.whl", hash = "sha256:70b1d7e85b1c96383f872a519b3375f92f14731e279a7b4c6cfd650cf5dffc52", size = 11110613, upload-time = "2025-01-10T08:06:54.115Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/59/8eb1872ca87009bdcdb7f3cdc679ad557b992c12f4b61f9250659e592c63/scikit_learn-1.6.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2ffa1e9e25b3d93990e74a4be2c2fc61ee5af85811562f1288d5d055880c4322", size = 12010001, upload-time = "2025-01-10T08:06:58.613Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/05/f2fc4effc5b32e525408524c982c468c29d22f828834f0625c5ef3d601be/scikit_learn-1.6.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:dc5cf3d68c5a20ad6d571584c0750ec641cc46aeef1c1507be51300e6003a7e1", size = 11096360, upload-time = "2025-01-10T08:07:01.556Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e4/4195d52cf4f113573fb8ebc44ed5a81bd511a92c0228889125fac2f4c3d1/scikit_learn-1.6.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c06beb2e839ecc641366000ca84f3cf6fa9faa1777e29cf0c04be6e4d096a348", size = 12209004, upload-time = "2025-01-10T08:07:06.931Z" },
+    { url = "https://files.pythonhosted.org/packages/94/be/47e16cdd1e7fcf97d95b3cb08bde1abb13e627861af427a3651fcb80b517/scikit_learn-1.6.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e8ca8cb270fee8f1f76fa9bfd5c3507d60c6438bbee5687f81042e2bb98e5a97", size = 13171776, upload-time = "2025-01-10T08:07:11.715Z" },
+    { url = "https://files.pythonhosted.org/packages/34/b0/ca92b90859070a1487827dbc672f998da95ce83edce1270fc23f96f1f61a/scikit_learn-1.6.1-cp313-cp313-win_amd64.whl", hash = "sha256:7a1c43c8ec9fde528d664d947dc4c0789be4077a3647f232869f41d9bf50e0fb", size = 11071865, upload-time = "2025-01-10T08:07:16.088Z" },
+    { url = "https://files.pythonhosted.org/packages/12/ae/993b0fb24a356e71e9a894e42b8a9eec528d4c70217353a1cd7a48bc25d4/scikit_learn-1.6.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:a17c1dea1d56dcda2fac315712f3651a1fea86565b64b48fa1bc090249cbf236", size = 11955804, upload-time = "2025-01-10T08:07:20.385Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/54/32fa2ee591af44507eac86406fa6bba968d1eb22831494470d0a2e4a1eb1/scikit_learn-1.6.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:6a7aa5f9908f0f28f4edaa6963c0a6183f1911e63a69aa03782f0d924c830a35", size = 11100530, upload-time = "2025-01-10T08:07:23.675Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/58/55856da1adec655bdce77b502e94a267bf40a8c0b89f8622837f89503b5a/scikit_learn-1.6.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0650e730afb87402baa88afbf31c07b84c98272622aaba002559b614600ca691", size = 12433852, upload-time = "2025-01-10T08:07:26.817Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/4f/c83853af13901a574f8f13b645467285a48940f185b690936bb700a50863/scikit_learn-1.6.1-cp313-cp313t-win_amd64.whl", hash = "sha256:3f59fe08dc03ea158605170eb52b22a105f238a5d512c4470ddeca71feae8e5f", size = 11337256, upload-time = "2025-01-10T08:07:31.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/37/b305b759cc65829fe1b8853ff3e308b12cdd9d8884aa27840835560f2b42/scikit_learn-1.6.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6849dd3234e87f55dce1db34c89a810b489ead832aaf4d4550b7ea85628be6c1", size = 12101868, upload-time = "2025-01-10T08:07:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/83/74/f64379a4ed5879d9db744fe37cfe1978c07c66684d2439c3060d19a536d8/scikit_learn-1.6.1-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:e7be3fa5d2eb9be7d77c3734ff1d599151bb523674be9b834e8da6abe132f44e", size = 11144062, upload-time = "2025-01-10T08:07:37.67Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/dc/d5457e03dc9c971ce2b0d750e33148dd060fefb8b7dc71acd6054e4bb51b/scikit_learn-1.6.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:44a17798172df1d3c1065e8fcf9019183f06c87609b49a124ebdf57ae6cb0107", size = 12693173, upload-time = "2025-01-10T08:07:42.713Z" },
+    { url = "https://files.pythonhosted.org/packages/79/35/b1d2188967c3204c78fa79c9263668cf1b98060e8e58d1a730fe5b2317bb/scikit_learn-1.6.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8b7a3b86e411e4bce21186e1c180d792f3d99223dcfa3b4f597ecc92fa1a422", size = 13518605, upload-time = "2025-01-10T08:07:46.551Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d8/8d603bdd26601f4b07e2363032b8565ab82eb857f93d86d0f7956fcf4523/scikit_learn-1.6.1-cp39-cp39-win_amd64.whl", hash = "sha256:7a73d457070e3318e32bdb3aa79a8d990474f19035464dfd8bede2883ab5dc3b", size = 11155078, upload-time = "2025-01-10T08:07:51.376Z" },
+]
+
+[[package]]
+name = "scikit-learn"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.10.*'",
+]
+dependencies = [
+    { name = "joblib", marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "threadpoolctl", marker = "python_full_version == '3.10.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/3e/daed796fd69cce768b8788401cc464ea90b306fb196ae1ffed0b98182859/scikit_learn-1.7.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6b33579c10a3081d076ab403df4a4190da4f4432d443521674637677dc91e61f", size = 9336221, upload-time = "2025-09-09T08:20:19.328Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ce/af9d99533b24c55ff4e18d9b7b4d9919bbc6cd8f22fe7a7be01519a347d5/scikit_learn-1.7.2-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:36749fb62b3d961b1ce4fedf08fa57a1986cd409eff2d783bca5d4b9b5fce51c", size = 8653834, upload-time = "2025-09-09T08:20:22.073Z" },
+    { url = "https://files.pythonhosted.org/packages/58/0e/8c2a03d518fb6bd0b6b0d4b114c63d5f1db01ff0f9925d8eb10960d01c01/scikit_learn-1.7.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7a58814265dfc52b3295b1900cfb5701589d30a8bb026c7540f1e9d3499d5ec8", size = 9660938, upload-time = "2025-09-09T08:20:24.327Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/75/4311605069b5d220e7cf5adabb38535bd96f0079313cdbb04b291479b22a/scikit_learn-1.7.2-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a847fea807e278f821a0406ca01e387f97653e284ecbd9750e3ee7c90347f18", size = 9477818, upload-time = "2025-09-09T08:20:26.845Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/9b/87961813c34adbca21a6b3f6b2bea344c43b30217a6d24cc437c6147f3e8/scikit_learn-1.7.2-cp310-cp310-win_amd64.whl", hash = "sha256:ca250e6836d10e6f402436d6463d6c0e4d8e0234cfb6a9a47835bd392b852ce5", size = 8886969, upload-time = "2025-09-09T08:20:29.329Z" },
+    { url = "https://files.pythonhosted.org/packages/43/83/564e141eef908a5863a54da8ca342a137f45a0bfb71d1d79704c9894c9d1/scikit_learn-1.7.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c7509693451651cd7361d30ce4e86a1347493554f172b1c72a39300fa2aea79e", size = 9331967, upload-time = "2025-09-09T08:20:32.421Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d6/ba863a4171ac9d7314c4d3fc251f015704a2caeee41ced89f321c049ed83/scikit_learn-1.7.2-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:0486c8f827c2e7b64837c731c8feff72c0bd2b998067a8a9cbc10643c31f0fe1", size = 8648645, upload-time = "2025-09-09T08:20:34.436Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/0e/97dbca66347b8cf0ea8b529e6bb9367e337ba2e8be0ef5c1a545232abfde/scikit_learn-1.7.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:89877e19a80c7b11a2891a27c21c4894fb18e2c2e077815bcade10d34287b20d", size = 9715424, upload-time = "2025-09-09T08:20:36.776Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/32/1f3b22e3207e1d2c883a7e09abb956362e7d1bd2f14458c7de258a26ac15/scikit_learn-1.7.2-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8da8bf89d4d79aaec192d2bda62f9b56ae4e5b4ef93b6a56b5de4977e375c1f1", size = 9509234, upload-time = "2025-09-09T08:20:38.957Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/71/34ddbd21f1da67c7a768146968b4d0220ee6831e4bcbad3e03dd3eae88b6/scikit_learn-1.7.2-cp311-cp311-win_amd64.whl", hash = "sha256:9b7ed8d58725030568523e937c43e56bc01cadb478fc43c042a9aca1dacb3ba1", size = 8894244, upload-time = "2025-09-09T08:20:41.166Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/aa/3996e2196075689afb9fce0410ebdb4a09099d7964d061d7213700204409/scikit_learn-1.7.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8d91a97fa2b706943822398ab943cde71858a50245e31bc71dba62aab1d60a96", size = 9259818, upload-time = "2025-09-09T08:20:43.19Z" },
+    { url = "https://files.pythonhosted.org/packages/43/5d/779320063e88af9c4a7c2cf463ff11c21ac9c8bd730c4a294b0000b666c9/scikit_learn-1.7.2-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:acbc0f5fd2edd3432a22c69bed78e837c70cf896cd7993d71d51ba6708507476", size = 8636997, upload-time = "2025-09-09T08:20:45.468Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/d0/0c577d9325b05594fdd33aa970bf53fb673f051a45496842caee13cfd7fe/scikit_learn-1.7.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e5bf3d930aee75a65478df91ac1225ff89cd28e9ac7bd1196853a9229b6adb0b", size = 9478381, upload-time = "2025-09-09T08:20:47.982Z" },
+    { url = "https://files.pythonhosted.org/packages/82/70/8bf44b933837ba8494ca0fc9a9ab60f1c13b062ad0197f60a56e2fc4c43e/scikit_learn-1.7.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b4d6e9deed1a47aca9fe2f267ab8e8fe82ee20b4526b2c0cd9e135cea10feb44", size = 9300296, upload-time = "2025-09-09T08:20:50.366Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/99/ed35197a158f1fdc2fe7c3680e9c70d0128f662e1fee4ed495f4b5e13db0/scikit_learn-1.7.2-cp312-cp312-win_amd64.whl", hash = "sha256:6088aa475f0785e01bcf8529f55280a3d7d298679f50c0bb70a2364a82d0b290", size = 8731256, upload-time = "2025-09-09T08:20:52.627Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/93/a3038cb0293037fd335f77f31fe053b89c72f17b1c8908c576c29d953e84/scikit_learn-1.7.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0b7dacaa05e5d76759fb071558a8b5130f4845166d88654a0f9bdf3eb57851b7", size = 9212382, upload-time = "2025-09-09T08:20:54.731Z" },
+    { url = "https://files.pythonhosted.org/packages/40/dd/9a88879b0c1104259136146e4742026b52df8540c39fec21a6383f8292c7/scikit_learn-1.7.2-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:abebbd61ad9e1deed54cca45caea8ad5f79e1b93173dece40bb8e0c658dbe6fe", size = 8592042, upload-time = "2025-09-09T08:20:57.313Z" },
+    { url = "https://files.pythonhosted.org/packages/46/af/c5e286471b7d10871b811b72ae794ac5fe2989c0a2df07f0ec723030f5f5/scikit_learn-1.7.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:502c18e39849c0ea1a5d681af1dbcf15f6cce601aebb657aabbfe84133c1907f", size = 9434180, upload-time = "2025-09-09T08:20:59.671Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/fd/df59faa53312d585023b2da27e866524ffb8faf87a68516c23896c718320/scikit_learn-1.7.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a4c328a71785382fe3fe676a9ecf2c86189249beff90bf85e22bdb7efaf9ae0", size = 9283660, upload-time = "2025-09-09T08:21:01.71Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c7/03000262759d7b6f38c836ff9d512f438a70d8a8ddae68ee80de72dcfb63/scikit_learn-1.7.2-cp313-cp313-win_amd64.whl", hash = "sha256:63a9afd6f7b229aad94618c01c252ce9e6fa97918c5ca19c9a17a087d819440c", size = 8702057, upload-time = "2025-09-09T08:21:04.234Z" },
+    { url = "https://files.pythonhosted.org/packages/55/87/ef5eb1f267084532c8e4aef98a28b6ffe7425acbfd64b5e2f2e066bc29b3/scikit_learn-1.7.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:9acb6c5e867447b4e1390930e3944a005e2cb115922e693c08a323421a6966e8", size = 9558731, upload-time = "2025-09-09T08:21:06.381Z" },
+    { url = "https://files.pythonhosted.org/packages/93/f8/6c1e3fc14b10118068d7938878a9f3f4e6d7b74a8ddb1e5bed65159ccda8/scikit_learn-1.7.2-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:2a41e2a0ef45063e654152ec9d8bcfc39f7afce35b08902bfe290c2498a67a6a", size = 9038852, upload-time = "2025-09-09T08:21:08.628Z" },
+    { url = "https://files.pythonhosted.org/packages/83/87/066cafc896ee540c34becf95d30375fe5cbe93c3b75a0ee9aa852cd60021/scikit_learn-1.7.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:98335fb98509b73385b3ab2bd0639b1f610541d3988ee675c670371d6a87aa7c", size = 9527094, upload-time = "2025-09-09T08:21:11.486Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/2b/4903e1ccafa1f6453b1ab78413938c8800633988c838aa0be386cbb33072/scikit_learn-1.7.2-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:191e5550980d45449126e23ed1d5e9e24b2c68329ee1f691a3987476e115e09c", size = 9367436, upload-time = "2025-09-09T08:21:13.602Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/aa/8444be3cfb10451617ff9d177b3c190288f4563e6c50ff02728be67ad094/scikit_learn-1.7.2-cp313-cp313t-win_amd64.whl", hash = "sha256:57dc4deb1d3762c75d685507fbd0bc17160144b2f2ba4ccea5dc285ab0d0e973", size = 9275749, upload-time = "2025-09-09T08:21:15.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/82/dee5acf66837852e8e68df6d8d3a6cb22d3df997b733b032f513d95205b7/scikit_learn-1.7.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fa8f63940e29c82d1e67a45d5297bdebbcb585f5a5a50c4914cc2e852ab77f33", size = 9208906, upload-time = "2025-09-09T08:21:18.557Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/30/9029e54e17b87cb7d50d51a5926429c683d5b4c1732f0507a6c3bed9bf65/scikit_learn-1.7.2-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:f95dc55b7902b91331fa4e5845dd5bde0580c9cd9612b1b2791b7e80c3d32615", size = 8627836, upload-time = "2025-09-09T08:21:20.695Z" },
+    { url = "https://files.pythonhosted.org/packages/60/18/4a52c635c71b536879f4b971c2cedf32c35ee78f48367885ed8025d1f7ee/scikit_learn-1.7.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9656e4a53e54578ad10a434dc1f993330568cfee176dff07112b8785fb413106", size = 9426236, upload-time = "2025-09-09T08:21:22.645Z" },
+    { url = "https://files.pythonhosted.org/packages/99/7e/290362f6ab582128c53445458a5befd471ed1ea37953d5bcf80604619250/scikit_learn-1.7.2-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96dc05a854add0e50d3f47a1ef21a10a595016da5b007c7d9cd9d0bffd1fcc61", size = 9312593, upload-time = "2025-09-09T08:21:24.65Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/87/24f541b6d62b1794939ae6422f8023703bbf6900378b2b34e0b4384dfefd/scikit_learn-1.7.2-cp314-cp314-win_amd64.whl", hash = "sha256:bb24510ed3f9f61476181e4db51ce801e2ba37541def12dc9333b946fc7a9cf8", size = 8820007, upload-time = "2025-09-09T08:21:26.713Z" },
+]
+
+[[package]]
+name = "scikit-learn"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
+    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "joblib", marker = "python_full_version >= '3.11'" },
+    { name = "narwhals", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "threadpoolctl", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/be/e844fd9586e66540a15b71924d17a6cbc1bb749e81ddd0a796bcdba4c055/scikit_learn-1.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9db6f4d34e68c8899e4cab27fdf8eafe6ed21f2ba52ceb25ea250cd237f8e47b", size = 8789686, upload-time = "2026-06-02T11:53:05.439Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e2/ff880f62677a17d035817d543cb0fc8727d01eccbee81c5f7fc733a9d856/scikit_learn-1.9.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:f401448645a3e7bc115aa3c094097865155b34bff1cba8101857d9104e99074c", size = 8256782, upload-time = "2026-06-02T11:53:08.904Z" },
+    { url = "https://files.pythonhosted.org/packages/25/64/eb40435e1a508ab1b4e284ce43ae80f6a162e5be5e38ed5a6fab467a9ea4/scikit_learn-1.9.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fd3a8ef0c758555a3b23c03adaa858af32f7736785ded50ad5991f59c4ed03fa", size = 8992419, upload-time = "2026-06-02T11:53:11.551Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/4810a28e473185429e45a57eebcc91fc991b33d889cc0676063e671db03d/scikit_learn-1.9.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f7e254636164090da847715a27f8e5478feb98c40a9e0ee90cbd277de9e5ceb8", size = 9281411, upload-time = "2026-06-02T11:53:15.063Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/67/be3d369f40d8178ba3bd86635d132e08cb5329b023e4669d9426d84bc007/scikit_learn-1.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:5dc1818c77575d149e25fce9ef82dd7b7263ae372f03494158668ad632a69759", size = 8272736, upload-time = "2026-06-02T11:53:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/37/79/a733f02dc2118da7e77a134b34f39f40201a353311b011d20859d2db3556/scikit_learn-1.9.0-cp311-cp311-win_arm64.whl", hash = "sha256:366652351f092b219c248f1e72821e841960a63d8f358f1dcfd54dc1cbdbbc28", size = 7919564, upload-time = "2026-06-02T11:53:21.2Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/20/75f915ff375d6249e6550ac740fdbbd66159a068fd3af1400ff62036b07a/scikit_learn-1.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2bd41b0d201bc81575531b96b713d3eb5e5f50fb0b82101ff0f92294fdc236ac", size = 8741122, upload-time = "2026-06-02T11:53:24.08Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d5/2b5148f2279196775e1db2aeb85d14b70ac80e7e32b3b28e7ebeafb0901d/scikit_learn-1.9.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5be45aa4a42a68a533913a6ed736cf309de2226411c79ef8d609a5456f1939b1", size = 8261512, upload-time = "2026-06-02T11:53:27.183Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/ee/5adbc77656b71f9456a2f5a7a9fdb4bcf9207a6b962889f1c2f9323afa4e/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e50ed4da51974e86e940690e9a3d82e729b62b5a49f7c9bac534d515d39d86f", size = 8837603, upload-time = "2026-06-02T11:53:30.328Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c2/63fdda36c56437eeb44aaf9493c8bcd62ce230ab1598924fc626ffbfa943/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:056c92bb67ad4c28463c2f2653d9701449201e7e7a9e94e321be0f71c4fef2b8", size = 9132097, upload-time = "2026-06-02T11:53:33.456Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a4/c8e67227c680e2259c8864ae72ff48b06e16a6f51253a22167aa02a8aa4e/scikit_learn-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:4306775fad04cc4b472a1b15af1ae9cede1540fbfcc17fbce3767cd8dc7ae283", size = 8211173, upload-time = "2026-06-02T11:53:36.602Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/fd/3c0863792e98e67e9184aa4029288a175935eb65443afcd30d4f143450cf/scikit_learn-1.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:26e22435f63bcdcf396b574273f29f13dd531f5ea035801f5be10ba1540a4e60", size = 7867451, upload-time = "2026-06-02T11:53:39.075Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/cf3310626b6d48d3e9be69a1223f9180360b5e6edb045f50fade723ce494/scikit_learn-1.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:80746d63bd4b6eaca54d36fe5feaf4d28bb38dc6f9470f81c7cad7c40155f119", size = 8705188, upload-time = "2026-06-02T11:53:41.964Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/04/5acd7ae280c5f93b6ac5ef6cdec14eef4c8d1cd91d85b3292989c94d96b1/scikit_learn-1.9.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5b934c45c252844a91d69fda3a34cff5e7307e1db10d77cb10a3980312c74713", size = 8228299, upload-time = "2026-06-02T11:53:44.817Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/39/ffe829a5b8ecb40a518724a997794657fdc354ada5e8fe8e64d998c0bac9/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:38c3dcb9a1ffb85505ec53d54c7b4aea0cff70050425a7760c2af661ac85df05", size = 8789690, upload-time = "2026-06-02T11:53:47.461Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/88/8dab5de10c638c083772a6be83a3d8106ced492f74a928c8693638e5bb50/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da76d09304a4706db7cc1e3ebaa3b6b98a67365cc11d2996c4f1e58ba47df714", size = 9087723, upload-time = "2026-06-02T11:53:50.702Z" },
+    { url = "https://files.pythonhosted.org/packages/20/3f/7917ca72464038f6240ec70c29f94862d08a34a74291ae4d4ec5eb8186a0/scikit_learn-1.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:5808d98f15c6bf6d9d96d2348c1997392a5888ce7097e664105f930c4bca1277", size = 8184330, upload-time = "2026-06-02T11:53:53.396Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c7/15739eb2f61fda3c54639e9942414e5a19ad8a8d1f5a3266afad7cb7df80/scikit_learn-1.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:d77f54c017633791bc0225a43e2f8d03745fdcfe4880268fcc4df15f505dec2e", size = 7840653, upload-time = "2026-06-02T11:53:56.035Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/c9a35cf59b20a86fec24d306f1547b78dec194b08d367ce2a3e4854169d9/scikit_learn-1.9.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9656acd4e93f74e0b66c8a36c88830a99252dfa900044d36bc2212ae89a47162", size = 8713289, upload-time = "2026-06-02T11:53:58.788Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a7/552a7821597c632b907f7bfe8f36f9f572777af8ef8a48353041cf8e091a/scikit_learn-1.9.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:24360002ae845e7866522b0a5bbf690802e7bc388cac8663502e78aa98598aa2", size = 8245141, upload-time = "2026-06-02T11:54:01.694Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/79/f4a0c4fe9711154cddabf913471153af79056382ddc612cfe5ee0ff4b72e/scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5162ad10a418c8a282dde04c9aa06965de3e9a65f33c1440c0ae69bb1a09d913", size = 8847671, upload-time = "2026-06-02T11:54:04.448Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/af/4d72d9e475ac83719160c662619e4bf7b95c19507cd582e7d0167a3c3dae/scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fea2cc5677ab49d6f5bade978c866da44957b712d92e9635e8b4f723013c3cb", size = 9118104, upload-time = "2026-06-02T11:54:07.205Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/d5/6a58eea2cb9abbb9b3f2bb8b2cfb3243d1152d69f442d256c7af71304769/scikit_learn-1.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:64fa347efc1c839c487433e40c5144d38c336e8a2b59c81aa8660373945c2673", size = 8290674, upload-time = "2026-06-02T11:54:10.087Z" },
+    { url = "https://files.pythonhosted.org/packages/65/5b/d4c879cf358f1187141cf90ced473f087183489090244f50c124a2ee478b/scikit_learn-1.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:1b944b6db288f6b926e3650026ddafb988929de95d11fc2cc5fa117773c9ba42", size = 7978807, upload-time = "2026-06-02T11:54:12.769Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/43/bfae3121ec67ae09150d453c442c7c1cc166e9aefe056e6ab3b7728a5cfc/scikit_learn-1.9.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4ccacf04ca5f4b492158a5f28afe0ace43f81b2571e4b9a66d34848b46128949", size = 9031941, upload-time = "2026-06-02T11:54:15.436Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b0/20a4546eb17f3b25d3c66df15810411c14ed5065bcfab50b53c96fb627b2/scikit_learn-1.9.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:ee1a8db2c18c08e34c7412d4b10be1cac214cd4ea7dc9715a6a327eb49a37c96", size = 8613528, upload-time = "2026-06-02T11:54:18.842Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3c/e440e039bb82cd19004edaaad00acbde0fb9b461083c3ecf37941c557312/scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:147e9329ef0e39f75d4cffa02b2aa48d827832684926cd5210d9a2cb5c57246b", size = 8855050, upload-time = "2026-06-02T11:54:21.699Z" },
+    { url = "https://files.pythonhosted.org/packages/43/26/b341b8dab5998da6270a3a42c2152c578501354d36f944b5856757035ef8/scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bad8f8b9950321b54c965fdcbac6c6c55e79e16646b49977bcf3668d3870a1a", size = 9097190, upload-time = "2026-06-02T11:54:24.454Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/de/b650b4d69b84468cfa2e28a3ff7b8103743029e6446ce1a97fe060ef688c/scikit_learn-1.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:78fc56eafd4edb9575d2d8950d1dd152061abb573341a1cb7e099fc40f6c6666", size = 8963204, upload-time = "2026-06-02T11:54:27.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f3/ff83d76d7418112e5a61326443cdda87be3545dd8d6599c95b2481a4419e/scikit_learn-1.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:051075bda8b7aab87b1906ab3d4740a1e1224a19d7b3781a576736edc94e76aa", size = 8222661, upload-time = "2026-06-02T11:54:30.192Z" },
+]
+
+[[package]]
 name = "scipy"
 version = "1.13.1"
 source = { registry = "https://pypi.org/simple" }
@@ -6164,6 +6338,9 @@ dependencies = [
     { name = "pyreadr" },
     { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "requests", version = "2.33.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "scikit-learn", version = "1.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -6201,6 +6378,9 @@ all = [
     { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "requests", version = "2.33.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "ruff" },
+    { name = "scikit-learn", version = "1.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -6222,6 +6402,9 @@ models = [
     { name = "pyreadr" },
     { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "requests", version = "2.33.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "scikit-learn", version = "1.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -6340,6 +6523,9 @@ requires-dist = [
     { name = "requests", marker = "extra == 'models'", specifier = ">=2.28.0" },
     { name = "ruff", marker = "extra == 'all'", specifier = ">=0.1.0" },
     { name = "ruff", marker = "extra == 'tests'", specifier = ">=0.1.0" },
+    { name = "scikit-learn", specifier = ">=1.0.0" },
+    { name = "scikit-learn", marker = "extra == 'all'", specifier = ">=1.0.0" },
+    { name = "scikit-learn", marker = "extra == 'models'", specifier = ">=1.0.0" },
     { name = "scipy", specifier = ">=1.10.0" },
     { name = "scipy", marker = "extra == 'all'", specifier = ">=1.10.0" },
     { name = "scipy", marker = "extra == 'models'", specifier = ">=1.10.0" },
@@ -6396,6 +6582,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds `sportsdataverse.cfb.cfb_adjusted_epa` and `cfb_adjusted_epa_by_game` — a
reusable ridge / RAPM opponent-adjustment primitive, lifted out of the
cfbfastR-cfb-data `team_summaries` builder (port of cfbfastR `adjust_epa`) so any
caller can run it on a supplied play-by-play frame.

It is **not** a bundled model artifact (unlike the EP/WP/QBR `.ubj` files): the
ridge is fit in-sample on team dummies, so the coefficients *are* that window's
team strengths — nothing to persist or apply to another season.

## Functions

- `cfb_adjusted_epa(plays)` — season per-team adjusted off/def/net EPA + ranks
  (in-sample, descriptive; the figure the team-summary tables use).
- `cfb_adjusted_epa_by_game(plays)` — **walk-forward / point-in-time** per
  team-game: week *w* is adjusted using opponent strengths fit only on
  competitive plays from weeks < *w*. Leak-free, so the values are valid as
  in-season power-rating / model inputs. Week 1 (no prior) → null adjustments;
  not-yet-seen opponents fall back to the league baseline (with the heavy ridge
  penalty, the intended early-season shrinkage toward average).

Shared `_fit_opponent_ridge` / `_adjust_games` helpers; the season function's
behavior is unchanged (`fill_strength=None` keeps null-on-reference).

## Wiring

- `scikit-learn>=1.0.0` added to deps (core + `models` + `all`, mirroring
  `xgboost`); imported lazily inside the fit, so base-install users who never
  call it pay no import cost.
- Module appended to the `[tool.mypy]` files ratchet.
- 10 offline structural tests; **full byte-for-value R parity is validated in
  cfbfastR-cfb-data** (the `team_summaries` integration suite) — here we lock the
  public contract (schema, net = off − def, valid-games filter, rankings, the
  walk-forward leak-free property, pandas option, missing-column guard).

## Notes

- Touches `uv.lock` (adds scikit-learn; also syncs the editable self-version to
  match `pyproject`). If #136 merges first this branch needs a re-lock.
- Follow-up: repoint cfb-data `team_summaries` at this shared function once it
  ships in a release (drops the builder's local copy of `adjust_epa`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opponent-adjusted EPA metrics for CFB with both season-level and walk-forward (by-game) views.
  * Exposed the new adjusted EPA helpers at the CFB module level for easier access.

* **Bug Fixes**
  * Ensured walk-forward adjustments only use prior-week information (week 1 yields null adjustments).

* **Documentation**
  * Added reference docs for the two new adjusted EPA functions.

* **Tests**
  * Added coverage for output schema, net identity, ranking, pandas compatibility, repeatability, and leak-free by-game behavior.

* **Chores**
  * Updated required dependencies to support the new calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->