### PR TITLE
feat(nba): through-date ratings panel, WAR, per-game BPM (Model Zoo v2 WP4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Unreleased](#unreleased)
+  - [NBA — through-date ratings panel, WAR, and single-game BPM (WP4)](#nba--through-date-ratings-panel-war-and-single-game-bpm-wp4)
   - [NBA — v3-to-v2 play-by-play adapter (`nba_v3_to_v2_pbp`)](#nba--v3-to-v2-play-by-play-adapter-nba_v3_to_v2_pbp)
   - [NBA / WNBA — stats.nba.com / stats.wnba.com flat-API family (`nba_stats` / `wnba_stats`)](#nba--wnba--statsnbacom--statswnbacom-flat-api-family-nba_stats--wnba_stats)
   - [NBA — possession event-detail columns, per-shooter shooting frame, `game_date`](#nba--possession-event-detail-columns-per-shooter-shooting-frame-game_date)
@@ -154,6 +155,13 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Unreleased
+
+### NBA — through-date ratings panel, WAR, and single-game BPM (WP4)
+
+- feat(nba): through-date ratings panel (`nba_ratings_panel` + `ratings_as_of`
+  primitive, leakage-free by construction — works with any harness model),
+  WAR layer (`nba_war` + `calibrate_pts_per_win`/`calibrate_replacement_level`
+  calibration helpers), and `nba_bpm(granularity="game")` single-game BPM 2.0.
 
 ### NBA — v3-to-v2 play-by-play adapter (`nba_v3_to_v2_pbp`)
 

--- a/docs/docs/nba/index.md
+++ b/docs/docs/nba/index.md
@@ -11,7 +11,7 @@ sidebar_label: NBA
 | [ESPN core API (v2)](reference/core) | 81 | `https://sports.core.api.espn.com/v2/sports` |
 | [NBA Stats API (stats.nba.com)](reference/nba_stats) | 112 | `https://stats.nba.com` |
 | [Dataset loaders](reference/loaders) | 13 | sportsdataverse-data releases |
-| [Additional functions](reference/additional) | 41 | hand-written wrappers, loaders & helpers |
+| [Additional functions](reference/additional) | 46 | hand-written wrappers, loaders & helpers |
 
 ## Examples
 

--- a/docs/docs/nba/reference/additional.md
+++ b/docs/docs/nba/reference/additional.md
@@ -696,6 +696,71 @@ totals = sh.group_by("player_id").agg(
 print(totals.head())
 ```
 
+### `calibrate_pts_per_win(team_season: 'pl.DataFrame') -> 'float'` {#calibrate_pts_per_win}
+
+Regress team wins on season point margin; return points-per-marginal-win.
+
+Fits `wins ~ total_margin` via ordinary least squares over one (or more,
+pooled) season's team-level rows and returns `1 / slope` — the amount of
+full-season point differential associated with one additional win. This is
+`nba_war`'s `pts_per_win` input.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `team_season` | `DataFrame` |  | One row per team-season with `team_id` (any dtype), `wins` (numeric), and `total_margin` (numeric — the team's full-season point differential: points scored minus points allowed across all its games, NOT a per-game average). |
+
+**Returns**
+
+`float` points of season margin per marginal win.
+
+**Example**
+
+```python
+from sportsdataverse.nba.nba_war import calibrate_pts_per_win
+pts_per_win = calibrate_pts_per_win(team_standings)  # team_id/wins/total_margin
+print(pts_per_win)
+```
+
+### `calibrate_replacement_level(ratings: 'pl.DataFrame', poss: 'pl.DataFrame', *, pts_per_win: 'float', target_total_war: 'float', rating_col: 'str' = 'rating', poss_col: 'str' = 'poss') -> 'float'` {#calibrate_replacement_level}
+
+Solve for the `replacement_level` that makes summed league WAR hit a target.
+
+WAR is affine in `replacement_level`:
+`war_i = (rating_i - replacement) * poss_i / 100 / pts_per_win`. Summed
+over all players this is a single linear equation in `replacement_level`;
+this function solves it in closed form (not an iterative search) for the
+`replacement_level` that makes `sum(war_i) == target_total_war`.
+
+`target_total_war` is a value the CALLER computes from real standings
+(e.g. total league wins above a chosen replacement-team win percentage) —
+this function does not assume or invent any such win-percentage convention.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `ratings` | `DataFrame` |  | Frame with `player_id` and `rating_col`. |
+| `poss` | `DataFrame` |  | Frame with `player_id` and `poss_col` (total possessions played). |
+| `pts_per_win` | `float` |  | Points of season margin per marginal win (`calibrate_pts_per_win`'s output). |
+| `target_total_war` | `float` |  | The desired sum of every player's WAR. |
+| `rating_col` | `str` | `'rating'` | Column in `ratings` holding the per-100-possession rating. |
+| `poss_col` | `str` | `'poss'` | Column in `poss` holding total possessions played. |
+
+**Returns**
+
+`float` replacement_level solving the equation exactly.
+
+**Example**
+
+```python
+from sportsdataverse.nba.nba_war import calibrate_replacement_level
+repl = calibrate_replacement_level(
+    ratings, poss, pts_per_win=250.0, target_total_war=300.0,
+)
+```
+
 ### `compile_nba_season(season: 'int', season_type: 'str' = 'Regular Season', *, resume: 'bool' = True, cache_dir: 'Optional[str]' = None, delay_s: 'float' = 0.6, lineup_source: 'str' = 'auto', return_as_pandas: 'bool' = False) -> 'Union[pl.DataFrame, pd.DataFrame]'` {#compile_nba_season}
 
 Compile a full season's possession stint matrix (cached + resumable + throttled).
@@ -1114,23 +1179,24 @@ logs = nba_box_logs("2023-24")
 print(logs["player"].shape)
 ```
 
-### `nba_bpm(player_logs: 'pl.DataFrame', team_logs: 'pl.DataFrame', positions: 'pl.DataFrame', *, team_adjust: 'bool' = True, return_as_pandas: 'bool' = False) -> 'pl.DataFrame'` {#nba_bpm}
+### `nba_bpm(player_logs: 'pl.DataFrame', team_logs: 'pl.DataFrame', positions: 'pl.DataFrame', *, team_adjust: 'bool' = True, granularity: 'str' = 'season', return_as_pandas: 'bool' = False) -> 'pl.DataFrame'` {#nba_bpm}
 
-Faithful BPM 2.0 per player over the given logs (a season).
+Faithful BPM 2.0 per player, at season or single-game granularity.
 
 **Parameters**
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `player_logs` | `DataFrame` |  | per-player-per-game box lines (`nba_box_logs`'s `player`). |
-| `team_logs` | `DataFrame` |  | per-team-per-game lines incl. `plus_minus` (`nba_box_logs`'s `team`). |
+| `player_logs` | `DataFrame` |  | per-player-per-game box lines (`nba_box_logs`'s `player`); must carry `game_id` when `granularity="game"`. |
+| `team_logs` | `DataFrame` |  | per-team-per-game lines incl. `plus_minus` (`nba_box_logs`'s `team`); must carry `game_id` when `granularity="game"`. |
 | `positions` | `DataFrame` |  | listed positions (`nba_player_positions`): player_id, position_num. |
 | `team_adjust` | `bool` | `True` | apply the team adjustment (True) or return raw box-BPM (False). |
+| `granularity` | `str` | `'season'` | `"season"` (default) aggregates every row in `player_logs`/ `team_logs` into one row per player. `"game"` runs the exact same pipeline independently per `game_id` (position/role are estimated game-native, mirroring `NbaBpmModel`'s existing fold-native design) and returns one row per (game_id, player_id) with a leading `game_id` column; `gp` is always 1 in this mode. |
 | `return_as_pandas` | `bool` | `False` | return pandas instead of polars. |
 
 **Returns**
 
-Frame with `player_id`, `obpm`, `dbpm`, `bpm`, `min`, `gp` (Int64 player_id/gp, Float64 obpm/dbpm/bpm/min).
+frame with `player_id`, `obpm`, `dbpm`, `bpm`, `min`, `gp` (Int64 player_id/gp, Float64 obpm/dbpm/bpm/min). `"game"`: the same columns prefixed with `game_id` (Utf8), one row per (game_id, player_id). Empty (that schema) input -> zero-row frame with the same schema; never raises on empty.
 
 **Example**
 
@@ -1139,6 +1205,11 @@ from sportsdataverse.nba import nba_bpm, nba_box_logs, nba_player_positions
 logs = nba_box_logs("2023-24"); pos = nba_player_positions("2023-24")
 bpm = nba_bpm(logs["player"], logs["team"], pos)
 print(bpm.sort("bpm", descending=True).head())
+
+# Per-game BPM
+
+bpm_game = nba_bpm(logs["player"], logs["team"], pos, granularity="game")
+print(bpm_game.filter(pl.col("game_id") == "0022300001").sort("bpm", descending=True))
 
 # Raw (no team adjustment)
 
@@ -1255,6 +1326,48 @@ stub = lambda **kw: pl.DataFrame({"person_id": [1], "position": ["PG"]})
 pos = nba_player_positions("2023-24", fetch=stub)
 ```
 
+### `nba_ratings_panel(model: 'AnyModel', possessions: 'pl.DataFrame', dates: 'Optional[Sequence[datetime.date]]' = None, *, return_as_pandas: 'bool' = False) -> 'Union[pl.DataFrame, pd.DataFrame]'` {#nba_ratings_panel}
+
+Player-ratings-through-date long panel: one row per (player_id, date).
+
+Refit-per-checkpoint (v1; no warm-start incrementality) — each date's row
+calls `ratings_as_of` independently, so the panel is leakage-free by
+construction: a possession dated after a given checkpoint can never affect
+that checkpoint's row, no matter what other dates are also being computed
+or what future rows exist in `possessions`. Cost is a full refit per
+checkpoint date; for a season's sparse RAPM-family design this is seconds
+per date, not minutes — acceptable for a nightly/daily cadence but not for
+live in-game updating (out of scope; see spec non-goals).
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `model` | `AnyModel` |  | A harness model conforming to `nba_model_validation.AnyModel`. |
+| `possessions` | `DataFrame` |  | A possession+lineup frame with a `game_date` (`pl.Date`) column (as emitted by `compile_nba_season`). |
+| `dates` | `Optional[Sequence[date]]` | `None` | Checkpoint dates to compute. `None` (default) uses every distinct `game_date` present in `possessions`, sorted ascending — a rating for every game day, matching what EPM/LEBRON publish nightly. Duplicates are deduped; input order does not matter (the output is always sorted by date). |
+| `return_as_pandas` | `bool` | `False` | Return pandas instead of polars. |
+
+**Returns**
+
+Long frame with `RATINGS_PANEL_SCHEMA` columns (`player_id`, `date`, `o_rating`, `d_rating`, `rating`). Zero-row (that schema) when `possessions` is empty or no date yields any players.
+
+**Example**
+
+```python
+import datetime
+from sportsdataverse.nba.nba_model_validation import RidgeRapmModel
+from sportsdataverse.nba.nba_ratings_panel import nba_ratings_panel
+
+checkpoints = [datetime.date(2023, 11, 1), datetime.date(2023, 12, 1)]
+panel = nba_ratings_panel(RidgeRapmModel(), season_poss, dates=checkpoints)
+print(panel.filter(pl.col("player_id") == 201939).sort("date"))
+
+# Every game day, no explicit grid
+
+panel = nba_ratings_panel(RidgeRapmModel(), season_poss)
+```
+
 ### `nba_spm(box_features: 'pl.DataFrame', coefficients: 'SpmCoefficients', *, return_as_pandas: 'bool' = False) -> 'Union[pl.DataFrame, pd.DataFrame]'` {#nba_spm}
 
 Apply fitted SPM coefficients to per-100 box features -> OSPM/DSPM/SPM.
@@ -1350,6 +1463,48 @@ print(type(df_pd))
 df.filter(pl.col("event_type") == "1").select("player1_name", "player2_name")
 ```
 
+### `nba_war(ratings: 'pl.DataFrame', poss: 'pl.DataFrame', *, replacement_level: 'float', pts_per_win: 'float', rating_col: 'str' = 'rating', poss_col: 'str' = 'poss', return_as_pandas: 'bool' = False) -> 'Union[pl.DataFrame, pd.DataFrame]'` {#nba_war}
+
+Points-above-replacement -> wins for each player.
+
+`war_i = (rating_i - replacement_level) * poss_i / 100 / pts_per_win`.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `ratings` | `DataFrame` |  | Per-player rating frame with `player_id` and `rating_col` (e.g. `nba_rapm`'s `rapm` column renamed, a `nba_ratings_panel` row filtered to one date, or `nba_bpm`'s `bpm` column). |
+| `poss` | `DataFrame` |  | Per-player possession-count frame with `player_id` and `poss_col` (e.g. `off_poss + def_poss` from `nba_rapm`). |
+| `replacement_level` | `float` |  | Per-100-possession rating of a replacement-level player. No built-in default — calibrate via `calibrate_replacement_level`. |
+| `pts_per_win` | `float` |  | Points of season point-margin per marginal win. No built-in default — calibrate via `calibrate_pts_per_win`. |
+| `rating_col` | `str` | `'rating'` | Column in `ratings` to score. |
+| `poss_col` | `str` | `'poss'` | Column in `poss` giving total possessions played. |
+| `return_as_pandas` | `bool` | `False` | Return pandas instead of polars. |
+
+**Returns**
+
+Frame with `WAR_SCHEMA` columns (`player_id`, `war`). Empty (that schema) when either input is empty.
+
+**Example**
+
+```python
+from sportsdataverse.nba.nba_war import nba_war
+war = nba_war(rapm_df.rename({"rapm": "rating"}), poss_df,
+               replacement_level=-2.0, pts_per_win=250.0)
+print(war.sort("war", descending=True).head())
+
+# Derive both required kwargs from real data first
+
+from sportsdataverse.nba.nba_war import (
+    calibrate_pts_per_win, calibrate_replacement_level, nba_war,
+)
+pts_per_win = calibrate_pts_per_win(team_standings)
+repl = calibrate_replacement_level(
+    ratings, poss, pts_per_win=pts_per_win, target_total_war=300.0,
+)
+war = nba_war(ratings, poss, replacement_level=repl, pts_per_win=pts_per_win)
+```
+
 ### `players_on_court_from_pbp(enhanced_pbp: 'pl.DataFrame', raw_box: 'dict', *, home_team_id: 'int', away_team_id: 'int') -> 'pl.DataFrame'` {#players_on_court_from_pbp}
 
 Reconstruct the 5-on-5 on-court lineup from pbp subs + boxscore starters.
@@ -1431,6 +1586,38 @@ df = players_on_court_from_rotation(
     enh, rotation, home_team_id=home, away_team_id=away
 )
 print(df.shape)
+```
+
+### `ratings_as_of(model: 'AnyModel', possessions: 'pl.DataFrame', asof: 'datetime.date') -> 'RatingsFit'` {#ratings_as_of}
+
+Fit `model` on every possession dated on or before `asof` and return ratings.
+
+This is the through-date primitive: possessions with `game_date > asof`
+are excluded from the fit entirely (never merely down-weighted), which is
+what makes the panel built from repeated calls to this function leakage-free
+by construction — see `tests/nba/test_nba_ratings_panel.py::test_ratings_as_of_is_leakage_free_append_invariant`.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `model` | `AnyModel` |  | A harness model conforming to `nba_model_validation.AnyModel` (a `RapmModel`, `RatingsModel`, or `PriorModel`). |
+| `possessions` | `DataFrame` |  | A possession+lineup frame that MUST carry a `game_date` (`pl.Date`) column (as emitted by `compile_nba_season`). |
+| `asof` | `date` |  | The through-date checkpoint (inclusive). |
+
+**Returns**
+
+`RatingsFit` with per-player offense/defense ratings (per-100-possession scale, same sign convention as `nba_rapm`: positive `d_ratings` means good defense). Empty dicts when no possessions fall on or before `asof` or when `possessions` is empty.
+
+**Example**
+
+```python
+import datetime
+from sportsdataverse.nba.nba_model_validation import RidgeRapmModel
+from sportsdataverse.nba.nba_ratings_panel import ratings_as_of
+
+rf = ratings_as_of(RidgeRapmModel(), season_poss, datetime.date(2023, 12, 1))
+print(rf.o_ratings[201939])   # per-100 offensive rating through Dec 1
 ```
 
 ### `render_report(report: 'ValidationReport') -> 'str'` {#render_report}

--- a/docs/docs/nba/reference/additional.md
+++ b/docs/docs/nba/reference/additional.md
@@ -1596,6 +1596,9 @@ This is the through-date primitive: possessions with `game_date > asof`
 are excluded from the fit entirely (never merely down-weighted), which is
 what makes the panel built from repeated calls to this function leakage-free
 by construction — see `tests/nba/test_nba_ratings_panel.py::test_ratings_as_of_is_leakage_free_append_invariant`.
+NOTE: the leakage property is proven by the append-invariance test TOGETHER
+with the panel's per-date-parity test — neither alone covers
+cross-checkpoint-window leaks; do not prune one without the other.
 
 **Parameters**
 

--- a/docs/src/pages/CHANGELOG.md
+++ b/docs/src/pages/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Unreleased](#unreleased)
+  - [NBA — through-date ratings panel, WAR, and single-game BPM (WP4)](#nba--through-date-ratings-panel-war-and-single-game-bpm-wp4)
   - [NBA — v3-to-v2 play-by-play adapter (`nba_v3_to_v2_pbp`)](#nba--v3-to-v2-play-by-play-adapter-nba_v3_to_v2_pbp)
   - [NBA / WNBA — stats.nba.com / stats.wnba.com flat-API family (`nba_stats` / `wnba_stats`)](#nba--wnba--statsnbacom--statswnbacom-flat-api-family-nba_stats--wnba_stats)
   - [NBA — possession event-detail columns, per-shooter shooting frame, `game_date`](#nba--possession-event-detail-columns-per-shooter-shooting-frame-game_date)
@@ -154,6 +155,13 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Unreleased
+
+### NBA — through-date ratings panel, WAR, and single-game BPM (WP4)
+
+- feat(nba): through-date ratings panel (`nba_ratings_panel` + `ratings_as_of`
+  primitive, leakage-free by construction — works with any harness model),
+  WAR layer (`nba_war` + `calibrate_pts_per_win`/`calibrate_replacement_level`
+  calibration helpers), and `nba_bpm(granularity="game")` single-game BPM 2.0.
 
 ### NBA — v3-to-v2 play-by-play adapter (`nba_v3_to_v2_pbp`)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -341,4 +341,5 @@ files = [
     "sportsdataverse/nba/nba_player_ages.py",
     "sportsdataverse/nba/nba_v3_v2_adapter.py",
     "sportsdataverse/nba/nba_possession_rules.py",
+    "sportsdataverse/nba/nba_ratings_panel.py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,4 +342,5 @@ files = [
     "sportsdataverse/nba/nba_v3_v2_adapter.py",
     "sportsdataverse/nba/nba_possession_rules.py",
     "sportsdataverse/nba/nba_ratings_panel.py",
+    "sportsdataverse/nba/nba_war.py",
 ]

--- a/sportsdataverse/nba/__init__.py
+++ b/sportsdataverse/nba/__init__.py
@@ -43,3 +43,14 @@ from sportsdataverse.nba.nba_possessions import (  # noqa: F401
     build_possession_shooting,
     POSSESSION_SHOOTING_SCHEMA,
 )
+from sportsdataverse.nba.nba_ratings_panel import (  # noqa: F401
+    RATINGS_PANEL_SCHEMA,
+    nba_ratings_panel,
+    ratings_as_of,
+)
+from sportsdataverse.nba.nba_war import (  # noqa: F401
+    WAR_SCHEMA,
+    calibrate_pts_per_win,
+    calibrate_replacement_level,
+    nba_war,
+)

--- a/sportsdataverse/nba/nba_bpm.py
+++ b/sportsdataverse/nba/nba_bpm.py
@@ -58,6 +58,19 @@ SHOOTING_BASELINE: float = 1.00
 THRESHOLD_MARGIN: float = 0.33
 _LISTED_BLEND_MIN: float = 50.0  # 50 minutes of listed position blended into the estimate
 
+#: Canonical per-player output schema shared by both granularity modes of :func:`nba_bpm`
+#: (``"game"`` mode additionally prefixes a ``game_id`` column).
+_BPM_SEASON_SCHEMA: Dict[str, type] = {
+    "player_id": pl.Int64,
+    "obpm": pl.Float64,
+    "dbpm": pl.Float64,
+    "bpm": pl.Float64,
+    "min": pl.Float64,
+    "gp": pl.Int64,
+}
+
+_VALID_BPM_GRANULARITY: Tuple[str, str] = ("season", "game")
+
 
 def _clamp(expr: pl.Expr, lo: float = 1.0, hi: float = 5.0) -> pl.Expr:
     return expr.clip(lo, hi)
@@ -320,49 +333,19 @@ def _team_adjust(raw: pl.DataFrame, team_margin: pl.DataFrame, ptm: pl.DataFrame
     )
 
 
-def nba_bpm(
+def _nba_bpm_one(
     player_logs: pl.DataFrame,
     team_logs: pl.DataFrame,
     positions: pl.DataFrame,
     *,
     team_adjust: bool = True,
-    return_as_pandas: bool = False,
 ) -> pl.DataFrame:
-    """Faithful BPM 2.0 per player over the given logs (a season).
+    """Season-mode BPM 2.0 core (single frame in, single frame out — no game looping).
 
-    Args:
-        player_logs: per-player-per-game box lines (``nba_box_logs``'s ``player``).
-        team_logs: per-team-per-game lines incl. ``plus_minus`` (``nba_box_logs``'s ``team``).
-        positions: listed positions (``nba_player_positions``): player_id, position_num.
-        team_adjust: apply the team adjustment (True) or return raw box-BPM (False).
-        return_as_pandas: return pandas instead of polars.
-
-    Returns:
-        Frame with ``player_id``, ``obpm``, ``dbpm``, ``bpm``, ``min``, ``gp``
-        (Int64 player_id/gp, Float64 obpm/dbpm/bpm/min).
-
-    Example:
-        Season BPM (residential IP)::
-
-            from sportsdataverse.nba import nba_bpm, nba_box_logs, nba_player_positions
-            logs = nba_box_logs("2023-24"); pos = nba_player_positions("2023-24")
-            bpm = nba_bpm(logs["player"], logs["team"], pos)
-            print(bpm.sort("bpm", descending=True).head())
-
-        Raw (no team adjustment)::
-
-            bpm_raw = nba_bpm(logs["player"], logs["team"], pos, team_adjust=False)
-
-        Pandas output::
-
-            bpm_pd = nba_bpm(logs["player"], logs["team"], pos, return_as_pandas=True)
-
-        See Also:
-            * `Basketball-Reference BPM 2.0`_ — published coefficient table and methodology
-            * `hoopR`_ — R companion package
-
-        .. _Basketball-Reference BPM 2.0: https://www.basketball-reference.com/about/bpm2.html
-        .. _hoopR: https://hoopR.sportsdataverse.org
+    This is the exact pre-``granularity`` ``nba_bpm`` body, unchanged, so that
+    ``granularity="game"`` can call it once per game_id without duplicating any
+    of the position/role/team-adjustment logic. See :func:`nba_bpm` for the
+    public, documented entry point.
     """
     # box_features returns oreb/dreb; _raw_bpm expects orb/drb — rename at the boundary
     feats_raw = box_features(player_logs, team_logs)
@@ -372,7 +355,6 @@ def nba_bpm(
     positions_est = _estimate_position(shares, positions)
     roles = _estimate_role(shares)
 
-    # shooting-context: adjust per-100 pts toward the baseline given team shooting environment
     tl = (
         team_logs.group_by("team_id")
         .agg(
@@ -402,18 +384,110 @@ def nba_bpm(
     else:
         adj = raw.select("player_id", pl.col("raw_obpm").alias("obpm"), pl.col("raw_bpm").alias("bpm"))
 
-    out = (
+    return (
         adj.join(feats_raw.select(["player_id", "min", "gp"]), on="player_id")
         .with_columns((pl.col("bpm") - pl.col("obpm")).alias("dbpm"))
         .select(
-            pl.col("player_id").cast(pl.Int64),
-            pl.col("obpm").cast(pl.Float64),
-            pl.col("dbpm").cast(pl.Float64),
-            pl.col("bpm").cast(pl.Float64),
-            pl.col("min").cast(pl.Float64),
-            pl.col("gp").cast(pl.Int64),
+            pl.col("player_id").cast(_BPM_SEASON_SCHEMA["player_id"]),
+            pl.col("obpm").cast(_BPM_SEASON_SCHEMA["obpm"]),
+            pl.col("dbpm").cast(_BPM_SEASON_SCHEMA["dbpm"]),
+            pl.col("bpm").cast(_BPM_SEASON_SCHEMA["bpm"]),
+            pl.col("min").cast(_BPM_SEASON_SCHEMA["min"]),
+            pl.col("gp").cast(_BPM_SEASON_SCHEMA["gp"]),
         )
     )
+
+
+def nba_bpm(
+    player_logs: pl.DataFrame,
+    team_logs: pl.DataFrame,
+    positions: pl.DataFrame,
+    *,
+    team_adjust: bool = True,
+    granularity: str = "season",
+    return_as_pandas: bool = False,
+) -> pl.DataFrame:
+    """Faithful BPM 2.0 per player, at season or single-game granularity.
+
+    Args:
+        player_logs: per-player-per-game box lines (``nba_box_logs``'s ``player``);
+            must carry ``game_id`` when ``granularity="game"``.
+        team_logs: per-team-per-game lines incl. ``plus_minus`` (``nba_box_logs``'s ``team``);
+            must carry ``game_id`` when ``granularity="game"``.
+        positions: listed positions (``nba_player_positions``): player_id, position_num.
+        team_adjust: apply the team adjustment (True) or return raw box-BPM (False).
+        granularity: ``"season"`` (default) aggregates every row in ``player_logs``/
+            ``team_logs`` into one row per player. ``"game"`` runs the exact same
+            pipeline independently per ``game_id`` (position/role are estimated
+            game-native, mirroring ``NbaBpmModel``'s existing fold-native design)
+            and returns one row per (game_id, player_id) with a leading ``game_id``
+            column; ``gp`` is always 1 in this mode.
+        return_as_pandas: return pandas instead of polars.
+
+    Returns:
+        ``"season"``: frame with ``player_id``, ``obpm``, ``dbpm``, ``bpm``, ``min``,
+        ``gp`` (Int64 player_id/gp, Float64 obpm/dbpm/bpm/min).
+        ``"game"``: the same columns prefixed with ``game_id`` (Utf8), one row
+        per (game_id, player_id). Empty (that schema) input -> zero-row frame
+        with the same schema; never raises on empty.
+
+    Raises:
+        ValueError: If ``granularity`` is not ``"season"``/``"game"``, or if
+            ``granularity="game"`` is requested but ``player_logs`` has no
+            ``game_id`` column.
+
+    Example:
+        Season BPM (residential IP)::
+
+            from sportsdataverse.nba import nba_bpm, nba_box_logs, nba_player_positions
+            logs = nba_box_logs("2023-24"); pos = nba_player_positions("2023-24")
+            bpm = nba_bpm(logs["player"], logs["team"], pos)
+            print(bpm.sort("bpm", descending=True).head())
+
+        Per-game BPM::
+
+            bpm_game = nba_bpm(logs["player"], logs["team"], pos, granularity="game")
+            print(bpm_game.filter(pl.col("game_id") == "0022300001").sort("bpm", descending=True))
+
+        Raw (no team adjustment)::
+
+            bpm_raw = nba_bpm(logs["player"], logs["team"], pos, team_adjust=False)
+
+        Pandas output::
+
+            bpm_pd = nba_bpm(logs["player"], logs["team"], pos, return_as_pandas=True)
+
+        See Also:
+            * `Basketball-Reference BPM 2.0`_ — published coefficient table and methodology
+            * `hoopR`_ — R companion package
+
+        .. _Basketball-Reference BPM 2.0: https://www.basketball-reference.com/about/bpm2.html
+        .. _hoopR: https://hoopR.sportsdataverse.org
+    """
+    if granularity not in _VALID_BPM_GRANULARITY:
+        raise ValueError(f"granularity must be one of {_VALID_BPM_GRANULARITY}, got {granularity!r}")
+
+    if granularity == "season":
+        out = _nba_bpm_one(player_logs, team_logs, positions, team_adjust=team_adjust)
+        return out.to_pandas() if return_as_pandas else out
+
+    if "game_id" not in player_logs.columns:
+        raise ValueError("player_logs must carry a game_id column for granularity='game'")
+
+    game_ids = player_logs["game_id"].unique().to_list()
+    frames: list[pl.DataFrame] = []
+    for gid in game_ids:
+        pl_g = player_logs.filter(pl.col("game_id") == gid)
+        tl_g = team_logs.filter(pl.col("game_id") == gid)
+        if pl_g.is_empty() or tl_g.is_empty():
+            continue
+        scored = _nba_bpm_one(pl_g, tl_g, positions, team_adjust=team_adjust)
+        frames.append(scored.with_columns(pl.lit(gid).cast(pl.Utf8).alias("game_id")))
+
+    if not frames:
+        out = pl.DataFrame(schema={"game_id": pl.Utf8, **_BPM_SEASON_SCHEMA})
+    else:
+        out = pl.concat(frames, how="diagonal_relaxed").select("game_id", *_BPM_SEASON_SCHEMA.keys())
     return out.to_pandas() if return_as_pandas else out
 
 

--- a/sportsdataverse/nba/nba_ratings_panel.py
+++ b/sportsdataverse/nba/nba_ratings_panel.py
@@ -11,10 +11,21 @@ checkpoint date.
 from __future__ import annotations
 
 import datetime
+from typing import Optional, Sequence, Union
 
+import pandas as pd
 import polars as pl
 
 from sportsdataverse.nba.nba_model_validation import AnyModel, RatingsFit, _fit_on
+
+#: Schema of the per-(player, date) long frame from :func:`nba_ratings_panel`.
+RATINGS_PANEL_SCHEMA: dict[str, pl.DataType] = {
+    "player_id": pl.Int64,
+    "date": pl.Date,
+    "o_rating": pl.Float64,
+    "d_rating": pl.Float64,
+    "rating": pl.Float64,
+}
 
 
 def ratings_as_of(model: AnyModel, possessions: pl.DataFrame, asof: datetime.date) -> RatingsFit:
@@ -68,3 +79,87 @@ def ratings_as_of(model: AnyModel, possessions: pl.DataFrame, asof: datetime.dat
     o_ratings = {int(p): float(fit.coef[k] * 100.0) for k, p in enumerate(pids)}
     d_ratings = {int(p): float(-fit.coef[P + k] * 100.0) for k, p in enumerate(pids)}
     return RatingsFit(o_ratings=o_ratings, d_ratings=d_ratings, posterior=fit.posterior)
+
+
+def _empty_panel_frame() -> pl.DataFrame:
+    return pl.DataFrame({c: pl.Series([], dtype=t) for c, t in RATINGS_PANEL_SCHEMA.items()})
+
+
+def nba_ratings_panel(
+    model: AnyModel,
+    possessions: pl.DataFrame,
+    dates: Optional[Sequence[datetime.date]] = None,
+    *,
+    return_as_pandas: bool = False,
+) -> Union[pl.DataFrame, pd.DataFrame]:
+    """Player-ratings-through-date long panel: one row per (player_id, date).
+
+    Refit-per-checkpoint (v1; no warm-start incrementality) — each date's row
+    calls :func:`ratings_as_of` independently, so the panel is leakage-free by
+    construction: a possession dated after a given checkpoint can never affect
+    that checkpoint's row, no matter what other dates are also being computed
+    or what future rows exist in ``possessions``. Cost is a full refit per
+    checkpoint date; for a season's sparse RAPM-family design this is seconds
+    per date, not minutes — acceptable for a nightly/daily cadence but not for
+    live in-game updating (out of scope; see spec non-goals).
+
+    Args:
+        model: A harness model conforming to ``nba_model_validation.AnyModel``.
+        possessions: A possession+lineup frame with a ``game_date`` (``pl.Date``)
+            column (as emitted by ``compile_nba_season``).
+        dates: Checkpoint dates to compute. ``None`` (default) uses every
+            distinct ``game_date`` present in ``possessions``, sorted ascending
+            — a rating for every game day, matching what EPM/LEBRON publish
+            nightly. Duplicates are deduped; input order does not matter (the
+            output is always sorted by date).
+        return_as_pandas: Return pandas instead of polars.
+
+    Returns:
+        Long frame with :data:`RATINGS_PANEL_SCHEMA` columns
+        (``player_id``, ``date``, ``o_rating``, ``d_rating``, ``rating``).
+        Zero-row (that schema) when ``possessions`` is empty or no date yields
+        any players.
+
+    Raises:
+        ValueError: If ``possessions`` (non-empty) lacks a ``game_date`` column.
+
+    Example:
+        Panel over a hand-picked checkpoint grid::
+
+            import datetime
+            from sportsdataverse.nba.nba_model_validation import RidgeRapmModel
+            from sportsdataverse.nba.nba_ratings_panel import nba_ratings_panel
+
+            checkpoints = [datetime.date(2023, 11, 1), datetime.date(2023, 12, 1)]
+            panel = nba_ratings_panel(RidgeRapmModel(), season_poss, dates=checkpoints)
+            print(panel.filter(pl.col("player_id") == 201939).sort("date"))
+
+        Every game day, no explicit grid::
+
+            panel = nba_ratings_panel(RidgeRapmModel(), season_poss)
+
+        See Also:
+            * `ratings_as_of`_ — the single-date primitive this loops over.
+
+        .. _ratings_as_of: sportsdataverse.nba.nba_ratings_panel.ratings_as_of
+    """
+    if possessions.is_empty():
+        empty = _empty_panel_frame()
+        return empty.to_pandas() if return_as_pandas else empty
+    if "game_date" not in possessions.columns:
+        raise ValueError("possessions must carry a game_date column (see compile_nba_season)")
+
+    checkpoint_dates = (
+        sorted(possessions["game_date"].unique().drop_nulls().to_list()) if dates is None else sorted(set(dates))
+    )
+
+    rows: list[dict[str, object]] = []
+    for d in checkpoint_dates:
+        rf = ratings_as_of(model, possessions, d)
+        for pid in sorted(set(rf.o_ratings) | set(rf.d_ratings)):
+            o = rf.o_ratings.get(pid, 0.0)
+            dd = rf.d_ratings.get(pid, 0.0)
+            rows.append({"player_id": pid, "date": d, "o_rating": o, "d_rating": dd, "rating": o + dd})
+
+    out = pl.DataFrame(rows, schema=RATINGS_PANEL_SCHEMA) if rows else _empty_panel_frame()
+    return out.to_pandas() if return_as_pandas else out

--- a/sportsdataverse/nba/nba_ratings_panel.py
+++ b/sportsdataverse/nba/nba_ratings_panel.py
@@ -1,0 +1,70 @@
+"""Through-date ratings panel — the WP4 daily-foundations engine.
+
+``ratings_as_of`` is the single-date primitive: it filters possessions to
+``game_date <= asof`` and reuses the model-validation harness's existing
+``_fit_on`` dispatcher, so it works unchanged for every ``AnyModel`` the
+harness already supports (RAPM/RidgeCV, BPM, SPM, Bayesian-prior models).
+``nba_ratings_panel`` (Task 2) is a thin loop over this primitive per
+checkpoint date.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import polars as pl
+
+from sportsdataverse.nba.nba_model_validation import AnyModel, RatingsFit, _fit_on
+
+
+def ratings_as_of(model: AnyModel, possessions: pl.DataFrame, asof: datetime.date) -> RatingsFit:
+    """Fit ``model`` on every possession dated on or before ``asof`` and return ratings.
+
+    This is the through-date primitive: possessions with ``game_date > asof``
+    are excluded from the fit entirely (never merely down-weighted), which is
+    what makes the panel built from repeated calls to this function leakage-free
+    by construction — see ``tests/nba/test_nba_ratings_panel.py::test_ratings_as_of_is_leakage_free_append_invariant``.
+
+    Args:
+        model: A harness model conforming to ``nba_model_validation.AnyModel``
+            (a ``RapmModel``, ``RatingsModel``, or ``PriorModel``).
+        possessions: A possession+lineup frame that MUST carry a ``game_date``
+            (``pl.Date``) column (as emitted by ``compile_nba_season``).
+        asof: The through-date checkpoint (inclusive).
+
+    Returns:
+        ``RatingsFit`` with per-player offense/defense ratings (per-100-possession
+        scale, same sign convention as ``nba_rapm``: positive ``d_ratings`` means
+        good defense). Empty dicts when no possessions fall on or before ``asof``
+        or when ``possessions`` is empty.
+
+    Raises:
+        ValueError: If ``possessions`` (non-empty) does not carry a ``game_date``
+            column — this is a caller-contract violation, not a normal empty case,
+            so it raises rather than silently returning empty ratings.
+
+    Example:
+        Through-date RAPM as of a single checkpoint::
+
+            import datetime
+            from sportsdataverse.nba.nba_model_validation import RidgeRapmModel
+            from sportsdataverse.nba.nba_ratings_panel import ratings_as_of
+
+            rf = ratings_as_of(RidgeRapmModel(), season_poss, datetime.date(2023, 12, 1))
+            print(rf.o_ratings[201939])   # per-100 offensive rating through Dec 1
+
+        See Also:
+            * `nba_rapm`_ — the per-100 sign convention this function reuses.
+
+        .. _nba_rapm: sportsdataverse.nba.nba_rapm
+    """
+    if not possessions.is_empty() and "game_date" not in possessions.columns:
+        raise ValueError("possessions must carry a game_date column (see compile_nba_season)")
+    window = possessions.filter(pl.col("game_date") <= asof) if not possessions.is_empty() else possessions
+    fit, pids = _fit_on(model, window)
+    if not pids:
+        return RatingsFit(o_ratings={}, d_ratings={})
+    P = len(pids)
+    o_ratings = {int(p): float(fit.coef[k] * 100.0) for k, p in enumerate(pids)}
+    d_ratings = {int(p): float(-fit.coef[P + k] * 100.0) for k, p in enumerate(pids)}
+    return RatingsFit(o_ratings=o_ratings, d_ratings=d_ratings, posterior=fit.posterior)

--- a/sportsdataverse/nba/nba_ratings_panel.py
+++ b/sportsdataverse/nba/nba_ratings_panel.py
@@ -35,6 +35,9 @@ def ratings_as_of(model: AnyModel, possessions: pl.DataFrame, asof: datetime.dat
     are excluded from the fit entirely (never merely down-weighted), which is
     what makes the panel built from repeated calls to this function leakage-free
     by construction — see ``tests/nba/test_nba_ratings_panel.py::test_ratings_as_of_is_leakage_free_append_invariant``.
+    NOTE: the leakage property is proven by the append-invariance test TOGETHER
+    with the panel's per-date-parity test — neither alone covers
+    cross-checkpoint-window leaks; do not prune one without the other.
 
     Args:
         model: A harness model conforming to ``nba_model_validation.AnyModel``

--- a/sportsdataverse/nba/nba_war.py
+++ b/sportsdataverse/nba/nba_war.py
@@ -9,8 +9,18 @@ requires them as explicit keyword arguments.
 
 from __future__ import annotations
 
+from typing import Union
+
 import numpy as np
+import pandas as pd
 import polars as pl
+
+#: Schema of the per-player frame returned by :func:`nba_war`.
+WAR_SCHEMA: dict[str, pl.DataType] = {"player_id": pl.Int64, "war": pl.Float64}
+
+
+def _empty_war_frame() -> pl.DataFrame:
+    return pl.DataFrame({c: pl.Series([], dtype=t) for c, t in WAR_SCHEMA.items()})
 
 
 def calibrate_pts_per_win(team_season: pl.DataFrame) -> float:
@@ -112,3 +122,76 @@ def calibrate_replacement_level(
         raise ValueError("calibrate_replacement_level: total possession weight is zero")
     weighted_rating = float((j[rating_col].cast(pl.Float64) * weight).sum())
     return (weighted_rating - target_total_war) / total_weight
+
+
+def nba_war(
+    ratings: pl.DataFrame,
+    poss: pl.DataFrame,
+    *,
+    replacement_level: float,
+    pts_per_win: float,
+    rating_col: str = "rating",
+    poss_col: str = "poss",
+    return_as_pandas: bool = False,
+) -> Union[pl.DataFrame, pd.DataFrame]:
+    """Points-above-replacement -> wins for each player.
+
+    ``war_i = (rating_i - replacement_level) * poss_i / 100 / pts_per_win``.
+
+    Args:
+        ratings: Per-player rating frame with ``player_id`` and ``rating_col``
+            (e.g. ``nba_rapm``'s ``rapm`` column renamed, a ``nba_ratings_panel``
+            row filtered to one date, or ``nba_bpm``'s ``bpm`` column).
+        poss: Per-player possession-count frame with ``player_id`` and
+            ``poss_col`` (e.g. ``off_poss + def_poss`` from ``nba_rapm``).
+        replacement_level: Per-100-possession rating of a replacement-level
+            player. No built-in default — calibrate via
+            :func:`calibrate_replacement_level`.
+        pts_per_win: Points of season point-margin per marginal win. No
+            built-in default — calibrate via :func:`calibrate_pts_per_win`.
+        rating_col: Column in ``ratings`` to score.
+        poss_col: Column in ``poss`` giving total possessions played.
+        return_as_pandas: Return pandas instead of polars.
+
+    Returns:
+        Frame with :data:`WAR_SCHEMA` columns (``player_id``, ``war``). Empty
+        (that schema) when either input is empty.
+
+    Raises:
+        ValueError: If both inputs are non-empty but share no ``player_id``
+            (a probable id-source or dtype mismatch, not a normal empty case).
+
+    Example:
+        Score WAR from a calibrated replacement level and pts-per-win::
+
+            from sportsdataverse.nba.nba_war import nba_war
+            war = nba_war(rapm_df.rename({"rapm": "rating"}), poss_df,
+                           replacement_level=-2.0, pts_per_win=250.0)
+            print(war.sort("war", descending=True).head())
+
+        Derive both required kwargs from real data first::
+
+            from sportsdataverse.nba.nba_war import (
+                calibrate_pts_per_win, calibrate_replacement_level, nba_war,
+            )
+            pts_per_win = calibrate_pts_per_win(team_standings)
+            repl = calibrate_replacement_level(
+                ratings, poss, pts_per_win=pts_per_win, target_total_war=300.0,
+            )
+            war = nba_war(ratings, poss, replacement_level=repl, pts_per_win=pts_per_win)
+    """
+    if ratings.is_empty() or poss.is_empty():
+        return _empty_war_frame().to_pandas() if return_as_pandas else _empty_war_frame()
+    j = ratings.join(poss, on="player_id", how="inner")
+    if j.is_empty():
+        raise ValueError("nba_war: ratings and poss share no shared player_id")
+    out = j.select(
+        pl.col("player_id").cast(pl.Int64),
+        (
+            (pl.col(rating_col).cast(pl.Float64) - replacement_level)
+            * pl.col(poss_col).cast(pl.Float64)
+            / 100.0
+            / pts_per_win
+        ).alias("war"),
+    )
+    return out.to_pandas() if return_as_pandas else out

--- a/sportsdataverse/nba/nba_war.py
+++ b/sportsdataverse/nba/nba_war.py
@@ -1,0 +1,114 @@
+"""WAR (points-above-replacement -> wins) layer for the NBA model zoo.
+
+Per the WP4 spec's Open Decision (see the plan's "Open decisions" section):
+this module ships NO invented numeric default for ``pts_per_win`` or
+``replacement_level`` — both are closed-form-calibrated from real
+compiled-season data via the two functions below, and ``nba_war`` (Task 4)
+requires them as explicit keyword arguments.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+
+
+def calibrate_pts_per_win(team_season: pl.DataFrame) -> float:
+    """Regress team wins on season point margin; return points-per-marginal-win.
+
+    Fits ``wins ~ total_margin`` via ordinary least squares over one (or more,
+    pooled) season's team-level rows and returns ``1 / slope`` — the amount of
+    full-season point differential associated with one additional win. This is
+    ``nba_war``'s ``pts_per_win`` input.
+
+    Args:
+        team_season: One row per team-season with ``team_id`` (any dtype),
+            ``wins`` (numeric), and ``total_margin`` (numeric — the team's
+            full-season point differential: points scored minus points allowed
+            across all its games, NOT a per-game average).
+
+    Returns:
+        ``float`` points of season margin per marginal win.
+
+    Raises:
+        ValueError: If ``team_season`` has fewer than 3 rows (a degenerate
+            regression), if ``total_margin`` has zero variance, or if the
+            fitted slope is exactly zero (undefined points-per-win).
+
+    Example:
+        Calibrate from a compiled season's standings::
+
+            from sportsdataverse.nba.nba_war import calibrate_pts_per_win
+            pts_per_win = calibrate_pts_per_win(team_standings)  # team_id/wins/total_margin
+            print(pts_per_win)
+    """
+    if team_season.height < 3:
+        raise ValueError(f"calibrate_pts_per_win needs >=3 team-season rows, got {team_season.height}")
+    x = team_season["total_margin"].to_numpy().astype(np.float64)
+    y = team_season["wins"].to_numpy().astype(np.float64)
+    if np.std(x) == 0:
+        raise ValueError("calibrate_pts_per_win: total_margin has zero variance")
+    slope, _intercept = np.polyfit(x, y, 1)
+    if slope == 0:
+        raise ValueError("calibrate_pts_per_win: fitted wins~total_margin slope is exactly zero")
+    return float(1.0 / slope)
+
+
+def calibrate_replacement_level(
+    ratings: pl.DataFrame,
+    poss: pl.DataFrame,
+    *,
+    pts_per_win: float,
+    target_total_war: float,
+    rating_col: str = "rating",
+    poss_col: str = "poss",
+) -> float:
+    """Solve for the ``replacement_level`` that makes summed league WAR hit a target.
+
+    WAR is affine in ``replacement_level``:
+    ``war_i = (rating_i - replacement) * poss_i / 100 / pts_per_win``. Summed
+    over all players this is a single linear equation in ``replacement_level``;
+    this function solves it in closed form (not an iterative search) for the
+    ``replacement_level`` that makes ``sum(war_i) == target_total_war``.
+
+    ``target_total_war`` is a value the CALLER computes from real standings
+    (e.g. total league wins above a chosen replacement-team win percentage) —
+    this function does not assume or invent any such win-percentage convention.
+
+    Args:
+        ratings: Frame with ``player_id`` and ``rating_col``.
+        poss: Frame with ``player_id`` and ``poss_col`` (total possessions played).
+        pts_per_win: Points of season margin per marginal win
+            (``calibrate_pts_per_win``'s output).
+        target_total_war: The desired sum of every player's WAR.
+        rating_col: Column in ``ratings`` holding the per-100-possession rating.
+        poss_col: Column in ``poss`` holding total possessions played.
+
+    Returns:
+        ``float`` replacement_level solving the equation exactly.
+
+    Raises:
+        ValueError: If ``ratings`` and ``poss`` share no ``player_id`` (an
+            inner join on two non-empty frames producing zero rows — a probable
+            id-source/dtype mismatch), or if the resulting total possession
+            weight sums to zero (the equation is then degenerate).
+
+    Example:
+        Solve replacement level against a chosen win-above-replacement target::
+
+            from sportsdataverse.nba.nba_war import calibrate_replacement_level
+            repl = calibrate_replacement_level(
+                ratings, poss, pts_per_win=250.0, target_total_war=300.0,
+            )
+    """
+    j = ratings.join(poss, on="player_id", how="inner")
+    if j.is_empty():
+        if ratings.is_empty() or poss.is_empty():
+            raise ValueError("calibrate_replacement_level: ratings or poss is empty — nothing to calibrate")
+        raise ValueError("calibrate_replacement_level: ratings and poss share no shared player_id")
+    weight = j[poss_col].cast(pl.Float64) / 100.0 / pts_per_win
+    total_weight = float(weight.sum())
+    if total_weight == 0:
+        raise ValueError("calibrate_replacement_level: total possession weight is zero")
+    weighted_rating = float((j[rating_col].cast(pl.Float64) * weight).sum())
+    return (weighted_rating - target_total_war) / total_weight

--- a/sportsdataverse/parsed/nba.py
+++ b/sportsdataverse/parsed/nba.py
@@ -150,6 +150,8 @@ from sportsdataverse.nba import SpmCoefficients as SpmCoefficients  # noqa: F401
 from sportsdataverse.nba import ValidationReport as ValidationReport  # noqa: F401
 from sportsdataverse.nba import box_features as box_features  # noqa: F401
 from sportsdataverse.nba import build_possession_shooting as build_possession_shooting  # noqa: F401
+from sportsdataverse.nba import calibrate_pts_per_win as calibrate_pts_per_win  # noqa: F401
+from sportsdataverse.nba import calibrate_replacement_level as calibrate_replacement_level  # noqa: F401
 from sportsdataverse.nba import compile_nba_season as compile_nba_season  # noqa: F401
 from sportsdataverse.nba import darko_forecast_accuracy as darko_forecast_accuracy  # noqa: F401
 from sportsdataverse.nba import download as download  # noqa: F401
@@ -190,11 +192,14 @@ from sportsdataverse.nba import nba_darko as nba_darko  # noqa: F401
 from sportsdataverse.nba import nba_pbp_disk as nba_pbp_disk  # noqa: F401
 from sportsdataverse.nba import nba_player_ages as nba_player_ages  # noqa: F401
 from sportsdataverse.nba import nba_player_positions as nba_player_positions  # noqa: F401
+from sportsdataverse.nba import nba_ratings_panel as nba_ratings_panel  # noqa: F401
 from sportsdataverse.nba import nba_spm as nba_spm  # noqa: F401
 from sportsdataverse.nba import nba_v3_to_v2_pbp as nba_v3_to_v2_pbp  # noqa: F401
+from sportsdataverse.nba import nba_war as nba_war  # noqa: F401
 from sportsdataverse.nba import normalize_team_roster_columns as normalize_team_roster_columns  # noqa: F401
 from sportsdataverse.nba import players_on_court_from_pbp as players_on_court_from_pbp  # noqa: F401
 from sportsdataverse.nba import players_on_court_from_rotation as players_on_court_from_rotation  # noqa: F401
+from sportsdataverse.nba import ratings_as_of as ratings_as_of  # noqa: F401
 from sportsdataverse.nba import render_report as render_report  # noqa: F401
 from sportsdataverse.nba import scoreboard_event_parsing as scoreboard_event_parsing  # noqa: F401
 from sportsdataverse.nba import train_spm as train_spm  # noqa: F401
@@ -213,6 +218,8 @@ __all__ = [
     "ValidationReport",
     "box_features",
     "build_possession_shooting",
+    "calibrate_pts_per_win",
+    "calibrate_replacement_level",
     "compile_nba_season",
     "darko_forecast_accuracy",
     "download",
@@ -370,11 +377,14 @@ __all__ = [
     "nba_pbp_disk",
     "nba_player_ages",
     "nba_player_positions",
+    "nba_ratings_panel",
     "nba_spm",
     "nba_v3_to_v2_pbp",
+    "nba_war",
     "normalize_team_roster_columns",
     "players_on_court_from_pbp",
     "players_on_court_from_rotation",
+    "ratings_as_of",
     "render_report",
     "scoreboard_event_parsing",
     "train_spm",

--- a/tests/nba/test_nba_bpm.py
+++ b/tests/nba/test_nba_bpm.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import numpy as np
 import polars as pl
+import pytest
 from sportsdataverse.nba.nba_bpm import (
     BPM2_COEFFICIENTS,
     NbaBpmModel,
@@ -313,6 +314,67 @@ def test_nba_bpm_model_head_to_head() -> None:
     rep = validate_model(model, [poss], model_name="bpm", oracles=("retrodiction",))
     assert rep.retrodiction is not None
     assert rep.retrodiction.n_test_games > 0
+
+
+# ---------------------------------------------------------------------------
+# Task 7 (WP4): granularity="game" — single-game BPM 2.0
+# ---------------------------------------------------------------------------
+
+
+def test_nba_bpm_game_granularity_one_row_per_game_player():
+    player_logs, team_logs = _synth_logs()  # 20 games, 2 teams x 8 players
+    positions = pl.DataFrame({"player_id": list(range(1, 17)), "position_num": [3.0] * 16})
+    out = nba_bpm(player_logs, team_logs, positions, granularity="game")
+    assert set(out.columns) == {"game_id", "player_id", "obpm", "dbpm", "bpm", "min", "gp"}
+    assert out.height == 20 * 16
+    assert (out["gp"] == 1).all()
+    assert set(out["game_id"].unique().to_list()) == {f"G{gi}" for gi in range(20)}
+
+
+def test_nba_bpm_game_granularity_per_game_team_adjustment_invariant():
+    """Per game: minute-weighted team BPM == that game's own efficiency margin
+    (same invariant test_team_adjustment_invariant checks at season grain)."""
+    player_logs, team_logs = _synth_logs()
+    positions = pl.DataFrame({"player_id": list(range(1, 17)), "position_num": [3.0] * 16})
+    out = nba_bpm(player_logs, team_logs, positions, granularity="game")
+    for gi in range(20):
+        gid = f"G{gi}"
+        og = out.filter(pl.col("game_id") == gid).join(
+            player_logs.filter(pl.col("game_id") == gid).select("player_id", "team_id"), on="player_id"
+        )
+        tlg = team_logs.filter(pl.col("game_id") == gid)
+        for team in (1, 2):
+            t = og.filter(pl.col("team_id") == team)
+            wbpm = (t["bpm"] * t["min"]).sum() / t["min"].sum()
+            tl = tlg.filter(pl.col("team_id") == team)
+            poss = (tl["fga"] - tl["oreb"] + tl["tov"] + 0.44 * tl["fta"]).sum()
+            margin = tl["plus_minus"].sum() / poss * 100
+            assert abs(wbpm - margin) < 1e-6, (gid, team)
+
+
+def test_nba_bpm_season_mode_unchanged_by_refactor():
+    """Regression guard for the _nba_bpm_one extraction: default (season) mode
+    must produce the exact same columns/shape as before the granularity dispatcher."""
+    player_logs, team_logs = _synth_logs()
+    positions = pl.DataFrame({"player_id": list(range(1, 17)), "position_num": [3.0] * 16})
+    out = nba_bpm(player_logs, team_logs, positions)  # default granularity="season"
+    assert set(out.columns) == {"player_id", "obpm", "dbpm", "bpm", "min", "gp"}
+    assert out.height == 16
+    assert out["gp"].to_list() == [20] * 16
+
+
+def test_nba_bpm_invalid_granularity_raises():
+    player_logs, team_logs = _synth_logs()
+    positions = pl.DataFrame({"player_id": list(range(1, 17)), "position_num": [3.0] * 16})
+    with pytest.raises(ValueError, match="granularity"):
+        nba_bpm(player_logs, team_logs, positions, granularity="quarter")
+
+
+def test_nba_bpm_game_granularity_requires_game_id():
+    player_logs, team_logs = _synth_logs()
+    positions = pl.DataFrame({"player_id": list(range(1, 17)), "position_num": [3.0] * 16})
+    with pytest.raises(ValueError, match="game_id"):
+        nba_bpm(player_logs.drop("game_id"), team_logs, positions, granularity="game")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/nba/test_nba_ratings_panel.py
+++ b/tests/nba/test_nba_ratings_panel.py
@@ -1,0 +1,83 @@
+"""Tests for the WP4 through-date ratings engine (nba_ratings_panel)."""
+
+from __future__ import annotations
+
+import datetime
+
+import polars as pl
+import pytest
+from sportsdataverse.nba.nba_model_validation import RidgeRapmModel, _synthetic_possessions
+from sportsdataverse.nba.nba_ratings_panel import ratings_as_of
+
+
+def _dated(poss: pl.DataFrame, d: datetime.date) -> pl.DataFrame:
+    return poss.with_columns(pl.lit(d).cast(pl.Date).alias("game_date"))
+
+
+def _three_day_possessions() -> tuple[pl.DataFrame, pl.DataFrame, pl.DataFrame]:
+    """Three disjoint game-day possession frames sharing the same 16-player pool."""
+    o = {p: 0.02 for p in range(1, 17)}
+    d = {p: 0.01 for p in range(1, 17)}
+    day1 = _dated(
+        _synthetic_possessions(o, d, n_games=10, poss_per_game=30, noise_sd=0.2, seed=1),
+        datetime.date(2023, 10, 24),
+    )
+    day2 = _dated(
+        _synthetic_possessions(o, d, n_games=10, poss_per_game=30, noise_sd=0.2, seed=2).with_columns(
+            (pl.col("game_id") + "_d2").alias("game_id")
+        ),
+        datetime.date(2023, 10, 26),
+    )
+    day3 = _dated(
+        _synthetic_possessions(o, d, n_games=10, poss_per_game=30, noise_sd=0.2, seed=3).with_columns(
+            (pl.col("game_id") + "_d3").alias("game_id")
+        ),
+        datetime.date(2023, 10, 28),
+    )
+    return day1, day2, day3
+
+
+def test_ratings_as_of_is_leakage_free_append_invariant():
+    """THE binding correctness property: appending future-dated games must not
+    change an earlier as-of checkpoint's ratings, at all, byte-for-byte."""
+    day1, day2, day3 = _three_day_possessions()
+    model = RidgeRapmModel()
+    d1 = datetime.date(2023, 10, 24)
+
+    rf_alone = ratings_as_of(model, day1, d1)
+    pooled = pl.concat([day1, day2, day3], how="diagonal_relaxed")
+    rf_from_pooled = ratings_as_of(model, pooled, d1)
+
+    assert rf_alone.o_ratings == rf_from_pooled.o_ratings
+    assert rf_alone.d_ratings == rf_from_pooled.d_ratings
+
+
+def test_ratings_as_of_round_trips_rapm_scale():
+    """coef -> per-100 conversion matches nba_rapm's own convention exactly."""
+    day1, _, _ = _three_day_possessions()
+    model = RidgeRapmModel()
+    d1 = datetime.date(2023, 10, 24)
+    rf = ratings_as_of(model, day1, d1)
+    assert set(rf.o_ratings) == set(range(1, 17))
+    assert set(rf.d_ratings) == set(range(1, 17))
+    # sanity: with a planted positive o-rating, the fit shouldn't collapse to exactly 0 for all players
+    assert any(v != 0.0 for v in rf.o_ratings.values())
+
+
+def test_ratings_as_of_before_any_games_is_empty():
+    day1, _, _ = _three_day_possessions()
+    model = RidgeRapmModel()
+    rf = ratings_as_of(model, day1, datetime.date(2020, 1, 1))
+    assert rf.o_ratings == {}
+    assert rf.d_ratings == {}
+
+
+def test_ratings_as_of_requires_game_date_column():
+    model = RidgeRapmModel()
+    # _synthetic_possessions samples 5-per-team without replacement, so the player
+    # pool must carry >=5 players per side (10 total) even for this error-path test.
+    o = {p: 0.0 for p in range(1, 11)}
+    d = {p: 0.0 for p in range(1, 11)}
+    poss = _synthetic_possessions(o, d, n_games=2, poss_per_game=5, noise_sd=0.0, seed=0)
+    with pytest.raises(ValueError, match="game_date"):
+        ratings_as_of(model, poss, datetime.date(2023, 10, 24))

--- a/tests/nba/test_nba_ratings_panel.py
+++ b/tests/nba/test_nba_ratings_panel.py
@@ -6,8 +6,9 @@ import datetime
 
 import polars as pl
 import pytest
+from polars.testing import assert_frame_equal
 from sportsdataverse.nba.nba_model_validation import RidgeRapmModel, _synthetic_possessions
-from sportsdataverse.nba.nba_ratings_panel import ratings_as_of
+from sportsdataverse.nba.nba_ratings_panel import RATINGS_PANEL_SCHEMA, nba_ratings_panel, ratings_as_of
 
 
 def _dated(poss: pl.DataFrame, d: datetime.date) -> pl.DataFrame:
@@ -81,3 +82,94 @@ def test_ratings_as_of_requires_game_date_column():
     poss = _synthetic_possessions(o, d, n_games=2, poss_per_game=5, noise_sd=0.0, seed=0)
     with pytest.raises(ValueError, match="game_date"):
         ratings_as_of(model, poss, datetime.date(2023, 10, 24))
+
+
+# ---------------------------------------------------------------------------
+# Task 2: nba_ratings_panel long-frame engine
+# ---------------------------------------------------------------------------
+
+
+def test_ratings_panel_is_leakage_free():
+    """Same binding property as Task 1, at the panel (multi-date) level: a
+    future-dated game appended to the frame must not move ANY earlier checkpoint."""
+    day1, day2, day3 = _three_day_possessions()
+    model = RidgeRapmModel()
+    d1, d2 = datetime.date(2023, 10, 24), datetime.date(2023, 10, 26)
+
+    pooled_all = pl.concat([day1, day2, day3], how="diagonal_relaxed")
+    pooled_two = pl.concat([day1, day2], how="diagonal_relaxed")
+
+    panel_from_all = nba_ratings_panel(model, pooled_all, dates=[d1, d2])
+    panel_from_two = nba_ratings_panel(model, pooled_two, dates=[d1, d2])
+
+    assert_frame_equal(
+        panel_from_all.sort(["date", "player_id"]),
+        panel_from_two.sort(["date", "player_id"]),
+    )
+
+
+def test_ratings_panel_matches_ratings_as_of_per_date():
+    day1, day2, _ = _three_day_possessions()
+    pooled = pl.concat([day1, day2], how="diagonal_relaxed")
+    model = RidgeRapmModel()
+    d1, d2 = datetime.date(2023, 10, 24), datetime.date(2023, 10, 26)
+
+    panel = nba_ratings_panel(model, pooled, dates=[d1, d2])
+    for d in (d1, d2):
+        rf = ratings_as_of(model, pooled, d)
+        sub = panel.filter(pl.col("date") == d).sort("player_id")
+        assert sub["player_id"].to_list() == sorted(rf.o_ratings)
+        for pid, o, dd in zip(sub["player_id"], sub["o_rating"], sub["d_rating"]):
+            assert o == rf.o_ratings[pid]
+            assert dd == rf.d_ratings[pid]
+            assert abs((o + dd) - sub.filter(pl.col("player_id") == pid)["rating"][0]) < 1e-12
+
+
+def test_ratings_panel_dates_deduped_and_sorted():
+    day1, day2, _ = _three_day_possessions()
+    pooled = pl.concat([day1, day2], how="diagonal_relaxed")
+    model = RidgeRapmModel()
+    d1, d2 = datetime.date(2023, 10, 24), datetime.date(2023, 10, 26)
+
+    panel = nba_ratings_panel(model, pooled, dates=[d2, d1, d1, d2])
+    assert panel["date"].unique().sort().to_list() == [d1, d2]
+
+
+def test_ratings_panel_default_dates_is_every_distinct_game_date():
+    day1, day2, _ = _three_day_possessions()
+    pooled = pl.concat([day1, day2], how="diagonal_relaxed")
+    model = RidgeRapmModel()
+    panel = nba_ratings_panel(model, pooled)
+    assert panel["date"].unique().sort().to_list() == [
+        datetime.date(2023, 10, 24),
+        datetime.date(2023, 10, 26),
+    ]
+
+
+def test_ratings_panel_empty_possessions_returns_documented_schema():
+    model = RidgeRapmModel()
+    empty = pl.DataFrame(schema={"game_id": pl.Utf8, "game_date": pl.Date})
+    panel = nba_ratings_panel(model, empty, dates=[datetime.date(2023, 10, 24)])
+    assert panel.height == 0
+    assert dict(panel.schema) == RATINGS_PANEL_SCHEMA
+
+
+def test_ratings_panel_requires_game_date_column():
+    model = RidgeRapmModel()
+    # _synthetic_possessions samples 5-per-team without replacement, so the player
+    # pool must carry >=5 players per side (10 total) even for this error-path test
+    # (same constraint documented on test_ratings_as_of_requires_game_date_column above).
+    o = {p: 0.0 for p in range(1, 11)}
+    d = {p: 0.0 for p in range(1, 11)}
+    poss = _synthetic_possessions(o, d, n_games=2, poss_per_game=5, noise_sd=0.0, seed=0)
+    with pytest.raises(ValueError, match="game_date"):
+        nba_ratings_panel(model, poss, dates=[datetime.date(2023, 10, 24)])
+
+
+def test_ratings_panel_return_as_pandas():
+    day1, _, _ = _three_day_possessions()
+    model = RidgeRapmModel()
+    panel_pd = nba_ratings_panel(model, day1, dates=[datetime.date(2023, 10, 24)], return_as_pandas=True)
+    import pandas as pd
+
+    assert isinstance(panel_pd, pd.DataFrame)

--- a/tests/nba/test_nba_war.py
+++ b/tests/nba/test_nba_war.py
@@ -1,0 +1,52 @@
+"""Tests for the WP4 WAR layer: calibration helpers + nba_war scoring."""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import pytest
+from sportsdataverse.nba.nba_war import calibrate_pts_per_win, calibrate_replacement_level
+
+
+def test_calibrate_pts_per_win_recovers_planted_noiseless_relationship():
+    # planted: wins = 41 + total_margin / 250  (K=250 points of margin per marginal win)
+    margins = np.array([-400.0, -200.0, -100.0, 0.0, 100.0, 200.0, 300.0, 400.0, 500.0, -300.0])
+    wins = 41.0 + margins / 250.0
+    team_season = pl.DataFrame({"team_id": list(range(1, 11)), "wins": wins.tolist(), "total_margin": margins.tolist()})
+    pts_per_win = calibrate_pts_per_win(team_season)
+    assert abs(pts_per_win - 250.0) < 1e-6
+
+
+def test_calibrate_pts_per_win_tolerates_noise():
+    rng = np.random.default_rng(0)
+    margins = np.linspace(-500.0, 500.0, 30)
+    wins = 41.0 + margins / 260.0 + rng.normal(0, 1.0, size=30)
+    team_season = pl.DataFrame({"team_id": list(range(1, 31)), "wins": wins.tolist(), "total_margin": margins.tolist()})
+    pts_per_win = calibrate_pts_per_win(team_season)
+    assert abs(pts_per_win - 260.0) / 260.0 < 0.2  # within 20%
+
+
+def test_calibrate_pts_per_win_raises_on_too_few_rows():
+    team_season = pl.DataFrame({"team_id": [1, 2], "wins": [40.0, 42.0], "total_margin": [-10.0, 10.0]})
+    with pytest.raises(ValueError, match="team-season"):
+        calibrate_pts_per_win(team_season)
+
+
+def test_calibrate_pts_per_win_raises_on_zero_variance_margin():
+    team_season = pl.DataFrame({"team_id": [1, 2, 3], "wins": [40.0, 41.0, 42.0], "total_margin": [0.0, 0.0, 0.0]})
+    with pytest.raises(ValueError, match="zero variance"):
+        calibrate_pts_per_win(team_season)
+
+
+def test_calibrate_replacement_level_solves_the_target_equation():
+    ratings = pl.DataFrame({"player_id": [1, 2, 3, 4, 5], "rating": [3.0, 1.0, 0.0, -1.0, -3.0]})
+    poss = pl.DataFrame({"player_id": [1, 2, 3, 4, 5], "poss": [1000, 1000, 1000, 1000, 1000]})
+    repl = calibrate_replacement_level(ratings, poss, pts_per_win=250.0, target_total_war=10.0)
+    assert abs(repl - (-50.0)) < 1e-9
+
+
+def test_calibrate_replacement_level_raises_on_empty_join():
+    ratings = pl.DataFrame({"player_id": [1], "rating": [3.0]})
+    poss = pl.DataFrame({"player_id": [2], "poss": [1000]})
+    with pytest.raises(ValueError, match="no shared player_id"):
+        calibrate_replacement_level(ratings, poss, pts_per_win=250.0, target_total_war=10.0)

--- a/tests/nba/test_nba_war.py
+++ b/tests/nba/test_nba_war.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import numpy as np
 import polars as pl
 import pytest
-from sportsdataverse.nba.nba_war import calibrate_pts_per_win, calibrate_replacement_level
+from sportsdataverse.nba.nba_war import WAR_SCHEMA, calibrate_pts_per_win, calibrate_replacement_level, nba_war
 
 
 def test_calibrate_pts_per_win_recovers_planted_noiseless_relationship():
@@ -50,3 +50,59 @@ def test_calibrate_replacement_level_raises_on_empty_join():
     poss = pl.DataFrame({"player_id": [2], "poss": [1000]})
     with pytest.raises(ValueError, match="no shared player_id"):
         calibrate_replacement_level(ratings, poss, pts_per_win=250.0, target_total_war=10.0)
+
+
+# ---------------------------------------------------------------------------
+# Task 4: nba_war scoring function
+# ---------------------------------------------------------------------------
+
+
+def test_nba_war_matches_hand_computed_values():
+    ratings = pl.DataFrame({"player_id": [1, 2], "rating": [5.0, -5.0]})
+    poss = pl.DataFrame({"player_id": [1, 2], "poss": [800, 800]})
+    out = nba_war(ratings, poss, replacement_level=0.0, pts_per_win=200.0)
+    assert dict(out.schema) == WAR_SCHEMA
+    got = dict(zip(out["player_id"], out["war"]))
+    assert abs(got[1] - 0.2) < 1e-9
+    assert abs(got[2] - (-0.2)) < 1e-9
+
+
+def test_nba_war_consistent_with_calibrate_replacement_level():
+    """Closed-loop check: calibrate a replacement level for a target, then
+    verify nba_war's own summed output actually hits that target."""
+    ratings = pl.DataFrame({"player_id": [1, 2, 3, 4, 5], "rating": [3.0, 1.0, 0.0, -1.0, -3.0]})
+    poss = pl.DataFrame({"player_id": [1, 2, 3, 4, 5], "poss": [1000, 1000, 1000, 1000, 1000]})
+    repl = calibrate_replacement_level(ratings, poss, pts_per_win=250.0, target_total_war=10.0)
+    out = nba_war(ratings, poss, replacement_level=repl, pts_per_win=250.0)
+    assert abs(out["war"].sum() - 10.0) < 1e-9
+
+
+def test_nba_war_custom_column_names():
+    ratings = pl.DataFrame({"player_id": [1], "my_rating": [10.0]})
+    poss = pl.DataFrame({"player_id": [1], "my_poss": [500]})
+    out = nba_war(ratings, poss, replacement_level=0.0, pts_per_win=100.0, rating_col="my_rating", poss_col="my_poss")
+    assert abs(out["war"][0] - (10.0 * 500 / 100 / 100.0)) < 1e-9
+
+
+def test_nba_war_empty_ratings_returns_documented_schema():
+    empty = pl.DataFrame(schema={"player_id": pl.Int64, "rating": pl.Float64})
+    poss = pl.DataFrame({"player_id": [1], "poss": [500]})
+    out = nba_war(empty, poss, replacement_level=0.0, pts_per_win=100.0)
+    assert out.height == 0
+    assert dict(out.schema) == WAR_SCHEMA
+
+
+def test_nba_war_disjoint_nonempty_inputs_raises():
+    ratings = pl.DataFrame({"player_id": [1], "rating": [5.0]})
+    poss = pl.DataFrame({"player_id": [2], "poss": [500]})
+    with pytest.raises(ValueError, match="no shared player_id"):
+        nba_war(ratings, poss, replacement_level=0.0, pts_per_win=100.0)
+
+
+def test_nba_war_return_as_pandas():
+    import pandas as pd
+
+    ratings = pl.DataFrame({"player_id": [1], "rating": [5.0]})
+    poss = pl.DataFrame({"player_id": [1], "poss": [500]})
+    out = nba_war(ratings, poss, replacement_level=0.0, pts_per_win=100.0, return_as_pandas=True)
+    assert isinstance(out, pd.DataFrame)


### PR DESCRIPTION
## Summary

WP4 of the Model-Zoo-v2 Tier-1 program — the through-date ratings infrastructure:

- **`ratings_as_of(model, possessions, asof)`** — leakage-free through-date fit primitive (inclusive `asof`, filter-then-fit, reuses the validation harness's `_fit_on` so it works for every harness model unmodified; per-100 scale byte-identical to `nba_rapm`).
- **`nba_ratings_panel`** — long-frame engine looping the primitive over a date grid (`RATINGS_PANEL_SCHEMA`: player_id/date/o_rating/d_rating/rating). Leakage-freedom is doubly gated: append-invariance (adding future games changes no as-of row) + exact per-date parity vs the primitive — with a docstring caveat that the proof needs the test *pair*.
- **`nba_war`** — points-above-replacement scoring with **required no-default kwargs** (`pts_per_win`, `replacement_level` — no fabricated league constants) plus closed-form, offline-testable `calibrate_pts_per_win` / `calibrate_replacement_level` (calibrate→score→sum round-trips exactly).
- **`nba_bpm(granularity="game")`** — per-game BPM rows via a behavior-preserving `_nba_bpm_one` extraction; season default pinned byte-identical by regression test; `NbaBpmModel` untouched.
- Exports, changelog (both files), codegen regen (generated-only commit).

WP3's walk-forward oracle consumes `ratings_as_of` as its stable, monkeypatchable contract.

## Test plan

- 38 passed / 1 gated-skip across the three new test files; full `tests/nba/` 298 passed / 26 skipped
- mypy clean (3 new modules on the ratchet); ruff clean; codegen `--check` clean
- Leakage gates: append-invariance + per-date parity (exact equality); WAR closed-loop to 1e-9; BPM season-mode regression pin

## Summary by Sourcery

Add through-date NBA ratings infrastructure, WAR scoring layer, and per-game BPM granularity, with supporting exports, documentation, and tests.

New Features:
- Introduce ratings_as_of primitive and nba_ratings_panel long-frame engine for leakage-free through-date player ratings.
- Add nba_war scoring API plus calibrate_pts_per_win and calibrate_replacement_level helpers for WAR calibration from real season data.
- Extend nba_bpm with granularity="game" to produce single-game BPM outputs alongside existing season aggregation.

Enhancements:
- Export new NBA ratings panel and WAR utilities through the top-level nba namespace and parsed bindings.
- Refactor nba_bpm core into a reusable _nba_bpm_one helper and define a shared BPM output schema for both season and game modes.

Documentation:
- Document the new WAR calibration functions, nba_war API, nba_ratings_panel, ratings_as_of, and the extended nba_bpm granularity parameter in the NBA additional reference.
- Update NBA documentation index and changelog pages to describe the through-date ratings panel, WAR layer, and per-game BPM support.

Tests:
- Add tests validating leakage-free behavior and schema guarantees for ratings_as_of and nba_ratings_panel.
- Add tests for WAR calibration helpers and nba_war, including closed-loop calibration-to-scoring consistency.
- Add tests covering nba_bpm granularity="game", regression-guarding season mode, and validating error handling for invalid granularity or missing game_id.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new NBA through-date ratings panel and an “as of” rating view for historical snapshots.
  * Added NBA WAR support with calibration helpers and per-player WAR scoring.
  * Expanded BPM support to include single-game calculations.

* **Documentation**
  * Updated NBA API docs and changelog entries to cover the new ratings, WAR, and game-level BPM capabilities.

* **Tests**
  * Added coverage for leakage-free ratings panels, WAR calibration/scoring, and game-level BPM behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->