### PR TITLE
feat(nba): trained SPM (box→RAPM) + RatingsModel harness extension

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -332,4 +332,6 @@ files = [
     "tools/validation/lint/leakage_r.py",
     "sportsdataverse/nba/nba_model_validation.py",
     "sportsdataverse/nba/nba_season_compile.py",
+    "sportsdataverse/nba/nba_box_logs.py",
+    "sportsdataverse/nba/nba_spm.py",
 ]

--- a/sportsdataverse/nba/__init__.py
+++ b/sportsdataverse/nba/__init__.py
@@ -15,3 +15,11 @@ from sportsdataverse.nba.nba_model_validation import (  # noqa: F401
     validate_model,
     render_report,
 )
+from sportsdataverse.nba.nba_box_logs import box_features, nba_box_logs  # noqa: F401
+from sportsdataverse.nba.nba_spm import (  # noqa: F401
+    NbaSpmModel,
+    SpmCoefficients,
+    SPM_FEATURES,
+    nba_spm,
+    train_spm,
+)

--- a/sportsdataverse/nba/nba_box_logs.py
+++ b/sportsdataverse/nba/nba_box_logs.py
@@ -22,6 +22,9 @@ def box_features(
 
     Restricting ``game_ids`` to a fold's games is the harness leakage guard.
 
+    Per-100 possessions are computed per game (so mid-window trades use each
+    game's own team pace), then summed — the result is fully deterministic.
+
     Args:
         player_logs: Per-player-per-game box lines (``game_id``, ``team_id``,
             ``player_id``, ``min``, and the counting stats in ``_STATS``).
@@ -36,21 +39,31 @@ def box_features(
     if game_ids is not None:
         player_logs = player_logs.filter(pl.col("game_id").is_in(game_ids))
         team_logs = team_logs.filter(pl.col("game_id").is_in(game_ids))
-    team = (
-        team_logs.with_columns((pl.col("fga") - pl.col("oreb") + pl.col("tov") + 0.44 * pl.col("fta")).alias("poss"))
-        .group_by("team_id")
-        .agg(pl.col("poss").sum().alias("team_poss"), pl.col("min").sum().alias("team_min"))
+    # Step 1: per-team-game possession frame
+    team_poss = team_logs.with_columns(
+        (pl.col("fga") - pl.col("oreb") + pl.col("tov") + 0.44 * pl.col("fta")).alias("team_poss"),
+        pl.col("min").alias("team_min"),
+    ).select("game_id", "team_id", "team_poss", "team_min")
+    # Step 2: join each player-game to its team-game; compute per-game player possessions
+    player_with_poss = player_logs.join(team_poss, on=["game_id", "team_id"], how="left").with_columns(
+        pl.when(pl.col("team_min") > 0)
+        .then(pl.col("team_poss") * (pl.col("min") / pl.col("team_min")))
+        .otherwise(0.0)
+        .alias("player_poss")
     )
-    agg = player_logs.group_by("player_id").agg(
-        pl.col("team_id").first(),
+    # Step 3: aggregate per player
+    agg = player_with_poss.group_by("player_id").agg(
         pl.col("min").sum().alias("min"),
         pl.len().alias("gp"),
+        pl.col("player_poss").sum().alias("player_poss"),
         *[pl.col(s).sum().alias(s) for s in _STATS],
     )
-    joined = agg.join(team, on="team_id", how="left")
-    player_poss = pl.col("team_poss") * (pl.col("min") / pl.col("team_min"))
-    per100 = [pl.when(player_poss > 0).then(pl.col(s) / player_poss * 100.0).otherwise(0.0).alias(s) for s in _STATS]
-    return joined.with_columns(per100).select(
+    # Step 4: per-100 rates
+    per100 = [
+        pl.when(pl.col("player_poss") > 0).then(pl.col(s) / pl.col("player_poss") * 100.0).otherwise(0.0).alias(s)
+        for s in _STATS
+    ]
+    return agg.with_columns(per100).select(
         pl.col("player_id").cast(pl.Int64),
         *_STATS,
         pl.col("min").cast(pl.Float64),
@@ -80,7 +93,7 @@ def nba_box_logs(
     Example:
         Fetch a season's logs (residential IP)::
 
-            from sportsdataverse.nba import nba_box_logs
+            from sportsdataverse.nba.nba_box_logs import nba_box_logs
             logs = nba_box_logs("2023-24")
             print(logs["player"].shape)
     """

--- a/sportsdataverse/nba/nba_box_logs.py
+++ b/sportsdataverse/nba/nba_box_logs.py
@@ -1,0 +1,100 @@
+"""NBA per-game box logs + per-100 feature builder (SPM/BPM input substrate)."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, List, Optional
+
+import polars as pl
+
+from sportsdataverse.nba.nba_stats import nba_stats_leaguegamelog
+
+# per-100 feature columns (snake-cased leaguegamelog player fields)
+_STATS = ["pts", "fg3m", "fga", "fta", "ast", "oreb", "dreb", "stl", "blk", "tov", "pf"]
+
+
+def box_features(
+    player_logs: pl.DataFrame,
+    team_logs: pl.DataFrame,
+    *,
+    game_ids: Optional[List[str]] = None,
+) -> pl.DataFrame:
+    """Aggregate per-player per-100-possession box features over a set of games.
+
+    Restricting ``game_ids`` to a fold's games is the harness leakage guard.
+
+    Args:
+        player_logs: Per-player-per-game box lines (``game_id``, ``team_id``,
+            ``player_id``, ``min``, and the counting stats in ``_STATS``).
+        team_logs: Per-team-per-game lines (``game_id``, ``team_id``, ``min``,
+            ``fga``, ``oreb``, ``tov``, ``fta``) for the possession estimate.
+        game_ids: Optional subset of ``game_id`` to include (default: all).
+
+    Returns:
+        One row per player: ``player_id``, the ``_STATS`` per-100 rates, ``min``
+        (total), ``gp`` (games). Empty frame with that schema on empty input.
+    """
+    if game_ids is not None:
+        player_logs = player_logs.filter(pl.col("game_id").is_in(game_ids))
+        team_logs = team_logs.filter(pl.col("game_id").is_in(game_ids))
+    team = (
+        team_logs.with_columns((pl.col("fga") - pl.col("oreb") + pl.col("tov") + 0.44 * pl.col("fta")).alias("poss"))
+        .group_by("team_id")
+        .agg(pl.col("poss").sum().alias("team_poss"), pl.col("min").sum().alias("team_min"))
+    )
+    agg = player_logs.group_by("player_id").agg(
+        pl.col("team_id").first(),
+        pl.col("min").sum().alias("min"),
+        pl.len().alias("gp"),
+        *[pl.col(s).sum().alias(s) for s in _STATS],
+    )
+    joined = agg.join(team, on="team_id", how="left")
+    player_poss = pl.col("team_poss") * (pl.col("min") / pl.col("team_min"))
+    per100 = [pl.when(player_poss > 0).then(pl.col(s) / player_poss * 100.0).otherwise(0.0).alias(s) for s in _STATS]
+    return joined.with_columns(per100).select(
+        pl.col("player_id").cast(pl.Int64),
+        *_STATS,
+        pl.col("min").cast(pl.Float64),
+        pl.col("gp").cast(pl.Int64),
+    )
+
+
+def nba_box_logs(
+    season: str,
+    *,
+    league_id: str = "00",
+    season_type: str = "Regular Season",
+    fetch: Optional[Callable[..., pl.DataFrame]] = None,
+) -> Dict[str, pl.DataFrame]:
+    """Fetch per-player and per-team game logs for a season (bulk, one call each).
+
+    Args:
+        season: NBA season in ``"2023-24"`` form.
+        league_id: LeagueID (``"00"`` NBA).
+        season_type: SeasonType (``"Regular Season"``).
+        fetch: Injectable ``nba_stats_leaguegamelog`` replacement for offline tests.
+
+    Returns:
+        ``{"player": <per-player-game logs>, "team": <per-team-game logs>}``
+        as snake-cased polars frames.
+
+    Example:
+        Fetch a season's logs (residential IP)::
+
+            from sportsdataverse.nba import nba_box_logs
+            logs = nba_box_logs("2023-24")
+            print(logs["player"].shape)
+    """
+    get = fetch or nba_stats_leaguegamelog
+    player = get(
+        player_or_team_abbreviation="P",
+        season=season,
+        league_id=league_id,
+        season_type_all_star=season_type,
+    )
+    team = get(
+        player_or_team_abbreviation="T",
+        season=season,
+        league_id=league_id,
+        season_type_all_star=season_type,
+    )
+    return {"player": player, "team": team}

--- a/sportsdataverse/nba/nba_model_validation.py
+++ b/sportsdataverse/nba/nba_model_validation.py
@@ -9,7 +9,7 @@ synthetic meta-oracle that proves the harness itself correct.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Protocol, Tuple
+from typing import Dict, List, Optional, Protocol, Tuple, TypeAlias, Union
 
 import numpy as np
 import polars as pl
@@ -71,6 +71,10 @@ class RatingsModel(Protocol):
     def fit_ratings(self, possessions: pl.DataFrame) -> RatingsFit: ...
 
 
+# a harness model is either a design-matrix RapmModel or a box/ratings RatingsModel
+AnyModel: TypeAlias = Union[RapmModel, RatingsModel]
+
+
 def _fit_on(model: object, possessions: pl.DataFrame) -> Tuple[FitResult, List[int]]:
     """Fit any harness model on ``possessions`` and return ``(FitResult, player_ids)``.
 
@@ -84,8 +88,8 @@ def _fit_on(model: object, possessions: pl.DataFrame) -> Tuple[FitResult, List[i
         possessions: The (train) possession+lineup frame.
 
     Returns:
-        ``(FitResult, pids)`` where ``pids`` is ``build_rapm_design``'s player-id column
-        map. Returns ``(FitResult(np.zeros(0), 0.0), [])`` when there are no players.
+        ``(FitResult, pids)`` where ``pids`` is ``build_rapm_design``'s ordered player-id
+        list. Returns ``(FitResult(np.zeros(0), 0.0), [])`` when there are no players.
     """
     X, y, pids = build_rapm_design(possessions)
     if not pids:
@@ -301,7 +305,7 @@ def _rmse(a: np.ndarray, b: np.ndarray) -> float:
 
 
 def retrodiction(
-    model: RapmModel,
+    model: AnyModel,
     possessions: pl.DataFrame,
     *,
     k_folds: int = 5,
@@ -398,7 +402,7 @@ class ReliabilityResult:
     n_shared_players: int
 
 
-def _fit_ratings(model: RapmModel, possessions: pl.DataFrame) -> Dict[int, float]:
+def _fit_ratings(model: AnyModel, possessions: pl.DataFrame) -> Dict[int, float]:
     """Fit the model on ``possessions`` and return player_id -> total rating (o - d_raw).
 
     Args:
@@ -417,7 +421,7 @@ def _fit_ratings(model: RapmModel, possessions: pl.DataFrame) -> Dict[int, float
     return {int(p): float(total[k]) for k, p in enumerate(pids)}
 
 
-def reliability(model: RapmModel, possessions: pl.DataFrame, *, seed: int = 0) -> ReliabilityResult:
+def reliability(model: AnyModel, possessions: pl.DataFrame, *, seed: int = 0) -> ReliabilityResult:
     """Oracle ②: split-half reliability of the per-player rating across two game halves.
 
     Randomly halves the games, fits each half independently, and correlates the
@@ -483,7 +487,7 @@ class CrossSeasonResult:
 
 
 def cross_season(
-    model: RapmModel,
+    model: AnyModel,
     season_frames: List[pl.DataFrame],
     *,
     unknown_player_rating: float = 0.0,
@@ -572,7 +576,7 @@ class CalibrationResult:
 
 
 def calibration(
-    model: RapmModel,
+    model: AnyModel,
     possessions: pl.DataFrame,
     *,
     levels: Tuple[float, ...] = (0.5, 0.8, 0.9, 0.95),
@@ -612,7 +616,7 @@ def calibration(
     Xa, ya, pids_a = build_rapm_design(a)
     if not pids_a:
         return None
-    fit_a = model.fit(Xa, ya)
+    fit_a = model.fit(Xa, ya)  # type: ignore[union-attr]  # calibration only meaningful for RapmModel
     if fit_a.posterior is None:
         return None
     P = len(pids_a)
@@ -737,7 +741,7 @@ class ValidationReport:
 
 
 def validate_model(
-    model: RapmModel,
+    model: AnyModel,
     season_frames: List[pl.DataFrame],
     *,
     model_name: str = "model",

--- a/sportsdataverse/nba/nba_model_validation.py
+++ b/sportsdataverse/nba/nba_model_validation.py
@@ -95,9 +95,9 @@ def _fit_on(model: object, possessions: pl.DataFrame) -> Tuple[FitResult, List[i
     if not pids:
         return FitResult(coef=np.zeros(0, dtype=np.float64), intercept=0.0), pids
     if hasattr(model, "fit_ratings"):
-        rf = model.fit_ratings(possessions)  # type: ignore[union-attr]
+        rf = model.fit_ratings(possessions)
         P = len(pids)
-        coef = np.zeros(2 * P, dtype=np.float64)
+        coef: np.ndarray = np.zeros(2 * P, dtype=np.float64)
         for k, pid in enumerate(pids):
             coef[k] = rf.o_ratings.get(int(pid), 0.0) / 100.0
             coef[P + k] = -rf.d_ratings.get(int(pid), 0.0) / 100.0
@@ -613,10 +613,9 @@ def calibration(
     mid = len(games) // 2
     a = possessions.filter(pl.col("game_id").is_in(games[:mid]))
     b = possessions.filter(pl.col("game_id").is_in(games[mid:]))
-    Xa, ya, pids_a = build_rapm_design(a)
+    fit_a, pids_a = _fit_on(model, a)
     if not pids_a:
         return None
-    fit_a = model.fit(Xa, ya)  # type: ignore[union-attr]  # calibration only meaningful for RapmModel
     if fit_a.posterior is None:
         return None
     P = len(pids_a)

--- a/sportsdataverse/nba/nba_model_validation.py
+++ b/sportsdataverse/nba/nba_model_validation.py
@@ -45,6 +45,63 @@ class RapmModel(Protocol):
     def fit(self, X: csr_matrix, y: np.ndarray) -> FitResult: ...
 
 
+@dataclass
+class RatingsFit:
+    """A ratings model's per-player per-100 offense/defense ratings.
+
+    Attributes:
+        o_ratings: player_id -> offensive rating (points per 100 possessions).
+        d_ratings: player_id -> defensive rating (per-100; positive = good defense,
+            i.e. lowers opponent points — the ``nba_rapm`` d_rapm convention).
+        posterior: Optional posterior samples; only models emitting one populate it.
+    """
+
+    o_ratings: Dict[int, float]
+    d_ratings: Dict[int, float]
+    posterior: Optional[np.ndarray] = None
+
+
+class RatingsModel(Protocol):
+    """A box/ratings model: emits per-player OBPM/DBPM from a fold's possessions.
+
+    ``fit_ratings`` receives the fold's possession frame and must restrict any box
+    aggregation to ``possessions["game_id"]`` (the leakage guard).
+    """
+
+    def fit_ratings(self, possessions: pl.DataFrame) -> RatingsFit: ...
+
+
+def _fit_on(model: object, possessions: pl.DataFrame) -> Tuple[FitResult, List[int]]:
+    """Fit any harness model on ``possessions`` and return ``(FitResult, player_ids)``.
+
+    Routes by model kind: a ``RatingsModel`` (has ``fit_ratings``) has its per-100
+    ratings mapped onto the design's per-possession coef vector
+    (``coef[i]=o/100``, ``coef[P+i]=-d/100``, ``intercept=mean(y - X @ coef)``);
+    otherwise the model's ``fit(X, y)`` is used unchanged (byte-identical RAPM path).
+
+    Args:
+        model: A ``RapmModel`` (``fit``) or ``RatingsModel`` (``fit_ratings``).
+        possessions: The (train) possession+lineup frame.
+
+    Returns:
+        ``(FitResult, pids)`` where ``pids`` is ``build_rapm_design``'s player-id column
+        map. Returns ``(FitResult(np.zeros(0), 0.0), [])`` when there are no players.
+    """
+    X, y, pids = build_rapm_design(possessions)
+    if not pids:
+        return FitResult(coef=np.zeros(0, dtype=np.float64), intercept=0.0), pids
+    if hasattr(model, "fit_ratings"):
+        rf = model.fit_ratings(possessions)  # type: ignore[union-attr]
+        P = len(pids)
+        coef = np.zeros(2 * P, dtype=np.float64)
+        for k, pid in enumerate(pids):
+            coef[k] = rf.o_ratings.get(int(pid), 0.0) / 100.0
+            coef[P + k] = -rf.d_ratings.get(int(pid), 0.0) / 100.0
+        intercept = float(np.mean(y - (X @ coef)))  # after the loop: coef fully built, one matmul
+        return FitResult(coef=coef, intercept=intercept, posterior=rf.posterior), pids
+    return model.fit(X, y), pids  # type: ignore[attr-defined]
+
+
 class RidgeRapmModel:
     """Reference model: the merged plain-RAPM RidgeCV fit, adapted to ``RapmModel``.
 
@@ -291,10 +348,9 @@ def retrodiction(
         test = possessions.filter(pl.col("game_id").is_in(list(test_ids)))
         if train.is_empty() or test.is_empty():
             continue
-        X_tr, y_tr, pids = build_rapm_design(train)
+        fit, pids = _fit_on(model, train)
         if not pids:
             continue
-        fit = model.fit(X_tr, y_tr)
         X_te, y_te = _design_with_ids(test, pids)
         # rebuild aligned test frame (rows with null lineups are dropped by _design_with_ids)
         test_valid = test.drop_nulls(subset=_OFF + _DEF)
@@ -353,10 +409,9 @@ def _fit_ratings(model: RapmModel, possessions: pl.DataFrame) -> Dict[int, float
         Dict mapping player_id to total impact rating (offense coef minus defense coef).
         Empty dict when ``possessions`` has no players.
     """
-    X, y, pids = build_rapm_design(possessions)
+    fit, pids = _fit_on(model, possessions)
     if not pids:
         return {}
-    fit = model.fit(X, y)
     P = len(pids)
     total = fit.coef[:P] - fit.coef[P:]  # offense minus (raw) defense coef = total impact
     return {int(p): float(total[k]) for k, p in enumerate(pids)}
@@ -461,10 +516,9 @@ def cross_season(
     covs: List[float] = []
     shared_counts: List[int] = []
     for n, np1 in zip(season_frames, season_frames[1:]):
-        X_n, y_n, pids_n = build_rapm_design(n)
+        fit_n, pids_n = _fit_on(model, n)
         if not pids_n:
             continue
-        fit_n = model.fit(X_n, y_n)
         # outcome: predict N+1 with coef_N
         X_np1, _ = _design_with_ids(np1, pids_n, unknown_player_rating=unknown_player_rating)
         np1_valid = np1.drop_nulls(subset=_OFF + _DEF)

--- a/sportsdataverse/nba/nba_spm.py
+++ b/sportsdataverse/nba/nba_spm.py
@@ -1,0 +1,163 @@
+"""Trained SPM: box-score features regressed onto our RAPM target (per-100)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Union
+
+import numpy as np
+import polars as pl
+from sklearn.linear_model import Ridge
+
+from sportsdataverse.nba.nba_box_logs import _STATS
+
+SPM_FEATURES: List[str] = list(_STATS)
+
+
+@dataclass(frozen=True)
+class SpmCoefficients:
+    """Fitted SPM coefficients (box features -> offense/defense RAPM, per-100).
+
+    Attributes:
+        o_coef: Coefficient vector for the offense regression (shape ``[n_features]``).
+        d_coef: Coefficient vector for the defense regression (shape ``[n_features]``).
+        o_intercept: Intercept for the offense regression.
+        d_intercept: Intercept for the defense regression.
+        feature_names: Ordered list of feature column names corresponding to the
+            coefficient vectors.
+    """
+
+    o_coef: np.ndarray
+    d_coef: np.ndarray
+    o_intercept: float
+    d_intercept: float
+    feature_names: List[str]
+
+
+def _feature_matrix(box_features: pl.DataFrame, feature_names: List[str]) -> np.ndarray:
+    """Extract a float64 numpy matrix from *box_features* for *feature_names*."""
+    return box_features.select(feature_names).to_numpy().astype(np.float64)
+
+
+def train_spm(
+    box_features: pl.DataFrame,
+    rapm_target: pl.DataFrame,
+    *,
+    feature_names: Optional[List[str]] = None,
+    alpha: float = 100.0,
+) -> SpmCoefficients:
+    """Ridge-fit box features onto ``o_rapm`` and ``d_rapm`` (two regressions).
+
+    The two models share the same feature matrix but separate target vectors,
+    producing independent offense and defense coefficient vectors.
+
+    Args:
+        box_features: Per-player per-100 features.  Must contain ``player_id``
+            and every column in *feature_names*.
+        rapm_target: Per-player RAPM target frame with columns
+            ``player_id``, ``o_rapm``, and ``d_rapm``.  Only the rows whose
+            ``player_id`` appears in *box_features* are used (inner join).
+        feature_names: Ordered list of feature columns to regress on.
+            Defaults to ``SPM_FEATURES`` (= ``_STATS`` from ``nba_box_logs``).
+        alpha: Ridge regularization strength (``sklearn.linear_model.Ridge``).
+            Lower values approach OLS; higher values shrink toward zero.
+
+    Returns:
+        ``SpmCoefficients`` with offense and defense coefficient vectors,
+        intercepts, and the ordered ``feature_names``.
+
+    Raises:
+        ValueError: If *feature_names* lists a column absent from *box_features*
+            or *rapm_target* is missing required columns.
+
+    Example:
+        Fit on pooled multi-season features + RAPM::
+
+            from sportsdataverse.nba import train_spm
+            coef = train_spm(box_feats, rapm_ratings)
+
+        With custom regularization::
+
+            coef = train_spm(box_feats, rapm_ratings, alpha=50.0)
+    """
+    names: List[str] = feature_names if feature_names is not None else SPM_FEATURES
+    joined = box_features.join(
+        rapm_target.select(["player_id", "o_rapm", "d_rapm"]),
+        on="player_id",
+        how="inner",
+    )
+    X = _feature_matrix(joined, names)
+    o_y = joined["o_rapm"].to_numpy().astype(np.float64)
+    d_y = joined["d_rapm"].to_numpy().astype(np.float64)
+    o_model = Ridge(alpha=alpha).fit(X, o_y)
+    d_model = Ridge(alpha=alpha).fit(X, d_y)
+    return SpmCoefficients(
+        o_coef=np.asarray(o_model.coef_, dtype=np.float64),
+        d_coef=np.asarray(d_model.coef_, dtype=np.float64),
+        o_intercept=float(o_model.intercept_),
+        d_intercept=float(d_model.intercept_),
+        feature_names=list(names),
+    )
+
+
+def nba_spm(
+    box_features: pl.DataFrame,
+    coefficients: SpmCoefficients,
+    *,
+    return_as_pandas: bool = False,
+) -> Union[pl.DataFrame, "pd.DataFrame"]:  # noqa: F821
+    """Apply fitted SPM coefficients to per-100 box features -> OSPM/DSPM/SPM.
+
+    Applies a linear scoring rule:
+
+    .. code-block:: text
+
+        ospm = X @ o_coef + o_intercept
+        dspm = X @ d_coef + d_intercept
+        spm  = ospm + dspm
+
+    Args:
+        box_features: Per-player per-100 features.  Must contain ``player_id``,
+            every column in ``coefficients.feature_names``, ``min``, and ``gp``.
+        coefficients: A ``SpmCoefficients`` instance from ``train_spm``.
+        return_as_pandas: When ``True``, return a ``pandas.DataFrame`` instead of
+            a ``polars.DataFrame``.
+
+    Returns:
+        Per-player frame with columns
+        ``player_id`` (Int64), ``ospm`` (Float64), ``dspm`` (Float64),
+        ``spm`` (Float64), ``min`` (Float64), ``gp`` (Int64).
+
+    Example:
+        Score a season::
+
+            from sportsdataverse.nba import nba_spm
+            ratings = nba_spm(box_feats, coef)
+            print(ratings.sort("spm", descending=True).head())
+
+        Pipeline next step::
+
+            ratings.filter(pl.col("min") >= 500).sort("spm", descending=True)
+
+        See Also:
+            * `nba_rapm`_ — RAPM target the SPM is trained on
+            * `hoopR`_ — companion R package for NBA data
+
+        .. _nba_rapm: sportsdataverse.nba.nba_rapm
+        .. _hoopR: https://hoopR.sportsdataverse.org
+    """
+    X = _feature_matrix(box_features, coefficients.feature_names)
+    ospm = X @ coefficients.o_coef + coefficients.o_intercept
+    dspm = X @ coefficients.d_coef + coefficients.d_intercept
+    out = (
+        box_features.select(["player_id", "min", "gp"])
+        .with_columns(
+            pl.Series("ospm", ospm).cast(pl.Float64),
+            pl.Series("dspm", dspm).cast(pl.Float64),
+            pl.Series("spm", (ospm + dspm)).cast(pl.Float64),
+        )
+        .select(["player_id", "ospm", "dspm", "spm", "min", "gp"])
+    )
+    if return_as_pandas:
+        return out.to_pandas()
+    return out

--- a/sportsdataverse/nba/nba_spm.py
+++ b/sportsdataverse/nba/nba_spm.py
@@ -83,6 +83,13 @@ def train_spm(
             coef = train_spm(box_feats, rapm_ratings, alpha=50.0)
     """
     names: List[str] = feature_names if feature_names is not None else SPM_FEATURES
+    missing_feats = [c for c in names if c not in box_features.columns]
+    if missing_feats:
+        raise ValueError(f"box_features is missing feature columns: {missing_feats}")
+    required_target = ["player_id", "o_rapm", "d_rapm"]
+    missing_target = [c for c in required_target if c not in rapm_target.columns]
+    if missing_target:
+        raise ValueError(f"rapm_target is missing required columns: {missing_target}")
     joined = box_features.join(
         rapm_target.select(["player_id", "o_rapm", "d_rapm"]),
         on="player_id",

--- a/sportsdataverse/nba/nba_spm.py
+++ b/sportsdataverse/nba/nba_spm.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Optional, Union
+from typing import TYPE_CHECKING, List, Optional, Union
+
+if TYPE_CHECKING:
+    from sportsdataverse.nba.nba_model_validation import RatingsFit
 
 import numpy as np
 import pandas as pd
 import polars as pl
 from sklearn.linear_model import Ridge
 
-from sportsdataverse.nba.nba_box_logs import _STATS
+from sportsdataverse.nba.nba_box_logs import _STATS, box_features
 
 SPM_FEATURES: List[str] = list(_STATS)
 
@@ -164,3 +167,58 @@ def nba_spm(
     if return_as_pandas:
         return out.to_pandas()
     return out
+
+
+class NbaSpmModel:
+    """A ``RatingsModel`` that scores a fold via fitted SPM coefficients.
+
+    Restricts its box aggregation to the fold's ``game_id`` (the leakage guard),
+    then applies the (globally pre-fit) SPM coefficients.
+
+    Args:
+        coefficients: A ``SpmCoefficients`` instance from ``train_spm``.
+        player_logs: Per-player-per-game box lines used to build fold features.
+        team_logs: Per-team-per-game lines used to estimate per-game possessions.
+
+    Example:
+        Validate SPM head-to-head with plain RAPM::
+
+            from sportsdataverse.nba import NbaSpmModel, train_spm
+            from sportsdataverse.nba.nba_model_validation import validate_model
+            model = NbaSpmModel(coef, logs["player"], logs["team"])
+            report = validate_model(model, season_frames, model_name="spm")
+    """
+
+    def __init__(
+        self,
+        coefficients: SpmCoefficients,
+        player_logs: pl.DataFrame,
+        team_logs: pl.DataFrame,
+    ) -> None:
+        self._coef = coefficients
+        self._player_logs = player_logs
+        self._team_logs = team_logs
+
+    def fit_ratings(self, possessions: pl.DataFrame) -> "RatingsFit":
+        """Aggregate the fold's box (restricted to its game_ids) and apply SPM coeffs.
+
+        Args:
+            possessions: The fold's possession+lineup frame.  Only the ``game_id``
+                values it contains are used to filter ``player_logs`` and
+                ``team_logs`` (the leakage guard).
+
+        Returns:
+            ``RatingsFit`` with ``o_ratings`` and ``d_ratings`` dicts mapping
+            player_id to per-100 OSPM/DSPM. Returns empty dicts when no
+            box features can be built from the fold's games.
+        """
+        from sportsdataverse.nba.nba_model_validation import RatingsFit
+
+        game_ids = possessions["game_id"].unique().to_list()
+        bf = box_features(self._player_logs, self._team_logs, game_ids=game_ids)
+        if bf.is_empty():
+            return RatingsFit(o_ratings={}, d_ratings={})
+        scored = nba_spm(bf, self._coef)
+        o = {int(p): float(v) for p, v in zip(scored["player_id"], scored["ospm"])}
+        d = {int(p): float(v) for p, v in zip(scored["player_id"], scored["dspm"])}
+        return RatingsFit(o_ratings=o, d_ratings=d)

--- a/sportsdataverse/nba/nba_spm.py
+++ b/sportsdataverse/nba/nba_spm.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Union
 
 import numpy as np
+import pandas as pd
 import polars as pl
 from sklearn.linear_model import Ridge
 
@@ -105,7 +106,7 @@ def nba_spm(
     coefficients: SpmCoefficients,
     *,
     return_as_pandas: bool = False,
-) -> Union[pl.DataFrame, "pd.DataFrame"]:  # noqa: F821
+) -> Union[pl.DataFrame, pd.DataFrame]:
     """Apply fitted SPM coefficients to per-100 box features -> OSPM/DSPM/SPM.
 
     Applies a linear scoring rule:
@@ -152,6 +153,8 @@ def nba_spm(
     out = (
         box_features.select(["player_id", "min", "gp"])
         .with_columns(
+            pl.col("player_id").cast(pl.Int64),
+            pl.col("gp").cast(pl.Int64),
             pl.Series("ospm", ospm).cast(pl.Float64),
             pl.Series("dspm", dspm).cast(pl.Float64),
             pl.Series("spm", (ospm + dspm)).cast(pl.Float64),

--- a/sportsdataverse/nba/nba_spm.py
+++ b/sportsdataverse/nba/nba_spm.py
@@ -3,10 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, List, Optional, Union
-
-if TYPE_CHECKING:
-    from sportsdataverse.nba.nba_model_validation import RatingsFit
+from typing import List, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -14,6 +11,7 @@ import polars as pl
 from sklearn.linear_model import Ridge
 
 from sportsdataverse.nba.nba_box_logs import _STATS, box_features
+from sportsdataverse.nba.nba_model_validation import RatingsFit
 
 SPM_FEATURES: List[str] = list(_STATS)
 
@@ -199,7 +197,7 @@ class NbaSpmModel:
         self._player_logs = player_logs
         self._team_logs = team_logs
 
-    def fit_ratings(self, possessions: pl.DataFrame) -> "RatingsFit":
+    def fit_ratings(self, possessions: pl.DataFrame) -> RatingsFit:
         """Aggregate the fold's box (restricted to its game_ids) and apply SPM coeffs.
 
         Args:
@@ -212,8 +210,6 @@ class NbaSpmModel:
             player_id to per-100 OSPM/DSPM. Returns empty dicts when no
             box features can be built from the fold's games.
         """
-        from sportsdataverse.nba.nba_model_validation import RatingsFit
-
         game_ids = possessions["game_id"].unique().to_list()
         bf = box_features(self._player_logs, self._team_logs, game_ids=game_ids)
         if bf.is_empty():

--- a/tests/nba/test_nba_box_logs.py
+++ b/tests/nba/test_nba_box_logs.py
@@ -1,0 +1,59 @@
+"""Tests for nba_box_logs: per-100 box features + fetch interface."""
+
+from __future__ import annotations
+
+import polars as pl
+
+from sportsdataverse.nba.nba_box_logs import box_features
+
+
+def _logs():
+    # 2 games, one team (id 1), one player (id 10) who plays all the team's minutes
+    player = pl.DataFrame(
+        {
+            "game_id": ["G1", "G2"],
+            "team_id": [1, 1],
+            "player_id": [10, 10],
+            "min": [240.0, 240.0],
+            "pts": [20, 30],
+            "fg3m": [2, 3],
+            "fga": [15, 20],
+            "fta": [4, 6],
+            "ast": [5, 7],
+            "oreb": [1, 2],
+            "dreb": [4, 5],
+            "stl": [1, 2],
+            "blk": [0, 1],
+            "tov": [3, 2],
+            "pf": [2, 3],
+        }
+    )
+    team = pl.DataFrame(
+        {
+            "game_id": ["G1", "G2"],
+            "team_id": [1, 1],
+            "min": [240.0, 240.0],
+            "fga": [80, 85],
+            "oreb": [10, 12],
+            "tov": [14, 12],
+            "fta": [20, 22],
+        }
+    )
+    return player, team
+
+
+def test_box_features_per100_and_totals():
+    player, team = _logs()
+    f = box_features(player, team)
+    assert f.height == 1 and f["player_id"][0] == 10
+    assert f["gp"][0] == 2 and abs(f["min"][0] - 480.0) < 1e-9
+    # team_poss = (80-10+14+0.44*20)+(85-12+12+0.44*22) = 92.8 + 94.68 = 187.48
+    # player plays all minutes -> player_poss = 187.48 ; pts/100 = 50/187.48*100
+    assert abs(f["pts"][0] - (50 / 187.48 * 100)) < 1e-6
+
+
+def test_box_features_game_id_restriction():
+    player, team = _logs()
+    only_g1 = box_features(player, team, game_ids=["G1"])
+    # G1 only: team_poss = 92.8 ; pts/100 = 20/92.8*100
+    assert abs(only_g1["pts"][0] - (20 / 92.8 * 100)) < 1e-6

--- a/tests/nba/test_nba_box_logs.py
+++ b/tests/nba/test_nba_box_logs.py
@@ -57,3 +57,42 @@ def test_box_features_game_id_restriction():
     only_g1 = box_features(player, team, game_ids=["G1"])
     # G1 only: team_poss = 92.8 ; pts/100 = 20/92.8*100
     assert abs(only_g1["pts"][0] - (20 / 92.8 * 100)) < 1e-6
+
+
+def test_box_features_traded_player_uses_per_game_pace():
+    # player 10 plays G1 for team 1 (fast) and G2 for team 2 (slow); each game full team minutes
+    player = pl.DataFrame(
+        {
+            "game_id": ["G1", "G2"],
+            "team_id": [1, 2],
+            "player_id": [10, 10],
+            "min": [240.0, 240.0],
+            "pts": [20, 20],
+            "fg3m": [2, 2],
+            "fga": [15, 15],
+            "fta": [4, 4],
+            "ast": [5, 5],
+            "oreb": [1, 1],
+            "dreb": [4, 4],
+            "stl": [1, 1],
+            "blk": [0, 0],
+            "tov": [3, 3],
+            "pf": [2, 2],
+        }
+    )
+    team = pl.DataFrame(
+        {
+            "game_id": ["G1", "G2"],
+            "team_id": [1, 2],
+            "min": [240.0, 240.0],
+            "fga": [100, 70],
+            "oreb": [10, 8],
+            "tov": [14, 10],
+            "fta": [20, 15],
+        }
+    )
+    f = box_features(player, team)
+    # per-game player_poss: G1 team_poss=100-10+14+0.44*20=112.8 ; G2=70-8+10+0.44*15=78.6
+    # player plays all minutes -> player_poss = 112.8 + 78.6 = 191.4 ; pts/100 = 40/191.4*100
+    assert f.height == 1 and f["player_id"][0] == 10
+    assert abs(f["pts"][0] - (40 / 191.4 * 100)) < 1e-6

--- a/tests/nba/test_nba_model_validation.py
+++ b/tests/nba/test_nba_model_validation.py
@@ -291,3 +291,61 @@ def test_end_to_end_real_slice_report(tmp_path, monkeypatch):
     assert rep.retrodiction is not None
     md = render_report(rep)
     assert "plain_rapm" in md
+
+
+# ---------------------------------------------------------------------------
+# Task 1 (SPM sub-project): RatingsModel harness path
+# ---------------------------------------------------------------------------
+
+from sportsdataverse.nba.nba_model_validation import (  # noqa: E402
+    RatingsFit,
+    _fit_on,
+)
+
+
+class _PlantedRatings:
+    """A RatingsModel that returns KNOWN per-100 ratings (meta-oracle ground truth)."""
+
+    def __init__(self, o100, d100):
+        self._o, self._d = o100, d100
+
+    def fit_ratings(self, possessions):
+        return RatingsFit(o_ratings=dict(self._o), d_ratings=dict(self._d))
+
+
+def _planted_ratings_setup():
+    ids = list(range(100, 110)) + list(range(200, 210))  # team A ids, team B ids
+    rng = __import__("numpy").random.default_rng(7)
+    # Use SD=20 (per-100) so rating signal (5*20/100*100poss = 10pts/game) >> noise
+    # (noise_sd=0.3 per poss -> sqrt(100)*0.3*sqrt(2) ~ 4.2 pts game noise)
+    o100 = {p: float(rng.normal(0, 20)) for p in ids}
+    d100 = {p: float(rng.normal(0, 20)) for p in ids}
+    # DGP is per-possession, so divide the per-100 ratings by 100 to generate
+    poss = _synthetic_possessions(
+        {p: v / 100 for p, v in o100.items()},
+        {p: v / 100 for p, v in d100.items()},
+        n_games=40,
+        poss_per_game=100,
+        noise_sd=0.3,
+        seed=1,
+    )
+    return o100, d100, poss
+
+
+def test_ratings_meta_oracle_planted_beats_noskill():
+    o100, d100, poss = _planted_ratings_setup()
+    planted = _PlantedRatings(o100, d100)
+    zero = _PlantedRatings({p: 0.0 for p in o100}, {p: 0.0 for p in d100})
+    rp = retrodiction(planted, poss, seed=2)
+    rz = retrodiction(zero, poss, seed=2)
+    assert rp.game_margin_rmse < rz.game_margin_rmse  # planted predicts; no-skill ~baseline
+    assert rp.game_margin_corr > 0.5  # planted tracks truth (no fold leakage collapse)
+
+
+def test_fit_on_maps_ratings_to_perpossession_coef():
+    o100, d100, poss = _planted_ratings_setup()
+    fit, pids = _fit_on(_PlantedRatings(o100, d100), poss)
+    P = len(pids)
+    k = pids.index(100)
+    assert abs(fit.coef[k] - o100[100] / 100) < 1e-9  # coef[i] = o/100
+    assert abs(fit.coef[P + k] + d100[100] / 100) < 1e-9  # coef[P+i] = -d/100

--- a/tests/nba/test_nba_model_validation.py
+++ b/tests/nba/test_nba_model_validation.py
@@ -349,3 +349,15 @@ def test_fit_on_maps_ratings_to_perpossession_coef():
     k = pids.index(100)
     assert abs(fit.coef[k] - o100[100] / 100) < 1e-9  # coef[i] = o/100
     assert abs(fit.coef[P + k] + d100[100] / 100) < 1e-9  # coef[P+i] = -d/100
+
+
+def test_validate_model_ratings_all_oracles_no_crash():
+    """A ratings model through validate_model with ALL default oracles must not crash;
+    calibration returns None (ratings models are point estimators)."""
+    o100, d100, poss = _planted_ratings_setup()
+    from sportsdataverse.nba.nba_model_validation import validate_model
+
+    rep = validate_model(_PlantedRatings(o100, d100), [poss], model_name="planted")
+    assert rep.calibration is None  # point model -> no posterior -> None, not a crash
+    assert rep.retrodiction is not None  # the predictive oracles still populate
+    assert rep.reliability is not None

--- a/tests/nba/test_nba_spm.py
+++ b/tests/nba/test_nba_spm.py
@@ -196,7 +196,7 @@ def _spm_setup():
     return ids, poss, game_ids
 
 
-def test_nba_spm_model_fold_restriction_and_validate(monkeypatch):
+def test_nba_spm_model_fold_restriction_and_validate():
     from sportsdataverse.nba.nba_spm import SPM_FEATURES, train_spm
 
     ids, poss, game_ids = _spm_setup()
@@ -230,3 +230,32 @@ def test_nba_spm_model_fold_restriction_and_validate(monkeypatch):
     rep_rapm = validate_model(RidgeRapmModel(), [poss], model_name="plain_rapm", oracles=("retrodiction",))
     assert rep_spm.model_name == "spm" and rep_rapm.model_name == "plain_rapm"
     assert rep_spm.retrodiction is not None and rep_rapm.retrodiction is not None
+
+
+# ---------------------------------------------------------------------------
+# Gated live smoke test
+# ---------------------------------------------------------------------------
+
+from tests.conftest import skip_if_no_nba_stats_live
+
+
+@skip_if_no_nba_stats_live
+def test_nba_spm_live_season_smoke():
+    from sportsdataverse.nba import nba_box_logs, box_features, train_spm, nba_spm
+
+    logs = nba_box_logs("2023-24")
+    bf = box_features(logs["player"], logs["team"])
+    assert bf.height > 0
+    # a self-referential target just to exercise the fit+apply plumbing live
+    import numpy as np
+    import polars as pl
+
+    target = pl.DataFrame(
+        {
+            "player_id": bf["player_id"],
+            "o_rapm": np.zeros(bf.height),
+            "d_rapm": np.zeros(bf.height),
+        }
+    )
+    out = nba_spm(bf, train_spm(bf, target))
+    assert set(out.columns) == {"player_id", "ospm", "dspm", "spm", "min", "gp"}

--- a/tests/nba/test_nba_spm.py
+++ b/tests/nba/test_nba_spm.py
@@ -1,0 +1,153 @@
+"""Tests for nba_spm: SpmCoefficients, train_spm, nba_spm (pure math, no live fetch)."""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import pytest
+
+from sportsdataverse.nba.nba_spm import SPM_FEATURES, SpmCoefficients, nba_spm, train_spm
+
+
+def test_train_spm_recovers_known_linear_map():
+    rng = np.random.default_rng(0)
+    n = 400
+    feats = {f: rng.normal(0, 1, n) for f in SPM_FEATURES}
+    bf = pl.DataFrame({"player_id": np.arange(n), **feats, "min": np.full(n, 500.0), "gp": np.full(n, 20)})
+    # planted linear map: o_rapm = 2*pts - 1.5*tov ; d_rapm = 1.2*stl + 0.8*blk
+    o = 2.0 * feats["pts"] - 1.5 * feats["tov"]
+    d = 1.2 * feats["stl"] + 0.8 * feats["blk"]
+    target = pl.DataFrame({"player_id": np.arange(n), "o_rapm": o, "d_rapm": d})
+    coef = train_spm(bf, target, alpha=0.01)
+    out = nba_spm(bf, coef)
+    # recovered predictions correlate near-perfectly with the planted targets
+    assert np.corrcoef(out["ospm"].to_numpy(), o)[0, 1] > 0.99
+    assert np.corrcoef(out["dspm"].to_numpy(), d)[0, 1] > 0.99
+    assert set(out.columns) == {"player_id", "ospm", "dspm", "spm", "min", "gp"}
+
+
+def test_spm_features_match_box_logs_stats():
+    from sportsdataverse.nba.nba_box_logs import _STATS
+
+    assert SPM_FEATURES == list(_STATS)
+
+
+def test_spm_coefficients_frozen():
+    coef = SpmCoefficients(
+        o_coef=np.zeros(len(SPM_FEATURES)),
+        d_coef=np.zeros(len(SPM_FEATURES)),
+        o_intercept=0.0,
+        d_intercept=0.0,
+        feature_names=SPM_FEATURES,
+    )
+    with pytest.raises((AttributeError, TypeError)):
+        coef.o_intercept = 1.0  # type: ignore[misc]
+
+
+def test_nba_spm_output_schema():
+    """nba_spm returns the documented column set with correct dtypes."""
+    rng = np.random.default_rng(42)
+    n = 10
+    feats = {f: rng.normal(0, 1, n) for f in SPM_FEATURES}
+    bf = pl.DataFrame(
+        {
+            "player_id": np.arange(n, dtype=np.int64),
+            **feats,
+            "min": np.full(n, 200.0),
+            "gp": np.full(n, 10, dtype=np.int64),
+        }
+    )
+    coef = SpmCoefficients(
+        o_coef=np.ones(len(SPM_FEATURES)),
+        d_coef=np.ones(len(SPM_FEATURES)) * 0.5,
+        o_intercept=1.0,
+        d_intercept=0.5,
+        feature_names=SPM_FEATURES,
+    )
+    out = nba_spm(bf, coef)
+    assert out.schema["player_id"] == pl.Int64
+    assert out.schema["ospm"] == pl.Float64
+    assert out.schema["dspm"] == pl.Float64
+    assert out.schema["spm"] == pl.Float64
+    assert out.schema["min"] == pl.Float64
+    assert out.schema["gp"] == pl.Int64
+    assert len(out) == n
+
+
+def test_nba_spm_return_as_pandas():
+    import pandas as pd
+
+    rng = np.random.default_rng(7)
+    n = 5
+    feats = {f: rng.normal(0, 1, n) for f in SPM_FEATURES}
+    bf = pl.DataFrame(
+        {
+            "player_id": np.arange(n, dtype=np.int64),
+            **feats,
+            "min": np.full(n, 100.0),
+            "gp": np.full(n, 5, dtype=np.int64),
+        }
+    )
+    coef = SpmCoefficients(
+        o_coef=np.zeros(len(SPM_FEATURES)),
+        d_coef=np.zeros(len(SPM_FEATURES)),
+        o_intercept=0.0,
+        d_intercept=0.0,
+        feature_names=SPM_FEATURES,
+    )
+    out_pd = nba_spm(bf, coef, return_as_pandas=True)
+    assert isinstance(out_pd, pd.DataFrame)
+    assert set(out_pd.columns) == {"player_id", "ospm", "dspm", "spm", "min", "gp"}
+
+
+def test_train_spm_inner_join_on_player_id():
+    """train_spm inner-joins: players in box_features but not in target are excluded."""
+    rng = np.random.default_rng(1)
+    n = 50
+    feats = {f: rng.normal(0, 1, n) for f in SPM_FEATURES}
+    bf = pl.DataFrame(
+        {
+            "player_id": np.arange(n, dtype=np.int64),
+            **feats,
+            "min": np.full(n, 300.0),
+            "gp": np.full(n, 15, dtype=np.int64),
+        }
+    )
+    # target only covers half the players
+    target = pl.DataFrame(
+        {
+            "player_id": np.arange(25, dtype=np.int64),
+            "o_rapm": rng.normal(0, 1, 25),
+            "d_rapm": rng.normal(0, 1, 25),
+        }
+    )
+    coef = train_spm(bf, target, alpha=10.0)
+    assert isinstance(coef, SpmCoefficients)
+    assert len(coef.feature_names) == len(SPM_FEATURES)
+
+
+def test_train_spm_custom_feature_names():
+    """train_spm respects a custom feature_names subset."""
+    rng = np.random.default_rng(2)
+    n = 100
+    feats = {f: rng.normal(0, 1, n) for f in SPM_FEATURES}
+    bf = pl.DataFrame(
+        {
+            "player_id": np.arange(n, dtype=np.int64),
+            **feats,
+            "min": np.full(n, 400.0),
+            "gp": np.full(n, 20, dtype=np.int64),
+        }
+    )
+    target = pl.DataFrame(
+        {
+            "player_id": np.arange(n, dtype=np.int64),
+            "o_rapm": rng.normal(0, 1, n),
+            "d_rapm": rng.normal(0, 1, n),
+        }
+    )
+    subset = ["pts", "ast", "tov"]
+    coef = train_spm(bf, target, feature_names=subset, alpha=10.0)
+    assert coef.feature_names == subset
+    assert len(coef.o_coef) == 3
+    assert len(coef.d_coef) == 3

--- a/tests/nba/test_nba_spm.py
+++ b/tests/nba/test_nba_spm.py
@@ -151,3 +151,26 @@ def test_train_spm_custom_feature_names():
     assert coef.feature_names == subset
     assert len(coef.o_coef) == 3
     assert len(coef.d_coef) == 3
+
+
+def test_nba_spm_enforces_int64_id_and_gp():
+    n = 30
+    feats = {f: np.linspace(0, 1, n) for f in SPM_FEATURES}
+    bf = pl.DataFrame(
+        {
+            "player_id": pl.Series(range(n), dtype=pl.Int32),
+            **feats,
+            "min": np.full(n, 100.0),
+            "gp": pl.Series([5] * n, dtype=pl.Int32),
+        }
+    )
+    target = pl.DataFrame(
+        {
+            "player_id": range(n),
+            "o_rapm": np.zeros(n),
+            "d_rapm": np.zeros(n),
+        }
+    )
+    out = nba_spm(bf, train_spm(bf, target, alpha=1.0))
+    assert out.schema["player_id"] == pl.Int64
+    assert out.schema["gp"] == pl.Int64

--- a/tests/nba/test_nba_spm.py
+++ b/tests/nba/test_nba_spm.py
@@ -174,3 +174,59 @@ def test_nba_spm_enforces_int64_id_and_gp():
     out = nba_spm(bf, train_spm(bf, target, alpha=1.0))
     assert out.schema["player_id"] == pl.Int64
     assert out.schema["gp"] == pl.Int64
+
+
+# ---------------------------------------------------------------------------
+# Task 4: NbaSpmModel adapter + head-to-head integration
+# ---------------------------------------------------------------------------
+
+from sportsdataverse.nba.nba_spm import NbaSpmModel
+from sportsdataverse.nba.nba_model_validation import validate_model, RidgeRapmModel, _synthetic_possessions
+
+
+def _spm_setup():
+    # synthetic possessions whose ids double as the box-log player_ids
+    ids = list(range(100, 110)) + list(range(200, 210))
+    rng = np.random.default_rng(3)
+    o = {p: float(rng.normal(0, 0.03)) for p in ids}
+    d = {p: float(rng.normal(0, 0.03)) for p in ids}
+    poss = _synthetic_possessions(o, d, n_games=30, poss_per_game=40, noise_sd=0.3, seed=4)
+    # trivial box logs: each player one game, one team, features = their o rating signal
+    game_ids = poss["game_id"].unique().to_list()
+    return ids, poss, game_ids
+
+
+def test_nba_spm_model_fold_restriction_and_validate(monkeypatch):
+    from sportsdataverse.nba.nba_spm import SPM_FEATURES, train_spm
+
+    ids, poss, game_ids = _spm_setup()
+    # build box logs covering all games; player features constant per player
+    rows_p, rows_t = [], []
+    for gi in game_ids:
+        for p in ids:
+            team = 1 if p < 200 else 2
+            rows_p.append(
+                {"game_id": gi, "team_id": team, "player_id": p, "min": 24.0, **{s: float(p % 7) for s in SPM_FEATURES}}
+            )
+        for team in (1, 2):
+            rows_t.append(
+                {"game_id": gi, "team_id": team, "min": 240.0, "fga": 85.0, "oreb": 10.0, "tov": 13.0, "fta": 20.0}
+            )
+    player_logs = pl.DataFrame(rows_p)
+    team_logs = pl.DataFrame(rows_t)
+    # a coefficients object (fit on a tiny synthetic target)
+    from sportsdataverse.nba.nba_box_logs import box_features
+
+    bf = box_features(player_logs, team_logs)
+    target = pl.DataFrame({"player_id": bf["player_id"], "o_rapm": np.zeros(bf.height), "d_rapm": np.zeros(bf.height)})
+    coef = train_spm(bf, target, alpha=1.0)
+    model = NbaSpmModel(coef, player_logs, team_logs)
+    # fold restriction: a 2-game fold's ratings come from only those games
+    rf_all = model.fit_ratings(poss)
+    rf_two = model.fit_ratings(poss.filter(pl.col("game_id").is_in(game_ids[:2])))
+    assert set(rf_all.o_ratings) and set(rf_two.o_ratings)  # both produce ratings
+    # head-to-head: SPM and RAPM both run through the SAME validate_model
+    rep_spm = validate_model(model, [poss], model_name="spm", oracles=("retrodiction",))
+    rep_rapm = validate_model(RidgeRapmModel(), [poss], model_name="plain_rapm", oracles=("retrodiction",))
+    assert rep_spm.model_name == "spm" and rep_rapm.model_name == "plain_rapm"
+    assert rep_spm.retrodiction is not None and rep_rapm.retrodiction is not None

--- a/tests/nba/test_nba_spm.py
+++ b/tests/nba/test_nba_spm.py
@@ -239,6 +239,20 @@ def test_nba_spm_model_fold_restriction_and_validate():
 from tests.conftest import skip_if_no_nba_stats_live
 
 
+def test_train_spm_raises_valueerror_on_missing_columns():
+    n = 10
+    bf = pl.DataFrame(
+        {"player_id": range(n), **{f: np.zeros(n) for f in SPM_FEATURES}, "min": np.full(n, 100.0), "gp": [5] * n}
+    )
+    good_target = pl.DataFrame({"player_id": range(n), "o_rapm": np.zeros(n), "d_rapm": np.zeros(n)})
+    # missing feature column
+    with pytest.raises(ValueError):
+        train_spm(bf.drop("pts"), good_target)
+    # missing target column
+    with pytest.raises(ValueError):
+        train_spm(bf, good_target.drop("d_rapm"))
+
+
 @skip_if_no_nba_stats_live
 def test_nba_spm_live_season_smoke():
     from sportsdataverse.nba import nba_box_logs, box_features, train_spm, nba_spm


### PR DESCRIPTION
## Summary

Adds a trained **SPM** (Statistical Plus-Minus) model to `sportsdataverse.nba` — box-score features regressed onto our RAPM target — plus an **additive `RatingsModel` extension** to the merged validation harness (#153), so plain RAPM and SPM run through the **same** `validate_model` and land in one head-to-head report card. First new model in the NBA model zoo. Reuses `nba_rapm` / `build_rapm_design` / `predict_points` / `nba_stats_leaguegamelog` — no re-implementation.

## What's new

- **Harness `RatingsModel` path** (`nba_model_validation.py`, additive — `RapmModel`/`RidgeRapmModel` unchanged): a `RatingsModel` Protocol + `RatingsFit` + a `_fit_on(model, poss)` router. All four oracles route through `_fit_on`, so a ratings model's per-100 OBPM/DBPM map onto the per-possession design coef (`coef[i]=o/100`, `coef[P+i]=-d/100`) and score via the existing `predict_points`. `validate_model` et al. widened to `AnyModel = Union[RapmModel, RatingsModel]`.
- **`nba_box_logs.py`** — per-game player/team box logs (`nba_stats_leaguegamelog`) + a pure `box_features` per-100 builder. Possessions are summed **per game** (deterministic; correct across mid-season trades), and a `game_ids=` filter is the leakage guard.
- **`nba_spm.py`** — `train_spm` (ridge box→`o_rapm`/`d_rapm`), `nba_spm` apply, and `NbaSpmModel` (the `RatingsModel` adapter whose `fit_ratings` restricts box aggregation to the fold's `game_id`s).

## Validation (all against KNOWN truth, not the model's own output)

- **Ratings meta-oracle:** a planted-ratings model beats a no-skill model on held-out game-margin retrodiction (and no-skill ≈ baseline) — proves the ratings path predicts and has no fold leakage.
- **SPM recovery:** `train_spm` recovers a planted linear box→RAPM map (corr > 0.99).
- **Leakage guards:** `box_features(game_ids=)` + `fit_ratings` fold restriction, both tested.

## Scope note

Faithful **BPM 2.0** was scoped out to its own next cycle (planning revealed it's ~4-5 tasks of position/role regressions + team adjustment); its B-Ref coefficient grounding is captured in the design doc so that cycle needn't re-derive it.

## Test plan

- [x] `uv run --frozen pytest tests/nba/ -q` → 110 passed, 12 skipped (live gated by `@skip_if_no_nba_stats_live`, never CI)
- [x] `uv run --frozen mypy` clean (`nba_box_logs.py` + `nba_spm.py` added to the ratchet); ruff clean
- [x] Built TDD via subagent-driven-development: per-task spec + quality reviews, then an opus whole-branch review (READY TO MERGE)

## Summary by Sourcery

Add a trained NBA Statistical Plus-Minus (SPM) model and extend the validation harness to support ratings-style models alongside RAPM, using shared evaluation oracles.

New Features:
- Introduce a RatingsModel protocol and RatingsFit container so ratings-style models can be evaluated through the existing validation harness.
- Add trained box-score-based SPM (box→RAPM) support, including coefficient training, scoring, and an NbaSpmModel adapter for harness integration.
- Provide utilities to fetch NBA per-game box logs and aggregate them into per-100 possession features for SPM/BPM-style models.

Enhancements:
- Generalize the model validation pipeline to accept both design-matrix RAPM models and ratings-based models via a unified AnyModel path.
- Reuse the existing RAPM design and prediction machinery by mapping ratings outputs onto per-possession coefficients, maintaining compatibility with current oracles.

Build:
- Register the new NBA SPM and box-log modules in the type-checking ratchet configuration.

Tests:
- Add synthetic and integration tests validating the RatingsModel path, including planted-ratings meta-oracle checks and harness compatibility.
- Add comprehensive tests for SPM training, application, schema contracts, error handling, and head-to-head validation against plain RAPM.
- Add tests for box feature aggregation, including per-100 rate correctness, game_id-based leakage guards, and traded-player handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NBA box-score feature aggregation and league game-log retrieval for player/team stats.
  * Introduced SPM scoring support to generate offense, defense, and combined player ratings.
  * Expanded validation to work with both traditional RAPM models and ratings-based models.
  * Exposed the new NBA analytics tools through the package interface.

* **Tests**
  * Added coverage for box-score aggregation, SPM scoring, and model validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->