### PR TITLE
feat(nba): model-zoo v1 — validation harness (4 oracles + meta-oracle + season compiler)

### DIFF
--- a/dev/run_rapm_validation_report.py
+++ b/dev/run_rapm_validation_report.py
@@ -1,0 +1,9 @@
+# dev/run_rapm_validation_report.py  — opt-in, run manually with SDV_PY_NBA_STATS_LIVE=1
+from pathlib import Path
+from sportsdataverse.nba.nba_season_compile import compile_nba_season
+from sportsdataverse.nba.nba_model_validation import RidgeRapmModel, validate_model, render_report
+
+seasons = [compile_nba_season(y) for y in (2021, 2022, 2023)]  # multi-hour cached pull
+rep = validate_model(RidgeRapmModel(), seasons, model_name="plain_rapm")
+Path("dev/nba_rapm_validation_report.md").write_text(render_report(rep), encoding="utf-8")
+print(render_report(rep))

--- a/docs/docs/nba/index.md
+++ b/docs/docs/nba/index.md
@@ -11,7 +11,7 @@ sidebar_label: NBA
 | [ESPN core API (v2)](reference/core) | 81 | `https://sports.core.api.espn.com/v2/sports` |
 | [NBA Stats API (stats.nba.com)](reference/nba_stats) | 112 | `https://stats.nba.com` |
 | [Dataset loaders](reference/loaders) | 13 | sportsdataverse-data releases |
-| [Additional functions](reference/additional) | 15 | hand-written wrappers, loaders & helpers |
+| [Additional functions](reference/additional) | 20 | hand-written wrappers, loaders & helpers |
 
 ## Examples
 

--- a/docs/docs/nba/reference/additional.md
+++ b/docs/docs/nba/reference/additional.md
@@ -367,6 +367,137 @@ print(year_to_season(1999))  # "1999-00"
 
 ## Other
 
+### `RidgeRapmModel(alphas: 'np.ndarray' = array([   100.        ,    268.26957953,    719.685673  ,   1930.69772888,
+         5179.47467923,  13894.95494373,  37275.93720315, 100000.        ])) -> 'None'` {#RidgeRapmModel}
+
+Reference model: the merged plain-RAPM RidgeCV fit, adapted to `RapmModel`.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `alphas` | `ndarray` | `array([   100.        ,    268.26957953,    719.685673  ,   1930.69772888,
+         5179.47467923,  13894.95494373,  37275.93720315, 100000.        ])` | Ridge penalty grid for cross-validation. Defaults to the merged `DEFAULT_RAPM_ALPHAS`. |
+
+**Example**
+
+```python
+import polars as pl
+from sportsdataverse.nba.nba_rapm import build_rapm_design
+from sportsdataverse.nba.nba_model_validation import RidgeRapmModel
+
+rows = {
+    "off_player_1": [1, 6], "off_player_2": [2, 7],
+    "off_player_3": [3, 8], "off_player_4": [4, 9],
+    "off_player_5": [5, 10],
+    "def_player_1": [6, 1], "def_player_2": [7, 2],
+    "def_player_3": [8, 3], "def_player_4": [9, 4],
+    "def_player_5": [10, 5],
+    "points": [2, 0],
+}
+poss = pl.DataFrame(rows)
+X, y, pids = build_rapm_design(poss)
+fit = RidgeRapmModel().fit(X, y)
+print(fit.coef.shape)    # (20,) — 10 players × 2 sides
+print(fit.posterior)     # None — point estimator
+```
+
+**Methods**
+
+#### `RidgeRapmModel.fit(X: 'csr_matrix', y: 'np.ndarray') -> 'FitResult'`
+
+Fit RidgeCV and return coefficients + intercept (no posterior).
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `X` | `csr_matrix` |  | Sparse design matrix of shape `(n_possessions, 2P)`. |
+| `y` | `ndarray` |  | Target points per possession, shape `(n_possessions,)`. |
+
+**Returns**
+
+FitResult with `coef` shape `(2P,)`, scalar `intercept`, and `posterior=None`.
+
+### `ValidationReport(model_name: 'str', n_seasons: 'int', retrodiction: 'Optional[RetrodictionResult]' = None, reliability: 'Optional[ReliabilityResult]' = None, cross_season: 'Optional[CrossSeasonResult]' = None, calibration: 'Optional[CalibrationResult]' = None) -> None` {#ValidationReport}
+
+Holds all oracle results for a single model evaluation run.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `model_name` | `str` |  | Human-readable label for the model being evaluated. |
+| `n_seasons` | `int` |  | Number of season frames supplied to `validate_model`. |
+| `retrodiction` | `Optional[RetrodictionResult]` | `None` | Result from Oracle 1, or `None` if not selected. |
+| `reliability` | `Optional[ReliabilityResult]` | `None` | Result from Oracle 2, or `None` if not selected. |
+| `cross_season` | `Optional[CrossSeasonResult]` | `None` | Result from Oracle 3, or `None` if not selected. |
+| `calibration` | `Optional[CalibrationResult]` | `None` | Result from Oracle 4, or `None` if not selected or the model is a point estimator. |
+
+**Example**
+
+```python
+from sportsdataverse.nba.nba_model_validation import (
+    RidgeRapmModel, validate_model,
+)
+
+# season_frames is a list[pl.DataFrame] of possession stints per season
+rep = validate_model(RidgeRapmModel(), season_frames, model_name="plain_rapm")
+print(rep.model_name)                        # "plain_rapm"
+print(rep.n_seasons)                         # len(season_frames)
+print(rep.retrodiction.game_margin_rmse)     # float
+print(rep.reliability.spearman_brown)        # float
+print(rep.calibration)                       # None — point estimator
+```
+
+### `compile_nba_season(season: 'int', season_type: 'str' = 'Regular Season', *, resume: 'bool' = True, cache_dir: 'Optional[str]' = None, delay_s: 'float' = 0.6, return_as_pandas: 'bool' = False) -> 'Union[pl.DataFrame, pd.DataFrame]'` {#compile_nba_season}
+
+Compile a full season's possession stint matrix (cached + resumable + throttled).
+
+Discovers game ids, dedupes, then per game loads the cached parquet if present
+(`resume`), else fetches via fetch_possessions`, caches it, and sleeps
+`delay_s` (throttle; only on live fetches). A game that errors or returns no
+possessions is logged and skipped (best-effort, never raises). The assembled
+frame is tagged with a `season` column.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `int` |  | Season start year (e.g. 2023 for 2023-24). |
+| `season_type` | `str` | `'Regular Season'` | `"Regular Season"` (default) or `"Playoffs"`. |
+| `resume` | `bool` | `True` | Reuse per-game cached parquet when present. |
+| `cache_dir` | `Optional[str]` | `None` | Cache root; defaults to `SDV_PY_NBA_CACHE_DIR` or `~/.sdv_py_nba_cache/possessions`. |
+| `delay_s` | `float` | `0.6` | Seconds to sleep after each live fetch (rate-limit throttle). |
+| `return_as_pandas` | `bool` | `False` | Return pandas instead of polars. |
+
+**Returns**
+
+The season possession frame (+ `season` col). Empty typed frame if no games.
+
+**Example**
+
+```python
+from sportsdataverse.nba.nba_season_compile import compile_nba_season
+
+poss = compile_nba_season(2023)
+print(poss.shape)          # (n_possessions, n_cols)
+print(poss["season"][0])   # 2023
+
+# Resume a partially completed run and return as pandas
+
+poss_pd = compile_nba_season(2023, resume=True, return_as_pandas=True)
+print(type(poss_pd))       # <class 'pandas.core.frame.DataFrame'>
+
+# Compile Playoffs with a custom cache directory
+
+poss = compile_nba_season(
+    2023,
+    season_type="Playoffs",
+    cache_dir="/tmp/nba_cache",
+)
+```
+
 ### `espn_nba_teams(return_as_pandas=False, **kwargs) -> 'pl.DataFrame'` {#espn_nba_teams}
 
 espn_nba_teams - look up NBA teams
@@ -627,6 +758,37 @@ pbp = nba_pbp_disk(game_id=401585183, path_to_json="./cache")
 print(list(pbp.keys()))
 ```
 
+### `render_report(report: 'ValidationReport') -> 'str'` {#render_report}
+
+Render a `ValidationReport` as a human-readable markdown validation card.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `report` | `ValidationReport` |  | A populated `ValidationReport` from `validate_model`. |
+
+**Returns**
+
+A multi-section markdown string with one `##` heading per oracle. Sections whose oracle result is `None` (either skipped or not applicable for a point-estimate model) are rendered as `- n/a`.
+
+**Example**
+
+```python
+from sportsdataverse.nba.nba_model_validation import (
+    RidgeRapmModel, validate_model, render_report,
+)
+
+rep = validate_model(RidgeRapmModel(), season_frames, model_name="plain_rapm")
+md = render_report(rep)
+print(md)
+
+# Capture the markdown string for downstream use
+
+with open("validation_card.md", "w") as f:
+    f.write(render_report(rep))
+```
+
 ### `scoreboard_event_parsing(event)` {#scoreboard_event_parsing}
 
 Internal helper that flattens an ESPN NBA scoreboard event dict into a
@@ -648,4 +810,48 @@ The same event dict, mutated in place with `home`/`away` copies of the competito
 ```python
 from sportsdataverse.nba import espn_nba_schedule
 sched = espn_nba_schedule(dates=20230102)
+```
+
+### `validate_model(model: 'RapmModel', season_frames: 'List[pl.DataFrame]', *, model_name: 'str' = 'model', oracles: 'Tuple[str, ...]' = ('retrodiction', 'reliability', 'cross_season', 'calibration'), seed: 'int' = 0) -> 'ValidationReport'` {#validate_model}
+
+Run the selected oracles and assemble a `ValidationReport`.
+
+`retrodiction`/`reliability`/`calibration` run on the pooled possessions
+(all seasons concatenated); `cross_season` runs on the ordered per-season
+frames. Any oracle not selected is left `None`.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `model` | `RapmModel` |  | A fitted or unfitted RAPM-family estimator (`fit(X, y)` protocol). |
+| `season_frames` | `List[DataFrame]` |  | Ordered list of per-season possession frames. All frames are concatenated into a single pooled frame for Oracles 1, 2, and 4. |
+| `model_name` | `str` | `'model'` | Label written into the returned report and markdown card. |
+| `oracles` | `Tuple[str, ...]` | `('retrodiction', 'reliability', 'cross_season', 'calibration')` | Tuple of oracle names to run. Omit a name to skip that oracle and leave its result field `None`. |
+| `seed` | `int` | `0` | RNG seed forwarded to each oracle for determinism. |
+
+**Returns**
+
+A `ValidationReport` whose fields are populated for every selected oracle and `None` for every skipped oracle.
+
+**Example**
+
+```python
+from sportsdataverse.nba.nba_model_validation import (
+    RidgeRapmModel, validate_model,
+)
+
+# season_frames is a list[pl.DataFrame] of possession stints
+rep = validate_model(RidgeRapmModel(), season_frames, model_name="plain_rapm")
+print(rep.retrodiction.game_margin_rmse)   # out-of-sample margin RMSE
+print(rep.reliability.spearman_brown)      # split-half Spearman-Brown
+print(rep.calibration)                     # None — RidgeRapmModel has no posterior
+
+# Skip slow oracles when iterating quickly
+
+rep = validate_model(
+    RidgeRapmModel(), season_frames,
+    oracles=("retrodiction", "reliability"),
+)
+print(rep.cross_season)   # None — not selected
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -330,4 +330,6 @@ files = [
     "tools/validation/checks/prep_published_parity.py",
     "tools/validation/lint/leakage_python.py",
     "tools/validation/lint/leakage_r.py",
+    "sportsdataverse/nba/nba_model_validation.py",
+    "sportsdataverse/nba/nba_season_compile.py",
 ]

--- a/sportsdataverse/nba/__init__.py
+++ b/sportsdataverse/nba/__init__.py
@@ -8,3 +8,10 @@ from sportsdataverse.nba.nba_pbp import *
 from sportsdataverse.nba.nba_player_stats import *
 from sportsdataverse.nba.nba_schedule import *
 from sportsdataverse.nba.nba_teams import *
+from sportsdataverse.nba.nba_season_compile import compile_nba_season  # noqa: F401
+from sportsdataverse.nba.nba_model_validation import (  # noqa: F401
+    RidgeRapmModel,
+    ValidationReport,
+    validate_model,
+    render_report,
+)

--- a/sportsdataverse/nba/nba_model_validation.py
+++ b/sportsdataverse/nba/nba_model_validation.py
@@ -478,6 +478,85 @@ def cross_season(
     )
 
 
+@dataclass(frozen=True)
+class CalibrationResult:
+    """Empirical coverage of a posterior model's credible intervals.
+
+    Attributes:
+        levels: The nominal coverage levels requested (e.g. ``[0.5, 0.9]``).
+        coverage: Empirical fraction of held-out player ratings falling inside
+            the credible interval at each corresponding level in ``levels``.
+        n_players: Number of players shared across both game halves (the basis
+            for coverage computation).
+    """
+
+    levels: List[float]
+    coverage: List[float]
+    n_players: int
+
+
+def calibration(
+    model: RapmModel,
+    possessions: pl.DataFrame,
+    *,
+    levels: Tuple[float, ...] = (0.5, 0.8, 0.9, 0.95),
+    seed: int = 0,
+) -> Optional[CalibrationResult]:
+    """Oracle ④ (forward-looking hook): empirical coverage of the model's intervals.
+
+    Fits the full frame; if the fit has no ``posterior`` (point model) returns
+    ``None`` (n/a). Otherwise splits games in half, treats each player's half-B
+    rating as the held-out "truth", forms central credible intervals from the
+    half-A posterior at each level, and reports the fraction of players whose
+    truth falls inside — the calibration curve.
+
+    Args:
+        model: A ``RapmModel`` instance; must emit ``FitResult.posterior`` (an
+            ``(S, 2P)`` sample array) to produce a non-``None`` result.
+        possessions: A season (or multi-game) possession+lineup frame with
+            ``game_id``, ``offense_team_id``, ``points``, and the ten lineup
+            columns (``off_player_1..5``, ``def_player_1..5``).
+        levels: Nominal coverage levels to evaluate (default
+            ``(0.5, 0.8, 0.9, 0.95)``).
+        seed: RNG seed for the game shuffle (default 0 for determinism).
+
+    Returns:
+        ``CalibrationResult`` with the empirical coverage curve, or ``None``
+        when the model is a point estimator (``posterior`` is ``None``) or when
+        fewer than 3 players are shared between the two game halves.
+    """
+    if possessions.is_empty():
+        return None
+    games = possessions["game_id"].unique().to_list()
+    rng = np.random.default_rng(seed)
+    rng.shuffle(games)
+    mid = len(games) // 2
+    a = possessions.filter(pl.col("game_id").is_in(games[:mid]))
+    b = possessions.filter(pl.col("game_id").is_in(games[mid:]))
+    Xa, ya, pids_a = build_rapm_design(a)
+    if not pids_a:
+        return None
+    fit_a = model.fit(Xa, ya)
+    if fit_a.posterior is None:
+        return None
+    P = len(pids_a)
+    post_total = fit_a.posterior[:, :P] - fit_a.posterior[:, P:]  # (S, P) total-impact posterior
+    truth_b = _fit_ratings(model, b)
+    shared = [(k, p) for k, p in enumerate(pids_a) if p in truth_b]
+    if len(shared) < 3:
+        return None
+    cover: List[float] = []
+    for lvl in levels:
+        lo_q, hi_q = (1 - lvl) / 2, 1 - (1 - lvl) / 2
+        hits = 0
+        for k, p in shared:
+            lo, hi = np.quantile(post_total[:, k], [lo_q, hi_q])
+            if lo <= truth_b[p] <= hi:
+                hits += 1
+        cover.append(hits / len(shared))
+    return CalibrationResult(levels=list(levels), coverage=cover, n_players=len(shared))
+
+
 _TEAM_A, _TEAM_B = 100, 200
 
 

--- a/sportsdataverse/nba/nba_model_validation.py
+++ b/sportsdataverse/nba/nba_model_validation.py
@@ -379,6 +379,105 @@ def reliability(model: RapmModel, possessions: pl.DataFrame, *, seed: int = 0) -
     return ReliabilityResult(split_half_corr=r, spearman_brown=sb, n_shared_players=len(shared))
 
 
+@dataclass(frozen=True)
+class CrossSeasonResult:
+    """Cross-season predictivity metrics from season-N ratings applied to season N+1.
+
+    Attributes:
+        outcome_corr: Pearson correlation of predicted vs actual per-(game, team)
+            margins in season N+1 when predicted with season-N coefficients.
+            ``nan`` when fewer than 2 adjacent season pairs are available.
+        outcome_rmse: RMSE of the same margin predictions. ``nan`` on insufficient data.
+        rating_corr: Pearson correlation of season-N per-player ratings with
+            season N+1 ratings over players shared across both seasons. Tests
+            whether skill persists year-to-year. ``nan`` when fewer than 3 shared
+            players exist.
+        coverage_pct: Percentage of season N+1 lineup slots (across all valid
+            possessions) whose player was seen in season N. Measures how much of
+            the N+1 population is covered by the N model.
+        n_shared_players: Total shared-player count summed across all adjacent pairs.
+    """
+
+    outcome_corr: float
+    outcome_rmse: float
+    rating_corr: float
+    coverage_pct: float
+    n_shared_players: int
+
+
+def cross_season(
+    model: RapmModel,
+    season_frames: List[pl.DataFrame],
+    *,
+    unknown_player_rating: float = 0.0,
+) -> CrossSeasonResult:
+    """Oracle ③: do season-N ratings predict season N+1 outcomes and ratings?
+
+    For each adjacent (N, N+1) pair: fit N -> coef_N; predict N+1's possessions
+    with coef_N (players unseen in N contribute ``unknown_player_rating``, v1=0);
+    aggregate to N+1 game margins for the outcome scores. Also correlate the N
+    ratings with the N+1 ratings over shared players. Multiple pairs are averaged.
+    ``coverage_pct`` = share of N+1 lineup slots whose player was seen in N.
+
+    Args:
+        model: A ``RapmModel`` instance.
+        season_frames: Ordered list of per-season possession frames (season N,
+            season N+1, ...). Must contain at least 2 frames to produce non-nan
+            results.
+        unknown_player_rating: Reserved; only ``0.0`` (skip unknown players) is
+            implemented in v1.
+
+    Returns:
+        ``CrossSeasonResult``. All metrics are ``nan`` and ``n_shared_players=0``
+        when fewer than 2 season frames are provided.
+    """
+    if len(season_frames) < 2:
+        return CrossSeasonResult(float("nan"), float("nan"), float("nan"), float("nan"), 0)
+    out_corrs: List[float] = []
+    out_rmses: List[float] = []
+    rate_corrs: List[float] = []
+    covs: List[float] = []
+    shared_counts: List[int] = []
+    for n, np1 in zip(season_frames, season_frames[1:]):
+        X_n, y_n, pids_n = build_rapm_design(n)
+        if not pids_n:
+            continue
+        fit_n = model.fit(X_n, y_n)
+        # outcome: predict N+1 with coef_N
+        X_np1, _ = _design_with_ids(np1, pids_n, unknown_player_rating=unknown_player_rating)
+        np1_valid = np1.drop_nulls(subset=_OFF + _DEF)
+        pp = predict_points(X_np1, fit_n)
+        p_pred, p_act = _team_game_margins(np1_valid, pp)
+        if p_act.size > 1 and np.std(p_pred) > 0:
+            out_corrs.append(float(np.corrcoef(p_pred, p_act)[0, 1]))
+            out_rmses.append(_rmse(p_pred, p_act))
+        # rating persistence
+        ratings_n = _fit_ratings(model, n)
+        ratings_np1 = _fit_ratings(model, np1)
+        shared = sorted(set(ratings_n) & set(ratings_np1))
+        if len(shared) >= 3:
+            va = np.array([ratings_n[p] for p in shared])
+            vb = np.array([ratings_np1[p] for p in shared])
+            if np.std(va) > 0 and np.std(vb) > 0:
+                rate_corrs.append(float(np.corrcoef(va, vb)[0, 1]))
+            shared_counts.append(len(shared))
+        # coverage: fraction of N+1 lineup ids seen in N
+        seen = set(pids_n)
+        np1_ids = np1_valid.select(_OFF + _DEF).to_numpy().ravel()
+        covs.append(100.0 * np.mean([int(x) in seen for x in np1_ids]) if np1_ids.size else 0.0)
+
+    def _mean(xs: List[float]) -> float:
+        return float(np.mean(xs)) if xs else float("nan")
+
+    return CrossSeasonResult(
+        outcome_corr=_mean(out_corrs),
+        outcome_rmse=_mean(out_rmses),
+        rating_corr=_mean(rate_corrs),
+        coverage_pct=_mean(covs),
+        n_shared_players=int(np.sum(shared_counts)) if shared_counts else 0,
+    )
+
+
 _TEAM_A, _TEAM_B = 100, 200
 
 

--- a/sportsdataverse/nba/nba_model_validation.py
+++ b/sportsdataverse/nba/nba_model_validation.py
@@ -301,6 +301,84 @@ def retrodiction(
     )
 
 
+@dataclass(frozen=True)
+class ReliabilityResult:
+    """Split-half reliability of per-player ratings with Spearman-Brown adjustment.
+
+    Attributes:
+        split_half_corr: Pearson correlation of per-player total ratings fitted on
+            the two random game halves. ``nan`` when fewer than 3 shared players.
+        spearman_brown: Spearman-Brown prophecy formula correction for the full-season
+            test length: ``2r / (1 + r)``. ``nan`` when ``split_half_corr`` is ``nan``
+            or exactly -1.
+        n_shared_players: Number of players present in both halves (the basis for
+            the correlation).
+    """
+
+    split_half_corr: float
+    spearman_brown: float
+    n_shared_players: int
+
+
+def _fit_ratings(model: RapmModel, possessions: pl.DataFrame) -> Dict[int, float]:
+    """Fit the model on ``possessions`` and return player_id -> total rating (o - d_raw).
+
+    Args:
+        model: A ``RapmModel`` instance.
+        possessions: A possession+lineup frame.
+
+    Returns:
+        Dict mapping player_id to total impact rating (offense coef minus defense coef).
+        Empty dict when ``possessions`` has no players.
+    """
+    X, y, pids = build_rapm_design(possessions)
+    if not pids:
+        return {}
+    fit = model.fit(X, y)
+    P = len(pids)
+    total = fit.coef[:P] - fit.coef[P:]  # offense minus (raw) defense coef = total impact
+    return {int(p): float(total[k]) for k, p in enumerate(pids)}
+
+
+def reliability(model: RapmModel, possessions: pl.DataFrame, *, seed: int = 0) -> ReliabilityResult:
+    """Oracle ②: split-half reliability of the per-player rating across two game halves.
+
+    Randomly halves the games, fits each half independently, and correlates the
+    per-player total ratings over players present in both. Reports the raw split-
+    half correlation and the Spearman-Brown-adjusted full-season reliability
+    ``2r / (1 + r)``.
+
+    Args:
+        model: A ``RapmModel`` instance.
+        possessions: A season (or multi-game) possession+lineup frame with
+            ``game_id``, ``offense_team_id``, ``points``, and the ten lineup
+            columns (``off_player_1..5``, ``def_player_1..5``).
+        seed: RNG seed for the game shuffle (default 0 for determinism).
+
+    Returns:
+        ``ReliabilityResult``. ``split_half_corr`` and ``spearman_brown`` are ``nan``
+        and ``n_shared_players=0`` on empty input or when fewer than 3 players are
+        shared between the two halves.
+    """
+    if possessions.is_empty():
+        return ReliabilityResult(float("nan"), float("nan"), 0)
+    games = possessions["game_id"].unique().to_list()
+    rng = np.random.default_rng(seed)
+    rng.shuffle(games)
+    mid = len(games) // 2
+    a = possessions.filter(pl.col("game_id").is_in(games[:mid]))
+    b = possessions.filter(pl.col("game_id").is_in(games[mid:]))
+    ra, rb = _fit_ratings(model, a), _fit_ratings(model, b)
+    shared = sorted(set(ra) & set(rb))
+    if len(shared) < 3:
+        return ReliabilityResult(float("nan"), float("nan"), len(shared))
+    va = np.array([ra[p] for p in shared])
+    vb = np.array([rb[p] for p in shared])
+    r = float(np.corrcoef(va, vb)[0, 1]) if np.std(va) > 0 and np.std(vb) > 0 else 0.0
+    sb = (2 * r / (1 + r)) if r > -1 else float("nan")
+    return ReliabilityResult(split_half_corr=r, spearman_brown=sb, n_shared_players=len(shared))
+
+
 _TEAM_A, _TEAM_B = 100, 200
 
 

--- a/sportsdataverse/nba/nba_model_validation.py
+++ b/sportsdataverse/nba/nba_model_validation.py
@@ -51,6 +51,28 @@ class RidgeRapmModel:
     Args:
         alphas: Ridge penalty grid for cross-validation. Defaults to the merged
             ``DEFAULT_RAPM_ALPHAS``.
+
+    Example:
+        Build a design from possession stints and fit the reference model::
+
+            import polars as pl
+            from sportsdataverse.nba.nba_rapm import build_rapm_design
+            from sportsdataverse.nba.nba_model_validation import RidgeRapmModel
+
+            rows = {
+                "off_player_1": [1, 6], "off_player_2": [2, 7],
+                "off_player_3": [3, 8], "off_player_4": [4, 9],
+                "off_player_5": [5, 10],
+                "def_player_1": [6, 1], "def_player_2": [7, 2],
+                "def_player_3": [8, 3], "def_player_4": [9, 4],
+                "def_player_5": [10, 5],
+                "points": [2, 0],
+            }
+            poss = pl.DataFrame(rows)
+            X, y, pids = build_rapm_design(poss)
+            fit = RidgeRapmModel().fit(X, y)
+            print(fit.coef.shape)    # (20,) — 10 players × 2 sides
+            print(fit.posterior)     # None — point estimator
     """
 
     def __init__(self, alphas: np.ndarray = DEFAULT_RAPM_ALPHAS) -> None:
@@ -635,6 +657,21 @@ class ValidationReport:
         cross_season: Result from Oracle 3, or ``None`` if not selected.
         calibration: Result from Oracle 4, or ``None`` if not selected or
             the model is a point estimator.
+
+    Example:
+        ``ValidationReport`` is returned by ``validate_model``; access fields directly::
+
+            from sportsdataverse.nba.nba_model_validation import (
+                RidgeRapmModel, validate_model,
+            )
+
+            # season_frames is a list[pl.DataFrame] of possession stints per season
+            rep = validate_model(RidgeRapmModel(), season_frames, model_name="plain_rapm")
+            print(rep.model_name)                        # "plain_rapm"
+            print(rep.n_seasons)                         # len(season_frames)
+            print(rep.retrodiction.game_margin_rmse)     # float
+            print(rep.reliability.spearman_brown)        # float
+            print(rep.calibration)                       # None — point estimator
     """
 
     model_name: str
@@ -671,6 +708,27 @@ def validate_model(
     Returns:
         A ``ValidationReport`` whose fields are populated for every selected oracle
         and ``None`` for every skipped oracle.
+
+    Example:
+        Run all four oracles on a single season::
+
+            from sportsdataverse.nba.nba_model_validation import (
+                RidgeRapmModel, validate_model,
+            )
+
+            # season_frames is a list[pl.DataFrame] of possession stints
+            rep = validate_model(RidgeRapmModel(), season_frames, model_name="plain_rapm")
+            print(rep.retrodiction.game_margin_rmse)   # out-of-sample margin RMSE
+            print(rep.reliability.spearman_brown)      # split-half Spearman-Brown
+            print(rep.calibration)                     # None — RidgeRapmModel has no posterior
+
+        Skip slow oracles when iterating quickly::
+
+            rep = validate_model(
+                RidgeRapmModel(), season_frames,
+                oracles=("retrodiction", "reliability"),
+            )
+            print(rep.cross_season)   # None — not selected
     """
     pooled = (
         pl.concat(season_frames, how="diagonal_relaxed") if season_frames else pl.DataFrame(schema={"game_id": pl.Utf8})
@@ -695,6 +753,22 @@ def render_report(report: ValidationReport) -> str:
         A multi-section markdown string with one ``##`` heading per oracle.
         Sections whose oracle result is ``None`` (either skipped or not
         applicable for a point-estimate model) are rendered as ``- n/a``.
+
+    Example:
+        Print a full markdown card after running validation::
+
+            from sportsdataverse.nba.nba_model_validation import (
+                RidgeRapmModel, validate_model, render_report,
+            )
+
+            rep = validate_model(RidgeRapmModel(), season_frames, model_name="plain_rapm")
+            md = render_report(rep)
+            print(md)
+
+        Capture the markdown string for downstream use::
+
+            with open("validation_card.md", "w") as f:
+                f.write(render_report(rep))
     """
     L: List[str] = [
         f"# Validation report — `{report.model_name}`",

--- a/sportsdataverse/nba/nba_model_validation.py
+++ b/sportsdataverse/nba/nba_model_validation.py
@@ -616,3 +616,119 @@ def _synthetic_possessions(
         **{c: pl.Int64 for c in _OFF + _DEF},
     }
     return pl.DataFrame(rows, schema=schema)
+
+
+# ---------------------------------------------------------------------------
+# Task 7: validate_model orchestrator + ValidationReport + render_report
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ValidationReport:
+    """Holds all oracle results for a single model evaluation run.
+
+    Attributes:
+        model_name: Human-readable label for the model being evaluated.
+        n_seasons: Number of season frames supplied to ``validate_model``.
+        retrodiction: Result from Oracle 1, or ``None`` if not selected.
+        reliability: Result from Oracle 2, or ``None`` if not selected.
+        cross_season: Result from Oracle 3, or ``None`` if not selected.
+        calibration: Result from Oracle 4, or ``None`` if not selected or
+            the model is a point estimator.
+    """
+
+    model_name: str
+    n_seasons: int
+    retrodiction: Optional[RetrodictionResult] = None
+    reliability: Optional[ReliabilityResult] = None
+    cross_season: Optional[CrossSeasonResult] = None
+    calibration: Optional[CalibrationResult] = None
+
+
+def validate_model(
+    model: RapmModel,
+    season_frames: List[pl.DataFrame],
+    *,
+    model_name: str = "model",
+    oracles: Tuple[str, ...] = ("retrodiction", "reliability", "cross_season", "calibration"),
+    seed: int = 0,
+) -> ValidationReport:
+    """Run the selected oracles and assemble a ``ValidationReport``.
+
+    ``retrodiction``/``reliability``/``calibration`` run on the pooled possessions
+    (all seasons concatenated); ``cross_season`` runs on the ordered per-season
+    frames. Any oracle not selected is left ``None``.
+
+    Args:
+        model: A fitted or unfitted RAPM-family estimator (``fit(X, y)`` protocol).
+        season_frames: Ordered list of per-season possession frames.  All frames
+            are concatenated into a single pooled frame for Oracles 1, 2, and 4.
+        model_name: Label written into the returned report and markdown card.
+        oracles: Tuple of oracle names to run.  Omit a name to skip that oracle
+            and leave its result field ``None``.
+        seed: RNG seed forwarded to each oracle for determinism.
+
+    Returns:
+        A ``ValidationReport`` whose fields are populated for every selected oracle
+        and ``None`` for every skipped oracle.
+    """
+    pooled = (
+        pl.concat(season_frames, how="diagonal_relaxed") if season_frames else pl.DataFrame(schema={"game_id": pl.Utf8})
+    )
+    return ValidationReport(
+        model_name=model_name,
+        n_seasons=len(season_frames),
+        retrodiction=retrodiction(model, pooled, seed=seed) if "retrodiction" in oracles else None,
+        reliability=reliability(model, pooled, seed=seed) if "reliability" in oracles else None,
+        cross_season=cross_season(model, season_frames) if "cross_season" in oracles else None,
+        calibration=calibration(model, pooled, seed=seed) if "calibration" in oracles else None,
+    )
+
+
+def render_report(report: ValidationReport) -> str:
+    """Render a ``ValidationReport`` as a human-readable markdown validation card.
+
+    Args:
+        report: A populated ``ValidationReport`` from ``validate_model``.
+
+    Returns:
+        A multi-section markdown string with one ``##`` heading per oracle.
+        Sections whose oracle result is ``None`` (either skipped or not
+        applicable for a point-estimate model) are rendered as ``- n/a``.
+    """
+    L: List[str] = [
+        f"# Validation report — `{report.model_name}`",
+        f"\n_{report.n_seasons} season(s)_\n",
+    ]
+    r = report.retrodiction
+    L.append("## Retrodiction (Oracle 1)")
+    L.append(
+        f"- game-margin RMSE: **{r.game_margin_rmse:.3f}** (baseline {r.baseline_rmse:.3f}); "
+        f"corr **{r.game_margin_corr:.3f}**; poss-RMSE {r.poss_rmse:.3f}; "
+        f"test games {r.n_test_games}"
+        if r
+        else "- n/a"
+    )
+    rel = report.reliability
+    L.append("## Split-half reliability (Oracle 2)")
+    L.append(
+        f"- split-half corr **{rel.split_half_corr:.3f}**, Spearman-Brown "
+        f"**{rel.spearman_brown:.3f}** ({rel.n_shared_players} shared players)"
+        if rel
+        else "- n/a"
+    )
+    cs = report.cross_season
+    L.append("## Cross-season predictivity (Oracle 3)")
+    L.append(
+        f"- rating corr **{cs.rating_corr:.3f}**, outcome corr {cs.outcome_corr:.3f}, coverage {cs.coverage_pct:.1f}%"
+        if cs
+        else "- n/a"
+    )
+    cal = report.calibration
+    L.append("## Interval calibration (Oracle 4)")
+    L.append(
+        "- n/a (point-estimate model — no posterior)"
+        if cal is None
+        else "- " + ", ".join(f"{int(lvl * 100)}%→{c:.2f}" for lvl, c in zip(cal.levels, cal.coverage))
+    )
+    return "\n".join(L) + "\n"

--- a/sportsdataverse/nba/nba_model_validation.py
+++ b/sportsdataverse/nba/nba_model_validation.py
@@ -9,7 +9,7 @@ synthetic meta-oracle that proves the harness itself correct.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Optional, Protocol, Tuple
+from typing import Dict, List, Optional, Protocol, Tuple
 
 import numpy as np
 import polars as pl
@@ -140,3 +140,64 @@ def predict_points(X: csr_matrix, fit: FitResult) -> np.ndarray:
         Float64 array of shape ``(n_possessions,)`` with predicted points.
     """
     return np.asarray(X @ fit.coef, dtype=np.float64) + fit.intercept
+
+
+_TEAM_A, _TEAM_B = 100, 200
+
+
+def _synthetic_possessions(
+    o_ratings: Dict[int, float],
+    d_ratings: Dict[int, float],
+    *,
+    n_games: int,
+    poss_per_game: int,
+    noise_sd: float,
+    seed: int,
+    base_points: float = 1.0,
+) -> pl.DataFrame:
+    """Generate possessions from KNOWN player ratings (the meta-oracle ground truth).
+
+    Two teams (A=100 players are the first half of the id set, B=200 the second
+    half). Each possession draws 5 offense from the possessing team and 5 defense
+    from the opponent; expected points = ``base_points + sum(o) - sum(d)`` on the
+    per-possession scale, observed = expected + Gaussian(0, ``noise_sd``), clamped
+    at 0. Each game, both teams take ``poss_per_game`` offensive possessions.
+
+    Args:
+        o_ratings: player_id -> per-possession offensive rating.
+        d_ratings: player_id -> per-possession defensive rating.
+        n_games: Number of games to simulate.
+        poss_per_game: Offensive possessions per team per game.
+        noise_sd: Standard deviation of Gaussian observation noise.
+        seed: Integer seed for the ``np.random.default_rng`` generator.
+        base_points: League-average points per possession baseline.
+
+    Returns:
+        A possession+lineup frame (``game_id``/``offense_team_id``/``points``/
+        ``off_player_1..5``/``def_player_1..5``), ``2 * n_games * poss_per_game`` rows.
+    """
+    rng = np.random.default_rng(seed)
+    ids = sorted(o_ratings)
+    half = len(ids) // 2
+    team_players: Dict[int, List[int]] = {_TEAM_A: ids[:half], _TEAM_B: ids[half:]}
+    rows: List[dict] = []
+    for g in range(n_games):
+        gid = f"SYN{g:05d}"
+        for off_team, def_team in ((_TEAM_A, _TEAM_B), (_TEAM_B, _TEAM_A)):
+            for _ in range(poss_per_game):
+                off5 = rng.choice(team_players[off_team], size=5, replace=False)
+                def5 = rng.choice(team_players[def_team], size=5, replace=False)
+                mu = base_points + sum(o_ratings[int(p)] for p in off5) - sum(d_ratings[int(p)] for p in def5)
+                pts = max(0.0, mu + rng.normal(0.0, noise_sd))
+                row: dict = {"game_id": gid, "offense_team_id": off_team, "points": int(round(pts))}
+                for i in range(5):
+                    row[f"off_player_{i + 1}"] = int(off5[i])
+                    row[f"def_player_{i + 1}"] = int(def5[i])
+                rows.append(row)
+    schema: Dict[str, pl.DataType] = {
+        "game_id": pl.Utf8,
+        "offense_team_id": pl.Int64,
+        "points": pl.Int64,
+        **{c: pl.Int64 for c in _OFF + _DEF},
+    }
+    return pl.DataFrame(rows, schema=schema)

--- a/sportsdataverse/nba/nba_model_validation.py
+++ b/sportsdataverse/nba/nba_model_validation.py
@@ -16,7 +16,7 @@ import polars as pl
 from scipy.sparse import csr_matrix
 from sklearn.linear_model import RidgeCV
 
-from .nba_rapm import DEFAULT_RAPM_ALPHAS
+from .nba_rapm import DEFAULT_RAPM_ALPHAS, build_rapm_design
 
 _OFF: List[str] = [f"off_player_{i}" for i in range(1, 6)]
 _DEF: List[str] = [f"def_player_{i}" for i in range(1, 6)]
@@ -140,6 +140,162 @@ def predict_points(X: csr_matrix, fit: FitResult) -> np.ndarray:
         Float64 array of shape ``(n_possessions,)`` with predicted points.
     """
     return np.asarray(X @ fit.coef, dtype=np.float64) + fit.intercept
+
+
+@dataclass(frozen=True)
+class RetrodictionResult:
+    """Out-of-sample retrodiction metrics from k-fold-over-games cross-validation.
+
+    Attributes:
+        game_margin_rmse: RMSE of predicted vs actual per-(game, team) margins on
+            held-out games, pooled across all folds.
+        game_margin_corr: Pearson correlation of predicted vs actual margins,
+            pooled across all folds. ``nan`` / 0 when fewer than 2 test margins.
+        baseline_rmse: RMSE of a zero-margin (intercept-only) predictor on the same
+            held-out margins — the floor any model must beat.
+        poss_rmse: RMSE of per-possession predicted vs actual points, pooled across
+            all folds (granular sanity check).
+        n_test_games: Total number of distinct game_ids held out across all folds.
+    """
+
+    game_margin_rmse: float
+    game_margin_corr: float
+    baseline_rmse: float
+    poss_rmse: float
+    n_test_games: int
+
+
+def _team_game_margins(
+    possessions: pl.DataFrame,
+    pred_points: np.ndarray,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Aggregate per-possession predicted vs actual points to per-(game, team) margins.
+
+    A team's margin = (points it scored on its offensive possessions) minus
+    (points it allowed on its defensive possessions = the opponent's offensive
+    possessions). Returned as aligned (predicted, actual) arrays over each
+    (game_id, team) present.
+
+    Args:
+        possessions: Possession frame with ``game_id``, ``offense_team_id``, and
+            ``points`` columns. Must not be empty.
+        pred_points: Per-possession predicted points, shape ``(n_rows,)``, aligned
+            row-for-row with ``possessions``.
+
+    Returns:
+        ``(predicted_margins, actual_margins)`` as float64 numpy arrays of equal
+        length — one entry per (game_id, offense_team_id) pair.
+    """
+    df = possessions.select(["game_id", "offense_team_id", "points"]).with_columns(pl.Series("pred", pred_points))
+    scored = df.group_by(["game_id", "offense_team_id"]).agg(
+        pl.col("points").sum().alias("scored"),
+        pl.col("pred").sum().alias("scored_pred"),
+    )
+    game_tot = df.group_by("game_id").agg(
+        pl.col("points").sum().alias("g_pts"),
+        pl.col("pred").sum().alias("g_pred"),
+    )
+    m = scored.join(game_tot, on="game_id", how="left")
+    m = m.with_columns(
+        (pl.col("scored") - (pl.col("g_pts") - pl.col("scored"))).alias("actual_margin"),
+        (pl.col("scored_pred") - (pl.col("g_pred") - pl.col("scored_pred"))).alias("pred_margin"),
+    )
+    return (
+        m["pred_margin"].to_numpy().astype(np.float64),
+        m["actual_margin"].to_numpy().astype(np.float64),
+    )
+
+
+def _rmse(a: np.ndarray, b: np.ndarray) -> float:
+    """Root mean squared error between arrays ``a`` and ``b``.
+
+    Args:
+        a: Predicted values.
+        b: Actual values.
+
+    Returns:
+        ``float`` RMSE, or ``nan`` when the arrays are empty.
+    """
+    return float(np.sqrt(np.mean((a - b) ** 2))) if a.size else float("nan")
+
+
+def retrodiction(
+    model: RapmModel,
+    possessions: pl.DataFrame,
+    *,
+    k_folds: int = 5,
+    seed: int = 0,
+) -> RetrodictionResult:
+    """Oracle ①: k-fold-over-games out-of-sample game-margin RMSE + correlation.
+
+    Games are partitioned into ``k_folds`` disjoint folds (never split a game
+    across train/test). For each fold: fit on the other games, predict the held-out
+    games' possessions, aggregate to per-(game, team) margins. Scores pool all
+    held-out margins. Baseline = predict every possession with the train mean
+    (zero margin everywhere).
+
+    Args:
+        model: A ``RapmModel`` instance.
+        possessions: A season (or multi-game) possession+lineup frame with
+            ``game_id``, ``offense_team_id``, ``points``, and the ten lineup
+            columns (``off_player_1..5``, ``def_player_1..5``).
+        k_folds: Number of game folds (default 5).
+        seed: RNG seed for the game shuffle (default 0 for determinism).
+
+    Returns:
+        ``RetrodictionResult``. All metrics are ``nan`` and ``n_test_games=0``
+        on empty input or when every fold is degenerate (no train or test rows).
+    """
+    if possessions.is_empty():
+        return RetrodictionResult(float("nan"), float("nan"), float("nan"), float("nan"), 0)
+
+    games = possessions["game_id"].unique().to_list()
+    rng = np.random.default_rng(seed)
+    rng.shuffle(games)
+    folds = np.array_split(np.array(games, dtype=object), min(k_folds, len(games)))
+
+    pred_m: List[np.ndarray] = []
+    act_m: List[np.ndarray] = []
+    base_m: List[np.ndarray] = []
+    poss_pred: List[np.ndarray] = []
+    poss_act: List[np.ndarray] = []
+
+    for fold in folds:
+        test_ids = set(fold.tolist())
+        train = possessions.filter(~pl.col("game_id").is_in(list(test_ids)))
+        test = possessions.filter(pl.col("game_id").is_in(list(test_ids)))
+        if train.is_empty() or test.is_empty():
+            continue
+        X_tr, y_tr, pids = build_rapm_design(train)
+        if not pids:
+            continue
+        fit = model.fit(X_tr, y_tr)
+        X_te, y_te = _design_with_ids(test, pids)
+        # rebuild aligned test frame (rows with null lineups are dropped by _design_with_ids)
+        test_valid = test.drop_nulls(subset=_OFF + _DEF)
+        pp = predict_points(X_te, fit)
+        p_pred, p_act = _team_game_margins(test_valid, pp)
+        pred_m.append(p_pred)
+        act_m.append(p_act)
+        base_m.append(np.zeros_like(p_act))  # mean model → 0 predicted margin
+        poss_pred.append(pp)
+        poss_act.append(y_te)
+
+    if not pred_m:
+        return RetrodictionResult(float("nan"), float("nan"), float("nan"), float("nan"), 0)
+
+    P = np.concatenate(pred_m)
+    A = np.concatenate(act_m)
+    B = np.concatenate(base_m)
+    corr = float(np.corrcoef(P, A)[0, 1]) if P.size > 1 and np.std(P) > 0 else 0.0
+    n_test = len(set().union(*[set(f.tolist()) for f in folds]))
+    return RetrodictionResult(
+        game_margin_rmse=_rmse(P, A),
+        game_margin_corr=corr,
+        baseline_rmse=_rmse(B, A),
+        poss_rmse=_rmse(np.concatenate(poss_pred), np.concatenate(poss_act)),
+        n_test_games=n_test,
+    )
 
 
 _TEAM_A, _TEAM_B = 100, 200

--- a/sportsdataverse/nba/nba_model_validation.py
+++ b/sportsdataverse/nba/nba_model_validation.py
@@ -151,11 +151,13 @@ class RetrodictionResult:
             held-out games, pooled across all folds.
         game_margin_corr: Pearson correlation of predicted vs actual margins,
             pooled across all folds. ``nan`` / 0 when fewer than 2 test margins.
-        baseline_rmse: RMSE of a zero-margin (intercept-only) predictor on the same
-            held-out margins — the floor any model must beat.
+        baseline_rmse: RMSE of a zero-margin (tossup) baseline on the same held-out
+            margins — predicts 0 margin for every game; the floor any model must beat.
         poss_rmse: RMSE of per-possession predicted vs actual points, pooled across
             all folds (granular sanity check).
-        n_test_games: Total number of distinct game_ids held out across all folds.
+        n_test_games: Total number of distinct game_ids actually evaluated across all
+            non-degenerate folds (folds skipped for empty train/test or no players
+            are excluded).
     """
 
     game_margin_rmse: float
@@ -231,8 +233,8 @@ def retrodiction(
     Games are partitioned into ``k_folds`` disjoint folds (never split a game
     across train/test). For each fold: fit on the other games, predict the held-out
     games' possessions, aggregate to per-(game, team) margins. Scores pool all
-    held-out margins. Baseline = predict every possession with the train mean
-    (zero margin everywhere).
+    held-out margins. Baseline = zero-margin (tossup) predictor: predicts 0 margin
+    for every held-out game.
 
     Args:
         model: A ``RapmModel`` instance.
@@ -259,6 +261,7 @@ def retrodiction(
     base_m: List[np.ndarray] = []
     poss_pred: List[np.ndarray] = []
     poss_act: List[np.ndarray] = []
+    evaluated_games: set = set()
 
     for fold in folds:
         test_ids = set(fold.tolist())
@@ -277,9 +280,10 @@ def retrodiction(
         p_pred, p_act = _team_game_margins(test_valid, pp)
         pred_m.append(p_pred)
         act_m.append(p_act)
-        base_m.append(np.zeros_like(p_act))  # mean model → 0 predicted margin
+        base_m.append(np.zeros_like(p_act))  # zero-margin (tossup) baseline
         poss_pred.append(pp)
         poss_act.append(y_te)
+        evaluated_games |= test_ids
 
     if not pred_m:
         return RetrodictionResult(float("nan"), float("nan"), float("nan"), float("nan"), 0)
@@ -288,13 +292,12 @@ def retrodiction(
     A = np.concatenate(act_m)
     B = np.concatenate(base_m)
     corr = float(np.corrcoef(P, A)[0, 1]) if P.size > 1 and np.std(P) > 0 else 0.0
-    n_test = len(set().union(*[set(f.tolist()) for f in folds]))
     return RetrodictionResult(
         game_margin_rmse=_rmse(P, A),
         game_margin_corr=corr,
         baseline_rmse=_rmse(B, A),
         poss_rmse=_rmse(np.concatenate(poss_pred), np.concatenate(poss_act)),
-        n_test_games=n_test,
+        n_test_games=len(evaluated_games),
     )
 
 

--- a/sportsdataverse/nba/nba_model_validation.py
+++ b/sportsdataverse/nba/nba_model_validation.py
@@ -1,0 +1,142 @@
+"""Out-of-sample validation harness for the NBA model zoo.
+
+A model is a design-matrix estimator (``fit(X, y) -> FitResult``); the harness
+owns the player-id column map (from ``build_rapm_design``) and scores fitted
+coefficients against held-out games. See the spec for the four oracles and the
+synthetic meta-oracle that proves the harness itself correct.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Protocol, Tuple
+
+import numpy as np
+import polars as pl
+from scipy.sparse import csr_matrix
+from sklearn.linear_model import RidgeCV
+
+from .nba_rapm import DEFAULT_RAPM_ALPHAS
+
+_OFF: List[str] = [f"off_player_{i}" for i in range(1, 6)]
+_DEF: List[str] = [f"def_player_{i}" for i in range(1, 6)]
+
+
+@dataclass(frozen=True)
+class FitResult:
+    """A fitted RAPM-family model's coefficients on the raw per-possession scale.
+
+    Attributes:
+        coef: Shape ``(2P,)``; offense columns ``0..P-1`` then defense ``P..2P-1``,
+            index-aligned to the ``player_ids`` the harness built the design with.
+        intercept: Scalar regression intercept.
+        posterior: Optional ``(S, 2P)`` posterior samples; only models that emit
+            uncertainty set it (enables interval calibration). ``None`` for point models.
+    """
+
+    coef: np.ndarray
+    intercept: float
+    posterior: Optional[np.ndarray] = None
+
+
+class RapmModel(Protocol):
+    """Design-matrix estimator: fit a sparse design ``X`` against targets ``y``."""
+
+    def fit(self, X: csr_matrix, y: np.ndarray) -> FitResult: ...
+
+
+class RidgeRapmModel:
+    """Reference model: the merged plain-RAPM RidgeCV fit, adapted to ``RapmModel``.
+
+    Args:
+        alphas: Ridge penalty grid for cross-validation. Defaults to the merged
+            ``DEFAULT_RAPM_ALPHAS``.
+    """
+
+    def __init__(self, alphas: np.ndarray = DEFAULT_RAPM_ALPHAS) -> None:
+        self._alphas = alphas
+
+    def fit(self, X: csr_matrix, y: np.ndarray) -> FitResult:
+        """Fit RidgeCV and return coefficients + intercept (no posterior).
+
+        Args:
+            X: Sparse design matrix of shape ``(n_possessions, 2P)``.
+            y: Target points per possession, shape ``(n_possessions,)``.
+
+        Returns:
+            FitResult with ``coef`` shape ``(2P,)``, scalar ``intercept``,
+            and ``posterior=None``.
+        """
+        model = RidgeCV(alphas=self._alphas, fit_intercept=True)
+        model.fit(X, y)
+        return FitResult(
+            coef=np.asarray(model.coef_, dtype=np.float64),
+            intercept=float(model.intercept_),
+            posterior=None,
+        )
+
+
+def _design_with_ids(
+    possessions: pl.DataFrame,
+    player_ids: List[int],
+    *,
+    unknown_player_rating: float = 0.0,  # v1: unknown players contribute 0 (league-average); reserved for a future non-zero prior
+) -> Tuple[csr_matrix, np.ndarray]:
+    """Build a design matrix against a FIXED ``player_ids`` column map.
+
+    Used to score a held-out split with the training fit: a player absent from
+    ``player_ids`` (unseen in training) has no column and contributes nothing to
+    the prediction (the ``unknown_player_rating=0.0`` neutral prior). Rows with a
+    null lineup cell are dropped (mirrors ``build_rapm_design``).
+
+    Args:
+        possessions: Held-out possession frame (same lineup + ``points`` columns).
+        player_ids: The training design's sorted player ids (defines the columns).
+        unknown_player_rating: Reserved; only ``0.0`` (skip unknown players) is
+            implemented in v1.
+
+    Returns:
+        ``(X, y)`` with ``X`` shape ``(n_rows, 2 * len(player_ids))`` float64 and
+        ``y`` the possession points. Empty input → ``(csr_matrix((0, 2P)), empty)``.
+    """
+    P = len(player_ids)
+    if possessions.is_empty() or P == 0:
+        return csr_matrix((0, 2 * P)), np.empty(0, dtype=np.float64)
+    possessions = possessions.drop_nulls(subset=_OFF + _DEF)
+    if possessions.is_empty():
+        return csr_matrix((0, 2 * P)), np.empty(0, dtype=np.float64)
+
+    idx = {p: k for k, p in enumerate(player_ids)}
+    off = possessions.select(_OFF).to_numpy().astype(np.int64)
+    deff = possessions.select(_DEF).to_numpy().astype(np.int64)
+    n = possessions.height
+    rows: List[int] = []
+    cols: List[int] = []
+    for r in range(n):
+        for p in off[r]:
+            c = idx.get(int(p))
+            if c is not None:
+                rows.append(r)
+                cols.append(c)
+        for p in deff[r]:
+            c = idx.get(int(p))
+            if c is not None:
+                rows.append(r)
+                cols.append(P + c)
+    data: np.ndarray = np.ones(len(rows), dtype=np.float64)
+    X = csr_matrix((data, (rows, cols)), shape=(n, 2 * P))
+    y = possessions["points"].to_numpy().astype(np.float64)
+    return X, y
+
+
+def predict_points(X: csr_matrix, fit: FitResult) -> np.ndarray:
+    """Predicted offense points per possession: ``X @ coef + intercept``.
+
+    Args:
+        X: Sparse design matrix of shape ``(n_possessions, 2P)``.
+        fit: Fitted model result from ``RapmModel.fit``.
+
+    Returns:
+        Float64 array of shape ``(n_possessions,)`` with predicted points.
+    """
+    return np.asarray(X @ fit.coef, dtype=np.float64) + fit.intercept

--- a/sportsdataverse/nba/nba_season_compile.py
+++ b/sportsdataverse/nba/nba_season_compile.py
@@ -1,0 +1,149 @@
+"""Resumable, cached, throttled full-season possession compiler.
+
+Mirrors ``nfl/nfl_build.py``: per-game parquet cache keyed by
+``(game_id, PIPELINE_VERSION)`` is the resume mechanism; a killed run skips
+already-compiled games. Best-effort — a failing/empty game is logged and skipped.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from pathlib import Path
+from typing import List, Optional, Union
+
+import pandas as pd
+import polars as pl
+
+_LOG = logging.getLogger(__name__)
+
+#: Bump when the possession pipeline changes in a way that invalidates cached parquet.
+PIPELINE_VERSION: int = 1
+
+_LEAGUE_ID = "00"
+
+
+def _default_cache_dir() -> Path:
+    root = os.environ.get("SDV_PY_NBA_CACHE_DIR") or str(Path.home() / ".sdv_py_nba_cache")
+    return Path(root) / "possessions"
+
+
+def _game_cache_key(game_id: str) -> str:
+    return f"{game_id}__v{PIPELINE_VERSION}.parquet"
+
+
+def _game_ids_for_season(season: int, season_type: str) -> List[str]:
+    """Return the (deduped) game ids for a season (monkeypatchable).
+
+    ``season`` is the start year (2023 -> "2023-24"). The team-level game log
+    returns two rows per game, so ids are deduplicated (order preserved).
+
+    Args:
+        season: Season start year (e.g. 2023 for 2023-24).
+        season_type: NBA season type string (e.g. ``"Regular Season"``).
+
+    Returns:
+        Ordered, deduplicated list of game id strings.
+    """
+    from .nba_schedule import year_to_season
+    from .nba_stats import nba_stats_leaguegamelog
+
+    log = nba_stats_leaguegamelog(
+        season=year_to_season(season),
+        season_type_all_star=season_type,
+        league_id=_LEAGUE_ID,
+    )
+    if log.is_empty() or "game_id" not in log.columns:
+        return []
+    return log["game_id"].cast(pl.Utf8).unique(maintain_order=True).to_list()
+
+
+def _fetch_possessions(game_id: str, league_id: str) -> pl.DataFrame:
+    """Fetch one game's possession+lineup frame (monkeypatchable).
+
+    Args:
+        game_id: ESPN/NBA game identifier string.
+        league_id: NBA league id (``"00"`` for NBA, ``"20"`` for G-League).
+
+    Returns:
+        Possession stint matrix as a polars DataFrame.
+    """
+    from .nba_possessions import nba_possessions
+
+    return nba_possessions(game_id, league_id)
+
+
+def compile_nba_season(
+    season: int,
+    season_type: str = "Regular Season",
+    *,
+    resume: bool = True,
+    cache_dir: Optional[str] = None,
+    delay_s: float = 0.6,
+    return_as_pandas: bool = False,
+) -> Union[pl.DataFrame, pd.DataFrame]:
+    """Compile a full season's possession stint matrix (cached + resumable + throttled).
+
+    Discovers game ids, dedupes, then per game loads the cached parquet if present
+    (``resume``), else fetches via :func:`_fetch_possessions`, caches it, and sleeps
+    ``delay_s`` (throttle; only on live fetches). A game that errors or returns no
+    possessions is logged and skipped (best-effort, never raises). The assembled
+    frame is tagged with a ``season`` column.
+
+    Args:
+        season: Season start year (e.g. 2023 for 2023-24).
+        season_type: ``"Regular Season"`` (default) or ``"Playoffs"``.
+        resume: Reuse per-game cached parquet when present.
+        cache_dir: Cache root; defaults to ``SDV_PY_NBA_CACHE_DIR`` or
+            ``~/.sdv_py_nba_cache/possessions``.
+        delay_s: Seconds to sleep after each live fetch (rate-limit throttle).
+        return_as_pandas: Return pandas instead of polars.
+
+    Returns:
+        The season possession frame (+ ``season`` col). Empty typed frame if no games.
+    """
+    cdir = Path(cache_dir) if cache_dir else _default_cache_dir()
+    cdir.mkdir(parents=True, exist_ok=True)
+
+    # dedupe preserving order
+    game_ids = list(dict.fromkeys(_game_ids_for_season(season, season_type)))
+
+    frames: List[pl.DataFrame] = []
+    total = len(game_ids)
+
+    for i, gid in enumerate(game_ids, 1):
+        cache_path = cdir / _game_cache_key(gid)
+
+        # --- cache hit ---
+        if resume and cache_path.exists():
+            try:
+                frames.append(pl.read_parquet(cache_path))
+                continue
+            except Exception as exc:  # corrupt cache -> fall through to re-fetch
+                _LOG.warning("re-fetch %s: bad cache (%s)", gid, exc)
+
+        # --- live fetch (throttle only on this path) ---
+        try:
+            poss = _fetch_possessions(gid, _LEAGUE_ID)
+        except Exception as exc:
+            _LOG.warning("skip game %s (%d/%d): fetch failed: %s", gid, i, total, exc)
+            continue
+        finally:
+            if delay_s:
+                time.sleep(delay_s)
+
+        if poss.is_empty():
+            _LOG.info("skip game %s (%d/%d): no possessions", gid, i, total)
+            continue
+
+        poss.write_parquet(cache_path)
+        frames.append(poss)
+        _LOG.info("compiled %s (%d/%d)", gid, i, total)
+
+    if frames:
+        out = pl.concat(frames, how="diagonal_relaxed").with_columns(pl.lit(season).alias("season"))
+    else:
+        out = pl.DataFrame(schema={"game_id": pl.Utf8, "season": pl.Int64})
+
+    return out.to_pandas() if return_as_pandas else out

--- a/sportsdataverse/nba/nba_season_compile.py
+++ b/sportsdataverse/nba/nba_season_compile.py
@@ -102,6 +102,28 @@ def compile_nba_season(
 
     Returns:
         The season possession frame (+ ``season`` col). Empty typed frame if no games.
+
+    Example:
+        Compile the 2023-24 regular season (requires live stats.nba.com access)::
+
+            from sportsdataverse.nba.nba_season_compile import compile_nba_season
+
+            poss = compile_nba_season(2023)
+            print(poss.shape)          # (n_possessions, n_cols)
+            print(poss["season"][0])   # 2023
+
+        Resume a partially completed run and return as pandas::
+
+            poss_pd = compile_nba_season(2023, resume=True, return_as_pandas=True)
+            print(type(poss_pd))       # <class 'pandas.core.frame.DataFrame'>
+
+        Compile Playoffs with a custom cache directory::
+
+            poss = compile_nba_season(
+                2023,
+                season_type="Playoffs",
+                cache_dir="/tmp/nba_cache",
+            )
     """
     cdir = Path(cache_dir) if cache_dir else _default_cache_dir()
     cdir.mkdir(parents=True, exist_ok=True)

--- a/sportsdataverse/nba/nba_season_compile.py
+++ b/sportsdataverse/nba/nba_season_compile.py
@@ -123,15 +123,14 @@ def compile_nba_season(
             except Exception as exc:  # corrupt cache -> fall through to re-fetch
                 _LOG.warning("re-fetch %s: bad cache (%s)", gid, exc)
 
-        # --- live fetch (throttle only on this path) ---
+        # --- live fetch (throttle only on successful fetches, not failures) ---
         try:
             poss = _fetch_possessions(gid, _LEAGUE_ID)
         except Exception as exc:
             _LOG.warning("skip game %s (%d/%d): fetch failed: %s", gid, i, total, exc)
             continue
-        finally:
-            if delay_s:
-                time.sleep(delay_s)
+        if delay_s:
+            time.sleep(delay_s)
 
         if poss.is_empty():
             _LOG.info("skip game %s (%d/%d): no possessions", gid, i, total)

--- a/sportsdataverse/parsed/nba.py
+++ b/sportsdataverse/parsed/nba.py
@@ -140,6 +140,9 @@ from sportsdataverse.nba import fox_nba_standings as _raw_fox_nba_standings
 from sportsdataverse.nba import fox_nba_team_gamelog as _raw_fox_nba_team_gamelog
 from sportsdataverse.nba import fox_nba_team_roster as _raw_fox_nba_team_roster
 from sportsdataverse.nba import fox_nba_team_stats as _raw_fox_nba_team_stats
+from sportsdataverse.nba import RidgeRapmModel as RidgeRapmModel  # noqa: F401
+from sportsdataverse.nba import ValidationReport as ValidationReport  # noqa: F401
+from sportsdataverse.nba import compile_nba_season as compile_nba_season  # noqa: F401
 from sportsdataverse.nba import download as download  # noqa: F401
 from sportsdataverse.nba import espn_nba_calendar as espn_nba_calendar  # noqa: F401
 from sportsdataverse.nba import espn_nba_game_rosters as espn_nba_game_rosters  # noqa: F401
@@ -172,11 +175,16 @@ from sportsdataverse.nba import load_nba_team_season_stats as load_nba_team_seas
 from sportsdataverse.nba import most_recent_nba_season as most_recent_nba_season  # noqa: F401
 from sportsdataverse.nba import nba_pbp_disk as nba_pbp_disk  # noqa: F401
 from sportsdataverse.nba import normalize_team_roster_columns as normalize_team_roster_columns  # noqa: F401
+from sportsdataverse.nba import render_report as render_report  # noqa: F401
 from sportsdataverse.nba import scoreboard_event_parsing as scoreboard_event_parsing  # noqa: F401
 from sportsdataverse.nba import underscore as underscore  # noqa: F401
+from sportsdataverse.nba import validate_model as validate_model  # noqa: F401
 from sportsdataverse.nba import year_to_season as year_to_season  # noqa: F401
 
 __all__ = [
+    "RidgeRapmModel",
+    "ValidationReport",
+    "compile_nba_season",
     "download",
     "espn_nba_award",
     "espn_nba_awards",
@@ -326,8 +334,10 @@ __all__ = [
     "most_recent_nba_season",
     "nba_pbp_disk",
     "normalize_team_roster_columns",
+    "render_report",
     "scoreboard_event_parsing",
     "underscore",
+    "validate_model",
     "year_to_season",
 ]
 

--- a/tests/nba/test_nba_model_validation.py
+++ b/tests/nba/test_nba_model_validation.py
@@ -238,3 +238,30 @@ def test_calibration_returns_curve_for_posterior_model():
     # an over-confident model (tiny posterior) should under-cover at 0.9
     tight = calibration(_PosteriorModel(sd_scale=0.05), poss, levels=(0.9,))
     assert tight.coverage[0] < 0.9
+
+
+# ---------------------------------------------------------------------------
+# Task 7: validate_model orchestrator + ValidationReport + render_report
+# ---------------------------------------------------------------------------
+
+from sportsdataverse.nba.nba_model_validation import validate_model, render_report, ValidationReport  # noqa: E402
+
+
+def test_validate_model_runs_selected_oracles_and_renders():
+    o, d = _planted_ratings()
+    s1 = _synthetic_possessions(o, d, n_games=40, poss_per_game=80, noise_sd=0.3, seed=1)
+    s2 = _synthetic_possessions(o, d, n_games=40, poss_per_game=80, noise_sd=0.3, seed=2)
+    rep = validate_model(RidgeRapmModel(), [s1, s2], model_name="plain_rapm")
+    assert isinstance(rep, ValidationReport)
+    assert rep.retrodiction is not None and rep.reliability is not None
+    assert rep.cross_season is not None
+    assert rep.calibration is None  # point model -> n/a
+    md = render_report(rep)
+    assert "plain_rapm" in md and "Retrodiction" in md and "n/a" in md.lower()
+
+
+def test_validate_model_respects_oracle_selection():
+    o, d = _planted_ratings()
+    s1 = _synthetic_possessions(o, d, n_games=20, poss_per_game=60, noise_sd=0.3, seed=1)
+    rep = validate_model(RidgeRapmModel(), [s1], oracles=("reliability",))
+    assert rep.reliability is not None and rep.retrodiction is None

--- a/tests/nba/test_nba_model_validation.py
+++ b/tests/nba/test_nba_model_validation.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+import numpy as np
+import polars as pl
+from sportsdataverse.nba.nba_model_validation import (
+    FitResult,
+    RidgeRapmModel,
+    _design_with_ids,
+    predict_points,
+)
+from sportsdataverse.nba.nba_rapm import build_rapm_design
+
+_OFF = [f"off_player_{i}" for i in range(1, 6)]
+_DEF = [f"def_player_{i}" for i in range(1, 6)]
+
+
+def _toy_possessions() -> pl.DataFrame:
+    # 2 possessions, players 1..10; offense {1..5} vs defense {6..10}, then swapped.
+    return pl.DataFrame(
+        {
+            "game_id": ["001", "001"],
+            "offense_team_id": [100, 200],
+            **{c: v for c, v in zip(_OFF, [[1, 6], [2, 7], [3, 8], [4, 9], [5, 10]])},
+            **{c: v for c, v in zip(_DEF, [[6, 1], [7, 2], [8, 3], [9, 4], [10, 5]])},
+            "points": [2, 0],
+        }
+    )
+
+
+def test_ridge_model_returns_fitresult_with_matching_shape():
+    poss = _toy_possessions()
+    X, y, pids = build_rapm_design(poss)
+    fit = RidgeRapmModel().fit(X, y)
+    assert isinstance(fit, FitResult)
+    assert fit.coef.shape == (2 * len(pids),)
+    assert isinstance(fit.intercept, float)
+    assert fit.posterior is None
+
+
+def test_design_with_ids_maps_to_train_columns_and_zeros_unknowns():
+    poss = _toy_possessions()
+    _, _, pids = build_rapm_design(poss)  # pids == [1..10]
+    # a test possession with a NEW player (99) on offense -> unknown -> contributes 0
+    test_poss = pl.DataFrame(
+        {
+            "game_id": ["002"],
+            "offense_team_id": [100],
+            **{c: [v] for c, v in zip(_OFF, [1, 2, 3, 4, 99])},
+            **{c: [v] for c, v in zip(_DEF, [6, 7, 8, 9, 10])},
+            "points": [3],
+        }
+    )
+    X_test, y_test = _design_with_ids(test_poss, pids)
+    assert X_test.shape == (1, 2 * len(pids))
+    # exactly 9 ones (4 known off + 5 known def); player 99 has no column
+    assert X_test.nnz == 9
+    assert y_test.tolist() == [3.0]
+
+
+def test_predict_points_is_linear():
+    poss = _toy_possessions()
+    X, y, pids = build_rapm_design(poss)
+    fit = RidgeRapmModel().fit(X, y)
+    pred = predict_points(X, fit)
+    assert pred.shape == (2,)
+    np.testing.assert_allclose(pred, X @ fit.coef + fit.intercept)

--- a/tests/nba/test_nba_model_validation.py
+++ b/tests/nba/test_nba_model_validation.py
@@ -139,3 +139,33 @@ def test_retrodiction_never_raises_on_empty():
     )
     res = retrodiction(RidgeRapmModel(), empty, k_folds=5, seed=0)
     assert res.n_test_games == 0
+
+
+# ---------------------------------------------------------------------------
+# Task 4: Oracle ② split-half reliability tests
+# ---------------------------------------------------------------------------
+
+from sportsdataverse.nba.nba_model_validation import reliability, ReliabilityResult  # noqa: E402
+
+
+def test_reliability_rises_with_possession_count():
+    o, d = _planted_ratings()
+    small = _synthetic_possessions(o, d, n_games=20, poss_per_game=40, noise_sd=0.3, seed=4)
+    large = _synthetic_possessions(o, d, n_games=120, poss_per_game=100, noise_sd=0.3, seed=4)
+    r_small = reliability(RidgeRapmModel(), small, seed=0)
+    r_large = reliability(RidgeRapmModel(), large, seed=0)
+    assert isinstance(r_small, ReliabilityResult)
+    assert r_large.split_half_corr > r_small.split_half_corr  # more data -> more stable
+    assert -1.0 <= r_small.split_half_corr <= 1.0
+
+
+def test_reliability_never_raises_on_empty():
+    empty = pl.DataFrame(
+        schema={
+            "game_id": pl.Utf8,
+            "offense_team_id": pl.Int64,
+            "points": pl.Int64,
+            **{c: pl.Int64 for c in _OFF + _DEF},
+        }
+    )
+    assert reliability(RidgeRapmModel(), empty, seed=0).n_shared_players == 0

--- a/tests/nba/test_nba_model_validation.py
+++ b/tests/nba/test_nba_model_validation.py
@@ -265,3 +265,29 @@ def test_validate_model_respects_oracle_selection():
     s1 = _synthetic_possessions(o, d, n_games=20, poss_per_game=60, noise_sd=0.3, seed=1)
     rep = validate_model(RidgeRapmModel(), [s1], oracles=("reliability",))
     assert rep.reliability is not None and rep.retrodiction is None
+
+
+# ---------------------------------------------------------------------------
+# Task 9: Gated end-to-end real-report test
+# ---------------------------------------------------------------------------
+
+from tests.conftest import skip_if_no_nba_stats_live  # noqa: E402
+from sportsdataverse.nba import nba_season_compile as C  # noqa: E402
+from sportsdataverse.nba.nba_season_compile import compile_nba_season  # noqa: E402
+
+
+@skip_if_no_nba_stats_live
+def test_end_to_end_real_slice_report(tmp_path, monkeypatch):
+    # small real slice compiled once, then validated (report shape only, not thresholds)
+    real_ids = C._game_ids_for_season(2023, "Regular Season")[:8]
+    monkeypatch.setattr(C, "_game_ids_for_season", lambda s, st: real_ids)
+    s = compile_nba_season(2023, cache_dir=str(tmp_path), delay_s=1.0)
+    rep = validate_model(
+        RidgeRapmModel(),
+        [s],
+        model_name="plain_rapm",
+        oracles=("retrodiction", "reliability"),
+    )
+    assert rep.retrodiction is not None
+    md = render_report(rep)
+    assert "plain_rapm" in md

--- a/tests/nba/test_nba_model_validation.py
+++ b/tests/nba/test_nba_model_validation.py
@@ -94,3 +94,48 @@ def test_ridge_recovers_planted_ratings_in_sample():
     planted_o = np.array([o[p] for p in pids])
     corr = np.corrcoef(fit.coef[:P], planted_o)[0, 1]
     assert corr > 0.5  # ridge shrinks, but signal present
+
+
+# ---------------------------------------------------------------------------
+# Task 3: Oracle ① holdout retrodiction tests
+# ---------------------------------------------------------------------------
+
+from sportsdataverse.nba.nba_model_validation import retrodiction, RetrodictionResult  # noqa: E402
+
+
+class _NoSkillModel:
+    """Fits an intercept only; all player coefficients are exactly 0 (no skill)."""
+
+    def fit(self, X, y):
+        return FitResult(coef=np.zeros(X.shape[1]), intercept=float(np.mean(y)))
+
+
+def test_retrodiction_planted_skill_beats_baseline():
+    o, d = _planted_ratings()
+    poss = _synthetic_possessions(o, d, n_games=80, poss_per_game=100, noise_sd=0.3, seed=2)
+    res = retrodiction(RidgeRapmModel(), poss, k_folds=5, seed=0)
+    assert isinstance(res, RetrodictionResult)
+    assert res.game_margin_corr > 0.2  # real out-of-sample signal
+    assert res.game_margin_rmse < res.baseline_rmse  # beats intercept-only
+
+
+def test_retrodiction_no_skill_model_matches_baseline():
+    o, d = _planted_ratings()
+    poss = _synthetic_possessions(o, d, n_games=80, poss_per_game=100, noise_sd=0.3, seed=3)
+    res = retrodiction(_NoSkillModel(), poss, k_folds=5, seed=0)
+    # a no-skill (zero-coef) model can't beat the mean out-of-sample
+    assert abs(res.game_margin_corr) < 0.15
+    assert res.game_margin_rmse >= res.baseline_rmse - 1e-6
+
+
+def test_retrodiction_never_raises_on_empty():
+    empty = pl.DataFrame(
+        schema={
+            "game_id": pl.Utf8,
+            "offense_team_id": pl.Int64,
+            "points": pl.Int64,
+            **{c: pl.Int64 for c in _OFF + _DEF},
+        }
+    )
+    res = retrodiction(RidgeRapmModel(), empty, k_folds=5, seed=0)
+    assert res.n_test_games == 0

--- a/tests/nba/test_nba_model_validation.py
+++ b/tests/nba/test_nba_model_validation.py
@@ -197,3 +197,44 @@ def test_cross_season_single_season_is_nan():
     one = _synthetic_possessions(o, d, n_games=10, poss_per_game=50, noise_sd=0.3, seed=1)
     res = cross_season(RidgeRapmModel(), [one])
     assert np.isnan(res.rating_corr)
+
+
+# ---------------------------------------------------------------------------
+# Task 6: Oracle ④ interval calibration tests
+# ---------------------------------------------------------------------------
+
+from sportsdataverse.nba.nba_model_validation import calibration, CalibrationResult  # noqa: E402
+
+
+class _PosteriorModel:
+    """RidgeCV point fit + a Gaussian posterior of chosen width (calibration knob)."""
+
+    def __init__(self, sd_scale: float, n_samples: int = 200, seed: int = 0):
+        self._sd_scale, self._n, self._seed = sd_scale, n_samples, seed
+
+    def fit(self, X, y):
+        base = RidgeRapmModel().fit(X, y)
+        rng = np.random.default_rng(self._seed)
+        # true residual scale ~ from fit; posterior width = sd_scale * that
+        resid = float(np.std(y - (X @ base.coef + base.intercept)))
+        sd = self._sd_scale * resid / np.sqrt(max(1, X.shape[0]))
+        post = base.coef + rng.normal(0, sd, size=(self._n, base.coef.shape[0]))
+        return FitResult(coef=base.coef, intercept=base.intercept, posterior=post)
+
+
+def test_calibration_none_for_point_model():
+    o, d = _planted_ratings()
+    poss = _synthetic_possessions(o, d, n_games=20, poss_per_game=60, noise_sd=0.3, seed=5)
+    assert calibration(RidgeRapmModel(), poss) is None
+
+
+def test_calibration_returns_curve_for_posterior_model():
+    o, d = _planted_ratings()
+    poss = _synthetic_possessions(o, d, n_games=40, poss_per_game=80, noise_sd=0.3, seed=6)
+    res = calibration(_PosteriorModel(sd_scale=1.0), poss, levels=(0.5, 0.9))
+    assert isinstance(res, CalibrationResult)
+    assert res.levels == [0.5, 0.9]
+    assert all(0.0 <= c <= 1.0 for c in res.coverage)
+    # an over-confident model (tiny posterior) should under-cover at 0.9
+    tight = calibration(_PosteriorModel(sd_scale=0.05), poss, levels=(0.9,))
+    assert tight.coverage[0] < 0.9

--- a/tests/nba/test_nba_model_validation.py
+++ b/tests/nba/test_nba_model_validation.py
@@ -5,12 +5,12 @@ from sportsdataverse.nba.nba_model_validation import (
     FitResult,
     RidgeRapmModel,
     _design_with_ids,
+    _synthetic_possessions,
     predict_points,
+    _OFF,
+    _DEF,
 )
 from sportsdataverse.nba.nba_rapm import build_rapm_design
-
-_OFF = [f"off_player_{i}" for i in range(1, 6)]
-_DEF = [f"def_player_{i}" for i in range(1, 6)]
 
 
 def _toy_possessions() -> pl.DataFrame:
@@ -63,3 +63,34 @@ def test_predict_points_is_linear():
     pred = predict_points(X, fit)
     assert pred.shape == (2,)
     np.testing.assert_allclose(pred, X @ fit.coef + fit.intercept)
+
+
+def _planted_ratings(seed: int = 0):
+    rng = np.random.default_rng(seed)
+    # team A players 1..8, team B players 9..16; ratings ~ per-possession points contribution
+    o = {p: float(rng.normal(0, 0.05)) for p in range(1, 17)}
+    d = {p: float(rng.normal(0, 0.05)) for p in range(1, 17)}
+    return o, d
+
+
+def test_synthetic_possessions_schema_and_determinism():
+    o, d = _planted_ratings()
+    a = _synthetic_possessions(o, d, n_games=4, poss_per_game=50, noise_sd=0.3, seed=7)
+    b = _synthetic_possessions(o, d, n_games=4, poss_per_game=50, noise_sd=0.3, seed=7)
+    assert a.equals(b)  # deterministic
+    for col in ["game_id", "offense_team_id", "points", *_OFF, *_DEF]:
+        assert col in a.columns
+    assert a.height == 4 * 50 * 2  # both teams take poss_per_game each
+    assert set(a["offense_team_id"].unique().to_list()) == {100, 200}
+
+
+def test_ridge_recovers_planted_ratings_in_sample():
+    # sanity: with enough possessions RidgeCV coef correlates with planted ratings
+    o, d = _planted_ratings()
+    poss = _synthetic_possessions(o, d, n_games=60, poss_per_game=100, noise_sd=0.3, seed=1)
+    X, y, pids = build_rapm_design(poss)
+    fit = RidgeRapmModel().fit(X, y)
+    P = len(pids)
+    planted_o = np.array([o[p] for p in pids])
+    corr = np.corrcoef(fit.coef[:P], planted_o)[0, 1]
+    assert corr > 0.5  # ridge shrinks, but signal present

--- a/tests/nba/test_nba_model_validation.py
+++ b/tests/nba/test_nba_model_validation.py
@@ -169,3 +169,31 @@ def test_reliability_never_raises_on_empty():
         }
     )
     assert reliability(RidgeRapmModel(), empty, seed=0).n_shared_players == 0
+
+
+# ---------------------------------------------------------------------------
+# Task 5: Oracle ③ cross-season predictivity tests
+# ---------------------------------------------------------------------------
+
+from sportsdataverse.nba.nba_model_validation import cross_season, CrossSeasonResult  # noqa: E402
+
+
+def test_cross_season_predicts_next_season_with_shared_players():
+    o, d = _planted_ratings(seed=0)
+    season_n = _synthetic_possessions(o, d, n_games=60, poss_per_game=100, noise_sd=0.3, seed=10)
+    # season N+1: same ratings (persistent skill) + 4 new players 17..20 replace 1..4
+    o2 = {**o, 17: 0.04, 18: -0.03, 19: 0.02, 20: -0.01}
+    d2 = {**d, 17: 0.01, 18: -0.02, 19: 0.03, 20: 0.00}
+    season_np1 = _synthetic_possessions(o2, d2, n_games=60, poss_per_game=100, noise_sd=0.3, seed=11)
+    res = cross_season(RidgeRapmModel(), [season_n, season_np1])
+    assert isinstance(res, CrossSeasonResult)
+    assert res.rating_corr > 0.3  # last year's rating forecasts this year's
+    assert 0.0 <= res.coverage_pct <= 100.0
+    assert res.n_shared_players > 0
+
+
+def test_cross_season_single_season_is_nan():
+    o, d = _planted_ratings()
+    one = _synthetic_possessions(o, d, n_games=10, poss_per_game=50, noise_sd=0.3, seed=1)
+    res = cross_season(RidgeRapmModel(), [one])
+    assert np.isnan(res.rating_corr)

--- a/tests/nba/test_nba_season_compile.py
+++ b/tests/nba/test_nba_season_compile.py
@@ -71,12 +71,12 @@ def test_compile_never_raises_on_no_games(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Gated live slice — only runs when SDV_PY_LIVE_TESTS=1
+# Gated live slice — only runs when SDV_PY_NBA_STATS_LIVE=1
 # ---------------------------------------------------------------------------
-from tests.conftest import skip_if_no_live  # noqa: E402
+from tests.conftest import skip_if_no_nba_stats_live  # noqa: E402
 
 
-@skip_if_no_live
+@skip_if_no_nba_stats_live
 def test_compile_live_small_slice(tmp_path, monkeypatch):
     # only the first 3 real regular-season game ids, real fetch, real cache
     real_ids = C._game_ids_for_season(2023, "Regular Season")[:3]

--- a/tests/nba/test_nba_season_compile.py
+++ b/tests/nba/test_nba_season_compile.py
@@ -1,0 +1,85 @@
+"""Offline + gated-live tests for nba_season_compile."""
+
+from __future__ import annotations
+
+import polars as pl
+
+from sportsdataverse.nba import nba_season_compile as C
+
+_OFF = [f"off_player_{i}" for i in range(1, 6)]
+_DEF = [f"def_player_{i}" for i in range(1, 6)]
+
+
+def _poss(gid: str) -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "game_id": [gid, gid],
+            "offense_team_id": [100, 200],
+            "points": [2, 0],
+            **{c: [1, 2] for c in _OFF},
+            **{c: [3, 4] for c in _DEF},
+        }
+    )
+
+
+def test_compile_dedups_gameids_and_tags_season(tmp_path, monkeypatch):
+    monkeypatch.setattr(C, "_game_ids_for_season", lambda s, st: ["001", "001", "002"])
+    calls = []
+
+    def fake_fetch(gid, league_id):
+        calls.append(gid)
+        return _poss(gid)
+
+    monkeypatch.setattr(C, "_fetch_possessions", fake_fetch)
+    out = C.compile_nba_season(2023, cache_dir=str(tmp_path), delay_s=0.0)
+    assert sorted(calls) == ["001", "002"]  # deduped
+    assert set(out["game_id"].unique().to_list()) == {"001", "002"}
+    assert out["season"].unique().to_list() == [2023]
+
+
+def test_compile_resume_skips_cached(tmp_path, monkeypatch):
+    monkeypatch.setattr(C, "_game_ids_for_season", lambda s, st: ["001", "002"])
+    monkeypatch.setattr(C, "_fetch_possessions", lambda gid, lid: _poss(gid))
+    C.compile_nba_season(2023, cache_dir=str(tmp_path), delay_s=0.0)  # warm cache
+    calls = []
+    monkeypatch.setattr(
+        C,
+        "_fetch_possessions",
+        lambda gid, lid: (calls.append(gid), _poss(gid))[1],
+    )
+    C.compile_nba_season(2023, cache_dir=str(tmp_path), delay_s=0.0)  # all cached
+    assert calls == []  # nothing re-fetched
+
+
+def test_compile_best_effort_skips_failing_game(tmp_path, monkeypatch):
+    monkeypatch.setattr(C, "_game_ids_for_season", lambda s, st: ["ok1", "bad", "ok2"])
+
+    def fetch(gid, lid):
+        if gid == "bad":
+            raise RuntimeError("api boom")
+        return _poss(gid)
+
+    monkeypatch.setattr(C, "_fetch_possessions", fetch)
+    out = C.compile_nba_season(2023, cache_dir=str(tmp_path), delay_s=0.0)
+    assert set(out["game_id"].unique().to_list()) == {"ok1", "ok2"}  # bad skipped, no raise
+
+
+def test_compile_never_raises_on_no_games(tmp_path, monkeypatch):
+    monkeypatch.setattr(C, "_game_ids_for_season", lambda s, st: [])
+    out = C.compile_nba_season(2023, cache_dir=str(tmp_path), delay_s=0.0)
+    assert out.is_empty() and "season" in out.columns
+
+
+# ---------------------------------------------------------------------------
+# Gated live slice — only runs when SDV_PY_LIVE_TESTS=1
+# ---------------------------------------------------------------------------
+from tests.conftest import skip_if_no_live  # noqa: E402
+
+
+@skip_if_no_live
+def test_compile_live_small_slice(tmp_path, monkeypatch):
+    # only the first 3 real regular-season game ids, real fetch, real cache
+    real_ids = C._game_ids_for_season(2023, "Regular Season")[:3]
+    monkeypatch.setattr(C, "_game_ids_for_season", lambda s, st: real_ids)
+    out = C.compile_nba_season(2023, cache_dir=str(tmp_path), delay_s=1.0)
+    assert not out.is_empty() and "off_player_1" in out.columns


### PR DESCRIPTION
## Summary

First sub-project of the NBA **model zoo**: an independent, out-of-sample **validation harness** that scores any RAPM-family model against data it never saw — built so every future model (adj-RAPM, SPM/BPM, DARKO-style) is validated-by-construction rather than trusted. Two additive `sportsdataverse/nba/` modules, Python-first (R port deferred).

- **`nba_model_validation.py`** — a design-matrix `RapmModel` interface (`RidgeRapmModel` wraps the merged plain-RAPM as the reference), four oracles, a `validate_model` orchestrator, and a markdown `render_report`:
  - **① holdout retrodiction** — k-fold-over-games out-of-sample team game-margin RMSE + correlation vs a baseline (the same class of benchmark EPM publishes, ~12.1–12.25).
  - **② split-half reliability** — Spearman-Brown-adjusted per-player rating stability.
  - **③ cross-season predictivity** — season-N ratings predict N+1 outcomes/ratings, with honest overlap coverage.
  - **④ interval calibration** — forward-looking hook: `None` for point models (plain RAPM), a coverage curve for posterior-emitting models (adj-RAPM later).
- **`nba_season_compile.py`** — a resumable + cached + throttled full-season possession compiler (`compile_nba_season`), mirroring `nfl/nfl_build.py`; best-effort/never-raise, per-game parquet keyed by `(game_id, PIPELINE_VERSION)`.

## Validation philosophy (the crux)

The harness's own correctness is proven **offline by a synthetic meta-oracle** with known planted ratings — a planted-skill model scores high, a no-skill model ≈ 0 (proving the k-fold-over-games split has no leakage), an over-confident interval model under-covers. It is **never validated against its own real output** (that would be circular). The real 2021-22..2023-24 report on the merged RAPM is a gated `dev/` runner (`dev/run_rapm_validation_report.py`), opt-in behind `SDV_PY_NBA_STATS_LIVE`.

## Quality

- **20 offline tests pass / 2 gated-live skip**; mypy Success (both modules in the ratchet); ruff clean.
- Live tests gated with `@skip_if_no_nba_stats_live` (never run in CI — stats.nba.com hangs on cloud IPs).
- Built via subagent-driven-development (fresh implementer + two-stage review per task); a final Opus whole-branch review returned **READY TO MERGE, 0 blockers**, independently confirming the meta-oracle genuinely discriminates skill.

## Follow-ons (not in this PR)

- The compiled possession seasons + model ratings + the production runner get their durable home in **`hoopR-nba-stats-data`** as a `python/` builder (reusing this library); raw JSON in `hoopR-nba-stats-raw`.
- Next model: **SPM/BPM** (the box-score prior — common ancestor of EPM/LEBRON/xRAPM), then adj-RAPM-with-prior, then DARKO-style projection — each plugging into this harness via the `RapmModel` interface.

## Summary by Sourcery

Introduce an out-of-sample NBA model validation harness and a resumable season possession compiler, wiring both into the nba package exports.

New Features:
- Add a generic RAPM-family validation module with a Ridge-based reference model, four evaluation oracles, and a markdown report renderer.
- Add a cached, resumable, throttled full-season NBA possession compiler that aggregates per-game possessions into a season frame and supports pandas/polars output.
- Provide a dev script to generate a real RAPM validation report over multiple seasons.

Enhancements:
- Export the new NBA validation and season compilation utilities from the nba package namespace for easier consumption.

Tests:
- Add comprehensive offline tests for the NBA model validation harness, including synthetic meta-oracle checks for all four oracles and the validation orchestrator.
- Add offline and gated-live tests for the season compiler to cover caching, resume behavior, error handling, and a small real-data slice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NBA season compilation with resumable caching and optional pandas output.
  * Added NBA RAPM model validation with markdown report rendering.
  * Exposed the new APIs directly from the NBA package (and the deprecated parsed alias).

* **Tests**
  * Added end-to-end tests for validation (design/prediction, oracle behaviors, reporting) and season compilation (deduping, caching, error tolerance), plus an optional live integration slice.

* **Documentation**
  * Updated NBA reference docs to include the new compilation and validation/reporting APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->