### PR TITLE
fix(nfl): derive home_opening_kickoff in enrich for the 4th-down decision step

### DIFF
--- a/sportsdataverse/nfl/ep_wp.py
+++ b/sportsdataverse/nfl/ep_wp.py
@@ -2867,6 +2867,28 @@ def _derive_qbr_epa(df: pl.DataFrame) -> pl.DataFrame:
     return df
 
 
+def _ensure_home_opening_kickoff(df: pl.DataFrame) -> pl.DataFrame:
+    """Derive ``home_opening_kickoff`` when absent (1 iff the home team received
+    the opening kickoff, i.e. it had the game's first possession).
+
+    The nfl4th 4th-down decision features require it (it sets ``home_receive_2h_ko``).
+    nflverse pbp and the ESPN construction path carry it, but native producers
+    reconstructed from the Shield feed (``native_pbp``) do not — without it
+    :func:`_add_fourth_down_decisions` skips the whole decision step on a
+    ``KeyError``.  Mirrors the ``receive_2h_ko`` derivation in :func:`_add_wp_aux`:
+    derived only when absent (never overrides an upstream column), and only when
+    the source columns exist.
+    """
+    if "home_opening_kickoff" in df.columns or "posteam" not in df.columns or "home_team" not in df.columns:
+        return df
+    return df.with_columns(
+        pl.when(pl.col("posteam").drop_nulls().first().over("game_id") == pl.col("home_team"))
+        .then(1)
+        .otherwise(0)
+        .alias("home_opening_kickoff"),
+    )
+
+
 def _add_fourth_down_decisions(
     df: pl.DataFrame,
     *,
@@ -2935,6 +2957,11 @@ def _add_fourth_down_decisions(
     # Stable join keys must be present; if not, return unchanged + null columns.
     if not all(c in df.columns for c in ("game_id", "play_id", "down", "yardline_100")):
         return _with_null_decisions(df)
+
+    # Derive home_opening_kickoff if the producer didn't supply it (native_pbp);
+    # the nfl4th features require it. Done on the full frame so the per-game
+    # first-possession lookup sees every play, not just the 4th-down subset.
+    df = _ensure_home_opening_kickoff(df)
 
     fourth = df.filter((pl.col("down") == 4) & pl.col("yardline_100").is_not_null())
 

--- a/sportsdataverse/nfl/ep_wp.py
+++ b/sportsdataverse/nfl/ep_wp.py
@@ -2877,14 +2877,24 @@ def _ensure_home_opening_kickoff(df: pl.DataFrame) -> pl.DataFrame:
     :func:`_add_fourth_down_decisions` skips the whole decision step on a
     ``KeyError``.  Mirrors the ``receive_2h_ko`` derivation in :func:`_add_wp_aux`:
     derived only when absent (never overrides an upstream column), and only when
-    the source columns exist.
+    the source columns exist.  The first-possession lookup is ordered by
+    ``play_id`` so the flag is deterministic regardless of input row order.
     """
-    if "home_opening_kickoff" in df.columns or "posteam" not in df.columns or "home_team" not in df.columns:
+    if (
+        "home_opening_kickoff" in df.columns
+        or "posteam" not in df.columns
+        or "home_team" not in df.columns
+        or "game_id" not in df.columns
+        or "play_id" not in df.columns
+    ):
         return df
     return df.with_columns(
-        pl.when(pl.col("posteam").drop_nulls().first().over("game_id") == pl.col("home_team"))
+        pl.when(pl.col("posteam").sort_by("play_id").drop_nulls().first().over("game_id") == pl.col("home_team"))
         .then(1)
         .otherwise(0)
+        # nflverse ships home_opening_kickoff as Float64; match it so a native-derived
+        # frame stays schema-compatible with nflverse-sourced frames under diagonal_relaxed.
+        .cast(pl.Float64)
         .alias("home_opening_kickoff"),
     )
 

--- a/tests/nfl/test_enrich_derive.py
+++ b/tests/nfl/test_enrich_derive.py
@@ -598,6 +598,37 @@ def test_ensure_home_opening_kickoff_does_not_override_existing() -> None:
     assert out["home_opening_kickoff"].to_list() == [0]
 
 
+def test_ensure_home_opening_kickoff_is_play_order_deterministic() -> None:
+    """The flag is ordered by play_id, so out-of-order input rows still resolve
+    the true opening possession (and the output dtype matches nflverse: Float64)."""
+    from sportsdataverse.nfl.ep_wp import _ensure_home_opening_kickoff
+
+    # Rows deliberately NOT in play order; play_id=1 is the kickoff (null posteam),
+    # play_id=2 is the first real possession (HOME).
+    df = pl.DataFrame(
+        {
+            "game_id": ["G", "G", "G"],
+            "play_id": [3, 1, 2],
+            "posteam": ["AWAY", None, "HOME"],
+            "home_team": ["HOME", "HOME", "HOME"],
+        }
+    )
+    out = _ensure_home_opening_kickoff(df)
+    # HOME took the first possession (play_id=2) → 1 everywhere, despite row order.
+    assert out["home_opening_kickoff"].to_list() == [1.0, 1.0, 1.0]
+    assert out.schema["home_opening_kickoff"] == pl.Float64
+
+
+def test_ensure_home_opening_kickoff_returns_unchanged_without_source_cols() -> None:
+    """Missing posteam/home_team → returns df unchanged (no column added, no crash)."""
+    from sportsdataverse.nfl.ep_wp import _ensure_home_opening_kickoff
+
+    df = pl.DataFrame({"game_id": ["G"], "play_id": [1], "home_team": ["HOME"]})  # no posteam
+    out = _ensure_home_opening_kickoff(df)
+    assert "home_opening_kickoff" not in out.columns
+    assert out.equals(df)
+
+
 def test_xpass_features_contract() -> None:
     """The 19-feature contract order (era0..era4 one-hot, era-aware retrain)."""
     assert XPASS_FEATURES == [

--- a/tests/nfl/test_enrich_derive.py
+++ b/tests/nfl/test_enrich_derive.py
@@ -542,6 +542,62 @@ def test_pass_oe_null_when_xpass_null(monkeypatch) -> None:  # noqa: ANN001
     assert out["pass_oe"].to_list()[0] is None
 
 
+# ---------------------------------------------------------------------------
+# home_opening_kickoff — derived when absent (native producers omit it).
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_home_opening_kickoff_derived_when_absent() -> None:
+    """home_opening_kickoff = 1 iff the home team had the game's first possession."""
+    from sportsdataverse.nfl.ep_wp import _ensure_home_opening_kickoff
+
+    df = pl.DataFrame(
+        {
+            "game_id": ["G1", "G1", "G2", "G2"],
+            "play_id": [1, 2, 1, 2],
+            # G1: home (HOME1) received the opening KO; G2: away (AWAY2) did.
+            "posteam": ["HOME1", "AWAY1", "AWAY2", "HOME2"],
+            "home_team": ["HOME1", "HOME1", "HOME2", "HOME2"],
+        }
+    )
+    out = _ensure_home_opening_kickoff(df).sort(["game_id", "play_id"])
+    assert out.filter(pl.col("game_id") == "G1")["home_opening_kickoff"].to_list() == [1, 1]
+    assert out.filter(pl.col("game_id") == "G2")["home_opening_kickoff"].to_list() == [0, 0]
+
+
+def test_ensure_home_opening_kickoff_skips_null_leading_posteam() -> None:
+    """A leading null posteam (the opening-kickoff row) is skipped — first NON-null wins."""
+    from sportsdataverse.nfl.ep_wp import _ensure_home_opening_kickoff
+
+    df = pl.DataFrame(
+        {
+            "game_id": ["G", "G", "G"],
+            "play_id": [1, 2, 3],
+            "posteam": [None, "HOME", "AWAY"],  # kickoff null; first real possession = HOME
+            "home_team": ["HOME", "HOME", "HOME"],
+        }
+    )
+    out = _ensure_home_opening_kickoff(df)
+    assert out["home_opening_kickoff"].to_list() == [1, 1, 1]
+
+
+def test_ensure_home_opening_kickoff_does_not_override_existing() -> None:
+    """An upstream-provided home_opening_kickoff (nflverse / ESPN path) is untouched."""
+    from sportsdataverse.nfl.ep_wp import _ensure_home_opening_kickoff
+
+    df = pl.DataFrame(
+        {
+            "game_id": ["G1"],
+            "play_id": [1],
+            "posteam": ["HOME1"],  # would derive 1 ...
+            "home_team": ["HOME1"],
+            "home_opening_kickoff": [0],  # ... but the existing value must win
+        }
+    )
+    out = _ensure_home_opening_kickoff(df)
+    assert out["home_opening_kickoff"].to_list() == [0]
+
+
 def test_xpass_features_contract() -> None:
     """The 19-feature contract order (era0..era4 one-hot, era-aware retrain)."""
     assert XPASS_FEATURES == [


### PR DESCRIPTION
## Problem

`enrich_nfl_pbp`'s 4th-down decision step needs `home_opening_kickoff` (it sets `home_receive_2h_ko` for the nfl4th features). nflverse pbp and the ESPN construction path carry it, but **native producers reconstructed from the Shield feed (`native_pbp`) do not** — so `get_4th_down_probs` raised `KeyError: 'home_opening_kickoff'`, the whole decision step was skipped (with a `RuntimeWarning`), and `go_wp` / `go_boost` / `fourth_down_recommendation` etc. shipped all-null in the published `nfl_model_pbp`.

## Fix

Derive `home_opening_kickoff` (= 1 iff the home team had the game's first possession) before the 4th-down step, when absent. Mirrors the existing `receive_2h_ko` derivation in `_add_wp_aux`:
- derived only when absent — never overrides an nflverse/ESPN-provided column;
- the per-game first-possession lookup (`posteam.drop_nulls().first().over("game_id")`) runs on the full frame before the 4th-down subset filter;
- skips the opening-kickoff row's null `posteam` (first NON-null possession wins).

## Validation

- **End-to-end** on a real `native_pbp` 2024 frame with no `home_opening_kickoff`: no skip warning, `home_opening_kickoff` derived, all 22 4th-down plays get a `fourth_down_recommendation` (`field_goal`/`punt`/`go`).
- 3 derivation unit tests (`test_enrich_derive.py`) + 128 enrich / 4th-down / ep_wp regression tests pass; mypy + ruff clean.

## Context

Surfaced by the sdv-py data-validation harness while reconciling the NFL producer (companion to the `yardline_100` and `spread_line`/`total_line` producer fixes in sportsdataverse/nfl-data). This is the sdv-py-side piece so the 4th-down surface populates for native producers once shipped.

## Summary by Sourcery

Ensure NFL fourth-down decision enrichment derives home_opening_kickoff when missing so 4th-down recommendation features populate for native play-by-play producers.

New Features:
- Add helper to derive home_opening_kickoff from first possession data when not supplied by upstream producers.

Tests:
- Add unit tests covering home_opening_kickoff derivation, handling of leading null posteam values, and preservation of existing upstream values.