### PR TITLE
2026 Parsing Updates

### DIFF
--- a/sportsdataverse/cfb/cfb_pbp.py
+++ b/sportsdataverse/cfb/cfb_pbp.py
@@ -66,7 +66,7 @@ def _extract_player_name(text_expr: pl.Expr, pattern: str) -> pl.Expr:
 #: whole word (real surnames effectively never do). Used to null garbage
 #: extractions like "bea loss of" / "for a loss" before the roster id-join.
 _PLAYER_NAME_GARBAGE = re.compile(
-    r"(?i)\b(loss|gain|yards?|incomplete|penalty|fumbled|sacked|touchdown|kickoff|punt|return)\b"
+    r"(?i)\b(loss|gain|yards?|incomplete|penalty|fumbled|sacked|touchdown|kickoff|punt|return|hurried by|QB)\b"
 )
 
 

--- a/sportsdataverse/cfb/cfb_pbp.py
+++ b/sportsdataverse/cfb/cfb_pbp.py
@@ -5221,6 +5221,7 @@ class CFBPlayProcess(object):
             .agg(
                 Comp=pl.col("completion").sum(),
                 Att=pl.col("pass_attempt").sum(),
+                xComp=pl.col("cp").sum(),
                 Yds=pl.col("yds_receiving").sum(),
                 Pass_TD=pl.col("pass_td").sum(),
                 Int=pl.col("int").sum(),
@@ -5232,7 +5233,14 @@ class CFBPlayProcess(object):
                 Sck=pl.col("sack_vec").sum(),
             )
             .with_columns(pl.col(pl.Float32).round(2))
-            .with_columns(pos_team=pl.col("pos_team").cast(pl.Int32))
+            .with_columns(
+                CompPct=(pl.when(pl.col("Att") == pl.lit(0)).then(0).otherwise(pl.col("Comp") / pl.col("Att"))),
+                xCompPct=(pl.when(pl.col("Att") == pl.lit(0)).then(0).otherwise(pl.col("xComp") / pl.col("Att"))),
+            )
+            .with_columns(
+                CPOE=(pl.col("CompPct") - pl.col("xCompPct")),
+                pos_team=pl.col("pos_team").cast(pl.Int32)
+            )
         )
         # passer_box = passer_box.replace(pl.all(), pl.Null)
         qbs_list = passer_box["passer_player_name"].to_list()

--- a/sportsdataverse/cfb/cfb_pbp.py
+++ b/sportsdataverse/cfb/cfb_pbp.py
@@ -5232,13 +5232,15 @@ class CFBPlayProcess(object):
                 SR=pl.col("EPA_success").mean(),
                 Sck=pl.col("sack_vec").sum(),
             )
-            .with_columns(pl.col(pl.Float32).round(2))
             .with_columns(
                 CompPct=(pl.when(pl.col("Att") == pl.lit(0)).then(0).otherwise(pl.col("Comp") / pl.col("Att"))),
                 xCompPct=(pl.when(pl.col("Att") == pl.lit(0)).then(0).otherwise(pl.col("xComp") / pl.col("Att"))),
             )
             .with_columns(
                 CPOE=(pl.col("CompPct") - pl.col("xCompPct")),
+            )
+            .with_columns(pl.col(pl.Float32).round(2))
+            .with_columns(
                 pos_team=pl.col("pos_team").cast(pl.Int32)
             )
         )

--- a/sportsdataverse/cfb/cfb_pbp.py
+++ b/sportsdataverse/cfb/cfb_pbp.py
@@ -5240,9 +5240,7 @@ class CFBPlayProcess(object):
                 CPOE=(pl.col("CompPct") - pl.col("xCompPct")),
             )
             .with_columns(pl.col(pl.Float32).round(2))
-            .with_columns(
-                pos_team=pl.col("pos_team").cast(pl.Int32)
-            )
+            .with_columns(pos_team=pl.col("pos_team").cast(pl.Int32))
         )
         # passer_box = passer_box.replace(pl.all(), pl.Null)
         qbs_list = passer_box["passer_player_name"].to_list()

--- a/tests/cfb/test_cfb_pbp.py
+++ b/tests/cfb/test_cfb_pbp.py
@@ -81,7 +81,7 @@ def test_cfb_adv_box_score_wr_names():
     }
     assert expected_sections.issubset(set(result.keys()))
 
-    bad_wr_names = [x for x in result["receiver"] if x["receiver_player_name"] and "hurried" in x["receiver_player_name"]]
+    bad_wr_names = [x["receiver_player_name"] for x in result["receiver"] if x["receiver_player_name"] and "hurried" in x["receiver_player_name"]]
     assert len(bad_wr_names) == 0
 
 

--- a/tests/cfb/test_cfb_pbp.py
+++ b/tests/cfb/test_cfb_pbp.py
@@ -57,6 +57,33 @@ def test_cfb_adv_box_score(cfb_box_score):
     }
     assert expected_sections.issubset(set(cfb_box_score.keys()))
 
+@skip_if_no_live
+def test_cfb_adv_box_score_wr_names():
+    test = CFBPlayProcess(gameId=401779840)
+    fetch_pbp_or_skip(test)
+    test.run_processing_pipeline()
+    result = test.create_box_score(pl.DataFrame(test.plays_json, infer_schema_length=400))
+
+    assert result is not None
+    # Subset direction (expected ⊆ actual): the box score must contain these sections;
+    # additive sections are allowed so the test doesn't break when new ones are introduced.
+    expected_sections = {
+        "pass",
+        "rush",
+        "receiver",
+        "team",
+        "situational",
+        "defensive",
+        "defensive_players",
+        "specialists",
+        "turnover",
+        "drives",
+    }
+    assert expected_sections.issubset(set(result.keys()))
+
+    bad_wr_names = [x for x in result["receiver"] if x["receiver_player_name"] and "hurried" in x["receiver_player_name"]]
+    assert len(bad_wr_names) == 0
+
 
 def test_havoc_rate(cfb_box_score):
     defense_home = cfb_box_score["defensive"][0]

--- a/tests/cfb/test_cfb_pbp.py
+++ b/tests/cfb/test_cfb_pbp.py
@@ -57,6 +57,7 @@ def test_cfb_adv_box_score(cfb_box_score):
     }
     assert expected_sections.issubset(set(cfb_box_score.keys()))
 
+
 @skip_if_no_live
 def test_cfb_adv_box_score_wr_names():
     test = CFBPlayProcess(gameId=401779840)
@@ -81,7 +82,11 @@ def test_cfb_adv_box_score_wr_names():
     }
     assert expected_sections.issubset(set(result.keys()))
 
-    bad_wr_names = [x["receiver_player_name"] for x in result["receiver"] if x["receiver_player_name"] and "hurried" in x["receiver_player_name"]]
+    bad_wr_names = [
+        x["receiver_player_name"]
+        for x in result["receiver"]
+        if x["receiver_player_name"] and "hurried" in x["receiver_player_name"]
+    ]
     assert len(bad_wr_names) == 0
 
 


### PR DESCRIPTION
## Summary

Basic changes to clean up player box score information.

## Changes

- Updated player cleaning regex to remove more cases
- Updated passing box score to aggregate `cp` (IE: xCompletion model results)

## Type of change

- [X] Bug fix (non-breaking)
- [X] New feature (non-breaking)
- [ ] Breaking change (existing API surface changes)
- [ ] Documentation only
- [ ] Test only
- [ ] Refactor (no behavior change)
- [ ] Tooling / CI / packaging

## Test plan

Running:
- `SDV_PY_LIVE_TESTS=1 uv run pytest ./tests/cfb/test_cfb_pbp.py::test_cfb_adv_box_score_wr_names` -- checks that player names affected by the updated regex aren't passed through
-  `SDV_PY_LIVE_TESTS=1 uv run pytest ./tests/cfb/test_cfb_pbp.py::test_cfb_adv_box_score` -- verifying that existing box scores don't break due to the addition of a new field

- [X] `uv run pytest tests/<scope>/` passes offline
- [X] `SDV_PY_LIVE_TESTS=1 uv run pytest tests/<scope>/` passes (if data-touching)
- [X] `uv run mypy sportsdataverse/<modules>` passes for newly-typed modules
- [X] `uv run ruff check sportsdataverse/<modules>` passes

## Breaking changes

None.

## Documentation

- [-] CHANGELOG.md entry added
- [-] Docstring(s) updated
- [-] CLAUDE.md / copilot-instructions.md updated (only if a convention or pattern changes)

## Checklist

- [X] My code follows the project's [code standards](../CONTRIBUTING.md#code-standards-for-new-modules).
- [X] I have NOT included AI agents (Claude, Copilot, GPT, etc.) as commit co-authors.
- [X] I have searched existing PRs to confirm this isn't a duplicate.

## Summary by Sourcery

Improve CFB advanced box score parsing by cleaning invalid player names and adding passing completion expectation metrics.

New Features:
- Add xComp and derived xCompPct and CPOE metrics to the CFB passing box score output.

Bug Fixes:
- Expand player name garbage filtering to exclude "hurried by" and "QB" fragments from extracted receiver names.

Tests:
- Add a live CFB advanced box score test to ensure wide receiver names no longer include "hurried" artifacts in the receiver section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enhanced advanced box scores with expected completions and updated passing efficiency metrics (including completion vs. expected).

* **Bug Fixes**
  * Improved play-text cleanup to reduce false roster/name matches from non-name artifacts (e.g., “hurried by”, “QB”).

* **Tests**
  * Added a live-only regression test to ensure advanced box score sections are produced and receiver names are not incorrectly populated with “hurried” content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->