### PR TITLE
feat(validation): domain ③ Phase 1 — data-prep checks (boundary_leakage + prep_published_parity)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -305,4 +305,6 @@ files = [
     "tools/validation/checks/numeric_parity.py",
     "tools/validation/checks/sweep.py",
     "tools/validation/checks/e2e.py",
+    "tools/validation/checks/boundary_leakage.py",
+    "tools/validation/checks/prep_published_parity.py",
 ]

--- a/tests/contracts/test_boundary_leakage.py
+++ b/tests/contracts/test_boundary_leakage.py
@@ -1,0 +1,37 @@
+import polars as pl
+
+from tools.validation.checks import boundary_leakage
+from tools.validation.findings import CheckContext, Severity
+
+
+def _ctx(**kw):
+    base = dict(domain="nfl", dataset="nfl_pbp", schema={}, group_key="game_id", lag_columns=("prev_ep",))
+    base.update(kw)
+    return CheckContext(**base)
+
+
+def test_lag_nonnull_on_first_of_game_is_error():
+    # game 1 first row has a carried prev_ep (leak); proper resets are null on row 0
+    frame = pl.DataFrame(
+        {
+            "game_id": [1, 1, 2, 2],
+            "prev_ep": [3.5, 1.0, None, 2.0],  # game 1 row0 = 3.5 (LEAK); game 2 row0 = None (ok)
+        }
+    )
+    findings = boundary_leakage.run("nfl_pbp", frame, _ctx())
+    assert any(f.severity is Severity.ERROR and "prev_ep" in f.message for f in findings)
+
+
+def test_clean_lag_resets_yield_no_findings():
+    frame = pl.DataFrame(
+        {
+            "game_id": [1, 1, 2, 2],
+            "prev_ep": [None, 1.0, None, 2.0],  # both games reset to null on row 0
+        }
+    )
+    assert boundary_leakage.run("nfl_pbp", frame, _ctx()) == []
+
+
+def test_no_group_key_column_skips():
+    frame = pl.DataFrame({"prev_ep": [None, 1.0]})
+    assert boundary_leakage.run("nfl_pbp", frame, _ctx()) == []

--- a/tests/contracts/test_boundary_leakage.py
+++ b/tests/contracts/test_boundary_leakage.py
@@ -35,3 +35,8 @@ def test_clean_lag_resets_yield_no_findings():
 def test_no_group_key_column_skips():
     frame = pl.DataFrame({"prev_ep": [None, 1.0]})
     assert boundary_leakage.run("nfl_pbp", frame, _ctx()) == []
+
+
+def test_lag_column_absent_from_frame_skips():
+    frame = pl.DataFrame({"game_id": [1, 1]})  # prev_ep absent
+    assert boundary_leakage.run("nfl_pbp", frame, _ctx()) == []

--- a/tests/contracts/test_boundary_leakage.py
+++ b/tests/contracts/test_boundary_leakage.py
@@ -40,3 +40,24 @@ def test_no_group_key_column_skips():
 def test_lag_column_absent_from_frame_skips():
     frame = pl.DataFrame({"game_id": [1, 1]})  # prev_ep absent
     assert boundary_leakage.run("nfl_pbp", frame, _ctx()) == []
+
+
+def test_two_lag_columns_both_detected():
+    # regression: when two lag columns are configured, leaks in both must be reported
+    frame = pl.DataFrame(
+        {
+            "game_id": [1, 1, 2, 2],
+            "prev_ep": [3.5, 1.0, None, 2.0],  # game 1 row0 leaks
+            "prev_wp": [0.8, 0.6, None, 0.5],  # game 1 row0 leaks
+        }
+    )
+    ctx = _ctx(lag_columns=("prev_ep", "prev_wp"))
+    findings = boundary_leakage.run("nfl_pbp", frame, ctx)
+    assert any("prev_ep" in f.message for f in findings)
+    assert any("prev_wp" in f.message for f in findings)
+
+
+def test_empty_lag_columns_returns_no_findings():
+    # early-exit: no lag columns configured → no findings regardless of frame content
+    frame = pl.DataFrame({"game_id": [1, 1], "prev_ep": [3.5, 1.0]})
+    assert boundary_leakage.run("nfl_pbp", frame, _ctx(lag_columns=())) == []

--- a/tests/contracts/test_prep_published_parity.py
+++ b/tests/contracts/test_prep_published_parity.py
@@ -29,3 +29,20 @@ def test_null_in_one_side_is_divergence():
     published = pl.DataFrame({"game_id": [1, 2], "epa": [0.1, None]})  # game 2 epa dropped to null
     findings = prep_published_parity.run("d", prep, published, ("game_id",), "nfl")
     assert any(f.severity is Severity.ERROR and "epa" in f.message for f in findings)
+
+
+def test_within_tolerance_yields_no_findings():
+    # diff of 5e-7 is below the default tolerance of 1e-6 — must not be reported
+    prep = pl.DataFrame({"game_id": [1, 2], "epa": [0.1, 0.2]})
+    published = pl.DataFrame({"game_id": [1, 2], "epa": [0.1, 0.2 + 5e-7]})
+    assert prep_published_parity.run("d", prep, published, ("game_id",), "nfl", tolerance=1e-6) == []
+
+
+def test_suffix_collision_still_reports_divergence():
+    # published already carries "epa__pub__" (the join suffix).  Without the
+    # collision guard this raises DuplicateError; with it, divergence in "epa"
+    # must still be detected correctly.
+    prep = pl.DataFrame({"game_id": [1, 2], "epa": [0.1, 0.2]})
+    published = pl.DataFrame({"game_id": [1, 2], "epa": [0.1, 0.9], "epa__pub__": [999.0, 999.0]})
+    findings = prep_published_parity.run("d", prep, published, ("game_id",), "nfl")
+    assert any(f.severity is Severity.ERROR and "epa" in f.message for f in findings)

--- a/tests/contracts/test_prep_published_parity.py
+++ b/tests/contracts/test_prep_published_parity.py
@@ -1,0 +1,24 @@
+import polars as pl
+
+from tools.validation.checks import prep_published_parity
+from tools.validation.findings import Severity
+
+
+def test_matching_frames_yield_no_findings():
+    prep = pl.DataFrame({"game_id": [1, 2], "epa": [0.1, 0.2]})
+    published = pl.DataFrame({"game_id": [1, 2], "epa": [0.1, 0.2]})
+    assert prep_published_parity.run("d", prep, published, ("game_id",), "nfl") == []
+
+
+def test_dropped_row_is_error():
+    prep = pl.DataFrame({"game_id": [1, 2], "epa": [0.1, 0.2]})
+    published = pl.DataFrame({"game_id": [1], "epa": [0.1]})  # game 2 dropped
+    findings = prep_published_parity.run("d", prep, published, ("game_id",), "nfl")
+    assert any(f.severity is Severity.ERROR and "dropped" in f.message for f in findings)
+
+
+def test_value_divergence_is_error():
+    prep = pl.DataFrame({"game_id": [1, 2], "epa": [0.1, 0.2]})
+    published = pl.DataFrame({"game_id": [1, 2], "epa": [0.1, 0.9]})  # game 2 epa diverges
+    findings = prep_published_parity.run("d", prep, published, ("game_id",), "nfl")
+    assert any(f.severity is Severity.ERROR and "epa" in f.message for f in findings)

--- a/tests/contracts/test_prep_published_parity.py
+++ b/tests/contracts/test_prep_published_parity.py
@@ -22,3 +22,10 @@ def test_value_divergence_is_error():
     published = pl.DataFrame({"game_id": [1, 2], "epa": [0.1, 0.9]})  # game 2 epa diverges
     findings = prep_published_parity.run("d", prep, published, ("game_id",), "nfl")
     assert any(f.severity is Severity.ERROR and "epa" in f.message for f in findings)
+
+
+def test_null_in_one_side_is_divergence():
+    prep = pl.DataFrame({"game_id": [1, 2], "epa": [0.1, 0.2]})
+    published = pl.DataFrame({"game_id": [1, 2], "epa": [0.1, None]})  # game 2 epa dropped to null
+    findings = prep_published_parity.run("d", prep, published, ("game_id",), "nfl")
+    assert any(f.severity is Severity.ERROR and "epa" in f.message for f in findings)

--- a/tests/contracts/test_registry.py
+++ b/tests/contracts/test_registry.py
@@ -11,3 +11,25 @@ def test_dataset_spec_defaults_are_not_shared():
 def test_load_thresholds_returns_dict():
     t = load_thresholds("nfl")
     assert isinstance(t, dict)
+
+
+def test_dataset_spec_has_leakage_fields_with_safe_defaults():
+    a = DatasetSpec(name="a", domain="nfl", parquet_glob="x", schema={})
+    assert a.lag_columns == () and a.cumulative_columns == ()
+    assert a.group_key == "game_id"
+
+
+def test_checkcontext_carries_leakage_fields():
+    from tools.validation.findings import CheckContext
+
+    ctx = CheckContext(
+        domain="nfl",
+        dataset="d",
+        schema={},
+        lag_columns=("prev_ep",),
+        cumulative_columns=("cum_epa",),
+        group_key="game_id",
+    )
+    assert ctx.lag_columns == ("prev_ep",)
+    assert ctx.cumulative_columns == ("cum_epa",)
+    assert ctx.group_key == "game_id"

--- a/tools/validation/checks/boundary_leakage.py
+++ b/tools/validation/checks/boundary_leakage.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import polars as pl
+
+from tools.validation.findings import CheckContext, Finding, Severity
+
+
+def run(dataset: str, frame: pl.DataFrame, ctx: CheckContext) -> list[Finding]:
+    """Detect cross-group leakage on lag columns at group boundaries.
+
+    Partitions the frame by ``ctx.group_key`` (frame assumed to be in play order
+    within each group) and flags any ``ctx.lag_columns`` value that is non-null on
+    a group's first row — a carried prior-group value (a cross-game leak).
+    ``ctx.cumulative_columns`` is accepted but not yet inspected (follow-up).
+
+    Args:
+        dataset: Dataset identifier recorded on each finding.
+        frame: The data frame under validation (play-ordered within each group).
+        ctx: Check context supplying ``group_key`` and ``lag_columns``.
+
+    Returns:
+        A list of Finding records; empty if ``group_key`` is absent or no
+        ``lag_columns`` are declared.
+    """
+    findings: list[Finding] = []
+    gk = ctx.group_key
+    if gk not in frame.columns or not ctx.lag_columns:
+        return findings
+
+    indexed = frame.with_columns(_grp_idx=pl.int_range(pl.len()).over(gk))
+    for col in ctx.lag_columns:
+        if col not in frame.columns:
+            continue
+        n_leak = indexed.filter((pl.col("_grp_idx") == 0) & pl.col(col).is_not_null()).height
+        if n_leak > 0:
+            findings.append(
+                Finding(
+                    "boundary_leakage",
+                    Severity.ERROR,
+                    ctx.domain,
+                    dataset,
+                    f"lag column {col!r} is non-null on {n_leak} first-of-{gk} row(s) (cross-game leak)",
+                    locator={"column": col, "group_key": gk},
+                    metric=float(n_leak),
+                )
+            )
+    return findings

--- a/tools/validation/checks/prep_published_parity.py
+++ b/tools/validation/checks/prep_published_parity.py
@@ -48,11 +48,23 @@ def run(
             )
         )
 
-    joined = prep.join(published, on=keys, how="inner", suffix="__pub__")
+    _suffix = "__pub__"
+    # Guard against published columns that already end with the join suffix (e.g.
+    # "epa__pub__").  If left as-is, polars raises DuplicateError when the join
+    # appends the suffix to published's "epa" column, because "epa__pub__" would
+    # already exist.  Rename the pre-existing colliders so the join can proceed.
+    _colliders = {
+        c: c + "_orig__"
+        for c in published.columns
+        if c not in keys and c.endswith(_suffix) and c[: -len(_suffix)] in prep.columns
+    }
+    pub_for_join = published.rename(_colliders) if _colliders else published
+
+    joined = prep.join(pub_for_join, on=keys, how="inner", suffix=_suffix)
     for col, dtype in prep.schema.items():
         if col in keys or col not in published.columns or not dtype.is_numeric():
             continue
-        pcol = f"{col}__pub__"
+        pcol = f"{col}{_suffix}"
         if pcol not in joined.columns:
             continue
         n_div = joined.filter(

--- a/tools/validation/checks/prep_published_parity.py
+++ b/tools/validation/checks/prep_published_parity.py
@@ -48,14 +48,16 @@ def run(
             )
         )
 
-    joined = prep.join(published, on=keys, how="inner", suffix="_published")
+    joined = prep.join(published, on=keys, how="inner", suffix="__pub__")
     for col, dtype in prep.schema.items():
         if col in keys or col not in published.columns or not dtype.is_numeric():
             continue
-        pcol = f"{col}_published"
+        pcol = f"{col}__pub__"
         if pcol not in joined.columns:
             continue
-        n_div = joined.filter((pl.col(col) - pl.col(pcol)).abs() > tolerance).height
+        n_div = joined.filter(
+            ((pl.col(col) - pl.col(pcol)).abs() > tolerance) | (pl.col(col).is_null() != pl.col(pcol).is_null())
+        ).height
         if n_div > 0:
             findings.append(
                 Finding(

--- a/tools/validation/checks/prep_published_parity.py
+++ b/tools/validation/checks/prep_published_parity.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import polars as pl
+
+from tools.validation.findings import Finding, Severity
+
+
+def run(
+    dataset: str,
+    prep: pl.DataFrame,
+    published: pl.DataFrame,
+    join_keys: tuple[str, ...],
+    domain: str,
+    tolerance: float = 1e-6,
+) -> list[Finding]:
+    """Validate that the published frame faithfully reflects the prep frame.
+
+    Joins ``prep`` to ``published`` on ``join_keys``. Emits an ERROR for prep key
+    groups absent from published (dropped rows), and for each shared numeric column
+    whose value diverges beyond ``tolerance`` on a joined row.
+
+    Args:
+        dataset: Dataset identifier recorded on each finding.
+        prep: The intermediate (producing-side) frame.
+        published: The published frame.
+        join_keys: Columns to join/compare on.
+        domain: Domain identifier recorded on each finding.
+        tolerance: Absolute tolerance for numeric divergence.
+
+    Returns:
+        A list of Finding records; empty when published faithfully reflects prep.
+    """
+    findings: list[Finding] = []
+    keys = list(join_keys)
+
+    dropped = prep.join(published.select(keys).unique(), on=keys, how="anti")
+    n_dropped = dropped.select(keys).unique().height
+    if n_dropped > 0:
+        findings.append(
+            Finding(
+                "prep_published_parity",
+                Severity.ERROR,
+                domain,
+                dataset,
+                f"{n_dropped} prep key group(s) dropped from published",
+                locator={"join_keys": keys},
+                metric=float(n_dropped),
+            )
+        )
+
+    joined = prep.join(published, on=keys, how="inner", suffix="_published")
+    for col, dtype in prep.schema.items():
+        if col in keys or col not in published.columns or not dtype.is_numeric():
+            continue
+        pcol = f"{col}_published"
+        if pcol not in joined.columns:
+            continue
+        n_div = joined.filter((pl.col(col) - pl.col(pcol)).abs() > tolerance).height
+        if n_div > 0:
+            findings.append(
+                Finding(
+                    "prep_published_parity",
+                    Severity.ERROR,
+                    domain,
+                    dataset,
+                    f"{col!r} diverges between prep and published in {n_div} row(s)",
+                    locator={"column": col},
+                    metric=float(n_div),
+                )
+            )
+    return findings

--- a/tools/validation/cli.py
+++ b/tools/validation/cli.py
@@ -4,11 +4,11 @@ import argparse
 import json
 import sys
 
-from tools.validation.checks import extraction, numeric_parity, schema_contract, sweep
+from tools.validation.checks import boundary_leakage, extraction, numeric_parity, schema_contract, sweep
 from tools.validation.findings import Finding
 from tools.validation.registry import resolve
 
-_CHECKS = (schema_contract, extraction, numeric_parity, sweep)
+_CHECKS = (schema_contract, extraction, numeric_parity, sweep, boundary_leakage)
 
 
 def run_dataset(dataset: str, release: str | None = None) -> list[dict]:

--- a/tools/validation/findings.py
+++ b/tools/validation/findings.py
@@ -74,3 +74,6 @@ class CheckContext:
     oracle: OracleLike | None = None
     prior_frame: pl.DataFrame | None = None
     thresholds: dict[str, float] = field(default_factory=dict)
+    lag_columns: tuple[str, ...] = ()
+    cumulative_columns: tuple[str, ...] = ()
+    group_key: str = "game_id"

--- a/tools/validation/registry.py
+++ b/tools/validation/registry.py
@@ -28,6 +28,9 @@ class DatasetSpec:
     prob_groups: tuple[tuple[str, ...], ...] = ()
     range_constraints: dict[str, tuple[float, float]] = field(default_factory=dict)
     oracle_domain: str | None = None
+    lag_columns: tuple[str, ...] = ()
+    cumulative_columns: tuple[str, ...] = ()
+    group_key: str = "game_id"
 
 
 DATASETS: dict[str, DatasetSpec] = {}  # registered incrementally; see spec §11
@@ -102,6 +105,9 @@ def _resolve_spec(spec: DatasetSpec, release: str | None = None) -> tuple[pl.Dat
         oracle=ORACLES.get(spec.oracle_domain) if spec.oracle_domain else None,
         prior_frame=None,
         thresholds=load_thresholds(spec.domain),
+        lag_columns=spec.lag_columns,
+        cumulative_columns=spec.cumulative_columns,
+        group_key=spec.group_key,
     )
     return frame, ctx
 


### PR DESCRIPTION
## Summary

Phase 1 (data-side) of **domain ③ — data-prep validation**, the next domain in the workspace validation program. **Stacked on the validation harness (#141)** — base branch is `feat/validation-harness-tier1`, so this PR shows only the four data-prep commits and should merge after #141.

Adds two language-agnostic data-prep checks to the Tier-1 engine, both emitting the existing `Finding` contract.

## What's included

- **`boundary_leakage`** (`checks/boundary_leakage.py`) — single-frame check (joins the CLI `run` loop). Flags **lag columns that are non-null on a group's first row** — a cross-game leak (e.g. a `prev_ep` carried from the prior game). Detected via `pl.int_range(pl.len()).over(group_key) == 0` (frame assumed play-ordered within each group).
- **`prep_published_parity`** (`checks/prep_published_parity.py`) — two-frame check (harness-driven, like `e2e`; **not** in the single-frame `_CHECKS`). Flags prep key groups dropped from published (anti-join) and per-numeric-column value divergence beyond tolerance — including the **null-side** case (a value dropped to null on one side).
- **Registry fields** — `lag_columns`, `cumulative_columns`, `group_key` on both `DatasetSpec` and `CheckContext`, threaded through `_resolve_spec`.
- Both new modules on the `[tool.mypy] files` ratchet.

## Gate

`uv run mypy` → Success (28 files) · `uv run pytest tests/contracts/` → 38 passing · ruff check + format clean.

## Review note

The whole-branch review caught two silent-failure bugs in `prep_published_parity` (both now fixed in `9b93820`): a **null-divergence miss** (a prep value dropped to `null` in published reported as parity) and a **suffix-collision crash** (`DuplicateError` if `published` ships a `<col>_published` column → now a collision-proof `__pub__` suffix). Both aligned with the harness's own "fail toward surfacing" charter.

## Deferred (by design — not gaps)

- Cumulative-column boundary heuristic (Phase 1.5; its reset semantics are column-specific). `cumulative_columns` is accepted on the spec but not yet inspected.
- `nfl_model_pbp` dataset registration with real lag/cumulative columns (`boundary_leakage` is fully fixture-tested without it).
- Source linters (Python `ast` / R `Rscript`) — Phases 2–3, separate PRs.

## Notes

- Design spec + plan live in `dev/` (gitignored internal notes, per repo convention).

## Summary by Sourcery

Introduce data-prep validation checks for boundary leakage and prep/published parity and thread required leakage metadata through the validation registry and context.

New Features:
- Add boundary_leakage single-frame check to flag non-null lag values on group boundary rows.
- Add prep_published_parity two-frame check to detect dropped prep key groups and numeric value divergence between prep and published frames.

Enhancements:
- Extend DatasetSpec and CheckContext with lag_columns, cumulative_columns, and group_key fields to support leakage-aware validation.
- Register the new data-prep checks with the CLI tier-1 engine and mypy ratchet configuration.

Tests:
- Add contract tests covering boundary_leakage behavior across leak, clean, and skip scenarios.
- Add contract tests ensuring prep_published_parity detects dropped rows, numeric divergence, and null-side divergence.