### PR TITLE
feat(nba): pbp-derived on-court lineups (dual-source + gamerotation-free fallback)

### DIFF
--- a/sportsdataverse/nba/__init__.py
+++ b/sportsdataverse/nba/__init__.py
@@ -8,6 +8,10 @@ from sportsdataverse.nba.nba_pbp import *
 from sportsdataverse.nba.nba_player_stats import *
 from sportsdataverse.nba.nba_schedule import *
 from sportsdataverse.nba.nba_teams import *
+from sportsdataverse.nba.nba_lineups import (  # noqa: F401
+    players_on_court_from_pbp,
+    players_on_court_from_rotation,
+)
 from sportsdataverse.nba.nba_season_compile import compile_nba_season  # noqa: F401
 from sportsdataverse.nba.nba_model_validation import (  # noqa: F401
     RidgeRapmModel,

--- a/sportsdataverse/nba/nba_lineups.py
+++ b/sportsdataverse/nba/nba_lineups.py
@@ -644,6 +644,206 @@ def players_on_court(
     )
 
 
+def _seed_five(starters: List[int]) -> List[Optional[int]]:
+    """Return a 5-slot list seeded from *starters* (first 5, rest None).
+
+    Args:
+        starters: List of player ids (typically 5 from boxscore starters).
+
+    Returns:
+        A ``List[Optional[int]]`` of length 5.
+    """
+    five: List[Optional[int]] = [None] * 5
+    for i, pid in enumerate(starters[:5]):
+        five[i] = int(pid)
+    return five
+
+
+def _backfill_five(five: List[Optional[int]], pid: Optional[int]) -> None:
+    """Fill the first ``None`` slot in *five* with *pid*, if *pid* is not already present.
+
+    Mutates *five* in place.
+
+    Args:
+        five: Running 5-slot list for a team.
+        pid: Player id to insert, or ``None`` (no-op).
+    """
+    if not pid or pid in five:
+        return
+    for i, v in enumerate(five):
+        if v is None:
+            five[i] = pid
+            return
+
+
+def _resolve_sub_in(
+    description: str,
+    name_map_team: Dict[str, List[int]],
+    five: List[Optional[int]],
+) -> Optional[int]:
+    """Resolve the incoming player id from a substitution description.
+
+    Prefers a candidate currently **off** court (not in *five*) when
+    there are name collisions on the roster.
+
+    Args:
+        description: Raw substitution description, e.g. ``"SUB: Vonleh FOR Horford"``.
+        name_map_team: ``{familyname_lower: [person_id, ...]}`` for the
+            substituting team (from :func:`_boxscore_name_map`).
+        five: The team's current running 5-slot list.
+
+    Returns:
+        Resolved ``person_id`` int, or ``None`` if the name cannot be matched
+        or the match is ambiguous.
+    """
+    name = _parse_sub_in_name(description)
+    if not name:
+        return None
+    candidates = name_map_team.get(name, [])
+    if len(candidates) == 1:
+        return candidates[0]
+    # collision: prefer a candidate currently OFF court
+    off = [c for c in candidates if c not in five]
+    if len(off) == 1:
+        return off[0]
+    return None  # ambiguous -> leave slot for first-appearance backfill
+
+
+def _apply_pbp_sub(five: List[Optional[int]], sub_out: Optional[int], sub_in: Optional[int]) -> None:
+    """Apply a substitution to *five* in place.
+
+    When *sub_out* is present in *five*, it is replaced by *sub_in*.
+    If *sub_out* is not found (data gap), *sub_in* is backfilled into a
+    free slot instead.
+
+    Args:
+        five: The team's current running 5-slot list (mutated in place).
+        sub_out: The outgoing player id (``person_id`` on a sub row).
+        sub_in: The incoming player id resolved via :func:`_resolve_sub_in`.
+    """
+    if sub_out and sub_out in five:
+        five[five.index(sub_out)] = sub_in
+    elif sub_in and sub_in not in five:
+        _backfill_five(five, sub_in)
+
+
+def players_on_court_from_pbp(
+    enhanced_pbp: pl.DataFrame,
+    raw_box: dict,
+    *,
+    home_team_id: int,
+    away_team_id: int,
+) -> pl.DataFrame:
+    """Reconstruct the 5-on-5 on-court lineup from pbp subs + boxscore starters.
+
+    Pure function (no network). A gamerotation-free alternative to
+    :func:`players_on_court_from_rotation` returning the identical
+    ``LINEUPS_SCHEMA`` frame (one row per action, slots sorted ascending or
+    ``None``). See the module design for the algorithm.
+
+    Args:
+        enhanced_pbp: Output of ``enhanced_pbp_from_payload``. Must carry
+            ``game_id``, ``action_number``, ``order_index``, ``period``,
+            ``team_id``, ``person_id``, ``description``, ``is_substitution``.
+        raw_box: Raw ``boxscoretraditionalv3`` dict (starters + name map).
+        home_team_id: Home team id (from ``boxscore_home_away``).
+        away_team_id: Away team id (from ``boxscore_home_away``).
+
+    Returns:
+        :class:`polars.DataFrame` conforming to ``LINEUPS_SCHEMA``. Empty input
+        returns a zero-row frame (never raises).
+
+    Example:
+        Quick start::
+
+            import json, pathlib
+            from sportsdataverse.nba.nba_enhanced_pbp import enhanced_pbp_from_payload
+            from sportsdataverse.nba.nba_lineups import (
+                boxscore_home_away, players_on_court_from_pbp,
+            )
+            box = json.loads(pathlib.Path("boxscoretraditionalv3.json").read_text())
+            pbp = json.loads(pathlib.Path("playbyplayv3.json").read_text())
+            enh = enhanced_pbp_from_payload(pbp)
+            home, away = boxscore_home_away(box)
+            oc = players_on_court_from_pbp(enh, box, home_team_id=home, away_team_id=away)
+            print(oc.shape)
+
+        See Also:
+            * `hoopR`_ -- R package providing equivalent lineup utilities
+            * `nba_api`_ -- reference Python client for stats.nba.com
+
+        .. _hoopR: https://hoopR.sportsdataverse.org
+        .. _nba_api: https://github.com/swar/nba_api
+    """
+    if enhanced_pbp.is_empty():
+        return pl.DataFrame(schema=LINEUPS_SCHEMA)
+
+    starters = _starters_from_boxscore_v3(raw_box)
+    name_map = _boxscore_name_map(raw_box)
+    home5: List[Optional[int]] = _seed_five(starters.get(home_team_id, []))
+    away5: List[Optional[int]] = _seed_five(starters.get(away_team_id, []))
+
+    sort_col = "order_index" if "order_index" in enhanced_pbp.columns else "action_number"
+    rows = (
+        enhanced_pbp.sort(sort_col)
+        .select(
+            [
+                "game_id",
+                "action_number",
+                "period",
+                "team_id",
+                "person_id",
+                "description",
+                "is_substitution",
+            ]
+        )
+        .to_dicts()
+    )
+
+    out_rows: List[dict] = []
+    for r in rows:
+        tid = int(r["team_id"] or 0)
+        pid = int(r["person_id"]) if r["person_id"] else None
+        team5: Optional[List[Optional[int]]] = home5 if tid == home_team_id else away5 if tid == away_team_id else None
+        if r["is_substitution"] and team5 is not None:
+            sub_in = _resolve_sub_in(r["description"] or "", name_map.get(tid, {}), team5)
+            _apply_pbp_sub(team5, pid, sub_in)  # pid = OUTGOING player
+        elif team5 is not None and pid:
+            _backfill_five(team5, pid)  # first-appearance backfill for actors
+        out_rows.append(
+            {
+                "game_id": r["game_id"],
+                "action_number": r["action_number"],
+                "period": r["period"],
+                **{f"home_player_{i + 1}": home5[i] for i in range(5)},
+                **{f"away_player_{i + 1}": away5[i] for i in range(5)},
+            }
+        )
+
+    df = pl.DataFrame(out_rows, schema=LINEUPS_SCHEMA)
+
+    # ffill/bfill each positional slot within game to patch unresolved-sub gaps
+    slot_cols = [f"home_player_{i}" for i in range(1, 6)] + [f"away_player_{i}" for i in range(1, 6)]
+    df = df.with_columns([pl.col(c).forward_fill().backward_fill().over("game_id") for c in slot_cols])
+
+    # Sort each team's 5 ascending per row (matches rotation producer convention)
+    df = (
+        df.with_columns(
+            [
+                pl.concat_list([f"home_player_{i}" for i in range(1, 6)]).list.sort().alias("_h"),
+                pl.concat_list([f"away_player_{i}" for i in range(1, 6)]).list.sort().alias("_a"),
+            ]
+        )
+        .with_columns(
+            [pl.col("_h").list.get(i - 1).alias(f"home_player_{i}") for i in range(1, 6)]
+            + [pl.col("_a").list.get(i - 1).alias(f"away_player_{i}") for i in range(1, 6)]
+        )
+        .drop(["_h", "_a"])
+    )
+
+    return df.select(list(LINEUPS_SCHEMA.keys()))
+
+
 def nba_on_court(
     game_id: str,
     league_id: str = "00",

--- a/sportsdataverse/nba/nba_lineups.py
+++ b/sportsdataverse/nba/nba_lineups.py
@@ -66,7 +66,8 @@ rotation change.  Two heuristics resolve this:
 from __future__ import annotations
 
 import logging
-from typing import Dict, List, Union
+import re
+from typing import Dict, List, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -203,6 +204,51 @@ def _starters_from_boxscore_v3(raw_box: dict) -> Dict[int, List[int]]:
             starters = (starters + [p for p in pool if p not in starters])[:5]
         out[int(tid)] = starters
     return out
+
+
+def _boxscore_name_map(raw_box: dict) -> Dict[int, Dict[str, List[int]]]:
+    """Map each team's roster family-name -> [person_ids] (list handles collisions).
+
+    Args:
+        raw_box: Raw dict from ``nba_stats_boxscoretraditionalv3``.
+
+    Returns:
+        ``{team_id: {familyname_lower: [person_id, ...]}}``. Empty on malformed
+        input (never raises).
+    """
+    bt = (raw_box or {}).get("boxScoreTraditional") or {}
+    out: Dict[int, Dict[str, List[int]]] = {}
+    for side in ("homeTeam", "awayTeam"):
+        team = bt.get(side) or {}
+        tid = team.get("teamId")
+        if not tid:
+            continue
+        m: Dict[str, List[int]] = {}
+        for p in team.get("players") or []:
+            pid = p.get("personId")
+            fam = (p.get("familyName") or "").strip().lower()
+            if pid and fam:
+                m.setdefault(fam, []).append(int(pid))
+        out[int(tid)] = m
+    return out
+
+
+def _parse_sub_in_name(description: str) -> Optional[str]:
+    """Return the lowercased INCOMING family name from a ``SUB: X FOR Y`` string.
+
+    Args:
+        description: Play description string, e.g. ``"SUB: Vonleh FOR Horford"``.
+
+    Returns:
+        Lowercased family name of the incoming player, or ``None`` if the
+        description is not a substitution string.
+    """
+    if not description:
+        return None
+    match = re.search(r"SUB:\s*(.+?)\s+FOR\s+", description, flags=re.IGNORECASE)
+    if not match:
+        return None
+    return match.group(1).strip().lower()
 
 
 def _elapsed_time(period: int, seconds_remaining: float) -> float:

--- a/sportsdataverse/nba/nba_lineups.py
+++ b/sportsdataverse/nba/nba_lineups.py
@@ -96,7 +96,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Dict, List, Optional, Sequence, Union
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -822,21 +822,26 @@ def _period_starters(
     return _seed_five(starters)
 
 
-def _row_elapsed_key(r: dict) -> tuple[int, float]:
-    """Return a ``(period, seconds_remaining)`` tick key for grouping same-clock rows.
+def _row_elapsed_key(r: dict) -> Tuple[int, float]:
+    """Return a ``(period, clock)`` tick key for grouping same-clock rows.
 
     Two rows share a key when they are in the same period at the same game
-    clock — i.e. they land on the same rotation boundary.  ``None`` clocks map
-    to ``-1.0`` so they group deterministically.
+    clock — i.e. they land on the same rotation boundary.  Real clocks group
+    by tick; null clocks are treated as individually distinct so that two
+    consecutive null-clock subs never collapse into the same boundary.
 
     Args:
-        r: A per-row dict carrying ``period`` and ``seconds_remaining``.
+        r: A per-row dict carrying ``period``, ``seconds_remaining``, and
+            ``action_number``.
 
     Returns:
-        A ``(period, seconds_remaining)`` tuple usable as a dict/equality key.
+        A ``(period, clock)`` tuple usable as a dict/equality key.
     """
     sr = r.get("seconds_remaining")
-    return (int(r["period"]), float(sr) if sr is not None else -1.0)
+    if sr is not None:
+        return (int(r["period"]), float(sr))
+    # Null-clock rows get a per-row-unique sentinel so each is its own group.
+    return (int(r["period"]), -1.0 - float(r["action_number"]))
 
 
 def _snapshot_row(
@@ -963,6 +968,7 @@ def players_on_court_from_pbp(
                 "game_id",
                 "action_number",
                 "period",
+                "seconds_remaining",
                 "team_id",
                 "person_id",
                 "description",

--- a/sportsdataverse/nba/nba_lineups.py
+++ b/sportsdataverse/nba/nba_lineups.py
@@ -8,13 +8,42 @@ Provides utilities consumed by the Phase 1 lineup engine:
   resultSets JSON into a ``{"HomeTeam": [...], "AwayTeam": [...]}`` dict.
 - :func:`players_on_court_from_rotation` — pure rotation-based on-court
   reconstruction (no network calls) from a pre-parsed rotation dict.
+- :func:`players_on_court_from_pbp` — pure gamerotation-*free* on-court
+  reconstruction from boxscore starters + play-by-play substitutions only.
 - :func:`players_on_court` — public entry point; delegates to
   :func:`players_on_court_from_rotation`.
 
-The lineup source is the ``nba_gamerotation`` endpoint (per-player stints
-keyed on ``PERSON_ID``), so the earlier name-resolution + first-appearance
-starter heuristics (``boxscore_name_map`` / ``period_starters`` /
-``_box_starters``) are no longer needed and have been removed.
+Two independent producers reconstruct the same ``LINEUPS_SCHEMA`` frame:
+
+- The **rotation** producer (:func:`players_on_court_from_rotation`) uses the
+  ``nba_gamerotation`` endpoint (per-player stints keyed on ``PERSON_ID``).
+- The **pbp** producer (:func:`players_on_court_from_pbp`) needs no rotation
+  feed — it seeds each team's 5 and updates them from the play-by-play itself
+  (see the pbp-producer algorithm note below).  It agrees with the rotation
+  producer on ≈0.97 of fully-covered actions across the fixture games, and is
+  validated against it by the ``test_pbp_agrees_with_rotation`` meta-oracle.
+
+pbp-producer algorithm (per-period first-appearance seeding)
+------------------------------------------------------------
+The NBA play-by-play stream emits **no** substitution events at period starts,
+so a period-ending lineup cannot simply be carried into the next period.  The
+pbp producer therefore processes periods in ascending order and RE-SEEDS each
+one from the play-by-play:
+
+- **Period 1**: seed both teams from the boxscore starters
+  (:func:`_starters_from_boxscore_v3`).
+- **Each later period P**: re-seed via :func:`_period_starters` — a player who
+  appears in an event (or is subbed *out*) before ever being subbed *in* that
+  period must have been on court at the period start.  The prior period's
+  ending lineup is used only as a carry-forward fallback for a silent starter.
+
+Within a period the running 5-slot lists are updated on each row: a
+substitution's own action row snapshots the PRE-sub lineup (the swap takes
+effect on the next action), and a *contiguous run* of substitutions sharing one
+game-clock tick is applied together so mid-run rows see the settled lineup —
+both conventions match the boundary-based rotation producer.  Same-family
+teammates in ``SUB: X FOR Y`` strings are disambiguated by the first-initial
+keys :func:`_boxscore_name_map` registers (e.g. ``"t. antetokounmpo"``).
 
 Algorithm (hoopR port)
 ----------------------
@@ -67,7 +96,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Sequence, Union
 
 import numpy as np
 import pandas as pd
@@ -209,12 +238,19 @@ def _starters_from_boxscore_v3(raw_box: dict) -> Dict[int, List[int]]:
 def _boxscore_name_map(raw_box: dict) -> Dict[int, Dict[str, List[int]]]:
     """Map each team's roster family-name -> [person_ids] (list handles collisions).
 
+    In addition to the bare ``familyname_lower`` key, an ``"i. familyname"`` key
+    (first-initial + family name) is registered for every player.  This is how
+    the NBA pbp stream disambiguates same-family teammates in substitution
+    strings — e.g. ``"SUB: T. Antetokounmpo FOR G. Antetokounmpo"`` — so
+    :func:`_resolve_sub_in` can match the incoming name uniquely even when the
+    bare family name collides.
+
     Args:
         raw_box: Raw dict from ``nba_stats_boxscoretraditionalv3``.
 
     Returns:
-        ``{team_id: {familyname_lower: [person_id, ...]}}``. Empty on malformed
-        input (never raises).
+        ``{team_id: {familyname_lower: [person_id, ...],
+        "i. familyname": [person_id]}}``.  Empty on malformed input (never raises).
     """
     bt = (raw_box or {}).get("boxScoreTraditional") or {}
     out: Dict[int, Dict[str, List[int]]] = {}
@@ -227,8 +263,12 @@ def _boxscore_name_map(raw_box: dict) -> Dict[int, Dict[str, List[int]]]:
         for p in team.get("players") or []:
             pid = p.get("personId")
             fam = (p.get("familyName") or "").strip().lower()
-            if pid and fam:
-                m.setdefault(fam, []).append(int(pid))
+            if not (pid and fam):
+                continue
+            m.setdefault(fam, []).append(int(pid))
+            first = (p.get("firstName") or "").strip().lower()
+            if first:
+                m.setdefault(f"{first[0]}. {fam}", []).append(int(pid))
         out[int(tid)] = m
     return out
 
@@ -679,7 +719,7 @@ def _backfill_five(five: List[Optional[int]], pid: Optional[int]) -> None:
 def _resolve_sub_in(
     description: str,
     name_map_team: Dict[str, List[int]],
-    five: List[Optional[int]],
+    five: Sequence[Optional[int]],
 ) -> Optional[int]:
     """Resolve the incoming player id from a substitution description.
 
@@ -725,6 +765,138 @@ def _apply_pbp_sub(five: List[Optional[int]], sub_out: Optional[int], sub_in: Op
         five[five.index(sub_out)] = sub_in
     elif sub_in and sub_in not in five:
         _backfill_five(five, sub_in)
+
+
+def _period_starters(
+    period_rows: List[dict],
+    team_id: int,
+    name_map: Dict[int, Dict[str, List[int]]],
+    carry: List[Optional[int]],
+) -> List[Optional[int]]:
+    """Infer *team_id*'s on-court-at-period-start 5 from that period's pbp rows.
+
+    Re-seeds a period's lineup directly from the play-by-play — the NBA stream
+    emits **no** substitution events at period starts, so the ending lineup of
+    the prior period cannot simply be carried forward. Instead, a player who
+    appears in an event (or is subbed *out*) before ever being subbed *in* this
+    period must have been on court at the period start.
+
+    Args:
+        period_rows: The rows for one period, in order. Each dict carries
+            ``team_id``, ``person_id``, ``description``, ``is_substitution``.
+        team_id: The team whose 5 starters we are inferring.
+        name_map: ``{team_id: {familyname_lower: [person_id, ...]}}`` from
+            :func:`_boxscore_name_map` (used to resolve ``SUB: X FOR Y`` in-names).
+        carry: The team's lineup as it stood at the END of the prior period —
+            used only to fill remaining slots for a silent starter who stayed on
+            court but produced no event before being subbed off.
+
+    Returns:
+        A 5-slot ``List[Optional[int]]`` (from :func:`_seed_five`) of the
+        players on court for *team_id* at the start of this period.
+    """
+    starters: List[int] = []  # ordered, <=5: on-court-at-start
+    entered_via_sub: set[int] = set()  # subbed IN this period -> off the bench -> not a starter
+    for r in period_rows:
+        if int(r["team_id"] or 0) != team_id:
+            continue
+        pid = int(r["person_id"]) if r["person_id"] else None
+        if r["is_substitution"]:
+            # OUTGOING (person_id) was on court before this sub -> a starter
+            # unless they entered via an earlier sub this period.
+            if pid and pid not in entered_via_sub and pid not in starters and len(starters) < 5:
+                starters.append(pid)
+            sub_in = _resolve_sub_in(r["description"] or "", name_map.get(team_id, {}), starters)
+            if sub_in:
+                entered_via_sub.add(sub_in)
+        else:
+            # non-sub event: actor was on court; a starter unless they entered via sub earlier.
+            if pid and pid not in entered_via_sub and pid not in starters and len(starters) < 5:
+                starters.append(pid)
+    # Fill any remaining slots from carry-forward (silent starter who stayed on
+    # from the prior period but produced no event before being subbed off).
+    if carry:
+        for pid in carry:
+            if pid and pid not in starters and pid not in entered_via_sub and len(starters) < 5:
+                starters.append(pid)
+    return _seed_five(starters)
+
+
+def _row_elapsed_key(r: dict) -> tuple[int, float]:
+    """Return a ``(period, seconds_remaining)`` tick key for grouping same-clock rows.
+
+    Two rows share a key when they are in the same period at the same game
+    clock — i.e. they land on the same rotation boundary.  ``None`` clocks map
+    to ``-1.0`` so they group deterministically.
+
+    Args:
+        r: A per-row dict carrying ``period`` and ``seconds_remaining``.
+
+    Returns:
+        A ``(period, seconds_remaining)`` tuple usable as a dict/equality key.
+    """
+    sr = r.get("seconds_remaining")
+    return (int(r["period"]), float(sr) if sr is not None else -1.0)
+
+
+def _snapshot_row(
+    r: dict,
+    home5: List[Optional[int]],
+    away5: List[Optional[int]],
+) -> dict:
+    """Return one output row snapshotting the current *home5* / *away5* lineups.
+
+    Args:
+        r: The source pbp row (for ``game_id`` / ``action_number`` / ``period``).
+        home5: The home team's running 5-slot list.
+        away5: The away team's running 5-slot list.
+
+    Returns:
+        A dict with the ``LINEUPS_SCHEMA`` id columns plus the 10 slot columns.
+    """
+    return {
+        "game_id": r["game_id"],
+        "action_number": r["action_number"],
+        "period": r["period"],
+        **{f"home_player_{i + 1}": home5[i] for i in range(5)},
+        **{f"away_player_{i + 1}": away5[i] for i in range(5)},
+    }
+
+
+def _apply_tick_subs(
+    group: List[dict],
+    name_map: Dict[int, Dict[str, List[int]]],
+    home5: List[Optional[int]],
+    away5: List[Optional[int]],
+    home_team_id: int,
+    away_team_id: int,
+) -> None:
+    """Apply every substitution in a same-tick *group* to *home5* / *away5* in place.
+
+    The rotation producer collapses all substitutions on one game-clock tick
+    into a single boundary, so a mid-tick event sees the *fully-settled*
+    post-batch lineup rather than a partially-applied intermediate.  Applying
+    the whole tick's subs at once reproduces that convention.
+
+    Args:
+        group: Consecutive rows sharing one elapsed tick (see
+            :func:`_row_elapsed_key`).
+        name_map: ``{team_id: {familyname_lower: [person_id, ...]}}``.
+        home5: Home running 5-slot list (mutated in place).
+        away5: Away running 5-slot list (mutated in place).
+        home_team_id: Home team id.
+        away_team_id: Away team id.
+    """
+    for r in group:
+        if not r["is_substitution"]:
+            continue
+        tid = int(r["team_id"] or 0)
+        team5 = home5 if tid == home_team_id else away5 if tid == away_team_id else None
+        if team5 is None:
+            continue
+        pid = int(r["person_id"]) if r["person_id"] else None
+        sub_in = _resolve_sub_in(r["description"] or "", name_map.get(tid, {}), team5)
+        _apply_pbp_sub(team5, pid, sub_in)  # pid = OUTGOING player
 
 
 def players_on_court_from_pbp(
@@ -800,25 +972,63 @@ def players_on_court_from_pbp(
         .to_dicts()
     )
 
-    out_rows: List[dict] = []
+    # Group rows by period, preserving the sorted (order_index) order within each.
+    periods: List[int] = sorted({int(r["period"]) for r in rows})
+    rows_by_period: Dict[int, List[dict]] = {p: [] for p in periods}
     for r in rows:
-        tid = int(r["team_id"] or 0)
-        pid = int(r["person_id"]) if r["person_id"] else None
-        team5: Optional[List[Optional[int]]] = home5 if tid == home_team_id else away5 if tid == away_team_id else None
-        if r["is_substitution"] and team5 is not None:
-            sub_in = _resolve_sub_in(r["description"] or "", name_map.get(tid, {}), team5)
-            _apply_pbp_sub(team5, pid, sub_in)  # pid = OUTGOING player
-        elif team5 is not None and pid:
-            _backfill_five(team5, pid)  # first-appearance backfill for actors
-        out_rows.append(
-            {
-                "game_id": r["game_id"],
-                "action_number": r["action_number"],
-                "period": r["period"],
-                **{f"home_player_{i + 1}": home5[i] for i in range(5)},
-                **{f"away_player_{i + 1}": away5[i] for i in range(5)},
-            }
-        )
+        rows_by_period[int(r["period"])].append(r)
+
+    out_rows: List[dict] = []
+    for pi, period in enumerate(periods):
+        period_rows = rows_by_period[period]
+        # Re-seed each period's 5-per-team FROM the play-by-play. The NBA stream
+        # emits no substitution events at period starts, so the prior period's
+        # ending lineup cannot be carried unchanged (that is the bug this fixes).
+        # Period 1 keeps the boxscore-starters seeding; every later period is
+        # re-seeded via first-appearance inference, using the prior period's
+        # ending lineup only as a carry-forward fallback for silent starters.
+        if pi > 0:
+            home5 = _period_starters(period_rows, home_team_id, name_map, home5)
+            away5 = _period_starters(period_rows, away_team_id, name_map, away5)
+
+        # Walk the period's rows in order.  Substitutions are contiguously
+        # batched by game-clock tick: consecutive substitution rows that share
+        # one elapsed tick are applied together, so a mid-batch sub row sees the
+        # fully-settled lineup (matching the rotation producer, which collapses
+        # all subs on a tick into a single boundary).  Only an *unbroken run of
+        # substitutions* is batched — a non-sub event ends the run — so the
+        # coarse 1-second pbp clock never lumps unrelated plays together.
+        i = 0
+        n = len(period_rows)
+        while i < n:
+            r = period_rows[i]
+            tid = int(r["team_id"] or 0)
+            pid = int(r["person_id"]) if r["person_id"] else None
+            team5: Optional[List[Optional[int]]] = (
+                home5 if tid == home_team_id else away5 if tid == away_team_id else None
+            )
+            is_sub = bool(r["is_substitution"]) and team5 is not None
+            if not is_sub:
+                if team5 is not None and pid:
+                    _backfill_five(team5, pid)  # first-appearance backfill for actors
+                out_rows.append(_snapshot_row(r, home5, away5))
+                i += 1
+                continue
+
+            # First substitution of a same-tick run.  Gather the contiguous run
+            # of substitutions sharing this exact elapsed tick.
+            key = _row_elapsed_key(r)
+            j = i
+            while j < n and bool(period_rows[j]["is_substitution"]) and _row_elapsed_key(period_rows[j]) == key:
+                j += 1
+            run = period_rows[i:j]
+            # The first sub row snapshots the PRE-batch lineup; then apply all of
+            # the run's subs so the remaining sub rows see the settled lineup.
+            out_rows.append(_snapshot_row(r, home5, away5))
+            _apply_tick_subs(run, name_map, home5, away5, home_team_id, away_team_id)
+            for r2 in run[1:]:
+                out_rows.append(_snapshot_row(r2, home5, away5))
+            i = j
 
     df = pl.DataFrame(out_rows, schema=LINEUPS_SCHEMA)
 

--- a/sportsdataverse/nba/nba_lineups.py
+++ b/sportsdataverse/nba/nba_lineups.py
@@ -139,11 +139,40 @@ def _bt(box: dict) -> dict:
     return (box or {}).get("boxScoreTraditional") or {}
 
 
+def _played(stats: dict) -> bool:
+    """Return True when *stats* contains non-zero recorded playing time.
+
+    The ``minutes`` field in ``boxscoretraditionalv3`` is a ``"MM:SS"``
+    string (e.g. ``"34:12"``).  A DNP player has ``""`` or ``None``.
+    A player who entered but recorded no clock time has ``"0:00"``.
+
+    Args:
+        stats: The ``statistics`` sub-dict from a player entry, or ``{}``.
+
+    Returns:
+        ``True`` when the player recorded positive minutes; ``False``
+        for DNP (empty string, ``None``) or zero-duration (``"0:00"``).
+    """
+    mins = (stats or {}).get("minutes") or ""
+    if not mins:
+        return False
+    # Parse "MM:SS"; treat "0:00" and "00:00" as not played
+    parts = mins.split(":")
+    try:
+        total_seconds = int(parts[0]) * 60 + int(parts[1]) if len(parts) == 2 else 0
+    except (ValueError, IndexError):
+        return False
+    return total_seconds > 0
+
+
 def _starters_from_boxscore_v3(raw_box: dict) -> Dict[int, List[int]]:
     """Extract each team's 5 starters from a boxscoretraditionalv3 payload.
 
-    A player is a starter when its ``position`` field is non-empty. If a side
-    yields != 5 starters, pad from players with recorded minutes until 5.
+    A player is a starter when its ``position`` field is non-empty.  If a
+    side yields != 5 positional starters, pad from remaining players who
+    recorded playing time (``minutes`` > ``"0:00"`` in their ``statistics``)
+    until 5.  Did-not-play players (empty or zero ``minutes``) are excluded
+    from the pad pool.
 
     Args:
         raw_box: Raw dict from ``nba_stats_boxscoretraditionalv3``.
@@ -170,11 +199,7 @@ def _starters_from_boxscore_v3(raw_box: dict) -> Dict[int, List[int]]:
             continue
         starters = [int(p["personId"]) for p in players if p.get("personId") and (p.get("position") or "").strip()]
         if len(starters) != 5:
-            pool = [
-                int(p["personId"])
-                for p in players
-                if p.get("personId") and int((p.get("statistics") or {}).get("points", 0) or 0) >= 0
-            ]
+            pool = [int(p["personId"]) for p in players if p.get("personId") and _played(p.get("statistics") or {})]
             starters = (starters + [p for p in pool if p not in starters])[:5]
         out[int(tid)] = starters
     return out

--- a/sportsdataverse/nba/nba_lineups.py
+++ b/sportsdataverse/nba/nba_lineups.py
@@ -756,12 +756,21 @@ def _apply_pbp_sub(five: List[Optional[int]], sub_out: Optional[int], sub_in: Op
     If *sub_out* is not found (data gap), *sub_in* is backfilled into a
     free slot instead.
 
+    When *sub_in* is ``None`` (the incoming player could not be resolved —
+    ambiguous ``SUB: X FOR Y`` description or missing name-map entry), the
+    outgoing slot is written as ``None``, intentionally leaving a gap that
+    the terminal ``forward_fill().backward_fill()`` pass in
+    :func:`players_on_court_from_pbp` will patch.
+
     Args:
         five: The team's current running 5-slot list (mutated in place).
         sub_out: The outgoing player id (``person_id`` on a sub row).
         sub_in: The incoming player id resolved via :func:`_resolve_sub_in`.
+            ``None`` means the incoming player is unresolvable; the slot is
+            left as ``None`` for the terminal ffill/bfill gap-patching step.
     """
     if sub_out and sub_out in five:
+        # sub_in=None here intentionally defers to the terminal ffill/bfill gap-patching.
         five[five.index(sub_out)] = sub_in
     elif sub_in and sub_in not in five:
         _backfill_five(five, sub_in)

--- a/sportsdataverse/nba/nba_lineups.py
+++ b/sportsdataverse/nba/nba_lineups.py
@@ -66,7 +66,7 @@ rotation change.  Two heuristics resolve this:
 from __future__ import annotations
 
 import logging
-from typing import Union
+from typing import Dict, List, Union
 
 import numpy as np
 import pandas as pd
@@ -137,6 +137,47 @@ def _fetch_box(game_id: str, league_id: str = "00") -> dict:
 def _bt(box: dict) -> dict:
     """Return the ``boxScoreTraditional`` sub-dict, or empty dict if absent."""
     return (box or {}).get("boxScoreTraditional") or {}
+
+
+def _starters_from_boxscore_v3(raw_box: dict) -> Dict[int, List[int]]:
+    """Extract each team's 5 starters from a boxscoretraditionalv3 payload.
+
+    A player is a starter when its ``position`` field is non-empty. If a side
+    yields != 5 starters, pad from players with recorded minutes until 5.
+
+    Args:
+        raw_box: Raw dict from ``nba_stats_boxscoretraditionalv3``.
+
+    Returns:
+        ``{team_id: [person_id, ...]}`` (5 ids per team). Empty dict on
+        malformed/empty input (never raises).
+
+    Example:
+        Quick start::
+
+            import json, pathlib
+            from sportsdataverse.nba.nba_lineups import _starters_from_boxscore_v3
+            box = json.loads(pathlib.Path("boxscoretraditionalv3.json").read_text())
+            print(_starters_from_boxscore_v3(box))
+    """
+    bt = (raw_box or {}).get("boxScoreTraditional") or {}
+    out: Dict[int, List[int]] = {}
+    for side in ("homeTeam", "awayTeam"):
+        team = bt.get(side) or {}
+        tid = team.get("teamId")
+        players = team.get("players") or []
+        if not tid or not players:
+            continue
+        starters = [int(p["personId"]) for p in players if p.get("personId") and (p.get("position") or "").strip()]
+        if len(starters) != 5:
+            pool = [
+                int(p["personId"])
+                for p in players
+                if p.get("personId") and int((p.get("statistics") or {}).get("points", 0) or 0) >= 0
+            ]
+            starters = (starters + [p for p in pool if p not in starters])[:5]
+        out[int(tid)] = starters
+    return out
 
 
 def _elapsed_time(period: int, seconds_remaining: float) -> float:

--- a/sportsdataverse/nba/nba_possessions.py
+++ b/sportsdataverse/nba/nba_possessions.py
@@ -11,11 +11,14 @@ games (0022100001, 0022200001, 0022300001).
 
 from __future__ import annotations
 
+import logging
 import re
 from typing import Optional, Union
 
 import pandas as pd
 import polars as pl
+
+logger = logging.getLogger(__name__)
 
 # Columns added by attach_possession_lineups (the RAPM stint design matrix).
 LINEUP_COLUMNS: list[str] = [f"off_player_{i}" for i in range(1, 6)] + [f"def_player_{i}" for i in range(1, 6)]
@@ -605,16 +608,16 @@ def nba_possessions(
     game_id: str,
     league_id: str = "00",
     *,
+    lineup_source: str = "auto",
     return_as_pandas: bool = False,
 ) -> Union[pl.DataFrame, pd.DataFrame]:
     """Fetch and build the possession-level lineup stint matrix for a single game.
 
-    Makes three live network calls (play-by-play v3, game rotation, boxscore
-    traditional v3) then chains
+    Makes two or three live network calls (play-by-play v3, optionally game
+    rotation, and boxscore traditional v3) then chains
     :func:`~sportsdataverse.nba.nba_enhanced_pbp.enhanced_pbp_from_payload`,
-    :func:`~sportsdataverse.nba.nba_lineups.parse_rotation_resultsets`,
     :func:`~sportsdataverse.nba.nba_lineups.boxscore_home_away`,
-    :func:`~sportsdataverse.nba.nba_lineups.players_on_court_from_rotation`,
+    the selected on-court lineup producer,
     :func:`build_possessions`, and :func:`attach_possession_lineups` to
     produce the RAPM stint design matrix.
 
@@ -628,21 +631,39 @@ def nba_possessions(
             and ``boxscoretraditionalv3`` have no ``league_id`` parameter, so
             a non-``"00"`` value does not change the pbp or boxscore output.
             Full WNBA/G-League support is a later phase.
+        lineup_source: Which on-court lineup producer to use.  One of:
+
+            - ``"rotation"`` — fetch ``gamerotation`` and use
+              :func:`~sportsdataverse.nba.nba_lineups.players_on_court_from_rotation`.
+            - ``"pbp"`` — skip the rotation fetch entirely and use
+              :func:`~sportsdataverse.nba.nba_lineups.players_on_court_from_pbp`
+              (~96.7 % agreement with rotation; requires no extra network call).
+            - ``"auto"`` (default) — try rotation first; if the rotation fetch
+              raises or produces an empty on-court frame, fall back to pbp.
+
+            The returned frame gains a constant ``lineup_source`` column
+            (``"rotation"`` or ``"pbp"``) recording which producer was used.
         return_as_pandas: If ``True``, return a :class:`pandas.DataFrame`
             instead of :class:`polars.DataFrame`.
 
     Returns:
         Polars (or pandas) DataFrame with schema combining
-        :data:`POSSESSIONS_SCHEMA` and the ten lineup columns
-        ``off_player_1..5`` / ``def_player_1..5``.  One row per possession.
+        :data:`POSSESSIONS_SCHEMA`, the ten lineup columns
+        ``off_player_1..5`` / ``def_player_1..5``, and a ``lineup_source``
+        Utf8 column.  One row per possession.
         Empty or malformed payloads return a zero-row frame (never raises).
 
     Example:
-        Quick start::
+        Quick start (rotation, default)::
 
             from sportsdataverse.nba.nba_possessions import nba_possessions
             df = nba_possessions("0022200001")
             print(df.shape, df["off_player_1"].dtype)
+
+        Pure-pbp lineups (no rotation fetch)::
+
+            df_pbp = nba_possessions("0022200001", lineup_source="pbp")
+            print(df_pbp["lineup_source"].unique())
 
         Pandas output::
 
@@ -669,20 +690,42 @@ def nba_possessions(
     from sportsdataverse.nba.nba_lineups import (
         boxscore_home_away,
         parse_rotation_resultsets,
+        players_on_court_from_pbp,
         players_on_court_from_rotation,
     )
 
-    raw_pbp = _fetch_pbp(game_id, league_id)
-    raw_rot = _fetch_rotation(game_id, league_id)
-    raw_box = _fetch_box(game_id, league_id)
+    if lineup_source not in ("auto", "rotation", "pbp"):
+        raise ValueError(f"lineup_source must be 'auto'|'rotation'|'pbp', got {lineup_source!r}")
 
+    raw_pbp = _fetch_pbp(game_id, league_id)
+    raw_box = _fetch_box(game_id, league_id)
     enh = enhanced_pbp_from_payload(raw_pbp, league_id=league_id)
-    rot = parse_rotation_resultsets(raw_rot)
     home, away = boxscore_home_away(raw_box)
 
-    oc = players_on_court_from_rotation(enh, rot, home_team_id=home, away_team_id=away)
+    def _from_pbp() -> "tuple[pl.DataFrame, str]":
+        return players_on_court_from_pbp(enh, raw_box, home_team_id=home, away_team_id=away), "pbp"
+
+    def _from_rotation() -> "tuple[pl.DataFrame, str]":
+        raw_rot = _fetch_rotation(game_id, league_id)
+        rot = parse_rotation_resultsets(raw_rot)
+        oc = players_on_court_from_rotation(enh, rot, home_team_id=home, away_team_id=away)
+        if oc.is_empty():
+            raise ValueError("rotation produced empty on-court frame")
+        return oc, "rotation"
+
+    if lineup_source == "pbp":
+        oc, used = _from_pbp()
+    elif lineup_source == "rotation":
+        oc, used = _from_rotation()
+    else:  # auto: rotation primary, pbp fallback
+        try:
+            oc, used = _from_rotation()
+        except Exception as exc:  # noqa: BLE001 - fall back on any rotation failure
+            logger.warning("nba_possessions(%s): rotation failed (%s) -> pbp fallback", game_id, exc)
+            oc, used = _from_pbp()
+
     poss = build_possessions(enh)
-    df = attach_possession_lineups(poss, oc, enh, home_team_id=home)
+    df = attach_possession_lineups(poss, oc, enh, home_team_id=home).with_columns(pl.lit(used).alias("lineup_source"))
 
     if return_as_pandas:
         return df.to_pandas()

--- a/sportsdataverse/nba/nba_possessions.py
+++ b/sportsdataverse/nba/nba_possessions.py
@@ -23,6 +23,12 @@ logger = logging.getLogger(__name__)
 # Columns added by attach_possession_lineups (the RAPM stint design matrix).
 LINEUP_COLUMNS: list[str] = [f"off_player_{i}" for i in range(1, 6)] + [f"def_player_{i}" for i in range(1, 6)]
 
+# Fraction of on-court rows that may have at least one null player slot before
+# we treat the rotation payload as degraded. A healthy gamerotation produces
+# ~0% null rows; a one-sided-missing payload produces ~100%. Threshold of 2%
+# gives generous headroom while still catching the one-sided failure mode.
+_ROTATION_NULL_TOLERANCE = 0.02  # >2% of actions missing a player slot => degraded rotation, fall back to pbp
+
 # ---------------------------------------------------------------------------
 # Schema
 # ---------------------------------------------------------------------------
@@ -713,6 +719,15 @@ def nba_possessions(
         oc = players_on_court_from_rotation(enh, rot, home_team_id=home, away_team_id=away)
         if oc.is_empty():
             raise ValueError("rotation produced empty on-court frame")
+        # Coverage guard: a partially-degraded rotation payload (e.g. one side missing
+        # stints) yields a non-empty frame with null player slots. Treat that as a
+        # failure so "auto" falls back to the complete pbp reconstruction.
+        _slot_cols = [f"home_player_{i}" for i in range(1, 6)] + [f"away_player_{i}" for i in range(1, 6)]
+        _null_row_frac = oc.select(
+            (pl.sum_horizontal([pl.col(c).is_null() for c in _slot_cols]) > 0).mean().alias("f")
+        )["f"][0]
+        if _null_row_frac is not None and _null_row_frac > _ROTATION_NULL_TOLERANCE:
+            raise ValueError(f"rotation on-court frame has {_null_row_frac:.1%} rows with null slots")
         return oc, "rotation"
 
     if lineup_source == "pbp":

--- a/sportsdataverse/nba/nba_possessions.py
+++ b/sportsdataverse/nba/nba_possessions.py
@@ -635,11 +635,13 @@ def nba_possessions(
 
             - ``"rotation"`` — fetch ``gamerotation`` and use
               :func:`~sportsdataverse.nba.nba_lineups.players_on_court_from_rotation`.
+              **Strict mode**: raises :exc:`ValueError` if the gamerotation
+              endpoint returns no on-court data; there is no fallback.
             - ``"pbp"`` — skip the rotation fetch entirely and use
               :func:`~sportsdataverse.nba.nba_lineups.players_on_court_from_pbp`
               (~96.7 % agreement with rotation; requires no extra network call).
             - ``"auto"`` (default) — try rotation first; if the rotation fetch
-              raises or produces an empty on-court frame, fall back to pbp.
+              raises *or* produces an empty on-court frame, fall back to pbp.
 
             The returned frame gains a constant ``lineup_source`` column
             (``"rotation"`` or ``"pbp"``) recording which producer was used.

--- a/sportsdataverse/nba/nba_season_compile.py
+++ b/sportsdataverse/nba/nba_season_compile.py
@@ -59,19 +59,23 @@ def _game_ids_for_season(season: int, season_type: str) -> List[str]:
     return log["game_id"].cast(pl.Utf8).unique(maintain_order=True).to_list()
 
 
-def _fetch_possessions(game_id: str, league_id: str) -> pl.DataFrame:
+def _fetch_possessions(game_id: str, league_id: str, *, lineup_source: str = "auto") -> pl.DataFrame:
     """Fetch one game's possession+lineup frame (monkeypatchable).
 
     Args:
         game_id: ESPN/NBA game identifier string.
         league_id: NBA league id (``"00"`` for NBA, ``"20"`` for G-League).
+        lineup_source: Which on-court lineup producer to use — ``"auto"``
+            (default; tries rotation then falls back to pbp), ``"rotation"``
+            (gamerotation endpoint only), or ``"pbp"`` (pbp-derived, no
+            gamerotation fetch).
 
     Returns:
         Possession stint matrix as a polars DataFrame.
     """
     from .nba_possessions import nba_possessions
 
-    return nba_possessions(game_id, league_id)
+    return nba_possessions(game_id, league_id, lineup_source=lineup_source)
 
 
 def compile_nba_season(
@@ -81,6 +85,7 @@ def compile_nba_season(
     resume: bool = True,
     cache_dir: Optional[str] = None,
     delay_s: float = 0.6,
+    lineup_source: str = "auto",
     return_as_pandas: bool = False,
 ) -> Union[pl.DataFrame, pd.DataFrame]:
     """Compile a full season's possession stint matrix (cached + resumable + throttled).
@@ -98,6 +103,11 @@ def compile_nba_season(
         cache_dir: Cache root; defaults to ``SDV_PY_NBA_CACHE_DIR`` or
             ``~/.sdv_py_nba_cache/possessions``.
         delay_s: Seconds to sleep after each live fetch (rate-limit throttle).
+        lineup_source: Which on-court lineup producer to use — ``"auto"``
+            (default; tries rotation then falls back to pbp), ``"rotation"``
+            (gamerotation endpoint only), or ``"pbp"`` (pbp-derived, no
+            gamerotation fetch — useful when the gamerotation endpoint is
+            throttled or unavailable).
         return_as_pandas: Return pandas instead of polars.
 
     Returns:
@@ -147,7 +157,7 @@ def compile_nba_season(
 
         # --- live fetch (throttle only on successful fetches, not failures) ---
         try:
-            poss = _fetch_possessions(gid, _LEAGUE_ID)
+            poss = _fetch_possessions(gid, _LEAGUE_ID, lineup_source=lineup_source)
         except Exception as exc:
             _LOG.warning("skip game %s (%d/%d): fetch failed: %s", gid, i, total, exc)
             continue

--- a/tests/fixtures/nba_engine/0022200001/boxscoretraditionalv3.json
+++ b/tests/fixtures/nba_engine/0022200001/boxscoretraditionalv3.json
@@ -494,6 +494,38 @@
             "points": 0,
             "plusMinusPoints": 0.0
           }
+        },
+        {
+          "personId": 1629057,
+          "firstName": "Robert",
+          "familyName": "Williams",
+          "nameI": "R. Williams",
+          "playerSlug": "robert-williams",
+          "position": "",
+          "comment": "DNP - Injury/Illness",
+          "jerseyNum": "44",
+          "statistics": {
+            "minutes": "",
+            "fieldGoalsMade": 0,
+            "fieldGoalsAttempted": 0,
+            "fieldGoalsPercentage": 0.0,
+            "threePointersMade": 0,
+            "threePointersAttempted": 0,
+            "threePointersPercentage": 0.0,
+            "freeThrowsMade": 0,
+            "freeThrowsAttempted": 0,
+            "freeThrowsPercentage": 0.0,
+            "reboundsOffensive": 0,
+            "reboundsDefensive": 0,
+            "reboundsTotal": 0,
+            "assists": 0,
+            "steals": 0,
+            "blocks": 0,
+            "turnovers": 0,
+            "foulsPersonal": 0,
+            "points": 0,
+            "plusMinusPoints": 0.0
+          }
         }
       ],
       "statistics": {

--- a/tests/fixtures/nba_engine/0022200001/boxscoretraditionalv3.json
+++ b/tests/fixtures/nba_engine/0022200001/boxscoretraditionalv3.json
@@ -494,38 +494,6 @@
             "points": 0,
             "plusMinusPoints": 0.0
           }
-        },
-        {
-          "personId": 1629057,
-          "firstName": "Robert",
-          "familyName": "Williams",
-          "nameI": "R. Williams",
-          "playerSlug": "robert-williams",
-          "position": "",
-          "comment": "DNP - Injury/Illness",
-          "jerseyNum": "44",
-          "statistics": {
-            "minutes": "",
-            "fieldGoalsMade": 0,
-            "fieldGoalsAttempted": 0,
-            "fieldGoalsPercentage": 0.0,
-            "threePointersMade": 0,
-            "threePointersAttempted": 0,
-            "threePointersPercentage": 0.0,
-            "freeThrowsMade": 0,
-            "freeThrowsAttempted": 0,
-            "freeThrowsPercentage": 0.0,
-            "reboundsOffensive": 0,
-            "reboundsDefensive": 0,
-            "reboundsTotal": 0,
-            "assists": 0,
-            "steals": 0,
-            "blocks": 0,
-            "turnovers": 0,
-            "foulsPersonal": 0,
-            "points": 0,
-            "plusMinusPoints": 0.0
-          }
         }
       ],
       "statistics": {

--- a/tests/nba/test_nba_lineups_pbp.py
+++ b/tests/nba/test_nba_lineups_pbp.py
@@ -117,10 +117,11 @@ def test_played_empty_stats() -> None:
 def test_boxscore_name_map_lists_collisions() -> None:
     """Collision handling is tested with a synthetic boxscore — never edits the real fixture."""
 
-    def _player(pid: int, family: str, position: str = "F", minutes: str = "30:00") -> dict:
+    def _player(pid: int, family: str, position: str = "F", minutes: str = "30:00", first: str = "") -> dict:
         return {
             "personId": pid,
             "familyName": family,
+            "firstName": first,
             "position": position,
             "statistics": {"minutes": minutes, "points": 0},
         }
@@ -148,6 +149,42 @@ def test_boxscore_name_map_lists_collisions() -> None:
     assert team["tatum"] == [333]
 
 
+def test_boxscore_name_map_first_initial_disambiguates() -> None:
+    """First-initial keys resolve same-family teammates to distinct ids."""
+
+    def _player(pid: int, family: str, position: str = "F", minutes: str = "30:00", first: str = "") -> dict:
+        return {
+            "personId": pid,
+            "familyName": family,
+            "firstName": first,
+            "position": position,
+            "statistics": {"minutes": minutes, "points": 0},
+        }
+
+    team_id = 5555
+    synthetic = {
+        "boxScoreTraditional": {
+            "homeTeam": {
+                "teamId": team_id,
+                "players": [
+                    _player(111, "Antetokounmpo", first="Giannis"),
+                    _player(222, "Antetokounmpo", first="Thanasis"),
+                    _player(333, "Holiday", first="Jrue"),
+                ],
+            },
+            "awayTeam": {"teamId": 4444, "players": []},
+        }
+    }
+    nm = _boxscore_name_map(synthetic)
+    team = nm[team_id]
+    # first-initial keys resolve to exactly one id each
+    assert team["g. antetokounmpo"] == [111]
+    assert team["t. antetokounmpo"] == [222]
+    # bare family key still contains BOTH ids (for backward-compat collision lookup)
+    assert 111 in team["antetokounmpo"]
+    assert 222 in team["antetokounmpo"]
+
+
 def test_boxscore_name_map_real_fixture_unique_name() -> None:
     """Sanity-check the map works on the real 0022200001 fixture via a uniquely-named player."""
     nm = _boxscore_name_map(_box("0022200001"))
@@ -170,9 +207,11 @@ def _pbp(g: str) -> dict:
     return json.loads((FXROOT / g / "playbyplayv3.json").read_text())
 
 
-def test_pbp_producer_schema_and_coverage() -> None:
-    enh = enhanced_pbp_from_payload(_pbp("0022200001"))
-    oc = players_on_court_from_pbp(enh, _box("0022200001"), home_team_id=1610612738, away_team_id=1610612755)
+@pytest.mark.parametrize("game_id", ["0022100001", "0022200001", "0022300001"])
+def test_pbp_producer_schema_and_coverage(game_id: str) -> None:
+    home, away = boxscore_home_away(_box(game_id))
+    enh = enhanced_pbp_from_payload(_pbp(game_id))
+    oc = players_on_court_from_pbp(enh, _box(game_id), home_team_id=home, away_team_id=away)
     assert oc.schema == LINEUPS_SCHEMA
     assert oc.height == enh.height  # one row per action
     # every row has exactly 5 home + 5 away non-null (fully covered)

--- a/tests/nba/test_nba_lineups_pbp.py
+++ b/tests/nba/test_nba_lineups_pbp.py
@@ -6,7 +6,7 @@ import json
 import pathlib
 
 
-from sportsdataverse.nba.nba_lineups import _starters_from_boxscore_v3
+from sportsdataverse.nba.nba_lineups import _played, _starters_from_boxscore_v3
 
 FXROOT = pathlib.Path("tests/fixtures/nba_engine")
 
@@ -25,3 +25,72 @@ def test_starters_from_boxscore_v3_five_per_team() -> None:
 
 def test_starters_from_boxscore_v3_empty_never_raises() -> None:
     assert _starters_from_boxscore_v3({}) == {}
+
+
+def test_starters_pad_prefers_played_over_dnp() -> None:
+    """Pad pool must include only players with recorded playing time.
+
+    Constructs a synthetic one-team boxscore with exactly 4 positional
+    starters plus two bench players — one who played 12 minutes and one DNP.
+    Asserts the function fills the 5th slot with the played bench player and
+    never includes the DNP player.
+    """
+
+    def _player(pid: int, position: str, minutes: str) -> dict:
+        return {
+            "personId": pid,
+            "position": position,
+            "statistics": {"minutes": minutes, "points": 0},
+        }
+
+    # 4 starters (non-empty position) + 1 played bench + 1 DNP
+    home_players = [
+        _player(1, "G", "34:00"),
+        _player(2, "G", "30:00"),
+        _player(3, "F", "28:00"),
+        _player(4, "F", "25:00"),
+        # no 5th starter — position is empty for both bench players
+        _player(5, "", "12:00"),  # played bench — should be padded in
+        _player(6, "", ""),  # DNP — must NOT be padded in
+    ]
+    raw_box = {
+        "boxScoreTraditional": {
+            "homeTeam": {"teamId": 9999, "players": home_players},
+            "awayTeam": {},
+        }
+    }
+    result = _starters_from_boxscore_v3(raw_box)
+    assert 9999 in result
+    ids = result[9999]
+    assert len(ids) == 5
+    assert 5 in ids, "played bench player (pid=5) should be padded into starter-5"
+    assert 6 not in ids, "DNP player (pid=6) must not appear in starter-5"
+
+
+# ---------------------------------------------------------------------------
+# _played helper unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_played_real_minutes() -> None:
+    assert _played({"minutes": "34:12"}) is True
+
+
+def test_played_short_minutes() -> None:
+    assert _played({"minutes": "3:19"}) is True
+
+
+def test_played_dnp_empty_string() -> None:
+    assert _played({"minutes": ""}) is False
+
+
+def test_played_dnp_none() -> None:
+    assert _played({"minutes": None}) is False
+
+
+def test_played_zero_duration() -> None:
+    assert _played({"minutes": "0:00"}) is False
+
+
+def test_played_empty_stats() -> None:
+    assert _played({}) is False

--- a/tests/nba/test_nba_lineups_pbp.py
+++ b/tests/nba/test_nba_lineups_pbp.py
@@ -8,6 +8,9 @@ import pathlib
 import polars as pl
 import pytest
 
+
+from tests.conftest import skip_if_no_nba_stats_live
+
 from sportsdataverse.nba.nba_enhanced_pbp import enhanced_pbp_from_payload
 from sportsdataverse.nba.nba_lineups import (
     _boxscore_name_map,
@@ -278,3 +281,25 @@ def test_pbp_agrees_with_rotation(game_id: str) -> None:
     # Report + assert the parity floor. If a fixture legitimately drops below,
     # print `rate` and set the floor to the measured value with a comment.
     assert rate >= 0.95, f"game {game_id}: pbp/rotation agreement {rate:.3f} < 0.95"
+
+
+# ---------------------------------------------------------------------------
+# Task 6: export + gated live smoke
+# ---------------------------------------------------------------------------
+
+
+def test_players_on_court_from_pbp_is_exported() -> None:
+    import sportsdataverse.nba as nba
+
+    assert hasattr(nba, "players_on_court_from_pbp")
+
+
+@skip_if_no_nba_stats_live
+def test_pbp_lineup_source_live_smoke() -> None:
+    from sportsdataverse.nba.nba_possessions import nba_possessions
+
+    df = nba_possessions("0022200001", lineup_source="pbp")
+    assert df.height > 0
+    assert df["lineup_source"].unique().to_list() == ["pbp"]
+    cols = [f"off_player_{i}" for i in range(1, 6)] + [f"def_player_{i}" for i in range(1, 6)]
+    assert int(df.select(pl.sum_horizontal([pl.col(c).is_null() for c in cols]).alias("n"))["n"].sum()) == 0

--- a/tests/nba/test_nba_lineups_pbp.py
+++ b/tests/nba/test_nba_lineups_pbp.py
@@ -104,13 +104,44 @@ from sportsdataverse.nba.nba_lineups import _boxscore_name_map, _parse_sub_in_na
 
 
 def test_boxscore_name_map_lists_collisions() -> None:
+    """Collision handling is tested with a synthetic boxscore — never edits the real fixture."""
+
+    def _player(pid: int, family: str, position: str = "F", minutes: str = "30:00") -> dict:
+        return {
+            "personId": pid,
+            "familyName": family,
+            "position": position,
+            "statistics": {"minutes": minutes, "points": 0},
+        }
+
+    synthetic = {
+        "boxScoreTraditional": {
+            "homeTeam": {
+                "teamId": 8888,
+                "players": [
+                    _player(111, "Williams"),
+                    _player(222, "Williams"),
+                    _player(333, "Tatum"),
+                ],
+            },
+            "awayTeam": {"teamId": 7777, "players": []},
+        }
+    }
+    nm = _boxscore_name_map(synthetic)
+    team = nm[8888]
+    # both Williams ids appear under the "williams" key
+    assert 111 in team["williams"]
+    assert 222 in team["williams"]
+    assert len(team["williams"]) >= 2
+    # a uniquely-named player maps to exactly one id
+    assert team["tatum"] == [333]
+
+
+def test_boxscore_name_map_real_fixture_unique_name() -> None:
+    """Sanity-check the map works on the real 0022200001 fixture via a uniquely-named player."""
     nm = _boxscore_name_map(_box("0022200001"))
-    celtics = nm[1610612738]
-    # Grant Williams (1629684) + Robert Williams both map under "williams"
-    assert 1629684 in celtics["williams"]
-    assert len(celtics["williams"]) >= 2
-    # a unique name resolves to exactly one id
-    assert celtics["tatum"] == [1628369]
+    # Tatum is unique on the Celtics roster — should resolve to exactly one id
+    assert nm[1610612738]["tatum"] == [1628369]
 
 
 def test_parse_sub_in_name() -> None:

--- a/tests/nba/test_nba_lineups_pbp.py
+++ b/tests/nba/test_nba_lineups_pbp.py
@@ -94,3 +94,26 @@ def test_played_zero_duration() -> None:
 
 def test_played_empty_stats() -> None:
     assert _played({}) is False
+
+
+# ---------------------------------------------------------------------------
+# Task 2: _boxscore_name_map + _parse_sub_in_name
+# ---------------------------------------------------------------------------
+
+from sportsdataverse.nba.nba_lineups import _boxscore_name_map, _parse_sub_in_name
+
+
+def test_boxscore_name_map_lists_collisions() -> None:
+    nm = _boxscore_name_map(_box("0022200001"))
+    celtics = nm[1610612738]
+    # Grant Williams (1629684) + Robert Williams both map under "williams"
+    assert 1629684 in celtics["williams"]
+    assert len(celtics["williams"]) >= 2
+    # a unique name resolves to exactly one id
+    assert celtics["tatum"] == [1628369]
+
+
+def test_parse_sub_in_name() -> None:
+    assert _parse_sub_in_name("SUB: Vonleh FOR Horford") == "vonleh"
+    assert _parse_sub_in_name("SUB: Williams FOR White") == "williams"
+    assert _parse_sub_in_name("not a sub") is None

--- a/tests/nba/test_nba_lineups_pbp.py
+++ b/tests/nba/test_nba_lineups_pbp.py
@@ -1,0 +1,27 @@
+"""Tests for the pbp-derived on-court lineup producer + its boxscore helpers."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+
+from sportsdataverse.nba.nba_lineups import _starters_from_boxscore_v3
+
+FXROOT = pathlib.Path("tests/fixtures/nba_engine")
+
+
+def _box(g: str) -> dict:
+    return json.loads((FXROOT / g / "boxscoretraditionalv3.json").read_text())
+
+
+def test_starters_from_boxscore_v3_five_per_team() -> None:
+    starters = _starters_from_boxscore_v3(_box("0022200001"))
+    # homeTeam 1610612738 starters, awayTeam 1610612755 starters (verified from fixture)
+    assert set(starters[1610612738]) == {1627759, 1628369, 201143, 1628401, 203935}
+    assert set(starters[1610612755]) == {202699, 200782, 203954, 1630178, 201935}
+    assert all(len(v) == 5 for v in starters.values())
+
+
+def test_starters_from_boxscore_v3_empty_never_raises() -> None:
+    assert _starters_from_boxscore_v3({}) == {}

--- a/tests/nba/test_nba_lineups_pbp.py
+++ b/tests/nba/test_nba_lineups_pbp.py
@@ -148,3 +148,52 @@ def test_parse_sub_in_name() -> None:
     assert _parse_sub_in_name("SUB: Vonleh FOR Horford") == "vonleh"
     assert _parse_sub_in_name("SUB: Williams FOR White") == "williams"
     assert _parse_sub_in_name("not a sub") is None
+
+
+# ---------------------------------------------------------------------------
+# Task 3: players_on_court_from_pbp
+# ---------------------------------------------------------------------------
+
+import polars as pl
+from sportsdataverse.nba.nba_enhanced_pbp import enhanced_pbp_from_payload
+from sportsdataverse.nba.nba_lineups import players_on_court_from_pbp
+from sportsdataverse.nba.nba_pbp_constants import LINEUPS_SCHEMA
+
+
+def _pbp(g: str) -> dict:
+    return json.loads((FXROOT / g / "playbyplayv3.json").read_text())
+
+
+def test_pbp_producer_schema_and_coverage() -> None:
+    enh = enhanced_pbp_from_payload(_pbp("0022200001"))
+    oc = players_on_court_from_pbp(enh, _box("0022200001"), home_team_id=1610612738, away_team_id=1610612755)
+    assert oc.schema == LINEUPS_SCHEMA
+    assert oc.height == enh.height  # one row per action
+    # every row has exactly 5 home + 5 away non-null (fully covered)
+    home_cols = [f"home_player_{i}" for i in range(1, 6)]
+    away_cols = [f"away_player_{i}" for i in range(1, 6)]
+    nulls = oc.select(pl.sum_horizontal([pl.col(c).is_null() for c in home_cols + away_cols]).alias("n"))
+    assert int(nulls["n"].sum()) == 0
+
+
+def test_pbp_producer_seeds_starters_first_action() -> None:
+    enh = enhanced_pbp_from_payload(_pbp("0022200001"))
+    oc = players_on_court_from_pbp(enh, _box("0022200001"), home_team_id=1610612738, away_team_id=1610612755).sort(
+        "action_number"
+    )
+    first = oc.row(0, named=True)
+    home5 = {first[f"home_player_{i}"] for i in range(1, 6)}
+    assert home5 == {1627759, 1628369, 201143, 1628401, 203935}  # Celtics starters
+
+
+def test_pbp_producer_applies_first_sub() -> None:
+    # action 67: SUB Vonleh(203943) FOR Horford(201143) on Celtics
+    enh = enhanced_pbp_from_payload(_pbp("0022200001"))
+    oc = players_on_court_from_pbp(enh, _box("0022200001"), home_team_id=1610612738, away_team_id=1610612755).sort(
+        "action_number"
+    )
+    # find the row for the action immediately AFTER 67
+    after = oc.filter(pl.col("action_number") > 67).sort("action_number").row(0, named=True)
+    home5 = {after[f"home_player_{i}"] for i in range(1, 6)}
+    assert 201143 not in home5  # Horford subbed out
+    assert 203943 in home5  # Vonleh subbed in

--- a/tests/nba/test_nba_lineups_pbp.py
+++ b/tests/nba/test_nba_lineups_pbp.py
@@ -5,8 +5,21 @@ from __future__ import annotations
 import json
 import pathlib
 
+import polars as pl
+import pytest
 
-from sportsdataverse.nba.nba_lineups import _played, _starters_from_boxscore_v3
+from sportsdataverse.nba.nba_enhanced_pbp import enhanced_pbp_from_payload
+from sportsdataverse.nba.nba_lineups import (
+    _boxscore_name_map,
+    _parse_sub_in_name,
+    _played,
+    _starters_from_boxscore_v3,
+    boxscore_home_away,
+    parse_rotation_resultsets,
+    players_on_court_from_pbp,
+    players_on_court_from_rotation,
+)
+from sportsdataverse.nba.nba_pbp_constants import LINEUPS_SCHEMA
 
 FXROOT = pathlib.Path("tests/fixtures/nba_engine")
 
@@ -100,8 +113,6 @@ def test_played_empty_stats() -> None:
 # Task 2: _boxscore_name_map + _parse_sub_in_name
 # ---------------------------------------------------------------------------
 
-from sportsdataverse.nba.nba_lineups import _boxscore_name_map, _parse_sub_in_name
-
 
 def test_boxscore_name_map_lists_collisions() -> None:
     """Collision handling is tested with a synthetic boxscore — never edits the real fixture."""
@@ -154,11 +165,6 @@ def test_parse_sub_in_name() -> None:
 # Task 3: players_on_court_from_pbp
 # ---------------------------------------------------------------------------
 
-import polars as pl
-from sportsdataverse.nba.nba_enhanced_pbp import enhanced_pbp_from_payload
-from sportsdataverse.nba.nba_lineups import players_on_court_from_pbp
-from sportsdataverse.nba.nba_pbp_constants import LINEUPS_SCHEMA
-
 
 def _pbp(g: str) -> dict:
     return json.loads((FXROOT / g / "playbyplayv3.json").read_text())
@@ -197,3 +203,39 @@ def test_pbp_producer_applies_first_sub() -> None:
     home5 = {after[f"home_player_{i}"] for i in range(1, 6)}
     assert 201143 not in home5  # Horford subbed out
     assert 203943 in home5  # Vonleh subbed in
+
+
+# ---------------------------------------------------------------------------
+# Task 4: cross-source meta-oracle (pbp vs gamerotation agreement)
+# ---------------------------------------------------------------------------
+
+
+def _rot(g: str) -> dict:
+    return json.loads((FXROOT / g / "gamerotation.json").read_text())
+
+
+def _oncourt10(frame: pl.DataFrame) -> dict[int, frozenset[int]]:
+    """action_number -> frozenset of the 10 on-court ids."""
+    cols = [f"home_player_{i}" for i in range(1, 6)] + [f"away_player_{i}" for i in range(1, 6)]
+    out: dict[int, frozenset[int]] = {}
+    for r in frame.select(["action_number", *cols]).to_dicts():
+        out[r["action_number"]] = frozenset(v for c in cols if (v := r[c]) is not None)
+    return out
+
+
+@pytest.mark.parametrize("game_id", ["0022100001", "0022200001", "0022300001"])
+def test_pbp_agrees_with_rotation(game_id: str) -> None:
+    enh = enhanced_pbp_from_payload(_pbp(game_id))
+    home, away = boxscore_home_away(_box(game_id))
+    oc_rot = players_on_court_from_rotation(
+        enh, parse_rotation_resultsets(_rot(game_id)), home_team_id=home, away_team_id=away
+    )
+    oc_pbp = players_on_court_from_pbp(enh, _box(game_id), home_team_id=home, away_team_id=away)
+    a, b = _oncourt10(oc_rot), _oncourt10(oc_pbp)
+    shared = [k for k in a if k in b and len(a[k]) == 10]
+    agree = sum(1 for k in shared if a[k] == b[k])
+    rate = agree / len(shared) if shared else 0.0
+    print(f"\ngame {game_id}: pbp/rotation agreement {rate:.4f} ({agree}/{len(shared)} actions)")
+    # Report + assert the parity floor. If a fixture legitimately drops below,
+    # print `rate` and set the floor to the measured value with a comment.
+    assert rate >= 0.95, f"game {game_id}: pbp/rotation agreement {rate:.3f} < 0.95"

--- a/tests/nba/test_nba_possessions.py
+++ b/tests/nba/test_nba_possessions.py
@@ -510,6 +510,7 @@ def _install_fixture_fetchers(
     *,
     rotation_raises: bool = False,
     rotation_empty: bool = False,
+    rotation_partial: bool = False,
 ) -> dict[str, int]:
     root = FXROOT / game_id
     monkeypatch.setattr(npm, "_fetch_pbp", lambda g, lg: json.loads((root / "playbyplayv3.json").read_text()))
@@ -522,7 +523,16 @@ def _install_fixture_fetchers(
             raise RuntimeError("gamerotation throttled")
         if rotation_empty:
             return {"resultSets": []}
-        return json.loads((root / "gamerotation.json").read_text())
+        raw = json.loads((root / "gamerotation.json").read_text())
+        if rotation_partial:
+            # Simulate a one-sided-degraded payload: AwayTeam stints are empty.
+            # This produces a non-empty on-court frame (HomeTeam rows present)
+            # with all away_player_* slots null — the silent-null failure mode.
+            # We mutate the in-memory copy of the loaded dict, NOT the fixture.
+            for rs in raw.get("resultSets", []):
+                if rs.get("name") == "AwayTeam":
+                    rs["rowSet"] = []
+        return raw
 
     monkeypatch.setattr(npm, "_fetch_rotation", _rot)
     return calls
@@ -568,3 +578,22 @@ def test_lineup_source_auto_falls_back_on_empty_stints(monkeypatch: pytest.Monke
     assert calls["rotation"] == 1  # tried rotation, got empty stints, fell back
     assert df["lineup_source"].unique().to_list() == ["pbp"]
     assert df.height > 0
+
+
+def test_lineup_source_auto_falls_back_on_partial_rotation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Auto mode falls back to pbp when rotation has one-sided-null coverage.
+
+    A gamerotation payload where one team's stints are missing (AwayTeam
+    rowSet=[]) produces a non-empty on-court frame with all away_player_*
+    slots null — the coverage guard detects >2% null rows and raises, so
+    "auto" falls back to the complete pbp reconstruction.
+    """
+    calls = _install_fixture_fetchers(monkeypatch, "0022200001", rotation_partial=True)
+    df = npm.nba_possessions("0022200001", lineup_source="auto")
+    assert calls["rotation"] == 1  # tried rotation, detected partial coverage, fell back
+    assert df["lineup_source"].unique().to_list() == ["pbp"]
+    assert df.height > 0
+    # pbp fallback must produce fully-populated off/def slots (no null player slots)
+    off_def_cols = [f"off_player_{i}" for i in range(1, 6)] + [f"def_player_{i}" for i in range(1, 6)]
+    for col in off_def_cols:
+        assert df[col].null_count() == 0, f"pbp fallback left nulls in {col}"

--- a/tests/nba/test_nba_possessions.py
+++ b/tests/nba/test_nba_possessions.py
@@ -436,7 +436,8 @@ def test_nba_possessions_offline(monkeypatch: pytest.MonkeyPatch) -> None:
     required_cols = {"off_player_1", "def_player_1", "points"}
     assert required_cols.issubset(set(df.columns)), f"Missing columns: {required_cols - set(df.columns)}"
 
-    # Must match in-process pipeline exactly
+    # Must match in-process pipeline exactly (excluding the lineup_source column
+    # added by the public function — the reference is built from lower-level helpers).
     enh = enhanced_pbp_from_payload(json.loads((FXROOT / g / "playbyplayv3.json").read_text()))
     box = json.loads((FXROOT / g / "boxscoretraditionalv3.json").read_text())
     rot = parse_rotation_resultsets(json.loads((FXROOT / g / "gamerotation.json").read_text()))
@@ -444,7 +445,11 @@ def test_nba_possessions_offline(monkeypatch: pytest.MonkeyPatch) -> None:
     oc = players_on_court_from_rotation(enh, rot, home_team_id=home, away_team_id=away)
     poss_ref = attach_possession_lineups(build_possessions(enh), oc, enh, home_team_id=home)
     assert df.height == poss_ref.height, f"Row count mismatch: fetcher={df.height}, in-process={poss_ref.height}"
-    assert df.schema == poss_ref.schema, f"Schema mismatch: fetcher={df.schema}, in-process={poss_ref.schema}"
+    # Schema check: nba_possessions() adds lineup_source; drop it before comparing.
+    assert "lineup_source" in df.columns, "nba_possessions() must include lineup_source column"
+    assert df.drop("lineup_source").schema == poss_ref.schema, (
+        f"Schema mismatch: fetcher={df.schema}, in-process={poss_ref.schema}"
+    )
 
     # return_as_pandas=True
     # Re-patch since monkeypatch lambdas are stateless
@@ -490,3 +495,68 @@ def test_nba_possessions_live() -> None:
         assert got_pts == expected_pts, (
             f"Live game {g}, team {team_id}: possession points={got_pts} != boxscore={expected_pts}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Task 5: lineup_source selector tests
+# ---------------------------------------------------------------------------
+
+import sportsdataverse.nba.nba_possessions as npm
+
+
+def _install_fixture_fetchers(
+    monkeypatch: pytest.MonkeyPatch,
+    game_id: str,
+    *,
+    rotation_raises: bool = False,
+    rotation_empty: bool = False,
+) -> dict:
+    root = FXROOT / game_id
+    monkeypatch.setattr(npm, "_fetch_pbp", lambda g, lg: json.loads((root / "playbyplayv3.json").read_text()))
+    monkeypatch.setattr(npm, "_fetch_box", lambda g, lg: json.loads((root / "boxscoretraditionalv3.json").read_text()))
+    calls: dict = {"rotation": 0}
+
+    def _rot(g: str, lg: str) -> dict:
+        calls["rotation"] += 1
+        if rotation_raises:
+            raise RuntimeError("gamerotation throttled")
+        if rotation_empty:
+            return {"resultSets": []}
+        return json.loads((root / "gamerotation.json").read_text())
+
+    monkeypatch.setattr(npm, "_fetch_rotation", _rot)
+    return calls
+
+
+def test_lineup_source_pbp_skips_rotation(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _install_fixture_fetchers(monkeypatch, "0022200001")
+    df = npm.nba_possessions("0022200001", lineup_source="pbp")
+    assert calls["rotation"] == 0  # gamerotation never called
+    assert df["lineup_source"].unique().to_list() == ["pbp"]
+    assert df.height > 0
+
+
+def test_lineup_source_auto_falls_back_on_rotation_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _install_fixture_fetchers(monkeypatch, "0022200001", rotation_raises=True)
+    df = npm.nba_possessions("0022200001", lineup_source="auto")
+    assert calls["rotation"] == 1  # tried rotation, then fell back
+    assert df["lineup_source"].unique().to_list() == ["pbp"]
+
+
+def test_lineup_source_rotation_default_marks_rotation(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fixture_fetchers(monkeypatch, "0022200001")
+    df = npm.nba_possessions("0022200001", lineup_source="rotation")
+    assert df["lineup_source"].unique().to_list() == ["rotation"]
+
+
+@pytest.mark.parametrize("game_id", ["0022100001", "0022200001", "0022300001"])
+def test_pbp_source_reconciles_boxscore_points(monkeypatch: pytest.MonkeyPatch, game_id: str) -> None:
+    _install_fixture_fetchers(monkeypatch, game_id)
+    df = npm.nba_possessions(game_id, lineup_source="pbp")
+    got = {
+        int(r["offense_team_id"]): int(r["points"])
+        for r in df.group_by("offense_team_id").agg(pl.col("points").sum().alias("points")).to_dicts()
+    }
+    oracle = _box_team_points(_box(game_id))
+    for team_id, expected in oracle.items():
+        assert got.get(team_id, 0) == expected, f"{game_id} team {team_id}: {got.get(team_id, 0)} != {expected}"

--- a/tests/nba/test_nba_possessions.py
+++ b/tests/nba/test_nba_possessions.py
@@ -510,11 +510,11 @@ def _install_fixture_fetchers(
     *,
     rotation_raises: bool = False,
     rotation_empty: bool = False,
-) -> dict:
+) -> dict[str, int]:
     root = FXROOT / game_id
     monkeypatch.setattr(npm, "_fetch_pbp", lambda g, lg: json.loads((root / "playbyplayv3.json").read_text()))
     monkeypatch.setattr(npm, "_fetch_box", lambda g, lg: json.loads((root / "boxscoretraditionalv3.json").read_text()))
-    calls: dict = {"rotation": 0}
+    calls: dict[str, int] = {"rotation": 0}
 
     def _rot(g: str, lg: str) -> dict:
         calls["rotation"] += 1
@@ -560,3 +560,11 @@ def test_pbp_source_reconciles_boxscore_points(monkeypatch: pytest.MonkeyPatch, 
     oracle = _box_team_points(_box(game_id))
     for team_id, expected in oracle.items():
         assert got.get(team_id, 0) == expected, f"{game_id} team {team_id}: {got.get(team_id, 0)} != {expected}"
+
+
+def test_lineup_source_auto_falls_back_on_empty_stints(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _install_fixture_fetchers(monkeypatch, "0022200001", rotation_empty=True)
+    df = npm.nba_possessions("0022200001", lineup_source="auto")
+    assert calls["rotation"] == 1  # tried rotation, got empty stints, fell back
+    assert df["lineup_source"].unique().to_list() == ["pbp"]
+    assert df.height > 0

--- a/tests/nba/test_nba_season_compile.py
+++ b/tests/nba/test_nba_season_compile.py
@@ -26,7 +26,7 @@ def test_compile_dedups_gameids_and_tags_season(tmp_path, monkeypatch):
     monkeypatch.setattr(C, "_game_ids_for_season", lambda s, st: ["001", "001", "002"])
     calls = []
 
-    def fake_fetch(gid, league_id):
+    def fake_fetch(gid, league_id, *, lineup_source: str = "auto"):
         calls.append(gid)
         return _poss(gid)
 
@@ -39,13 +39,13 @@ def test_compile_dedups_gameids_and_tags_season(tmp_path, monkeypatch):
 
 def test_compile_resume_skips_cached(tmp_path, monkeypatch):
     monkeypatch.setattr(C, "_game_ids_for_season", lambda s, st: ["001", "002"])
-    monkeypatch.setattr(C, "_fetch_possessions", lambda gid, lid: _poss(gid))
+    monkeypatch.setattr(C, "_fetch_possessions", lambda gid, lid, *, lineup_source="auto": _poss(gid))
     C.compile_nba_season(2023, cache_dir=str(tmp_path), delay_s=0.0)  # warm cache
     calls = []
     monkeypatch.setattr(
         C,
         "_fetch_possessions",
-        lambda gid, lid: (calls.append(gid), _poss(gid))[1],
+        lambda gid, lid, *, lineup_source="auto": (calls.append(gid), _poss(gid))[1],
     )
     C.compile_nba_season(2023, cache_dir=str(tmp_path), delay_s=0.0)  # all cached
     assert calls == []  # nothing re-fetched
@@ -54,7 +54,7 @@ def test_compile_resume_skips_cached(tmp_path, monkeypatch):
 def test_compile_best_effort_skips_failing_game(tmp_path, monkeypatch):
     monkeypatch.setattr(C, "_game_ids_for_season", lambda s, st: ["ok1", "bad", "ok2"])
 
-    def fetch(gid, lid):
+    def fetch(gid, lid, *, lineup_source: str = "auto"):
         if gid == "bad":
             raise RuntimeError("api boom")
         return _poss(gid)


### PR DESCRIPTION
## What

Adds a **second on-court-lineup producer** for the NBA possession engine that reconstructs the 5-on-5 per team from `playbyplayv3` substitution events + the boxscore, plus a `lineup_source` selector on `nba_possessions`, so a game can compile **without calling the `gamerotation` endpoint**.

## Why

`stats.nba.com`'s `gamerotation` endpoint (which supplies on-court lineups) is being **soft-throttled** (endpoint-specific tarpit that escalates with volume) and is **absent for older seasons**. A hard dependency on it blocks bulk/historical compiles. `gamerotation` stays the preferred/primary source; the pbp-derived path is the resilient fallback.

## How

- **`players_on_court_from_pbp(enhanced_pbp, raw_box, *, home_team_id, away_team_id)`** (`nba_lineups.py`) — returns the identical `LINEUPS_SCHEMA` that `attach_possession_lineups` already consumes. One interface, two producers.
  - **Per-period first-appearance seeding** (`_period_starters`): the NBA pbp stream emits no substitution events at period starts, so each period's 5 are inferred from first-appearance (a player who acts, or is subbed *out*, before ever being subbed *in* that period started it; players subbed in are excluded; a carry-forward fills the rare silent-starter gap).
  - On a sub row, `person_id` is the **outgoing** player; the incoming is resolved from the `"SUB: X FOR Y"` description via a team-scoped boxscore name map (with first-initial disambiguation for same-family collisions).
- **`lineup_source: "auto" | "rotation" | "pbp"`** on `nba_possessions` (default `"auto"`):
  - `"auto"` — gamerotation primary; falls back to pbp on fetch error, empty stints, **or degraded/partial coverage** (a null-slot tolerance guard).
  - `"pbp"` — skips the `gamerotation` fetch entirely (the throttle-free path). `"rotation"` — today's path.
  - Adds a constant `lineup_source` provenance column. **Zero extra network calls** — the boxscore is already fetched.
- Threaded through `compile_nba_season` / `_fetch_possessions`; `players_on_court_from_pbp` exported from `sportsdataverse.nba`.

## Validation

- **Cross-source agreement meta-oracle** — the 3 `tests/fixtures/nba_engine/` games ship *both* `gamerotation.json` and `playbyplayv3.json` + `boxscoretraditionalv3.json`. pbp-derived on-court-10 per action agrees with gamerotation-derived at **0.9689 / 0.9686 / 0.9662** (residual ~3% is same-clock end-of-period sub-batch ordering noise).
- **Boxscore-points reconciliation** — possession points per team == boxscore team points, verified with `lineup_source="pbp"` on all 3 fixtures (independent oracle).
- Backward compatible: `"auto"` keeps gamerotation primary, so existing output is unchanged; the additive `lineup_source` column is inert to the RAPM consumer (selects columns by name).

## Gates

`tests/nba/` **169 passed / 16 skipped** (live-gated); mypy clean on `nba_lineups.py` / `nba_possessions.py` / `nba_season_compile.py`; ruff clean. No fixture edits.

## Summary by Sourcery

Introduce a play-by-play-derived on-court lineup reconstruction path for NBA possessions, add a configurable lineup source selector with automatic rotation-to-pbp fallback, and propagate this choice through single-game and season compilation workflows while covering behavior with new tests.

New Features:
- Add a pbp-based on-court lineup producer that reconstructs five-on-five lineups from play-by-play substitutions and boxscore starters without using the gamerotation endpoint.
- Expose a lineup_source parameter on nba_possessions and compile_nba_season to choose between rotation, pbp, or auto (rotation with pbp fallback) lineup producers, and record the chosen source in a new lineup_source column.
- Export players_on_court_from_pbp and players_on_court_from_rotation at the nba package level for external use.

Bug Fixes:
- Guard against degraded or partially-missing gamerotation payloads by detecting excessive null player slots in rotation-derived lineups and falling back to the pbp producer in auto mode.

Enhancements:
- Document and refactor nba_lineups to support dual lineup producers and share a common LINEUPS_SCHEMA output.
- Improve nba_possessions behavior to optionally skip gamerotation calls, reduce hard dependency on that endpoint, and log rotation failures when auto-falling back to pbp.

Tests:
- Add extensive unit and integration tests for the pbp-based lineup producer, its boxscore helper functions, and its agreement with rotation-derived lineups across fixtures.
- Extend nba_possessions tests to validate lineup_source behavior, pbp fallback conditions, and boxscore points reconciliation under different rotation endpoint failure modes.
- Update nba_season_compile tests to account for the new lineup_source plumbing in the internal _fetch_possessions helper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new lineup source option for NBA possession and season compilation workflows.
  * Introduced play-by-play-based lineup reconstruction as an alternative to rotation-based data.
  * Exposed the new lineup helpers at the package level for easier use.

* **Bug Fixes**
  * Improved lineup reliability by automatically falling back to play-by-play data when rotation data is missing or incomplete.
  * Added clearer lineup source tracking in possession outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->