### PR TITLE
fix(validation): R-lint UTF-8 decode + workflow/registry lint-target drift guard

### DIFF
--- a/.claude/workflows/validation-harness.js
+++ b/.claude/workflows/validation-harness.js
@@ -10,9 +10,10 @@ export const meta = {
 
 // --- configuration -----------------------------------------------------------
 // Registered datasets (tools/validation/registry.py DATASETS) and lint targets
-// (LINT_TARGETS). Keep in sync with the registry.
+// (LINT_TARGETS). Must stay in sync with the registry — enforced by
+// tests/contracts/test_workflow_registry_sync.py (drift fails CI).
 const DATASETS = ['cfb_model_pbp', 'nfl_model_pbp']
-const LINT_TARGETS = ['nfl_native_pbp', 'sdv_nfl_ep_wp']
+const LINT_TARGETS = ['nfl_native_pbp', 'sdv_nfl_ep_wp', 'cfb_data_r']
 
 // finding.check -> the sdv-toolkit judgment agent that adjudicates it.
 // Every check that emits needs_judgment=True has exactly one consumer here.

--- a/tests/contracts/fixtures/lint_r/utf8.R
+++ b/tests/contracts/fixtures/lint_r/utf8.R
@@ -1,0 +1,7 @@
+library(dplyr)
+
+# Non-ASCII content — “smart quotes”, an em-dash —, and an accented name José —
+# exercises the UTF-8 decode path in _parse_data_csv (Windows cp1252 default
+# would UnicodeDecodeError and silently drop this file instead of linting it).
+bad <- df |>
+  mutate(prev_ep = lag(ep))

--- a/tests/contracts/test_leakage_lint_r.py
+++ b/tests/contracts/test_leakage_lint_r.py
@@ -113,7 +113,10 @@ def test_parse_data_csv_decodes_rscript_output_as_utf8(monkeypatch):
 
     monkeypatch.setattr(leakage_r.subprocess, "run", _fake_run)
     out, err = leakage_r._parse_data_csv("rscript", Path("x.R"))
+    # Pin the full decode contract: UTF-8 with a replace fallback (a stray byte
+    # degrades one char instead of dropping the whole file).
     assert captured.get("encoding") == "utf-8", "Rscript output must be decoded as UTF-8"
+    assert captured.get("errors") == "replace", "a stray byte must degrade one char, not drop the file"
     assert out == _Proc.stdout and err == ""
 
 

--- a/tests/contracts/test_leakage_lint_r.py
+++ b/tests/contracts/test_leakage_lint_r.py
@@ -95,3 +95,33 @@ def test_analyze_lambda_wrapped_ungrouped_lag_is_flagged():
 def test_run_lambdawrap_live_warns():
     findings = leakage_r.run(str(_FIXTURES / "lambdawrap.R"))
     assert len(findings) == 1 and findings[0].locator["call"] == "lag"
+
+
+def test_parse_data_csv_decodes_rscript_output_as_utf8(monkeypatch):
+    """getParseData emits UTF-8; _parse_data_csv must decode it as UTF-8, not the
+    Windows cp1252 default (which UnicodeDecodeError's and silently drops the file)."""
+    captured: dict = {}
+
+    class _Proc:
+        returncode = 0
+        stdout = "id,parent,token,text\n"
+        stderr = ""
+
+    def _fake_run(_cmd, **kwargs):
+        captured.update(kwargs)
+        return _Proc()
+
+    monkeypatch.setattr(leakage_r.subprocess, "run", _fake_run)
+    out, err = leakage_r._parse_data_csv("rscript", Path("x.R"))
+    assert captured.get("encoding") == "utf-8", "Rscript output must be decoded as UTF-8"
+    assert out == _Proc.stdout and err == ""
+
+
+@skip_if_no_rscript
+def test_run_handles_utf8_source_file():
+    """A UTF-8 R file (smart quotes / em-dash / accents) is linted, not silently
+    dropped — regression for the cp1252 decode bug. The ungrouped lag is flagged."""
+    findings = leakage_r.run(str(_FIXTURES / "utf8.R"))
+    assert len(findings) == 1
+    assert findings[0].locator["call"] == "lag"
+    assert findings[0].severity is Severity.WARN and findings[0].needs_judgment

--- a/tests/contracts/test_workflow_registry_sync.py
+++ b/tests/contracts/test_workflow_registry_sync.py
@@ -1,0 +1,42 @@
+"""Drift guard: the validation-harness workflow's hardcoded dataset/lint-target
+lists must stay in sync with the Python registry.
+
+The Workflow runtime is JS and can't import the Python registry, so
+``.claude/workflows/validation-harness.js`` hardcodes ``DATASETS`` /
+``LINT_TARGETS``. When those drift from ``tools/validation/registry.py`` the
+workflow silently skips the missing target (this is exactly how the ``cfb_data_r``
+lint went unrun). These tests fail CI on any divergence.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from tools.validation.registry import DATASETS, LINT_TARGETS
+
+_WORKFLOW = Path(__file__).resolve().parents[2] / ".claude" / "workflows" / "validation-harness.js"
+
+
+def _js_string_array(const_name: str) -> set[str]:
+    """Extract the quoted entries of a ``const <name> = [...]`` JS array."""
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    m = re.search(rf"const\s+{const_name}\s*=\s*\[([^\]]*)\]", text)
+    assert m, f"{const_name} array not found in {_WORKFLOW.name}"
+    return set(re.findall(r"['\"]([^'\"]+)['\"]", m.group(1)))
+
+
+def test_workflow_file_exists():
+    assert _WORKFLOW.is_file(), f"workflow not found at {_WORKFLOW}"
+
+
+def test_workflow_datasets_match_registry():
+    assert _js_string_array("DATASETS") == set(DATASETS), (
+        "validation-harness.js DATASETS drifted from tools/validation/registry.py DATASETS"
+    )
+
+
+def test_workflow_lint_targets_match_registry():
+    assert _js_string_array("LINT_TARGETS") == set(LINT_TARGETS), (
+        "validation-harness.js LINT_TARGETS drifted from tools/validation/registry.py LINT_TARGETS"
+    )

--- a/tests/contracts/test_workflow_registry_sync.py
+++ b/tests/contracts/test_workflow_registry_sync.py
@@ -19,7 +19,14 @@ _WORKFLOW = Path(__file__).resolve().parents[2] / ".claude" / "workflows" / "val
 
 
 def _js_string_array(const_name: str) -> set[str]:
-    """Extract the quoted entries of a ``const <name> = [...]`` JS array."""
+    """Extract the quoted entries of a ``const <name> = [...]`` JS array.
+
+    Assumes a single-line array literal with no ``]`` or line comment between the
+    brackets (``[^\\]]*`` stops at the first ``]``). The workflow's ``DATASETS`` /
+    ``LINT_TARGETS`` are deliberately kept single-line for exactly this reason; if
+    a future edit wraps one across lines this returns a partial set and the
+    match/equality assertions below fail loudly rather than passing silently.
+    """
     text = _WORKFLOW.read_text(encoding="utf-8")
     m = re.search(rf"const\s+{const_name}\s*=\s*\[([^\]]*)\]", text)
     assert m, f"{const_name} array not found in {_WORKFLOW.name}"

--- a/tools/validation/lint/leakage_r.py
+++ b/tools/validation/lint/leakage_r.py
@@ -217,6 +217,13 @@ def _parse_data_csv(rscript: str, file: Path) -> tuple[str | None, str]:
             [rscript, str(_HELPER), str(file)],
             capture_output=True,
             text=True,
+            # getParseData emits UTF-8 (R source carries non-ASCII: smart quotes,
+            # em-dashes, accented names). Decode it as UTF-8 explicitly — the
+            # Windows default (cp1252) raises UnicodeDecodeError and the file is
+            # silently dropped instead of linted. errors="replace" is a last-resort
+            # guard so a stray byte degrades one char rather than the whole file.
+            encoding="utf-8",
+            errors="replace",
             timeout=_RSCRIPT_TIMEOUT,
         )
     except subprocess.TimeoutExpired:


### PR DESCRIPTION
Two harness blind spots surfaced while harvesting the CFB producer (running the `cfb_data_r` lint that had never actually executed). The CFB data-prep R itself is clean (0 leakage across 16 parsed files) — these are *harness* bugs that were hiding that coverage gap:

## A) `leakage_r` decoded Rscript output as cp1252 on Windows
`_parse_data_csv` ran `subprocess.run(..., text=True)` with no `encoding`, so on Windows it used cp1252 and `UnicodeDecodeError`'d on UTF-8 R sources (smart quotes / em-dashes / accented names) — **silently dropping those files instead of linting them** (2 cfb-data `presentation/` scripts were skipped). Fix: `encoding="utf-8", errors="replace"`.

## B) Workflow `LINT_TARGETS` drifted from the registry
`.claude/workflows/validation-harness.js` hardcoded `LINT_TARGETS = ['nfl_native_pbp','sdv_nfl_ep_wp']` — stale, **missing `cfb_data_r`** (registered in the harness since #147/#149). So the workflow never ran the CFB R lint at all. Fix: add it, and add `tests/contracts/test_workflow_registry_sync.py` asserting the workflow's `DATASETS`/`LINT_TARGETS` match `registry.py` (CI fails on future drift).

## Tests
- Hermetic: `_parse_data_csv` is called with `encoding="utf-8"`.
- Live (`@skip_if_no_rscript`): a UTF-8 fixture (`utf8.R`) is linted, not dropped — the ungrouped `lag` is flagged.
- 3 drift-guard tests (workflow ↔ registry).

Full contracts suite 84 passed / 1 skipped; mypy + ruff clean; `node --check` on the workflow passes.

## Summary by Sourcery

Ensure R leakage lint correctly handles UTF-8 sources and keep the validation-harness workflow configuration in sync with the Python registry.

Bug Fixes:
- Decode Rscript getParseData output as UTF-8 with a fallback to replacement characters to prevent Windows cp1252 decode failures and dropped files.
- Add the cfb_data_r lint target to the validation-harness workflow so its R lint actually runs.

Enhancements:
- Add a CI drift-guard test suite that verifies the validation-harness workflow DATASETS and LINT_TARGETS arrays match the Python registry configuration.

Tests:
- Add regression tests confirming UTF-8 R sources are linted rather than dropped and that _parse_data_csv invokes subprocess.run with UTF-8 decoding.
- Introduce tests that parse the JS workflow file and assert its dataset and lint-target arrays stay aligned with the Python registry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTF-8 handling during R linting by explicitly decoding process output as UTF-8 and replacing invalid bytes instead of failing/omitting results.

* **Tests**
  * Added new UTF-8 regression fixture and contract tests to verify decoding behavior and expected warning output.
  * Introduced a CI drift check to ensure workflow validation settings stay aligned with the canonical registry.
  * Updated the workflow validation harness to include an additional lint target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->