### PR TITLE
feat(validation): Tier-2 judgment harness + deterministic cron (sdv-py side)

### DIFF
--- a/.claude/workflows/validation-harness.js
+++ b/.claude/workflows/validation-harness.js
@@ -49,6 +49,7 @@ const FINDINGS_SCHEMA = {
           locator: { type: 'object', additionalProperties: true },
           metric: { type: ['number', 'null'] },
           needs_judgment: { type: 'boolean' },
+          sample: { type: ['array', 'null'], items: { type: 'object', additionalProperties: true } },
         },
         required: ['check', 'severity', 'message', 'needs_judgment'],
       },

--- a/.claude/workflows/validation-harness.js
+++ b/.claude/workflows/validation-harness.js
@@ -27,6 +27,8 @@ const CHECK_TO_AGENT = {
 // The runner agent must export the data roots so the CLI can resolve the
 // env-var-rooted dataset globs / lint targets (cfb is User-scope; nfl is passed
 // here). A dataset whose parquet is absent should be reported, not crash the run.
+// NOTE: these absolute paths are MACHINE-SPECIFIC — this harness is the on-demand
+// local-session path; the portable CI path is .github/workflows/validation-cron.yml.
 const SDV_PY = 'c:/Users/saiem/Documents/GitHub-Data/sdv-dev/sdv-py'
 const NFL_DATA_ROOT = 'C:/Users/saiem/Documents/GitHub-Data/sdv-dev/nflverse-dev/nfl-data'
 

--- a/.claude/workflows/validation-harness.js
+++ b/.claude/workflows/validation-harness.js
@@ -1,0 +1,151 @@
+export const meta = {
+  name: 'validation-harness',
+  description:
+    'Tier-2 deep validation: run the Tier-1 deterministic checks over the registered datasets + lint targets, route each needs_judgment WARN finding to the matching sdv-toolkit judgment reviewer, and consolidate a report of ERRORs + confirmed verdicts.',
+  phases: [
+    { title: 'Collect', detail: 'a runner agent shells the Tier-1 CLI for Finding[] per dataset/target' },
+    { title: 'Judge', detail: 'route each needs_judgment finding to its reviewer subagent for a Verdict' },
+  ],
+}
+
+// --- configuration -----------------------------------------------------------
+// Registered datasets (tools/validation/registry.py DATASETS) and lint targets
+// (LINT_TARGETS). Keep in sync with the registry.
+const DATASETS = ['cfb_model_pbp', 'nfl_model_pbp']
+const LINT_TARGETS = ['nfl_native_pbp', 'sdv_nfl_ep_wp']
+
+// finding.check -> the sdv-toolkit judgment agent that adjudicates it.
+// Every check that emits needs_judgment=True has exactly one consumer here.
+const CHECK_TO_AGENT = {
+  extraction: 'sdv-toolkit:extraction-semantics-reviewer',
+  sweep: 'sdv-toolkit:anomaly-triage-reviewer',
+  numeric_parity: 'sdv-toolkit:parity-divergence-reviewer',
+  leakage_lint: 'sdv-toolkit:leakage-reviewer',
+  boundary_leakage: 'sdv-toolkit:leakage-reviewer',
+}
+
+// The runner agent must export the data roots so the CLI can resolve the
+// env-var-rooted dataset globs / lint targets (cfb is User-scope; nfl is passed
+// here). A dataset whose parquet is absent should be reported, not crash the run.
+const SDV_PY = 'c:/Users/saiem/Documents/GitHub-Data/sdv-dev/sdv-py'
+const NFL_DATA_ROOT = 'C:/Users/saiem/Documents/GitHub-Data/sdv-dev/nflverse-dev/nfl-data'
+
+// JSON Schemas (Finding[] from the CLI; Verdict from the reviewers) ------------
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: true,
+        properties: {
+          check: { type: 'string' },
+          severity: { type: 'string', enum: ['error', 'warn', 'info'] },
+          domain: { type: 'string' },
+          dataset: { type: 'string' },
+          message: { type: 'string' },
+          locator: { type: 'object', additionalProperties: true },
+          metric: { type: ['number', 'null'] },
+          needs_judgment: { type: 'boolean' },
+        },
+        required: ['check', 'severity', 'message', 'needs_judgment'],
+      },
+    },
+    run_error: { type: ['string', 'null'], description: 'a CLI/resolve failure (e.g. data absent), or null' },
+  },
+  required: ['findings'],
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    finding_ref: { type: 'string' },
+    status: { type: 'string', enum: ['confirmed', 'dismissed', 'uncertain'] },
+    confidence: { type: 'number' },
+    rationale: { type: 'string' },
+    suggested_fix: { type: ['string', 'null'] },
+  },
+  required: ['finding_ref', 'status', 'confidence', 'rationale'],
+}
+
+// --- helpers -----------------------------------------------------------------
+function runnerPrompt(kind, name) {
+  const cmd =
+    kind === 'dataset'
+      ? `uv run --frozen python -m tools.validation.cli run --dataset ${name} --json`
+      : `uv run --frozen python -m tools.validation.cli lint --target ${name} --json`
+  return [
+    `You are a deterministic runner. Work from \`${SDV_PY}\`. Export the data roots so the`,
+    `env-var-rooted globs resolve: set \`SDV_VALIDATION_NFL_DATA_ROOT="${NFL_DATA_ROOT}"\` (and leave`,
+    '`SDV_VALIDATION_DATA_ROOT` as already configured at User scope). Then run EXACTLY this and',
+    'capture its stdout:',
+    '',
+    `    ${cmd}`,
+    '',
+    'The command prints a JSON array of finding dicts. Return it as {"findings": [...]}.',
+    'If the command FAILS (non-zero exit, FileNotFoundError on a missing parquet glob, etc.),',
+    'return {"findings": [], "run_error": "<the salient error line>"} — do NOT crash the workflow.',
+    'Do not add, drop, or reinterpret findings; pass the CLI output through verbatim.',
+  ].join('\n')
+}
+
+function verdictPrompt(finding) {
+  return [
+    'Triage this single sdv-py validation finding and emit a Verdict (your agent instructions',
+    'define the judgment + the exact Verdict JSON shape). The finding:',
+    '',
+    JSON.stringify(finding, null, 2),
+  ].join('\n')
+}
+
+// --- stage 1: collect deterministic findings ---------------------------------
+phase('Collect')
+const datasetRuns = await parallel(
+  DATASETS.map((d) => () => agent(runnerPrompt('dataset', d), { label: `run:${d}`, phase: 'Collect', schema: FINDINGS_SCHEMA })),
+)
+const lintRuns = await parallel(
+  LINT_TARGETS.map((t) => () => agent(runnerPrompt('lint', t), { label: `lint:${t}`, phase: 'Collect', schema: FINDINGS_SCHEMA })),
+)
+
+const collected = [...datasetRuns, ...lintRuns].filter(Boolean)
+const runErrors = collected.filter((r) => r.run_error).map((r) => r.run_error)
+const allFindings = collected.flatMap((r) => r.findings || [])
+const errors = allFindings.filter((f) => f.severity === 'error')
+const toJudge = allFindings.filter((f) => f.needs_judgment === true)
+log(`collected ${allFindings.length} findings (${errors.length} ERROR, ${toJudge.length} needs_judgment); ${runErrors.length} run error(s)`)
+
+// --- stage 2: route needs_judgment findings to the reviewers -----------------
+phase('Judge')
+const verdicts = await parallel(
+  toJudge.map((f) => () => {
+    const agentType = CHECK_TO_AGENT[f.check]
+    if (!agentType) {
+      log(`no reviewer registered for check '${f.check}' — leaving unadjudicated`)
+      return null
+    }
+    return agent(verdictPrompt(f), { agentType, schema: VERDICT_SCHEMA, label: `judge:${f.check}`, phase: 'Judge' }).then((v) => ({
+      finding: f,
+      verdict: v,
+    }))
+  }),
+)
+
+const adjudicated = verdicts.filter(Boolean)
+const confirmed = adjudicated.filter((a) => a.verdict && a.verdict.status === 'confirmed')
+
+// --- consolidated report -----------------------------------------------------
+return {
+  datasets: DATASETS,
+  lint_targets: LINT_TARGETS,
+  run_errors: runErrors,
+  total_findings: allFindings.length,
+  errors,
+  needs_judgment: toJudge.length,
+  adjudicated: adjudicated.length,
+  confirmed: confirmed.map((a) => ({ finding: a.finding, verdict: a.verdict })),
+  // exit-worthy = any deterministic ERROR, or any reviewer-CONFIRMED WARN
+  actionable: errors.length + confirmed.length,
+}

--- a/.github/workflows/validation-cron.yml
+++ b/.github/workflows/validation-cron.yml
@@ -19,14 +19,15 @@
 #                                  cfb_model_pbp_2004_2025.parquet, which the registry glob
 #                                  does NOT match, so we deliberately do NOT pull it.)
 #                   glob root    : $SDV_VALIDATION_DATA_ROOT/cfb/model_pbp/parquet/
-#   nfl_model_pbp : sportsdataverse/nfl-data @ nfl_model_pbp
-#                   asset pattern: model_pbp_*.parquet
+#   nfl_model_pbp : sportsdataverse/sportsdataverse-data @ nfl_model_pbp
+#                   asset pattern: model_pbp_202*.parquet  (recent seasons only —
+#                                  2020-2024 today, ~5 files. The release publishes
+#                                  per-season parquet back to model_pbp_1999.parquet
+#                                  (26 files / ~300MB); a weekly cron shouldn't pull
+#                                  all of them. Recent seasons still catch contract
+#                                  regressions and the glob auto-extends through
+#                                  model_pbp_2029.parquet.)
 #                   glob root    : $SDV_VALIDATION_NFL_DATA_ROOT/out/
-#                   NOTE: re-verified 2026-06-29 — sportsdataverse/nfl-data has NO
-#                   releases (the nfl_model_pbp tag does not exist yet), so this
-#                   dataset gracefully skips. The download step is already wired to
-#                   the correct tag/repo/pattern, so it auto-activates with no edit
-#                   the first cron run after the nfl_model_pbp parquet is published.
 #
 # Triggers:
 #   * schedule        — every Monday at 12:00 UTC
@@ -123,23 +124,26 @@ jobs:
 
       # -----------------------------------------------------------------------
       # Dataset: nfl_model_pbp
-      # Release: sportsdataverse/nfl-data @ nfl_model_pbp
+      # Release: sportsdataverse/sportsdataverse-data @ nfl_model_pbp
       # Glob root: $SDV_VALIDATION_NFL_DATA_ROOT/out/
-      # NOTE: no release exists yet; graceful skip expected until published.
       # -----------------------------------------------------------------------
       - name: Download nfl_model_pbp parquet
         id: dl_nfl
         run: |
           dest="${SDV_VALIDATION_NFL_DATA_ROOT}/out"
           mkdir -p "$dest"
+          # Pull recent seasons only (model_pbp_2020.parquet .. model_pbp_2024.parquet,
+          # ~5 files). The release ships per-season parquet back to 1999 (26 files /
+          # ~300MB); a weekly cron shouldn't pull all of them. Recent seasons catch
+          # contract regressions and the glob auto-extends through model_pbp_2029.parquet.
           if gh release download nfl_model_pbp \
-              -R sportsdataverse/nfl-data \
-              --pattern 'model_pbp_*.parquet' \
+              -R sportsdataverse/sportsdataverse-data \
+              --pattern 'model_pbp_202*.parquet' \
               --dir "$dest" \
               --clobber 2>&1; then
-            count=$(ls "$dest"/model_pbp_*.parquet 2>/dev/null | wc -l)
+            count=$(ls "$dest"/model_pbp_202*.parquet 2>/dev/null | wc -l)
             if [ "$count" -eq 0 ]; then
-              echo "::notice::nfl_model_pbp — download succeeded but no model_pbp_*.parquet assets found; skipping"
+              echo "::notice::nfl_model_pbp — download succeeded but no model_pbp_202*.parquet assets found; skipping"
               echo "available=false" >> "$GITHUB_OUTPUT"
             else
               echo "::notice::nfl_model_pbp — downloaded $count parquet file(s)"

--- a/.github/workflows/validation-cron.yml
+++ b/.github/workflows/validation-cron.yml
@@ -115,8 +115,17 @@ jobs:
           uv run --frozen python -m tools.validation.cli run \
             --dataset cfb_model_pbp \
             --json > findings_cfb_model_pbp.json 2>validate_cfb.log
-          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          exit_code=$?
+          echo "exit_code=${exit_code}" >> "$GITHUB_OUTPUT"
           set -e
+          # If the CLI crashed (non-zero exit), inject a run_error sentinel so
+          # the aggregation step surfaces this as an ERROR finding rather than
+          # treating a missing/truncated findings file as a clean zero-finding run.
+          if [ "${exit_code}" -ne 0 ]; then
+            log_tail=$(tail -c 500 validate_cfb.log 2>/dev/null || true)
+            printf '[{"check":"run_error","severity":"error","message":"cfb_model_pbp validation CLI exited %s: %s"}]\n' \
+              "${exit_code}" "${log_tail}" > findings_cfb_model_pbp.json
+          fi
 
       - name: Skip cfb_model_pbp (no data)
         if: steps.dl_cfb.outputs.available != 'true'
@@ -162,8 +171,17 @@ jobs:
           uv run --frozen python -m tools.validation.cli run \
             --dataset nfl_model_pbp \
             --json > findings_nfl_model_pbp.json 2>validate_nfl.log
-          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          exit_code=$?
+          echo "exit_code=${exit_code}" >> "$GITHUB_OUTPUT"
           set -e
+          # If the CLI crashed (non-zero exit), inject a run_error sentinel so
+          # the aggregation step surfaces this as an ERROR finding rather than
+          # treating a missing/truncated findings file as a clean zero-finding run.
+          if [ "${exit_code}" -ne 0 ]; then
+            log_tail=$(tail -c 500 validate_nfl.log 2>/dev/null || true)
+            printf '[{"check":"run_error","severity":"error","message":"nfl_model_pbp validation CLI exited %s: %s"}]\n' \
+              "${exit_code}" "${log_tail}" > findings_nfl_model_pbp.json
+          fi
 
       - name: Skip nfl_model_pbp (no data)
         if: steps.dl_nfl.outputs.available != 'true'
@@ -261,7 +279,7 @@ jobs:
               lines.push('| check | message |');
               lines.push('|---|---|');
               for (const f of errors) {
-                const msg = f.message.replace(/\|/g, '\\|');
+                let msg = f.message.replace(/\|/g, '\\|').replace(/\r?\n/g, '<br>').replace(/`/g, '\\`');
                 lines.push(`| \`${f.check}\` | ${msg} |`);
               }
               lines.push('');

--- a/.github/workflows/validation-cron.yml
+++ b/.github/workflows/validation-cron.yml
@@ -12,12 +12,21 @@
 #
 # Release coordinates (resolved 2026-06-29):
 #   cfb_model_pbp : sportsdataverse/sportsdataverse-data @ espn_cfb_model_pbp
-#                   asset pattern: cfb_model_pbp_*.parquet
+#                   asset pattern: model_pbp_*.parquet  (matches model_pbp_2024.parquet
+#                                  and any future model_pbp_YYYY.parquet — these match the
+#                                  registry glob model_pbp_*.parquet. The release also
+#                                  ships a cfb_-prefixed full-history file
+#                                  cfb_model_pbp_2004_2025.parquet, which the registry glob
+#                                  does NOT match, so we deliberately do NOT pull it.)
 #                   glob root    : $SDV_VALIDATION_DATA_ROOT/cfb/model_pbp/parquet/
 #   nfl_model_pbp : sportsdataverse/nfl-data @ nfl_model_pbp
 #                   asset pattern: model_pbp_*.parquet
 #                   glob root    : $SDV_VALIDATION_NFL_DATA_ROOT/out/
-#                   NOTE: no release exists yet → graceful skip until published.
+#                   NOTE: re-verified 2026-06-29 — sportsdataverse/nfl-data has NO
+#                   releases (the nfl_model_pbp tag does not exist yet), so this
+#                   dataset gracefully skips. The download step is already wired to
+#                   the correct tag/repo/pattern, so it auto-activates with no edit
+#                   the first cron run after the nfl_model_pbp parquet is published.
 #
 # Triggers:
 #   * schedule        — every Monday at 12:00 UTC
@@ -76,14 +85,17 @@ jobs:
         run: |
           dest="${SDV_VALIDATION_DATA_ROOT}/cfb/model_pbp/parquet"
           mkdir -p "$dest"
+          # Match the registry glob model_pbp_*.parquet (e.g. model_pbp_2024.parquet).
+          # The cfb_-prefixed full-history asset is intentionally excluded — it does
+          # not match the glob the validation CLI reads.
           if gh release download espn_cfb_model_pbp \
               -R sportsdataverse/sportsdataverse-data \
-              --pattern 'cfb_model_pbp_*.parquet' \
+              --pattern 'model_pbp_*.parquet' \
               --dir "$dest" \
               --clobber 2>&1; then
-            count=$(ls "$dest"/cfb_model_pbp_*.parquet 2>/dev/null | wc -l)
+            count=$(ls "$dest"/model_pbp_*.parquet 2>/dev/null | wc -l)
             if [ "$count" -eq 0 ]; then
-              echo "::notice::cfb_model_pbp — download succeeded but no cfb_model_pbp_*.parquet assets found; skipping"
+              echo "::notice::cfb_model_pbp — download succeeded but no model_pbp_*.parquet assets found; skipping"
               echo "available=false" >> "$GITHUB_OUTPUT"
             else
               echo "::notice::cfb_model_pbp — downloaded $count parquet file(s)"
@@ -166,7 +178,11 @@ jobs:
             const today = new Date().toISOString().slice(0, 10);
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
-            // Collect findings from each dataset JSON (missing file → empty array).
+            // Collect findings from each dataset JSON. A dataset may have been
+            // skipped (file is `[]`) or its validate step may have crashed
+            // (file missing / empty / truncated / non-JSON). In every such case
+            // treat it as "no findings" and continue — never let a read or parse
+            // failure abort the aggregation.
             const datasets = ['cfb_model_pbp', 'nfl_model_pbp'];
             const allFindings = {};
             let anyError = false;
@@ -174,12 +190,26 @@ jobs:
               const path = `findings_${ds}.json`;
               let findings = [];
               try {
-                findings = JSON.parse(fs.readFileSync(path, 'utf8'));
+                if (!fs.existsSync(path)) {
+                  core.info(`${path} missing — treating ${ds} as no findings.`);
+                } else {
+                  const raw = fs.readFileSync(path, 'utf8').trim();
+                  if (raw === '') {
+                    core.info(`${path} empty — treating ${ds} as no findings.`);
+                  } else {
+                    const parsed = JSON.parse(raw);
+                    if (Array.isArray(parsed)) {
+                      findings = parsed;
+                    } else {
+                      core.warning(`${path} is not a JSON array — treating ${ds} as no findings.`);
+                    }
+                  }
+                }
               } catch (e) {
-                core.info(`Could not read ${path}: ${e.message}`);
+                core.warning(`Could not parse ${path} (${e.message}) — treating ${ds} as no findings.`);
               }
               allFindings[ds] = findings;
-              if (findings.some(f => f.severity === 'error')) {
+              if (findings.some(f => f && f.severity === 'error')) {
                 anyError = true;
               }
             }

--- a/.github/workflows/validation-cron.yml
+++ b/.github/workflows/validation-cron.yml
@@ -1,0 +1,277 @@
+# Weekly deterministic validation cron for the registered datasets.
+#
+# Downloads the published model_pbp parquet for each registered dataset from
+# the public GitHub releases and runs the Tier-1 validation CLI over them.
+# Any ERROR-severity finding opens (or re-comments on) a single tracking
+# issue labelled ``validation:drift`` instead of opening a new issue every
+# week.
+#
+# Graceful degrade: if a release / asset is absent (network failure, release
+# tag not yet published) the dataset is skipped with a ::notice:: annotation
+# and the rest of the datasets continue.
+#
+# Release coordinates (resolved 2026-06-29):
+#   cfb_model_pbp : sportsdataverse/sportsdataverse-data @ espn_cfb_model_pbp
+#                   asset pattern: cfb_model_pbp_*.parquet
+#                   glob root    : $SDV_VALIDATION_DATA_ROOT/cfb/model_pbp/parquet/
+#   nfl_model_pbp : sportsdataverse/nfl-data @ nfl_model_pbp
+#                   asset pattern: model_pbp_*.parquet
+#                   glob root    : $SDV_VALIDATION_NFL_DATA_ROOT/out/
+#                   NOTE: no release exists yet → graceful skip until published.
+#
+# Triggers:
+#   * schedule        — every Monday at 12:00 UTC
+#   * workflow_dispatch — manual trigger for ad-hoc validation outside the
+#                         schedule cadence.
+name: validation-cron
+on:
+  schedule:
+    - cron: "0 12 * * 1" # Every Monday at 12:00 UTC
+  workflow_dispatch:
+permissions:
+  contents: read
+  issues: write # required to open / update the drift tracking issue
+concurrency:
+  group: validation-cron
+  cancel-in-progress: false
+jobs:
+  validate:
+    name: Validation drift check (ubuntu / py3.13.2)
+    runs-on: ubuntu-latest
+    env:
+      # Roots that match the registry glob patterns.
+      SDV_VALIDATION_DATA_ROOT: ${{ github.workspace }}/validation-data
+      SDV_VALIDATION_NFL_DATA_ROOT: ${{ github.workspace }}/validation-data-nfl
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        # setup-uv stopped publishing major/minor tags at v8 for supply-chain
+        # hardening. Pin to an immutable patch tag.
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Set up Python 3.13.2
+        run: uv python install 3.13.2
+
+      - name: Install Linux build deps for pyreadr sdist fallback
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libbz2-dev liblzma-dev
+
+      - name: Install project + extras + dep groups
+        run: uv sync --all-extras --all-groups --frozen --python 3.13.2
+
+      # -----------------------------------------------------------------------
+      # Dataset: cfb_model_pbp
+      # Release: sportsdataverse/sportsdataverse-data @ espn_cfb_model_pbp
+      # Glob root: $SDV_VALIDATION_DATA_ROOT/cfb/model_pbp/parquet/
+      # -----------------------------------------------------------------------
+      - name: Download cfb_model_pbp parquet
+        id: dl_cfb
+        run: |
+          dest="${SDV_VALIDATION_DATA_ROOT}/cfb/model_pbp/parquet"
+          mkdir -p "$dest"
+          if gh release download espn_cfb_model_pbp \
+              -R sportsdataverse/sportsdataverse-data \
+              --pattern 'cfb_model_pbp_*.parquet' \
+              --dir "$dest" \
+              --clobber 2>&1; then
+            count=$(ls "$dest"/cfb_model_pbp_*.parquet 2>/dev/null | wc -l)
+            if [ "$count" -eq 0 ]; then
+              echo "::notice::cfb_model_pbp — download succeeded but no cfb_model_pbp_*.parquet assets found; skipping"
+              echo "available=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "::notice::cfb_model_pbp — downloaded $count parquet file(s)"
+              echo "available=true" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "::notice::cfb_model_pbp — release download failed (release or asset absent); skipping dataset"
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run validation — cfb_model_pbp
+        id: validate_cfb
+        if: steps.dl_cfb.outputs.available == 'true'
+        run: |
+          set +e
+          uv run --frozen python -m tools.validation.cli run \
+            --dataset cfb_model_pbp \
+            --json > findings_cfb_model_pbp.json 2>validate_cfb.log
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          set -e
+
+      - name: Skip cfb_model_pbp (no data)
+        if: steps.dl_cfb.outputs.available != 'true'
+        run: echo '[]' > findings_cfb_model_pbp.json
+
+      # -----------------------------------------------------------------------
+      # Dataset: nfl_model_pbp
+      # Release: sportsdataverse/nfl-data @ nfl_model_pbp
+      # Glob root: $SDV_VALIDATION_NFL_DATA_ROOT/out/
+      # NOTE: no release exists yet; graceful skip expected until published.
+      # -----------------------------------------------------------------------
+      - name: Download nfl_model_pbp parquet
+        id: dl_nfl
+        run: |
+          dest="${SDV_VALIDATION_NFL_DATA_ROOT}/out"
+          mkdir -p "$dest"
+          if gh release download nfl_model_pbp \
+              -R sportsdataverse/nfl-data \
+              --pattern 'model_pbp_*.parquet' \
+              --dir "$dest" \
+              --clobber 2>&1; then
+            count=$(ls "$dest"/model_pbp_*.parquet 2>/dev/null | wc -l)
+            if [ "$count" -eq 0 ]; then
+              echo "::notice::nfl_model_pbp — download succeeded but no model_pbp_*.parquet assets found; skipping"
+              echo "available=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "::notice::nfl_model_pbp — downloaded $count parquet file(s)"
+              echo "available=true" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "::notice::nfl_model_pbp — release download failed (release or asset absent); skipping dataset"
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run validation — nfl_model_pbp
+        id: validate_nfl
+        if: steps.dl_nfl.outputs.available == 'true'
+        run: |
+          set +e
+          uv run --frozen python -m tools.validation.cli run \
+            --dataset nfl_model_pbp \
+            --json > findings_nfl_model_pbp.json 2>validate_nfl.log
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          set -e
+
+      - name: Skip nfl_model_pbp (no data)
+        if: steps.dl_nfl.outputs.available != 'true'
+        run: echo '[]' > findings_nfl_model_pbp.json
+
+      # -----------------------------------------------------------------------
+      # Aggregate findings and open/update the drift tracking issue
+      # -----------------------------------------------------------------------
+      - name: Aggregate findings and file drift issue
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const label = 'validation:drift';
+            const today = new Date().toISOString().slice(0, 10);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            // Collect findings from each dataset JSON (missing file → empty array).
+            const datasets = ['cfb_model_pbp', 'nfl_model_pbp'];
+            const allFindings = {};
+            let anyError = false;
+            for (const ds of datasets) {
+              const path = `findings_${ds}.json`;
+              let findings = [];
+              try {
+                findings = JSON.parse(fs.readFileSync(path, 'utf8'));
+              } catch (e) {
+                core.info(`Could not read ${path}: ${e.message}`);
+              }
+              allFindings[ds] = findings;
+              if (findings.some(f => f.severity === 'error')) {
+                anyError = true;
+              }
+            }
+
+            if (!anyError) {
+              core.info('No ERROR findings — checking for open drift issue to close.');
+              // Close any previously-open drift issue so stale issues don't linger.
+              const open = await github.rest.issues.listForRepo({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                state: 'open',
+                labels: label,
+                per_page: 5,
+              });
+              for (const issue of open.data) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo:  context.repo.repo,
+                  issue_number: issue.number,
+                  body: `Validation cron on **${today}** found no ERROR findings — drift resolved.\n\nRun: ${runUrl}`,
+                });
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo:  context.repo.repo,
+                  issue_number: issue.number,
+                  state: 'closed',
+                });
+                core.info(`Closed drift issue #${issue.number} (no errors this run).`);
+              }
+              return;
+            }
+
+            // Build the body: group ERROR findings by dataset.
+            const lines = [
+              `Validation drift detected on **${today}**.`,
+              ``,
+              `Run: ${runUrl}`,
+              ``,
+            ];
+            for (const [ds, findings] of Object.entries(allFindings)) {
+              const errors = findings.filter(f => f.severity === 'error');
+              if (errors.length === 0) continue;
+              lines.push(`## \`${ds}\` — ${errors.length} ERROR finding(s)`);
+              lines.push('');
+              lines.push('| check | message |');
+              lines.push('|---|---|');
+              for (const f of errors) {
+                const msg = f.message.replace(/\|/g, '\\|');
+                lines.push(`| \`${f.check}\` | ${msg} |`);
+              }
+              lines.push('');
+            }
+            lines.push('---');
+            lines.push('**Resolve by**: fixing the producer pipeline, updating the schema snapshot, or adjusting thresholds, then closing this issue. The next cron run that finds no ERRORs will close it automatically.');
+            const body = lines.join('\n');
+
+            // Open a new issue or comment on the existing one (dedup by label).
+            const open = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              state: 'open',
+              labels: label,
+              per_page: 5,
+            });
+            if (open.data.length > 0) {
+              const issue = open.data[0];
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                issue_number: issue.number,
+                body: `Re-occurred on ${today}.\n\n${body}`,
+              });
+              core.info(`Commented on existing drift issue #${issue.number}`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                title: `validation drift detected (${today})`,
+                body:  body,
+                labels: [label],
+              });
+              core.info(`Opened new drift issue #${created.data.number}`);
+            }
+
+      # -----------------------------------------------------------------------
+      # Upload findings JSON for inspection (always — even on skip)
+      # -----------------------------------------------------------------------
+      - name: Upload findings artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: validation-findings-${{ github.run_id }}
+          path: findings_*.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/tools/validation/lint/leakage_python.py
+++ b/tools/validation/lint/leakage_python.py
@@ -67,6 +67,12 @@ def _receiver_is_grouped(node: ast.Call) -> bool:
     return False
 
 
+# Known false-negative (under-warn, by design): a lag/cum call inside a lambda
+# passed to ``group_by(...).agg(lambda s: s.shift(1))`` is NOT flagged — the
+# shift sits in the lambda's AST subtree, which is neither an ancestor of the
+# call (``_is_grouped``) nor on its receiver chain (``_receiver_is_grouped``).
+# The Tier-2 leakage-reviewer references this limit; WARN-only routing means the
+# inverse (a survivor) is adjudicated downstream rather than silently trusted.
 def _lint_source(src: str, rel: str) -> list[Finding]:
     findings: list[Finding] = []
     try:

--- a/tools/validation/lint/leakage_python.py
+++ b/tools/validation/lint/leakage_python.py
@@ -67,12 +67,13 @@ def _receiver_is_grouped(node: ast.Call) -> bool:
     return False
 
 
-# Known false-negative (under-warn, by design): a lag/cum call inside a lambda
-# passed to ``group_by(...).agg(lambda s: s.shift(1))`` is NOT flagged — the
-# shift sits in the lambda's AST subtree, which is neither an ancestor of the
-# call (``_is_grouped``) nor on its receiver chain (``_receiver_is_grouped``).
-# The Tier-2 leakage-reviewer references this limit; WARN-only routing means the
-# inverse (a survivor) is adjudicated downstream rather than silently trusted.
+# Known false-positive (over-warn): a lag/cum call inside a lambda passed to
+# ``group_by(...).agg(lambda s: s.shift(1))`` IS WARN-flagged even though the
+# enclosing ``group_by`` makes it safe — the grouping is an "uncle" of the call
+# (it is the receiver of ``.agg``), invisible to both ``_is_grouped`` (the
+# ancestor walk) and ``_receiver_is_grouped`` (the call's own receiver chain),
+# so the call falls through to flagged. WARN-only routing sends it to the Tier-2
+# leakage-reviewer, which dismisses this grouped-but-unprovable case.
 def _lint_source(src: str, rel: str) -> list[Finding]:
     findings: list[Finding] = []
     try:


### PR DESCRIPTION
## Validation Harness — Tier-2 (LLM judgment layer + automation), sdv-py side

The Tier-2 layer on top of the shipped Tier-1 deterministic engine + domain ③ checks/linters (#141–#145): an on-demand **judgment harness** that routes the `needs_judgment` WARN findings to reviewer subagents, and a **deterministic weekly cron**. Stacked on #145.

> **Stacked PR.** Base = `feat/validation-domain3-phase15` (#145 ← #144 ← #143 ← #142 ← #141). Review/merge the parents first.

> **Two-repo change.** The 4 judgment **agents** live in the **sdv-toolkit plugin** (separate repo — already pushed to both remotes, `plugin.json` 0.2.1→0.2.2, `claude plugin update` done). This PR is the **sdv-py** side: the harness that routes to them + the cron.

### The complete check → agent mapping
Five Tier-1 check-types emit `needs_judgment=True`; each has exactly one consumer (the agents in sdv-toolkit):

| `finding.check` | reviewer agent | source |
|---|---|---|
| `extraction` | `extraction-semantics-reviewer` | data check |
| `sweep` | `anomaly-triage-reviewer` | data check |
| `numeric_parity` | `parity-divergence-reviewer` | oracle corr |
| `leakage_lint` | `leakage-reviewer` | Python + R source linters |
| `boundary_leakage` | `leakage-reviewer` | cumulative non-reset (Phase 1.5) |

### `.claude/workflows/validation-harness.js` — on-demand deep validation
A Claude `Workflow`-tool script. **Collect** stage: runner `agent()`s shell the Tier-1 CLI (`run --dataset` / `lint --target` `--json`) and pass the `Finding[]` through verbatim (a missing-parquet dataset returns `{findings:[], run_error}` rather than crashing). **Judge** stage: routes each `needs_judgment` finding by `finding.check` to its reviewer via `agent(prompt, {agentType, schema: VERDICT_SCHEMA})`; consolidates ERRORs + confirmed Verdicts. It never re-implements check logic — the deterministic engine stays the single source of findings. `VERDICT_SCHEMA` matches the `Verdict` dataclass exactly.

> The harness can't be fully run in the authoring session — the 4 reviewer agents were just installed (plugin 0.2.2) and need a session **restart** to become active. It was structurally validated (parses as a module; routing/registry/schemas cross-checked); the deterministic CLI stage is independently proven. The absolute paths in it are machine-specific (local-session path) — the cron is the portable CI path.

### `.github/workflows/validation-cron.yml` — deterministic weekly automation
No LLM (GH Actions can't invoke the Workflow tool). Weekly + `workflow_dispatch`. For each registered dataset it **downloads the published `model_pbp` parquet** into a dir matching the registry glob, runs `cli run --dataset <d> --json`, aggregates, and opens/updates a `validation:drift` issue on any ERROR (mirroring `live-tests-cron.yml`'s idempotent filer).

- **cfb_model_pbp** ← `sportsdataverse-data @ espn_cfb_model_pbp`, pattern `model_pbp_*.parquet` (matches the glob; the `cfb_`-prefixed full-history asset is correctly excluded).
- **nfl_model_pbp** ← `sportsdataverse-data @ nfl_model_pbp`, pattern `model_pbp_202*.parquet` (recent seasons — a weekly cron shouldn't pull ~300MB; auto-extends through 2029).
- **Graceful per-dataset skip** (`::notice::`, no job failure) if a download yields no parquet; the aggregation is robust to a missing/empty/non-JSON findings file.
- The NFL `numeric_parity` **oracle reference** (nflverse cache) is local-only / absent in CI → it **degrades to INFO** (the Phase 1.5 empty-glob guard), so schema/range/boundary/sweep/extraction still ERROR-gate while parity-vs-nflfastR stays an on-demand local concern. The two phases compose.

### Reviews
Built via subagent-driven development: the 4 agents got a dedicated prompt review; the harness + cron each got a per-task review (the controller caught a cfb asset-name-vs-glob mismatch + a wrong nfl release repo); a final **opus whole-branch** review returned Ready-with-minors, all applied — incl. correcting a backwards `.agg(lambda)`-limit code comment (it's an over-warn the leakage-reviewer dismisses, not an under-warn — caught by *running* the linter). Gate: **67 contract tests / 1 gated-skip, mypy 30, ruff**; actionlint + check-github-workflows pass on the cron; `uv.lock` untouched.

### Follow-ups (not here)
- Recalibrate the NFL parity floors (or model-domain-filter the reference) — informed by the parity-divergence-reviewer's verdicts.
- A scheduled Routine could run the LLM harness on-demand (the cron is deterministic-only by GH Actions constraint).
- Register the cfb-data R `LINT_TARGET`; extend the harness/cron to lint targets in CI once a fetchable source surface is decided.

## Summary by Sourcery

Add a Tier-2 validation harness that routes deterministic Tier-1 findings to sdv-toolkit judgment agents and introduce a weekly deterministic validation cron for registered datasets.

Enhancements:
- Document a known over-warning false positive case in the Python leakage linter to clarify WARN-only routing behavior.

CI:
- Add a GitHub Actions workflow that downloads published model_pbp parquet releases, runs the validation CLI for cfb and nfl datasets, aggregates findings, and manages a persistent validation drift tracking issue.

Documentation:
- Add a Claude Workflow script implementing an on-demand validation harness that runs Tier-1 checks over datasets and lint targets, routes needs_judgment findings to appropriate reviewer agents, and consolidates adjudicated results.