### PR TITLE
fix(nba): canonicalize real leaguegamelog fg3_m -> fg3m in box_features

### DIFF
--- a/sportsdataverse/nba/nba_box_logs.py
+++ b/sportsdataverse/nba/nba_box_logs.py
@@ -39,6 +39,11 @@ def box_features(
     if game_ids is not None:
         player_logs = player_logs.filter(pl.col("game_id").is_in(game_ids))
         team_logs = team_logs.filter(pl.col("game_id").is_in(game_ids))
+    # Canonicalize real-parser column-name variants to the names ``_STATS`` expects:
+    # ``leaguegamelog`` snake-cases ``FG3M`` -> ``"fg3_m"`` but our stats use ``"fg3m"``.
+    # Backward-compatible: synthetic fixtures already use ``"fg3m"`` (no rename applied).
+    if "fg3_m" in player_logs.columns and "fg3m" not in player_logs.columns:
+        player_logs = player_logs.rename({"fg3_m": "fg3m"})
     # Step 1: per-team-game possession frame
     team_poss = team_logs.with_columns(
         (pl.col("fga") - pl.col("oreb") + pl.col("tov") + 0.44 * pl.col("fta")).alias("team_poss"),

--- a/tests/nba/test_nba_box_logs.py
+++ b/tests/nba/test_nba_box_logs.py
@@ -52,6 +52,22 @@ def test_box_features_per100_and_totals():
     assert abs(f["pts"][0] - (50 / 187.48 * 100)) < 1e-6
 
 
+def test_box_features_real_parser_fg3_m_column():
+    # The live ``leaguegamelog`` parser snake-cases ``FG3M`` -> ``"fg3_m"`` (underscore
+    # before the trailing M), NOT ``"fg3m"``. ``box_features`` must canonicalize that at
+    # the boundary or it raises ``ColumnNotFoundError`` on real data (synthetic fixtures
+    # hid the bug by using ``"fg3m"`` directly). This exercises the real column name.
+    player, team = _logs()
+    player = player.rename({"fg3m": "fg3_m"})
+    f = box_features(player, team)
+    # Same team_poss as test_box_features_per100_and_totals (187.48); fg3m total = 2+3 = 5
+    assert f.height == 1 and f["player_id"][0] == 10
+    assert "fg3m" in f.columns and "fg3_m" not in f.columns
+    assert abs(f["fg3m"][0] - (5 / 187.48 * 100)) < 1e-6
+    # pts unaffected by the rename
+    assert abs(f["pts"][0] - (50 / 187.48 * 100)) < 1e-6
+
+
 def test_box_features_game_id_restriction():
     player, team = _logs()
     only_g1 = box_features(player, team, game_ids=["G1"])


### PR DESCRIPTION
## What

The live `stats.nba.com` `leaguegamelog` parser snake-cases `FG3M` to **`"fg3_m"`** (underscore before the trailing M), but `box_features` in `nba_box_logs.py` aggregates the stat list `["pts", "fg3m", ...]`. The mismatch raises `ColumnNotFoundError` inside the per-player `group_by` on real data.

## Why offline tests missed it

The synthetic test fixtures used `"fg3m"` directly, so every offline test passed while the **first real-NBA-data run** of the SPM/BPM box-feature surface (#154, #155) crashed immediately. This is the canonical "validated-on-synthetic, unmeasured-on-real" gap — the meta-oracles proved each estimator recovers *planted* truth, but nothing exercised the real column names until data actually flowed from the API.

## Fix

A backward-compatible boundary rename at the top of `box_features`, applied **only** when `"fg3_m"` is present and `"fg3m"` is absent — so existing callers and synthetic fixtures (which already use `"fg3m"`) are untouched:

```python
if "fg3_m" in player_logs.columns and "fg3m" not in player_logs.columns:
    player_logs = player_logs.rename({"fg3_m": "fg3m"})
```

## Test

`test_box_features_real_parser_fg3_m_column` feeds the real column name and asserts the rename produces correct `fg3m` per-100 output. Verified to have teeth: **passes with the fix, fails with `ColumnNotFoundError` without it** (reproducing the live crash).

## Gates

- `tests/nba/test_nba_box_logs.py` + `test_nba_spm.py` + `test_nba_bpm.py`: 24 passed, 2 skipped
- `mypy sportsdataverse/nba/nba_box_logs.py`: clean
- `ruff check`: clean

## Summary by Sourcery

Canonicalize NBA three-point made field names in box score features to match real leaguegamelog parser output and add coverage to prevent regressions.

Bug Fixes:
- Map the real leaguegamelog FG3M column name variant fg3_m to the expected fg3m in box_features to prevent ColumnNotFoundError on real data.

Tests:
- Add a regression test ensuring box_features correctly canonicalizes fg3_m to fg3m and produces expected per-100 outputs using real-parser-style column names.