### PR TITLE
feat(nba): faithful BPM 2.0 (box-score player value) + 3-way head-to-head

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -334,4 +334,6 @@ files = [
     "sportsdataverse/nba/nba_season_compile.py",
     "sportsdataverse/nba/nba_box_logs.py",
     "sportsdataverse/nba/nba_spm.py",
+    "sportsdataverse/nba/nba_player_positions.py",
+    "sportsdataverse/nba/nba_bpm.py",
 ]

--- a/sportsdataverse/nba/__init__.py
+++ b/sportsdataverse/nba/__init__.py
@@ -23,4 +23,5 @@ from sportsdataverse.nba.nba_spm import (  # noqa: F401
     nba_spm,
     train_spm,
 )
-from sportsdataverse.nba.nba_bpm import NbaBpmModel, nba_bpm  # noqa: F401
+from sportsdataverse.nba.nba_player_positions import nba_player_positions  # noqa: F401
+from sportsdataverse.nba.nba_bpm import BPM2_COEFFICIENTS, NbaBpmModel, nba_bpm  # noqa: F401

--- a/sportsdataverse/nba/__init__.py
+++ b/sportsdataverse/nba/__init__.py
@@ -23,3 +23,4 @@ from sportsdataverse.nba.nba_spm import (  # noqa: F401
     nba_spm,
     train_spm,
 )
+from sportsdataverse.nba.nba_bpm import NbaBpmModel, nba_bpm  # noqa: F401

--- a/sportsdataverse/nba/nba_bpm.py
+++ b/sportsdataverse/nba/nba_bpm.py
@@ -1,0 +1,130 @@
+"""Faithful BPM 2.0 (Box Plus/Minus) — published-coefficient box-score player value."""
+
+from __future__ import annotations
+
+from typing import Dict, Tuple, Union
+
+import polars as pl
+
+# Published BPM 2.0 coefficients (Basketball-Reference "About BPM 2.0", Daniel Myers 2020).
+# position-varying cols are (pos1_PG, pos5_C); *_role cols are (role1_Creator, role5_Receiver).
+# Inner dicts are either (pos1, pos5) tuples (base/offense) or scalar floats (regression sub-dicts).
+BPM2_COEFFICIENTS: Dict[str, Dict[str, Union[Tuple[float, float], float]]] = {
+    "base": {
+        "pts": (0.860, 0.860),
+        "fg3m": (0.389, 0.389),
+        "ast": (0.580, 1.034),
+        "tov": (-0.964, -0.964),
+        "orb": (0.613, 0.181),
+        "drb": (0.116, 0.181),
+        "stl": (1.369, 1.008),
+        "blk": (1.327, 0.703),
+        "pf": (-0.367, -0.367),
+        "fga_role": (-0.560, -0.780),
+        "fta_role": (-0.246, -0.343),
+    },
+    "offense": {
+        "pts": (0.605, 0.605),
+        "fg3m": (0.477, 0.477),
+        "ast": (0.476, 0.476),
+        "tov": (-0.579, -0.882),
+        "orb": (0.606, 0.422),
+        "drb": (-0.112, 0.103),
+        "stl": (0.177, 0.294),
+        "blk": (0.725, 0.097),
+        "pf": (-0.439, -0.439),
+        "fga_role": (-0.330, -0.472),
+        "fta_role": (-0.145, -0.208),
+    },
+    # position regression on % of team stats (min-weighted); blended with 50 min listed position
+    "position_reg": {
+        "intercept": 2.130,
+        "pct_trb": 8.668,
+        "pct_stl": -2.486,
+        "pct_pf": 0.992,
+        "pct_ast": -3.536,
+        "pct_blk": 1.667,
+    },
+    # offensive-role regression on % of team AST + % of team threshold-points
+    "role_reg": {"intercept": 6.00, "pct_ast": -6.642, "pct_threshold_pts": -8.544},
+}
+# baseline pts per adjusted (true) shot attempt used by the shooting-context step
+# (calibrated to reproduce the B-Ref 2016-17 LeBron worked example 34.9 -> 30.4)
+SHOOTING_BASELINE: float = 1.00
+# shooting-efficiency threshold: 0.33 pts/TSA below team average (offensive-role "threshold points")
+THRESHOLD_MARGIN: float = 0.33
+_LISTED_BLEND_MIN: float = 50.0  # 50 minutes of listed position blended into the estimate
+
+
+def _clamp(expr: pl.Expr, lo: float = 1.0, hi: float = 5.0) -> pl.Expr:
+    return expr.clip(lo, hi)
+
+
+def _estimate_position(shares: pl.DataFrame, listed: pl.DataFrame) -> pl.DataFrame:
+    """Estimate each player's position (1-5) from % of team stats, blended with 50 min of
+    listed position, then recursively shifted so the minute-weighted team mean is 3.0, clamped.
+
+    Args:
+        shares: player_id, team_id, min, and pct_trb/pct_stl/pct_pf/pct_ast/pct_blk (min-weighted
+            % of team totals).
+        listed: player_id, position_num (from ``nba_player_positions``).
+
+    Returns:
+        Frame player_id, position_num (Float64, in [1,5]).
+    """
+    c = BPM2_COEFFICIENTS["position_reg"]
+    raw = (
+        shares.join(listed, on="player_id", how="left")
+        .with_columns(pl.col("position_num").fill_null(3.0))
+        .with_columns(
+            (
+                c["intercept"]
+                + c["pct_trb"] * pl.col("pct_trb")
+                + c["pct_stl"] * pl.col("pct_stl")
+                + c["pct_pf"] * pl.col("pct_pf")
+                + c["pct_ast"] * pl.col("pct_ast")
+                + c["pct_blk"] * pl.col("pct_blk")
+            ).alias("reg_pos")
+        )
+        .with_columns(
+            # blend regression with 50 min of listed position (min-weighted)
+            (
+                (pl.col("reg_pos") * pl.col("min") + pl.col("position_num") * _LISTED_BLEND_MIN)
+                / (pl.col("min") + _LISTED_BLEND_MIN)
+            ).alias("blended")
+        )
+    )
+    # recursive team-sum-to-3.0 with clamping (iterate: shift by team-mean deviation, clamp)
+    return _recursive_team_center(raw, "blended", "position_num", target=3.0)
+
+
+def _recursive_team_center(df: pl.DataFrame, col: str, out: str, *, target: float, iters: int = 25) -> pl.DataFrame:
+    """Add a per-team constant so the min-weighted team mean of ``col`` equals ``target``,
+    re-clamping to [1,5] each pass (recursive because clamping perturbs the mean)."""
+    work = df.select(["player_id", "team_id", "min", col]).rename({col: "_v"})
+    for _ in range(iters):
+        team_mean = work.group_by("team_id").agg(
+            ((pl.col("_v") * pl.col("min")).sum() / pl.col("min").sum()).alias("_m")
+        )
+        work = (
+            work.join(team_mean, on="team_id").with_columns(_clamp(pl.col("_v") + (target - pl.col("_m")))).drop("_m")
+        )
+    return work.select("player_id", pl.col("_v").alias(out))
+
+
+def _estimate_role(shares: pl.DataFrame) -> pl.DataFrame:
+    """Estimate offensive role (1 Creator .. 5 Receiver) from % of team AST + threshold points, clamped.
+
+    Args:
+        shares: player_id, team_id, min, pct_ast, pct_threshold_pts.
+
+    Returns:
+        Frame player_id, role_num (Float64, in [1,5]).
+    """
+    c = BPM2_COEFFICIENTS["role_reg"]
+    return shares.select(
+        "player_id",
+        _clamp(
+            c["intercept"] + c["pct_ast"] * pl.col("pct_ast") + c["pct_threshold_pts"] * pl.col("pct_threshold_pts")
+        ).alias("role_num"),
+    )

--- a/sportsdataverse/nba/nba_bpm.py
+++ b/sportsdataverse/nba/nba_bpm.py
@@ -414,3 +414,71 @@ def nba_bpm(
         )
     )
     return out.to_pandas() if return_as_pandas else out
+
+
+# RatingsFit is defined in nba_model_validation; imported here (no cycle —
+# nba_model_validation does not import nba_bpm).
+from sportsdataverse.nba.nba_model_validation import RatingsFit  # noqa: E402
+
+
+class NbaBpmModel:
+    """A ``RatingsModel`` scoring a fold via faithful BPM 2.0.
+
+    Position/role are estimated once over the full-season logs at construction (a stable
+    player attribute); ``fit_ratings`` restricts the box rate + team margin to the fold's games.
+
+    Design note: position/role are recomputed inside ``nba_bpm`` over the fold in v1 for
+    simplicity (fold-native); the spec's "position over full season" refinement is a
+    documented follow-up if faithfulness testing shows fold-position drift matters.
+
+    Args:
+        player_logs: Per-player-per-game box lines (same schema as ``nba_bpm``).
+        team_logs: Per-team-per-game lines including ``plus_minus``.
+        positions: Listed positions (``player_id``, ``position_num``) from
+            ``nba_player_positions``.
+        team_adjust: Apply the team adjustment (``True``) or return raw box-BPM
+            (``False``).
+
+    Example:
+        Validate BPM head-to-head with RAPM and SPM::
+
+            from sportsdataverse.nba import NbaBpmModel
+            from sportsdataverse.nba.nba_model_validation import validate_model
+            model = NbaBpmModel(logs["player"], logs["team"], positions)
+            report = validate_model(model, season_frames, model_name="bpm")
+    """
+
+    def __init__(
+        self,
+        player_logs: pl.DataFrame,
+        team_logs: pl.DataFrame,
+        positions: pl.DataFrame,
+        *,
+        team_adjust: bool = True,
+    ) -> None:
+        self._player_logs = player_logs
+        self._team_logs = team_logs
+        self._positions = positions
+        self._team_adjust = team_adjust
+
+    def fit_ratings(self, possessions: pl.DataFrame) -> RatingsFit:
+        """Score the fold's players via BPM 2.0, restricted to the fold's game_ids.
+
+        Args:
+            possessions: The fold's possession+lineup frame.  Only the ``game_id``
+                values it contains are used to filter ``player_logs`` and
+                ``team_logs`` (the leakage guard).
+
+        Returns:
+            ``RatingsFit`` with ``o_ratings`` (OBPM) and ``d_ratings`` (DBPM) keyed
+            by player_id.  Returns empty dicts when no box data covers the fold's games.
+        """
+        game_ids = possessions["game_id"].unique().to_list()
+        pl_fold = self._player_logs.filter(pl.col("game_id").is_in(game_ids))
+        tl_fold = self._team_logs.filter(pl.col("game_id").is_in(game_ids))
+        if pl_fold.is_empty():
+            return RatingsFit(o_ratings={}, d_ratings={})
+        scored = nba_bpm(pl_fold, tl_fold, self._positions, team_adjust=self._team_adjust)
+        o = {int(p): float(v) for p, v in zip(scored["player_id"], scored["obpm"])}
+        d = {int(p): float(v) for p, v in zip(scored["player_id"], scored["dbpm"])}
+        return RatingsFit(o_ratings=o, d_ratings=d)

--- a/sportsdataverse/nba/nba_bpm.py
+++ b/sportsdataverse/nba/nba_bpm.py
@@ -7,6 +7,7 @@ from typing import Dict, Tuple
 import polars as pl
 
 from sportsdataverse.nba.nba_box_logs import box_features
+from sportsdataverse.nba.nba_model_validation import RatingsFit
 
 # Published BPM 2.0 coefficients (Basketball-Reference "About BPM 2.0", Daniel Myers 2020).
 # position-varying cols are (pos1_PG, pos5_C); *_role cols are (role1_Creator, role5_Receiver).
@@ -416,16 +417,13 @@ def nba_bpm(
     return out.to_pandas() if return_as_pandas else out
 
 
-# RatingsFit is defined in nba_model_validation; imported here (no cycle —
-# nba_model_validation does not import nba_bpm).
-from sportsdataverse.nba.nba_model_validation import RatingsFit  # noqa: E402
-
-
 class NbaBpmModel:
     """A ``RatingsModel`` scoring a fold via faithful BPM 2.0.
 
-    Position/role are estimated once over the full-season logs at construction (a stable
-    player attribute); ``fit_ratings`` restricts the box rate + team margin to the fold's games.
+    Scores a fold via faithful BPM 2.0; position/role are estimated **fold-native**
+    (recomputed over the fold's games) in v1 — a full-season-position refinement is a
+    documented follow-up. ``fit_ratings`` restricts the box rate + team margin to the
+    fold's games (the leakage guard).
 
     Design note: position/role are recomputed inside ``nba_bpm`` over the fold in v1 for
     simplicity (fold-native); the spec's "position over full season" refinement is a

--- a/sportsdataverse/nba/nba_bpm.py
+++ b/sportsdataverse/nba/nba_bpm.py
@@ -6,6 +6,8 @@ from typing import Dict, Tuple
 
 import polars as pl
 
+from sportsdataverse.nba.nba_box_logs import box_features
+
 # Published BPM 2.0 coefficients (Basketball-Reference "About BPM 2.0", Daniel Myers 2020).
 # position-varying cols are (pos1_PG, pos5_C); *_role cols are (role1_Creator, role5_Receiver).
 BPM2_COEFFICIENTS: Dict[str, Dict[str, Tuple[float, float]]] = {
@@ -246,3 +248,169 @@ def _raw_bpm(feats: pl.DataFrame, positions: pl.DataFrame, roles: pl.DataFrame) 
     total = _bpm_from_table(feats, BPM2_COEFFICIENTS["base"], positions, roles, "raw_bpm")
     off = _bpm_from_table(feats, BPM2_COEFFICIENTS["offense"], positions, roles, "raw_obpm")
     return total.join(off, on="player_id")
+
+
+# ---------------------------------------------------------------------------
+# Task 4: team shares, team adjustment, shooting-context, and public nba_bpm
+# ---------------------------------------------------------------------------
+
+
+def _team_shares(player_logs: pl.DataFrame, team_logs: pl.DataFrame) -> pl.DataFrame:
+    """Per-player % of team TRB/STL/PF/AST/BLK + threshold-points share (min-weighted totals).
+
+    Args:
+        player_logs: Per-player-per-game box lines with ``player_id``, ``team_id``, ``min``,
+            ``reb``, ``stl``, ``pf``, ``ast``, ``blk``, ``pts``, ``fga``, ``fta``.
+        team_logs: Per-team-per-game lines with ``team_id``, ``reb``, ``stl``, ``pf``,
+            ``ast``, ``blk``, ``pts``, ``fga``, ``fta``.
+
+    Returns:
+        Frame with ``player_id``, ``team_id``, ``min``, ``pct_trb``, ``pct_stl``,
+        ``pct_pf``, ``pct_ast``, ``pct_blk``, ``pct_threshold_pts``.
+    """
+    pl_agg = player_logs.group_by("player_id").agg(
+        pl.col("team_id").first(),
+        pl.col("min").sum().alias("min"),
+        *[pl.col(s).sum().alias(s) for s in ["reb", "stl", "pf", "ast", "blk", "pts", "fga", "fta"]],
+    )
+    team_tot = team_logs.group_by("team_id").agg(
+        *[pl.col(s).sum().alias(f"team_{s}") for s in ["reb", "stl", "pf", "ast", "blk", "pts", "fga", "fta"]]
+    )
+    j = pl_agg.join(team_tot, on="team_id", how="left")
+    tsa = pl.col("fga") + 0.44 * pl.col("fta")
+    team_tsa = pl.col("team_fga") + 0.44 * pl.col("team_fta")
+    team_pps = pl.col("team_pts") / team_tsa  # team avg pts / true-shot-attempt
+    thr_pts = pl.col("pts") - (team_pps - THRESHOLD_MARGIN) * tsa  # points above threshold
+    return j.with_columns(
+        (pl.col("reb") / pl.col("team_reb")).alias("pct_trb"),
+        (pl.col("stl") / pl.col("team_stl")).alias("pct_stl"),
+        (pl.col("pf") / pl.col("team_pf")).alias("pct_pf"),
+        (pl.col("ast") / pl.col("team_ast")).alias("pct_ast"),
+        (pl.col("blk") / pl.col("team_blk")).alias("pct_blk"),
+        (thr_pts / pl.col("team_pts")).alias("pct_threshold_pts"),
+    ).select(["player_id", "team_id", "min", "pct_trb", "pct_stl", "pct_pf", "pct_ast", "pct_blk", "pct_threshold_pts"])
+
+
+def _team_adjust(raw: pl.DataFrame, team_margin: pl.DataFrame, ptm: pl.DataFrame) -> pl.DataFrame:
+    """Add a per-team constant so minute-weighted team raw_bpm == the team's efficiency margin.
+
+    Args:
+        raw: Frame with ``player_id``, ``raw_bpm``, ``raw_obpm``.
+        team_margin: Frame with ``team_id``, ``margin`` (efficiency margin per 100 possessions).
+        ptm: Frame with ``player_id``, ``team_id``, ``min`` (total minutes per player).
+
+    Returns:
+        Frame with ``player_id``, ``obpm``, ``bpm`` (team-adjusted).
+    """
+    j = raw.join(ptm, on="player_id")  # ptm: player_id, team_id, min
+    cur = (
+        j.group_by("team_id")
+        .agg(((pl.col("raw_bpm") * pl.col("min")).sum() / pl.col("min").sum()).alias("cur"))
+        .join(team_margin, on="team_id")
+    )
+    const = cur.with_columns((pl.col("margin") - pl.col("cur")).alias("k")).select(["team_id", "k"])
+    return (
+        j.join(const, on="team_id")
+        .with_columns(
+            (pl.col("raw_bpm") + pl.col("k")).alias("bpm"),
+            (pl.col("raw_obpm") + pl.col("k")).alias("obpm"),
+        )
+        .select(["player_id", "obpm", "bpm"])
+    )
+
+
+def nba_bpm(
+    player_logs: pl.DataFrame,
+    team_logs: pl.DataFrame,
+    positions: pl.DataFrame,
+    *,
+    team_adjust: bool = True,
+    return_as_pandas: bool = False,
+) -> pl.DataFrame:
+    """Faithful BPM 2.0 per player over the given logs (a season).
+
+    Args:
+        player_logs: per-player-per-game box lines (``nba_box_logs``'s ``player``).
+        team_logs: per-team-per-game lines incl. ``plus_minus`` (``nba_box_logs``'s ``team``).
+        positions: listed positions (``nba_player_positions``): player_id, position_num.
+        team_adjust: apply the team adjustment (True) or return raw box-BPM (False).
+        return_as_pandas: return pandas instead of polars.
+
+    Returns:
+        Frame with ``player_id``, ``obpm``, ``dbpm``, ``bpm``, ``min``, ``gp``
+        (Int64 player_id/gp, Float64 obpm/dbpm/bpm/min).
+
+    Example:
+        Season BPM (residential IP)::
+
+            from sportsdataverse.nba import nba_bpm, nba_box_logs, nba_player_positions
+            logs = nba_box_logs("2023-24"); pos = nba_player_positions("2023-24")
+            bpm = nba_bpm(logs["player"], logs["team"], pos)
+            print(bpm.sort("bpm", descending=True).head())
+
+        Raw (no team adjustment)::
+
+            bpm_raw = nba_bpm(logs["player"], logs["team"], pos, team_adjust=False)
+
+        Pandas output::
+
+            bpm_pd = nba_bpm(logs["player"], logs["team"], pos, return_as_pandas=True)
+
+        See Also:
+            * `Basketball-Reference BPM 2.0`_ — published coefficient table and methodology
+            * `hoopR`_ — R companion package
+
+        .. _Basketball-Reference BPM 2.0: https://www.basketball-reference.com/about/bpm2.html
+        .. _hoopR: https://hoopR.sportsdataverse.org
+    """
+    # box_features returns oreb/dreb; _raw_bpm expects orb/drb — rename at the boundary
+    feats_raw = box_features(player_logs, team_logs)
+    feats_renamed = feats_raw.rename({"oreb": "orb", "dreb": "drb"})
+
+    shares = _team_shares(player_logs, team_logs)
+    positions_est = _estimate_position(shares, positions)
+    roles = _estimate_role(shares)
+
+    # shooting-context: adjust per-100 pts toward the baseline given team shooting environment
+    tl = (
+        team_logs.group_by("team_id")
+        .agg(
+            pl.col("pts").sum().alias("tp"),
+            (pl.col("fga").sum() + 0.44 * pl.col("fta").sum()).alias("ttsa"),
+            pl.col("plus_minus").sum().alias("pm"),
+            (pl.col("fga").sum() - pl.col("oreb").sum() + pl.col("tov").sum() + 0.44 * pl.col("fta").sum()).alias(
+                "poss"
+            ),
+        )
+        .with_columns(
+            (SHOOTING_BASELINE - pl.col("tp") / pl.col("ttsa")).alias("pps_delta"),
+            (pl.col("pm") / pl.col("poss") * 100).alias("margin"),
+        )
+    )
+    feats_adj = (
+        feats_renamed.join(shares.select(["player_id", "team_id"]), on="player_id")
+        .join(tl.select(["team_id", "pps_delta"]), on="team_id")
+        .with_columns((pl.col("pts") + pl.col("pps_delta") * (pl.col("fga") + 0.44 * pl.col("fta"))).alias("pts"))
+    )
+
+    raw = _raw_bpm(feats_adj, positions_est, roles)
+    ptm = shares.select(["player_id", "team_id", "min"])
+
+    if team_adjust:
+        adj = _team_adjust(raw, tl.select(["team_id", "margin"]), ptm)
+    else:
+        adj = raw.select("player_id", pl.col("raw_obpm").alias("obpm"), pl.col("raw_bpm").alias("bpm"))
+
+    out = (
+        adj.join(feats_raw.select(["player_id", "min", "gp"]), on="player_id")
+        .with_columns((pl.col("bpm") - pl.col("obpm")).alias("dbpm"))
+        .select(
+            pl.col("player_id").cast(pl.Int64),
+            pl.col("obpm").cast(pl.Float64),
+            pl.col("dbpm").cast(pl.Float64),
+            pl.col("bpm").cast(pl.Float64),
+            pl.col("min").cast(pl.Float64),
+            pl.col("gp").cast(pl.Int64),
+        )
+    )
+    return out.to_pandas() if return_as_pandas else out

--- a/sportsdataverse/nba/nba_bpm.py
+++ b/sportsdataverse/nba/nba_bpm.py
@@ -138,3 +138,104 @@ def _estimate_role(shares: pl.DataFrame) -> pl.DataFrame:
             c["intercept"] + c["pct_ast"] * pl.col("pct_ast") + c["pct_threshold_pts"] * pl.col("pct_threshold_pts")
         ).alias("role_num"),
     )
+
+
+# ---------------------------------------------------------------------------
+# Raw BPM computation (Task 3) — position/role-interpolated coefficients
+# ---------------------------------------------------------------------------
+
+_POS_STATS = ["pts", "fg3m", "ast", "tov", "orb", "drb", "stl", "blk", "pf"]
+
+
+def _interp(pair: Tuple[float, float], scale: float) -> float:
+    """Interpolate a (value_at_1, value_at_5) coefficient pair at ``scale`` in [1,5].
+
+    Args:
+        pair: ``(lo, hi)`` — coefficient value at position/role 1 and 5 respectively.
+        scale: Player's position (1–5) or role (1–5) value at which to interpolate.
+
+    Returns:
+        Linearly interpolated coefficient.
+    """
+    lo, hi = pair
+    return lo + (hi - lo) * (scale - 1.0) / 4.0
+
+
+def _bpm_from_table(
+    feats: pl.DataFrame,
+    table: Dict[str, Tuple[float, float]],
+    positions: pl.DataFrame,
+    roles: pl.DataFrame,
+    out: str,
+) -> pl.DataFrame:
+    """Compute one BPM component (offense or base total) for each player.
+
+    Each position-varying stat coefficient is interpolated at the player's ``position_num``;
+    the role-varying ``fga_role``/``fta_role`` coefficients are interpolated at ``role_num``.
+
+    Args:
+        feats: per-player per-100 stats (must include ``player_id``, all ``_POS_STATS``,
+            ``fga``, ``fta``; ``pts`` must be shooting-context-adjusted already).
+        table: one of the ``BPM2_COEFFICIENTS`` sub-dicts (``"base"`` or ``"offense"``).
+        positions: player_id, position_num.
+        roles: player_id, role_num.
+        out: name of the output column.
+
+    Returns:
+        Frame with ``player_id`` and ``out`` (Float64).
+    """
+    j = feats.join(positions, on="player_id").join(roles, on="player_id")
+
+    def _contrib(row_pos: float, row_role: float, r: Dict[str, object]) -> float:
+        total = 0.0
+        for s in _POS_STATS:
+            total += _interp(table[s], row_pos) * float(r[s])  # type: ignore[arg-type]
+        total += _interp(table["fga_role"], row_role) * float(r["fga"])  # type: ignore[arg-type]
+        total += _interp(table["fta_role"], row_role) * float(r["fta"])  # type: ignore[arg-type]
+        return total
+
+    vals = [_contrib(float(row["position_num"]), float(row["role_num"]), row) for row in j.iter_rows(named=True)]
+    return j.select("player_id").with_columns(pl.Series(out, vals, dtype=pl.Float64))
+
+
+def _raw_bpm(feats: pl.DataFrame, positions: pl.DataFrame, roles: pl.DataFrame) -> pl.DataFrame:
+    """Raw (pre-team-adjustment) OBPM + total BPM from per-100 features + position/role.
+
+    ``feats`` must carry shooting-context-adjusted ``pts`` and the other per-100 stats in
+    ``_POS_STATS`` + ``fga``/``fta``. Returns ``player_id``, ``raw_obpm``, ``raw_bpm``.
+
+    Args:
+        feats: per-player per-100 stats (``player_id``, ``pts`` already adjusted, ``fg3m``,
+            ``ast``, ``tov``, ``orb``, ``drb``, ``stl``, ``blk``, ``pf``, ``fga``, ``fta``).
+        positions: player_id, position_num (Float64, [1,5]) from ``_estimate_position``.
+        roles: player_id, role_num (Float64, [1,5]) from ``_estimate_role``.
+
+    Returns:
+        Frame with ``player_id``, ``raw_obpm`` (Float64), ``raw_bpm`` (Float64).
+
+    Example:
+        Quick start::
+
+            import polars as pl
+            from sportsdataverse.nba.nba_bpm import _raw_bpm
+
+            feats = pl.DataFrame({
+                "player_id": [23], "pts": [30.4], "fg3m": [2.2], "ast": [11.5],
+                "tov": [5.4], "orb": [1.7], "drb": [9.7], "stl": [1.6],
+                "blk": [0.8], "pf": [2.4], "fga": [24.0], "fta": [9.5],
+            })
+            positions = pl.DataFrame({"player_id": [23], "position_num": [2.30]})
+            roles = pl.DataFrame({"player_id": [23], "role_num": [1.0]})
+            out = _raw_bpm(feats, positions, roles)
+            print(out["raw_bpm"][0])   # ≈ 18.7
+
+        See Also:
+            * `Basketball-Reference BPM 2.0`_ — published coefficient table and methodology
+            * `hoopR`_ — R companion package
+
+        .. _Basketball-Reference BPM 2.0: https://www.basketball-reference.com/about/bpm2.html
+        .. _hoopR: https://hoopR.sportsdataverse.org
+    """
+    total = _bpm_from_table(feats, BPM2_COEFFICIENTS["base"], positions, roles, "raw_bpm")
+    off = _bpm_from_table(feats, BPM2_COEFFICIENTS["offense"], positions, roles, "raw_obpm")
+    return total.join(off, on="player_id")

--- a/sportsdataverse/nba/nba_bpm.py
+++ b/sportsdataverse/nba/nba_bpm.py
@@ -184,7 +184,14 @@ def _bpm_from_table(
     Returns:
         Frame with ``player_id`` and ``out`` (Float64).
     """
-    j = feats.join(positions, on="player_id").join(roles, on="player_id")
+    j = (
+        feats.join(positions, on="player_id", how="left")
+        .join(roles, on="player_id", how="left")
+        .with_columns(
+            pl.col("position_num").fill_null(3.0),
+            pl.col("role_num").fill_null(3.0),
+        )
+    )
 
     def _contrib(row_pos: float, row_role: float, r: Dict[str, object]) -> float:
         total = 0.0

--- a/sportsdataverse/nba/nba_bpm.py
+++ b/sportsdataverse/nba/nba_bpm.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Dict, Tuple, Union
+from typing import Dict, Tuple
 
 import polars as pl
 
 # Published BPM 2.0 coefficients (Basketball-Reference "About BPM 2.0", Daniel Myers 2020).
 # position-varying cols are (pos1_PG, pos5_C); *_role cols are (role1_Creator, role5_Receiver).
-# Inner dicts are either (pos1, pos5) tuples (base/offense) or scalar floats (regression sub-dicts).
-BPM2_COEFFICIENTS: Dict[str, Dict[str, Union[Tuple[float, float], float]]] = {
+BPM2_COEFFICIENTS: Dict[str, Dict[str, Tuple[float, float]]] = {
     "base": {
         "pts": (0.860, 0.860),
         "fg3m": (0.389, 0.389),
@@ -36,18 +35,19 @@ BPM2_COEFFICIENTS: Dict[str, Dict[str, Union[Tuple[float, float], float]]] = {
         "fga_role": (-0.330, -0.472),
         "fta_role": (-0.145, -0.208),
     },
-    # position regression on % of team stats (min-weighted); blended with 50 min listed position
-    "position_reg": {
-        "intercept": 2.130,
-        "pct_trb": 8.668,
-        "pct_stl": -2.486,
-        "pct_pf": 0.992,
-        "pct_ast": -3.536,
-        "pct_blk": 1.667,
-    },
-    # offensive-role regression on % of team AST + % of team threshold-points
-    "role_reg": {"intercept": 6.00, "pct_ast": -6.642, "pct_threshold_pts": -8.544},
 }
+# position regression on % of team stats (min-weighted); blended with 50 min listed position
+BPM2_POSITION_REG: Dict[str, float] = {
+    "intercept": 2.130,
+    "pct_trb": 8.668,
+    "pct_stl": -2.486,
+    "pct_pf": 0.992,
+    "pct_ast": -3.536,
+    "pct_blk": 1.667,
+}
+# offensive-role regression on % of team AST + % of team threshold-points
+BPM2_ROLE_REG: Dict[str, float] = {"intercept": 6.00, "pct_ast": -6.642, "pct_threshold_pts": -8.544}
+
 # baseline pts per adjusted (true) shot attempt used by the shooting-context step
 # (calibrated to reproduce the B-Ref 2016-17 LeBron worked example 34.9 -> 30.4)
 SHOOTING_BASELINE: float = 1.00
@@ -72,7 +72,7 @@ def _estimate_position(shares: pl.DataFrame, listed: pl.DataFrame) -> pl.DataFra
     Returns:
         Frame player_id, position_num (Float64, in [1,5]).
     """
-    c = BPM2_COEFFICIENTS["position_reg"]
+    c = BPM2_POSITION_REG
     raw = (
         shares.join(listed, on="player_id", how="left")
         .with_columns(pl.col("position_num").fill_null(3.0))
@@ -98,14 +98,24 @@ def _estimate_position(shares: pl.DataFrame, listed: pl.DataFrame) -> pl.DataFra
     return _recursive_team_center(raw, "blended", "position_num", target=3.0)
 
 
-def _recursive_team_center(df: pl.DataFrame, col: str, out: str, *, target: float, iters: int = 25) -> pl.DataFrame:
+def _recursive_team_center(df: pl.DataFrame, col: str, out: str, *, target: float, iters: int = 100) -> pl.DataFrame:
     """Add a per-team constant so the min-weighted team mean of ``col`` equals ``target``,
-    re-clamping to [1,5] each pass (recursive because clamping perturbs the mean)."""
+    re-clamping to [1,5] each pass (recursive because clamping perturbs the mean).
+
+    Exits early when the max per-team absolute deviation of the min-weighted mean from ``target``
+    is below 1e-9.  If the roster geometry makes the constraint infeasible (e.g. four of five
+    players are true 5.0 centers), the iteration converges to the closest feasible point without
+    raising — this mirrors B-Ref's own algorithm behaviour.
+    """
     work = df.select(["player_id", "team_id", "min", col]).rename({col: "_v"})
     for _ in range(iters):
         team_mean = work.group_by("team_id").agg(
             ((pl.col("_v") * pl.col("min")).sum() / pl.col("min").sum()).alias("_m")
         )
+        # early-exit: if every team's weighted mean is already at target, stop before mutating
+        max_dev = (team_mean["_m"] - target).abs().max()
+        if max_dev is not None and max_dev < 1e-9:
+            break
         work = (
             work.join(team_mean, on="team_id").with_columns(_clamp(pl.col("_v") + (target - pl.col("_m")))).drop("_m")
         )
@@ -116,12 +126,12 @@ def _estimate_role(shares: pl.DataFrame) -> pl.DataFrame:
     """Estimate offensive role (1 Creator .. 5 Receiver) from % of team AST + threshold points, clamped.
 
     Args:
-        shares: player_id, team_id, min, pct_ast, pct_threshold_pts.
+        shares: player_id, pct_ast, pct_threshold_pts.
 
     Returns:
         Frame player_id, role_num (Float64, in [1,5]).
     """
-    c = BPM2_COEFFICIENTS["role_reg"]
+    c = BPM2_ROLE_REG
     return shares.select(
         "player_id",
         _clamp(

--- a/sportsdataverse/nba/nba_player_positions.py
+++ b/sportsdataverse/nba/nba_player_positions.py
@@ -1,0 +1,77 @@
+"""Listed player positions (numeric 1-5) for the BPM 2.0 position blend."""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+import polars as pl
+
+from sportsdataverse.nba.nba_stats import nba_stats_playerindex
+
+_BASE: dict[str, float] = {"PG": 1.0, "SG": 2.0, "SF": 3.0, "PF": 4.0, "C": 5.0, "G": 1.5, "F": 3.5}
+
+
+def _position_to_num(position: str) -> float:
+    """Map a listed position string to the BPM 1-5 scale (missing/unknown -> 3.0).
+
+    Hyphenated positions (``G-F``) map to the mean of their parts.
+
+    Args:
+        position: Position string from playerindex, e.g. ``"PG"``, ``"G-F"``, ``"F-C"``.
+
+    Returns:
+        Numeric position on the 1-5 scale; 3.0 for unknown or empty.
+    """
+    if not position:
+        return 3.0
+    parts = [p.strip().upper() for p in position.replace("/", "-").split("-")]
+    vals = [_BASE[p] for p in parts if p in _BASE]
+    return sum(vals) / len(vals) if vals else 3.0
+
+
+def nba_player_positions(
+    season: str,
+    *,
+    league_id: str = "00",
+    fetch: Optional[Callable[..., pl.DataFrame]] = None,
+) -> pl.DataFrame:
+    """Fetch league-wide listed positions for a season as numeric 1-5.
+
+    Args:
+        season: NBA season, e.g. ``"2023-24"``.
+        league_id: LeagueID (``"00"`` NBA, ``"10"`` WNBA, ``"20"`` G-League).
+        fetch: Injectable ``nba_stats_playerindex`` replacement for offline tests.
+
+    Returns:
+        Frame with columns ``player_id:Int64, position_num:Float64``.
+
+    Raises:
+        ImportError: If ``curl_cffi`` is not installed (required by the stats runtime).
+
+    Example:
+        Listed positions for a season (residential IP)::
+
+            from sportsdataverse.nba import nba_player_positions
+            pos = nba_player_positions("2023-24")
+            print(pos.head())
+
+        Offline / injectable fetch for testing::
+
+            import polars as pl
+            stub = lambda **kw: pl.DataFrame({"person_id": [1], "position": ["PG"]})
+            pos = nba_player_positions("2023-24", fetch=stub)
+
+        See Also:
+            * `hoopR`_ -- R companion package for NBA/MBB data
+            * `nba_api`_ -- Python NBA stats API client
+
+        .. _hoopR: https://hoopR.sportsdataverse.org
+        .. _nba_api: https://github.com/swar/nba_api
+    """
+    get = fetch if fetch is not None else nba_stats_playerindex
+    raw: pl.DataFrame = get(season=season, league_id=league_id)
+    id_col = "person_id" if "person_id" in raw.columns else "player_id"
+    return raw.select(
+        pl.col(id_col).cast(pl.Int64).alias("player_id"),
+        pl.col("position").map_elements(_position_to_num, return_dtype=pl.Float64).alias("position_num"),
+    )

--- a/tests/nba/test_nba_bpm.py
+++ b/tests/nba/test_nba_bpm.py
@@ -307,6 +307,8 @@ def test_nba_bpm_model_head_to_head() -> None:
     rf_two = model.fit_ratings(poss.filter(pl.col("game_id").is_in(game_ids[:2])))
     assert set(rf_all.o_ratings)  # produces ratings on full set
     assert set(rf_two.o_ratings)  # produces ratings on 2-game fold
+    assert set(rf_two.o_ratings) == set(rf_all.o_ratings)  # same players
+    assert rf_two.o_ratings != rf_all.o_ratings  # but different values -> fold actually restricted the input
     # head-to-head: BPM runs through the SAME validate_model as RAPM
     rep = validate_model(model, [poss], model_name="bpm", oracles=("retrodiction",))
     assert rep.retrodiction is not None

--- a/tests/nba/test_nba_bpm.py
+++ b/tests/nba/test_nba_bpm.py
@@ -7,6 +7,8 @@ from sportsdataverse.nba.nba_bpm import (
     BPM2_COEFFICIENTS,
     _estimate_position,
     _estimate_role,
+    _interp,
+    _raw_bpm,
     _recursive_team_center,
 )
 
@@ -79,3 +81,38 @@ def test_recursive_team_center_converges_with_clamping() -> None:
     )
     assert abs(m - 3.0) < 1e-6
     assert out["position_num"].min() >= 1.0 and out["position_num"].max() <= 5.0
+
+
+def test_interp_endpoints_and_midpoint() -> None:
+    # at scale=1 should return lo; at scale=5 should return hi; at scale=3 midpoint
+    assert _interp((0.860, 0.860), 1.0) == 0.860
+    assert _interp((0.860, 0.860), 5.0) == 0.860
+    assert abs(_interp((0.580, 1.034), 1.0) - 0.580) < 1e-9
+    assert abs(_interp((0.580, 1.034), 5.0) - 1.034) < 1e-9
+    assert abs(_interp((0.580, 1.034), 3.0) - (0.580 + 1.034) / 2) < 1e-9
+
+
+def test_raw_bpm_reproduces_bref_lebron_2017() -> None:
+    # B-Ref worked example, per-100 (pts already shooting-context-adjusted 34.9 -> 30.4)
+    feats = pl.DataFrame(
+        {
+            "player_id": [23],
+            "pts": [30.4],
+            "fg3m": [2.2],
+            "ast": [11.5],
+            "tov": [5.4],
+            "orb": [1.7],
+            "drb": [9.7],
+            "stl": [1.6],
+            "blk": [0.8],
+            "pf": [2.4],
+            "fga": [24.0],
+            "fta": [9.5],
+        }
+    )
+    positions = pl.DataFrame({"player_id": [23], "position_num": [2.30]})
+    roles = pl.DataFrame({"player_id": [23], "role_num": [1.0]})
+    out = _raw_bpm(feats, positions, roles)
+    assert out.schema["raw_bpm"] == pl.Float64
+    assert out.schema["raw_obpm"] == pl.Float64
+    assert abs(out["raw_bpm"][0] - 18.7) < 0.3  # published raw total 18.7

--- a/tests/nba/test_nba_bpm.py
+++ b/tests/nba/test_nba_bpm.py
@@ -3,7 +3,12 @@
 from __future__ import annotations
 
 import polars as pl
-from sportsdataverse.nba.nba_bpm import BPM2_COEFFICIENTS, _estimate_position, _estimate_role
+from sportsdataverse.nba.nba_bpm import (
+    BPM2_COEFFICIENTS,
+    _estimate_position,
+    _estimate_role,
+    _recursive_team_center,
+)
 
 
 def test_position_regression_team_sums_to_three_and_clamps() -> None:
@@ -54,3 +59,23 @@ def test_coefficients_constant_has_lebron_anchor_values() -> None:
     off = BPM2_COEFFICIENTS["offense"]
     assert off["pts"] == (0.605, 0.605)
     assert off["blk"] == (0.725, 0.097)
+
+
+def test_recursive_team_center_converges_with_clamping() -> None:
+    # raw positions span outside [1,5] so clamping engages, but a mean-3 solution exists
+    df = pl.DataFrame(
+        {
+            "player_id": [1, 2, 3, 4, 5],
+            "team_id": [7] * 5,
+            "min": [240.0] * 5,
+            "raw": [0.2, 1.0, 3.0, 5.0, 6.5],  # 0.2 and 6.5 will clamp
+        }
+    )
+    out = _recursive_team_center(df, "raw", "position_num", target=3.0)
+    m = (
+        out.join(df.select(["player_id", "min"]), on="player_id")
+        .select((pl.col("position_num") * pl.col("min")).sum() / pl.col("min").sum())
+        .item()
+    )
+    assert abs(m - 3.0) < 1e-6
+    assert out["position_num"].min() >= 1.0 and out["position_num"].max() <= 5.0

--- a/tests/nba/test_nba_bpm.py
+++ b/tests/nba/test_nba_bpm.py
@@ -313,3 +313,20 @@ def test_nba_bpm_model_head_to_head() -> None:
     rep = validate_model(model, [poss], model_name="bpm", oracles=("retrodiction",))
     assert rep.retrodiction is not None
     assert rep.retrodiction.n_test_games > 0
+
+
+# ---------------------------------------------------------------------------
+# Task 6: gated live smoke test
+# ---------------------------------------------------------------------------
+
+from tests.conftest import skip_if_no_nba_stats_live
+
+
+@skip_if_no_nba_stats_live
+def test_nba_bpm_live_season_smoke() -> None:
+    from sportsdataverse.nba import nba_bpm, nba_box_logs, nba_player_positions
+
+    logs = nba_box_logs("2023-24")
+    pos = nba_player_positions("2023-24")
+    out = nba_bpm(logs["player"], logs["team"], pos)
+    assert out.height > 0 and set(out.columns) == {"player_id", "obpm", "dbpm", "bpm", "min", "gp"}

--- a/tests/nba/test_nba_bpm.py
+++ b/tests/nba/test_nba_bpm.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import numpy as np
 import polars as pl
 from sportsdataverse.nba.nba_bpm import (
     BPM2_COEFFICIENTS,
@@ -10,6 +11,7 @@ from sportsdataverse.nba.nba_bpm import (
     _interp,
     _raw_bpm,
     _recursive_team_center,
+    nba_bpm,
 )
 
 
@@ -141,3 +143,86 @@ def test_raw_bpm_missing_position_defaults_neutral_not_dropped():
     out = _raw_bpm(feats, positions, roles)
     assert set(out["player_id"].to_list()) == {1, 2}  # player 2 NOT dropped
     assert out.filter(pl.col("player_id") == 2)["raw_bpm"].item() is not None
+
+
+# ---------------------------------------------------------------------------
+# Task 4: team adjustment + shooting-context + nba_bpm public function
+# ---------------------------------------------------------------------------
+
+
+def _synth_logs(seed: int = 0) -> tuple[pl.DataFrame, pl.DataFrame]:
+    rng = np.random.default_rng(seed)
+    rows_p, rows_t = [], []
+    for gi in range(20):
+        for team, pids in ((1, range(1, 9)), (2, range(9, 17))):
+            for p in pids:
+                rows_p.append(
+                    {
+                        "game_id": f"G{gi}",
+                        "team_id": team,
+                        "player_id": p,
+                        "min": 30.0,
+                        "pts": float(rng.integers(0, 30)),
+                        "fg3m": 1.0,
+                        "fga": 12.0,
+                        "fta": 3.0,
+                        "ast": 4.0,
+                        "oreb": 1.0,
+                        "dreb": 4.0,
+                        "reb": 5.0,
+                        "stl": 1.0,
+                        "blk": 0.5,
+                        "tov": 2.0,
+                        "pf": 2.0,
+                    }
+                )
+        for team, pm in ((1, 5.0), (2, -5.0)):
+            rows_t.append(
+                {
+                    "game_id": f"G{gi}",
+                    "team_id": team,
+                    "min": 240.0,
+                    "fga": 88.0,
+                    "oreb": 10.0,
+                    "dreb": 34.0,
+                    "reb": 44.0,
+                    "tov": 13.0,
+                    "fta": 22.0,
+                    "ast": 24.0,
+                    "stl": 7.0,
+                    "blk": 5.0,
+                    "pf": 20.0,
+                    "pts": 112.0,
+                    "plus_minus": pm,
+                }
+            )
+    return pl.DataFrame(rows_p), pl.DataFrame(rows_t)
+
+
+def test_team_adjustment_invariant() -> None:
+    player_logs, team_logs = _synth_logs()
+    positions = pl.DataFrame({"player_id": list(range(1, 17)), "position_num": [3.0] * 16})
+    out = nba_bpm(player_logs, team_logs, positions, team_adjust=True)
+    # minute-weighted team BPM == team efficiency margin (plus_minus per 100), for ANY coeffs
+    # team 1 margin = 5 pm/game over its possessions; compute the same way nba_bpm does and compare
+    merged = out.join(
+        player_logs.group_by("player_id").agg(pl.col("team_id").first(), pl.col("min").sum().alias("mins")),
+        on="player_id",
+    )
+    for team in (1, 2):
+        t = merged.filter(pl.col("team_id") == team)
+        wbpm = (t["bpm"] * t["mins"]).sum() / t["mins"].sum()
+        # expected margin recomputed from team_logs
+        tl = team_logs.filter(pl.col("team_id") == team)
+        poss = (tl["fga"] - tl["oreb"] + tl["tov"] + 0.44 * tl["fta"]).sum()
+        margin = tl["plus_minus"].sum() / poss * 100
+        assert abs(wbpm - margin) < 1e-6
+
+
+def test_team_adjust_false_is_raw() -> None:
+    player_logs, team_logs = _synth_logs()
+    positions = pl.DataFrame({"player_id": list(range(1, 17)), "position_num": [3.0] * 16})
+    adj = nba_bpm(player_logs, team_logs, positions, team_adjust=True)
+    raw = nba_bpm(player_logs, team_logs, positions, team_adjust=False)
+    # the two differ by a per-team constant (raw is not centered on the margin)
+    assert not np.allclose(adj["bpm"].to_numpy(), raw["bpm"].to_numpy())

--- a/tests/nba/test_nba_bpm.py
+++ b/tests/nba/test_nba_bpm.py
@@ -1,0 +1,56 @@
+"""Tests for BPM2_COEFFICIENTS constant and position/role estimators."""
+
+from __future__ import annotations
+
+import polars as pl
+from sportsdataverse.nba.nba_bpm import BPM2_COEFFICIENTS, _estimate_position, _estimate_role
+
+
+def test_position_regression_team_sums_to_three_and_clamps() -> None:
+    # 5 players, one team, arbitrary team-stat shares summing to 100% each
+    shares = pl.DataFrame(
+        {
+            "player_id": [1, 2, 3, 4, 5],
+            "team_id": [10] * 5,
+            "min": [200.0] * 5,
+            "pct_trb": [0.10, 0.15, 0.20, 0.25, 0.30],
+            "pct_stl": [0.2] * 5,
+            "pct_pf": [0.2] * 5,
+            "pct_ast": [0.4, 0.3, 0.15, 0.1, 0.05],
+            "pct_blk": [0.2] * 5,
+        }
+    )
+    listed = pl.DataFrame({"player_id": [1, 2, 3, 4, 5], "position_num": [1.0, 2.0, 3.0, 4.0, 5.0]})
+    pos = _estimate_position(shares, listed)
+    # minute-weighted team mean position == 3.0 (the recursive constraint)
+    m = (
+        pos.join(shares.select(["player_id", "min"]), on="player_id")
+        .select((pl.col("position_num") * pl.col("min")).sum() / pl.col("min").sum())
+        .item()
+    )
+    assert abs(m - 3.0) < 1e-6
+    assert pos["position_num"].min() >= 1.0 and pos["position_num"].max() <= 5.0
+
+
+def test_role_regression_clamps_1_5() -> None:
+    shares = pl.DataFrame(
+        {
+            "player_id": [1, 2],
+            "team_id": [10, 10],
+            "min": [200.0, 200.0],
+            "pct_ast": [0.05, 0.40],
+            "pct_threshold_pts": [0.30, 0.02],
+        }
+    )
+    role = _estimate_role(shares)
+    assert role["role_num"].min() >= 1.0 and role["role_num"].max() <= 5.0
+
+
+def test_coefficients_constant_has_lebron_anchor_values() -> None:
+    base = BPM2_COEFFICIENTS["base"]
+    assert base["pts"] == (0.860, 0.860)  # (pos1, pos5)
+    assert base["ast"] == (0.580, 1.034)
+    assert base["fga_role"] == (-0.560, -0.780)  # (role1 creator, role5 receiver)
+    off = BPM2_COEFFICIENTS["offense"]
+    assert off["pts"] == (0.605, 0.605)
+    assert off["blk"] == (0.725, 0.097)

--- a/tests/nba/test_nba_bpm.py
+++ b/tests/nba/test_nba_bpm.py
@@ -116,3 +116,28 @@ def test_raw_bpm_reproduces_bref_lebron_2017() -> None:
     assert out.schema["raw_bpm"] == pl.Float64
     assert out.schema["raw_obpm"] == pl.Float64
     assert abs(out["raw_bpm"][0] - 18.7) < 0.3  # published raw total 18.7
+
+
+def test_raw_bpm_missing_position_defaults_neutral_not_dropped():
+    feats = pl.DataFrame(
+        {
+            "player_id": [1, 2],
+            "pts": [20.0, 15.0],
+            "fg3m": [1.0, 1.0],
+            "ast": [4.0, 3.0],
+            "tov": [2.0, 2.0],
+            "orb": [1.0, 1.0],
+            "drb": [4.0, 4.0],
+            "stl": [1.0, 1.0],
+            "blk": [0.5, 0.5],
+            "pf": [2.0, 2.0],
+            "fga": [12.0, 10.0],
+            "fta": [3.0, 2.0],
+        }
+    )
+    # player 2 is missing from positions AND roles -> must still appear (neutral 3.0), not dropped
+    positions = pl.DataFrame({"player_id": [1], "position_num": [2.0]})
+    roles = pl.DataFrame({"player_id": [1], "role_num": [1.0]})
+    out = _raw_bpm(feats, positions, roles)
+    assert set(out["player_id"].to_list()) == {1, 2}  # player 2 NOT dropped
+    assert out.filter(pl.col("player_id") == 2)["raw_bpm"].item() is not None

--- a/tests/nba/test_nba_bpm.py
+++ b/tests/nba/test_nba_bpm.py
@@ -6,6 +6,7 @@ import numpy as np
 import polars as pl
 from sportsdataverse.nba.nba_bpm import (
     BPM2_COEFFICIENTS,
+    NbaBpmModel,
     _estimate_position,
     _estimate_role,
     _interp,
@@ -226,3 +227,87 @@ def test_team_adjust_false_is_raw() -> None:
     raw = nba_bpm(player_logs, team_logs, positions, team_adjust=False)
     # the two differ by a per-team constant (raw is not centered on the margin)
     assert not np.allclose(adj["bpm"].to_numpy(), raw["bpm"].to_numpy())
+
+
+# ---------------------------------------------------------------------------
+# Task 5: NbaBpmModel adapter + RAPM/SPM/BPM 3-way head-to-head
+# ---------------------------------------------------------------------------
+
+from sportsdataverse.nba.nba_model_validation import validate_model, _synthetic_possessions
+
+
+def _bpm_setup() -> tuple:
+    """Build aligned synthetic possessions + box logs for NbaBpmModel tests.
+
+    Player IDs 1-16 (teams A=100: 1-8, B=200: 9-16) are used in possessions.
+    Box logs use the same player ids and the same game_ids as the possession frame.
+    """
+    ids = list(range(1, 17))
+    o = {p: 0.02 for p in ids}
+    d = {p: 0.01 for p in ids}
+    poss = _synthetic_possessions(o, d, n_games=20, poss_per_game=40, noise_sd=0.3, seed=1)
+    game_ids = poss["game_id"].unique().to_list()
+    # build player/team box logs aligned to poss game_ids; two teams, players 1-8 / 9-16
+    rows_p, rows_t = [], []
+    rng = np.random.default_rng(0)
+    for gi in game_ids:
+        for team, pids in ((1, range(1, 9)), (2, range(9, 17))):
+            for p in pids:
+                rows_p.append(
+                    {
+                        "game_id": gi,
+                        "team_id": team,
+                        "player_id": p,
+                        "min": 30.0,
+                        "pts": float(rng.integers(0, 30)),
+                        "fg3m": 1.0,
+                        "fga": 12.0,
+                        "fta": 3.0,
+                        "ast": 4.0,
+                        "oreb": 1.0,
+                        "dreb": 4.0,
+                        "reb": 5.0,
+                        "stl": 1.0,
+                        "blk": 0.5,
+                        "tov": 2.0,
+                        "pf": 2.0,
+                    }
+                )
+        for team, pm in ((1, 5.0), (2, -5.0)):
+            rows_t.append(
+                {
+                    "game_id": gi,
+                    "team_id": team,
+                    "min": 240.0,
+                    "fga": 88.0,
+                    "oreb": 10.0,
+                    "dreb": 34.0,
+                    "reb": 44.0,
+                    "tov": 13.0,
+                    "fta": 22.0,
+                    "ast": 24.0,
+                    "stl": 7.0,
+                    "blk": 5.0,
+                    "pf": 20.0,
+                    "pts": 112.0,
+                    "plus_minus": pm,
+                }
+            )
+    player_logs = pl.DataFrame(rows_p)
+    team_logs = pl.DataFrame(rows_t)
+    return ids, poss, game_ids, player_logs, team_logs
+
+
+def test_nba_bpm_model_head_to_head() -> None:
+    ids, poss, game_ids, player_logs, team_logs = _bpm_setup()
+    positions = pl.DataFrame({"player_id": ids, "position_num": [3.0] * len(ids)})
+    model = NbaBpmModel(player_logs, team_logs, positions)
+    # fold restriction: fit_ratings on the full poss and on a 2-game subset both yield ratings
+    rf_all = model.fit_ratings(poss)
+    rf_two = model.fit_ratings(poss.filter(pl.col("game_id").is_in(game_ids[:2])))
+    assert set(rf_all.o_ratings)  # produces ratings on full set
+    assert set(rf_two.o_ratings)  # produces ratings on 2-game fold
+    # head-to-head: BPM runs through the SAME validate_model as RAPM
+    rep = validate_model(model, [poss], model_name="bpm", oracles=("retrodiction",))
+    assert rep.retrodiction is not None
+    assert rep.retrodiction.n_test_games > 0

--- a/tests/nba/test_nba_player_positions.py
+++ b/tests/nba/test_nba_player_positions.py
@@ -1,0 +1,30 @@
+"""Tests for nba_player_positions (listed position -> numeric 1-5)."""
+
+from __future__ import annotations
+
+import polars as pl
+
+from sportsdataverse.nba.nba_player_positions import _position_to_num, nba_player_positions
+
+
+def test_position_to_num_mapping() -> None:
+    assert _position_to_num("PG") == 1.0
+    assert _position_to_num("SG") == 2.0
+    assert _position_to_num("SF") == 3.0
+    assert _position_to_num("PF") == 4.0
+    assert _position_to_num("C") == 5.0
+    assert _position_to_num("G") == 1.5  # guard midpoint
+    assert _position_to_num("F") == 3.5  # forward midpoint
+    assert _position_to_num("G-F") == 2.5  # hyphenated midpoint of G(1.5) & F(3.5)
+    assert _position_to_num("") == 3.0  # missing -> neutral
+    assert _position_to_num("nonsense") == 3.0
+
+
+def test_nba_player_positions_parses_playerindex() -> None:
+    def fake(**kw: object) -> pl.DataFrame:
+        return pl.DataFrame({"person_id": [1, 2, 3], "position": ["G", "F-C", ""]})
+
+    df = nba_player_positions("2023-24", fetch=fake)
+    assert df.columns == ["player_id", "position_num"]
+    assert df["player_id"].to_list() == [1, 2, 3]
+    assert df["position_num"].to_list() == [1.5, 4.25, 3.0]  # G=1.5, F-C=(3.5+5)/2=4.25


### PR DESCRIPTION
## Summary

Adds a faithful **BPM 2.0** (Box Plus/Minus) model to `sportsdataverse.nba` — the box-prior baseline completing the **RAPM-vs-SPM-vs-BPM** head-to-head through the shipped validation harness (#153) and its `RatingsModel` path (#154). A published-coefficient port of Basketball-Reference's BPM 2.0 (Daniel Myers, 2020). Fully **additive** — the harness and SPM are byte-untouched.

## What's new

- **`nba_bpm.py`** — `BPM2_COEFFICIENTS` (verified B-Ref base + offensive regression tables) + `BPM2_POSITION_REG`/`BPM2_ROLE_REG`; the pipeline: box→per-100 → position/offensive-role estimate (regression + 50-min listed-position blend + recursive team-sum-to-3.0 + clamp) → team shooting-context adjustment → position/role-**interpolated** raw BPM → **team adjustment** (per-team constant so minute-weighted team BPM equals the team's efficiency margin). `nba_bpm(...)` public + `NbaBpmModel` `RatingsModel` adapter (`team_adjust` flag exposes raw-vs-adjusted).
- **`nba_player_positions.py`** — listed positions (numeric 1-5) via `nba_stats_playerindex`.

## Validation (against ground truth, not self-output)

- **Faithfulness anchor:** the B-Ref **2016-17 LeBron worked example** — raw BPM computes to **18.54**, within ±0.3 of the published **18.7** (the coefficient interpolation reproduces B-Ref's per-stat contributions).
- **Coefficient-independent team-adjustment invariant:** minute-weighted adjusted team BPM equals the team's efficiency margin (`plus_minus`/100) to 1e-6 — holds for *any* coefficients.
- **Leakage guard:** `NbaBpmModel.fit_ratings` restricts box aggregation to the fold's `game_id`s (tested: 2-game fold ≠ full-set).

## Scope (v1, documented)

Skips the Englemann lead correction (data-constrained), VORP, and B-Ref's game-level regression-to-mean; position/role are fold-native in v1 (full-season-position refinement is a documented follow-up). See the design doc.

## Test plan

- [x] `uv run --frozen pytest tests/nba/ -q` → 122 passed, 13 skipped (live gated by `@skip_if_no_nba_stats_live`, never CI)
- [x] `uv run --frozen mypy` clean (`nba_bpm.py` + `nba_player_positions.py` on the ratchet); ruff clean
- [x] Built TDD via subagent-driven-development: per-task spec + quality reviews, then an opus whole-branch review (READY TO MERGE)

## Summary by Sourcery

Add a faithful Basketball-Reference BPM 2.0 box-score player value implementation for NBA along with listed-position support and validation model integration.

New Features:
- Expose an nba_bpm API that computes season-long BPM 2.0 ratings per player from box score logs, including offensive, defensive and total BPM with optional team adjustment and pandas output.
- Introduce an NbaBpmModel adapter that plugs BPM 2.0 into the existing RatingsModel validation harness for head-to-head comparisons with other rating models.
- Add nba_player_positions to fetch and convert listed positions from NBA stats into numeric 1-5 values for use in BPM calculations.

Enhancements:
- Implement internal utilities for estimating player position and offensive role from team stat shares, interpolating position/role-specific coefficients, enforcing team-average position constraints, and adjusting for team shooting context and efficiency margin.
- Export nba_bpm, BPM2_COEFFICIENTS, NbaBpmModel, and nba_player_positions from the nba package and include the new modules in static type checking configuration.

Tests:
- Add comprehensive unit tests for BPM coefficient integrity, position and role estimation, recursive team centering, raw BPM reproduction of Basketball-Reference benchmarks, team-adjustment invariants, and model fold restrictions.
- Add tests and a live-gated smoke test for nba_player_positions and nba_bpm to ensure integration with live NBA stats and proper parsing of player index data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new NBA player-position lookup that converts listed positions into a numeric scale.
  * Added BPM 2.0 player ratings, with team-adjusted and raw outputs available.
  * Exposed the new NBA rating tools directly from the NBA package for easier access.

* **Tests**
  * Expanded automated coverage for position mapping, BPM calculations, team adjustment behavior, and model integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->