### PR TITLE
feat(nba): possession event-detail substrate (Model Zoo v2 WP1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [Unreleased](#unreleased)
   - [NBA — v3-to-v2 play-by-play adapter (`nba_v3_to_v2_pbp`)](#nba--v3-to-v2-play-by-play-adapter-nba_v3_to_v2_pbp)
   - [NBA / WNBA — stats.nba.com / stats.wnba.com flat-API family (`nba_stats` / `wnba_stats`)](#nba--wnba--statsnbacom--statswnbacom-flat-api-family-nba_stats--wnba_stats)
+  - [NBA — possession event-detail columns, per-shooter shooting frame, `game_date`](#nba--possession-event-detail-columns-per-shooter-shooting-frame-game_date)
 - [0.0.71 Release: June 24, 2026](#0071-release-june-24-2026)
   - [CFB — opponent-adjusted EPA (`cfb_adjusted_epa`): season + walk-forward](#cfb--opponent-adjusted-epa-cfb_adjusted_epa-season--walk-forward)
   - [NFL — era-aware decision models + both-path (ESPN + nflverse) model parity](#nfl--era-aware-decision-models--both-path-espn--nflverse-model-parity)
@@ -194,6 +195,12 @@ Two new codegen-generated flat-API stems wrap the official stats API surface:
 - **Browser-TLS runtime:** `stats.nba.com` TLS/JA3-fingerprint-blocks plain `requests` (silent timeout, not an IP block). The runtime `_get` uses **`curl_cffi` with `impersonate="chrome"`**. `curl_cffi` is a **lazy optional import** shipped under the `tests` and `all` extras — not a hard runtime dep. A clear `ImportError` guides users to `pip install curl_cffi` (or `pip install sportsdataverse[all]`). The HTTP transport is injectable so wrappers and tests can run fully offline.
 - Wrappers default to `return_parsed=True` (tidy polars DataFrame). Pass `return_parsed=False` for the raw `Dict` or `return_as_pandas=True` for pandas. There is no user-facing `headers=` param — the TLS impersonation is handled inside the runtime, not via a user token.
 - Generated from the enriched canonical catalog (`tools/codegen/gen_nba_stats.py`) and registered in `FLAT_APIS` in `tools/codegen/generate.py`. Param `default`/`example` values are mined from the hoopR/wehoop roxygen signatures + `@examples`. Returns-table descriptions are authored for the pilot slugs and back-filled by column name from the SDV R-package docs (`_r_col_desc`); the remaining un-authored `native/nba_stats` + `native/wnba_stats` columns are a tracked follow-up exempted from the coverage ratchet via `extract_residual_columns._DEFERRED_BUCKETS` (surfaced by `deferred_columns()`).
+
+### NBA — possession event-detail columns, per-shooter shooting frame, `game_date`
+
+- feat(nba): possession event-detail columns (`fg2a/fg2m/fg3a/fg3m/fta/ftm/oreb/tov`),
+  per-shooter `build_possession_shooting` companion frame, and `game_date` on
+  `compile_nba_season` output (possession cache `PIPELINE_VERSION` 1 -> 2).
 
 ## 0.0.71 Release: June 24, 2026
 

--- a/docs/docs/nba/index.md
+++ b/docs/docs/nba/index.md
@@ -11,7 +11,7 @@ sidebar_label: NBA
 | [ESPN core API (v2)](reference/core) | 81 | `https://sports.core.api.espn.com/v2/sports` |
 | [NBA Stats API (stats.nba.com)](reference/nba_stats) | 112 | `https://stats.nba.com` |
 | [Dataset loaders](reference/loaders) | 13 | sportsdataverse-data releases |
-| [Additional functions](reference/additional) | 40 | hand-written wrappers, loaders & helpers |
+| [Additional functions](reference/additional) | 41 | hand-written wrappers, loaders & helpers |
 
 ## Examples
 

--- a/docs/docs/nba/reference/additional.md
+++ b/docs/docs/nba/reference/additional.md
@@ -703,7 +703,8 @@ Compile a full season's possession stint matrix (cached + resumable + throttled)
 Discovers game ids, dedupes, then per game loads the cached parquet if present
 (`resume`), else fetches via fetch_possessions`, caches it, and sleeps
 `delay_s` (throttle; only on live fetches). A game that errors or returns no
-possessions is logged and skipped (best-effort, never raises). The assembled
+possessions is logged and skipped (best-effort — a per-game failure never
+raises; see `Raises` for the game_date integrity error). The assembled
 frame is tagged with a `season` column.
 
 **Parameters**

--- a/docs/docs/nba/reference/additional.md
+++ b/docs/docs/nba/reference/additional.md
@@ -653,6 +653,49 @@ game's own team pace), then summed — the result is fully deterministic.
 
 One row per player: `player_id`, the STATS` per-100 rates, `min` (total), `gp` (games). Empty frame with that schema on empty input.
 
+### `build_possession_shooting(enhanced_pbp: 'pl.DataFrame') -> 'pl.DataFrame'` {#build_possession_shooting}
+
+Build the per-shooter companion frame from an enhanced play-by-play DataFrame.
+
+Companion to `build_possessions`: instead of one team-level row per
+possession, emits one row per distinct shooter (`player_id`) per
+possession, with their own `fg2a/fg2m/fg3a/fg3m/fta/ftm` counts. Shares
+the same possession-group traversal as `build_possessions` via
+assemble` — the two frames are always built from a single
+consistent pass over the play-by-play. Consumed by WP2's luck-adjusted
+shooting response.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `enhanced_pbp` | `DataFrame` |  | Polars DataFrame with schema `ENHANCED_PBP_SCHEMA` (from `~sportsdataverse.nba.nba_enhanced_pbp.enhanced_pbp_from_payload`). An empty or malformed frame returns a zero-row frame with `POSSESSION_SHOOTING_SCHEMA` — never raises. |
+
+**Returns**
+
+Polars DataFrame with schema `POSSESSION_SHOOTING_SCHEMA`. One row per `(possession_number, player_id)` pair. Events with `person_id == 0` are skipped (unattributable to a shooter — they still count toward `build_possessions`' team-level totals). Per-possession sums of the six shooting columns match the corresponding `build_possessions` columns exactly.
+
+**Example**
+
+```python
+import json, pathlib
+from sportsdataverse.nba.nba_enhanced_pbp import enhanced_pbp_from_payload
+from sportsdataverse.nba.nba_possessions import build_possession_shooting
+
+payload = json.loads(pathlib.Path("playbyplayv3.json").read_text())
+pbp = enhanced_pbp_from_payload(payload)
+sh = build_possession_shooting(pbp)
+print(sh.shape, sh.schema["player_id"])
+
+# Per-player shooting totals
+
+import polars as pl
+totals = sh.group_by("player_id").agg(
+    pl.col("fg3m").sum(), pl.col("ftm").sum()
+)
+print(totals.head())
+```
+
 ### `compile_nba_season(season: 'int', season_type: 'str' = 'Regular Season', *, resume: 'bool' = True, cache_dir: 'Optional[str]' = None, delay_s: 'float' = 0.6, lineup_source: 'str' = 'auto', return_as_pandas: 'bool' = False) -> 'Union[pl.DataFrame, pd.DataFrame]'` {#compile_nba_season}
 
 Compile a full season's possession stint matrix (cached + resumable + throttled).
@@ -677,7 +720,7 @@ frame is tagged with a `season` column.
 
 **Returns**
 
-The season possession frame (+ `season` col). Empty typed frame if no games.
+The season possession frame (+ `season` and `game_date` cols). Empty typed frame if no games.
 
 **Example**
 

--- a/docs/src/pages/CHANGELOG.md
+++ b/docs/src/pages/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [Unreleased](#unreleased)
   - [NBA — v3-to-v2 play-by-play adapter (`nba_v3_to_v2_pbp`)](#nba--v3-to-v2-play-by-play-adapter-nba_v3_to_v2_pbp)
   - [NBA / WNBA — stats.nba.com / stats.wnba.com flat-API family (`nba_stats` / `wnba_stats`)](#nba--wnba--statsnbacom--statswnbacom-flat-api-family-nba_stats--wnba_stats)
+  - [NBA — possession event-detail columns, per-shooter shooting frame, `game_date`](#nba--possession-event-detail-columns-per-shooter-shooting-frame-game_date)
 - [0.0.71 Release: June 24, 2026](#0071-release-june-24-2026)
   - [CFB — opponent-adjusted EPA (`cfb_adjusted_epa`): season + walk-forward](#cfb--opponent-adjusted-epa-cfb_adjusted_epa-season--walk-forward)
   - [NFL — era-aware decision models + both-path (ESPN + nflverse) model parity](#nfl--era-aware-decision-models--both-path-espn--nflverse-model-parity)
@@ -194,6 +195,12 @@ Two new codegen-generated flat-API stems wrap the official stats API surface:
 - **Browser-TLS runtime:** `stats.nba.com` TLS/JA3-fingerprint-blocks plain `requests` (silent timeout, not an IP block). The runtime `_get` uses **`curl_cffi` with `impersonate="chrome"`**. `curl_cffi` is a **lazy optional import** shipped under the `tests` and `all` extras — not a hard runtime dep. A clear `ImportError` guides users to `pip install curl_cffi` (or `pip install sportsdataverse[all]`). The HTTP transport is injectable so wrappers and tests can run fully offline.
 - Wrappers default to `return_parsed=True` (tidy polars DataFrame). Pass `return_parsed=False` for the raw `Dict` or `return_as_pandas=True` for pandas. There is no user-facing `headers=` param — the TLS impersonation is handled inside the runtime, not via a user token.
 - Generated from the enriched canonical catalog (`tools/codegen/gen_nba_stats.py`) and registered in `FLAT_APIS` in `tools/codegen/generate.py`. Param `default`/`example` values are mined from the hoopR/wehoop roxygen signatures + `@examples`. Returns-table descriptions are authored for the pilot slugs and back-filled by column name from the SDV R-package docs (`_r_col_desc`); the remaining un-authored `native/nba_stats` + `native/wnba_stats` columns are a tracked follow-up exempted from the coverage ratchet via `extract_residual_columns._DEFERRED_BUCKETS` (surfaced by `deferred_columns()`).
+
+### NBA — possession event-detail columns, per-shooter shooting frame, `game_date`
+
+- feat(nba): possession event-detail columns (`fg2a/fg2m/fg3a/fg3m/fta/ftm/oreb/tov`),
+  per-shooter `build_possession_shooting` companion frame, and `game_date` on
+  `compile_nba_season` output (possession cache `PIPELINE_VERSION` 1 -> 2).
 
 ## 0.0.71 Release: June 24, 2026
 

--- a/sportsdataverse/nba/__init__.py
+++ b/sportsdataverse/nba/__init__.py
@@ -39,3 +39,7 @@ from sportsdataverse.nba.nba_darko import (  # noqa: F401
     nba_darko,
 )
 from sportsdataverse.nba.nba_v3_v2_adapter import nba_v3_to_v2_pbp  # noqa: F401
+from sportsdataverse.nba.nba_possessions import (  # noqa: F401
+    build_possession_shooting,
+    POSSESSION_SHOOTING_SCHEMA,
+)

--- a/sportsdataverse/nba/nba_possessions.py
+++ b/sportsdataverse/nba/nba_possessions.py
@@ -45,6 +45,15 @@ POSSESSIONS_SCHEMA: dict[str, pl.DataType] = {
     "end_seconds_remaining": pl.Float64,
     "points": pl.Int64,
     "is_second_chance": pl.Boolean,
+    # WP1 event detail (team-level counts within the possession)
+    "fg2a": pl.Int64,
+    "fg2m": pl.Int64,
+    "fg3a": pl.Int64,
+    "fg3m": pl.Int64,
+    "fta": pl.Int64,
+    "ftm": pl.Int64,
+    "oreb": pl.Int64,
+    "tov": pl.Int64,
 }
 
 # ---------------------------------------------------------------------------
@@ -114,6 +123,63 @@ def _offense_from_events(
     return 0
 
 
+def _ft_made(ev: dict) -> bool:
+    """A made free throw carries a score string (same signal as boundary detection)."""
+    return bool((ev.get("score_home") or "").strip() or (ev.get("score_away") or "").strip())
+
+
+def _event_detail(
+    events: list[dict],
+    offense: int,
+    home_id: int,
+    away_id: int,
+) -> dict[str, int]:
+    """Team-level counting-stat detail for one possession group.
+
+    ``fg2*``/``fg3*`` split on ``shot_value``; FT makes use the score-string
+    signal (:func:`_ft_made`); ``oreb`` replicates the rebound-team resolution
+    used for boundary detection (player rebound -> ``team_id``, team rebound ->
+    ``location``); ``tov`` counts turnover events.
+
+    Args:
+        events: The possession group's event rows (row-dicts from
+            ``enhanced_pbp.to_dicts()``).
+        offense: Resolved offense team ID for this possession (0 if
+            unattributable at the time of the call — see
+            :func:`build_possessions`, which resolves ``offense`` via
+            delta-attribution before calling this helper, so ``oreb`` is
+            correctly attributed even for delta-attributed groups).
+        home_id: Home team ID.
+        away_id: Away team ID.
+
+    Returns:
+        Dict with keys ``fg2a, fg2m, fg3a, fg3m, fta, ftm, oreb, tov`` (all
+        ``int`` counts for this possession group).
+    """
+    d = {"fg2a": 0, "fg2m": 0, "fg3a": 0, "fg3m": 0, "fta": 0, "ftm": 0, "oreb": 0, "tov": 0}
+    for ev in events:
+        et = ev.get("event_type") or ""
+        if et in ("made_shot", "missed_shot"):
+            three = int(ev.get("shot_value") or 0) == 3
+            d["fg3a" if three else "fg2a"] += 1
+            if et == "made_shot":
+                d["fg3m" if three else "fg2m"] += 1
+        elif et == "free_throw":
+            d["fta"] += 1
+            if _ft_made(ev):
+                d["ftm"] += 1
+        elif et == "turnover":
+            d["tov"] += 1
+        elif et == "rebound":
+            reb_team = ev.get("team_id") or 0
+            if reb_team == 0:
+                loc = ev.get("location") or ""
+                reb_team = home_id if loc == "h" else (away_id if loc == "v" else 0)
+            if offense != 0 and reb_team == offense:
+                d["oreb"] += 1
+    return d
+
+
 def _resolve_teams(df: pl.DataFrame) -> tuple[int, int]:
     """Return ``(home_team_id, away_team_id)`` from the PBP frame.
 
@@ -174,6 +240,22 @@ def _build_possession_groups(
         if prev_period is not None and period != prev_period:
             _flush()
         prev_period = period
+
+        # A technical free throw is an isolated administrative scoring event:
+        # its shooter is whoever benefits from the OPPONENT's technical foul,
+        # not the team about to have the ball (play resumes with whoever had
+        # it before the stoppage). Merging it into the surrounding drive would
+        # misattribute both the technical FT itself (to the wrong team, since
+        # the group can only carry one offense_team_id) and the real shot/
+        # rebound that follows (by wrongly seeding current_offense from the
+        # FT's location). Flush whatever was building, emit the technical FT
+        # as its own single-event group (offense resolved independently via
+        # its own location), then resume with a clean slate.
+        if et == "free_throw" and _is_technical_ft(sub_type):
+            _flush()
+            current.append(row)
+            _flush()
+            continue
 
         current.append(row)
 
@@ -264,7 +346,11 @@ def build_possessions(enhanced_pbp: pl.DataFrame) -> pl.DataFrame:
 
     Returns:
         Polars DataFrame with schema :data:`POSSESSIONS_SCHEMA`.  One row
-        per possession, ordered by ``possession_number`` ascending.
+        per possession, ordered by ``possession_number`` ascending.  Includes
+        eight team-level event-detail count columns (``fg2a``, ``fg2m``,
+        ``fg3a``, ``fg3m``, ``fta``, ``ftm``, ``oreb``, ``tov``) computed by
+        :func:`_event_detail` from the possession's events; ``points ==
+        2*fg2m + 3*fg3m + ftm`` holds on every possession.
 
     Example:
         Quick start::
@@ -359,6 +445,7 @@ def build_possessions(enhanced_pbp: pl.DataFrame) -> pl.DataFrame:
         pts = (end_home - prev_home) if offense == home_id else (end_away - prev_away)
 
         poss_num += 1
+        detail = _event_detail(events, int(offense), home_id, away_id)
         records.append(
             {
                 "game_id": game_id,
@@ -372,6 +459,7 @@ def build_possessions(enhanced_pbp: pl.DataFrame) -> pl.DataFrame:
                 "end_seconds_remaining": float(end_ev.get("seconds_remaining") or 0.0),
                 "points": int(pts),
                 "is_second_chance": bool(is_sc),
+                **detail,
             }
         )
 

--- a/sportsdataverse/nba/nba_possessions.py
+++ b/sportsdataverse/nba/nba_possessions.py
@@ -56,6 +56,19 @@ POSSESSIONS_SCHEMA: dict[str, pl.DataType] = {
     "tov": pl.Int64,
 }
 
+#: Schema of the per-shooter companion frame from :func:`build_possession_shooting`.
+POSSESSION_SHOOTING_SCHEMA: dict[str, pl.DataType] = {
+    "game_id": pl.Utf8,
+    "possession_number": pl.Int64,
+    "player_id": pl.Int64,
+    "fg2a": pl.Int64,
+    "fg2m": pl.Int64,
+    "fg3a": pl.Int64,
+    "fg3m": pl.Int64,
+    "fta": pl.Int64,
+    "ftm": pl.Int64,
+}
+
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
@@ -178,6 +191,50 @@ def _event_detail(
             if offense != 0 and reb_team == offense:
                 d["oreb"] += 1
     return d
+
+
+def _shooting_rows(events: list[dict], game_id: str, poss_num: int) -> list[dict]:
+    """Per-shooter shooting lines for one possession group (person_id-attributed events only).
+
+    Companion to :func:`_event_detail`: instead of one team-level row per
+    possession, emits one row per distinct shooter (``person_id``) who
+    attempted a shot or free throw during the possession's events. Reuses the
+    ``shot_value`` 2/3 split convention and the :func:`_ft_made` score-string
+    signal for free-throw makes.
+
+    Args:
+        events: The possession group's event rows (row-dicts from
+            ``enhanced_pbp.to_dicts()``).
+        game_id: The game identifier to stamp onto each output row.
+        poss_num: The 1-indexed possession number to stamp onto each output row.
+
+    Returns:
+        List of row-dicts (one per shooter), each with keys ``game_id``,
+        ``possession_number``, ``player_id``, and the six shooting-count keys
+        ``fg2a, fg2m, fg3a, fg3m, fta, ftm``. Events with ``person_id == 0``
+        (unattributable to a shooter) are skipped — they still count toward
+        the team-level :func:`_event_detail` totals but cannot be attributed
+        to a player here.
+    """
+    by_shooter: dict[int, dict[str, int]] = {}
+    for ev in events:
+        et = ev.get("event_type") or ""
+        if et not in ("made_shot", "missed_shot", "free_throw"):
+            continue
+        pid = int(ev.get("person_id") or 0)
+        if pid == 0:
+            continue
+        s = by_shooter.setdefault(pid, {"fg2a": 0, "fg2m": 0, "fg3a": 0, "fg3m": 0, "fta": 0, "ftm": 0})
+        if et == "free_throw":
+            s["fta"] += 1
+            if _ft_made(ev):
+                s["ftm"] += 1
+        else:
+            three = int(ev.get("shot_value") or 0) == 3
+            s["fg3a" if three else "fg2a"] += 1
+            if et == "made_shot":
+                s["fg3m" if three else "fg2m"] += 1
+    return [{"game_id": game_id, "possession_number": poss_num, "player_id": pid, **s} for pid, s in by_shooter.items()]
 
 
 def _resolve_teams(df: pl.DataFrame) -> tuple[int, int]:
@@ -321,79 +378,45 @@ def _build_possession_groups(
 # ---------------------------------------------------------------------------
 
 
-def build_possessions(enhanced_pbp: pl.DataFrame) -> pl.DataFrame:
-    """Build one row per possession from an enhanced play-by-play DataFrame.
+def _assemble(enhanced_pbp: pl.DataFrame) -> tuple[pl.DataFrame, pl.DataFrame]:
+    """Shared possession-construction pass: build both companion frames in one traversal.
 
-    Consumes the output of
-    :func:`~sportsdataverse.nba.nba_enhanced_pbp.enhanced_pbp_from_payload`.
-    Possession boundaries follow pbpstats-core rules: made field goal,
-    turnover, defensive rebound, made last free throw of a trip, or end of
-    period.  An offensive rebound extends the current possession and sets
-    ``is_second_chance = True``.
-
-    Points are the offense team's score delta over the possession, derived
-    by forward-filling ``score_home`` / ``score_away`` and differencing at
-    possession boundaries.  The sum of ``points`` per offense team is
-    reconciled against the boxscore oracle for the three canonical fixture
-    games.
+    Does the full possession-group traversal exactly once — empty guards, home/away
+    team resolution, score forward-fill, and the group loop — and emits both the
+    team-level possession frame (:data:`POSSESSIONS_SCHEMA`) and the per-shooter
+    companion frame (:data:`POSSESSION_SHOOTING_SCHEMA`) from it.
+    :func:`build_possessions` and :func:`build_possession_shooting` are thin
+    wrappers over this function's two return slots.
 
     Args:
-        enhanced_pbp: Polars DataFrame with schema
-            ``ENHANCED_PBP_SCHEMA`` (from
+        enhanced_pbp: Polars DataFrame with schema ``ENHANCED_PBP_SCHEMA`` (from
             :func:`~sportsdataverse.nba.nba_enhanced_pbp.enhanced_pbp_from_payload`).
-            An empty or malformed frame returns a zero-row frame with
-            ``POSSESSIONS_SCHEMA`` — never raises.
+            An empty or malformed frame returns ``(empty_possessions,
+            empty_shooting)`` — never raises.
 
     Returns:
-        Polars DataFrame with schema :data:`POSSESSIONS_SCHEMA`.  One row
-        per possession, ordered by ``possession_number`` ascending.  Includes
-        eight team-level event-detail count columns (``fg2a``, ``fg2m``,
-        ``fg3a``, ``fg3m``, ``fta``, ``ftm``, ``oreb``, ``tov``) computed by
-        :func:`_event_detail` from the possession's events; ``points ==
-        2*fg2m + 3*fg3m + ftm`` holds on every possession.
-
-    Example:
-        Quick start::
-
-            import json, pathlib
-            from sportsdataverse.nba.nba_enhanced_pbp import enhanced_pbp_from_payload
-            from sportsdataverse.nba.nba_possessions import build_possessions
-
-            payload = json.loads(pathlib.Path("playbyplayv3.json").read_text())
-            pbp = enhanced_pbp_from_payload(payload)
-            poss = build_possessions(pbp)
-            print(poss.shape, poss.schema["offense_team_id"])
-
-        Boxscore reconciliation check::
-
-            import polars as pl
-            pts = poss.group_by("offense_team_id").agg(pl.col("points").sum())
-            print(pts)
-
-        See Also:
-            * `nba_api`_ -- reference Python client for stats.nba.com
-            * `nflverse`_ -- analogous NFL possession engine
-
-        .. _nba_api: https://github.com/swar/nba_api
-        .. _nflverse: https://nflverse.nflverse.com
+        Tuple ``(possessions, shooting)`` — the first with schema
+        :data:`POSSESSIONS_SCHEMA`, the second with schema
+        :data:`POSSESSION_SHOOTING_SCHEMA`.
     """
-    empty = pl.DataFrame(schema=POSSESSIONS_SCHEMA)
+    empty_poss = pl.DataFrame(schema=POSSESSIONS_SCHEMA)
+    empty_shooting = pl.DataFrame(schema=POSSESSION_SHOOTING_SCHEMA)
 
     if enhanced_pbp is None or enhanced_pbp.height == 0:
-        return empty
+        return empty_poss, empty_shooting
 
     try:
         home_id, away_id = _resolve_teams(enhanced_pbp)
     except Exception:
-        return empty
+        return empty_poss, empty_shooting
 
     if home_id == 0 or away_id == 0:
-        return empty
+        return empty_poss, empty_shooting
 
     try:
         game_id: str = str(enhanced_pbp["game_id"][0])
     except Exception:
-        return empty
+        return empty_poss, empty_shooting
 
     # Sort by order_index and convert to row-dicts for imperative traversal
     rows = enhanced_pbp.sort("order_index").to_dicts()
@@ -417,6 +440,7 @@ def build_possessions(enhanced_pbp: pl.DataFrame) -> pl.DataFrame:
     prev_home = 0
     prev_away = 0
     records: list[dict] = []
+    shooting: list[dict] = []
     poss_num = 0
 
     for events, is_sc, offense in groups:
@@ -462,14 +486,137 @@ def build_possessions(enhanced_pbp: pl.DataFrame) -> pl.DataFrame:
                 **detail,
             }
         )
+        shooting.extend(_shooting_rows(events, game_id, poss_num))
 
         prev_home = end_home
         prev_away = end_away
 
     if not records:
-        return empty
+        return empty_poss, empty_shooting
 
-    return pl.DataFrame(records, schema=POSSESSIONS_SCHEMA)
+    return (
+        pl.DataFrame(records, schema=POSSESSIONS_SCHEMA),
+        pl.DataFrame(shooting, schema=POSSESSION_SHOOTING_SCHEMA) if shooting else empty_shooting,
+    )
+
+
+def build_possessions(enhanced_pbp: pl.DataFrame) -> pl.DataFrame:
+    """Build one row per possession from an enhanced play-by-play DataFrame.
+
+    Consumes the output of
+    :func:`~sportsdataverse.nba.nba_enhanced_pbp.enhanced_pbp_from_payload`.
+    Possession boundaries follow pbpstats-core rules: made field goal,
+    turnover, defensive rebound, made last free throw of a trip, or end of
+    period.  An offensive rebound extends the current possession and sets
+    ``is_second_chance = True``.
+
+    Points are the offense team's score delta over the possession, derived
+    by forward-filling ``score_home`` / ``score_away`` and differencing at
+    possession boundaries.  The sum of ``points`` per offense team is
+    reconciled against the boxscore oracle for the three canonical fixture
+    games.
+
+    Thin wrapper over :func:`_assemble`, which does the shared possession-group
+    traversal once and also produces the per-shooter companion frame consumed
+    by :func:`build_possession_shooting`.
+
+    Args:
+        enhanced_pbp: Polars DataFrame with schema
+            ``ENHANCED_PBP_SCHEMA`` (from
+            :func:`~sportsdataverse.nba.nba_enhanced_pbp.enhanced_pbp_from_payload`).
+            An empty or malformed frame returns a zero-row frame with
+            ``POSSESSIONS_SCHEMA`` — never raises.
+
+    Returns:
+        Polars DataFrame with schema :data:`POSSESSIONS_SCHEMA`.  One row
+        per possession, ordered by ``possession_number`` ascending.  Includes
+        eight team-level event-detail count columns (``fg2a``, ``fg2m``,
+        ``fg3a``, ``fg3m``, ``fta``, ``ftm``, ``oreb``, ``tov``) computed by
+        :func:`_event_detail` from the possession's events; ``points ==
+        2*fg2m + 3*fg3m + ftm`` holds on every possession.
+
+    Example:
+        Quick start::
+
+            import json, pathlib
+            from sportsdataverse.nba.nba_enhanced_pbp import enhanced_pbp_from_payload
+            from sportsdataverse.nba.nba_possessions import build_possessions
+
+            payload = json.loads(pathlib.Path("playbyplayv3.json").read_text())
+            pbp = enhanced_pbp_from_payload(payload)
+            poss = build_possessions(pbp)
+            print(poss.shape, poss.schema["offense_team_id"])
+
+        Boxscore reconciliation check::
+
+            import polars as pl
+            pts = poss.group_by("offense_team_id").agg(pl.col("points").sum())
+            print(pts)
+
+        See Also:
+            * `nba_api`_ -- reference Python client for stats.nba.com
+            * `nflverse`_ -- analogous NFL possession engine
+
+        .. _nba_api: https://github.com/swar/nba_api
+        .. _nflverse: https://nflverse.nflverse.com
+    """
+    return _assemble(enhanced_pbp)[0]
+
+
+def build_possession_shooting(enhanced_pbp: pl.DataFrame) -> pl.DataFrame:
+    """Build the per-shooter companion frame from an enhanced play-by-play DataFrame.
+
+    Companion to :func:`build_possessions`: instead of one team-level row per
+    possession, emits one row per distinct shooter (``player_id``) per
+    possession, with their own ``fg2a/fg2m/fg3a/fg3m/fta/ftm`` counts. Shares
+    the same possession-group traversal as :func:`build_possessions` via
+    :func:`_assemble` — the two frames are always built from a single
+    consistent pass over the play-by-play. Consumed by WP2's luck-adjusted
+    shooting response.
+
+    Args:
+        enhanced_pbp: Polars DataFrame with schema
+            ``ENHANCED_PBP_SCHEMA`` (from
+            :func:`~sportsdataverse.nba.nba_enhanced_pbp.enhanced_pbp_from_payload`).
+            An empty or malformed frame returns a zero-row frame with
+            ``POSSESSION_SHOOTING_SCHEMA`` — never raises.
+
+    Returns:
+        Polars DataFrame with schema :data:`POSSESSION_SHOOTING_SCHEMA`. One
+        row per ``(possession_number, player_id)`` pair. Events with
+        ``person_id == 0`` are skipped (unattributable to a shooter — they
+        still count toward :func:`build_possessions`' team-level totals).
+        Per-possession sums of the six shooting columns match the
+        corresponding :func:`build_possessions` columns exactly.
+
+    Example:
+        Quick start::
+
+            import json, pathlib
+            from sportsdataverse.nba.nba_enhanced_pbp import enhanced_pbp_from_payload
+            from sportsdataverse.nba.nba_possessions import build_possession_shooting
+
+            payload = json.loads(pathlib.Path("playbyplayv3.json").read_text())
+            pbp = enhanced_pbp_from_payload(payload)
+            sh = build_possession_shooting(pbp)
+            print(sh.shape, sh.schema["player_id"])
+
+        Per-player shooting totals::
+
+            import polars as pl
+            totals = sh.group_by("player_id").agg(
+                pl.col("fg3m").sum(), pl.col("ftm").sum()
+            )
+            print(totals.head())
+
+        See Also:
+            * `nba_api`_ -- reference Python client for stats.nba.com
+            * `nflverse`_ -- analogous NFL possession engine
+
+        .. _nba_api: https://github.com/swar/nba_api
+        .. _nflverse: https://nflverse.nflverse.com
+    """
+    return _assemble(enhanced_pbp)[1]
 
 
 # ---------------------------------------------------------------------------

--- a/sportsdataverse/nba/nba_season_compile.py
+++ b/sportsdataverse/nba/nba_season_compile.py
@@ -33,18 +33,19 @@ def _game_cache_key(game_id: str) -> str:
     return f"{game_id}__v{PIPELINE_VERSION}.parquet"
 
 
-def _game_ids_for_season(season: int, season_type: str) -> List[str]:
-    """Return the (deduped) game ids for a season (monkeypatchable).
+def _season_game_index(season: int, season_type: str) -> pl.DataFrame:
+    """``(game_id, game_date)`` index for a season from leaguegamelog (monkeypatchable).
 
-    ``season`` is the start year (2023 -> "2023-24"). The team-level game log
-    returns two rows per game, so ids are deduplicated (order preserved).
+    One row per game id (the team-level log has two rows per game; first kept).
+    ``game_date`` is parsed from the first 10 chars, tolerating both bare-date
+    and ISO-datetime string forms.
 
     Args:
         season: Season start year (e.g. 2023 for 2023-24).
         season_type: NBA season type string (e.g. ``"Regular Season"``).
 
     Returns:
-        Ordered, deduplicated list of game id strings.
+        Polars DataFrame with ``game_id: Utf8`` and ``game_date: Date``.
     """
     from .nba_schedule import year_to_season
     from .nba_stats import nba_stats_leaguegamelog
@@ -54,9 +55,17 @@ def _game_ids_for_season(season: int, season_type: str) -> List[str]:
         season_type_all_star=season_type,
         league_id=_LEAGUE_ID,
     )
-    if log.is_empty() or "game_id" not in log.columns:
-        return []
-    return log["game_id"].cast(pl.Utf8).unique(maintain_order=True).to_list()
+    if log.is_empty() or "game_id" not in log.columns or "game_date" not in log.columns:
+        return pl.DataFrame(schema={"game_id": pl.Utf8, "game_date": pl.Date})
+    return log.select(
+        pl.col("game_id").cast(pl.Utf8),
+        pl.col("game_date").cast(pl.Utf8).str.slice(0, 10).str.to_date("%Y-%m-%d"),
+    ).unique(subset=["game_id"], keep="first", maintain_order=True)
+
+
+def _game_ids_for_season(season: int, season_type: str) -> List[str]:
+    """Return the (deduped) game ids for a season (delegates to :func:`_season_game_index`)."""
+    return _season_game_index(season, season_type)["game_id"].to_list()
 
 
 def _fetch_possessions(game_id: str, league_id: str, *, lineup_source: str = "auto") -> pl.DataFrame:
@@ -111,7 +120,13 @@ def compile_nba_season(
         return_as_pandas: Return pandas instead of polars.
 
     Returns:
-        The season possession frame (+ ``season`` col). Empty typed frame if no games.
+        The season possession frame (+ ``season`` and ``game_date`` cols). Empty
+        typed frame if no games.
+
+    Raises:
+        ValueError: If any compiled possession's ``game_id`` is missing (or has a
+            null) ``game_date`` in the season index — surfaced as an explicit
+            error rather than silently emitting null dates.
 
     Example:
         Compile the 2023-24 regular season (requires live stats.nba.com access)::
@@ -138,8 +153,9 @@ def compile_nba_season(
     cdir = Path(cache_dir) if cache_dir else _default_cache_dir()
     cdir.mkdir(parents=True, exist_ok=True)
 
+    index = _season_game_index(season, season_type)
     # dedupe preserving order
-    game_ids = list(dict.fromkeys(_game_ids_for_season(season, season_type)))
+    game_ids = list(dict.fromkeys(index["game_id"].to_list()))
 
     frames: List[pl.DataFrame] = []
     total = len(game_ids)
@@ -173,8 +189,12 @@ def compile_nba_season(
         _LOG.info("compiled %s (%d/%d)", gid, i, total)
 
     if frames:
-        out = pl.concat(frames, how="diagonal_relaxed").with_columns(pl.lit(season).alias("season"))
+        out = pl.concat(frames, how="diagonal_relaxed").join(index, on="game_id", how="left")
+        n_missing = int(out["game_date"].null_count())
+        if n_missing:
+            raise ValueError(f"game_date join failed for {n_missing} possessions — season game index incomplete")
+        out = out.with_columns(pl.lit(season).alias("season"))
     else:
-        out = pl.DataFrame(schema={"game_id": pl.Utf8, "season": pl.Int64})
+        out = pl.DataFrame(schema={"game_id": pl.Utf8, "game_date": pl.Date, "season": pl.Int64})
 
     return out.to_pandas() if return_as_pandas else out

--- a/sportsdataverse/nba/nba_season_compile.py
+++ b/sportsdataverse/nba/nba_season_compile.py
@@ -102,7 +102,8 @@ def compile_nba_season(
     Discovers game ids, dedupes, then per game loads the cached parquet if present
     (``resume``), else fetches via :func:`_fetch_possessions`, caches it, and sleeps
     ``delay_s`` (throttle; only on live fetches). A game that errors or returns no
-    possessions is logged and skipped (best-effort, never raises). The assembled
+    possessions is logged and skipped (best-effort — a per-game failure never
+    raises; see ``Raises`` for the game_date integrity error). The assembled
     frame is tagged with a ``season`` column.
 
     Args:

--- a/sportsdataverse/nba/nba_season_compile.py
+++ b/sportsdataverse/nba/nba_season_compile.py
@@ -19,7 +19,7 @@ import polars as pl
 _LOG = logging.getLogger(__name__)
 
 #: Bump when the possession pipeline changes in a way that invalidates cached parquet.
-PIPELINE_VERSION: int = 1
+PIPELINE_VERSION: int = 2
 
 _LEAGUE_ID = "00"
 

--- a/sportsdataverse/parsed/nba.py
+++ b/sportsdataverse/parsed/nba.py
@@ -149,6 +149,7 @@ from sportsdataverse.nba import RidgeRapmModel as RidgeRapmModel  # noqa: F401
 from sportsdataverse.nba import SpmCoefficients as SpmCoefficients  # noqa: F401
 from sportsdataverse.nba import ValidationReport as ValidationReport  # noqa: F401
 from sportsdataverse.nba import box_features as box_features  # noqa: F401
+from sportsdataverse.nba import build_possession_shooting as build_possession_shooting  # noqa: F401
 from sportsdataverse.nba import compile_nba_season as compile_nba_season  # noqa: F401
 from sportsdataverse.nba import darko_forecast_accuracy as darko_forecast_accuracy  # noqa: F401
 from sportsdataverse.nba import download as download  # noqa: F401
@@ -211,6 +212,7 @@ __all__ = [
     "SpmCoefficients",
     "ValidationReport",
     "box_features",
+    "build_possession_shooting",
     "compile_nba_season",
     "darko_forecast_accuracy",
     "download",

--- a/tests/nba/test_nba_model_validation.py
+++ b/tests/nba/test_nba_model_validation.py
@@ -279,8 +279,8 @@ from sportsdataverse.nba.nba_season_compile import compile_nba_season  # noqa: E
 @skip_if_no_nba_stats_live
 def test_end_to_end_real_slice_report(tmp_path, monkeypatch):
     # small real slice compiled once, then validated (report shape only, not thresholds)
-    real_ids = C._game_ids_for_season(2023, "Regular Season")[:8]
-    monkeypatch.setattr(C, "_game_ids_for_season", lambda s, st: real_ids)
+    real_index = C._season_game_index(2023, "Regular Season").head(8)
+    monkeypatch.setattr(C, "_season_game_index", lambda s, st: real_index)
     s = compile_nba_season(2023, cache_dir=str(tmp_path), delay_s=1.0)
     rep = validate_model(
         RidgeRapmModel(),

--- a/tests/nba/test_nba_possessions.py
+++ b/tests/nba/test_nba_possessions.py
@@ -129,6 +129,14 @@ def test_possessions_schema_matches_constant() -> None:
         "end_seconds_remaining",
         "points",
         "is_second_chance",
+        "fg2a",
+        "fg2m",
+        "fg3a",
+        "fg3m",
+        "fta",
+        "ftm",
+        "oreb",
+        "tov",
     }
     assert set(POSSESSIONS_SCHEMA.keys()) == required
     assert POSSESSIONS_SCHEMA["game_id"] == pl.Utf8
@@ -597,3 +605,76 @@ def test_lineup_source_auto_falls_back_on_partial_rotation(monkeypatch: pytest.M
     off_def_cols = [f"off_player_{i}" for i in range(1, 6)] + [f"def_player_{i}" for i in range(1, 6)]
     for col in off_def_cols:
         assert df[col].null_count() == 0, f"pbp fallback left nulls in {col}"
+
+
+# ---------------------------------------------------------------------------
+# WP1 Task 1: event-detail columns
+# ---------------------------------------------------------------------------
+
+DETAIL_COLS = ["fg2a", "fg2m", "fg3a", "fg3m", "fta", "ftm", "oreb", "tov"]
+
+
+def _box_team_shooting(box: dict) -> dict[int, dict[str, int]]:
+    """Per-team counting stats from the boxscore (sum of player rows) — external oracle."""
+    b = box["boxScoreTraditional"]
+    out: dict[int, dict[str, int]] = {}
+    keys = {
+        "fga": "fieldGoalsAttempted",
+        "fgm": "fieldGoalsMade",
+        "fg3a": "threePointersAttempted",
+        "fg3m": "threePointersMade",
+        "fta": "freeThrowsAttempted",
+        "ftm": "freeThrowsMade",
+        "oreb": "reboundsOffensive",
+        "tov": "turnovers",
+    }
+    for side in ("homeTeam", "awayTeam"):
+        t = b[side]
+        agg = {k: 0 for k in keys}
+        for p in t["players"]:
+            s = p.get("statistics", {}) or {}
+            for k, bk in keys.items():
+                agg[k] += int(s.get(bk, 0) or 0)
+        out[int(t["teamId"])] = agg
+    return out
+
+
+@pytest.mark.parametrize("game_id", GAMES)
+def test_event_detail_columns_present_and_typed(game_id):
+    poss = build_possessions(_enh(game_id))
+    for c in DETAIL_COLS:
+        assert c in poss.columns, c
+        assert poss.schema[c] == pl.Int64, c
+
+
+@pytest.mark.parametrize("game_id", GAMES)
+def test_points_identity(game_id):
+    """points == 2*fg2m + 3*fg3m + ftm on EVERY possession (exact)."""
+    poss = build_possessions(_enh(game_id))
+    bad = poss.filter(pl.col("points") != 2 * pl.col("fg2m") + 3 * pl.col("fg3m") + pl.col("ftm"))
+    assert bad.height == 0, bad.select("possession_number", "points", "fg2m", "fg3m", "ftm").to_dicts()[:5]
+
+
+@pytest.mark.parametrize("game_id", GAMES)
+def test_event_detail_boxscore_reconciliation(game_id):
+    """Team sums of the new columns reconcile against the boxscore oracle."""
+    poss = build_possessions(_enh(game_id))
+    box = _box_team_shooting(_box(game_id))
+    got = poss.group_by("offense_team_id").agg([pl.col(c).sum() for c in DETAIL_COLS]).to_dicts()
+    assert len(got) == 2
+    for row in got:
+        exp = box[row["offense_team_id"]]
+        # Shooting: exact (shots are always player-attributed and always in kept groups)
+        assert row["fg2a"] + row["fg3a"] == exp["fga"]
+        assert row["fg2a"] == exp["fga"] - exp["fg3a"]
+        assert row["fg2m"] == exp["fgm"] - exp["fg3m"]
+        assert row["fg3a"] == exp["fg3a"]
+        assert row["fg3m"] == exp["fg3m"]
+        assert row["ftm"] == exp["ftm"]
+        # FTA: a MISSED technical FT in a dropped unattributable group can vanish
+        # from pbp-derived counts — bounded, documented divergence.
+        assert row["fta"] <= exp["fta"]
+        assert exp["fta"] - row["fta"] <= 4, (row["fta"], exp["fta"])
+        # OREB/TOV: pbp counts include TEAM rebounds/turnovers, player sums don't.
+        assert row["oreb"] >= exp["oreb"]
+        assert row["tov"] >= exp["tov"]

--- a/tests/nba/test_nba_possessions.py
+++ b/tests/nba/test_nba_possessions.py
@@ -21,9 +21,11 @@ from sportsdataverse.nba.nba_lineups import (
     players_on_court_from_rotation,
 )
 from sportsdataverse.nba.nba_possessions import (
+    POSSESSION_SHOOTING_SCHEMA,
     POSSESSIONS_SCHEMA,
     _is_last_ft,
     attach_possession_lineups,
+    build_possession_shooting,
     build_possessions,
 )
 from tests.conftest import skip_if_no_nba_stats_live
@@ -678,3 +680,57 @@ def test_event_detail_boxscore_reconciliation(game_id):
         # OREB/TOV: pbp counts include TEAM rebounds/turnovers, player sums don't.
         assert row["oreb"] >= exp["oreb"]
         assert row["tov"] >= exp["tov"]
+
+
+# ---------------------------------------------------------------------------
+# WP1 Task 2: possession_shooting companion frame
+# ---------------------------------------------------------------------------
+
+_SHOOT_COLS = ["fg2a", "fg2m", "fg3a", "fg3m", "fta", "ftm"]
+
+
+def _box_player_shooting(box: dict) -> dict[int, dict[str, int]]:
+    b = box["boxScoreTraditional"]
+    out: dict[int, dict[str, int]] = {}
+    for side in ("homeTeam", "awayTeam"):
+        for p in b[side]["players"]:
+            s = p.get("statistics", {}) or {}
+            out[int(p["personId"])] = {
+                "fg3m": int(s.get("threePointersMade", 0) or 0),
+                "ftm": int(s.get("freeThrowsMade", 0) or 0),
+            }
+    return out
+
+
+def test_shooting_frame_empty_input():
+    sh = build_possession_shooting(pl.DataFrame())
+    assert sh.height == 0
+    assert dict(sh.schema) == POSSESSION_SHOOTING_SCHEMA
+
+
+@pytest.mark.parametrize("game_id", GAMES)
+def test_shooting_frame_matches_team_columns(game_id):
+    """Per-possession shooter sums == the team-level detail columns (exact)."""
+    enh = _enh(game_id)
+    poss = build_possessions(enh)
+    sh = build_possession_shooting(enh)
+    sums = sh.group_by("possession_number").agg([pl.col(c).sum() for c in _SHOOT_COLS])
+    j = poss.join(sums, on="possession_number", how="left", suffix="_sh").with_columns(
+        [pl.col(f"{c}_sh").fill_null(0) for c in _SHOOT_COLS]
+    )
+    for c in _SHOOT_COLS:
+        bad = j.filter(pl.col(c) != pl.col(f"{c}_sh"))
+        assert bad.height == 0, (c, bad.select("possession_number", c, f"{c}_sh").to_dicts()[:5])
+
+
+@pytest.mark.parametrize("game_id", GAMES)
+def test_shooting_frame_player_boxscore_reconciliation(game_id):
+    """Per-player fg3m/ftm sums == boxscore player rows (independent oracle)."""
+    sh = build_possession_shooting(_enh(game_id))
+    box = _box_player_shooting(_box(game_id))
+    got = sh.group_by("player_id").agg(pl.col("fg3m").sum(), pl.col("ftm").sum()).to_dicts()
+    for row in got:
+        exp = box.get(row["player_id"])
+        assert exp is not None, f"shooter {row['player_id']} missing from boxscore"
+        assert row["fg3m"] == exp["fg3m"], row
+        assert row["ftm"] == exp["ftm"], row

--- a/tests/nba/test_nba_season_compile.py
+++ b/tests/nba/test_nba_season_compile.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+import datetime
+import json
+import pathlib
+
 import polars as pl
+import pytest
 
 from sportsdataverse.nba import nba_season_compile as C
 
@@ -22,8 +27,19 @@ def _poss(gid: str) -> pl.DataFrame:
     )
 
 
+def _idx(ids: list, dates: list) -> pl.DataFrame:
+    return pl.DataFrame(
+        {"game_id": ids, "game_date": dates},
+        schema={"game_id": pl.Utf8, "game_date": pl.Date},
+    )
+
+
 def test_compile_dedups_gameids_and_tags_season(tmp_path, monkeypatch):
-    monkeypatch.setattr(C, "_game_ids_for_season", lambda s, st: ["001", "001", "002"])
+    monkeypatch.setattr(
+        C,
+        "_season_game_index",
+        lambda s, st: _idx(["001", "002"], [datetime.date(2023, 10, 24), datetime.date(2023, 10, 25)]),
+    )
     calls = []
 
     def fake_fetch(gid, league_id, *, lineup_source: str = "auto"):
@@ -38,7 +54,11 @@ def test_compile_dedups_gameids_and_tags_season(tmp_path, monkeypatch):
 
 
 def test_compile_resume_skips_cached(tmp_path, monkeypatch):
-    monkeypatch.setattr(C, "_game_ids_for_season", lambda s, st: ["001", "002"])
+    monkeypatch.setattr(
+        C,
+        "_season_game_index",
+        lambda s, st: _idx(["001", "002"], [datetime.date(2023, 10, 24), datetime.date(2023, 10, 25)]),
+    )
     monkeypatch.setattr(C, "_fetch_possessions", lambda gid, lid, *, lineup_source="auto": _poss(gid))
     C.compile_nba_season(2023, cache_dir=str(tmp_path), delay_s=0.0)  # warm cache
     calls = []
@@ -52,7 +72,14 @@ def test_compile_resume_skips_cached(tmp_path, monkeypatch):
 
 
 def test_compile_best_effort_skips_failing_game(tmp_path, monkeypatch):
-    monkeypatch.setattr(C, "_game_ids_for_season", lambda s, st: ["ok1", "bad", "ok2"])
+    monkeypatch.setattr(
+        C,
+        "_season_game_index",
+        lambda s, st: _idx(
+            ["ok1", "bad", "ok2"],
+            [datetime.date(2023, 10, 24), datetime.date(2023, 10, 25), datetime.date(2023, 10, 26)],
+        ),
+    )
 
     def fetch(gid, lid, *, lineup_source: str = "auto"):
         if gid == "bad":
@@ -65,9 +92,71 @@ def test_compile_best_effort_skips_failing_game(tmp_path, monkeypatch):
 
 
 def test_compile_never_raises_on_no_games(tmp_path, monkeypatch):
-    monkeypatch.setattr(C, "_game_ids_for_season", lambda s, st: [])
+    monkeypatch.setattr(C, "_season_game_index", lambda s, st: _idx([], []))
     out = C.compile_nba_season(2023, cache_dir=str(tmp_path), delay_s=0.0)
     assert out.is_empty() and "season" in out.columns
+
+
+# ---------------------------------------------------------------------------
+# WP1 Task 3: game_date attachment
+# ---------------------------------------------------------------------------
+
+
+def _fake_index() -> pl.DataFrame:
+    return pl.DataFrame(
+        {"game_id": ["0022300001"], "game_date": [datetime.date(2023, 10, 24)]},
+        schema={"game_id": pl.Utf8, "game_date": pl.Date},
+    )
+
+
+def _fixture_poss() -> pl.DataFrame:
+    payload = json.loads(pathlib.Path("tests/fixtures/nba_engine/0022300001/playbyplayv3.json").read_text())
+    from sportsdataverse.nba.nba_enhanced_pbp import enhanced_pbp_from_payload
+    from sportsdataverse.nba.nba_possessions import build_possessions
+
+    return build_possessions(enhanced_pbp_from_payload(payload))
+
+
+def test_compile_attaches_game_date(monkeypatch, tmp_path):
+    from sportsdataverse.nba import nba_season_compile as mod
+
+    monkeypatch.setattr(mod, "_season_game_index", lambda s, st: _fake_index())
+    monkeypatch.setattr(mod, "_fetch_possessions", lambda gid, lid, lineup_source="auto": _fixture_poss())
+    out = mod.compile_nba_season(2023, cache_dir=str(tmp_path), delay_s=0.0)
+    assert out.schema["game_date"] == pl.Date
+    assert out["game_date"].null_count() == 0
+    assert out["game_date"][0] == datetime.date(2023, 10, 24)
+
+
+def test_compile_game_date_covers_cached_parquet(monkeypatch, tmp_path):
+    """Upgrade-on-read: a pre-existing cache parquet WITHOUT game_date still gets one."""
+    from sportsdataverse.nba import nba_season_compile as mod
+
+    cache = tmp_path / mod._game_cache_key("0022300001")
+    _fixture_poss().write_parquet(cache)  # simulates a cache written before this change
+    monkeypatch.setattr(mod, "_season_game_index", lambda s, st: _fake_index())
+    monkeypatch.setattr(
+        mod,
+        "_fetch_possessions",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not fetch — cache hit expected")),
+    )
+    out = mod.compile_nba_season(2023, cache_dir=str(tmp_path), delay_s=0.0)
+    assert out["game_date"].null_count() == 0
+
+
+def test_compile_missing_game_date_raises(monkeypatch, tmp_path):
+    """A game id absent from the season index is an explicit error, not silent nulls."""
+    from sportsdataverse.nba import nba_season_compile as mod
+
+    # index knows the id (so it is compiled) but its game_date is null
+    bad_index = pl.DataFrame(
+        {"game_id": ["0022300001"], "game_date": [None]},
+        schema={"game_id": pl.Utf8, "game_date": pl.Date},
+    )
+    monkeypatch.setattr(mod, "_season_game_index", lambda s, st: bad_index)
+    monkeypatch.setattr(mod, "_fetch_possessions", lambda gid, lid, lineup_source="auto": _fixture_poss())
+    with pytest.raises(ValueError, match="game_date"):
+        mod.compile_nba_season(2023, cache_dir=str(tmp_path), delay_s=0.0)
 
 
 # ---------------------------------------------------------------------------
@@ -79,7 +168,7 @@ from tests.conftest import skip_if_no_nba_stats_live  # noqa: E402
 @skip_if_no_nba_stats_live
 def test_compile_live_small_slice(tmp_path, monkeypatch):
     # only the first 3 real regular-season game ids, real fetch, real cache
-    real_ids = C._game_ids_for_season(2023, "Regular Season")[:3]
-    monkeypatch.setattr(C, "_game_ids_for_season", lambda s, st: real_ids)
+    real_index = C._season_game_index(2023, "Regular Season").head(3)
+    monkeypatch.setattr(C, "_season_game_index", lambda s, st: real_index)
     out = C.compile_nba_season(2023, cache_dir=str(tmp_path), delay_s=1.0)
     assert not out.is_empty() and "off_player_1" in out.columns


### PR DESCRIPTION
## Summary

WP1 of the Model Zoo v2 Tier-1 program — the shared possession-level substrate for LA-RAPM, four-factor RAPM, time-decay RAPM, and the through-date ratings engine:

- **8 team-level event-detail columns** on the possessions frame (`fg2a/fg2m/fg3a/fg3m/fta/ftm/oreb/tov`), extracted in the existing single pass over possession groups; gated by an exact per-possession points identity (`points == 2*fg2m + 3*fg3m + ftm`) and boxscore reconciliation on all 3 committed fixture games.
- **`build_possession_shooting`** per-shooter companion frame from a shared `_assemble()` pass (the two frames cannot drift); per-player fg3m/ftm reconcile exactly against boxscore player rows.
- **`game_date`** on `compile_nba_season` output via a new `_season_game_index` (leaguegamelog), joined at assembly time so stale caches upgrade on read; missing dates raise instead of producing nulls.
- Possession cache `PIPELINE_VERSION` 1 → 2 (new columns change cached content).
- New exports: `build_possession_shooting`, `POSSESSION_SHOOTING_SCHEMA`; codegen regen included.

## Bug fix surfaced by the identity gate

Technical free throws were previously merged into the surrounding drive, misattributing the tech FT and the following shot between teams. They are now isolated as their own possession group. This is an interim boundary behavior (possession counts on fixtures move +0/+3/+3); Phase B rewrites `_build_possession_groups` to pbpstats `is_possession_ending_event` semantics wholesale and owns driving the count delta to zero vs the pbpstats oracle.

## Test plan

- `tests/nba/` 235 passed / 20 skipped; `tests/codegen/` 107 passed / 4 skipped
- mypy clean (`nba_possessions.py`, `nba_season_compile.py`); ruff clean; codegen `--check` clean
- New gates: points identity (exact), team + player boxscore reconciliation, shooting↔team consistency, game_date coverage incl. upgrade-on-read + explicit-error contract

## Summary by Sourcery

Add richer NBA possession outputs and season metadata to support downstream RAPM-style models.

New Features:
- Expose eight team-level shooting and turnover event-detail columns on the NBA possessions dataframe.
- Introduce a per-shooter possession-level shooting companion frame and export its schema in the public NBA API.
- Attach non-null game_date to compile_nba_season outputs based on a season game index derived from leaguegamelog.

Bug Fixes:
- Correct handling of technical free throws by isolating them into their own possession group to prevent team misattribution.

Enhancements:
- Refactor possession construction into a shared assembly pass that simultaneously produces team-level and per-shooter outputs with integrity checks against boxscore and points identity.
- Tighten compile_nba_season behavior by enforcing game_date coverage via an indexed join and raising on missing dates.

Build:
- Bump the possession cache PIPELINE_VERSION from 1 to 2 to invalidate older parquet artifacts.

Documentation:
- Document the new build_possession_shooting helper and update NBA changelog and index to reflect the additional functionality.

Tests:
- Add comprehensive tests for possession event-detail columns, per-shooter shooting frame reconciliation against boxscores, and game_date attachment and upgrade-on-read semantics in season compilation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer NBA possession details, including shooting, free throw, rebound, and turnover counts.
  * Added a per-shooter shooting summary alongside possession data.
  * NBA season compilation now includes `game_date` in compiled outputs.

* **Bug Fixes**
  * Technical free throws are now handled as separate possession events for cleaner results.
  * Improved handling of missing or invalid season date data during compilation.

* **Chores**
  * Updated the NBA reference docs and changelog to reflect the new output fields and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->