### PR TITLE
feat(nfl): nflfastR parity closure — air/YAC EPA-WPA, clean_nfl_pbp, def/kicking stats, series rates, standings

### DIFF
--- a/docs/docs/nfl/index.md
+++ b/docs/docs/nfl/index.md
@@ -11,7 +11,7 @@ sidebar_label: NFL
 | [ESPN core API (v2)](reference/core) | 83 | `https://sports.core.api.espn.com/v2/sports` |
 | [NFL.com API](reference/nfl_api) | 11 | `https://api.nfl.com` |
 | [Dataset loaders](reference/loaders) | 8 | nflverse data releases |
-| [Additional functions](reference/additional) | 107 | hand-written wrappers, loaders & helpers |
+| [Additional functions](reference/additional) | 111 | hand-written wrappers, loaders & helpers |
 
 ## Examples
 

--- a/docs/docs/nfl/index.md
+++ b/docs/docs/nfl/index.md
@@ -11,7 +11,7 @@ sidebar_label: NFL
 | [ESPN core API (v2)](reference/core) | 83 | `https://sports.core.api.espn.com/v2/sports` |
 | [NFL.com API](reference/nfl_api) | 11 | `https://api.nfl.com` |
 | [Dataset loaders](reference/loaders) | 8 | nflverse data releases |
-| [Additional functions](reference/additional) | 105 | hand-written wrappers, loaders & helpers |
+| [Additional functions](reference/additional) | 107 | hand-written wrappers, loaders & helpers |
 
 ## Examples
 

--- a/docs/docs/nfl/reference/additional.md
+++ b/docs/docs/nfl/reference/additional.md
@@ -4898,6 +4898,96 @@ df_pd = build_nfl_player_stats([2023], summary_level="season",
 wk.filter(pl.col("attempts") >= 5).sort("passing_epa", descending=True).head()
 ```
 
+### `build_nfl_player_stats_def(pbp: 'pl.DataFrame', *, weekly: 'bool' = False, return_as_pandas: 'bool' = False) -> "pl.DataFrame | 'pd.DataFrame'"` {#build_nfl_player_stats_def}
+
+Build player-level defensive stats from play-by-play (nflfastR parity).
+
+A faithful polars port of nflfastR's deprecated
+`calculate_player_stats_def()` (`aggregate_game_stats_def.R`). Tackle,
+sack (half-sack = 0.5 weighting), pass-defense, interception, safety,
+fumble (own/opponent recovery), penalty, and touchdown sub-frames are each
+aggregated on `(season, week, team=defteam, player_id)` and full-outer
+joined together, then player metadata is joined from
+`sportsdataverse.nfl.load_nfl_players`.
+
+Unlike `build_nfl_player_stats`, this function takes a
+caller-supplied `pbp` frame directly rather than loading one -- matching
+the R function's own signature.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `pbp` | `DataFrame` |  | Play-by-play frame carrying the wide nflverse defensive columns (`solo_tackle_1_player_id`, `sack_player_id`, `half_sack_{1,2}_player_id`, `interception_player_id`, `pass_defense_{1,2}_player_id`, `fumbled_{1,2}_team` / `fumble_recovery_{1,2}_team`, etc. -- the same columns `sportsdataverse.nfl.load_nfl_pbp` serves). |
+| `weekly` | `bool` | `False` | If `True` return one row per (season, week, player); if `False` collapse to one row per `(player_id, team)` -- note this does NOT retain a `season` column even if `pbp` spans multiple seasons (see the module-level note above), matching the R source's own `group_by(player_id, team)` (no `season`). |
+| `return_as_pandas` | `bool` | `False` | If `True` return a pandas DataFrame; else polars. |
+
+**Returns**
+
+A polars (or pandas) DataFrame with the `def_*` column set documented in the nflfastR-parity reference (weekly grain carries `season`/`week`/`season_type`; the season collapse replaces those with `games`).
+
+**Example**
+
+```python
+from sportsdataverse.nfl import build_nfl_player_stats_def, load_nfl_pbp
+pbp = load_nfl_pbp([2023])
+wk = build_nfl_player_stats_def(pbp, weekly=True)
+print(wk.shape)
+
+# Season totals (one season's worth of ``pbp`` at a time)
+
+season = build_nfl_player_stats_def(pbp, weekly=False)
+
+# Pipeline next step (one line)
+
+wk.sort("def_sacks", descending=True).head()
+```
+
+### `build_nfl_player_stats_kicking(pbp: 'pl.DataFrame', *, weekly: 'bool' = False, return_as_pandas: 'bool' = False) -> "pl.DataFrame | 'pd.DataFrame'"` {#build_nfl_player_stats_kicking}
+
+Build player-level kicking stats from play-by-play (nflfastR parity).
+
+A faithful polars port of nflfastR's deprecated
+`calculate_player_stats_kicking()` (`aggregate_game_stats_kicking.R`).
+Field goals (made-distance buckets, `fg_long`, `fg_pct`, `;`-joined
+distance lists), extra points, and game-winning-FG attempts (last drive of
+the game, trailing by 2 or fewer points) are each aggregated on the kicker
+and full-outer joined together, then player metadata is joined from
+`sportsdataverse.nfl.load_nfl_players`.
+
+Unlike `build_nfl_team_stats`, this function takes a caller-supplied
+`pbp` frame directly rather than loading one -- matching the R
+function's own signature.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `pbp` | `DataFrame` |  | Play-by-play frame carrying `kicker_player_id` / `kicker_player_name`, `field_goal_attempt` / `field_goal_result` / `kick_distance`, `extra_point_attempt` / `extra_point_result`, `fixed_drive`, and `score_differential` (the same columns `sportsdataverse.nfl.load_nfl_pbp` serves). |
+| `weekly` | `bool` | `False` | If `True` return one row per (season, week, player) with a `gwfg_distance` list column; if `False` collapse to one row per `(player_id, team)` with a `games` column and a `;`-joined `gwfg_distance_list` string column in place of `gwfg_distance` (the R source's own deliberate column-name change based on the `weekly` flag). Note this does NOT retain a `season` column even if `pbp` spans multiple seasons (see the module-level note above `build_nfl_player_stats_def`). |
+| `return_as_pandas` | `bool` | `False` | If `True` return a pandas DataFrame; else polars. |
+
+**Returns**
+
+A polars (or pandas) DataFrame with the `fg_*`/`pat_*`/`gwfg_*` column set documented in the nflfastR-parity reference.
+
+**Example**
+
+```python
+from sportsdataverse.nfl import build_nfl_player_stats_kicking, load_nfl_pbp
+pbp = load_nfl_pbp([2023])
+wk = build_nfl_player_stats_kicking(pbp, weekly=True)
+print(wk.shape)
+
+# Season totals (one season's worth of ``pbp`` at a time)
+
+season = build_nfl_player_stats_kicking(pbp, weekly=False)
+
+# Pipeline next step (one line)
+
+wk.filter(pl.col("fg_att") >= 1).sort("fg_pct", descending=True).head()
+```
+
 ### `build_nfl_players(*, return_as_pandas: 'bool' = False) -> "Union[pl.DataFrame, 'pd.DataFrame']"` {#build_nfl_players}
 
 Build an SDV-native NFL players frame from ESPN's public athletes endpoint.
@@ -5267,6 +5357,85 @@ from sportsdataverse.nfl.ep_wp import calculate_expected_points
 pbp = load_nfl_pbp([2023])
 pbp_ep = calculate_expected_points(pbp)
 print(pbp_ep.select("ep").head())
+```
+
+### `calculate_nfl_series_conversion_rates(pbp: 'pl.DataFrame', *, weekly: 'bool' = False, return_as_pandas: 'bool' = False) -> "pl.DataFrame | 'pd.DataFrame'"` {#calculate_nfl_series_conversion_rates}
+
+Compute per-team offense + defense series conversion rates.
+
+A faithful polars port of nflfastR's `calculate_series_conversion_rates`.
+Series where `down` is null (kickoffs, PAT/2pt attempts, non-plays, no
+`posteam`) and series ending in a `"QB kneel"` are excluded from the
+series count before rates are computed, matching the R source.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `pbp` | `DataFrame` |  | Play-by-play frame carrying `season`, `week`, `posteam`, `defteam`, `down`, `series`, `series_success`, and `series_result` (added by the `add_series_data` port). Rows must already be in play order within each series so the internal `first()`/`last()` series collapse is correct. |
+| `weekly` | `bool` | `False` | If `True`, group on `(season, team, week)`; if `False` (default), group on `(season, team)` -- collapsing every week into one season-level rate. |
+| `return_as_pandas` | `bool` | `False` | If `True` return a pandas DataFrame; else polars. |
+
+**Returns**
+
+A polars (or pandas) DataFrame with one row per team (per week when `weekly=True`), `off_n`/`def_n` (series count) plus the `off_*`/`def_*` rate columns documented in reference Sec 11. A team with offensive series but zero defensive series in a group (or vice versa -- effectively never happens in real data) carries nulls in the missing side rather than being dropped (full outer join).
+
+**Example**
+
+```python
+from sportsdataverse.nfl import calculate_nfl_series_conversion_rates
+rates = calculate_nfl_series_conversion_rates(pbp)
+rates.filter(pl.col("team") == "KC").select("off_scr", "def_scr")
+
+# Weekly grain
+
+weekly = calculate_nfl_series_conversion_rates(pbp, weekly=True)
+
+# Pipeline next step (one line)
+
+rates.sort("off_scr", descending=True).head()
+```
+
+### `calculate_nfl_standings(games: 'pl.DataFrame', *, teams: 'pl.DataFrame | None' = None, tiebreaker_depth: 'int' = 3, playoff_seeds: 'int | None' = None, return_as_pandas: 'bool' = False) -> "pl.DataFrame | 'pd.DataFrame'"` {#calculate_nfl_standings}
+
+Compute NFL division standings + conference playoff seeds.
+
+A reduced port of the tiebreaker ladder nflfastR delegates to the external
+`nflseedR` package (see the module docstring for the exact scope). Games
+are doubled into one row per team per game, regular-season win/loss/tie
+records are computed per team, and ties are broken win_pct -> head-to-head
+-> division record -> conference record, to the depth configured by
+`tiebreaker_depth`.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `games` | `DataFrame` |  | A `load_nfl_schedule`-shaped frame: `game_id`, `season`, `game_type`, `week`, `home_team`, `away_team`, `home_score`, `away_score`. Only `game_type == "REG"` rows with both scores present are used. |
+| `teams` | `DataFrame \| None` | `None` | A `load_nfl_teams`-shaped frame (`team_abbr`, `team_conf`, `team_division`). When `None` (default), calls `sportsdataverse.nfl.load_nfl_teams`. |
+| `tiebreaker_depth` | `int` | `3` | `1` (win_pct only), `2` (adds head-to-head + division record), or `3` (default; adds conference record too). |
+| `playoff_seeds` | `int \| None` | `None` | Number of teams per conference that receive a non-null `seed`. When `None` (default), uses the 2020 playoff -format cutover: `6` for seasons <= 2019, `7` for 2020+. |
+| `return_as_pandas` | `bool` | `False` | If `True` return a pandas DataFrame; else polars. |
+
+**Returns**
+
+A polars (or pandas) DataFrame with one row per (season, team): `conf`, `division`, `div_rank`, `seed` (null past `playoff_seeds`), `team`, `games`, `wins`, `losses`, `ties`, `win_pct` (ties count as 0.5 win), `div_pct`, `conf_pct`. Sorted by `(season, division, div_rank, seed)`.
+
+**Example**
+
+```python
+from sportsdataverse.nfl import calculate_nfl_standings, load_nfl_schedule
+games = load_nfl_schedule(seasons=[2023])
+standings = calculate_nfl_standings(games)
+standings.filter(standings["div_rank"] == 1)
+
+# Injected teams frame (offline)
+
+standings = calculate_nfl_standings(games, teams=my_teams_df)
+
+# Pipeline next step (one line)
+
+standings.sort(["conf", "seed"]).select("team", "seed", "win_pct")
 ```
 
 ### `calculate_win_probability(pbp_data: 'pl.DataFrame', *, return_as_pandas: 'bool' = False) -> "Union[pl.DataFrame, 'pd.DataFrame']"` {#calculate_win_probability}

--- a/docs/docs/nfl/reference/additional.md
+++ b/docs/docs/nfl/reference/additional.md
@@ -5493,6 +5493,45 @@ print(pbp.select("xyac_epa", "xyac_mean_yardage").head())
 pbp.filter(pl.col("xyac_epa").is_not_null()).select("xyac_epa", "xyac_fd").head()
 ```
 
+### `clean_nfl_pbp(df: 'pl.DataFrame', *, return_as_pandas: 'bool' = False) -> "Union[pl.DataFrame, 'pd.DataFrame']"` {#clean_nfl_pbp}
+
+Canonicalize names/ids/teams on a play-by-play frame (nflfastR `clean_pbp` port).
+
+See the module docstring for the full column set added, the
+compute-if-absent scope note on `pass`/`rush`, and the lookaround ->
+capture-group regex rewrites.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `df` | `DataFrame` |  | An nflverse-shape (or ESPN/native) play-by-play `polars.DataFrame`. Required columns: `desc`, `epa`, `game_id`, `play_id`, `season`, `posteam`. See the module docstring for the full optional-column-with-default list. |
+| `return_as_pandas` | `bool` | `False` | If `True`, return a `pandas.DataFrame`; otherwise a `polars.DataFrame` (default). |
+
+**Returns**
+
+The input frame with every §6 column added/overwritten (idempotent -- pre-existing values of those columns, except `pass`/`rush`, are dropped and recomputed). A zero-row input yields a zero-row frame carrying the full documented schema rather than raising.
+
+**Example**
+
+```python
+from sportsdataverse.nfl import load_nfl_pbp
+from sportsdataverse.nfl.nfl_clean import clean_nfl_pbp
+
+pbp = load_nfl_pbp([2023])
+cleaned = clean_nfl_pbp(pbp)
+print(cleaned.select("name", "id", "fantasy").head())
+
+# Pandas output
+
+cleaned_pd = clean_nfl_pbp(pbp, return_as_pandas=True)
+
+# Pipeline next step (one line)
+
+import polars as pl
+cleaned.filter(pl.col("play") == 1).group_by("passer").len()
+```
+
 ### `clear_cache() -> 'None'` {#clear_cache}
 
 Clear both memory and filesystem caches.
@@ -7131,6 +7170,28 @@ wk1.select(["season", "week", "player_display_name", "team_abbr"]).head()
 
 tot = scrape_ngs_week("rushing", 2023, week=0)
 ```
+
+### `team_name_fn(expr: 'pl.Expr') -> 'pl.Expr'` {#team_name_fn}
+
+Fold historical/relocated team codes onto their current abbreviation.
+
+Verbatim port of nflfastR's `team_name_fn` (a plain
+`stringr::str_replace_all` over a 10-entry named vector). Operates as a
+**substring** replace (not a full-value lookup) so it also fixes
+embedded codes like `"SD 49" -> "LAC 49"` on yard-line columns. The
+10 from-codes are disjoint from all of their to-values, so the order of
+the 10 sequential replacements does not matter (verified in
+`tests.nfl.test_nfl_clean`).
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `expr` | `Expr` |  | A `polars.Expr` over a Utf8 column (e.g. `pl.col("posteam")`). |
+
+**Returns**
+
+The same expression with every occurrence of the 10 historical codes replaced by their current-franchise code.
 
 ### `update_config(**kwargs: 'object') -> 'NflConfig'` {#update_config}
 

--- a/docs/docs/nfl/reference/additional.md
+++ b/docs/docs/nfl/reference/additional.md
@@ -5412,7 +5412,7 @@ records are computed per team, and ties are broken win_pct -> head-to-head
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `games` | `DataFrame` |  | A `load_nfl_schedule`-shaped frame: `game_id`, `season`, `game_type`, `week`, `home_team`, `away_team`, `home_score`, `away_score`. Only `game_type == "REG"` rows with both scores present are used. |
-| `teams` | `DataFrame \| None` | `None` | A `load_nfl_teams`-shaped frame (`team_abbr`, `team_conf`, `team_division`). When `None` (default), calls `sportsdataverse.nfl.load_nfl_teams`. |
+| `teams` | `DataFrame \| None` | `None` | A `load_nfl_teams`-shaped frame (`team_abbr`, `team_conf`, `team_division`). When `None` (default), calls `sportsdataverse.nfl.load_nfl_teams`. Must cover every team abbreviation appearing in `games` -- a team absent from `teams` gets null `conf`/`division` and is silently pooled into the `(season, None)` division/conference group rather than raising. |
 | `tiebreaker_depth` | `int` | `3` | `1` (win_pct only), `2` (adds head-to-head + division record), or `3` (default; adds conference record too). |
 | `playoff_seeds` | `int \| None` | `None` | Number of teams per conference that receive a non-null `seed`. When `None` (default), uses the 2020 playoff -format cutover: `6` for seasons <= 2019, `7` for 2020+. |
 | `return_as_pandas` | `bool` | `False` | If `True` return a pandas DataFrame; else polars. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -347,5 +347,5 @@ files = [
     "sportsdataverse/nba/nba_rapm_variants.py",
     "sportsdataverse/nfl/nfl_clean.py",
     "sportsdataverse/nfl/nfl_series.py",
-    "sportsdataverse/nfl/nfl_standings.py",
+    "sportsdataverse/nfl/nfl_standings_calc.py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -345,4 +345,5 @@ files = [
     "sportsdataverse/nba/nba_ratings_panel.py",
     "sportsdataverse/nba/nba_war.py",
     "sportsdataverse/nba/nba_rapm_variants.py",
+    "sportsdataverse/nfl/nfl_clean.py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -346,4 +346,6 @@ files = [
     "sportsdataverse/nba/nba_war.py",
     "sportsdataverse/nba/nba_rapm_variants.py",
     "sportsdataverse/nfl/nfl_clean.py",
+    "sportsdataverse/nfl/nfl_series.py",
+    "sportsdataverse/nfl/nfl_standings.py",
 ]

--- a/sportsdataverse/nfl/__init__.py
+++ b/sportsdataverse/nfl/__init__.py
@@ -106,6 +106,8 @@ from sportsdataverse.nfl.nfl_stats import (
     build_nfl_player_stats_kicking,
     build_nfl_team_stats,
 )
+from sportsdataverse.nfl.nfl_series import calculate_nfl_series_conversion_rates
+from sportsdataverse.nfl.nfl_standings import calculate_nfl_standings
 from sportsdataverse.nfl.nfl_schedule import *
 from sportsdataverse.nfl.nfl_teams import *
 from sportsdataverse.nfl.utils_date import *

--- a/sportsdataverse/nfl/__init__.py
+++ b/sportsdataverse/nfl/__init__.py
@@ -107,7 +107,7 @@ from sportsdataverse.nfl.nfl_stats import (
     build_nfl_team_stats,
 )
 from sportsdataverse.nfl.nfl_series import calculate_nfl_series_conversion_rates
-from sportsdataverse.nfl.nfl_standings import calculate_nfl_standings
+from sportsdataverse.nfl.nfl_standings_calc import calculate_nfl_standings
 from sportsdataverse.nfl.nfl_schedule import *
 from sportsdataverse.nfl.nfl_teams import *
 from sportsdataverse.nfl.utils_date import *

--- a/sportsdataverse/nfl/__init__.py
+++ b/sportsdataverse/nfl/__init__.py
@@ -96,6 +96,7 @@ from sportsdataverse.nfl.ep_wp import (
     calculate_xpass,
     calculate_xyac,
 )
+from sportsdataverse.nfl.nfl_clean import clean_nfl_pbp, team_name_fn
 from sportsdataverse.nfl.nfl_fourth_down import *
 from sportsdataverse.nfl.nfl_pbp import *
 from sportsdataverse.nfl.nfl_player_stats import *

--- a/sportsdataverse/nfl/__init__.py
+++ b/sportsdataverse/nfl/__init__.py
@@ -100,7 +100,12 @@ from sportsdataverse.nfl.nfl_clean import clean_nfl_pbp, team_name_fn
 from sportsdataverse.nfl.nfl_fourth_down import *
 from sportsdataverse.nfl.nfl_pbp import *
 from sportsdataverse.nfl.nfl_player_stats import *
-from sportsdataverse.nfl.nfl_stats import build_nfl_player_stats, build_nfl_team_stats
+from sportsdataverse.nfl.nfl_stats import (
+    build_nfl_player_stats,
+    build_nfl_player_stats_def,
+    build_nfl_player_stats_kicking,
+    build_nfl_team_stats,
+)
 from sportsdataverse.nfl.nfl_schedule import *
 from sportsdataverse.nfl.nfl_teams import *
 from sportsdataverse.nfl.utils_date import *

--- a/sportsdataverse/nfl/ep_wp.py
+++ b/sportsdataverse/nfl/ep_wp.py
@@ -3276,8 +3276,11 @@ def _derive_air_yac_wpa(df: pl.DataFrame) -> pl.DataFrame:
     # non-null defteam across ALL plays; deriving it on the pass subset would
     # misidentify it whenever possession changes before the game's first
     # qualifying pass (flag inverted game-wide).  Mirrors _add_wp_aux.
+    # ``_r2k_col`` names whichever column holds the flag: the existing
+    # ``receive_2h_ko`` is referenced directly (no duplicate materialized),
+    # else a fresh ``_ay_r2k`` is computed and cleaned up below.
     if "receive_2h_ko" in df.columns:
-        df = df.with_columns(pl.col("receive_2h_ko").cast(pl.Float64).alias("_ay_r2k"))
+        _r2k_col = "receive_2h_ko"
     elif "qtr" in df.columns and "defteam" in df.columns:
         df = df.with_columns(
             pl.when(
@@ -3287,8 +3290,10 @@ def _derive_air_yac_wpa(df: pl.DataFrame) -> pl.DataFrame:
             .otherwise(0.0)
             .alias("_ay_r2k")
         )
+        _r2k_col = "_ay_r2k"
     else:
         df = df.with_columns(pl.lit(0.0).alias("_ay_r2k"))
+        _r2k_col = "_ay_r2k"
 
     pass_df = df.filter(pl.col("air_yards").is_not_null() & (pl.col("play_type") == "pass"))
 
@@ -3309,7 +3314,7 @@ def _derive_air_yac_wpa(df: pl.DataFrame) -> pl.DataFrame:
             if "elapsed_share" in pass_df.columns
             else ((3600.0 - gsr) / 3600.0).clip(0.0, 1.0)
         )
-        receive_2h_ko = pl.col("_ay_r2k")
+        receive_2h_ko = pl.col(_r2k_col).cast(pl.Float64)
 
         pass_df = pass_df.with_columns(
             _r_ifelse((down == 4) & (air < tg), 1.0, 0.0).alias("_ay_turnover"),
@@ -3387,7 +3392,8 @@ def _derive_air_yac_wpa(df: pl.DataFrame) -> pl.DataFrame:
     else:
         merged = _null_air_yac(df, ("air_wpa", "yac_wpa"))
 
-    return _air_yac_family_block(merged, kind="wpa").drop("_ay_idx", "_ay_r2k")
+    drop_cols = ["_ay_idx"] + (["_ay_r2k"] if _r2k_col == "_ay_r2k" else [])
+    return _air_yac_family_block(merged, kind="wpa").drop(drop_cols)
 
 
 def _derive_qbr_epa(df: pl.DataFrame) -> pl.DataFrame:

--- a/sportsdataverse/nfl/ep_wp.py
+++ b/sportsdataverse/nfl/ep_wp.py
@@ -1956,6 +1956,12 @@ def calculate_epa(df: pl.DataFrame) -> pl.DataFrame:
         ep_end=pl.col("EP_end"),
     )
 
+    # Per-game cumulative EPA totals (shared nflfastR add_ep_variables tail).
+    # No-op when the frame lacks the nflverse identity columns (the raw ESPN
+    # internal frame carries start.pos_team.id / type.text instead of
+    # posteam / play_type) — the totals then simply aren't emitted.
+    play_df = _add_epa_running_totals(play_df)
+
     return play_df
 
 
@@ -2207,6 +2213,11 @@ def calculate_wpa(df: pl.DataFrame) -> pl.DataFrame:
         home_wp=pl.col("home_wp_before"),
         away_wp=pl.col("away_wp_before"),
     )
+
+    # Per-game cumulative rush/pass WPA totals (shared nflfastR
+    # add_wp_variables tail).  No-op when the frame lacks the nflverse
+    # identity columns (see calculate_epa) — the totals then aren't emitted.
+    play_df = _add_wpa_running_totals(play_df)
 
     return play_df
 
@@ -2524,7 +2535,12 @@ def _derive_epa(df: pl.DataFrame) -> pl.DataFrame:
             pl.when(pl.col("desc") == pl.lit("END QUARTER 2")).then(None).otherwise(pl.col("ep")).alias("ep"),
         )
 
-    return df.drop([c for c in ("_tmp_posteam", "_home_ep", "_home_epa", "_end_game") if c in df.columns])
+    df = df.drop([c for c in ("_tmp_posteam", "_home_ep", "_home_epa", "_end_game") if c in df.columns])
+
+    # Per-game cumulative EPA totals (add_ep_variables L735-801) — computed on
+    # the FINAL ``epa`` (post end-of-half / end-of-game overlays), matching the
+    # R mutate order.
+    return _add_epa_running_totals(df)
 
 
 def _derive_qb_epa(df: pl.DataFrame) -> pl.DataFrame:
@@ -2748,15 +2764,20 @@ def _derive_wpa(df: pl.DataFrame) -> pl.DataFrame:
     )
     df = df.with_columns((1.0 - pl.col("wp")).alias("def_wp"))
 
-    # WPA: lead of home WP, flipped into possession-team frame.
+    # WPA: lead of home WP, flipped into possession-team frame.  nflfastR keeps
+    # ``vegas_home_wpa`` as a public column (add_wp_variables L1153) — the plain
+    # home-frame lead difference, deliberately NOT NA'd on kneel/end-of-game
+    # rows (only ``wpa`` / ``vegas_wpa`` are) — while ``home_wpa`` "isn't saved".
     df = df.with_columns(
-        (pl.col("vegas_home_wp").shift(-1).over(grp) - pl.col("vegas_home_wp")).alias("_vegas_home_wpa"),
+        (pl.col("vegas_home_wp").shift(-1).over(grp) - pl.col("vegas_home_wp"))
+        .cast(pl.Float64)
+        .alias("vegas_home_wpa"),
         (pl.col("home_wp").shift(-1).over(grp) - pl.col("home_wp")).alias("_home_wpa"),
     )
     df = df.with_columns(
         pl.when(pl.col("_tmp_posteam") == pl.col("home_team"))
-        .then(pl.col("_vegas_home_wpa"))
-        .otherwise(-pl.col("_vegas_home_wpa"))
+        .then(pl.col("vegas_home_wpa"))
+        .otherwise(-pl.col("vegas_home_wpa"))
         .alias("vegas_wpa"),
         pl.when(pl.col("_tmp_posteam") == pl.col("home_team"))
         .then(pl.col("_home_wpa"))
@@ -2771,9 +2792,583 @@ def _derive_wpa(df: pl.DataFrame) -> pl.DataFrame:
             pl.when(kneel_or_end).then(None).otherwise(pl.col("wpa")).alias("wpa"),
         )
 
-    return df.drop(
-        [c for c in ("_tmp_posteam", "_end_game", "_vegas_home_wpa", "_home_wpa", "vegas_home_wp") if c in df.columns]
+    df = df.drop([c for c in ("_tmp_posteam", "_end_game", "_home_wpa", "vegas_home_wp") if c in df.columns])
+
+    # Per-game cumulative rush/pass WPA totals (add_wp_variables L1252-1324) —
+    # computed on the FINAL ``wpa`` (post kneel / end-of-game NA overrides),
+    # matching the R mutate order.
+    return _add_wpa_running_totals(df)
+
+
+# ---------------------------------------------------------------------------
+# Air / YAC EPA-WPA column family + per-game running totals
+# (nflfastR helper_add_ep_wp.R — add_air_yac_ep[_variables],
+#  add_air_yac_wp[_variables], and the totals blocks of add_ep_variables /
+#  add_wp_variables)
+# ---------------------------------------------------------------------------
+
+#: Average seconds elapsed on a pass play; subtracted from the clock before the
+#: air-yards EP / WP re-score (nflfastR ``helper_add_ep_wp.R``, same literal in
+#: both the air-yac EP and air-yac WP functions).
+_PASS_TIME_ELAPSED: float = 5.704673
+
+#: Per-game running totals emitted by the ``add_ep_variables`` tail (L735-801).
+_EPA_RUNNING_TOTAL_COLS: tuple[str, ...] = (
+    "total_home_epa",
+    "total_away_epa",
+    "total_home_rush_epa",
+    "total_away_rush_epa",
+    "total_home_pass_epa",
+    "total_away_pass_epa",
+)
+
+#: Per-game running totals emitted by the ``add_wp_variables`` tail
+#: (L1252-1324).  nflfastR has NO ``total_home_wpa`` / ``total_away_wpa`` —
+#: only the rush/pass splits.
+_WPA_RUNNING_TOTAL_COLS: tuple[str, ...] = (
+    "total_home_rush_wpa",
+    "total_away_rush_wpa",
+    "total_home_pass_wpa",
+    "total_away_pass_wpa",
+)
+
+#: Public air/YAC EPA family columns (``add_air_yac_ep_variables``).  The
+#: intermediate signed columns the R computes (``home_team_comp_air_epa`` etc.)
+#: are folded into the cumulative expressions and never materialised — the
+#: published nflverse play-by-play drops them, so this is the shipped surface.
+_AIR_YAC_EPA_COLS: tuple[str, ...] = (
+    "air_epa",
+    "yac_epa",
+    "comp_air_epa",
+    "comp_yac_epa",
+    "total_home_comp_air_epa",
+    "total_away_comp_air_epa",
+    "total_home_comp_yac_epa",
+    "total_away_comp_yac_epa",
+    "total_home_raw_air_epa",
+    "total_away_raw_air_epa",
+    "total_home_raw_yac_epa",
+    "total_away_raw_yac_epa",
+)
+
+#: Public air/YAC WPA family columns (``add_air_yac_wp_variables``) — exact
+#: WPA mirrors of :data:`_AIR_YAC_EPA_COLS`.
+_AIR_YAC_WPA_COLS: tuple[str, ...] = tuple(c.replace("epa", "wpa") for c in _AIR_YAC_EPA_COLS)
+
+#: §5 input columns ``_derive_air_yac_epa`` needs; when any is absent the
+#: family is emitted as all-null Float64 (schema-stable degradation).
+_AIR_YAC_EPA_REQUIRED: tuple[str, ...] = (
+    "game_id",
+    "air_yards",
+    "play_type",
+    "yardline_100",
+    "ydstogo",
+    "down",
+    "half_seconds_remaining",
+    "posteam_timeouts_remaining",
+    "defteam_timeouts_remaining",
+    "posteam",
+    "home_team",
+    "away_team",
+    "season",
+    "ep",
+    "epa",
+    "complete_pass",
+    "penalty",
+    "yards_after_catch",
+    "two_point_attempt",
+)
+
+#: §5 input columns ``_derive_air_yac_wpa`` needs (same degradation rule).
+_AIR_YAC_WPA_REQUIRED: tuple[str, ...] = (
+    "game_id",
+    "air_yards",
+    "play_type",
+    "yardline_100",
+    "ydstogo",
+    "down",
+    "half_seconds_remaining",
+    "game_seconds_remaining",
+    "score_differential",
+    "posteam_timeouts_remaining",
+    "defteam_timeouts_remaining",
+    "posteam",
+    "home_team",
+    "away_team",
+    "wp",
+    "wpa",
+    "complete_pass",
+    "penalty",
+    "yards_after_catch",
+    "two_point_attempt",
+)
+
+
+def _r_ifelse(
+    cond: pl.Expr,
+    if_true: Union[pl.Expr, float],
+    if_false: Union[pl.Expr, float],
+) -> pl.Expr:
+    """``dplyr::if_else`` semantics: a null condition yields null.
+
+    polars' ``when/then/otherwise`` sends a Kleene-null condition down the
+    ``otherwise`` branch, which silently rewrites R's NA-propagation into the
+    false branch — this helper restores the R behaviour.
+    """
+    return pl.when(cond.is_null()).then(None).when(cond).then(if_true).otherwise(if_false)
+
+
+def _signed_to_team(value: pl.Expr, team_col: str) -> pl.Expr:
+    """nflfastR's signed-then-zeroed team attribution, as one expression.
+
+    ``dplyr::if_else(posteam == <team>, v, -v)`` followed by ``NA -> 0`` —
+    a null ``posteam`` or null ``v`` contributes ``0`` to the cumulative
+    totals (R L745-753 and the equivalent blocks in the air/yac functions).
+    """
+    return (
+        pl.when(pl.col("posteam") == pl.col(team_col))
+        .then(value)
+        .when(pl.col("posteam") != pl.col(team_col))
+        .then(-value)
+        .otherwise(None)
+        .fill_null(0.0)
+        .cast(pl.Float64)
     )
+
+
+def _add_epa_running_totals(df: pl.DataFrame) -> pl.DataFrame:
+    """Add the per-game cumulative EPA totals (nflfastR ``add_ep_variables`` tail).
+
+    Ports L735-801 of ``helper_add_ep_wp.R``: ``home_team_epa`` /
+    ``away_team_epa`` flip ``epa`` into the home/away frame (NA -> 0), the
+    rush/pass gates zero everything except ``play_type == "run"`` /
+    ``"pass"`` rows (NA ``play_type`` -> 0), and each series is ``cumsum``'d
+    **within** ``game_id``.  The single shared implementation is called from
+    both :func:`_derive_epa` (nflverse lead_diff path) and
+    :func:`calculate_epa` (ESPN construction path).
+
+    Requires ``game_id`` / ``posteam`` / ``home_team`` / ``away_team`` /
+    ``play_type`` / ``epa``; when any is absent (e.g. the ESPN internal frame,
+    which carries ``start.pos_team.id`` / ``type.text`` instead) the frame is
+    returned unchanged.
+    """
+    required = ("game_id", "posteam", "home_team", "away_team", "play_type", "epa")
+    if any(c not in df.columns for c in required):
+        return df
+    df = df.drop([c for c in _EPA_RUNNING_TOTAL_COLS if c in df.columns])
+
+    epa = pl.col("epa").cast(pl.Float64)
+    home_epa = _signed_to_team(epa, "home_team")
+    away_epa = _signed_to_team(epa, "away_team")
+    is_run = pl.col("play_type") == "run"
+    is_pass = pl.col("play_type") == "pass"
+    home_rush = _r_ifelse(is_run, home_epa, 0.0).fill_null(0.0)
+    away_rush = _r_ifelse(is_run, away_epa, 0.0).fill_null(0.0)
+    home_pass = _r_ifelse(is_pass, home_epa, 0.0).fill_null(0.0)
+    away_pass = _r_ifelse(is_pass, away_epa, 0.0).fill_null(0.0)
+
+    return df.with_columns(
+        home_epa.cum_sum().over("game_id").alias("total_home_epa"),
+        away_epa.cum_sum().over("game_id").alias("total_away_epa"),
+        home_rush.cum_sum().over("game_id").cast(pl.Float64).alias("total_home_rush_epa"),
+        away_rush.cum_sum().over("game_id").cast(pl.Float64).alias("total_away_rush_epa"),
+        home_pass.cum_sum().over("game_id").cast(pl.Float64).alias("total_home_pass_epa"),
+        away_pass.cum_sum().over("game_id").cast(pl.Float64).alias("total_away_pass_epa"),
+    )
+
+
+def _add_wpa_running_totals(df: pl.DataFrame) -> pl.DataFrame:
+    """Add the per-game cumulative rush/pass WPA totals (``add_wp_variables`` tail).
+
+    Ports L1252-1324 of ``helper_add_ep_wp.R``.  Identical structure to
+    :func:`_add_epa_running_totals` but on ``wpa``, and — matching nflfastR —
+    emitting ONLY the rush/pass splits (there is no ``total_home_wpa``).
+    Called from both :func:`_derive_wpa` and :func:`calculate_wpa`; returns
+    the frame unchanged when the nflverse input columns are absent.
+    """
+    required = ("game_id", "posteam", "home_team", "away_team", "play_type", "wpa")
+    if any(c not in df.columns for c in required):
+        return df
+    df = df.drop([c for c in _WPA_RUNNING_TOTAL_COLS if c in df.columns])
+
+    wpa = pl.col("wpa").cast(pl.Float64)
+    home_wpa = _signed_to_team(wpa, "home_team")
+    away_wpa = _signed_to_team(wpa, "away_team")
+    is_run = pl.col("play_type") == "run"
+    is_pass = pl.col("play_type") == "pass"
+    home_rush = _r_ifelse(is_run, home_wpa, 0.0).fill_null(0.0)
+    away_rush = _r_ifelse(is_run, away_wpa, 0.0).fill_null(0.0)
+    home_pass = _r_ifelse(is_pass, home_wpa, 0.0).fill_null(0.0)
+    away_pass = _r_ifelse(is_pass, away_wpa, 0.0).fill_null(0.0)
+
+    return df.with_columns(
+        home_rush.cum_sum().over("game_id").cast(pl.Float64).alias("total_home_rush_wpa"),
+        away_rush.cum_sum().over("game_id").cast(pl.Float64).alias("total_away_rush_wpa"),
+        home_pass.cum_sum().over("game_id").cast(pl.Float64).alias("total_home_pass_wpa"),
+        away_pass.cum_sum().over("game_id").cast(pl.Float64).alias("total_away_pass_wpa"),
+    )
+
+
+def _null_air_yac(df: pl.DataFrame, cols: tuple[str, ...]) -> pl.DataFrame:
+    """Emit *cols* as all-null ``Float64`` (short-circuit / degraded input)."""
+    return df.with_columns([pl.lit(None, dtype=pl.Float64).alias(c) for c in cols])
+
+
+def _air_yac_family_block(df: pl.DataFrame, *, kind: str) -> pl.DataFrame:
+    """Completion gating + signed per-game cumulative totals for air/yac columns.
+
+    Shared tail of ``add_air_yac_ep_variables`` / ``add_air_yac_wp_variables``
+    (the ``group_by(game_id) |> mutate(...)`` block): ``comp_air_* `` /
+    ``comp_yac_*`` gate the raw values to ``complete_pass == 1`` (R
+    ``dplyr::if_else`` — a null ``complete_pass`` yields null), then the
+    completion-gated and raw values are home/away-signed (NA -> 0) and
+    ``cumsum``'d within ``game_id``.  The R's intermediate
+    ``home_team_comp_air_*`` columns are folded into the cumulative
+    expressions (the published nflverse frame does not carry them).
+
+    Args:
+        df: Frame already carrying ``air_<kind>`` / ``yac_<kind>``.
+        kind: ``"epa"`` or ``"wpa"`` (column-name suffix).
+    """
+    air, yac = f"air_{kind}", f"yac_{kind}"
+    complete = pl.col("complete_pass").cast(pl.Float64)
+    df = df.with_columns(
+        _r_ifelse(complete == 1, pl.col(air), 0.0).cast(pl.Float64).alias(f"comp_air_{kind}"),
+        _r_ifelse(complete == 1, pl.col(yac), 0.0).cast(pl.Float64).alias(f"comp_yac_{kind}"),
+    )
+    comp_air = pl.col(f"comp_air_{kind}")
+    comp_yac = pl.col(f"comp_yac_{kind}")
+    raw_air = pl.col(air)
+    raw_yac = pl.col(yac)
+    return df.with_columns(
+        _signed_to_team(comp_air, "home_team").cum_sum().over("game_id").alias(f"total_home_comp_air_{kind}"),
+        _signed_to_team(comp_air, "away_team").cum_sum().over("game_id").alias(f"total_away_comp_air_{kind}"),
+        _signed_to_team(comp_yac, "home_team").cum_sum().over("game_id").alias(f"total_home_comp_yac_{kind}"),
+        _signed_to_team(comp_yac, "away_team").cum_sum().over("game_id").alias(f"total_away_comp_yac_{kind}"),
+        _signed_to_team(raw_air, "home_team").cum_sum().over("game_id").alias(f"total_home_raw_air_{kind}"),
+        _signed_to_team(raw_air, "away_team").cum_sum().over("game_id").alias(f"total_away_raw_air_{kind}"),
+        _signed_to_team(raw_yac, "home_team").cum_sum().over("game_id").alias(f"total_home_raw_yac_{kind}"),
+        _signed_to_team(raw_yac, "away_team").cum_sum().over("game_id").alias(f"total_away_raw_yac_{kind}"),
+    )
+
+
+def _derive_air_yac_epa(df: pl.DataFrame) -> pl.DataFrame:
+    """Add the nflfastR air/YAC EPA family (``add_air_yac_ep[_variables]``).
+
+    Faithful port of ``helper_add_ep_wp.R`` L1345-1584 plus the
+    ``add_air_yac_ep`` all-NA short-circuit (L13-47).  For every non-sack pass
+    attempt (``air_yards`` non-null and ``play_type == "pass"``) the game state
+    is projected to the catch spot — ``yardline_100 - air_yards`` (flipped to
+    the opponent frame when a 4th-down throw comes up short of the sticks:
+    ``Turnover_Ind``), ``down`` / ``ydstogo`` advanced, the half clock
+    decremented by :data:`_PASS_TIME_ELAPSED` — and re-scored with the EP model
+    (:func:`calculate_expected_points`, resolved off the module so tests can
+    stub it).  Then:
+
+    * ``airEP = 0`` when the projected clock is <= 0;
+    * ``air_epa = 7 - ep`` when the throw crossed the goal line,
+      ``-2 - ep`` when it overshot its own endzone (> 99), ``-airEP - ep`` on
+      a ``Turnover_Ind`` play, else ``airEP - ep`` (``ep`` = the play's
+      start-of-play EP);
+    * two-point attempts get null ``air_epa`` (no real air yards);
+    * ``yac_epa = epa - air_epa``; a zero-YAC completion (``penalty == 0 &
+      yards_after_catch == 0 & complete_pass == 1``) forces ``yac_epa = 0``
+      and ``air_epa = epa``;
+    * completion-gated ``comp_*`` variants and the 8 home/away signed
+      cumulative totals are added via :func:`_air_yac_family_block` — every
+      ``cum_sum`` is ``.over("game_id")``.
+
+    Frames with no non-null ``air_yards`` (the R short-circuit) or missing any
+    :data:`_AIR_YAC_EPA_REQUIRED` input emit the whole family as all-null
+    ``Float64`` — schema-stable degradation instead of raising.
+
+    Args:
+        df: Play-by-play frame carrying :data:`_AIR_YAC_EPA_REQUIRED`
+            (``roof`` optional).  Existing family columns are dropped and
+            recomputed.
+
+    Returns:
+        The frame plus the 12 :data:`_AIR_YAC_EPA_COLS` (all ``Float64``).
+    """
+    import sportsdataverse.nfl.ep_wp as _self
+
+    df = df.drop([c for c in _AIR_YAC_EPA_COLS if c in df.columns])
+    if any(c not in df.columns for c in _AIR_YAC_EPA_REQUIRED):
+        return _null_air_yac(df, _AIR_YAC_EPA_COLS)
+    if df.filter(pl.col("air_yards").is_not_null()).height == 0:
+        # R add_air_yac_ep: "No non-NA air_yards detected" -> all NA.
+        return _null_air_yac(df, _AIR_YAC_EPA_COLS)
+
+    if "_ay_idx" in df.columns:
+        df = df.drop("_ay_idx")
+    df = df.with_row_index("_ay_idx")
+    pass_df = df.filter(pl.col("air_yards").is_not_null() & (pl.col("play_type") == "pass"))
+
+    if pass_df.height > 0:
+        air = pl.col("air_yards").cast(pl.Float64)
+        yl = pl.col("yardline_100").cast(pl.Float64)
+        tg = pl.col("ydstogo").cast(pl.Float64)
+        down = pl.col("down").cast(pl.Float64)
+        pos_to = pl.col("posteam_timeouts_remaining").cast(pl.Float64)
+        def_to = pl.col("defteam_timeouts_remaining").cast(pl.Float64)
+
+        pass_df = pass_df.with_columns(
+            _r_ifelse((down == 4) & (air < tg), 1.0, 0.0).alias("_ay_turnover"),
+        )
+        t = pl.col("_ay_turnover")
+        converted = (air >= tg) | (t == 1)
+        pass_df = pass_df.with_columns(
+            _r_ifelse(t == 0, yl - air, 100.0 - (yl - air)).alias("_ay_yardline_100"),
+            _r_ifelse(converted, 10.0, tg - air).alias("_ay_ydstogo"),
+            _r_ifelse(converted, 1.0, down + 1.0).alias("_ay_down"),
+            (pl.col("half_seconds_remaining").cast(pl.Float64) - _PASS_TIME_ELAPSED).alias("_ay_half_seconds"),
+            _r_ifelse(t == 1, def_to, pos_to).alias("_ay_pos_to"),
+            _r_ifelse(t == 1, pos_to, def_to).alias("_ay_def_to"),
+        )
+
+        # Feature view for the EP re-score (air-yards-projected state).  The
+        # identity columns ride along for stubbed scorers / debuggability.
+        id_cols = [c for c in ("game_id", "play_id", "roof") if c in pass_df.columns]
+        feat = pass_df.select(
+            *[pl.col(c) for c in id_cols],
+            pl.col("season"),
+            pl.col("posteam"),
+            pl.col("home_team"),
+            pl.col("_ay_half_seconds").alias("half_seconds_remaining"),
+            pl.col("_ay_yardline_100").alias("yardline_100"),
+            pl.col("_ay_down").alias("down"),
+            pl.col("_ay_ydstogo").alias("ydstogo"),
+            pl.col("_ay_pos_to").alias("posteam_timeouts_remaining"),
+            pl.col("_ay_def_to").alias("defteam_timeouts_remaining"),
+        )
+        scored = _self.calculate_expected_points(feat)
+        scored_df = scored if isinstance(scored, pl.DataFrame) else pl.from_pandas(scored)
+        pass_df = pass_df.with_columns(scored_df["ep"].cast(pl.Float64).alias("_ay_air_ep"))
+        pass_df = pass_df.with_columns(
+            pl.when(pl.col("_ay_half_seconds") <= 0).then(0.0).otherwise(pl.col("_ay_air_ep")).alias("_ay_air_ep"),
+        )
+
+        ep0 = pl.col("ep").cast(pl.Float64)
+        epa0 = pl.col("epa").cast(pl.Float64)
+        pass_df = pass_df.with_columns(
+            # The 4-scenario airEPA (R L632-643): TD in the air / overshot own
+            # endzone / turnover-in-air flip / plain airEP - ep.
+            pl.when((yl - air) <= 0)
+            .then(7.0 - ep0)
+            .when((yl - air) > 99.0)
+            .then(-2.0 - ep0)
+            .when(t == 1)
+            .then(-1.0 * pl.col("_ay_air_ep") - ep0)
+            .otherwise(pl.col("_ay_air_ep") - ep0)
+            .alias("air_epa"),
+        )
+        pass_df = pass_df.with_columns(
+            pl.when(pl.col("two_point_attempt").cast(pl.Float64) == 1)
+            .then(None)
+            .otherwise(pl.col("air_epa"))
+            .alias("air_epa"),
+        )
+        pass_df = pass_df.with_columns((epa0 - pl.col("air_epa")).alias("yac_epa"))
+        zero_yac = (
+            (pl.col("penalty").cast(pl.Float64) == 0)
+            & (pl.col("yards_after_catch").cast(pl.Float64) == 0)
+            & (pl.col("complete_pass").cast(pl.Float64) == 1)
+        )
+        pass_df = pass_df.with_columns(
+            pl.when(zero_yac).then(0.0).otherwise(pl.col("yac_epa")).alias("yac_epa"),
+            pl.when(zero_yac).then(epa0).otherwise(pl.col("air_epa")).alias("air_epa"),
+        )
+        merged = df.join(
+            pass_df.select(
+                "_ay_idx",
+                pl.col("air_epa").cast(pl.Float64),
+                pl.col("yac_epa").cast(pl.Float64),
+            ),
+            on="_ay_idx",
+            how="left",
+        )
+    else:
+        merged = _null_air_yac(df, ("air_epa", "yac_epa"))
+
+    return _air_yac_family_block(merged, kind="epa").drop("_ay_idx")
+
+
+def _score_wp_naive(features: pl.DataFrame) -> np.ndarray:
+    """Score the naive WP model (``wp_naive.ubj``) on a prepared feature frame.
+
+    Mirrors nflfastR's ``get_preds_wp`` — the air/YAC WPA derivation resolves
+    this off the module so tests can stub the model.  *features* must carry
+    :data:`WP_NAIVE_FEATURES`.
+    """
+    from xgboost import DMatrix
+
+    X = features.select(WP_NAIVE_FEATURES).to_numpy(allow_copy=True).astype(np.float32)
+    preds = _load_model("wp_naive.ubj").predict(DMatrix(X, feature_names=WP_NAIVE_FEATURES))
+    return np.asarray(preds, dtype=np.float64)
+
+
+def _derive_air_yac_wpa(df: pl.DataFrame) -> pl.DataFrame:
+    """Add the nflfastR air/YAC WPA family (``add_air_yac_wp[_variables]``).
+
+    Faithful port of ``helper_add_ep_wp.R`` L1591-2036 plus the
+    ``add_air_yac_wp`` all-NA short-circuit (L55-89).  For every non-sack pass
+    attempt the WP-model inputs are projected: both clocks decremented by
+    :data:`_PASS_TIME_ELAPSED`, ``Diff_Time_Ratio`` recomputed from the
+    original ``elapsed_share`` and sign-flipped on ``Turnover_Ind`` (a
+    4th-down throw short of the sticks), timeouts swapped on the flip — note
+    the R deliberately does NOT project field position for the WP re-score
+    (unlike the EP one).  The naive WP model scores the state
+    (:func:`_score_wp_naive`, resolved off the module so tests can stub it),
+    then:
+
+    * ``airWP = 1 - airWP`` on ``Turnover_Ind`` plays (back to the original
+      possession frame); ``airWP = 0`` when either projected clock is <= 0;
+    * ``air_wpa = airWP - wp``; ``yac_wpa = wpa - air_wpa``; two-point
+      attempts get null in both;
+    * a zero-YAC completion forces ``yac_wpa = 0`` and ``air_wpa = wpa``;
+    * completion-gated ``comp_*`` variants and the 8 signed cumulative totals
+      via :func:`_air_yac_family_block` (every ``cum_sum`` over ``game_id``).
+
+    The R source's overtime branch (Sudden-Death / One-FG blend on the
+    projected state, L1674-1912) is **dead code upstream**: line 1907
+    re-assigns ``pass_overtime_df <- pass_pbp_data[pass_overtime_i, ]``
+    immediately before writing back, so the OT rows keep the main-branch
+    values.  The faithful port therefore applies the main-branch formula to
+    overtime rows too.
+
+    Frames with no non-null ``air_yards`` or missing any
+    :data:`_AIR_YAC_WPA_REQUIRED` input emit the family as all-null
+    ``Float64``.
+
+    Args:
+        df: Play-by-play frame carrying :data:`_AIR_YAC_WPA_REQUIRED`
+            (``receive_2h_ko`` / ``elapsed_share`` are derived when absent).
+            Existing family columns are dropped and recomputed.
+
+    Returns:
+        The frame plus the 12 :data:`_AIR_YAC_WPA_COLS` (all ``Float64``).
+    """
+    import sportsdataverse.nfl.ep_wp as _self
+
+    df = df.drop([c for c in _AIR_YAC_WPA_COLS if c in df.columns])
+    if any(c not in df.columns for c in _AIR_YAC_WPA_REQUIRED):
+        return _null_air_yac(df, _AIR_YAC_WPA_COLS)
+    if df.filter(pl.col("air_yards").is_not_null()).height == 0:
+        return _null_air_yac(df, _AIR_YAC_WPA_COLS)
+
+    if "_ay_idx" in df.columns:
+        df = df.drop("_ay_idx")
+    df = df.with_row_index("_ay_idx")
+    pass_df = df.filter(pl.col("air_yards").is_not_null() & (pl.col("play_type") == "pass"))
+
+    if pass_df.height > 0:
+        air = pl.col("air_yards").cast(pl.Float64)
+        tg = pl.col("ydstogo").cast(pl.Float64)
+        down = pl.col("down").cast(pl.Float64)
+        gsr = pl.col("game_seconds_remaining").cast(pl.Float64)
+        pos_to = pl.col("posteam_timeouts_remaining").cast(pl.Float64)
+        def_to = pl.col("defteam_timeouts_remaining").cast(pl.Float64)
+
+        # elapsed_share: reuse the frame's column when present (computed by
+        # _add_wp_aux on the enrich path from the ORIGINAL clock), else derive
+        # it from the un-decremented game clock — matching the R, where
+        # Diff_Time_Ratio reads the pre-existing elapsed_share column.
+        elapsed_share = (
+            pl.col("elapsed_share").cast(pl.Float64)
+            if "elapsed_share" in pass_df.columns
+            else ((3600.0 - gsr) / 3600.0).clip(0.0, 1.0)
+        )
+        if "receive_2h_ko" in pass_df.columns:
+            receive_2h_ko = pl.col("receive_2h_ko").cast(pl.Float64)
+        elif "qtr" in pass_df.columns and "defteam" in pass_df.columns:
+            receive_2h_ko = (
+                pl.when(
+                    (pl.col("qtr") <= 2) & (pl.col("posteam") == pl.col("defteam").drop_nulls().first().over("game_id"))
+                )
+                .then(1.0)
+                .otherwise(0.0)
+            )
+        else:
+            receive_2h_ko = pl.lit(0.0)
+
+        pass_df = pass_df.with_columns(
+            _r_ifelse((down == 4) & (air < tg), 1.0, 0.0).alias("_ay_turnover"),
+            (pl.col("half_seconds_remaining").cast(pl.Float64) - _PASS_TIME_ELAPSED).alias("_ay_half_seconds"),
+            (gsr - _PASS_TIME_ELAPSED).alias("_ay_game_seconds"),
+            (pl.col("score_differential").cast(pl.Float64) / ((-4.0 * elapsed_share).exp())).alias("_ay_dtr"),
+        )
+        t = pl.col("_ay_turnover")
+        pass_df = pass_df.with_columns(
+            _r_ifelse(t == 1, -pl.col("_ay_dtr"), pl.col("_ay_dtr")).alias("_ay_dtr"),
+            _r_ifelse(t == 1, def_to, pos_to).alias("_ay_pos_to"),
+            _r_ifelse(t == 1, pos_to, def_to).alias("_ay_def_to"),
+        )
+
+        feat = pass_df.select(
+            receive_2h_ko.alias("receive_2h_ko"),
+            pl.when(pl.col("posteam") == pl.col("home_team")).then(1.0).otherwise(0.0).alias("home"),
+            pl.col("_ay_half_seconds").alias("half_seconds_remaining"),
+            pl.col("_ay_game_seconds").alias("game_seconds_remaining"),
+            pl.col("_ay_dtr").alias("Diff_Time_Ratio"),
+            pl.col("score_differential").cast(pl.Float64),
+            down.alias("down"),
+            tg.alias("ydstogo"),
+            pl.col("yardline_100").cast(pl.Float64),
+            pl.col("_ay_pos_to").alias("posteam_timeouts_remaining"),
+            pl.col("_ay_def_to").alias("defteam_timeouts_remaining"),
+        )
+        air_wp = _self._score_wp_naive(feat)
+        pass_df = pass_df.with_columns(pl.Series("_ay_air_wp", np.asarray(air_wp, dtype=np.float64), dtype=pl.Float64))
+        pass_df = pass_df.with_columns(
+            # Turnover flip back to the original possession frame, then the
+            # clock-expiry zeroing (R L1639-1649).
+            _r_ifelse(t == 1, 1.0 - pl.col("_ay_air_wp"), pl.col("_ay_air_wp")).alias("_ay_air_wp"),
+        )
+        pass_df = pass_df.with_columns(
+            pl.when((pl.col("_ay_half_seconds") <= 0) | (pl.col("_ay_game_seconds") <= 0))
+            .then(0.0)
+            .otherwise(pl.col("_ay_air_wp"))
+            .alias("_ay_air_wp"),
+        )
+
+        wp0 = pl.col("wp").cast(pl.Float64)
+        wpa0 = pl.col("wpa").cast(pl.Float64)
+        pass_df = pass_df.with_columns((pl.col("_ay_air_wp") - wp0).alias("air_wpa"))
+        pass_df = pass_df.with_columns(
+            pl.when(pl.col("two_point_attempt").cast(pl.Float64) == 1)
+            .then(None)
+            .otherwise(pl.col("air_wpa"))
+            .alias("air_wpa"),
+        )
+        pass_df = pass_df.with_columns((wpa0 - pl.col("air_wpa")).alias("yac_wpa"))
+        pass_df = pass_df.with_columns(
+            pl.when(pl.col("two_point_attempt").cast(pl.Float64) == 1)
+            .then(None)
+            .otherwise(pl.col("yac_wpa"))
+            .alias("yac_wpa"),
+        )
+        zero_yac = (
+            (pl.col("penalty").cast(pl.Float64) == 0)
+            & (pl.col("yards_after_catch").cast(pl.Float64) == 0)
+            & (pl.col("complete_pass").cast(pl.Float64) == 1)
+        )
+        pass_df = pass_df.with_columns(
+            pl.when(zero_yac).then(0.0).otherwise(pl.col("yac_wpa")).alias("yac_wpa"),
+            pl.when(zero_yac).then(wpa0).otherwise(pl.col("air_wpa")).alias("air_wpa"),
+        )
+        merged = df.join(
+            pass_df.select(
+                "_ay_idx",
+                pl.col("air_wpa").cast(pl.Float64),
+                pl.col("yac_wpa").cast(pl.Float64),
+            ),
+            on="_ay_idx",
+            how="left",
+        )
+    else:
+        merged = _null_air_yac(df, ("air_wpa", "yac_wpa"))
+
+    return _air_yac_family_block(merged, kind="wpa").drop("_ay_idx")
 
 
 def _derive_qbr_epa(df: pl.DataFrame) -> pl.DataFrame:
@@ -3081,6 +3676,29 @@ def enrich_nfl_pbp(
         * ``away_wp`` — away-team win probability (``1 - home_wp``).
         * ``wpa`` — win probability added (float64; null on kneel/terminal rows).
         * ``vegas_wpa`` — spread-adjusted WPA.
+        * ``vegas_home_wpa`` — home-frame spread-adjusted WPA lead difference
+          (kept as a real column per nflfastR; NOT null'd on kneel rows).
+        * ``total_home_epa``, ``total_away_epa``, ``total_home_rush_epa``,
+          ``total_away_rush_epa``, ``total_home_pass_epa``,
+          ``total_away_pass_epa``, ``total_home_rush_wpa``,
+          ``total_away_rush_wpa``, ``total_home_pass_wpa``,
+          ``total_away_pass_wpa`` — per-game cumulative home/away-signed
+          EPA/WPA running totals (nflfastR ``add_ep_variables`` /
+          ``add_wp_variables`` tails; every cumsum is within ``game_id``).
+        * ``air_epa``, ``yac_epa``, ``comp_air_epa``, ``comp_yac_epa``,
+          ``total_home_comp_air_epa``, ``total_away_comp_air_epa``,
+          ``total_home_comp_yac_epa``, ``total_away_comp_yac_epa``,
+          ``total_home_raw_air_epa``, ``total_away_raw_air_epa``,
+          ``total_home_raw_yac_epa``, ``total_away_raw_yac_epa`` — the air/YAC
+          EPA family (nflfastR ``add_air_yac_ep_variables``): an EP re-score
+          on the air-yards-projected state splits ``epa`` into its air and
+          yards-after-catch components; ``comp_*`` gate to completions; the
+          totals are per-game signed cumulative sums.  Null on non-qualifying
+          plays (all float64).
+        * ``air_wpa``, ``yac_wpa``, ``comp_air_wpa``, ``comp_yac_wpa``, and
+          the eight ``total_{home,away}_{comp,raw}_{air,yac}_wpa`` mirrors —
+          the air/YAC WPA family (``add_air_yac_wp_variables``), same
+          structure on ``wp`` / ``wpa``.
         * ``cp`` — completion probability for intended pass plays (null
           otherwise; float64).
         * ``cpoe`` — completion probability over expected, percentage-point
@@ -3187,6 +3805,13 @@ def enrich_nfl_pbp(
     #     the QB keeps completion + YAC credit (nflfastR add_qb_epa).
     raw = _derive_qb_epa(raw)
 
+    # 2c. Air/YAC EPA family — nflfastR add_air_yac_ep_variables (an EP
+    #     re-score on the air-yards-projected state; nflfastR order runs it
+    #     right after the EP/EPA step and before WP).  Also the point where
+    #     air_epa becomes a real column, which calculate_xyac (step 6) then
+    #     consumes verbatim instead of re-deriving it.
+    raw = _self._derive_air_yac_epa(raw)
+
     # 3. WP — naive + spread-adjusted.
     raw = raw.drop([c for c in ("wp", "vegas_wp") if c in raw.columns])
     raw = _self.calculate_win_probability(raw)
@@ -3194,6 +3819,11 @@ def enrich_nfl_pbp(
     # 4. WPA + home/away/def WP — native lead-of-home-WP + posteam perspective.
     raw = raw.drop([c for c in ("home_wp", "away_wp", "def_wp", "wpa", "vegas_wpa") if c in raw.columns])
     raw = _derive_wpa(raw)
+
+    # 4b. Air/YAC WPA family — nflfastR add_air_yac_wp_variables (a naive-WP
+    #     re-score on the air-yards state; the R OT branch is dead code
+    #     upstream — see _derive_air_yac_wpa).
+    raw = _self._derive_air_yac_wpa(raw)
 
     # 5. CP / CPOE.
     raw = _self.calculate_completion_probability(raw)

--- a/sportsdataverse/nfl/ep_wp.py
+++ b/sportsdataverse/nfl/ep_wp.py
@@ -52,6 +52,7 @@ import polars as pl
 
 from sportsdataverse.nfl.model_vars import (
     _EP_POINT_VALUES,
+    SPREAD_TIME_DECAY_EXPONENT,
     TOUCHBACK_YARDLINE_POST_2016,
     TOUCHBACK_YARDLINE_PRE_2016,
     defense_score_vec,
@@ -2906,8 +2907,8 @@ _AIR_YAC_WPA_REQUIRED: tuple[str, ...] = (
 
 def _r_ifelse(
     cond: pl.Expr,
-    if_true: Union[pl.Expr, float],
-    if_false: Union[pl.Expr, float],
+    if_true: Union[pl.Expr, float, None],
+    if_false: Union[pl.Expr, float, None],
 ) -> pl.Expr:
     """``dplyr::if_else`` semantics: a null condition yields null.
 
@@ -3152,21 +3153,28 @@ def _derive_air_yac_epa(df: pl.DataFrame) -> pl.DataFrame:
         epa0 = pl.col("epa").cast(pl.Float64)
         pass_df = pass_df.with_columns(
             # The 4-scenario airEPA (R L632-643): TD in the air / overshot own
-            # endzone / turnover-in-air flip / plain airEP - ep.
-            pl.when((yl - air) <= 0)
-            .then(7.0 - ep0)
-            .when((yl - air) > 99.0)
-            .then(-2.0 - ep0)
-            .when(t == 1)
-            .then(-1.0 * pl.col("_ay_air_ep") - ep0)
-            .otherwise(pl.col("_ay_air_ep") - ep0)
-            .alias("air_epa"),
+            # endzone / turnover-in-air flip / plain airEP - ep.  Nested
+            # _r_ifelse mirrors R's nested base ifelse: a null yardline_100 or
+            # null Turnover_Ind yields null airEPA (NA propagation), not the
+            # innermost fall-through branch.
+            _r_ifelse(
+                (yl - air) <= 0,
+                7.0 - ep0,
+                _r_ifelse(
+                    (yl - air) > 99.0,
+                    -2.0 - ep0,
+                    _r_ifelse(
+                        t == 1,
+                        -1.0 * pl.col("_ay_air_ep") - ep0,
+                        pl.col("_ay_air_ep") - ep0,
+                    ),
+                ),
+            ).alias("air_epa"),
         )
         pass_df = pass_df.with_columns(
-            pl.when(pl.col("two_point_attempt").cast(pl.Float64) == 1)
-            .then(None)
-            .otherwise(pl.col("air_epa"))
-            .alias("air_epa"),
+            # R: ifelse(two_point_attempt == 1, NA, airEPA) — a null flag
+            # yields NA, so _r_ifelse (not a raw when-chain) is required.
+            _r_ifelse(pl.col("two_point_attempt").cast(pl.Float64) == 1, None, pl.col("air_epa")).alias("air_epa"),
         )
         pass_df = pass_df.with_columns((epa0 - pl.col("air_epa")).alias("yac_epa"))
         zero_yac = (
@@ -3175,8 +3183,10 @@ def _derive_air_yac_epa(df: pl.DataFrame) -> pl.DataFrame:
             & (pl.col("complete_pass").cast(pl.Float64) == 1)
         )
         pass_df = pass_df.with_columns(
-            pl.when(zero_yac).then(0.0).otherwise(pl.col("yac_epa")).alias("yac_epa"),
-            pl.when(zero_yac).then(epa0).otherwise(pl.col("air_epa")).alias("air_epa"),
+            # R base ifelse: a truly-null condition (e.g. null
+            # yards_after_catch on a completion) yields NA in both columns.
+            _r_ifelse(zero_yac, 0.0, pl.col("yac_epa")).alias("yac_epa"),
+            _r_ifelse(zero_yac, epa0, pl.col("air_epa")).alias("air_epa"),
         )
         merged = df.join(
             pass_df.select(
@@ -3259,6 +3269,27 @@ def _derive_air_yac_wpa(df: pl.DataFrame) -> pl.DataFrame:
     if "_ay_idx" in df.columns:
         df = df.drop("_ay_idx")
     df = df.with_row_index("_ay_idx")
+
+    # receive_2h_ko: reuse the frame's column when present (it exists on the
+    # enrich path after _add_wp_aux).  When absent, derive it on the FULL
+    # frame BEFORE the pass filter — the opening defense is the game's first
+    # non-null defteam across ALL plays; deriving it on the pass subset would
+    # misidentify it whenever possession changes before the game's first
+    # qualifying pass (flag inverted game-wide).  Mirrors _add_wp_aux.
+    if "receive_2h_ko" in df.columns:
+        df = df.with_columns(pl.col("receive_2h_ko").cast(pl.Float64).alias("_ay_r2k"))
+    elif "qtr" in df.columns and "defteam" in df.columns:
+        df = df.with_columns(
+            pl.when(
+                (pl.col("qtr") <= 2) & (pl.col("posteam") == pl.col("defteam").drop_nulls().first().over("game_id"))
+            )
+            .then(1.0)
+            .otherwise(0.0)
+            .alias("_ay_r2k")
+        )
+    else:
+        df = df.with_columns(pl.lit(0.0).alias("_ay_r2k"))
+
     pass_df = df.filter(pl.col("air_yards").is_not_null() & (pl.col("play_type") == "pass"))
 
     if pass_df.height > 0:
@@ -3278,24 +3309,15 @@ def _derive_air_yac_wpa(df: pl.DataFrame) -> pl.DataFrame:
             if "elapsed_share" in pass_df.columns
             else ((3600.0 - gsr) / 3600.0).clip(0.0, 1.0)
         )
-        if "receive_2h_ko" in pass_df.columns:
-            receive_2h_ko = pl.col("receive_2h_ko").cast(pl.Float64)
-        elif "qtr" in pass_df.columns and "defteam" in pass_df.columns:
-            receive_2h_ko = (
-                pl.when(
-                    (pl.col("qtr") <= 2) & (pl.col("posteam") == pl.col("defteam").drop_nulls().first().over("game_id"))
-                )
-                .then(1.0)
-                .otherwise(0.0)
-            )
-        else:
-            receive_2h_ko = pl.lit(0.0)
+        receive_2h_ko = pl.col("_ay_r2k")
 
         pass_df = pass_df.with_columns(
             _r_ifelse((down == 4) & (air < tg), 1.0, 0.0).alias("_ay_turnover"),
             (pl.col("half_seconds_remaining").cast(pl.Float64) - _PASS_TIME_ELAPSED).alias("_ay_half_seconds"),
             (gsr - _PASS_TIME_ELAPSED).alias("_ay_game_seconds"),
-            (pl.col("score_differential").cast(pl.Float64) / ((-4.0 * elapsed_share).exp())).alias("_ay_dtr"),
+            (
+                pl.col("score_differential").cast(pl.Float64) / ((SPREAD_TIME_DECAY_EXPONENT * elapsed_share).exp())
+            ).alias("_ay_dtr"),
         )
         t = pl.col("_ay_turnover")
         pass_df = pass_df.with_columns(
@@ -3335,17 +3357,13 @@ def _derive_air_yac_wpa(df: pl.DataFrame) -> pl.DataFrame:
         wpa0 = pl.col("wpa").cast(pl.Float64)
         pass_df = pass_df.with_columns((pl.col("_ay_air_wp") - wp0).alias("air_wpa"))
         pass_df = pass_df.with_columns(
-            pl.when(pl.col("two_point_attempt").cast(pl.Float64) == 1)
-            .then(None)
-            .otherwise(pl.col("air_wpa"))
-            .alias("air_wpa"),
+            # R: ifelse(two_point_attempt == 1, NA, x) on BOTH columns — a
+            # null flag yields NA, so _r_ifelse (not a raw when-chain).
+            _r_ifelse(pl.col("two_point_attempt").cast(pl.Float64) == 1, None, pl.col("air_wpa")).alias("air_wpa"),
         )
         pass_df = pass_df.with_columns((wpa0 - pl.col("air_wpa")).alias("yac_wpa"))
         pass_df = pass_df.with_columns(
-            pl.when(pl.col("two_point_attempt").cast(pl.Float64) == 1)
-            .then(None)
-            .otherwise(pl.col("yac_wpa"))
-            .alias("yac_wpa"),
+            _r_ifelse(pl.col("two_point_attempt").cast(pl.Float64) == 1, None, pl.col("yac_wpa")).alias("yac_wpa"),
         )
         zero_yac = (
             (pl.col("penalty").cast(pl.Float64) == 0)
@@ -3353,8 +3371,9 @@ def _derive_air_yac_wpa(df: pl.DataFrame) -> pl.DataFrame:
             & (pl.col("complete_pass").cast(pl.Float64) == 1)
         )
         pass_df = pass_df.with_columns(
-            pl.when(zero_yac).then(0.0).otherwise(pl.col("yac_wpa")).alias("yac_wpa"),
-            pl.when(zero_yac).then(wpa0).otherwise(pl.col("air_wpa")).alias("air_wpa"),
+            # R base ifelse: a truly-null condition yields NA in both columns.
+            _r_ifelse(zero_yac, 0.0, pl.col("yac_wpa")).alias("yac_wpa"),
+            _r_ifelse(zero_yac, wpa0, pl.col("air_wpa")).alias("air_wpa"),
         )
         merged = df.join(
             pass_df.select(
@@ -3368,7 +3387,7 @@ def _derive_air_yac_wpa(df: pl.DataFrame) -> pl.DataFrame:
     else:
         merged = _null_air_yac(df, ("air_wpa", "yac_wpa"))
 
-    return _air_yac_family_block(merged, kind="wpa").drop("_ay_idx")
+    return _air_yac_family_block(merged, kind="wpa").drop("_ay_idx", "_ay_r2k")
 
 
 def _derive_qbr_epa(df: pl.DataFrame) -> pl.DataFrame:

--- a/sportsdataverse/nfl/nfl_clean.py
+++ b/sportsdataverse/nfl/nfl_clean.py
@@ -69,13 +69,15 @@ Scope decisions (read before using on non-nflverse frames)
   the one capture group that corresponds to the name (or jersey number) --
   see :data:`_NAME_CORE` / :data:`_PASS_CONTEXT` / :data:`_RUSH_CONTEXT` and
   the ``_PASSER_PATTERN`` / ``_RUSHER_PATTERN`` / ``_RECEIVER_PATTERN``
-  family below. One deliberate simplification: R's ``rush_finder`` has a
-  literal (almost certainly accidental) stray ``" | "`` alternative
-  (``"(FUMBLES) | (left end)|..."``) that -- taken literally in a
-  non-``(?x)`` R regex -- adds a bare space as a matching alternative, making
-  the lookahead nearly vacuous. This port implements the *intended* semantics
-  (the named FUMBLES/rush-direction phrases only) rather than replicating
-  that stray-space quirk; see the task report for the parity discussion.
+  family below. R's ``rush_finder`` contains stray literal spaces around its
+  first ``|`` (``"(FUMBLES) | (left end)|..."``); in a non-``(?x)`` regex
+  those spaces are part of the alternatives, so the FUMBLES branch requires a
+  trailing space (a desc ending exactly at ``"...FUMBLES"`` does NOT match in
+  R) and the ``left end`` branch carries a leading space. Almost certainly
+  accidental, but empirically verified against R and **replicated verbatim**
+  here (see :data:`_RUSH_CONTEXT`) -- R's accidents are the parity target.
+  The one deviation NOT replicated is `big_parser`'s ``[A-z]`` class typo;
+  see :data:`_NAME_CORE`.
 * **``fix_weird_pass_plays``** (§3, the 15-row hardcoded ``game_id_play_id``
   false-positive override) is ported as :data:`_FIX_WEIRD_PASS_PLAYS` and
   applied in the same post-hoc position as the R source (after ``pass`` has
@@ -219,9 +221,13 @@ def team_name_fn(expr: pl.Expr) -> pl.Expr:
 # support at all). See the module docstring's "Regex rewrite" note.
 # ---------------------------------------------------------------------------
 
-#: First.Last name core -- rewrite of nflfastR's `big_parser` (the leading
-#: `(?<=)` in the R source is a zero-width empty lookbehind, i.e. a no-op, so
-#: it is simply dropped here).
+#: First.Last name core -- rewrite of nflfastR's `big_parser`. Two deliberate
+#: deviations from the R source, both documented rather than replicated:
+#: (1) the leading `(?<=)` is a zero-width EMPTY lookbehind, i.e. a no-op --
+#: dropped; (2) R's `[A-z]` character class is replaced with `[A-Za-z]` --
+#: `[A-z]` is an ASCII-range typo that additionally spans the six punctuation
+#: codepoints between 'Z' and 'a' (`[ \ ] ^ _` and backtick), which are never
+#: legitimate name characters; replicating it would only admit garbage.
 _NAME_CORE = r"[A-Z][A-Za-z]*(?:\.|\s)+[A-Z][A-Za-z']*-?[A-Za-z]*(?:\s(?:Jr\.|Sr\.|I{2,3})|IV)?"
 
 #: Trailing context for a pass play -- rewrite of `pass_finder`'s lookahead
@@ -229,10 +235,15 @@ _NAME_CORE = r"[A-Z][A-Za-z]*(?:\.|\s)+[A-Z][A-Za-z']*-?[A-Za-z]*(?:\s(?:Jr\.|Sr
 _PASS_CONTEXT = r"(?:\s*[a-z]*\s*(?: pass|sack|scramble))"
 
 #: Trailing context for a rush play -- rewrite of `rush_finder`'s lookahead.
-#: Intentionally implements the *named* rush-direction/FUMBLES alternatives
-#: only (see the module docstring's stray-space note on the R source).
+#: The R source's alternation is transcribed VERBATIM including its stray
+#: literal spaces around the first `|` ("(FUMBLES) | (left end)|..."): the
+#: FUMBLES alternative therefore requires a TRAILING space (a desc ending
+#: exactly at "...FUMBLES" does not match -- R-verified behavior, pinned in
+#: tests), and the `left end` alternative carries a leading space (absorbed
+#: by the preceding `\s*` in practice). Almost certainly accidental in R,
+#: but R's accidents are the parity target.
 _RUSH_CONTEXT = (
-    r"(?:\s*[a-z]*\s*(?:FUMBLES|left end|left tackle|left guard"
+    r"(?:\s*[a-z]*\s*(?:FUMBLES | left end|left tackle|left guard"
     r"|up the middle|right guard|right tackle|right end))"
 )
 
@@ -401,6 +412,14 @@ def _resolve_name_id(
     share one id, and (verbatim R semantics) nulls ``name_col`` out wherever
     ``id_col`` is null, even if a name string was present pre-resolution.
 
+    Both joins use ``nulls_equal=True``: dplyr's ``group_by`` treats ``NA``
+    as an ordinary groupable value (a ``(name, NA, NA)`` group still gets a
+    mode vote), so the polars join that maps each group's result back onto
+    the rows must also match null keys to null keys. With polars' default
+    (``nulls_equal=False``, SQL semantics) a row with a null ``posteam`` or
+    ``season`` would never re-join its own group row, silently nulling BOTH
+    the id and (via pass 2) the name -- a data-loss divergence from R.
+
     Assumes ``df`` already carries the row-order-restoring index column (the
     caller re-sorts once, after all three name/id pairs are resolved, rather
     than after each one) and that any pre-existing ``id_col`` has already
@@ -415,7 +434,7 @@ def _resolve_name_id(
         .with_columns(pl.col("_ids").map_elements(_first_seen_mode, return_dtype=pl.Utf8).alias(id_col))
         .select([*group_cols, id_col])
     )
-    df = df.join(pass1, on=group_cols, how="left")
+    df = df.join(pass1, on=group_cols, how="left", nulls_equal=True)
 
     pass2 = (
         df.filter(pl.col(id_col).is_not_null())
@@ -424,7 +443,7 @@ def _resolve_name_id(
         .with_columns(pl.col("_names").map_elements(_first_seen_mode, return_dtype=pl.Utf8).alias("_name_mode"))
         .select([id_col, "_name_mode"])
     )
-    df = df.drop(name_col).join(pass2, on=id_col, how="left").rename({"_name_mode": name_col})
+    df = df.drop(name_col).join(pass2, on=id_col, how="left", nulls_equal=True).rename({"_name_mode": name_col})
     return df
 
 
@@ -580,6 +599,16 @@ def clean_nfl_pbp(
     )
 
     # pass / rush / first_down / special / play flags.
+    #
+    # Cross-port note: nfl-data's native pipeline (native_pbp/description.py)
+    # derives its pass/rush from the RAW `rusher_player_name` column, whereas
+    # this module -- following §6's mutate ordering -- uses the CLEANED
+    # `rusher` (post abnormal-play overwrite / passer-nulling). Residual gap:
+    # on lateral / direct-snap plays the abnormal-play overwrite can null
+    # `rusher` here without `pass` being forced to 1, so the backward/lateral
+    # `pass -> 0` exception can fire differently between the two ports for
+    # those rare descs. Known + accepted; revisit if a parity sweep against
+    # real nflverse data surfaces divergent `pass` values on lateral plays.
     if had_pass:
         pass_expr = pl.col("pass")
     else:

--- a/sportsdataverse/nfl/nfl_clean.py
+++ b/sportsdataverse/nfl/nfl_clean.py
@@ -1,0 +1,789 @@
+"""NFL play-by-play name/id/team canonicalization (nflfastR ``clean_pbp`` port).
+
+Faithful Python port of nflfastR's ``helper_additional_functions.R::clean_pbp``
+(lines 51-447) plus ``team_name_fn`` (lines 499-515) and
+``fix_weird_pass_plays`` (lines 641-661, already ported standalone). Given a
+play-by-play frame, :func:`clean_nfl_pbp` derives/overwrites the columns
+nflfastR's cleaning stage is responsible for:
+
+* ``aborted_play`` (0/1 from ``desc`` containing ``"Aborted"``).
+* ``success`` (``epa > 0`` -> 1.0 / 0.0, null when ``epa`` is null).
+* ``passer`` / ``rusher`` / ``receiver`` (+ ``*_jersey_number``) — extracted
+  from ``desc`` via the four nflfastR parser regexes, then patched through the
+  hardcoded name-fix tables (``"G.Minshew" -> "G.Minshew II"``, etc.) and the
+  ``qb_scramble``/season<=2005 passer-from-rusher fallback.
+* ``pass`` / ``rush`` (0/1 play-type flags) — see the **compute-if-absent**
+  note below.
+* ``first_down`` / ``special`` / ``play`` (0/1 gate flags).
+* Team-abbreviation normalization (``SD -> LAC``, ``OAK -> LV``, ...) applied
+  to every team-ish column nflfastR's ``mutate_at(..., team_name_fn)`` touches
+  (27 columns per the verbatim R ``vars()`` list — see :data:`TEAM_COLUMNS`;
+  only touches whichever of those are present on the input frame).
+* ``passer_id`` / ``rusher_id`` / ``receiver_id`` and canonicalized
+  ``passer`` / ``rusher`` / ``receiver`` names — a per-``(name, posteam,
+  season)`` mode vote onto the id, then a per-id mode vote back onto the name
+  string (irons out name-string variants that share one id). See
+  :func:`_resolve_name_id`.
+* ``name`` / ``jersey_number`` / ``id`` (passer-else-rusher).
+* ``fantasy`` / ``fantasy_id`` (cleaned rusher-else-receiver, else passer on a
+  scramble) and ``fantasy_player_name`` / ``fantasy_player_id`` (same
+  fallback, but sourced from the **raw**, uncleaned ``rusher_player_name`` /
+  ``receiver_player_name`` columns — nflfastR deliberately uses the raw names
+  here, not the cleaned ``rusher``/``receiver``).
+* ``out_of_bounds`` (0/1 from ``desc``).
+* ``home_opening_kickoff`` (0/1, per ``game_id``: was the home team the first
+  team with a non-null ``posteam``).
+
+Scope decisions (read before using on non-nflverse frames)
+-----------------------------------------------------------
+* **``pass`` / ``rush`` are compute-if-absent, not always-recompute.** The R
+  source pre-strips *every* drop.cols entry (including ``pass``/``rush``) and
+  unconditionally recomputes them, making ``clean_pbp`` idempotent end to end.
+  This port narrows that for exactly these two columns: nflverse-loaded
+  frames (:func:`sportsdataverse.nfl.load_nfl_pbp`) already carry
+  authoritative ``pass``/``rush`` from nflfastR itself, so re-deriving them
+  from this port's simplified regex extraction would be redundant at best and
+  a silent downgrade at worst. ESPN/native frames that lack ``pass``/``rush``
+  still get them computed via the verbatim §6 formula. Every other drop.cols
+  entry (``passer``, ``rusher``, ``receiver``, ``success``, ``first_down``,
+  ``special``, ``play``, the three ``*_id`` columns, ``name``, ``id``, the
+  jersey-number columns, ``aborted_play``, the four ``fantasy*`` columns,
+  ``out_of_bounds``) is still pre-stripped-then-recomputed every call, exactly
+  matching R's idempotent-rerun contract.
+* **``maybe_valid`` / ``uniquify_ids`` (old GameCenter-id handling) are
+  document-and-skip, verified absent from this function.** These names do
+  not appear anywhere in ``helper_additional_functions.R`` (grep-verified
+  against the nflfastR source) — they live in ``helper_scrape_gc.R``, the
+  retired GameCenter-era scraper, and are never called from ``clean_pbp``.
+  The only id-resolution logic ``clean_pbp`` performs is the ``custom_mode``
+  two-pass mode-vote ported in :func:`_resolve_name_id`, which is fully
+  ported above; there is no GC-id branch to skip.
+* **Regex rewrite: lookaround -> capture group.** nflfastR's four parser
+  regexes (``big_parser``, ``rush_finder``, ``pass_finder``,
+  ``receiver_finder``, plus ``number_parser``/``receiver_number``) are
+  PCRE lookbehind/lookahead-heavy; polars' Rust regex engine has no
+  lookaround support at all. Since R's ``str_extract`` only ever returns the
+  *matched text* (and every lookaround in these patterns is zero-width), each
+  rewrite here keeps the semantically-equivalent behavior by turning the
+  lookaround into a **consumed-but-non-captured** group and extracting only
+  the one capture group that corresponds to the name (or jersey number) --
+  see :data:`_NAME_CORE` / :data:`_PASS_CONTEXT` / :data:`_RUSH_CONTEXT` and
+  the ``_PASSER_PATTERN`` / ``_RUSHER_PATTERN`` / ``_RECEIVER_PATTERN``
+  family below. One deliberate simplification: R's ``rush_finder`` has a
+  literal (almost certainly accidental) stray ``" | "`` alternative
+  (``"(FUMBLES) | (left end)|..."``) that -- taken literally in a
+  non-``(?x)`` R regex -- adds a bare space as a matching alternative, making
+  the lookahead nearly vacuous. This port implements the *intended* semantics
+  (the named FUMBLES/rush-direction phrases only) rather than replicating
+  that stray-space quirk; see the task report for the parity discussion.
+* **``fix_weird_pass_plays``** (§3, the 15-row hardcoded ``game_id_play_id``
+  false-positive override) is ported as :data:`_FIX_WEIRD_PASS_PLAYS` and
+  applied in the same post-hoc position as the R source (after ``pass`` has
+  already been derived from ``desc``/backward-lateral/kickoff logic, only
+  ever forcing ``1 -> 0``, never the reverse).
+
+Required / optional input columns
+----------------------------------
+Required: ``desc``, ``epa``, ``game_id``, ``play_id``, ``season``,
+``posteam``. Everything else nflfastR's derivation touches
+(``qb_scramble``, ``kickoff_attempt``, ``qb_kneel``, ``first_down_rush``,
+``first_down_pass``, ``first_down_penalty``, ``play_type``,
+``passer_player_name``/``_id``, ``rusher_player_name``/``_id``,
+``receiver_player_name``/``_id``, ``fumbled_1_player_name``/``_id``) is
+filled with a safe default (``0`` for the int flags, null for the rest) when
+absent from the input frame, so the function is usable on ESPN/native frames
+that don't carry the full nflverse column set. The 27 :data:`TEAM_COLUMNS`
+are normalized only for whichever of them are actually present.
+
+Example:
+    Quick start on a loaded nflverse frame::
+
+        from sportsdataverse.nfl import load_nfl_pbp
+        from sportsdataverse.nfl.nfl_clean import clean_nfl_pbp
+
+        pbp = load_nfl_pbp([2023])
+        cleaned = clean_nfl_pbp(pbp)
+        print(cleaned.select("passer", "passer_id", "name", "id").head())
+
+    Pandas output::
+
+        cleaned_pd = clean_nfl_pbp(pbp, return_as_pandas=True)
+
+    Pipeline next step (one line)::
+
+        import polars as pl
+        cleaned.filter(pl.col("play") == 1).group_by("passer").len()
+
+    See Also:
+        * `nflfastR`_ -- the R package this API mirrors
+        * `nflreadpy`_ -- Python parity wrapper for nflverse loaders
+
+    .. _nflfastR: https://www.nflfastr.com
+    .. _nflreadpy: https://github.com/nflverse/nflreadpy
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Union, overload
+
+import polars as pl
+
+from sportsdataverse.nfl.datasets import team_abbr_mapping
+
+if TYPE_CHECKING:  # pragma: no cover -- annotation-only import (PEP 563 defers eval)
+    import pandas as pd
+
+__all__ = ["clean_nfl_pbp", "team_name_fn"]
+
+# ---------------------------------------------------------------------------
+# team_name_fn -- verbatim §6 team-abbreviation fixups (10 historical codes),
+# sourced from datasets.py::team_abbr_mapping rather than re-hardcoded. Every
+# one of the 10 R codes is present in team_abbr_mapping with an identical
+# target, so no local additions were needed.
+# ---------------------------------------------------------------------------
+_TEAM_NAME_FIX_CODES: tuple[str, ...] = (
+    "JAC",
+    "STL",
+    "SL",
+    "LAR",
+    "ARZ",
+    "BLT",
+    "CLV",
+    "HST",
+    "SD",
+    "OAK",
+)
+
+#: The 27 team-ish columns nflfastR's `mutate_at(vars(...), team_name_fn)`
+#: touches (verbatim R `vars()` list, `helper_additional_functions.R` lines
+#: 2687-2714 of the reference doc). The port-contract prose there says "26
+#: columns"; the actual transcribed `vars()` list has 27 entries -- the R
+#: source (transcribed above it) wins per the porting reference's own rule.
+TEAM_COLUMNS: List[str] = [
+    "posteam",
+    "defteam",
+    "home_team",
+    "away_team",
+    "timeout_team",
+    "td_team",
+    "return_team",
+    "penalty_team",
+    "side_of_field",
+    "forced_fumble_player_1_team",
+    "forced_fumble_player_2_team",
+    "solo_tackle_1_team",
+    "solo_tackle_2_team",
+    "assist_tackle_1_team",
+    "assist_tackle_2_team",
+    "assist_tackle_3_team",
+    "assist_tackle_4_team",
+    "tackle_with_assist_1_team",
+    "tackle_with_assist_2_team",
+    "fumbled_1_team",
+    "fumbled_2_team",
+    "fumble_recovery_1_team",
+    "fumble_recovery_2_team",
+    "yrdln",
+    "end_yard_line",
+    "drive_start_yard_line",
+    "drive_end_yard_line",
+]
+
+
+def team_name_fn(expr: pl.Expr) -> pl.Expr:
+    """Fold historical/relocated team codes onto their current abbreviation.
+
+    Verbatim port of nflfastR's ``team_name_fn`` (a plain
+    ``stringr::str_replace_all`` over a 10-entry named vector). Operates as a
+    **substring** replace (not a full-value lookup) so it also fixes
+    embedded codes like ``"SD 49" -> "LAC 49"`` on yard-line columns. The
+    10 from-codes are disjoint from all of their to-values, so the order of
+    the 10 sequential replacements does not matter (verified in
+    :mod:`tests.nfl.test_nfl_clean`).
+
+    Args:
+        expr: A ``polars.Expr`` over a Utf8 column (e.g. ``pl.col("posteam")``).
+
+    Returns:
+        The same expression with every occurrence of the 10 historical codes
+        replaced by their current-franchise code.
+    """
+    for code in _TEAM_NAME_FIX_CODES:
+        expr = expr.str.replace_all(code, team_abbr_mapping[code], literal=True)
+    return expr
+
+
+# ---------------------------------------------------------------------------
+# Regex constants -- rewritten from nflfastR's lookaround-heavy PCRE patterns
+# into consumed-but-not-captured groups (polars/Rust regex has no lookaround
+# support at all). See the module docstring's "Regex rewrite" note.
+# ---------------------------------------------------------------------------
+
+#: First.Last name core -- rewrite of nflfastR's `big_parser` (the leading
+#: `(?<=)` in the R source is a zero-width empty lookbehind, i.e. a no-op, so
+#: it is simply dropped here).
+_NAME_CORE = r"[A-Z][A-Za-z]*(?:\.|\s)+[A-Z][A-Za-z']*-?[A-Za-z]*(?:\s(?:Jr\.|Sr\.|I{2,3})|IV)?"
+
+#: Trailing context for a pass play -- rewrite of `pass_finder`'s lookahead
+#: as a consumed (non-captured) suffix.
+_PASS_CONTEXT = r"(?:\s*[a-z]*\s*(?: pass|sack|scramble))"
+
+#: Trailing context for a rush play -- rewrite of `rush_finder`'s lookahead.
+#: Intentionally implements the *named* rush-direction/FUMBLES alternatives
+#: only (see the module docstring's stray-space note on the R source).
+_RUSH_CONTEXT = (
+    r"(?:\s*[a-z]*\s*(?:FUMBLES|left end|left tackle|left guard"
+    r"|up the middle|right guard|right tackle|right end))"
+)
+
+#: `abnormal_play` -- plain alternation, no lookaround in the original, ported
+#: as-is.
+_ABNORMAL_PLAY = (
+    r"(?:Lateral|lateral|pitches to|Direct snap to|New quarterback for"
+    r"|Aborted|backwards pass|Pass back to|Flea-flicker)"
+)
+
+_PASSER_PATTERN = f"({_NAME_CORE}){_PASS_CONTEXT}"
+_PASSER_JERSEY_PATTERN = rf"(\d{{1,2}})-(?:{_NAME_CORE}){_PASS_CONTEXT}"
+_RUSHER_PATTERN = f"({_NAME_CORE}){_RUSH_CONTEXT}"
+_RUSHER_JERSEY_PATTERN = rf"(\d{{1,2}})-(?:{_NAME_CORE}){_RUSH_CONTEXT}"
+_RECEIVER_PATTERN = rf"(?:to|for)\s\d{{0,2}}-?({_NAME_CORE})"
+_RECEIVER_JERSEY_PATTERN = rf"(?:to|for)\s(\d{{0,2}})-?(?:{_NAME_CORE})"
+
+#: `desc` whitespace cleanup -- collapses a stray run of spaces right after a
+#: "space-or-dash + Capital + period" token (e.g. ``"  T. Brady"`` ->
+#: ``"  T.Brady"``). No lookaround in the R source; ported as a plain
+#: capture-group + `${1}` replacement.
+_DESC_CLEANUP_PATTERN = r"((?:\s|-)[A-Z]\.)\s+"
+
+#: §3 `fix_weird_pass_plays` -- the 15 hardcoded `{game_id}_{play_id}` keys
+#: where the desc-based `pass` derivation is a known false positive. Verbatim
+#: from the reference doc (count verified: 15).
+_FIX_WEIRD_PASS_PLAYS: List[str] = [
+    "1999_01_ARI_PHI_1611",
+    "1999_01_SF_JAX_1788",
+    "1999_01_SF_JAX_2081",
+    "1999_11_ATL_TB_1740",
+    "2001_09_MIN_PHI_1307",
+    "2001_14_NE_BUF_452",
+    "2002_16_PIT_TB_527",
+    "2003_02_HOU_NO_3924",
+    "2003_15_PIT_NYJ_873",
+    "2004_05_BUF_NYJ_2555",
+    "2005_07_SD_PHI_321",
+    "2011_02_STL_NYG_1369",
+    "2016_05_NE_CLE_912",
+    "2016_06_CAR_NO_2690",
+    "2020_10_BAL_NE_2013",
+]
+
+#: drop.cols (§6), minus `pass`/`rush` -- see the module docstring's
+#: compute-if-absent scope note for why those two are excluded here.
+_DROP_COLS: List[str] = [
+    "success",
+    "passer",
+    "rusher",
+    "receiver",
+    "special",
+    "first_down",
+    "play",
+    "passer_id",
+    "rusher_id",
+    "receiver_id",
+    "name",
+    "id",
+    "passer_jersey_number",
+    "rusher_jersey_number",
+    "receiver_jersey_number",
+    "jersey_number",
+    "aborted_play",
+    "fantasy",
+    "fantasy_id",
+    "fantasy_player_name",
+    "fantasy_player_id",
+    "out_of_bounds",
+]
+
+#: Documented output schema (dtypes) for every column `clean_nfl_pbp` adds,
+#: used to build a stable empty-frame result and for reference.
+_ADDED_SCHEMA: Dict[str, pl.DataType] = {
+    "aborted_play": pl.Int64,
+    "success": pl.Float64,
+    "passer": pl.Utf8,
+    "passer_jersey_number": pl.Int64,
+    "rusher": pl.Utf8,
+    "rusher_jersey_number": pl.Int64,
+    "receiver": pl.Utf8,
+    "receiver_jersey_number": pl.Int64,
+    "pass": pl.Int64,
+    "rush": pl.Int64,
+    "first_down": pl.Int64,
+    "special": pl.Int64,
+    "play": pl.Int64,
+    "passer_id": pl.Utf8,
+    "rusher_id": pl.Utf8,
+    "receiver_id": pl.Utf8,
+    "name": pl.Utf8,
+    "jersey_number": pl.Int64,
+    "id": pl.Utf8,
+    "fantasy": pl.Utf8,
+    "fantasy_id": pl.Utf8,
+    "fantasy_player_name": pl.Utf8,
+    "fantasy_player_id": pl.Utf8,
+    "out_of_bounds": pl.Int64,
+    "home_opening_kickoff": pl.Int64,
+}
+
+#: Optional input columns this port fills with a safe default when absent
+#: (name -> (dtype, default)), so the function is usable on ESPN/native
+#: frames that don't carry the full nflverse column set.
+_OPTIONAL_DEFAULTS: Dict[str, "tuple[pl.DataType, object]"] = {
+    "qb_scramble": (pl.Int64, 0),
+    "kickoff_attempt": (pl.Int64, 0),
+    "qb_kneel": (pl.Int64, 0),
+    "first_down_rush": (pl.Int64, 0),
+    "first_down_pass": (pl.Int64, 0),
+    "first_down_penalty": (pl.Int64, 0),
+    "play_type": (pl.Utf8, None),
+    "passer_player_name": (pl.Utf8, None),
+    "passer_player_id": (pl.Utf8, None),
+    "rusher_player_name": (pl.Utf8, None),
+    "rusher_player_id": (pl.Utf8, None),
+    "receiver_player_name": (pl.Utf8, None),
+    "receiver_player_id": (pl.Utf8, None),
+    "fumbled_1_player_name": (pl.Utf8, None),
+    "fumbled_1_player_id": (pl.Utf8, None),
+}
+
+
+def _first_seen_mode(values: Union[pl.Series, List[Optional[str]], None]) -> Optional[str]:
+    """Most-frequent value, ties broken by first occurrence.
+
+    ``values`` is whatever ``map_elements`` hands us for one group's list --
+    in practice a ``polars.Series`` (iterable, yielding ``None`` for nulls),
+    but a plain Python list works identically.
+
+    Port of nflfastR's ``custom_mode`` (``utils.R``): ``unique(x)`` preserves
+    first-occurrence order and ``which.max`` returns the *first* index
+    achieving the max, so on a tie the earliest-seen value wins -- not
+    ``pandas.Series.mode()`` (sorts, returns all ties) and not
+    ``collections.Counter.most_common`` (arbitrary/insertion-order tie
+    behavior that differs by Python version).
+    """
+    if values is None or len(values) == 0:
+        return None
+    counts: Dict[str, int] = {}
+    first_pos: Dict[str, int] = {}
+    for i, v in enumerate(values):
+        if v is None:
+            continue
+        counts[v] = counts.get(v, 0) + 1
+        if v not in first_pos:
+            first_pos[v] = i
+    if not counts:
+        return None
+    return min(counts, key=lambda k: (-counts[k], first_pos[k]))
+
+
+def _resolve_name_id(
+    df: pl.DataFrame,
+    name_col: str,
+    id_col: str,
+    source_id_col: str,
+    extra_group_cols: Sequence[str],
+) -> pl.DataFrame:
+    """Two-pass per-name-per-team-per-season id resolution ("Seb's stuff").
+
+    Pass 1: group by ``(name_col, *extra_group_cols)`` and mode-vote
+    ``source_id_col`` onto a new ``id_col`` (null when ``name_col`` is null).
+    Pass 2: re-group by the just-computed ``id_col`` and mode-vote
+    ``name_col`` back onto itself -- this irons out name-string variants that
+    share one id, and (verbatim R semantics) nulls ``name_col`` out wherever
+    ``id_col`` is null, even if a name string was present pre-resolution.
+
+    Assumes ``df`` already carries the row-order-restoring index column (the
+    caller re-sorts once, after all three name/id pairs are resolved, rather
+    than after each one) and that any pre-existing ``id_col`` has already
+    been dropped by the drop.cols pre-strip.
+    """
+    group_cols = [name_col, *extra_group_cols]
+
+    pass1 = (
+        df.filter(pl.col(name_col).is_not_null())
+        .group_by(group_cols, maintain_order=True)
+        .agg(pl.col(source_id_col).alias("_ids"))
+        .with_columns(pl.col("_ids").map_elements(_first_seen_mode, return_dtype=pl.Utf8).alias(id_col))
+        .select([*group_cols, id_col])
+    )
+    df = df.join(pass1, on=group_cols, how="left")
+
+    pass2 = (
+        df.filter(pl.col(id_col).is_not_null())
+        .group_by(id_col, maintain_order=True)
+        .agg(pl.col(name_col).alias("_names"))
+        .with_columns(pl.col("_names").map_elements(_first_seen_mode, return_dtype=pl.Utf8).alias("_name_mode"))
+        .select([id_col, "_name_mode"])
+    )
+    df = df.drop(name_col).join(pass2, on=id_col, how="left").rename({"_name_mode": name_col})
+    return df
+
+
+def _with_default(df: pl.DataFrame, name: str, dtype: "pl.DataType", default: object) -> pl.DataFrame:
+    """Add ``name`` with a constant default when absent; no-op otherwise."""
+    if name in df.columns:
+        return df
+    return df.with_columns(pl.lit(default, dtype=dtype).alias(name))
+
+
+def _empty_result(df: pl.DataFrame, return_as_pandas: bool) -> Union[pl.DataFrame, "pd.DataFrame"]:
+    """Zero-row result carrying the input schema plus the documented added
+    columns (never raises, matches the project's empty-frame convention).
+    """
+    missing = {name: dtype for name, dtype in _ADDED_SCHEMA.items() if name not in df.columns}
+    if missing:
+        df = df.with_columns([pl.lit(None, dtype=dtype).alias(name) for name, dtype in missing.items()])
+    return df.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else df
+
+
+@overload
+def clean_nfl_pbp(df: pl.DataFrame) -> pl.DataFrame: ...
+@overload
+def clean_nfl_pbp(df: pl.DataFrame, *, return_as_pandas: bool = ...) -> Union[pl.DataFrame, "pd.DataFrame"]: ...
+
+
+def clean_nfl_pbp(
+    df: pl.DataFrame,
+    *,
+    return_as_pandas: bool = False,
+) -> Union[pl.DataFrame, "pd.DataFrame"]:
+    """Canonicalize names/ids/teams on a play-by-play frame (nflfastR ``clean_pbp`` port).
+
+    See the module docstring for the full column set added, the
+    compute-if-absent scope note on ``pass``/``rush``, and the lookaround ->
+    capture-group regex rewrites.
+
+    Args:
+        df: An nflverse-shape (or ESPN/native) play-by-play ``polars.DataFrame``.
+            Required columns: ``desc``, ``epa``, ``game_id``, ``play_id``,
+            ``season``, ``posteam``. See the module docstring for the full
+            optional-column-with-default list.
+        return_as_pandas: If ``True``, return a ``pandas.DataFrame``; otherwise
+            a ``polars.DataFrame`` (default).
+
+    Returns:
+        The input frame with every §6 column added/overwritten (idempotent --
+        pre-existing values of those columns, except ``pass``/``rush``, are
+        dropped and recomputed). A zero-row input yields a zero-row frame
+        carrying the full documented schema rather than raising.
+
+    Example:
+        Quick start::
+
+            from sportsdataverse.nfl import load_nfl_pbp
+            from sportsdataverse.nfl.nfl_clean import clean_nfl_pbp
+
+            pbp = load_nfl_pbp([2023])
+            cleaned = clean_nfl_pbp(pbp)
+            print(cleaned.select("name", "id", "fantasy").head())
+
+        Pandas output::
+
+            cleaned_pd = clean_nfl_pbp(pbp, return_as_pandas=True)
+
+        Pipeline next step (one line)::
+
+            import polars as pl
+            cleaned.filter(pl.col("play") == 1).group_by("passer").len()
+
+        See Also:
+            * `nflfastR`_ -- the R package this API mirrors
+            * `nflreadpy`_ -- Python parity wrapper for nflverse loaders
+
+        .. _nflfastR: https://www.nflfastr.com
+        .. _nflreadpy: https://github.com/nflverse/nflreadpy
+    """
+    if df.height == 0:
+        return _empty_result(df, return_as_pandas)
+
+    # Idempotent pre-strip: drop any pre-existing values of the columns this
+    # function is about to (re)compute, mirroring R's
+    # `select(-any_of(drop.cols))`. `pass`/`rush` are deliberately excluded --
+    # see the module docstring's compute-if-absent scope note.
+    df = df.drop([c for c in _DROP_COLS if c in df.columns])
+
+    had_pass = "pass" in df.columns
+    had_rush = "rush" in df.columns
+
+    for name, (dtype, default) in _OPTIONAL_DEFAULTS.items():
+        df = _with_default(df, name, dtype, default)
+
+    df = df.with_columns(
+        aborted_play=pl.col("desc").str.contains("Aborted").cast(pl.Int64),
+        desc=pl.col("desc").str.replace_all(_DESC_CLEANUP_PATTERN, "${1}"),
+    )
+
+    df = df.with_columns(
+        success=pl.when(pl.col("epa").is_null())
+        .then(None)
+        .otherwise(pl.when(pl.col("epa") > 0).then(1.0).otherwise(0.0))
+        .cast(pl.Float64),
+        passer=pl.col("desc").str.extract(_PASSER_PATTERN, 1),
+        passer_jersey_number=pl.col("desc").str.extract(_PASSER_JERSEY_PATTERN, 1).cast(pl.Int64, strict=False),
+        rusher=pl.col("desc").str.extract(_RUSHER_PATTERN, 1),
+        rusher_jersey_number=pl.col("desc").str.extract(_RUSHER_JERSEY_PATTERN, 1).cast(pl.Int64, strict=False),
+        receiver=pl.col("desc").str.extract(_RECEIVER_PATTERN, 1),
+        receiver_jersey_number=pl.col("desc").str.extract(_RECEIVER_JERSEY_PATTERN, 1).cast(pl.Int64, strict=False),
+    )
+
+    # rusher-as-last-resort: aborted snaps / plain "F.Last to NYG 44." plays
+    # where neither the pass nor rush regex fired.
+    df = df.with_columns(
+        rusher=pl.when(
+            pl.col("rusher").is_null() & pl.col("passer").is_null() & pl.col("rusher_player_name").is_not_null()
+        )
+        .then(pl.col("rusher_player_name"))
+        .otherwise(pl.col("rusher"))
+    )
+
+    # abnormal-play overwrite (laterals, direct snaps, aborted snaps, ...):
+    # prefer the ESPN/nflverse-supplied raw name over the regex extraction.
+    abnormal = pl.col("desc").str.contains(_ABNORMAL_PLAY)
+    df = df.with_columns(
+        receiver=pl.when(abnormal & pl.col("receiver_player_name").is_not_null())
+        .then(pl.col("receiver_player_name"))
+        .otherwise(pl.col("receiver")),
+        rusher=pl.when(abnormal & pl.col("rusher_player_name").is_not_null())
+        .then(pl.col("rusher_player_name"))
+        .otherwise(pl.col("rusher")),
+        passer=pl.when(abnormal & pl.col("passer_player_name").is_not_null())
+        .then(pl.col("passer_player_name"))
+        .otherwise(pl.col("passer")),
+    )
+
+    # pre-2006 charting fix: scramble plays with no passer inherit the rusher
+    # as the passer (season <= 2005 only).
+    df = df.with_columns(
+        passer=pl.when(
+            pl.col("passer").is_null()
+            & (pl.col("qb_scramble") == 1)
+            & pl.col("rusher").is_not_null()
+            & (pl.col("season") <= 2005)
+        )
+        .then(pl.col("rusher"))
+        .otherwise(pl.col("passer"))
+    )
+    # once a passer is resolved (incl. the scramble fallback above), there is
+    # no rusher on that play.
+    df = df.with_columns(
+        rusher=pl.when(pl.col("passer").is_not_null()).then(None).otherwise(pl.col("rusher")),
+        receiver=pl.when(pl.col("desc").str.contains(" pass ", literal=True)).then(pl.col("receiver")).otherwise(None),
+    )
+
+    # pass / rush / first_down / special / play flags.
+    if had_pass:
+        pass_expr = pl.col("pass")
+    else:
+        pass_expr = (
+            pl.col("desc").str.contains(r"(?: pass )|(?:sacked)|(?:scramble)") | (pl.col("qb_scramble") == 1)
+        ).cast(pl.Int64)
+        pass_expr = (
+            pl.when(
+                pl.col("desc").str.to_lowercase().str.contains(r"(?:backward pass)|(?:backwards pass)|(?:lateral pass)")
+                & pl.col("rusher").is_not_null()
+            )
+            .then(0)
+            .otherwise(pass_expr)
+        )
+        pass_expr = pl.when(pl.col("kickoff_attempt") == 1).then(0).otherwise(pass_expr)
+        combined_id = pl.concat_str(["game_id", pl.col("play_id").cast(pl.Utf8)], separator="_")
+        pass_expr = pl.when(combined_id.is_in(_FIX_WEIRD_PASS_PLAYS)).then(0).otherwise(pass_expr)
+
+    df = df.with_columns(pass_expr.alias("pass"))
+
+    if had_rush:
+        rush_expr = pl.col("rush")
+    else:
+        rush_expr = (pl.col("rusher").is_not_null() & (pl.col("qb_kneel") == 0) & (pl.col("pass") == 0)).cast(pl.Int64)
+
+    df = df.with_columns(
+        rush=rush_expr,
+        first_down=(
+            (pl.col("first_down_rush") == 1) | (pl.col("first_down_pass") == 1) | (pl.col("first_down_penalty") == 1)
+        ).cast(pl.Int64),
+        special=pl.col("play_type").is_in(["extra_point", "field_goal", "kickoff", "punt"]).cast(pl.Int64),
+        play=(
+            pl.col("epa").is_not_null()
+            & pl.col("posteam").is_not_null()
+            & (pl.col("desc") != "*** play under review ***")
+            & (pl.col("desc").str.slice(0, 8) != "Timeout ")
+            & pl.col("play_type").is_in(["no_play", "pass", "run"])
+        ).cast(pl.Int64),
+    )
+
+    # Hardcoded name-fix tables -- transcribed verbatim (parity-critical, not
+    # illustrative). `posteam` here is still the RAW (pre-team_name_fn) value,
+    # matching R's mutate ordering (this whole block runs before the
+    # `mutate_at(..., team_name_fn)` step), though none of the three
+    # `posteam == "..."` conditions reference a code team_name_fn would touch.
+    df = df.with_columns(
+        passer=pl.when(pl.col("passer") == "Jos.Allen")
+        .then(pl.lit("J.Allen"))
+        .when(pl.col("passer").is_in(["Alex Smith", "Ale.Smith"]))
+        .then(pl.lit("A.Smith"))
+        .when((pl.col("passer") == "Ryan") & (pl.col("posteam") == "ATL"))
+        .then(pl.lit("M.Ryan"))
+        .when(pl.col("passer") == "Tr.Brown")
+        .then(pl.lit("T.Brown"))
+        .when(pl.col("passer") == "Sh.Hill")
+        .then(pl.lit("S.Hill"))
+        .when(pl.col("passer").is_in(["Matt.Moore", "Mat.Moore"]))
+        .then(pl.lit("M.Moore"))
+        .when(pl.col("passer") == "Jo.Freeman")
+        .then(pl.lit("J.Freeman"))
+        .when(pl.col("passer") == "G.Minshew")
+        .then(pl.lit("G.Minshew II"))
+        .when(pl.col("passer") == "R.Griffin")
+        .then(pl.lit("R.Griffin III"))
+        .when(pl.col("passer").is_in(["Randel El", "Randle El"]))
+        .then(pl.lit("A.Randle El"))
+        .when((pl.col("season") <= 2003) & (pl.col("passer") == "Van Pelt"))
+        .then(pl.lit("A.Van Pelt"))
+        .when((pl.col("season") > 2003) & (pl.col("passer") == "Van Pelt"))
+        .then(pl.lit("B.Van Pelt"))
+        .when(pl.col("passer") == "Dom.Davis")
+        .then(pl.lit("D.Davis"))
+        .otherwise(pl.col("passer")),
+        rusher=pl.when(
+            (pl.col("rusher") == "D.Johnson")
+            & (pl.col("posteam") == "HOU")
+            & (pl.col("season") == 2020)
+            & (pl.col("rusher_jersey_number") == 31)
+        )
+        .then(pl.lit("Da.Johnson"))
+        .when(
+            (pl.col("rusher") == "D.Johnson")
+            & (pl.col("posteam") == "HOU")
+            & (pl.col("season") == 2020)
+            & (pl.col("rusher_jersey_number") == 25)
+        )
+        .then(pl.lit("Du.Johnson"))
+        .when(pl.col("rusher") == "Jos.Allen")
+        .then(pl.lit("J.Allen"))
+        .when(pl.col("rusher").is_in(["Alex Smith", "Ale.Smith"]))
+        .then(pl.lit("A.Smith"))
+        .when((pl.col("rusher") == "Ryan") & (pl.col("posteam") == "ATL"))
+        .then(pl.lit("M.Ryan"))
+        .when(pl.col("rusher") == "Tr.Brown")
+        .then(pl.lit("T.Brown"))
+        .when(pl.col("rusher") == "Sh.Hill")
+        .then(pl.lit("S.Hill"))
+        .when(pl.col("rusher").is_in(["Matt.Moore", "Mat.Moore"]))
+        .then(pl.lit("M.Moore"))
+        .when(pl.col("rusher") == "Jo.Freeman")
+        .then(pl.lit("J.Freeman"))
+        .when(pl.col("rusher") == "G.Minshew")
+        .then(pl.lit("G.Minshew II"))
+        .when(pl.col("rusher") == "R.Griffin")
+        .then(pl.lit("R.Griffin III"))
+        .when(pl.col("rusher").is_in(["Randel El", "Randle El"]))
+        .then(pl.lit("A.Randle El"))
+        .when((pl.col("season") <= 2003) & (pl.col("rusher") == "Van Pelt"))
+        .then(pl.lit("A.Van Pelt"))
+        .when((pl.col("season") > 2003) & (pl.col("rusher") == "Van Pelt"))
+        .then(pl.lit("B.Van Pelt"))
+        .when(pl.col("rusher") == "Dom.Davis")
+        .then(pl.lit("D.Davis"))
+        .otherwise(pl.col("rusher")),
+        receiver=pl.when(pl.col("receiver") == "F.R")
+        .then(pl.lit("F.Jones"))
+        .when((pl.col("receiver_player_name") == "D.Wells") & (pl.col("receiver_player_id") == "00-0017421"))
+        .then(pl.lit("D.Wells"))
+        .when((pl.col("receiver_player_name") == "D.Hayes") & (pl.col("receiver_player_id") == "00-0007144"))
+        .then(pl.lit("D.Hayes"))
+        .when(pl.col("receiver_player_name") == "DanielThomas")
+        .then(pl.lit("D.Thomas"))
+        .when(pl.col("receiver_player_name") == "JulioJones")
+        .then(pl.lit("J.Jones"))
+        .when(pl.col("receiver_player_name") == "Andre' Davis")
+        .then(pl.lit("A.Davis"))
+        .when(pl.col("receiver_player_name") == "A.al-Jabbar")
+        .then(pl.lit("A.al-Jabbar"))
+        .when(pl.col("receiver_player_name") == "A.St. Brown")
+        .then(pl.lit("A.St. Brown"))
+        .otherwise(pl.col("receiver")),
+    )
+
+    # Team-abbreviation normalization (only touch columns actually present).
+    df = df.with_columns([team_name_fn(pl.col(c)) for c in TEAM_COLUMNS if c in df.columns])
+
+    # "Seb's stuff" -- per-name-per-team-per-season id mode-vote, then a
+    # per-id mode-vote back onto the name. A stable row index restores
+    # original row order once after all three passes (R restores order once
+    # too, via `arrange(index)` right after `ungroup()`).
+    df = df.with_row_index("_orig_idx")
+    df = _resolve_name_id(df, "passer", "passer_id", "passer_player_id", ["posteam", "season"])
+    df = _resolve_name_id(df, "rusher", "rusher_id", "rusher_player_id", ["posteam", "season"])
+    df = _resolve_name_id(df, "receiver", "receiver_id", "receiver_player_id", ["posteam", "season"])
+    df = df.sort("_orig_idx").drop("_orig_idx")
+
+    # Aborted-snap fumble override (after all custom_mode resolution, exactly
+    # as in R -- doing it earlier would get "messed up" by the mode votes).
+    df = df.with_columns(
+        rusher=pl.when(
+            (pl.col("aborted_play") == 1) & pl.col("passer").is_null() & pl.col("fumbled_1_player_name").is_not_null()
+        )
+        .then(pl.col("fumbled_1_player_name"))
+        .otherwise(pl.col("rusher")),
+        rusher_id=pl.when(
+            (pl.col("aborted_play") == 1) & pl.col("passer").is_null() & pl.col("fumbled_1_player_id").is_not_null()
+        )
+        .then(pl.col("fumbled_1_player_id"))
+        .otherwise(pl.col("rusher_id")),
+    )
+
+    df = df.with_columns(
+        name=pl.when(pl.col("passer").is_not_null()).then(pl.col("passer")).otherwise(pl.col("rusher")),
+        jersey_number=pl.when(pl.col("passer_jersey_number").is_not_null())
+        .then(pl.col("passer_jersey_number"))
+        .otherwise(pl.col("rusher_jersey_number")),
+        id=pl.when(pl.col("passer_id").is_not_null()).then(pl.col("passer_id")).otherwise(pl.col("rusher_id")),
+    )
+
+    # Fantasy fallback -- `fantasy_player_name`/`_id` use the RAW (uncleaned)
+    # rusher_player_name/receiver_player_name/*_id columns; `fantasy`/`_id`
+    # use the CLEANED rusher/receiver/passer + id (matches R exactly).
+    df = df.with_columns(
+        fantasy_player_name=pl.when(pl.col("rusher_player_name").is_not_null())
+        .then(pl.col("rusher_player_name"))
+        .when(pl.col("receiver_player_name").is_not_null())
+        .then(pl.col("receiver_player_name"))
+        .otherwise(None),
+        fantasy_player_id=pl.when(pl.col("rusher_player_id").is_not_null())
+        .then(pl.col("rusher_player_id"))
+        .when(pl.col("receiver_player_id").is_not_null())
+        .then(pl.col("receiver_player_id"))
+        .otherwise(None),
+        fantasy=pl.when(pl.col("rusher").is_not_null())
+        .then(pl.col("rusher"))
+        .when(pl.col("receiver").is_not_null())
+        .then(pl.col("receiver"))
+        .when(pl.col("qb_scramble") == 1)
+        .then(pl.col("passer"))
+        .otherwise(None),
+        fantasy_id=pl.when(pl.col("rusher_id").is_not_null())
+        .then(pl.col("rusher_id"))
+        .when(pl.col("receiver_id").is_not_null())
+        .then(pl.col("receiver_id"))
+        .when(pl.col("qb_scramble") == 1)
+        .then(pl.col("passer_id"))
+        .otherwise(None),
+        out_of_bounds=pl.col("desc").str.contains(r"(?:ran ob)|(?:pushed ob)|(?:sacked ob)").cast(pl.Int64),
+    )
+
+    df = df.with_columns(
+        home_opening_kickoff=(
+            pl.col("home_team") == pl.col("posteam").filter(pl.col("posteam").is_not_null()).first().over("game_id")
+        ).cast(pl.Int64)
+    )
+
+    return df.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else df

--- a/sportsdataverse/nfl/nfl_pbp.py
+++ b/sportsdataverse/nfl/nfl_pbp.py
@@ -4282,11 +4282,19 @@ class NFLPlayProcess(object):
         (``xyac_epa``/``xyac_mean_yardage``/``xyac_median_yardage``/
         ``xyac_success``/``xyac_fd``) are *derived* by re-scoring expected points
         on each of 76 YAC outcomes — see
-        :func:`sportsdataverse.nfl.ep_wp.calculate_xyac`.  That derivation needs
-        ``air_epa`` and a clean per-play EP baseline, which the ESPN play frame
-        does not carry in nflverse form, so this in-pipeline ESPN path emits the
-        five columns as nulls for schema stability.  Run ``calculate_xyac`` on a
-        nflverse-format frame (or ``enrich_nfl_pbp``) to populate them.
+        :func:`sportsdataverse.nfl.ep_wp.calculate_xyac`.  The primary blocker
+        on the ESPN path is ``air_yards`` itself — a tracking/GSIS measure ESPN
+        never ships and that is not text-derivable (see
+        ``__add_description_features``) — plus the nflverse-named model inputs
+        (``yardline_100`` / ``ydstogo`` / ``down`` / ``receiver_player_name``
+        / the ``complete_pass``-family flags).  ``air_epa`` is no longer a
+        blocker in itself: on the nflverse path it is a real column
+        (``ep_wp._derive_air_yac_epa``), and ``calculate_xyac`` consumes it
+        verbatim when present or derives a catch-spot fallback when absent —
+        but without ``air_yards`` neither the family nor xYAC can score here,
+        so this in-pipeline ESPN path emits the five columns as nulls for
+        schema stability.  Run ``calculate_xyac`` on a nflverse-format frame
+        (or ``enrich_nfl_pbp``) to populate them.
         """
         return play_df.with_columns([pl.lit(None, dtype=pl.Float64).alias(c) for c in _XYAC_OUT_COLS])
 

--- a/sportsdataverse/nfl/nfl_series.py
+++ b/sportsdataverse/nfl/nfl_series.py
@@ -1,0 +1,188 @@
+"""Series conversion rates -- a faithful polars port of nflfastR's
+``calculate_series_conversion_rates`` (``calculate_series_conversion_rates.R``).
+
+Consumes a caller-supplied play-by-play frame carrying ``series`` /
+``series_success`` / ``series_result`` (added by the ``add_series_data`` port --
+see the reference Sec 7 docstring for the exact semantics) plus ``posteam`` /
+``defteam``. Produces per-team offense (``off_*``) and defense (``def_*``) rate
+columns at either the season grain (``weekly=False``, default) or the
+season+week grain (``weekly=True``).
+
+**Operator-precedence quirk transcribed verbatim (reference Sec 11):** the R
+source literally computes ``off_scr_Nth`` as
+``mean(last_down == N * conversion)``, which (R operator precedence: ``*``
+binds tighter than ``==``) parses as ``mean(last_down == (N * conversion))``.
+Because ``conversion`` is 0/1, this is accidentally equivalent to
+``mean((last_down == N) & (conversion == 1))`` -- the naming survives even
+though the R expression as written is confusing. That accidentally-correct
+formula is what is ported here.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, overload
+
+import polars as pl
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+# Series-result buckets shared by offense + defense.
+_FG_RESULTS: tuple[str, ...] = ("Field goal", "Missed field goal")
+_TO_RESULTS: tuple[str, ...] = (
+    "Turnover on downs",
+    "Turnover",
+    "Opp touchdown",
+    "Safety",
+    "End of half",
+)
+
+_RATE_SUFFIXES: tuple[str, ...] = (
+    "n",
+    "scr",
+    "scr_1st",
+    "scr_2nd",
+    "scr_3rd",
+    "scr_4th",
+    "1st",
+    "td",
+    "fg",
+    "punt",
+    "to",
+)
+
+
+def _empty_series_frame(*, weekly: bool, return_as_pandas: bool) -> pl.DataFrame | "pd.DataFrame":
+    """Return a zero-row frame carrying the documented schema."""
+    schema: dict[str, type[pl.DataType] | pl.DataType] = {"season": pl.Int64, "team": pl.Utf8}
+    if weekly:
+        schema["week"] = pl.Int64
+    for side in ("off", "def"):
+        for suffix in _RATE_SUFFIXES:
+            schema[f"{side}_{suffix}"] = pl.Int64 if suffix == "n" else pl.Float64
+    out = pl.DataFrame(schema=schema)
+    if return_as_pandas:
+        return out.to_pandas()
+    return out
+
+
+def _team_series_rates(pbp: pl.DataFrame, *, team_col: str, prefix: str, grp: list[str]) -> pl.DataFrame:
+    """Collapse plays -> per-series conversion/result/last_down, then -> team rates.
+
+    Mirrors the two-stage R pipeline: series-level ``first()``/``last()``
+    collapse over ``(season, week, team, series)`` (relies on the input frame
+    already being in play order within a series), then a team-level ``mean()``
+    over ``grp`` (``(season, team)`` or ``(season, team, week)``).
+    """
+    per_series = (
+        pbp.filter(pl.col("down").is_not_null() & (pl.col("series_result") != "QB kneel"))
+        .group_by(["season", "week", pl.col(team_col).alias("team"), "series"])
+        .agg(
+            pl.first("series_success").alias("conversion"),
+            pl.first("series_result").alias("result"),
+            pl.last("down").alias("last_down"),
+        )
+    )
+
+    def _scr_nth(n: int) -> pl.Expr:
+        return ((pl.col("last_down") == n) & (pl.col("conversion") == 1)).cast(pl.Float64)
+
+    return per_series.group_by(grp).agg(
+        pl.len().cast(pl.Int64).alias(f"{prefix}_n"),
+        pl.col("conversion").cast(pl.Float64).mean().alias(f"{prefix}_scr"),
+        _scr_nth(1).mean().alias(f"{prefix}_scr_1st"),
+        _scr_nth(2).mean().alias(f"{prefix}_scr_2nd"),
+        _scr_nth(3).mean().alias(f"{prefix}_scr_3rd"),
+        _scr_nth(4).mean().alias(f"{prefix}_scr_4th"),
+        (pl.col("result") == "First down").cast(pl.Float64).mean().alias(f"{prefix}_1st"),
+        (pl.col("result") == "Touchdown").cast(pl.Float64).mean().alias(f"{prefix}_td"),
+        pl.col("result").is_in(_FG_RESULTS).cast(pl.Float64).mean().alias(f"{prefix}_fg"),
+        (pl.col("result") == "Punt").cast(pl.Float64).mean().alias(f"{prefix}_punt"),
+        pl.col("result").is_in(_TO_RESULTS).cast(pl.Float64).mean().alias(f"{prefix}_to"),
+    )
+
+
+@overload
+def calculate_nfl_series_conversion_rates(
+    pbp: pl.DataFrame,
+    *,
+    weekly: bool = ...,
+    return_as_pandas: Literal[False] = ...,
+) -> pl.DataFrame: ...
+@overload
+def calculate_nfl_series_conversion_rates(
+    pbp: pl.DataFrame,
+    *,
+    weekly: bool = ...,
+    return_as_pandas: Literal[True],
+) -> "pd.DataFrame": ...
+def calculate_nfl_series_conversion_rates(
+    pbp: pl.DataFrame,
+    *,
+    weekly: bool = False,
+    return_as_pandas: bool = False,
+) -> pl.DataFrame | "pd.DataFrame":
+    """Compute per-team offense + defense series conversion rates.
+
+    A faithful polars port of nflfastR's ``calculate_series_conversion_rates``.
+    Series where ``down`` is null (kickoffs, PAT/2pt attempts, non-plays, no
+    ``posteam``) and series ending in a ``"QB kneel"`` are excluded from the
+    series count before rates are computed, matching the R source.
+
+    Args:
+        pbp: Play-by-play frame carrying ``season``, ``week``, ``posteam``,
+            ``defteam``, ``down``, ``series``, ``series_success``, and
+            ``series_result`` (added by the ``add_series_data`` port). Rows
+            must already be in play order within each series so the internal
+            ``first()``/``last()`` series collapse is correct.
+        weekly: If ``True``, group on ``(season, team, week)``; if ``False``
+            (default), group on ``(season, team)`` -- collapsing every week
+            into one season-level rate.
+        return_as_pandas: If ``True`` return a pandas DataFrame; else polars.
+
+    Returns:
+        A polars (or pandas) DataFrame with one row per team (per week when
+        ``weekly=True``), ``off_n``/``def_n`` (series count) plus the
+        ``off_*``/``def_*`` rate columns documented in reference Sec 11.
+        A team with offensive series but zero defensive series in a group (or
+        vice versa -- effectively never happens in real data) carries nulls in
+        the missing side rather than being dropped (full outer join).
+
+    Example:
+        Season-level rates::
+
+            from sportsdataverse.nfl import calculate_nfl_series_conversion_rates
+            rates = calculate_nfl_series_conversion_rates(pbp)
+            rates.filter(pl.col("team") == "KC").select("off_scr", "def_scr")
+
+        Weekly grain::
+
+            weekly = calculate_nfl_series_conversion_rates(pbp, weekly=True)
+
+        Pipeline next step (one line)::
+
+            rates.sort("off_scr", descending=True).head()
+
+    See Also:
+        * `nflfastR <https://www.nflfastr.com>`_ -- the ``calculate_series_conversion_rates`` source
+        * `nflreadpy <https://github.com/nflverse/nflreadpy>`_ -- nflverse loaders (Python)
+
+    .. _nflfastR: https://www.nflfastr.com
+    .. _nflreadpy: https://github.com/nflverse/nflreadpy
+    """
+    if pbp.height == 0:
+        return _empty_series_frame(weekly=weekly, return_as_pandas=return_as_pandas)
+
+    grp = ["season", "team", "week"] if weekly else ["season", "team"]
+
+    offense = _team_series_rates(pbp, team_col="posteam", prefix="off", grp=grp)
+    defense = _team_series_rates(pbp, team_col="defteam", prefix="def", grp=grp)
+
+    combined = offense.join(defense, on=grp, how="full", coalesce=True).sort(grp)
+
+    if combined.height == 0:
+        return _empty_series_frame(weekly=weekly, return_as_pandas=return_as_pandas)
+
+    if return_as_pandas:
+        return combined.to_pandas()
+    return combined

--- a/sportsdataverse/nfl/nfl_series.py
+++ b/sportsdataverse/nfl/nfl_series.py
@@ -180,9 +180,6 @@ def calculate_nfl_series_conversion_rates(
 
     combined = offense.join(defense, on=grp, how="full", coalesce=True).sort(grp)
 
-    if combined.height == 0:
-        return _empty_series_frame(weekly=weekly, return_as_pandas=return_as_pandas)
-
     if return_as_pandas:
         return combined.to_pandas()
     return combined

--- a/sportsdataverse/nfl/nfl_standings.py
+++ b/sportsdataverse/nfl/nfl_standings.py
@@ -1,0 +1,368 @@
+"""NFL standings + playoff seeding -- a reduced, self-contained port of the
+win_pct -> head-to-head -> division record -> conference record tiebreaker
+ladder.
+
+nflfastR's own ``calculate_standings`` (``calculate_standings.R``) is a thin
+dispatch/reshape wrapper: it delegates ALL actual tiebreaker logic to the
+external ``nflseedR`` package (``compute_division_ranks`` /
+``compute_conference_seeds``) and carries no tiebreaker rules of its own (see
+reference Sec 12). ``nflseedR``'s full ladder continues past conference record
+through common games / strength of victory / strength of schedule with a
+recursive largest-tied-group-first resolution -- reimplementing that in full
+is out of scope here (YAGNI per the task brief). This module instead ports a
+bounded four-tier ladder -- **win_pct -> head-to-head -> division record ->
+conference record** -- gated by ``tiebreaker_depth`` (1: win_pct only, 2: adds
+head-to-head + division record, 3 [default]: adds conference record too).
+Any tie still unresolved after the configured depth falls back to a
+deterministic alphabetical-by-team ordering rather than nflseedR's random
+coinflip, so results are reproducible.
+
+The one piece of nflfastR-specific domain knowledge preserved verbatim here is
+the 2020 playoff-format cutover: seasons 1999-2019 default to
+``playoff_seeds=6``, seasons >= 2020 default to ``playoff_seeds=7``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal, overload
+
+import polars as pl
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+# One team-season record (as produced by ``.to_dicts()``); keys include
+# season/conf/division/team/games/wins/losses/ties/win_pct/div_pct/conf_pct
+# plus the later-assigned div_rank/seed.
+_Record = dict[str, Any]
+
+# Tiers applied cumulatively above win_pct, gated by tiebreaker_depth.
+_TIERS_BY_DEPTH: dict[int, tuple[str, ...]] = {
+    1: (),
+    2: ("h2h", "div_pct"),
+    3: ("h2h", "div_pct", "conf_pct"),
+}
+
+_OUTPUT_COLUMNS: tuple[str, ...] = (
+    "season",
+    "conf",
+    "division",
+    "div_rank",
+    "seed",
+    "team",
+    "games",
+    "wins",
+    "losses",
+    "ties",
+    "win_pct",
+    "div_pct",
+    "conf_pct",
+)
+
+
+def _empty_standings(*, return_as_pandas: bool) -> pl.DataFrame | "pd.DataFrame":
+    """Return a zero-row frame carrying the documented schema."""
+    int_cols = {"season", "games", "wins", "losses", "ties", "div_rank", "seed"}
+    schema: dict[str, type[pl.DataType] | pl.DataType] = {}
+    for c in _OUTPUT_COLUMNS:
+        if c in ("conf", "division", "team"):
+            schema[c] = pl.Utf8
+        elif c in int_cols:
+            schema[c] = pl.Int64
+        else:
+            schema[c] = pl.Float64
+    out = pl.DataFrame(schema=schema)
+    if return_as_pandas:
+        return out.to_pandas()
+    return out
+
+
+def _double_games(games: pl.DataFrame) -> pl.DataFrame:
+    """One row per (season, team, opp, outcome) for each direction of each game.
+
+    ``outcome`` is 1.0 (win) / 0.0 (loss) / 0.5 (tie), keyed off
+    ``home_score - away_score``.
+    """
+    g = games.filter(
+        (pl.col("game_type") == "REG") & pl.col("home_score").is_not_null() & pl.col("away_score").is_not_null()
+    ).with_columns((pl.col("home_score") - pl.col("away_score")).alias("result"))
+
+    home_outcome = pl.when(pl.col("result") > 0).then(1.0).when(pl.col("result") < 0).then(0.0).otherwise(0.5)
+
+    home = g.select(
+        "season",
+        pl.col("home_team").alias("team"),
+        pl.col("away_team").alias("opp"),
+        home_outcome.alias("outcome"),
+    )
+    away = g.select(
+        "season",
+        pl.col("away_team").alias("team"),
+        pl.col("home_team").alias("opp"),
+        (1.0 - home_outcome).alias("outcome"),
+    )
+    return pl.concat([home, away])
+
+
+def _with_team_meta(doubled: pl.DataFrame, teams: pl.DataFrame) -> pl.DataFrame:
+    """Join conference/division for both ``team`` and ``opp``, add game-type flags."""
+    meta = teams.select(
+        pl.col("team_abbr").alias("team"),
+        pl.col("team_conf").alias("conf"),
+        pl.col("team_division").alias("division"),
+    )
+    out = doubled.join(meta, on="team", how="left")
+    opp_meta = meta.rename({"team": "opp", "conf": "opp_conf", "division": "opp_division"})
+    out = out.join(opp_meta, on="opp", how="left")
+    return out.with_columns(
+        (pl.col("division") == pl.col("opp_division")).cast(pl.Int64).alias("div_game"),
+        (pl.col("conf") == pl.col("opp_conf")).cast(pl.Int64).alias("conf_game"),
+    )
+
+
+def _team_records(doubled_meta: pl.DataFrame) -> pl.DataFrame:
+    """Per-(season, team) games/wins/losses/ties/win_pct/div_pct/conf_pct."""
+    return doubled_meta.group_by(["season", "conf", "division", "team"]).agg(
+        pl.len().cast(pl.Int64).alias("games"),
+        (pl.col("outcome") == 1.0).sum().cast(pl.Int64).alias("wins"),
+        (pl.col("outcome") == 0.0).sum().cast(pl.Int64).alias("losses"),
+        (pl.col("outcome") == 0.5).sum().cast(pl.Int64).alias("ties"),
+        (pl.col("outcome").sum() / pl.len()).alias("win_pct"),
+        pl.when((pl.col("div_game") == 1).sum() == 0)
+        .then(0.5)
+        .otherwise((pl.col("outcome") * pl.col("div_game")).sum() / pl.col("div_game").sum())
+        .alias("div_pct"),
+        pl.when((pl.col("conf_game") == 1).sum() == 0)
+        .then(0.5)
+        .otherwise((pl.col("outcome") * pl.col("conf_game")).sum() / pl.col("conf_game").sum())
+        .alias("conf_pct"),
+    )
+
+
+def _h2h_lookup(doubled: pl.DataFrame) -> dict[tuple[int, str, str], tuple[int, float]]:
+    """``(season, team, opp) -> (games, wins)`` for head-to-head tiebreaks."""
+    agg = doubled.group_by(["season", "team", "opp"]).agg(
+        pl.len().cast(pl.Int64).alias("h2h_games"),
+        pl.col("outcome").sum().alias("h2h_wins"),
+    )
+    return {(r["season"], r["team"], r["opp"]): (r["h2h_games"], r["h2h_wins"]) for r in agg.to_dicts()}
+
+
+def _break_ties(
+    candidates: list[_Record],
+    tiers: tuple[str, ...],
+    h2h: dict[tuple[int, str, str], tuple[int, float]],
+) -> list[_Record]:
+    """Order a tied group best-first, applying ``tiers`` in sequence.
+
+    Any subgroup still tied after every configured tier is ordered
+    alphabetically by team (deterministic fallback -- ponytail: real
+    nflseedR breaks a residual tie with a random coinflip; this port stays
+    deterministic and does not implement common-games / strength-of-victory /
+    strength-of-schedule, add if a caller needs the full ladder).
+    """
+    groups: list[list[_Record]] = [list(candidates)]
+    for tier in tiers:
+        next_groups: list[list[_Record]] = []
+        for grp in groups:
+            if len(grp) < 2:
+                next_groups.append(grp)
+                continue
+            if tier == "h2h":
+                names = {t["team"] for t in grp}
+                scored = []
+                for t in grp:
+                    h2h_g = h2h_w = 0.0
+                    for opp in names:
+                        if opp == t["team"]:
+                            continue
+                        rec = h2h.get((t["season"], t["team"], opp))
+                        if rec:
+                            h2h_g += rec[0]
+                            h2h_w += rec[1]
+                    value = 0.5 if h2h_g == 0 else h2h_w / h2h_g
+                    scored.append((value, t))
+            else:
+                scored = [(t[tier], t) for t in grp]
+            best_val = max(v for v, _ in scored)
+            best = [t for v, t in scored if v == best_val]
+            rest = [t for v, t in scored if v != best_val]
+            next_groups.append(best)
+            if rest:
+                next_groups.append(rest)
+        groups = next_groups
+
+    ordered: list[_Record] = []
+    for grp in groups:
+        ordered.extend(sorted(grp, key=lambda t: t["team"]) if len(grp) > 1 else grp)
+    return ordered
+
+
+def _rank_group(
+    records: list[_Record],
+    tiers: tuple[str, ...],
+    h2h: dict[tuple[int, str, str], tuple[int, float]],
+    *,
+    start: int = 1,
+) -> dict[str, int]:
+    """Assign 1-based ranks within a single group (division or conference pool)."""
+    ranks: dict[str, int] = {}
+    remaining = list(records)
+    rank = start
+    while remaining:
+        max_wp = max(r["win_pct"] for r in remaining)
+        tied = [r for r in remaining if r["win_pct"] == max_wp]
+        ordered = _break_ties(tied, tiers, h2h) if len(tied) > 1 else tied
+        for r in ordered:
+            ranks[r["team"]] = rank
+            rank += 1
+        remaining = [r for r in remaining if r["team"] not in ranks]
+    return ranks
+
+
+def _default_playoff_seeds(season: int) -> int:
+    """2020 playoff-format cutover: 6 seeds pre-2020, 7 from 2020 on."""
+    return 6 if season <= 2019 else 7
+
+
+@overload
+def calculate_nfl_standings(
+    games: pl.DataFrame,
+    *,
+    teams: pl.DataFrame | None = ...,
+    tiebreaker_depth: int = ...,
+    playoff_seeds: int | None = ...,
+    return_as_pandas: Literal[False] = ...,
+) -> pl.DataFrame: ...
+@overload
+def calculate_nfl_standings(
+    games: pl.DataFrame,
+    *,
+    teams: pl.DataFrame | None = ...,
+    tiebreaker_depth: int = ...,
+    playoff_seeds: int | None = ...,
+    return_as_pandas: Literal[True],
+) -> "pd.DataFrame": ...
+def calculate_nfl_standings(
+    games: pl.DataFrame,
+    *,
+    teams: pl.DataFrame | None = None,
+    tiebreaker_depth: int = 3,
+    playoff_seeds: int | None = None,
+    return_as_pandas: bool = False,
+) -> pl.DataFrame | "pd.DataFrame":
+    """Compute NFL division standings + conference playoff seeds.
+
+    A reduced port of the tiebreaker ladder nflfastR delegates to the external
+    ``nflseedR`` package (see the module docstring for the exact scope). Games
+    are doubled into one row per team per game, regular-season win/loss/tie
+    records are computed per team, and ties are broken win_pct -> head-to-head
+    -> division record -> conference record, to the depth configured by
+    ``tiebreaker_depth``.
+
+    Args:
+        games: A ``load_nfl_schedule``-shaped frame: ``game_id``, ``season``,
+            ``game_type``, ``week``, ``home_team``, ``away_team``,
+            ``home_score``, ``away_score``. Only ``game_type == "REG"`` rows
+            with both scores present are used.
+        teams: A ``load_nfl_teams``-shaped frame (``team_abbr``, ``team_conf``,
+            ``team_division``). When ``None`` (default), calls
+            :func:`sportsdataverse.nfl.load_nfl_teams`.
+        tiebreaker_depth: ``1`` (win_pct only), ``2`` (adds head-to-head +
+            division record), or ``3`` (default; adds conference record too).
+        playoff_seeds: Number of teams per conference that receive a
+            non-null ``seed``. When ``None`` (default), uses the 2020 playoff
+            -format cutover: ``6`` for seasons <= 2019, ``7`` for 2020+.
+        return_as_pandas: If ``True`` return a pandas DataFrame; else polars.
+
+    Returns:
+        A polars (or pandas) DataFrame with one row per (season, team):
+        ``conf``, ``division``, ``div_rank``, ``seed`` (null past
+        ``playoff_seeds``), ``team``, ``games``, ``wins``, ``losses``,
+        ``ties``, ``win_pct`` (ties count as 0.5 win), ``div_pct``,
+        ``conf_pct``. Sorted by ``(season, division, div_rank, seed)``.
+
+    Raises:
+        ValueError: If ``tiebreaker_depth`` is not ``1``, ``2``, or ``3``.
+
+    Example:
+        Quick start::
+
+            from sportsdataverse.nfl import calculate_nfl_standings, load_nfl_schedule
+            games = load_nfl_schedule(seasons=[2023])
+            standings = calculate_nfl_standings(games)
+            standings.filter(standings["div_rank"] == 1)
+
+        Injected teams frame (offline)::
+
+            standings = calculate_nfl_standings(games, teams=my_teams_df)
+
+        Pipeline next step (one line)::
+
+            standings.sort(["conf", "seed"]).select("team", "seed", "win_pct")
+
+    See Also:
+        * `nflfastR <https://www.nflfastr.com>`_ -- ``calculate_standings`` (dispatch-only)
+        * `nflseedR <https://github.com/nflverse/nflseedR>`_ -- the real tiebreaker engine
+        * `nflreadpy <https://github.com/nflverse/nflreadpy>`_ -- nflverse loaders (Python)
+
+    .. _nflfastR: https://www.nflfastr.com
+    .. _nflseedR: https://github.com/nflverse/nflseedR
+    .. _nflreadpy: https://github.com/nflverse/nflreadpy
+    """
+    if tiebreaker_depth not in (1, 2, 3):
+        raise ValueError(f"Invalid tiebreaker_depth {tiebreaker_depth!r}; expected 1, 2, or 3.")
+
+    if teams is None:
+        from sportsdataverse.nfl.nfl_loaders import load_nfl_teams  # noqa: PLC0415
+
+        teams = load_nfl_teams()
+
+    doubled = _double_games(games)
+    if doubled.height == 0:
+        return _empty_standings(return_as_pandas=return_as_pandas)
+
+    doubled_meta = _with_team_meta(doubled, teams)
+    records = _team_records(doubled_meta)
+    h2h = _h2h_lookup(doubled)
+    tiers = _TIERS_BY_DEPTH[tiebreaker_depth]
+
+    rows = records.to_dicts()
+
+    # -- Division rank: rank within each (season, division) pool. -----------
+    by_division: dict[tuple[int, str], list[_Record]] = {}
+    for r in rows:
+        by_division.setdefault((r["season"], r["division"]), []).append(r)
+
+    div_ranks: dict[tuple[int, str], int] = {}
+    for (season, division), grp in by_division.items():
+        ranks = _rank_group(grp, tiers, h2h)
+        for team, rank in ranks.items():
+            div_ranks[(season, team)] = rank
+    for r in rows:
+        r["div_rank"] = div_ranks[(r["season"], r["team"])]
+
+    # -- Conference seed: division winners first, then wildcards. -----------
+    by_conf: dict[tuple[int, str], list[_Record]] = {}
+    for r in rows:
+        by_conf.setdefault((r["season"], r["conf"]), []).append(r)
+
+    seeds: dict[tuple[int, str], int | None] = {}
+    for (season, conf), grp in by_conf.items():
+        n_seeds = playoff_seeds if playoff_seeds is not None else _default_playoff_seeds(season)
+        winners = [r for r in grp if r["div_rank"] == 1]
+        wildcards = [r for r in grp if r["div_rank"] != 1]
+        ranks = _rank_group(winners, tiers, h2h, start=1)
+        ranks.update(_rank_group(wildcards, tiers, h2h, start=len(winners) + 1))
+        for r in grp:
+            rank = ranks[r["team"]]
+            seeds[(season, r["team"])] = rank if rank <= n_seeds else None
+    for r in rows:
+        r["seed"] = seeds[(r["season"], r["team"])]
+
+    out = pl.DataFrame(rows, schema_overrides={"seed": pl.Int64}).select(list(_OUTPUT_COLUMNS))
+    out = out.sort(["season", "division", "div_rank", "seed"])
+
+    if return_as_pandas:
+        return out.to_pandas()
+    return out

--- a/sportsdataverse/nfl/nfl_standings_calc.py
+++ b/sportsdataverse/nfl/nfl_standings_calc.py
@@ -267,7 +267,11 @@ def calculate_nfl_standings(
             with both scores present are used.
         teams: A ``load_nfl_teams``-shaped frame (``team_abbr``, ``team_conf``,
             ``team_division``). When ``None`` (default), calls
-            :func:`sportsdataverse.nfl.load_nfl_teams`.
+            :func:`sportsdataverse.nfl.load_nfl_teams`. Must cover every team
+            abbreviation appearing in ``games`` -- a team absent from
+            ``teams`` gets null ``conf``/``division`` and is silently pooled
+            into the ``(season, None)`` division/conference group rather than
+            raising.
         tiebreaker_depth: ``1`` (win_pct only), ``2`` (adds head-to-head +
             division record), or ``3`` (default; adds conference record too).
         playoff_seeds: Number of teams per conference that receive a

--- a/sportsdataverse/nfl/nfl_standings_calc.py
+++ b/sportsdataverse/nfl/nfl_standings_calc.py
@@ -313,14 +313,14 @@ def calculate_nfl_standings(
     if tiebreaker_depth not in (1, 2, 3):
         raise ValueError(f"Invalid tiebreaker_depth {tiebreaker_depth!r}; expected 1, 2, or 3.")
 
+    doubled = _double_games(games)
+    if doubled.height == 0:
+        return _empty_standings(return_as_pandas=return_as_pandas)
+
     if teams is None:
         from sportsdataverse.nfl.nfl_loaders import load_nfl_teams  # noqa: PLC0415
 
         teams = load_nfl_teams()
-
-    doubled = _double_games(games)
-    if doubled.height == 0:
-        return _empty_standings(return_as_pandas=return_as_pandas)
 
     doubled_meta = _with_team_meta(doubled, teams)
     records = _team_records(doubled_meta)

--- a/sportsdataverse/nfl/nfl_stats.py
+++ b/sportsdataverse/nfl/nfl_stats.py
@@ -1695,7 +1695,8 @@ def _empty_player_stats_def(*, weekly: bool, return_as_pandas: bool) -> pl.DataF
     """Return a zero-row def-stats frame carrying the canonical schema."""
     cols = list(_DEF_OUTPUT_COLUMNS)
     if not weekly:
-        cols = [c for c in cols if c not in ("week", "season_type")]
+        # Season grain drops season too (grouped on player_id/team only).
+        cols = [c for c in cols if c not in ("season", "week", "season_type")]
         cols.insert(cols.index("player_display_name") + 1, "games")
     schema: dict[str, type[pl.DataType] | pl.DataType] = {}
     str_cols = {
@@ -1975,7 +1976,14 @@ def _def_fumble_own_frame(data: pl.DataFrame) -> pl.DataFrame:
 
 
 def _def_fumble_yards_own_frame(data: pl.DataFrame) -> pl.DataFrame:
-    """``def_fumble_recovery_yards_own`` -- sum of recovery yards for the own-fumble rows."""
+    """``def_fumble_recovery_yards_own`` -- sum of recovery yards for the own-fumble rows.
+
+    Deviation from the verbatim R source (mirroring :func:`_def_fumble_own_frame`'s
+    documented choice): each recovery slot is additionally gated on
+    ``fumble_recovery_{k}_team == defteam``, where R's ``fumble_yds_own_df``
+    groups on the raw recovery team with no such guard -- the formula-table
+    semantics ("restricted to the own recovery rows") rather than the R quirk.
+    """
     fumbled_cols = [f"fumbled_{k}_team" for k in (1, 2) if f"fumbled_{k}_team" in data.columns]
     if not fumbled_cols:
         return _def_empty({"def_fumble_recovery_yards_own": pl.Float64})
@@ -2114,6 +2122,9 @@ def _collapse_def_to_season(player_df: pl.DataFrame) -> pl.DataFrame:
     sum_cols = [c for c in _DEF_OUTPUT_COLUMNS if c.startswith("def_") and c in player_df.columns]
     return player_df.group_by(["player_id", "team"]).agg(
         pl.len().alias("games"),
+        # pl.first is equivalent to R's custom_mode here: all five meta
+        # columns come solely from the deduped players-master join, so they
+        # are constant within a (player_id, team) group.
         pl.first("player_name").alias("player_name"),
         pl.first("player_display_name").alias("player_display_name"),
         pl.first("position").alias("position"),
@@ -2124,10 +2135,14 @@ def _collapse_def_to_season(player_df: pl.DataFrame) -> pl.DataFrame:
 
 
 def _finalize_def(player_df: pl.DataFrame, *, weekly: bool) -> pl.DataFrame:
-    """Select the canonical def-stats column order + cast + sort."""
+    """Select the canonical def-stats column order + cast + sort.
+
+    The season grain drops ``season`` too, not just ``week``/``season_type`` --
+    R's ``group_by(player_id, team) |> summarise(...)`` consumes them all.
+    """
     cols = list(_DEF_OUTPUT_COLUMNS)
     if not weekly:
-        cols = [c for c in cols if c not in ("week", "season_type")]
+        cols = [c for c in cols if c not in ("season", "week", "season_type")]
         cols.insert(cols.index("player_display_name") + 1, "games")
     for c in cols:
         if c not in player_df.columns:
@@ -2359,8 +2374,12 @@ _KICK_INT_COLUMNS: tuple[str, ...] = (
 
 
 def _kick_season_columns(cols: List[str]) -> List[str]:
-    """Season-grain column list: drop week/season_type, insert games, rename gwfg_distance."""
-    out = [c for c in cols if c not in ("week", "season_type")]
+    """Season-grain column list: drop season/week/season_type, insert games, rename gwfg_distance.
+
+    ``season`` is dropped too -- the R season grain groups on
+    ``(player_id, team)`` only, so its output carries no season column.
+    """
+    out = [c for c in cols if c not in ("season", "week", "season_type")]
     out.insert(out.index("player_display_name") + 1, "games")
     return ["gwfg_distance_list" if c == "gwfg_distance" else c for c in out]
 

--- a/sportsdataverse/nfl/nfl_stats.py
+++ b/sportsdataverse/nfl/nfl_stats.py
@@ -1625,3 +1625,1144 @@ def _finalize_team(team_df: pl.DataFrame, *, weekly: bool, return_as_pandas: boo
     if return_as_pandas:
         return out.to_pandas()
     return out
+
+
+# ---------------------------------------------------------------------------
+# player_stats_def (nflfastR ``calculate_player_stats_def`` parity)
+# ---------------------------------------------------------------------------
+#
+# Unlike :func:`build_nfl_player_stats` / :func:`build_nfl_team_stats` (which
+# load their own PBP via ``load_nfl_pbp``), these two builders take a
+# caller-supplied ``pbp`` frame directly -- matching the (deprecated, but
+# still the parity target) nflfastR functions ``calculate_player_stats_def()``
+# and ``calculate_player_stats_kicking()``, which both accept a ``pbp``
+# argument rather than loading data themselves.
+#
+# IMPORTANT season-collapse quirk (transcribed verbatim from the R source):
+# both R functions group the ``weekly=FALSE`` aggregate on ``(player_id,
+# team)`` ONLY -- *not* ``season`` -- so passing multiple seasons of PBP with
+# ``weekly=False`` folds them into a single row per player/team. This matches
+# nflfastR's shipped (if surprising) behavior for these specific deprecated
+# functions; callers who need a season column should pre-filter ``pbp`` to one
+# season before calling with ``weekly=False``.
+
+_DEF_OUTPUT_COLUMNS: tuple[str, ...] = (
+    "season",
+    "week",
+    "season_type",
+    "player_id",
+    "player_name",
+    "player_display_name",
+    "position",
+    "position_group",
+    "headshot_url",
+    "team",
+    "def_tackles",
+    "def_tackles_solo",
+    "def_tackles_with_assist",
+    "def_tackle_assists",
+    "def_tackles_for_loss",
+    "def_tackles_for_loss_yards",
+    "def_fumbles_forced",
+    "def_sacks",
+    "def_sack_yards",
+    "def_qb_hits",
+    "def_interceptions",
+    "def_interception_yards",
+    "def_pass_defended",
+    "def_tds",
+    "def_fumbles",
+    "def_fumble_recovery_own",
+    "def_fumble_recovery_yards_own",
+    "def_fumble_recovery_opp",
+    "def_fumble_recovery_yards_opp",
+    "def_safety",
+    "def_penalty",
+    "def_penalty_yards",
+)
+
+_DEF_JOIN_KEYS: tuple[str, str, str, str] = ("season", "week", "team", "player_id")
+
+_DEF_EMPTY_KEY_SCHEMA: dict[str, type[pl.DataType] | pl.DataType] = {
+    "season": pl.Int64,
+    "week": pl.Int64,
+    "team": pl.Utf8,
+    "player_id": pl.Utf8,
+}
+
+
+def _empty_player_stats_def(*, weekly: bool, return_as_pandas: bool) -> pl.DataFrame | "pd.DataFrame":
+    """Return a zero-row def-stats frame carrying the canonical schema."""
+    cols = list(_DEF_OUTPUT_COLUMNS)
+    if not weekly:
+        cols = [c for c in cols if c not in ("week", "season_type")]
+        cols.insert(cols.index("player_display_name") + 1, "games")
+    schema: dict[str, type[pl.DataType] | pl.DataType] = {}
+    str_cols = {
+        "player_id",
+        "player_name",
+        "player_display_name",
+        "position",
+        "position_group",
+        "headshot_url",
+        "team",
+        "season_type",
+    }
+    int_cols = {"season", "week", "games"}
+    for c in cols:
+        if c in str_cols:
+            schema[c] = pl.Utf8
+        elif c in int_cols:
+            schema[c] = pl.Int64
+        else:
+            schema[c] = pl.Float64
+    out = pl.DataFrame(schema=schema)
+    if return_as_pandas:
+        return out.to_pandas()
+    return out
+
+
+def _def_empty(value_cols: dict[str, type[pl.DataType] | pl.DataType]) -> pl.DataFrame:
+    """A zero-row (season, week, team, player_id) frame plus the given extra value columns."""
+    schema = dict(_DEF_EMPTY_KEY_SCHEMA)
+    schema.update(value_cols)
+    return pl.DataFrame(schema=schema)
+
+
+def _def_cast_keys(frame: pl.DataFrame) -> pl.DataFrame:
+    """Cast the four def join-key columns to their canonical dtypes.
+
+    Root-cause guard: a synthetic/real pbp column that is entirely null (e.g.
+    a slot-2 id column with no occurrences in a given batch) infers as
+    polars ``Null`` dtype rather than ``Utf8``/``Int64``. That ``Null``
+    survives through ``filter``/``group_by`` on an otherwise-empty frame and
+    then breaks a downstream ``.join(..., how="full")`` against a sibling
+    frame whose keys did get real values (``SchemaError: datatypes of join
+    keys don't match``). Casting at the single join choke point
+    (:func:`_def_join`) rather than chasing every sub-frame constructor keeps
+    every def sub-frame's keys pinned to the schema documented in
+    ``_DEF_EMPTY_KEY_SCHEMA``.
+    """
+    return frame.with_columns(
+        pl.col("season").cast(pl.Int64, strict=False),
+        pl.col("week").cast(pl.Int64, strict=False),
+        pl.col("team").cast(pl.Utf8, strict=False),
+        pl.col("player_id").cast(pl.Utf8, strict=False),
+    )
+
+
+def _def_join(left: pl.DataFrame, right: pl.DataFrame) -> pl.DataFrame:
+    """Full-outer join two def sub-frames on ``_DEF_JOIN_KEYS``, key dtypes guaranteed."""
+    return _def_cast_keys(left).join(_def_cast_keys(right), on=list(_DEF_JOIN_KEYS), how="full", coalesce=True)
+
+
+def _def_slot_frame(data: pl.DataFrame, id_col: str) -> pl.DataFrame:
+    """One row per non-null ``id_col`` occurrence, keyed on (season, week, team=defteam, player_id)."""
+    if id_col not in data.columns:
+        return _def_empty({})
+    return (
+        data.filter(pl.col(id_col).is_not_null())
+        .select("season", "week", pl.col("defteam").alias("team"), pl.col(id_col).alias("player_id"))
+        .filter(pl.col("team").is_not_null())
+    )
+
+
+def _def_count(frames: List[pl.DataFrame], *, value_name: str) -> pl.DataFrame:
+    """Count rows per (season, week, team, player_id) across the union of ``frames``."""
+    present = [f for f in frames if f.width > 0]
+    if not present:
+        return _def_empty({value_name: pl.Float64})
+    return _def_cast_keys(
+        pl.concat(present, how="vertical_relaxed")
+        .group_by(list(_DEF_JOIN_KEYS))
+        .agg(pl.len().cast(pl.Float64).alias(value_name))
+    )
+
+
+def _def_tackle_frame(data: pl.DataFrame) -> pl.DataFrame:
+    """Tackle-family counts, transcribed from nflfastR's ``tackle_vars`` pivot.
+
+    Per the R ``calculate_player_stats_def`` source, ``tackle_vars`` only lists
+    slot 1 for ``tackle_with_assist`` and ``tackle_for_loss`` (the count -- see
+    :func:`_def_tackle_for_loss_yards` for the yards, which DOES use both
+    slots), while ``solo_tackle``, ``assist_tackle``, and
+    ``forced_fumble_player`` count both slots 1 and 2. This intentionally
+    diverges from the team-level :func:`_team_defense_frame` (which counts up
+    to 4 ``assist_tackle`` slots and both ``tackle_with_assist`` slots to match
+    the real data shape) -- this function instead transcribes the literal,
+    narrower ``tackle_vars`` list from the deprecated ``calculate_player_stats_def``
+    R source being ported here.
+    """
+    solo = _def_count(
+        [_def_slot_frame(data, "solo_tackle_1_player_id"), _def_slot_frame(data, "solo_tackle_2_player_id")],
+        value_name="def_tackles_solo",
+    )
+    twa = _def_count([_def_slot_frame(data, "tackle_with_assist_1_player_id")], value_name="def_tackles_with_assist")
+    asst = _def_count(
+        [_def_slot_frame(data, "assist_tackle_1_player_id"), _def_slot_frame(data, "assist_tackle_2_player_id")],
+        value_name="def_tackle_assists",
+    )
+    tfl = _def_count([_def_slot_frame(data, "tackle_for_loss_1_player_id")], value_name="def_tackles_for_loss")
+    ff = _def_count(
+        [
+            _def_slot_frame(data, "forced_fumble_player_1_player_id"),
+            _def_slot_frame(data, "forced_fumble_player_2_player_id"),
+        ],
+        value_name="def_fumbles_forced",
+    )
+
+    out = solo
+    for frame in (twa, asst, tfl, ff):
+        out = _def_join(out, frame)
+    fill_cols = [
+        "def_tackles_solo",
+        "def_tackles_with_assist",
+        "def_tackle_assists",
+        "def_tackles_for_loss",
+        "def_fumbles_forced",
+    ]
+    out = out.with_columns([pl.col(c).fill_null(0.0) for c in fill_cols])
+    return out.with_columns((pl.col("def_tackles_solo") + pl.col("def_tackles_with_assist")).alias("def_tackles"))
+
+
+def _def_tackle_for_loss_yards(data: pl.DataFrame) -> pl.DataFrame:
+    """``def_tackles_for_loss_yards`` = ``sum(-yards_gained)`` over TFL plays, both slots.
+
+    Gated to ``tackled_for_loss==1 & fumble==0 & sack==0`` per the R source
+    (a TFL that's also a fumble or sack is excluded here to avoid double
+    counting with the sack-yards / fumble-yards ledgers).
+    """
+    needed = {"tackled_for_loss", "fumble", "sack", "yards_gained"}
+    if not needed.issubset(data.columns):
+        return _def_empty({"def_tackles_for_loss_yards": pl.Float64})
+    base = data.filter((_i("tackled_for_loss") == 1) & (_i("fumble") == 0) & (_i("sack") == 0))
+    frames = []
+    for k in (1, 2):
+        col = f"tackle_for_loss_{k}_player_id"
+        if col not in base.columns:
+            continue
+        frames.append(
+            base.filter(pl.col(col).is_not_null()).select(
+                "season",
+                "week",
+                pl.col("defteam").alias("team"),
+                pl.col(col).alias("player_id"),
+                (-1.0 * _f("yards_gained")).alias("def_tackles_for_loss_yards"),
+            )
+        )
+    if not frames:
+        return _def_empty({"def_tackles_for_loss_yards": pl.Float64})
+    return (
+        pl.concat(frames, how="vertical_relaxed")
+        .group_by(list(_DEF_JOIN_KEYS))
+        .agg(pl.col("def_tackles_for_loss_yards").sum())
+    )
+
+
+def _def_sack_frame(data: pl.DataFrame) -> pl.DataFrame:
+    """``def_sacks`` / ``def_sack_yards`` -- full sack weight 1.0, each half-sack slot 0.5."""
+    parts = []
+    if "sack_player_id" in data.columns:
+        parts.append(
+            data.filter(pl.col("sack_player_id").is_not_null()).select(
+                "season",
+                "week",
+                pl.col("defteam").alias("team"),
+                pl.col("sack_player_id").alias("player_id"),
+                pl.lit(1.0).alias("n"),
+                (-1.0 * _f("yards_gained")).alias("sack_yards"),
+            )
+        )
+    for k in (1, 2):
+        col = f"half_sack_{k}_player_id"
+        if col in data.columns:
+            parts.append(
+                data.filter(pl.col(col).is_not_null()).select(
+                    "season",
+                    "week",
+                    pl.col("defteam").alias("team"),
+                    pl.col(col).alias("player_id"),
+                    pl.lit(0.5).alias("n"),
+                    (-0.5 * _f("yards_gained")).alias("sack_yards"),
+                )
+            )
+    if not parts:
+        return _def_empty({"def_sacks": pl.Float64, "def_sack_yards": pl.Float64})
+    return (
+        pl.concat(parts, how="vertical_relaxed")
+        .group_by(list(_DEF_JOIN_KEYS))
+        .agg(pl.col("n").sum().alias("def_sacks"), pl.col("sack_yards").sum().alias("def_sack_yards"))
+    )
+
+
+def _def_int_frame(data: pl.DataFrame) -> pl.DataFrame:
+    """``def_interceptions`` / ``def_pass_defended`` / ``def_interception_yards``."""
+    int_count = _def_count([_def_slot_frame(data, "interception_player_id")], value_name="def_interceptions")
+    pdef = _def_count(
+        [_def_slot_frame(data, "pass_defense_1_player_id"), _def_slot_frame(data, "pass_defense_2_player_id")],
+        value_name="def_pass_defended",
+    )
+    if "interception_player_id" in data.columns and "return_yards" in data.columns:
+        int_yards = (
+            data.filter(pl.col("interception_player_id").is_not_null())
+            .group_by(
+                ["season", "week", pl.col("defteam").alias("team"), pl.col("interception_player_id").alias("player_id")]
+            )
+            .agg(_f("return_yards").sum().alias("def_interception_yards"))
+        )
+    else:
+        int_yards = _def_empty({"def_interception_yards": pl.Float64})
+    out = _def_join(int_count, pdef)
+    return _def_join(out, int_yards)
+
+
+def _def_safety_frame(data: pl.DataFrame) -> pl.DataFrame:
+    """``def_safety`` -- count of ``safety==1`` rows keyed on ``safety_player_id``."""
+    if not {"safety", "safety_player_id"}.issubset(data.columns):
+        return _def_empty({"def_safety": pl.Float64})
+    return (
+        data.filter((_i("safety") == 1) & pl.col("safety_player_id").is_not_null())
+        .group_by(["season", "week", pl.col("defteam").alias("team"), pl.col("safety_player_id").alias("player_id")])
+        .agg(pl.len().cast(pl.Float64).alias("def_safety"))
+    )
+
+
+def _def_fumble_own_frame(data: pl.DataFrame) -> pl.DataFrame:
+    """``def_fumbles`` + ``def_fumble_recovery_own`` (the defense fumbled its own ball).
+
+    Ported from nflfastR's ``fumble_df_own``: restricted to rows where the
+    defense itself fumbled (``defteam`` matches either ``fumbled_{1,2}_team``
+    slot), then split per-slot into "who fumbled" (``def_fumbles``) and "who on
+    ``defteam`` recovered it back" (``def_fumble_recovery_own``), each slot
+    independently gated on its own ``_team`` match. The R source only
+    conditionally nulls the *slot-1* ``fumbled_1_player_id`` in this block
+    (leaving ``fumbled_2_player_id`` unguarded) -- an asymmetry NOT called out
+    as a required-replicate gotcha in the reference (unlike the flagged
+    ``fumble_yds_opp_data`` guard in :func:`_def_fumble_yards_opp_frame`
+    below); transcribed here as the documented, slot-symmetric formula-table
+    semantics instead, for maintainability.
+    """
+    fumbled_cols = [f"fumbled_{k}_team" for k in (1, 2) if f"fumbled_{k}_team" in data.columns]
+    if not fumbled_cols:
+        return _def_empty({"def_fumbles": pl.Float64, "def_fumble_recovery_own": pl.Float64})
+
+    own_cond = pl.lit(False)
+    for col in fumbled_cols:
+        own_cond = own_cond | (pl.col("defteam") == pl.col(col))
+    own_fum = data.filter(((_i("fumble") == 1) | (_i("fumble_lost") == 1)) & own_cond)
+
+    fumbled_frames = []
+    recovery_frames = []
+    for k in (1, 2):
+        f_team, f_id = f"fumbled_{k}_team", f"fumbled_{k}_player_id"
+        if f_team in own_fum.columns and f_id in own_fum.columns:
+            fumbled_frames.append(
+                own_fum.filter((pl.col(f_team) == pl.col("defteam")) & pl.col(f_id).is_not_null()).select(
+                    "season", "week", pl.col("defteam").alias("team"), pl.col(f_id).alias("player_id")
+                )
+            )
+        r_team, r_id = f"fumble_recovery_{k}_team", f"fumble_recovery_{k}_player_id"
+        if r_team in own_fum.columns and r_id in own_fum.columns:
+            recovery_frames.append(
+                own_fum.filter((pl.col(r_team) == pl.col("defteam")) & pl.col(r_id).is_not_null()).select(
+                    "season", "week", pl.col("defteam").alias("team"), pl.col(r_id).alias("player_id")
+                )
+            )
+
+    fumbles = _def_count(fumbled_frames, value_name="def_fumbles")
+    recov_own = _def_count(recovery_frames, value_name="def_fumble_recovery_own")
+    return _def_join(fumbles, recov_own)
+
+
+def _def_fumble_yards_own_frame(data: pl.DataFrame) -> pl.DataFrame:
+    """``def_fumble_recovery_yards_own`` -- sum of recovery yards for the own-fumble rows."""
+    fumbled_cols = [f"fumbled_{k}_team" for k in (1, 2) if f"fumbled_{k}_team" in data.columns]
+    if not fumbled_cols:
+        return _def_empty({"def_fumble_recovery_yards_own": pl.Float64})
+    own_cond = pl.lit(False)
+    for col in fumbled_cols:
+        own_cond = own_cond | (pl.col("defteam") == pl.col(col))
+    own_fum = data.filter(((_i("fumble") == 1) | (_i("fumble_lost") == 1)) & own_cond)
+
+    frames = []
+    for k in (1, 2):
+        r_team, r_id, r_yds = (
+            f"fumble_recovery_{k}_team",
+            f"fumble_recovery_{k}_player_id",
+            f"fumble_recovery_{k}_yards",
+        )
+        if r_team in own_fum.columns and r_id in own_fum.columns:
+            yds_expr = _f(r_yds) if r_yds in own_fum.columns else pl.lit(0.0)
+            frames.append(
+                own_fum.filter((pl.col(r_team) == pl.col("defteam")) & pl.col(r_id).is_not_null()).select(
+                    "season",
+                    "week",
+                    pl.col("defteam").alias("team"),
+                    pl.col(r_id).alias("player_id"),
+                    yds_expr.alias("yds"),
+                )
+            )
+    if not frames:
+        return _def_empty({"def_fumble_recovery_yards_own": pl.Float64})
+    return (
+        pl.concat(frames, how="vertical_relaxed")
+        .group_by(list(_DEF_JOIN_KEYS))
+        .agg(pl.col("yds").sum().alias("def_fumble_recovery_yards_own"))
+    )
+
+
+def _def_fumble_opp_frame(data: pl.DataFrame) -> pl.DataFrame:
+    """``def_fumble_recovery_opp`` -- ``defteam`` recovered an opponent (non-own) fumble.
+
+    Symmetric per-slot guard, mirroring nflfastR's ``fumble_df_opp`` mutate
+    (which nulls each ``fumble_recovery_{k}_player_id`` unless ``defteam !=
+    fumbled_{k}_team``) -- this count IS slot-symmetric in the R source
+    itself (unlike the yards variant below).
+    """
+    base = data.filter((_i("fumble") == 1) | (_i("fumble_lost") == 1))
+    frames = []
+    for k in (1, 2):
+        r_team, r_id, f_team = f"fumble_recovery_{k}_team", f"fumble_recovery_{k}_player_id", f"fumbled_{k}_team"
+        if r_team not in base.columns or r_id not in base.columns:
+            continue
+        not_own = (pl.col(f_team) != pl.col("defteam")) if f_team in base.columns else pl.lit(True)
+        frames.append(
+            base.filter((pl.col(r_team) == pl.col("defteam")) & not_own & pl.col(r_id).is_not_null()).select(
+                "season", "week", pl.col("defteam").alias("team"), pl.col(r_id).alias("player_id")
+            )
+        )
+    if not frames:
+        return _def_empty({"def_fumble_recovery_opp": pl.Float64})
+    return _def_count(frames, value_name="def_fumble_recovery_opp")
+
+
+def _def_fumble_yards_opp_frame(data: pl.DataFrame) -> pl.DataFrame:
+    """``def_fumble_recovery_yards_opp`` -- REPLICATES the flagged asymmetric R guard.
+
+    nflfastR's ``fumble_yds_opp_data`` filters ONLY on slot-1 conditions
+    (``defteam == fumble_recovery_1_team & defteam != fumbled_1_team``), then
+    reuses that SAME slot-1-filtered row set for BOTH the slot-1 AND slot-2
+    yards group-bys -- slot 2's own conditions are never independently
+    re-checked. This is exactly as shipped (4+ years) in nflfastR; replicated
+    verbatim here rather than "fixed" to be symmetric, per the reference's
+    explicit instruction to preserve this exact (possibly slightly
+    under/over-inclusive on a rare double-fumble-recovery play) behavior.
+    """
+    if not {"fumble_recovery_1_team", "fumbled_1_team"}.issubset(data.columns):
+        return _def_empty({"def_fumble_recovery_yards_opp": pl.Float64})
+    base = data.filter(
+        ((_i("fumble") == 1) | (_i("fumble_lost") == 1))
+        & (pl.col("fumble_recovery_1_team") == pl.col("defteam"))
+        & (pl.col("defteam") != pl.col("fumbled_1_team"))
+    )
+    if base.height == 0:
+        return _def_empty({"def_fumble_recovery_yards_opp": pl.Float64})
+    frames = []
+    for k in (1, 2):
+        r_team, r_id, r_yds = (
+            f"fumble_recovery_{k}_team",
+            f"fumble_recovery_{k}_player_id",
+            f"fumble_recovery_{k}_yards",
+        )
+        if r_team not in base.columns or r_id not in base.columns:
+            continue
+        yds_expr = _f(r_yds) if r_yds in base.columns else pl.lit(0.0)
+        frames.append(
+            base.filter(pl.col(r_id).is_not_null()).select(
+                "season", "week", pl.col(r_team).alias("team"), pl.col(r_id).alias("player_id"), yds_expr.alias("yds")
+            )
+        )
+    if not frames:
+        return _def_empty({"def_fumble_recovery_yards_opp": pl.Float64})
+    return (
+        pl.concat(frames, how="vertical_relaxed")
+        .group_by(list(_DEF_JOIN_KEYS))
+        .agg(pl.col("yds").sum().alias("def_fumble_recovery_yards_opp"))
+    )
+
+
+def _def_penalty_frame(pbp: pl.DataFrame) -> pl.DataFrame:
+    """``def_penalty`` / ``def_penalty_yards`` -- uses the FULL ``pbp`` (not the down-restricted ``data``)."""
+    if not {"penalty", "penalty_team", "penalty_player_id", "penalty_yards"}.issubset(pbp.columns):
+        return _def_empty({"def_penalty": pl.Float64, "def_penalty_yards": pl.Float64})
+    return (
+        pbp.filter(
+            (_i("penalty") == 1)
+            & pl.col("penalty_player_id").is_not_null()
+            & (pl.col("defteam") == pl.col("penalty_team"))
+        )
+        .group_by(["season", "week", pl.col("defteam").alias("team"), pl.col("penalty_player_id").alias("player_id")])
+        .agg(pl.len().cast(pl.Float64).alias("def_penalty"), _f("penalty_yards").sum().alias("def_penalty_yards"))
+    )
+
+
+def _def_td_frame(data: pl.DataFrame) -> pl.DataFrame:
+    """``def_tds`` -- touchdowns credited to ``defteam`` (returns / pick-sixes / fumble-return TDs)."""
+    if not {"touchdown", "td_team", "td_player_id"}.issubset(data.columns):
+        return _def_empty({"def_tds": pl.Float64})
+    return (
+        data.filter(
+            (_i("touchdown") == 1) & (pl.col("defteam") == pl.col("td_team")) & pl.col("td_player_id").is_not_null()
+        )
+        .group_by(["season", "week", pl.col("td_team").alias("team"), pl.col("td_player_id").alias("player_id")])
+        .agg(_i("touchdown").sum().cast(pl.Float64).alias("def_tds"))
+    )
+
+
+def _collapse_def_to_season(player_df: pl.DataFrame) -> pl.DataFrame:
+    """Season collapse per the R source: grouped on ``(player_id, team)`` ONLY (no season)."""
+    sum_cols = [c for c in _DEF_OUTPUT_COLUMNS if c.startswith("def_") and c in player_df.columns]
+    return player_df.group_by(["player_id", "team"]).agg(
+        pl.len().alias("games"),
+        pl.first("player_name").alias("player_name"),
+        pl.first("player_display_name").alias("player_display_name"),
+        pl.first("position").alias("position"),
+        pl.first("position_group").alias("position_group"),
+        pl.first("headshot_url").alias("headshot_url"),
+        *[pl.col(c).sum().alias(c) for c in sum_cols],
+    )
+
+
+def _finalize_def(player_df: pl.DataFrame, *, weekly: bool) -> pl.DataFrame:
+    """Select the canonical def-stats column order + cast + sort."""
+    cols = list(_DEF_OUTPUT_COLUMNS)
+    if not weekly:
+        cols = [c for c in cols if c not in ("week", "season_type")]
+        cols.insert(cols.index("player_display_name") + 1, "games")
+    for c in cols:
+        if c not in player_df.columns:
+            player_df = player_df.with_columns(pl.lit(None).alias(c))
+    out = player_df.select(cols).filter(pl.col("player_id").is_not_null())
+    sort_keys = ["player_id", "season", "week"] if weekly else ["player_id"]
+    return out.sort(sort_keys)
+
+
+@overload
+def build_nfl_player_stats_def(
+    pbp: pl.DataFrame,
+    *,
+    weekly: bool = ...,
+    return_as_pandas: Literal[False] = ...,
+) -> pl.DataFrame: ...
+@overload
+def build_nfl_player_stats_def(
+    pbp: pl.DataFrame,
+    *,
+    weekly: bool = ...,
+    return_as_pandas: Literal[True],
+) -> "pd.DataFrame": ...
+def build_nfl_player_stats_def(
+    pbp: pl.DataFrame,
+    *,
+    weekly: bool = False,
+    return_as_pandas: bool = False,
+) -> pl.DataFrame | "pd.DataFrame":
+    """Build player-level defensive stats from play-by-play (nflfastR parity).
+
+    A faithful polars port of nflfastR's deprecated
+    ``calculate_player_stats_def()`` (``aggregate_game_stats_def.R``). Tackle,
+    sack (half-sack = 0.5 weighting), pass-defense, interception, safety,
+    fumble (own/opponent recovery), penalty, and touchdown sub-frames are each
+    aggregated on ``(season, week, team=defteam, player_id)`` and full-outer
+    joined together, then player metadata is joined from
+    :func:`sportsdataverse.nfl.load_nfl_players`.
+
+    Unlike :func:`build_nfl_player_stats`, this function takes a
+    caller-supplied ``pbp`` frame directly rather than loading one -- matching
+    the R function's own signature.
+
+    Args:
+        pbp: Play-by-play frame carrying the wide nflverse defensive columns
+            (``solo_tackle_1_player_id``, ``sack_player_id``,
+            ``half_sack_{1,2}_player_id``, ``interception_player_id``,
+            ``pass_defense_{1,2}_player_id``, ``fumbled_{1,2}_team`` /
+            ``fumble_recovery_{1,2}_team``, etc. -- the same columns
+            :func:`sportsdataverse.nfl.load_nfl_pbp` serves).
+        weekly: If ``True`` return one row per (season, week, player); if
+            ``False`` collapse to one row per ``(player_id, team)`` -- note
+            this does NOT retain a ``season`` column even if ``pbp`` spans
+            multiple seasons (see the module-level note above), matching the
+            R source's own ``group_by(player_id, team)`` (no ``season``).
+        return_as_pandas: If ``True`` return a pandas DataFrame; else polars.
+
+    Returns:
+        A polars (or pandas) DataFrame with the ``def_*`` column set
+        documented in the nflfastR-parity reference (weekly grain carries
+        ``season``/``week``/``season_type``; the season collapse replaces
+        those with ``games``).
+
+    Example:
+        Weekly defensive stats from an already-loaded PBP frame::
+
+            from sportsdataverse.nfl import build_nfl_player_stats_def, load_nfl_pbp
+            pbp = load_nfl_pbp([2023])
+            wk = build_nfl_player_stats_def(pbp, weekly=True)
+            print(wk.shape)
+
+        Season totals (one season's worth of ``pbp`` at a time)::
+
+            season = build_nfl_player_stats_def(pbp, weekly=False)
+
+        Pipeline next step (one line)::
+
+            wk.sort("def_sacks", descending=True).head()
+
+    See Also:
+        * `nflfastR <https://www.nflfastr.com>`_ -- the ``calculate_player_stats_def`` source
+        * `nflreadpy <https://github.com/nflverse/nflreadpy>`_ -- nflverse loaders (Python)
+    """
+    if pbp.height == 0:
+        return _empty_player_stats_def(weekly=weekly, return_as_pandas=return_as_pandas)
+
+    pbp = _prepare_pbp(pbp)
+    data = pbp.filter(pl.col("down").is_not_null() & pl.col("play_type").is_in(["pass", "qb_kneel", "qb_spike", "run"]))
+
+    frames = [
+        _def_tackle_frame(data),
+        _def_tackle_for_loss_yards(data),
+        _def_sack_frame(data),
+        _def_int_frame(data),
+        _def_safety_frame(data),
+        _def_fumble_own_frame(data),
+        _def_fumble_yards_own_frame(data),
+        _def_fumble_opp_frame(data),
+        _def_fumble_yards_opp_frame(data),
+        _def_penalty_frame(pbp),
+        _def_td_frame(data),
+    ]
+    # def_qb_hits shares the slot-count helper (kept separate from the sack
+    # frame since it has no yards component).
+    frames.append(
+        _def_count(
+            [_def_slot_frame(data, "qb_hit_1_player_id"), _def_slot_frame(data, "qb_hit_2_player_id")],
+            value_name="def_qb_hits",
+        )
+    )
+
+    player_df = _def_cast_keys(frames[0])
+    for frame in frames[1:]:
+        player_df = _def_join(player_df, frame)
+
+    player_df = player_df.filter(pl.col("player_id").is_not_null())
+
+    count_cols = [c for c in _DEF_OUTPUT_COLUMNS if c.startswith("def_") and c in player_df.columns]
+    player_df = player_df.with_columns([pl.col(c).fill_null(0.0) for c in count_cols])
+
+    # season_type per (season, week), joined from the down-restricted grain.
+    s_type = data.select(["season", "week", "season_type"]).unique(subset=["season", "week"], keep="first")
+    player_df = player_df.join(s_type, on=["season", "week"], how="left")
+
+    from sportsdataverse.nfl.nfl_loaders import load_nfl_players  # noqa: PLC0415
+
+    # Unlike build_nfl_player_stats, the def-stats source never derives a
+    # player_name from pbp itself (per the R source, player_name/
+    # player_display_name/position/position_group/headshot_url all come
+    # exclusively from the load_players() join) -- satisfy _join_player_meta's
+    # coalesce-with-pbp-name contract with an all-null placeholder so the
+    # players-master short_name always wins.
+    if "player_name" not in player_df.columns:
+        player_df = player_df.with_columns(pl.lit(None, dtype=pl.Utf8).alias("player_name"))
+    player_df = _join_player_meta(player_df, load_nfl_players())
+
+    if not weekly:
+        player_df = _collapse_def_to_season(player_df)
+
+    player_df = _finalize_def(player_df, weekly=weekly)
+
+    if return_as_pandas:
+        return player_df.to_pandas()
+    return player_df
+
+
+# ---------------------------------------------------------------------------
+# player_stats_kicking (nflfastR ``calculate_player_stats_kicking`` parity)
+# ---------------------------------------------------------------------------
+
+_KICK_OUTPUT_COLUMNS: tuple[str, ...] = (
+    "season",
+    "week",
+    "season_type",
+    "player_id",
+    "team",
+    "player_name",
+    "player_display_name",
+    "position",
+    "position_group",
+    "headshot_url",
+    "fg_made",
+    "fg_att",
+    "fg_missed",
+    "fg_blocked",
+    "fg_long",
+    "fg_pct",
+    "fg_made_0_19",
+    "fg_made_20_29",
+    "fg_made_30_39",
+    "fg_made_40_49",
+    "fg_made_50_59",
+    "fg_made_60_",
+    "fg_missed_0_19",
+    "fg_missed_20_29",
+    "fg_missed_30_39",
+    "fg_missed_40_49",
+    "fg_missed_50_59",
+    "fg_missed_60_",
+    "fg_made_list",
+    "fg_missed_list",
+    "fg_blocked_list",
+    "fg_made_distance",
+    "fg_missed_distance",
+    "fg_blocked_distance",
+    "pat_made",
+    "pat_att",
+    "pat_missed",
+    "pat_blocked",
+    "pat_pct",
+    "gwfg_att",
+    "gwfg_distance",
+    "gwfg_made",
+    "gwfg_missed",
+    "gwfg_blocked",
+)
+
+_KICK_LIST_COLUMNS: tuple[str, ...] = ("fg_made_list", "fg_missed_list", "fg_blocked_list")
+
+_KICK_INT_COLUMNS: tuple[str, ...] = (
+    "fg_made",
+    "fg_att",
+    "fg_missed",
+    "fg_blocked",
+    "fg_made_0_19",
+    "fg_made_20_29",
+    "fg_made_30_39",
+    "fg_made_40_49",
+    "fg_made_50_59",
+    "fg_made_60_",
+    "fg_missed_0_19",
+    "fg_missed_20_29",
+    "fg_missed_30_39",
+    "fg_missed_40_49",
+    "fg_missed_50_59",
+    "fg_missed_60_",
+    "fg_made_distance",
+    "fg_missed_distance",
+    "fg_blocked_distance",
+    "pat_made",
+    "pat_att",
+    "pat_missed",
+    "pat_blocked",
+    "gwfg_att",
+    "gwfg_made",
+    "gwfg_missed",
+    "gwfg_blocked",
+)
+
+
+def _kick_season_columns(cols: List[str]) -> List[str]:
+    """Season-grain column list: drop week/season_type, insert games, rename gwfg_distance."""
+    out = [c for c in cols if c not in ("week", "season_type")]
+    out.insert(out.index("player_display_name") + 1, "games")
+    return ["gwfg_distance_list" if c == "gwfg_distance" else c for c in out]
+
+
+def _empty_player_stats_kicking(*, weekly: bool, return_as_pandas: bool) -> pl.DataFrame | "pd.DataFrame":
+    """Return a zero-row kicking-stats frame carrying the canonical schema."""
+    cols = _kick_season_columns(list(_KICK_OUTPUT_COLUMNS)) if not weekly else list(_KICK_OUTPUT_COLUMNS)
+    schema: dict[str, type[pl.DataType] | pl.DataType] = {}
+    str_cols = {
+        "player_id",
+        "team",
+        "player_name",
+        "player_display_name",
+        "position",
+        "position_group",
+        "headshot_url",
+        "season_type",
+        *_KICK_LIST_COLUMNS,
+        "gwfg_distance_list",
+    }
+    int_cols = {"season", "week", "games", *_KICK_INT_COLUMNS}
+    for c in cols:
+        if c == "gwfg_distance":
+            schema[c] = pl.List(pl.Float64)
+        elif c in str_cols:
+            schema[c] = pl.Utf8
+        elif c in int_cols:
+            schema[c] = pl.Int64
+        else:
+            schema[c] = pl.Float64
+    out = pl.DataFrame(schema=schema)
+    if return_as_pandas:
+        return out.to_pandas()
+    return out
+
+
+_KICK_BASE_SCHEMA: dict[str, type[pl.DataType] | pl.DataType] = {
+    "game_id": pl.Utf8,
+    "season": pl.Int64,
+    "week": pl.Int64,
+    "season_type": pl.Utf8,
+    "team": pl.Utf8,
+    "player_name": pl.Utf8,
+    "player_id": pl.Utf8,
+    "dist": pl.Float64,
+    "field_goal_attempt": pl.Int64,
+    "fg_res": pl.Utf8,
+    "extra_point_attempt": pl.Int64,
+    "pat_res": pl.Utf8,
+    "fixed_drive": pl.Int64,
+    "score_differential": pl.Float64,
+}
+
+
+def _kick_base_frame(pbp: pl.DataFrame) -> pl.DataFrame:
+    """The nflfastR ``df_fg_or_pat`` base frame: FG/PAT attempts + the kicking team's final drive."""
+    needed = {"game_id", "posteam", "kicker_player_id", "field_goal_attempt", "extra_point_attempt", "fixed_drive"}
+    if not needed.issubset(pbp.columns):
+        return pl.DataFrame(schema=_KICK_BASE_SCHEMA)
+
+    work = pbp.with_columns(pl.col("fixed_drive").max().over(["game_id", "posteam"]).alias("_max_fixed_drive"))
+    base = work.filter(
+        (_i("field_goal_attempt") == 1)
+        | (_i("extra_point_attempt") == 1)
+        | (pl.col("fixed_drive") == pl.col("_max_fixed_drive"))
+    ).filter(pl.col("kicker_player_id").is_not_null())
+    if base.height == 0:
+        return pl.DataFrame(schema=_KICK_BASE_SCHEMA)
+
+    name_expr = pl.col("kicker_player_name") if "kicker_player_name" in base.columns else pl.lit(None, dtype=pl.Utf8)
+    season_type_expr = pl.col("season_type") if "season_type" in base.columns else pl.lit(None, dtype=pl.Utf8)
+    score_diff_expr = (
+        _f("score_differential") if "score_differential" in base.columns else pl.lit(None, dtype=pl.Float64)
+    )
+    return base.select(
+        pl.col("game_id").cast(pl.Utf8, strict=False),
+        pl.col("season").cast(pl.Int64, strict=False),
+        pl.col("week").cast(pl.Int64, strict=False),
+        season_type_expr.alias("season_type"),
+        pl.col("posteam").cast(pl.Utf8, strict=False).alias("team"),
+        name_expr.alias("player_name"),
+        pl.col("kicker_player_id").cast(pl.Utf8, strict=False).alias("player_id"),
+        _f("kick_distance").alias("dist"),
+        _i("field_goal_attempt").alias("field_goal_attempt"),
+        pl.col("field_goal_result").alias("fg_res"),
+        _i("extra_point_attempt").alias("extra_point_attempt"),
+        pl.col("extra_point_result").alias("pat_res"),
+        pl.col("fixed_drive").cast(pl.Int64, strict=False),
+        score_diff_expr.alias("score_differential"),
+    )
+
+
+def _kick_grp_cols(weekly: bool) -> List[str]:
+    return ["season", "week", "season_type", "player_id", "team"] if weekly else ["player_id", "team"]
+
+
+def _kick_field_goals(base: pl.DataFrame, grp: List[str]) -> pl.DataFrame:
+    """``fg_made``/``fg_att``/... + the 6 made/missed distance buckets + long/pct/lists."""
+    fg = base.filter(pl.col("field_goal_attempt") == 1)
+    made = pl.col("fg_res") == "made"
+    miss = pl.col("fg_res") == "missed"
+    blk = pl.col("fg_res") == "blocked"
+    dist = pl.col("dist")
+
+    def _bucket(flag: pl.Expr, lo: int, hi: "int | None") -> pl.Expr:
+        cond = (flag & (dist >= lo)) if hi is None else (flag & (dist >= lo) & (dist <= hi))
+        return cond.sum().cast(pl.Int64)
+
+    if fg.height == 0:
+        return pl.DataFrame(
+            schema={
+                **{c: pl.Utf8 for c in grp if c in ("season_type", "player_id", "team")},
+                **{c: pl.Int64 for c in grp if c in ("season", "week")},
+                "fg_made": pl.Int64,
+                "fg_att": pl.Int64,
+                "fg_missed": pl.Int64,
+                "fg_blocked": pl.Int64,
+                "fg_long": pl.Float64,
+                "fg_pct": pl.Float64,
+                "fg_made_0_19": pl.Int64,
+                "fg_made_20_29": pl.Int64,
+                "fg_made_30_39": pl.Int64,
+                "fg_made_40_49": pl.Int64,
+                "fg_made_50_59": pl.Int64,
+                "fg_made_60_": pl.Int64,
+                "fg_missed_0_19": pl.Int64,
+                "fg_missed_20_29": pl.Int64,
+                "fg_missed_30_39": pl.Int64,
+                "fg_missed_40_49": pl.Int64,
+                "fg_missed_50_59": pl.Int64,
+                "fg_missed_60_": pl.Int64,
+                "fg_made_list": pl.Utf8,
+                "fg_missed_list": pl.Utf8,
+                "fg_blocked_list": pl.Utf8,
+                "fg_made_distance": pl.Int64,
+                "fg_missed_distance": pl.Int64,
+                "fg_blocked_distance": pl.Int64,
+            }
+        )
+
+    return (
+        fg.group_by(grp)
+        .agg(
+            made.sum().cast(pl.Int64).alias("fg_made"),
+            pl.col("field_goal_attempt").sum().cast(pl.Int64).alias("fg_att"),
+            miss.sum().cast(pl.Int64).alias("fg_missed"),
+            blk.sum().cast(pl.Int64).alias("fg_blocked"),
+            pl.when(made.any()).then(dist.filter(made).max()).otherwise(None).alias("fg_long"),
+            _bucket(made, 0, 19).alias("fg_made_0_19"),
+            _bucket(made, 20, 29).alias("fg_made_20_29"),
+            _bucket(made, 30, 39).alias("fg_made_30_39"),
+            _bucket(made, 40, 49).alias("fg_made_40_49"),
+            _bucket(made, 50, 59).alias("fg_made_50_59"),
+            _bucket(made, 60, None).alias("fg_made_60_"),
+            _bucket(miss, 0, 19).alias("fg_missed_0_19"),
+            _bucket(miss, 20, 29).alias("fg_missed_20_29"),
+            _bucket(miss, 30, 39).alias("fg_missed_30_39"),
+            _bucket(miss, 40, 49).alias("fg_missed_40_49"),
+            _bucket(miss, 50, 59).alias("fg_missed_50_59"),
+            _bucket(miss, 60, None).alias("fg_missed_60_"),
+            dist.filter(made).drop_nulls().cast(pl.Int64).cast(pl.Utf8).str.join(";").alias("fg_made_list"),
+            dist.filter(miss).drop_nulls().cast(pl.Int64).cast(pl.Utf8).str.join(";").alias("fg_missed_list"),
+            dist.filter(blk).drop_nulls().cast(pl.Int64).cast(pl.Utf8).str.join(";").alias("fg_blocked_list"),
+            dist.filter(made).sum().cast(pl.Int64).alias("fg_made_distance"),
+            dist.filter(miss).sum().cast(pl.Int64).alias("fg_missed_distance"),
+            dist.filter(blk).sum().cast(pl.Int64).alias("fg_blocked_distance"),
+        )
+        .with_columns(
+            pl.when(pl.col("fg_att") > 0)
+            .then((pl.col("fg_made") / pl.col("fg_att")).round(3))
+            .otherwise(None)
+            .alias("fg_pct")
+        )
+    )
+
+
+def _kick_pat(base: pl.DataFrame, grp: List[str]) -> pl.DataFrame:
+    """``pat_made``/``pat_att``/``pat_missed``/``pat_blocked``/``pat_pct``."""
+    pat = base.filter(pl.col("extra_point_attempt") == 1)
+    if pat.height == 0:
+        return pl.DataFrame(
+            schema={
+                **{c: pl.Utf8 for c in grp if c in ("season_type", "player_id", "team")},
+                **{c: pl.Int64 for c in grp if c in ("season", "week")},
+                "pat_made": pl.Int64,
+                "pat_att": pl.Int64,
+                "pat_missed": pl.Int64,
+                "pat_blocked": pl.Int64,
+                "pat_pct": pl.Float64,
+            }
+        )
+    return (
+        pat.group_by(grp)
+        .agg(
+            (pl.col("pat_res") == "good").sum().cast(pl.Int64).alias("pat_made"),
+            pl.col("extra_point_attempt").sum().cast(pl.Int64).alias("pat_att"),
+            (pl.col("pat_res") == "failed").sum().cast(pl.Int64).alias("pat_missed"),
+            (pl.col("pat_res") == "blocked").sum().cast(pl.Int64).alias("pat_blocked"),
+        )
+        .with_columns(
+            pl.when(pl.col("pat_att") > 0)
+            .then((pl.col("pat_made") / pl.col("pat_att")).round(3))
+            .otherwise(None)
+            .alias("pat_pct")
+        )
+    )
+
+
+def _kick_gwfg(base: pl.DataFrame, grp: List[str], *, weekly: bool) -> pl.DataFrame:
+    """Game-winning FG attempts: last fixed_drive of the game, trailing by <=2 points.
+
+    Mirrors the R ``game_winners`` block exactly (no ``defteam_score``
+    cross-check, unlike the team-level :func:`_team_gwfg_frame` which adds one
+    as a deliberate improvement) -- this player-level builder is the literal
+    ``calculate_player_stats_kicking`` port.
+    """
+    dist_name = "gwfg_distance" if weekly else "gwfg_distance_list"
+    empty_schema: dict[str, type[pl.DataType] | pl.DataType] = {
+        **{c: pl.Utf8 for c in grp if c in ("season_type", "player_id", "team")},
+        **{c: pl.Int64 for c in grp if c in ("season", "week")},
+        "gwfg_att": pl.Int64,
+        dist_name: pl.List(pl.Float64) if weekly else pl.Utf8,
+        "gwfg_made": pl.Int64,
+        "gwfg_missed": pl.Int64,
+        "gwfg_blocked": pl.Int64,
+    }
+    if base.height == 0:
+        return pl.DataFrame(schema=empty_schema)
+
+    work = base.with_columns(pl.col("fixed_drive").max().over(["game_id", "team"]).alias("_max_fd"))
+    gwfg = work.filter(
+        (pl.col("fixed_drive") == pl.col("_max_fd"))
+        & (pl.col("field_goal_attempt") == 1)
+        & (pl.col("score_differential") >= -2)
+        & (pl.col("score_differential") <= 0)
+    )
+    if gwfg.height == 0:
+        return pl.DataFrame(schema=empty_schema)
+
+    dist_agg = (
+        pl.col("dist").alias(dist_name)
+        if weekly
+        else pl.col("dist").drop_nulls().cast(pl.Int64).cast(pl.Utf8).str.join(";").alias(dist_name)
+    )
+    return gwfg.group_by(grp).agg(
+        pl.len().cast(pl.Int64).alias("gwfg_att"),
+        dist_agg,
+        (pl.col("fg_res") == "made").sum().cast(pl.Int64).alias("gwfg_made"),
+        (pl.col("fg_res") == "missed").sum().cast(pl.Int64).alias("gwfg_missed"),
+        (pl.col("fg_res") == "blocked").sum().cast(pl.Int64).alias("gwfg_blocked"),
+    )
+
+
+def _kick_games(base: pl.DataFrame, grp: List[str]) -> pl.DataFrame:
+    """``games`` -- distinct ``game_id`` count over FG-or-PAT attempts (GWFG is a subset of FG)."""
+    qualifying = base.filter((pl.col("field_goal_attempt") == 1) | (pl.col("extra_point_attempt") == 1))
+    if qualifying.height == 0:
+        empty_schema: dict[str, type[pl.DataType] | pl.DataType] = {
+            **{c: pl.Utf8 for c in grp if c in ("season_type", "player_id", "team")},
+            **{c: pl.Int64 for c in grp if c in ("season", "week")},
+            "games": pl.Int64,
+        }
+        return pl.DataFrame(schema=empty_schema)
+    return qualifying.group_by(grp).agg(pl.col("game_id").n_unique().cast(pl.Int64).alias("games"))
+
+
+def _finalize_kicking(kick_df: pl.DataFrame, *, weekly: bool) -> pl.DataFrame:
+    """Select the canonical kicking-stats column order + sort."""
+    cols = list(_KICK_OUTPUT_COLUMNS) if weekly else _kick_season_columns(list(_KICK_OUTPUT_COLUMNS))
+    for c in cols:
+        if c not in kick_df.columns:
+            kick_df = kick_df.with_columns(pl.lit(None).alias(c))
+    out = kick_df.select(cols).filter(pl.col("player_id").is_not_null())
+    sort_keys = ["player_id", "season", "week"] if weekly else ["player_id"]
+    return out.sort(sort_keys)
+
+
+@overload
+def build_nfl_player_stats_kicking(
+    pbp: pl.DataFrame,
+    *,
+    weekly: bool = ...,
+    return_as_pandas: Literal[False] = ...,
+) -> pl.DataFrame: ...
+@overload
+def build_nfl_player_stats_kicking(
+    pbp: pl.DataFrame,
+    *,
+    weekly: bool = ...,
+    return_as_pandas: Literal[True],
+) -> "pd.DataFrame": ...
+def build_nfl_player_stats_kicking(
+    pbp: pl.DataFrame,
+    *,
+    weekly: bool = False,
+    return_as_pandas: bool = False,
+) -> pl.DataFrame | "pd.DataFrame":
+    """Build player-level kicking stats from play-by-play (nflfastR parity).
+
+    A faithful polars port of nflfastR's deprecated
+    ``calculate_player_stats_kicking()`` (``aggregate_game_stats_kicking.R``).
+    Field goals (made-distance buckets, ``fg_long``, ``fg_pct``, ``;``-joined
+    distance lists), extra points, and game-winning-FG attempts (last drive of
+    the game, trailing by 2 or fewer points) are each aggregated on the kicker
+    and full-outer joined together, then player metadata is joined from
+    :func:`sportsdataverse.nfl.load_nfl_players`.
+
+    Unlike :func:`build_nfl_team_stats`, this function takes a caller-supplied
+    ``pbp`` frame directly rather than loading one -- matching the R
+    function's own signature.
+
+    Args:
+        pbp: Play-by-play frame carrying ``kicker_player_id`` /
+            ``kicker_player_name``, ``field_goal_attempt`` /
+            ``field_goal_result`` / ``kick_distance``, ``extra_point_attempt``
+            / ``extra_point_result``, ``fixed_drive``, and
+            ``score_differential`` (the same columns
+            :func:`sportsdataverse.nfl.load_nfl_pbp` serves).
+        weekly: If ``True`` return one row per (season, week, player) with a
+            ``gwfg_distance`` list column; if ``False`` collapse to one row
+            per ``(player_id, team)`` with a ``games`` column and a
+            ``;``-joined ``gwfg_distance_list`` string column in place of
+            ``gwfg_distance`` (the R source's own deliberate column-name
+            change based on the ``weekly`` flag). Note this does NOT retain a
+            ``season`` column even if ``pbp`` spans multiple seasons (see the
+            module-level note above :func:`build_nfl_player_stats_def`).
+        return_as_pandas: If ``True`` return a pandas DataFrame; else polars.
+
+    Returns:
+        A polars (or pandas) DataFrame with the ``fg_*``/``pat_*``/``gwfg_*``
+        column set documented in the nflfastR-parity reference.
+
+    Example:
+        Weekly kicking stats from an already-loaded PBP frame::
+
+            from sportsdataverse.nfl import build_nfl_player_stats_kicking, load_nfl_pbp
+            pbp = load_nfl_pbp([2023])
+            wk = build_nfl_player_stats_kicking(pbp, weekly=True)
+            print(wk.shape)
+
+        Season totals (one season's worth of ``pbp`` at a time)::
+
+            season = build_nfl_player_stats_kicking(pbp, weekly=False)
+
+        Pipeline next step (one line)::
+
+            wk.filter(pl.col("fg_att") >= 1).sort("fg_pct", descending=True).head()
+
+    See Also:
+        * `nflfastR <https://www.nflfastr.com>`_ -- the ``calculate_player_stats_kicking`` source
+        * `nflreadpy <https://github.com/nflverse/nflreadpy>`_ -- nflverse loaders (Python)
+    """
+    if pbp.height == 0:
+        return _empty_player_stats_kicking(weekly=weekly, return_as_pandas=return_as_pandas)
+
+    base = _kick_base_frame(pbp)
+    if base.height == 0:
+        return _empty_player_stats_kicking(weekly=weekly, return_as_pandas=return_as_pandas)
+
+    grp = _kick_grp_cols(weekly)
+    fg = _kick_field_goals(base, grp)
+    pat = _kick_pat(base, grp)
+    gwfg = _kick_gwfg(base, grp, weekly=weekly)
+    games = _kick_games(base, grp)
+    names = base.group_by(grp).agg(pl.first("player_name").alias("player_name"))
+
+    kick_df = fg.join(pat, on=grp, how="full", coalesce=True)
+    kick_df = kick_df.join(gwfg, on=grp, how="full", coalesce=True)
+    kick_df = kick_df.join(names, on=grp, how="full", coalesce=True)
+    kick_df = kick_df.join(games, on=grp, how="left")
+
+    kick_df = kick_df.filter(pl.col("player_id").is_not_null())
+
+    # Attempt counts never null (0 when a player attempted none of that kick type).
+    for c in ("fg_att", "pat_att", "gwfg_att"):
+        if c in kick_df.columns:
+            kick_df = kick_df.with_columns(pl.col(c).fill_null(0))
+        else:
+            kick_df = kick_df.with_columns(pl.lit(0).cast(pl.Int64).alias(c))
+    for c in _KICK_INT_COLUMNS:
+        if c not in ("fg_att", "pat_att", "gwfg_att") and c in kick_df.columns:
+            kick_df = kick_df.with_columns(pl.col(c).fill_null(0))
+
+    dist_name = "gwfg_distance" if weekly else "gwfg_distance_list"
+    if dist_name not in kick_df.columns:
+        kick_df = kick_df.with_columns(pl.lit(None).alias(dist_name))
+
+    # Blanket "" -> null across the ``;``-joined list columns (mirrors the R
+    # source's ``replace(.x, nchar(.x)==0 | is.nan(.x), NA)`` cleanup, applied
+    # per-dtype here rather than the R blanket-stringify approach).
+    str_list_cols = [c for c in (*_KICK_LIST_COLUMNS, "gwfg_distance_list") if c in kick_df.columns]
+    if str_list_cols:
+        kick_df = kick_df.with_columns(
+            [pl.when(pl.col(c).str.len_chars() == 0).then(None).otherwise(pl.col(c)).alias(c) for c in str_list_cols]
+        )
+
+    from sportsdataverse.nfl.nfl_loaders import load_nfl_players  # noqa: PLC0415
+
+    kick_df = _join_player_meta(kick_df, load_nfl_players())
+
+    kick_df = _finalize_kicking(kick_df, weekly=weekly)
+
+    if return_as_pandas:
+        return kick_df.to_pandas()
+    return kick_df

--- a/sportsdataverse/nfl/nfl_stats.py
+++ b/sportsdataverse/nfl/nfl_stats.py
@@ -1549,7 +1549,10 @@ def build_nfl_team_stats(
     # String lists default to empty string.
     team_df = team_df.with_columns([pl.col(c).fill_null("") for c in _TEAM_STR_COLUMNS if c in team_df.columns])
 
-    # FG / PAT percentages (avoid 0/0).
+    # FG / PAT percentages (avoid 0/0). The reference's per-dtype NaN->null
+    # cleanup is intentionally skipped here for these float columns: the
+    # when-guard only divides when the attempt count is > 0, so NaN (0/0) is
+    # unreachable.
     team_df = team_df.with_columns(
         pl.when(pl.col("fg_att") > 0)
         .then(pl.col("fg_made") / pl.col("fg_att"))
@@ -1596,6 +1599,7 @@ def _collapse_team_to_season(team_df: pl.DataFrame, *, season_type: str) -> pl.D
         team_df.group_by(["season", "team"])
         .agg(agg)
         .with_columns(
+            # Same NaN-unreachable reasoning as the weekly fg_pct/pat_pct above.
             pl.when(pl.col("fg_att") > 0)
             .then(pl.col("fg_made") / pl.col("fg_att"))
             .otherwise(None)
@@ -1709,7 +1713,10 @@ def _empty_player_stats_def(*, weekly: bool, return_as_pandas: bool) -> pl.DataF
         "team",
         "season_type",
     }
-    int_cols = {"season", "week", "games"}
+    # "season" is only ever in ``cols`` on the weekly grain (season-grain
+    # drops it above), so it's included here conditionally rather than
+    # carrying a dead entry on the season-grain path.
+    int_cols = {"week", "games"} | ({"season"} if weekly else set())
     for c in cols:
         if c in str_cols:
             schema[c] = pl.Utf8
@@ -2264,7 +2271,17 @@ def build_nfl_player_stats_def(
     player_df = player_df.with_columns([pl.col(c).fill_null(0.0) for c in count_cols])
 
     # season_type per (season, week), joined from the down-restricted grain.
-    s_type = data.select(["season", "week", "season_type"]).unique(subset=["season", "week"], keep="first")
+    # Cast season/week identically to _def_cast_keys so this join shares the
+    # same dtype guarantee as every other def-path join (player_df's keys
+    # were already routed through _def_cast_keys above).
+    s_type = (
+        data.select(["season", "week", "season_type"])
+        .unique(subset=["season", "week"], keep="first")
+        .with_columns(
+            pl.col("season").cast(pl.Int64, strict=False),
+            pl.col("week").cast(pl.Int64, strict=False),
+        )
+    )
     player_df = player_df.join(s_type, on=["season", "week"], how="left")
 
     from sportsdataverse.nfl.nfl_loaders import load_nfl_players  # noqa: PLC0415
@@ -2548,6 +2565,8 @@ def _kick_field_goals(base: pl.DataFrame, grp: List[str]) -> pl.DataFrame:
             dist.filter(blk).sum().cast(pl.Int64).alias("fg_blocked_distance"),
         )
         .with_columns(
+            # NaN-unreachable (only divides when fg_att > 0): the reference's
+            # per-dtype NaN->null cleanup is intentionally skipped for floats.
             pl.when(pl.col("fg_att") > 0)
             .then((pl.col("fg_made") / pl.col("fg_att")).round(3))
             .otherwise(None)
@@ -2580,6 +2599,7 @@ def _kick_pat(base: pl.DataFrame, grp: List[str]) -> pl.DataFrame:
             (pl.col("pat_res") == "blocked").sum().cast(pl.Int64).alias("pat_blocked"),
         )
         .with_columns(
+            # Same NaN-unreachable reasoning as fg_pct above.
             pl.when(pl.col("pat_att") > 0)
             .then((pl.col("pat_made") / pl.col("pat_att")).round(3))
             .otherwise(None)
@@ -2778,6 +2798,11 @@ def build_nfl_player_stats_kicking(
 
     from sportsdataverse.nfl.nfl_loaders import load_nfl_players  # noqa: PLC0415
 
+    # Deliberate divergence from R: R's calculate_player_stats_kicking yields
+    # NA for a kicker missing from load_players(); _join_player_meta's
+    # coalesce falls back to the pbp-derived kicker_player_name (set on
+    # kick_df's "player_name" above via _kick_base_frame) instead -- a strict
+    # superset, not a bug.
     kick_df = _join_player_meta(kick_df, load_nfl_players())
 
     kick_df = _finalize_kicking(kick_df, weekly=weekly)

--- a/sportsdataverse/parsed/nfl.py
+++ b/sportsdataverse/parsed/nfl.py
@@ -160,6 +160,7 @@ from sportsdataverse.nfl import calculate_win_probability as calculate_win_proba
 from sportsdataverse.nfl import calculate_wpa as calculate_wpa  # noqa: F401
 from sportsdataverse.nfl import calculate_xpass as calculate_xpass  # noqa: F401
 from sportsdataverse.nfl import calculate_xyac as calculate_xyac  # noqa: F401
+from sportsdataverse.nfl import clean_nfl_pbp as clean_nfl_pbp  # noqa: F401
 from sportsdataverse.nfl import clear_cache as clear_cache  # noqa: F401
 from sportsdataverse.nfl import download as download  # noqa: F401
 from sportsdataverse.nfl import espn_nfl_calendar as espn_nfl_calendar  # noqa: F401
@@ -265,6 +266,7 @@ from sportsdataverse.nfl import scoreboard_event_parsing as scoreboard_event_par
 from sportsdataverse.nfl import scrape_ngs_season as scrape_ngs_season  # noqa: F401
 from sportsdataverse.nfl import scrape_ngs_week as scrape_ngs_week  # noqa: F401
 from sportsdataverse.nfl import season_not_found_error as season_not_found_error  # noqa: F401
+from sportsdataverse.nfl import team_name_fn as team_name_fn  # noqa: F401
 from sportsdataverse.nfl import underscore as underscore  # noqa: F401
 from sportsdataverse.nfl import update_config as update_config  # noqa: F401
 
@@ -284,6 +286,7 @@ __all__ = [
     "calculate_wpa",
     "calculate_xpass",
     "calculate_xyac",
+    "clean_nfl_pbp",
     "clear_cache",
     "download",
     "espn_nfl_award",
@@ -511,6 +514,7 @@ __all__ = [
     "scrape_ngs_season",
     "scrape_ngs_week",
     "season_not_found_error",
+    "team_name_fn",
     "underscore",
     "update_config",
 ]

--- a/sportsdataverse/parsed/nfl.py
+++ b/sportsdataverse/parsed/nfl.py
@@ -148,6 +148,8 @@ from sportsdataverse.nfl import nfl_weeks_by_date as _raw_nfl_weeks_by_date
 from sportsdataverse.nfl import NFLPlayProcess as NFLPlayProcess  # noqa: F401
 from sportsdataverse.nfl import NflConfig as NflConfig  # noqa: F401
 from sportsdataverse.nfl import build_nfl_player_stats as build_nfl_player_stats  # noqa: F401
+from sportsdataverse.nfl import build_nfl_player_stats_def as build_nfl_player_stats_def  # noqa: F401
+from sportsdataverse.nfl import build_nfl_player_stats_kicking as build_nfl_player_stats_kicking  # noqa: F401
 from sportsdataverse.nfl import build_nfl_players as build_nfl_players  # noqa: F401
 from sportsdataverse.nfl import build_nfl_rosters as build_nfl_rosters  # noqa: F401
 from sportsdataverse.nfl import build_nfl_season as build_nfl_season  # noqa: F401
@@ -156,6 +158,8 @@ from sportsdataverse.nfl import cached_loader as cached_loader  # noqa: F401
 from sportsdataverse.nfl import calculate_completion_probability as calculate_completion_probability  # noqa: F401
 from sportsdataverse.nfl import calculate_epa as calculate_epa  # noqa: F401
 from sportsdataverse.nfl import calculate_expected_points as calculate_expected_points  # noqa: F401
+from sportsdataverse.nfl import calculate_nfl_series_conversion_rates as calculate_nfl_series_conversion_rates  # noqa: F401
+from sportsdataverse.nfl import calculate_nfl_standings as calculate_nfl_standings  # noqa: F401
 from sportsdataverse.nfl import calculate_win_probability as calculate_win_probability  # noqa: F401
 from sportsdataverse.nfl import calculate_wpa as calculate_wpa  # noqa: F401
 from sportsdataverse.nfl import calculate_xpass as calculate_xpass  # noqa: F401
@@ -274,6 +278,8 @@ __all__ = [
     "NFLPlayProcess",
     "NflConfig",
     "build_nfl_player_stats",
+    "build_nfl_player_stats_def",
+    "build_nfl_player_stats_kicking",
     "build_nfl_players",
     "build_nfl_rosters",
     "build_nfl_season",
@@ -282,6 +288,8 @@ __all__ = [
     "calculate_completion_probability",
     "calculate_epa",
     "calculate_expected_points",
+    "calculate_nfl_series_conversion_rates",
+    "calculate_nfl_standings",
     "calculate_win_probability",
     "calculate_wpa",
     "calculate_xpass",

--- a/tests/nfl/test_ep_wp_air_yac.py
+++ b/tests/nfl/test_ep_wp_air_yac.py
@@ -1,0 +1,753 @@
+"""Offline tests for the air/YAC EPA-WPA column family + per-game running totals.
+
+Faithful port targets (nflfastR ``R/helper_add_ep_wp.R``):
+
+* ``add_air_yac_ep`` / ``add_air_yac_ep_variables`` -> ``_derive_air_yac_epa``
+* ``add_air_yac_wp`` / ``add_air_yac_wp_variables`` -> ``_derive_air_yac_wpa``
+* ``add_ep_variables`` totals block (L735-801)      -> ``_add_epa_running_totals``
+* ``add_wp_variables`` totals block (L1252-1324)    -> ``_add_wpa_running_totals``
+* ``vegas_home_wpa`` (L1153)                        -> kept by ``_derive_wpa``
+
+Model isolation
+---------------
+``air_epa`` / ``air_wpa`` are model-dependent (an EP / WP re-score on the
+air-yards-projected game state).  The model-free logic (the airEPA 4-branch
+formula, ``yac = epa - air``, ``comp_*`` completion gating, NA->0 home/away
+signing, per-game ``cum_sum`` totals) is tested EXACTLY by monkeypatching the
+two scorer seams:
+
+* ``ep_wp.calculate_expected_points`` -> deterministic ``ep`` from the
+  (mutated) ``yardline_100``, so the expected ``airEP`` is hand-computable and
+  the test doubles as proof the air-yards state substitution reached the
+  scorer.
+* ``ep_wp._score_wp_naive`` -> constant array, so ``air_wpa = airWP - wp`` is
+  hand-computable.
+
+The bundled real models are exercised once in structural (non-numeric) tests.
+
+The nflfastR OT branch of ``add_air_yac_wp_variables`` is dead code upstream
+(``helper_add_ep_wp.R`` line 1907 re-assigns ``pass_overtime_df`` from the
+untouched main-branch frame immediately before writing back), so a faithful
+port applies the main-branch formula to overtime rows too — pinned by
+``test_wpa_overtime_rows_use_main_branch_formula``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import pytest
+
+import sportsdataverse.nfl.ep_wp as ep_wp
+from sportsdataverse.nfl.ep_wp import (
+    _AIR_YAC_EPA_COLS,
+    _AIR_YAC_WPA_COLS,
+    _EPA_RUNNING_TOTAL_COLS,
+    _WPA_RUNNING_TOTAL_COLS,
+    _add_epa_running_totals,
+    _add_wpa_running_totals,
+    _derive_air_yac_epa,
+    _derive_air_yac_wpa,
+    _derive_epa,
+    _derive_wpa,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture builder — one-game, nflverse-shape rows with hand-supplied ep / epa /
+# wp / wpa.  Individual rows override only the fields they exercise.
+# ---------------------------------------------------------------------------
+
+_DEFAULT: dict = {
+    "game_id": "2023_01_AAA_BBB",
+    "season": 2023,
+    "qtr": 1.0,
+    "posteam": "BBB",  # == home_team by default (home perspective)
+    "home_team": "BBB",
+    "away_team": "AAA",
+    "defteam": "AAA",
+    "play_type": "pass",
+    "yardline_100": 50.0,
+    "ydstogo": 10.0,
+    "down": 1.0,
+    "half_seconds_remaining": 1500.0,
+    "game_seconds_remaining": 3300.0,
+    "score_differential": 0.0,
+    "posteam_timeouts_remaining": 3.0,
+    "defteam_timeouts_remaining": 3.0,
+    "roof": "outdoors",
+    "receive_2h_ko": 0.0,
+    "air_yards": None,
+    "complete_pass": 0.0,
+    "penalty": 0.0,
+    "yards_after_catch": None,
+    "two_point_attempt": 0.0,
+    "ep": 0.0,
+    "epa": 0.0,
+    "wp": 0.5,
+    "wpa": 0.0,
+}
+
+
+def _frame(rows: list[dict]) -> pl.DataFrame:
+    full = []
+    for i, r in enumerate(rows):
+        merged = dict(_DEFAULT)
+        merged["play_id"] = i + 1
+        merged.update(r)
+        full.append(merged)
+    return pl.DataFrame(full)
+
+
+def _one_game() -> pl.DataFrame:
+    """8 hand-computed plays: completion, incompletion, TD-in-air, rush,
+    4th-down turnover-in-air, 2pt attempt, zero-YAC completion, marker."""
+    return _frame(
+        [
+            # A: completed pass, yac > 0 — the plain airEP - ep branch.
+            dict(
+                yardline_100=70.0,
+                air_yards=10.0,
+                ydstogo=5.0,
+                down=1.0,
+                ep=1.2,
+                epa=0.8,
+                complete_pass=1.0,
+                yards_after_catch=5.0,
+                wp=0.50,
+                wpa=0.03,
+            ),
+            # B: incompletion — air_epa nonzero, comp_* gated to 0.
+            dict(
+                yardline_100=50.0,
+                air_yards=12.0,
+                ydstogo=8.0,
+                down=2.0,
+                ep=0.5,
+                epa=-0.6,
+                complete_pass=0.0,
+                wp=0.48,
+                wpa=-0.04,
+            ),
+            # C: throw into the endzone (yardline - air <= 0) — 7 - ep branch.
+            dict(
+                yardline_100=10.0,
+                air_yards=12.0,
+                ydstogo=8.0,
+                down=1.0,
+                ep=3.0,
+                epa=-1.4,
+                complete_pass=0.0,
+                wp=0.60,
+                wpa=-0.02,
+            ),
+            # D: rush — air/yac null, contributes 0 to totals.
+            dict(play_type="run", air_yards=None, ep=0.9, epa=0.4, wp=0.50, wpa=0.01),
+            # E: 4th-and-10 thrown 6 yards (Turnover_Ind) by the AWAY team.
+            dict(
+                posteam="AAA",
+                defteam="BBB",
+                yardline_100=40.0,
+                air_yards=6.0,
+                ydstogo=10.0,
+                down=4.0,
+                ep=0.3,
+                epa=-0.9,
+                complete_pass=0.0,
+                wp=0.40,
+                wpa=-0.06,
+            ),
+            # F: two-point attempt — air/yac forced null.
+            dict(
+                two_point_attempt=1.0,
+                down=None,
+                air_yards=2.0,
+                yardline_100=3.0,
+                ep=1.0,
+                epa=-0.5,
+                complete_pass=0.0,
+                wp=0.52,
+                wpa=-0.01,
+            ),
+            # G: zero-YAC completion — yac := 0, air := epa (EPA) / wpa (WPA).
+            dict(
+                yardline_100=30.0,
+                air_yards=8.0,
+                ydstogo=10.0,
+                down=2.0,
+                ep=2.0,
+                epa=1.1,
+                complete_pass=1.0,
+                yards_after_catch=0.0,
+                wp=0.55,
+                wpa=0.02,
+            ),
+            # H: marker row — everything null; comp_* stays null (R NA if_else).
+            dict(
+                play_type="no_play",
+                air_yards=None,
+                ep=None,
+                epa=None,
+                wp=None,
+                wpa=None,
+                complete_pass=None,
+                penalty=None,
+            ),
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scorer stubs (module-attr seams; the derivations resolve them off ep_wp)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def stub_air_scorers(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_cep(df: pl.DataFrame, *, return_as_pandas: bool = False) -> pl.DataFrame:
+        # Deterministic EP from the (air-yards-substituted) yardline so the
+        # expected airEP is hand-computable: airEP = (50 - yardline_100) / 10.
+        return df.with_columns(((50.0 - pl.col("yardline_100").cast(pl.Float64)) / 10.0).alias("ep"))
+
+    def fake_wp_naive(df: pl.DataFrame) -> np.ndarray:
+        return np.full(df.height, 0.55, dtype=np.float64)
+
+    monkeypatch.setattr(ep_wp, "calculate_expected_points", fake_cep)
+    monkeypatch.setattr(ep_wp, "_score_wp_naive", fake_wp_naive)
+
+
+# ---------------------------------------------------------------------------
+# air / yac EPA — per-play formulas
+# ---------------------------------------------------------------------------
+
+
+def _col(out: pl.DataFrame, col: str, play_id: int):
+    return out.filter(pl.col("play_id") == play_id)[col][0]
+
+
+def test_air_epa_plain_branch_and_yac_identity(stub_air_scorers: None) -> None:
+    """A: mutated yardline = 70-10 = 60 -> airEP = -1.0 -> air = -2.2, yac = epa - air."""
+    out = _derive_air_yac_epa(_one_game())
+    assert _col(out, "air_epa", 1) == pytest.approx(-2.2)
+    assert _col(out, "yac_epa", 1) == pytest.approx(0.8 - (-2.2))
+    # identity: yac_epa == epa - air_epa on the completion
+    assert _col(out, "yac_epa", 1) == pytest.approx(_col(out, "epa", 1) - _col(out, "air_epa", 1))
+
+
+def test_air_epa_nonzero_on_incompletion_comp_gated_to_zero(stub_air_scorers: None) -> None:
+    """B: air_epa = (50-38)/10 - 0.5 = 0.7 on the incompletion; comp_* == 0."""
+    out = _derive_air_yac_epa(_one_game())
+    assert _col(out, "air_epa", 2) == pytest.approx(0.7)
+    assert _col(out, "yac_epa", 2) == pytest.approx(-0.6 - 0.7)
+    assert _col(out, "comp_air_epa", 2) == 0.0
+    assert _col(out, "comp_yac_epa", 2) == 0.0
+
+
+def test_air_epa_td_in_air_is_seven_minus_ep(stub_air_scorers: None) -> None:
+    """C: yardline - air <= 0 -> air_epa = 7 - ep (model-independent)."""
+    out = _derive_air_yac_epa(_one_game())
+    assert _col(out, "air_epa", 3) == pytest.approx(7.0 - 3.0)
+    assert _col(out, "yac_epa", 3) == pytest.approx(-1.4 - 4.0)
+
+
+def test_air_epa_turnover_ind_flips_air_ep(stub_air_scorers: None) -> None:
+    """E: 4th-and-10, 6-yard throw -> flip state; airEP = (50-66)/10 = -1.6;
+    air_epa = -(-1.6) - 0.3 = 1.3."""
+    out = _derive_air_yac_epa(_one_game())
+    assert _col(out, "air_epa", 5) == pytest.approx(1.3)
+    assert _col(out, "yac_epa", 5) == pytest.approx(-0.9 - 1.3)
+
+
+def test_air_epa_two_point_attempt_is_null(stub_air_scorers: None) -> None:
+    out = _derive_air_yac_epa(_one_game())
+    assert _col(out, "air_epa", 6) is None
+    assert _col(out, "yac_epa", 6) is None
+    # complete_pass == 0 -> comp_* gate to 0, not null (R if_else false branch)
+    assert _col(out, "comp_air_epa", 6) == 0.0
+
+
+def test_air_epa_zero_yac_completion_overrides(stub_air_scorers: None) -> None:
+    """G: penalty==0 & yac==0 & complete==1 -> yac_epa = 0, air_epa = epa."""
+    out = _derive_air_yac_epa(_one_game())
+    assert _col(out, "air_epa", 7) == pytest.approx(1.1)
+    assert _col(out, "yac_epa", 7) == 0.0
+
+
+def test_air_epa_null_on_rush_and_marker_rows(stub_air_scorers: None) -> None:
+    out = _derive_air_yac_epa(_one_game())
+    assert _col(out, "air_epa", 4) is None  # rush
+    assert _col(out, "air_epa", 8) is None  # marker
+    # marker row: complete_pass null -> comp_* null (dplyr::if_else NA cond)
+    assert _col(out, "comp_air_epa", 8) is None
+    assert _col(out, "comp_yac_epa", 8) is None
+
+
+def test_air_epa_totals_cumulative_hand_values(stub_air_scorers: None) -> None:
+    out = _derive_air_yac_epa(_one_game()).sort("play_id")
+    # home-signed comp_air per play: [-2.2, 0, 0, 0, 0, 0, 1.1, 0 (null->0)]
+    assert out["total_home_comp_air_epa"].to_list() == pytest.approx([-2.2, -2.2, -2.2, -2.2, -2.2, -2.2, -1.1, -1.1])
+    assert out["total_away_comp_air_epa"][-1] == pytest.approx(1.1)
+    # raw (ungated), home-signed: [-2.2, 0.7, 4.0, 0, -1.3 (away play), 0, 1.1, 0]
+    assert out["total_home_raw_air_epa"][-1] == pytest.approx(2.3)
+    # raw yac home-signed: [3.0, -1.3, -5.4, 0, +2.2, 0, 0, 0]
+    assert out["total_home_raw_yac_epa"][-1] == pytest.approx(-1.5)
+
+
+def test_air_epa_all_columns_float64(stub_air_scorers: None) -> None:
+    out = _derive_air_yac_epa(_one_game())
+    for c in _AIR_YAC_EPA_COLS:
+        assert out.schema[c] == pl.Float64, f"{c} is {out.schema[c]}, want Float64"
+
+
+def test_air_epa_short_circuit_all_null_air_yards(stub_air_scorers: None) -> None:
+    """R add_air_yac_ep: no non-NA air_yards -> every column NA (Float64)."""
+    df = _frame([dict(play_type="run"), dict(play_type="run")])
+    out = _derive_air_yac_epa(df)
+    for c in _AIR_YAC_EPA_COLS:
+        assert out.schema[c] == pl.Float64
+        assert out[c].null_count() == out.height, f"{c} should be all null"
+
+
+def test_air_epa_missing_inputs_null_emit(stub_air_scorers: None) -> None:
+    """Frames lacking a required §5 input get schema-stable all-null columns."""
+    out = _derive_air_yac_epa(_one_game().drop("yards_after_catch"))
+    for c in _AIR_YAC_EPA_COLS:
+        assert out.schema[c] == pl.Float64
+        assert out[c].null_count() == out.height
+
+
+def test_air_epa_totals_reset_at_game_boundary(stub_air_scorers: None) -> None:
+    """Two-game concat: cumulative totals must restart per game (leak test)."""
+    g1 = _frame(
+        [
+            dict(
+                yardline_100=50.0,
+                air_yards=5.0,
+                ydstogo=10.0,
+                ep=1.0,
+                epa=0.5,
+                complete_pass=1.0,
+                yards_after_catch=3.0,
+            ),
+            dict(play_type="run"),
+        ]
+    )
+    g2 = g1.with_columns(pl.lit("2023_02_CCC_BBB").alias("game_id"))
+    out = _derive_air_yac_epa(pl.concat([g1, g2], how="vertical"))
+    # mutated yardline = 45 -> airEP = 0.5 -> air_epa = 0.5 - 1.0 = -0.5
+    per_game = out.group_by("game_id", maintain_order=True).agg(
+        pl.col("total_home_raw_air_epa").first().alias("first_total"),
+        pl.col("total_home_raw_air_epa").last().alias("last_total"),
+    )
+    firsts = per_game["first_total"].to_list()
+    assert firsts[0] == pytest.approx(-0.5)
+    # second game restarts at its OWN first value — not the accumulated -1.0
+    assert firsts[1] == pytest.approx(-0.5)
+
+
+# ---------------------------------------------------------------------------
+# air / yac WPA — per-play formulas (constant 0.55 airWP stub)
+# ---------------------------------------------------------------------------
+
+
+def test_air_wpa_plain_branch_and_yac_identity(stub_air_scorers: None) -> None:
+    out = _derive_air_yac_wpa(_one_game())
+    assert _col(out, "air_wpa", 1) == pytest.approx(0.55 - 0.50)
+    assert _col(out, "yac_wpa", 1) == pytest.approx(0.03 - 0.05)
+    assert _col(out, "comp_air_wpa", 1) == pytest.approx(0.05)
+
+
+def test_air_wpa_incompletion_comp_gated_to_zero(stub_air_scorers: None) -> None:
+    out = _derive_air_yac_wpa(_one_game())
+    assert _col(out, "air_wpa", 2) == pytest.approx(0.55 - 0.48)
+    assert _col(out, "comp_air_wpa", 2) == 0.0
+    assert _col(out, "comp_yac_wpa", 2) == 0.0
+
+
+def test_air_wpa_turnover_ind_uses_one_minus_air_wp(stub_air_scorers: None) -> None:
+    """E: Turnover_Ind -> airWP = 1 - 0.55 = 0.45; air_wpa = 0.45 - 0.40."""
+    out = _derive_air_yac_wpa(_one_game())
+    assert _col(out, "air_wpa", 5) == pytest.approx(0.45 - 0.40)
+    assert _col(out, "yac_wpa", 5) == pytest.approx(-0.06 - 0.05)
+
+
+def test_air_wpa_two_point_attempt_is_null(stub_air_scorers: None) -> None:
+    out = _derive_air_yac_wpa(_one_game())
+    assert _col(out, "air_wpa", 6) is None
+    assert _col(out, "yac_wpa", 6) is None
+
+
+def test_air_wpa_zero_yac_completion_overrides(stub_air_scorers: None) -> None:
+    """G: yac==0 completion -> yac_wpa = 0, air_wpa = wpa."""
+    out = _derive_air_yac_wpa(_one_game())
+    assert _col(out, "air_wpa", 7) == pytest.approx(0.02)
+    assert _col(out, "yac_wpa", 7) == 0.0
+
+
+def test_air_wpa_clock_expiry_zeroes_air_wp(stub_air_scorers: None) -> None:
+    """half_seconds - 5.704673 <= 0 -> airWP = 0 -> air_wpa = -wp."""
+    df = _frame(
+        [
+            dict(
+                yardline_100=50.0,
+                air_yards=10.0,
+                half_seconds_remaining=4.0,
+                ep=1.0,
+                epa=0.5,
+                complete_pass=1.0,
+                yards_after_catch=2.0,
+                wp=0.5,
+                wpa=0.1,
+            ),
+        ]
+    )
+    out = _derive_air_yac_wpa(df)
+    assert out["air_wpa"][0] == pytest.approx(-0.5)
+
+
+def test_wpa_overtime_rows_use_main_branch_formula(stub_air_scorers: None) -> None:
+    """nflfastR's OT air-WP branch is dead code (L1907 re-assignment overwrites
+    it), so a qtr==5 pass must get the plain main-branch air_wpa."""
+    df = _frame(
+        [
+            dict(
+                qtr=5.0,
+                yardline_100=50.0,
+                air_yards=10.0,
+                ydstogo=8.0,
+                down=1.0,
+                ep=1.0,
+                epa=0.5,
+                complete_pass=1.0,
+                yards_after_catch=2.0,
+                wp=0.5,
+                wpa=0.1,
+            ),
+        ]
+    )
+    out = _derive_air_yac_wpa(df)
+    assert out["air_wpa"][0] == pytest.approx(0.55 - 0.5)
+
+
+def test_air_wpa_all_columns_float64_and_totals_reset(stub_air_scorers: None) -> None:
+    g1 = _frame(
+        [
+            dict(
+                yardline_100=50.0,
+                air_yards=5.0,
+                ydstogo=10.0,
+                ep=1.0,
+                epa=0.5,
+                complete_pass=1.0,
+                yards_after_catch=3.0,
+                wp=0.5,
+                wpa=0.1,
+            ),
+            dict(play_type="run"),
+        ]
+    )
+    g2 = g1.with_columns(pl.lit("2023_02_CCC_BBB").alias("game_id"))
+    out = _derive_air_yac_wpa(pl.concat([g1, g2], how="vertical"))
+    for c in _AIR_YAC_WPA_COLS:
+        assert out.schema[c] == pl.Float64, f"{c} is {out.schema[c]}, want Float64"
+    per_game = out.group_by("game_id", maintain_order=True).agg(
+        pl.col("total_home_raw_air_wpa").first().alias("first_total"),
+    )
+    # air_wpa = 0.55 - 0.5 = 0.05 in both games; game 2 must restart at 0.05.
+    assert per_game["first_total"].to_list() == pytest.approx([0.05, 0.05])
+
+
+def test_air_wpa_short_circuit_all_null_air_yards(stub_air_scorers: None) -> None:
+    df = _frame([dict(play_type="run"), dict(play_type="run")])
+    out = _derive_air_yac_wpa(df)
+    for c in _AIR_YAC_WPA_COLS:
+        assert out.schema[c] == pl.Float64
+        assert out[c].null_count() == out.height
+
+
+# ---------------------------------------------------------------------------
+# Running totals — add_ep_variables / add_wp_variables blocks
+# ---------------------------------------------------------------------------
+
+
+def _totals_frame() -> pl.DataFrame:
+    rows = [
+        # g1: home run, away pass, null-epa marker, null play_type
+        dict(game_id="g1", posteam="BBB", play_type="run", epa=1.0, wpa=0.10),
+        dict(game_id="g1", posteam="AAA", play_type="pass", epa=-0.5, wpa=-0.05),
+        dict(game_id="g1", posteam=None, play_type=None, epa=None, wpa=None),
+        dict(game_id="g1", posteam="BBB", play_type=None, epa=2.0, wpa=0.20),
+        # g2: totals must restart
+        dict(game_id="g2", posteam="BBB", play_type="run", epa=1.0, wpa=0.10),
+    ]
+    return pl.DataFrame(rows).with_columns(
+        pl.lit("BBB").alias("home_team"),
+        pl.lit("AAA").alias("away_team"),
+    )
+
+
+def test_epa_running_totals_hand_values() -> None:
+    out = _add_epa_running_totals(_totals_frame())
+    g1 = out.filter(pl.col("game_id") == "g1")
+    # home-signed epa: [1.0, +0.5, 0 (null), 2.0]
+    assert g1["total_home_epa"].to_list() == pytest.approx([1.0, 1.5, 1.5, 3.5])
+    assert g1["total_away_epa"].to_list() == pytest.approx([-1.0, -1.5, -1.5, -3.5])
+    # rush/pass gates: null play_type contributes 0 (R NA -> 0)
+    assert g1["total_home_rush_epa"].to_list() == pytest.approx([1.0, 1.0, 1.0, 1.0])
+    assert g1["total_home_pass_epa"].to_list() == pytest.approx([0.0, 0.5, 0.5, 0.5])
+    assert g1["total_away_pass_epa"].to_list() == pytest.approx([0.0, -0.5, -0.5, -0.5])
+    # reset at game boundary
+    g2 = out.filter(pl.col("game_id") == "g2")
+    assert g2["total_home_epa"].to_list() == pytest.approx([1.0])
+    for c in _EPA_RUNNING_TOTAL_COLS:
+        assert out.schema[c] == pl.Float64
+
+
+def test_wpa_running_totals_hand_values() -> None:
+    out = _add_wpa_running_totals(_totals_frame())
+    g1 = out.filter(pl.col("game_id") == "g1")
+    # nflfastR emits only the rush/pass WPA totals (no total_home_wpa)
+    assert "total_home_wpa" not in out.columns
+    assert g1["total_home_rush_wpa"].to_list() == pytest.approx([0.1, 0.1, 0.1, 0.1])
+    assert g1["total_home_pass_wpa"].to_list() == pytest.approx([0.0, 0.05, 0.05, 0.05])
+    assert g1["total_away_pass_wpa"].to_list() == pytest.approx([0.0, -0.05, -0.05, -0.05])
+    g2 = out.filter(pl.col("game_id") == "g2")
+    assert g2["total_home_rush_wpa"].to_list() == pytest.approx([0.1])
+    for c in _WPA_RUNNING_TOTAL_COLS:
+        assert out.schema[c] == pl.Float64
+
+
+def test_derive_epa_emits_running_totals() -> None:
+    """The shared totals helper is wired into the nflverse ``_derive_epa``."""
+    df = pl.DataFrame(
+        [
+            dict(
+                game_id="g1",
+                play_id=1,
+                season=2023,
+                qtr=1.0,
+                sp=0.0,
+                down=1.0,
+                play_type="run",
+                posteam="BBB",
+                home_team="BBB",
+                away_team="AAA",
+                home_score=20,
+                away_score=17,
+                desc="(15:00) run",
+                ep=1.0,
+                td_team=None,
+                field_goal_result=None,
+                extra_point_result=None,
+                two_point_conv_result=None,
+                safety=0,
+                kickoff_attempt=0,
+                extra_point_attempt=0,
+                two_point_attempt=0,
+            ),
+            dict(
+                game_id="g1",
+                play_id=2,
+                season=2023,
+                qtr=1.0,
+                sp=0.0,
+                down=2.0,
+                play_type="pass",
+                posteam="BBB",
+                home_team="BBB",
+                away_team="AAA",
+                home_score=20,
+                away_score=17,
+                desc="(14:20) pass",
+                ep=2.0,
+                td_team=None,
+                field_goal_result=None,
+                extra_point_result=None,
+                two_point_conv_result=None,
+                safety=0,
+                kickoff_attempt=0,
+                extra_point_attempt=0,
+                two_point_attempt=0,
+            ),
+        ]
+    )
+    out = _derive_epa(df).sort("play_id")
+    for c in _EPA_RUNNING_TOTAL_COLS:
+        assert c in out.columns
+        assert out.schema[c] == pl.Float64
+    # play1 epa = lead(home_ep) - home_ep = 2.0 - 1.0 = 1.0 (run by home)
+    assert out["total_home_rush_epa"].to_list() == pytest.approx([1.0, 1.0])
+
+
+def test_derive_wpa_emits_vegas_home_wpa_and_totals() -> None:
+    df = pl.DataFrame(
+        [
+            dict(
+                game_id="g1",
+                play_id=1,
+                season=2023,
+                qtr=1.0,
+                sp=0.0,
+                down=1.0,
+                play_type="run",
+                posteam="BBB",
+                home_team="BBB",
+                away_team="AAA",
+                home_score=20,
+                away_score=17,
+                desc="(15:00) run",
+                wp=0.5,
+                vegas_wp=0.5,
+            ),
+            dict(
+                game_id="g1",
+                play_id=2,
+                season=2023,
+                qtr=1.0,
+                sp=0.0,
+                down=2.0,
+                play_type="pass",
+                posteam="BBB",
+                home_team="BBB",
+                away_team="AAA",
+                home_score=20,
+                away_score=17,
+                desc="(14:20) pass",
+                wp=0.6,
+                vegas_wp=0.62,
+            ),
+        ]
+    )
+    out = _derive_wpa(df).sort("play_id")
+    assert "vegas_home_wpa" in out.columns
+    assert out.schema["vegas_home_wpa"] == pl.Float64
+    # posteam == home both plays: vegas_home_wpa play1 = 0.62 - 0.5 = 0.12
+    assert out["vegas_home_wpa"][0] == pytest.approx(0.12)
+    for c in _WPA_RUNNING_TOTAL_COLS:
+        assert c in out.columns
+        assert out.schema[c] == pl.Float64
+    # play1 wpa = lead(home_wp) - home_wp = 0.1 (run by home)
+    assert out["total_home_rush_wpa"].to_list() == pytest.approx([0.1, 0.1])
+
+
+# ---------------------------------------------------------------------------
+# Real bundled models — structural assertions only (no hardcoded outputs)
+# ---------------------------------------------------------------------------
+
+
+def _realistic_game() -> pl.DataFrame:
+    return _frame(
+        [
+            # completion with YAC (plain branch)
+            dict(
+                yardline_100=65.0,
+                air_yards=8.0,
+                ydstogo=10.0,
+                down=1.0,
+                ep=1.0,
+                epa=0.5,
+                complete_pass=1.0,
+                yards_after_catch=4.0,
+                wp=0.55,
+                wpa=0.02,
+            ),
+            # incompletion — air_epa must still be populated
+            dict(
+                yardline_100=45.0,
+                air_yards=12.0,
+                ydstogo=7.0,
+                down=2.0,
+                ep=1.8,
+                epa=-0.7,
+                complete_pass=0.0,
+                wp=0.52,
+                wpa=-0.03,
+            ),
+            # rush — stays null
+            dict(play_type="run", ep=0.9, epa=0.1, wp=0.5, wpa=0.01),
+            # TD at the catch spot — model-independent 7 - ep relationship
+            dict(
+                yardline_100=5.0,
+                air_yards=7.0,
+                ydstogo=5.0,
+                down=1.0,
+                ep=4.2,
+                epa=-2.0,
+                complete_pass=0.0,
+                wp=0.7,
+                wpa=-0.05,
+            ),
+        ]
+    )
+
+
+def test_air_epa_real_model_structural() -> None:
+    out = _derive_air_yac_epa(_realistic_game()).sort("play_id")
+    air = out["air_epa"].to_list()
+    # non-null on qualifying rows (incl. the incompletion), null on the rush
+    assert air[0] is not None and air[1] is not None and air[3] is not None
+    assert air[2] is None
+    # sane bounds: ep in [-10, 10], airEP in [-7, 7] -> |air_epa| <= 17
+    for v in (air[0], air[1], air[3]):
+        assert abs(v) <= 17.0
+    # yac identity on the completion (no zero-yac override fired)
+    assert out["yac_epa"][0] == pytest.approx(0.5 - air[0])
+    # TD-at-catch-spot special case: exactly 7 - ep
+    assert air[3] == pytest.approx(7.0 - 4.2)
+    assert out.schema["air_epa"] == pl.Float64
+
+
+def test_air_wpa_real_model_structural() -> None:
+    out = _derive_air_yac_wpa(_realistic_game()).sort("play_id")
+    air = out["air_wpa"].to_list()
+    assert air[0] is not None and air[1] is not None
+    assert air[2] is None
+    # airWP and wp are both probabilities -> air_wpa strictly inside (-1, 1)
+    for v in (air[0], air[1]):
+        assert -1.0 < v < 1.0
+    assert out["yac_wpa"][0] == pytest.approx(0.02 - air[0])
+    assert out.schema["air_wpa"] == pl.Float64
+
+
+# ---------------------------------------------------------------------------
+# enrich_nfl_pbp wiring — the family runs inside the nflverse orchestrator
+# ---------------------------------------------------------------------------
+
+
+def test_enrich_wires_air_yac_family(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tests.nfl.test_enrich import (
+        _stub_cp,
+        _stub_ep_factory,
+        _stub_wp,
+        _stub_xyac,
+        _synthetic_frame,
+    )
+
+    monkeypatch.setattr(ep_wp, "calculate_expected_points", _stub_ep_factory({}))
+    monkeypatch.setattr(ep_wp, "calculate_win_probability", _stub_wp)
+    monkeypatch.setattr(ep_wp, "calculate_completion_probability", _stub_cp)
+    monkeypatch.setattr(ep_wp, "calculate_xyac", _stub_xyac)
+    monkeypatch.setattr(ep_wp, "_score_wp_naive", lambda df: np.full(df.height, 0.55, dtype=np.float64))
+
+    # complete the §5 input surface the synthetic frame doesn't carry
+    df = _synthetic_frame().with_columns(
+        pl.lit(0.0).alias("penalty"),
+        pl.lit(None, dtype=pl.Float64).alias("yards_after_catch"),
+    )
+    out = ep_wp.enrich_nfl_pbp(df, add_fourth_down=False)
+    assert isinstance(out, pl.DataFrame)
+
+    for c in (
+        *_AIR_YAC_EPA_COLS,
+        *_AIR_YAC_WPA_COLS,
+        *_EPA_RUNNING_TOTAL_COLS,
+        *_WPA_RUNNING_TOTAL_COLS,
+        "vegas_home_wpa",
+    ):
+        assert c in out.columns, f"enrich output missing {c}"
+        assert out.schema[c] == pl.Float64, f"{c} is {out.schema[c]}, want Float64"
+
+    # the qualifying pass (air_yards == 8.0) got a real air_epa / air_wpa
+    qualifying = out.filter(pl.col("air_yards").is_not_null() & (pl.col("play_type") == "pass"))
+    assert qualifying.height > 0
+    assert qualifying["air_epa"].null_count() < qualifying.height
+    assert qualifying["air_wpa"].null_count() < qualifying.height

--- a/tests/nfl/test_ep_wp_air_yac.py
+++ b/tests/nfl/test_ep_wp_air_yac.py
@@ -465,6 +465,128 @@ def test_air_wpa_short_circuit_all_null_air_yards(stub_air_scorers: None) -> Non
 
 
 # ---------------------------------------------------------------------------
+# dplyr / base-R NA-propagation fidelity (the _r_ifelse sites)
+# ---------------------------------------------------------------------------
+
+
+def test_air_epa_null_yardline_yields_null(stub_air_scorers: None) -> None:
+    """R's nested ifelse propagates NA: null yardline_100 -> null airEPA."""
+    df = _frame(
+        [
+            dict(yardline_100=None, air_yards=5.0, ydstogo=10.0, down=1.0, ep=1.0, epa=0.5, complete_pass=0.0),
+            dict(yardline_100=50.0, air_yards=5.0, ydstogo=10.0, down=1.0, ep=1.0, epa=0.5, complete_pass=0.0),
+        ]
+    )
+    out = _derive_air_yac_epa(df)
+    assert _col(out, "air_epa", 1) is None
+    assert _col(out, "yac_epa", 1) is None
+    # the well-formed sibling row still scores
+    assert _col(out, "air_epa", 2) is not None
+
+
+def test_null_two_point_flag_yields_null(stub_air_scorers: None) -> None:
+    """R: ifelse(two_point_attempt == 1, NA, x) — a null flag yields NA."""
+    df = _frame(
+        [
+            dict(
+                two_point_attempt=None,
+                yardline_100=50.0,
+                air_yards=5.0,
+                ydstogo=10.0,
+                down=1.0,
+                ep=1.0,
+                epa=0.5,
+                complete_pass=1.0,
+                yards_after_catch=5.0,
+                wp=0.5,
+                wpa=0.05,
+            ),
+        ]
+    )
+    out_epa = _derive_air_yac_epa(df)
+    assert out_epa["air_epa"][0] is None
+    assert out_epa["yac_epa"][0] is None
+    out_wpa = _derive_air_yac_wpa(df)
+    assert out_wpa["air_wpa"][0] is None
+    assert out_wpa["yac_wpa"][0] is None
+
+
+def test_zero_yac_null_condition_yields_null(stub_air_scorers: None) -> None:
+    """R base ifelse on the zero-YAC override: null yards_after_catch on a
+    completion (penalty == 0 & complete == 1 & yac NA -> NA cond) NAs both."""
+    df = _frame(
+        [
+            dict(
+                yardline_100=50.0,
+                air_yards=5.0,
+                ydstogo=10.0,
+                down=1.0,
+                ep=1.0,
+                epa=0.5,
+                complete_pass=1.0,
+                yards_after_catch=None,
+                penalty=0.0,
+                wp=0.5,
+                wpa=0.05,
+            ),
+        ]
+    )
+    out_epa = _derive_air_yac_epa(df)
+    assert out_epa["air_epa"][0] is None
+    assert out_epa["yac_epa"][0] is None
+    out_wpa = _derive_air_yac_wpa(df)
+    assert out_wpa["air_wpa"][0] is None
+    assert out_wpa["yac_wpa"][0] is None
+
+
+def test_receive_2h_ko_derived_on_full_frame(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The receive_2h_ko fallback must read the game's TRUE opening defense.
+
+    Possession changes before the game's first qualifying pass: play 1 is a
+    rush by AAA (so the opening defense — the 2H-kickoff receiver — is BBB);
+    the first pass is thrown by BBB.  Deriving the flag on the pass subset
+    would see first defteam == AAA and emit 0.0 game-wide; the full-frame
+    derivation must emit 1.0 for BBB's first-half pass.
+    """
+
+    def fake_cep(df: pl.DataFrame, *, return_as_pandas: bool = False) -> pl.DataFrame:
+        return df.with_columns(((50.0 - pl.col("yardline_100").cast(pl.Float64)) / 10.0).alias("ep"))
+
+    captured: dict = {}
+
+    def fake_wp_naive(feat: pl.DataFrame) -> np.ndarray:
+        captured["r2k"] = feat["receive_2h_ko"].to_list()
+        return np.full(feat.height, 0.55, dtype=np.float64)
+
+    monkeypatch.setattr(ep_wp, "calculate_expected_points", fake_cep)
+    monkeypatch.setattr(ep_wp, "_score_wp_naive", fake_wp_naive)
+
+    df = _frame(
+        [
+            dict(play_type="run", posteam="AAA", defteam="BBB", ep=1.0, epa=0.2),
+            dict(
+                posteam="BBB",
+                defteam="AAA",
+                yardline_100=60.0,
+                air_yards=8.0,
+                ydstogo=10.0,
+                down=1.0,
+                ep=1.0,
+                epa=0.4,
+                complete_pass=1.0,
+                yards_after_catch=3.0,
+                wp=0.5,
+                wpa=0.05,
+            ),
+        ]
+    ).drop("receive_2h_ko")
+    out = _derive_air_yac_wpa(df)
+    assert captured["r2k"] == [1.0]
+    # the temp derivation column must not leak into the output
+    assert "_ay_r2k" not in out.columns
+
+
+# ---------------------------------------------------------------------------
 # Running totals — add_ep_variables / add_wp_variables blocks
 # ---------------------------------------------------------------------------
 

--- a/tests/nfl/test_nfl_clean.py
+++ b/tests/nfl/test_nfl_clean.py
@@ -1,0 +1,371 @@
+"""Tests for the nflfastR ``clean_pbp`` port (:mod:`sportsdataverse.nfl.nfl_clean`)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import polars as pl
+
+from sportsdataverse.nfl.nfl_clean import _ADDED_SCHEMA, TEAM_COLUMNS, clean_nfl_pbp, team_name_fn
+
+
+def _row(**overrides: Any) -> Dict[str, Any]:
+    """One minimal nflverse-shape pbp row, with sensible pass-play defaults."""
+    row: Dict[str, Any] = {
+        "game_id": "2023_01_JAX_IND",
+        "play_id": 100,
+        "season": 2023,
+        "desc": "(15:00) 6-G.Minshew pass incomplete short right to 15-D.Parker",
+        "epa": 0.5,
+        "posteam": "JAX",
+        "defteam": "IND",
+        "home_team": "JAX",
+        "away_team": "IND",
+        "qb_scramble": 0,
+        "qb_kneel": 0,
+        "kickoff_attempt": 0,
+        "first_down_rush": 0,
+        "first_down_pass": 0,
+        "first_down_penalty": 0,
+        "play_type": "pass",
+        "passer_player_name": None,
+        "passer_player_id": None,
+        "rusher_player_name": None,
+        "rusher_player_id": None,
+        "receiver_player_name": None,
+        "receiver_player_id": None,
+        "fumbled_1_player_name": None,
+        "fumbled_1_player_id": None,
+    }
+    row.update(overrides)
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Name cleaning -- suffix-case hardcoded fix table
+# ---------------------------------------------------------------------------
+
+
+def test_passer_name_fix_minshew_suffix() -> None:
+    """ "G.Minshew" extracted from desc is patched to "G.Minshew II" (verbatim
+    §6 hardcoded fix table -- not something the extraction regex itself
+    produces). A resolvable ``passer_player_id`` is required: the second
+    custom_mode pass re-derives the name FROM the id and nulls it out when
+    the id is unresolved (verbatim R semantics -- see
+    ``test_name_without_resolvable_id_is_nulled``)."""
+    df = pl.DataFrame([_row(passer_player_id="00-0035228")])
+    out = clean_nfl_pbp(df)
+    assert out["passer"][0] == "G.Minshew II"
+
+
+def test_rusher_name_fix_griffin_suffix() -> None:
+    """ "R.Griffin" -> "R.Griffin III" on the rusher side of the same table."""
+    df = pl.DataFrame(
+        [
+            _row(
+                desc="(15:00) 10-R.Griffin left tackle for 4 yards",
+                play_type="run",
+                passer_player_id=None,
+                rusher_player_id="00-0029263",
+            )
+        ]
+    )
+    out = clean_nfl_pbp(df)
+    assert out["rusher"][0] == "R.Griffin III"
+    assert out["passer"][0] is None
+
+
+def test_name_without_resolvable_id_is_nulled() -> None:
+    """Verbatim (if surprising) R semantics: if a name is extracted from
+    ``desc`` but no non-null player id exists in its ``(name, posteam,
+    season)`` group, the second custom_mode pass explicitly nulls the name
+    back out (``passer = if_else(is.na(passer_id), NA, custom_mode(passer))``
+    in the R source)."""
+    df = pl.DataFrame([_row()])  # no passer_player_id supplied
+    out = clean_nfl_pbp(df)
+    assert out["passer_id"][0] is None
+    assert out["passer"][0] is None
+
+
+def test_receiver_name_fix_no_op_id_guarded() -> None:
+    """The D.Wells / D.Hayes receiver fixups only fire when both the raw name
+    AND raw id match -- verbatim guard, not a plain name check."""
+    df = pl.DataFrame(
+        [
+            _row(
+                desc="(15:00) 6-G.Minshew pass short right to 88-D.Wells for 9 yards",
+                receiver_player_name="D.Wells",
+                receiver_player_id="00-0017421",
+            )
+        ]
+    )
+    out = clean_nfl_pbp(df)
+    assert out["receiver"][0] == "D.Wells"
+
+
+# ---------------------------------------------------------------------------
+# name / id fallback (passer-else-rusher)
+# ---------------------------------------------------------------------------
+
+
+def test_name_id_fallback_pass_row_uses_passer() -> None:
+    df = pl.DataFrame(
+        [
+            _row(
+                desc="(15:00) 6-T.Brady pass short right to 15-D.Parker for 9 yards",
+                passer_player_name="T.Brady",
+                passer_player_id="00-0019596",
+            )
+        ]
+    )
+    out = clean_nfl_pbp(df)
+    assert out["name"][0] == out["passer"][0] == "T.Brady"
+    assert out["id"][0] == out["passer_id"][0] == "00-0019596"
+
+
+def test_name_id_fallback_rush_row_uses_rusher() -> None:
+    df = pl.DataFrame(
+        [
+            _row(
+                desc="(15:00) 22-D.Henry left tackle for 5 yards",
+                play_type="run",
+                rusher_player_name="D.Henry",
+                rusher_player_id="00-0033118",
+            )
+        ]
+    )
+    out = clean_nfl_pbp(df)
+    assert out["passer"][0] is None
+    assert out["name"][0] == out["rusher"][0] == "D.Henry"
+    assert out["id"][0] == out["rusher_id"][0] == "00-0033118"
+
+
+# ---------------------------------------------------------------------------
+# fantasy fallback (rusher else receiver, else passer on a scramble)
+# ---------------------------------------------------------------------------
+
+
+def test_fantasy_fallback_receiver_on_reception() -> None:
+    df = pl.DataFrame(
+        [
+            _row(
+                desc="(15:00) 6-T.Brady pass short right to 15-D.Parker for 9 yards",
+                passer_player_name="T.Brady",
+                passer_player_id="00-0019596",
+                receiver_player_name="D.Parker",
+                receiver_player_id="00-0034348",
+            )
+        ]
+    )
+    out = clean_nfl_pbp(df)
+    assert out["fantasy"][0] == "D.Parker"
+    assert out["fantasy_id"][0] == "00-0034348"
+    assert out["fantasy_player_name"][0] == "D.Parker"
+    assert out["fantasy_player_id"][0] == "00-0034348"
+
+
+def test_fantasy_fallback_rusher_beats_receiver() -> None:
+    df = pl.DataFrame(
+        [
+            _row(
+                desc="(15:00) 22-D.Henry left tackle for 5 yards",
+                play_type="run",
+                rusher_player_name="D.Henry",
+                rusher_player_id="00-0033118",
+                receiver_player_name="D.Parker",
+                receiver_player_id="00-0034348",
+            )
+        ]
+    )
+    out = clean_nfl_pbp(df)
+    assert out["fantasy"][0] == "D.Henry"
+    assert out["fantasy_id"][0] == "00-0033118"
+    # fantasy_player_name/_id mirror the raw rusher/receiver fallback too.
+    assert out["fantasy_player_name"][0] == "D.Henry"
+
+
+def test_fantasy_fallback_scramble_passer() -> None:
+    """No rusher, no receiver, but a QB scramble -> fantasy falls back to the
+    (cleaned) passer."""
+    df = pl.DataFrame(
+        [
+            _row(
+                desc="(15:00) 6-T.Brady scramble up the middle for 4 yards",
+                qb_scramble=1,
+                passer_player_name="T.Brady",
+                passer_player_id="00-0019596",
+            )
+        ]
+    )
+    out = clean_nfl_pbp(df)
+    assert out["fantasy"][0] == out["passer"][0] == "T.Brady"
+    assert out["fantasy_id"][0] == "00-0019596"
+
+
+# ---------------------------------------------------------------------------
+# Team normalization -- every touched column, historical codes
+# ---------------------------------------------------------------------------
+
+
+def test_team_normalization_sd_to_lac_and_oak_to_lv() -> None:
+    df = pl.DataFrame(
+        [
+            _row(
+                posteam="SD",
+                defteam="OAK",
+                home_team="SD",
+                away_team="OAK",
+                yrdln="SD 49",
+                td_team="OAK",
+                return_team="SD",
+                penalty_team="OAK",
+                side_of_field="SD",
+            )
+        ]
+    )
+    out = clean_nfl_pbp(df)
+    assert out["posteam"][0] == "LAC"
+    assert out["defteam"][0] == "LV"
+    assert out["home_team"][0] == "LAC"
+    assert out["away_team"][0] == "LV"
+    assert out["yrdln"][0] == "LAC 49"
+    assert out["td_team"][0] == "LV"
+    assert out["return_team"][0] == "LAC"
+    assert out["penalty_team"][0] == "LV"
+    assert out["side_of_field"][0] == "LAC"
+
+
+def test_team_name_fn_helper_direct() -> None:
+    """``team_name_fn`` itself, applied directly to an expression."""
+    df = pl.DataFrame({"col": ["JAC 20", "STL", "SL", "LAR", "ARZ", "BLT", "CLV", "HST", "SD", "OAK"]})
+    out = df.select(team_name_fn(pl.col("col")).alias("col"))
+    assert out["col"].to_list() == ["JAX 20", "LA", "LA", "LA", "ARI", "BAL", "CLE", "HOU", "LAC", "LV"]
+
+
+def test_team_columns_all_present_in_team_abbr_mapping_source() -> None:
+    """Sanity check on the port decision to source team_name_fn's 10 codes
+    from datasets.py::team_abbr_mapping rather than a re-hardcoded dict."""
+    from sportsdataverse.nfl.datasets import team_abbr_mapping
+
+    expected = {
+        "JAC": "JAX",
+        "STL": "LA",
+        "SL": "LA",
+        "LAR": "LA",
+        "ARZ": "ARI",
+        "BLT": "BAL",
+        "CLV": "CLE",
+        "HST": "HOU",
+        "SD": "LAC",
+        "OAK": "LV",
+    }
+    for code, target in expected.items():
+        assert team_abbr_mapping[code] == target
+
+
+def test_team_columns_list_has_27_entries() -> None:
+    assert len(TEAM_COLUMNS) == 27
+
+
+# ---------------------------------------------------------------------------
+# aborted_play
+# ---------------------------------------------------------------------------
+
+
+def test_aborted_play_detected_from_desc() -> None:
+    df = pl.DataFrame(
+        [
+            _row(desc="(15:00) Aborted. G.Minshew FUMBLES at JAX 20", epa=None),
+            _row(desc="(15:00) 6-G.Minshew pass incomplete short right to 15-D.Parker"),
+        ]
+    )
+    out = clean_nfl_pbp(df)
+    assert out["aborted_play"].to_list() == [1, 0]
+
+
+def test_aborted_play_rusher_fumble_override() -> None:
+    """On an aborted snap with no passer, rusher/rusher_id fall back to
+    fumbled_1_player_name/_id -- applied AFTER the custom_mode resolution."""
+    df = pl.DataFrame(
+        [
+            _row(
+                desc="(15:00) Aborted. Snap mishandled, RECOVERED by JAX-99",
+                play_type="no_play",
+                fumbled_1_player_name="C.Cominsky",
+                fumbled_1_player_id="00-0099999",
+            )
+        ]
+    )
+    out = clean_nfl_pbp(df)
+    assert out["aborted_play"][0] == 1
+    assert out["rusher"][0] == "C.Cominsky"
+    assert out["rusher_id"][0] == "00-0099999"
+
+
+# ---------------------------------------------------------------------------
+# empty-frame schema stability
+# ---------------------------------------------------------------------------
+
+
+def test_empty_frame_returns_documented_schema() -> None:
+    df = pl.DataFrame(schema={"desc": pl.Utf8, "epa": pl.Float64, "game_id": pl.Utf8})
+    out = clean_nfl_pbp(df)
+    assert out.height == 0
+    for name in _ADDED_SCHEMA:
+        assert name in out.columns
+
+
+def test_empty_frame_return_as_pandas() -> None:
+    df = pl.DataFrame(schema={"desc": pl.Utf8, "epa": pl.Float64})
+    out = clean_nfl_pbp(df, return_as_pandas=True)
+    assert len(out) == 0
+    assert "passer" in out.columns
+
+
+# ---------------------------------------------------------------------------
+# pass/rush compute-if-absent scope decision
+# ---------------------------------------------------------------------------
+
+
+def test_pass_rush_computed_when_absent() -> None:
+    df = pl.DataFrame([_row()])
+    assert "pass" not in df.columns
+    out = clean_nfl_pbp(df)
+    assert out["pass"][0] == 1
+    assert out["rush"][0] == 0
+
+
+def test_pass_rush_left_untouched_when_present() -> None:
+    """A pre-existing pass/rush value is NOT recomputed (scope decision:
+    nflverse frames already carry authoritative pass/rush)."""
+    df = pl.DataFrame([_row(pass_=0, rush=1)]).rename({"pass_": "pass"})
+    out = clean_nfl_pbp(df)
+    assert out["pass"][0] == 0
+    assert out["rush"][0] == 1
+
+
+def test_return_as_pandas_flag() -> None:
+    df = pl.DataFrame([_row()])
+    out = clean_nfl_pbp(df, return_as_pandas=True)
+    assert out.__class__.__name__ == "DataFrame"
+    assert "passer" in out.columns
+    assert out.shape[0] == 1
+
+
+# ---------------------------------------------------------------------------
+# fix_weird_pass_plays override
+# ---------------------------------------------------------------------------
+
+
+def test_fix_weird_pass_plays_forces_zero() -> None:
+    df = pl.DataFrame(
+        [
+            _row(
+                game_id="1999_01_ARI_PHI",
+                play_id=1611,
+                desc="(15:00) 6-G.Minshew pass incomplete short right to 15-D.Parker",
+            )
+        ]
+    )
+    out = clean_nfl_pbp(df)
+    assert out["pass"][0] == 0

--- a/tests/nfl/test_nfl_clean.py
+++ b/tests/nfl/test_nfl_clean.py
@@ -369,3 +369,111 @@ def test_fix_weird_pass_plays_forces_zero() -> None:
     )
     out = clean_nfl_pbp(df)
     assert out["pass"][0] == 0
+
+
+# ---------------------------------------------------------------------------
+# Review fixes (task-6 verdict): null-key join regression, rush_finder
+# stray-space parity, success / jersey / home_opening_kickoff coverage
+# ---------------------------------------------------------------------------
+
+
+def test_null_posteam_season_does_not_wipe_name_and_id() -> None:
+    """CRITICAL regression: a row with null posteam AND null season must keep
+    its resolved passer + passer_id. dplyr's group_by treats NA as an ordinary
+    groupable value, so the mode vote still runs within the (name, NA, NA)
+    group; the polars joins in _resolve_name_id therefore need
+    nulls_equal=True or the row never re-matches its own group row and BOTH
+    passer and passer_id come back null (silent data loss)."""
+    df = pl.DataFrame(
+        [
+            _row(
+                desc="(15:00) 12-T.Brady pass short right to 15-D.Parker for 9 yards",
+                posteam=None,
+                season=None,
+                passer_player_name="T.Brady",
+                passer_player_id="00-0019596",
+            )
+        ],
+        schema_overrides={"posteam": pl.Utf8, "season": pl.Int64},
+    )
+    out = clean_nfl_pbp(df)
+    assert out["passer"][0] == "T.Brady"
+    assert out["passer_id"][0] == "00-0019596"
+
+
+def test_rush_finder_fumbles_requires_trailing_space() -> None:
+    """R-parity pin (verified against R 4.5.3 running the verbatim nflfastR
+    regexes): the stray literal space in rush_finder's "(FUMBLES) | ..."
+    alternation makes the FUMBLES branch require a TRAILING space, so a desc
+    ending exactly at "...FUMBLES" does NOT extract a rusher, while
+    "...FUMBLES (Aggressive)..." does."""
+    from sportsdataverse.nfl.nfl_clean import _RUSHER_PATTERN
+
+    df = pl.DataFrame(
+        {
+            "desc": [
+                "J.Doe FUMBLES",
+                "J.Doe FUMBLES (Aggressive) at NYG 44",
+                "(1:00) 22-D.Henry left end for 5 yards",
+            ]
+        }
+    )
+    out = df.select(pl.col("desc").str.extract(_RUSHER_PATTERN, 1).alias("rusher"))
+    # R oracle: c(NA, "J.Doe", "D.Henry")
+    assert out["rusher"].to_list() == [None, "J.Doe", "D.Henry"]
+
+
+def test_success_from_epa() -> None:
+    """success = 1.0 when epa > 0, 0.0 when epa <= 0, null passthrough."""
+    df = pl.DataFrame(
+        [
+            _row(play_id=1, epa=0.5),
+            _row(play_id=2, epa=-0.5),
+            _row(play_id=3, epa=0.0),
+            _row(play_id=4, epa=None),
+        ]
+    )
+    out = clean_nfl_pbp(df)
+    assert out["success"].to_list() == [1.0, 0.0, 0.0, None]
+    assert out["success"].dtype == pl.Float64
+
+
+def test_jersey_number_extraction() -> None:
+    """passer/receiver jersey numbers come from the NN- prefix in desc;
+    jersey_number is passer-else-rusher."""
+    df = pl.DataFrame(
+        [
+            _row(
+                desc="(15:00) 6-G.Minshew pass short right to 15-D.Parker for 9 yards",
+                passer_player_id="00-0035228",
+            ),
+            _row(
+                play_id=200,
+                desc="(14:00) 22-D.Henry left tackle for 5 yards",
+                play_type="run",
+                rusher_player_id="00-0033118",
+            ),
+        ]
+    )
+    out = clean_nfl_pbp(df)
+    assert out["passer_jersey_number"].to_list() == [6, None]
+    assert out["receiver_jersey_number"].to_list() == [15, None]
+    assert out["rusher_jersey_number"].to_list() == [None, 22]
+    assert out["jersey_number"].to_list() == [6, 22]
+
+
+def test_home_opening_kickoff_per_game() -> None:
+    """home_opening_kickoff = 1 for every row of a game whose first non-null
+    posteam is the home team, 0 otherwise -- computed per game_id."""
+    df = pl.DataFrame(
+        [
+            # game A: home team (IND) has the ball first -> 1 on all rows
+            _row(game_id="2023_01_JAX_IND", play_id=1, posteam="IND", home_team="IND", away_team="JAX"),
+            _row(game_id="2023_01_JAX_IND", play_id=2, posteam="JAX", home_team="IND", away_team="JAX"),
+            # game B: away team (KC) has the ball first -> 0 on all rows
+            _row(game_id="2023_01_KC_BUF", play_id=1, posteam="KC", home_team="BUF", away_team="KC"),
+            _row(game_id="2023_01_KC_BUF", play_id=2, posteam="BUF", home_team="BUF", away_team="KC"),
+        ]
+    )
+    out = clean_nfl_pbp(df)
+    assert out["home_opening_kickoff"].to_list() == [1, 1, 0, 0]

--- a/tests/nfl/test_nfl_series.py
+++ b/tests/nfl/test_nfl_series.py
@@ -165,6 +165,20 @@ def test_series_empty_pbp_returns_zero_row_schema() -> None:
     assert "week" not in season.columns
 
 
+def test_series_outer_join_defense_only_team_gets_null_offense() -> None:
+    """CCC only ever appears as ``defteam`` (week 2, vs AAA's offense) -- never
+    as ``posteam`` -- so it's absent from the ``offense`` sub-frame entirely.
+    The full outer join must still surface CCC's row (per the documented
+    schema semantics) with the missing offense side null, not drop it."""
+    df = calculate_nfl_series_conversion_rates(_synthetic_pbp(), weekly=True)
+    ccc = df.filter((pl.col("season") == 2023) & (pl.col("team") == "CCC") & (pl.col("week") == 2)).row(0, named=True)
+    assert ccc["off_n"] is None
+    assert ccc["off_scr"] is None
+    assert ccc["def_n"] == 1
+    assert ccc["def_scr"] == 1.0
+    assert ccc["def_td"] == 1.0
+
+
 def test_series_return_as_pandas() -> None:
     import pandas as pd
 

--- a/tests/nfl/test_nfl_series.py
+++ b/tests/nfl/test_nfl_series.py
@@ -1,0 +1,173 @@
+"""Tests for :func:`calculate_nfl_series_conversion_rates`.
+
+A faithful polars port of nflfastR's ``calculate_series_conversion_rates``
+(``calculate_series_conversion_rates.R``). The function consumes a caller-
+supplied play-by-play frame carrying ``series`` / ``series_success`` /
+``series_result`` (added by the Track A ``add_series_data`` port) -- these
+tests build a small synthetic pbp frame in-process, no live data required.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+from sportsdataverse.nfl import calculate_nfl_series_conversion_rates
+
+
+def _row(**kw):  # type: ignore[no-untyped-def]
+    base = {
+        "season": 2023,
+        "week": 1,
+        "posteam": "AAA",
+        "defteam": "BBB",
+        "down": 1,
+        "series": 1,
+        "series_success": 0,
+        "series_result": "Punt",
+    }
+    base.update(kw)
+    return base
+
+
+def _synthetic_pbp() -> pl.DataFrame:
+    rows = [
+        # --- Week 1: AAA offense vs BBB defense --------------------------
+        # Series 1: 3 plays, ends in a punt (no conversion).
+        _row(down=1, series=1, series_success=0, series_result="Punt"),
+        _row(down=2, series=1, series_success=0, series_result="Punt"),
+        _row(down=3, series=1, series_success=0, series_result="Punt"),
+        # Series 2: 1 play, converts for a touchdown on 1st down.
+        _row(down=1, series=2, series_success=1, series_result="Touchdown"),
+        # Series 3: 4 plays, converts a first down on 4th down.
+        _row(down=1, series=3, series_success=1, series_result="First down"),
+        _row(down=2, series=3, series_success=1, series_result="First down"),
+        _row(down=3, series=3, series_success=1, series_result="First down"),
+        _row(down=4, series=3, series_success=1, series_result="First down"),
+        # Series 4: 3 plays, turnover on downs^H^H a turnover (no conversion).
+        _row(down=1, series=4, series_success=0, series_result="Turnover"),
+        _row(down=2, series=4, series_success=0, series_result="Turnover"),
+        _row(down=3, series=4, series_success=0, series_result="Turnover"),
+        # Series 5: a QB kneel -- must be excluded entirely from off_n.
+        _row(down=1, series=5, series_success=1, series_result="QB kneel"),
+        # A kickoff (down IS NULL) -- must be excluded via the down filter.
+        _row(down=None, series=None, series_success=None, series_result=None, play_type="kickoff"),
+        # --- Week 1: BBB offense vs AAA defense --------------------------
+        # Series A: 2 plays, converts a first down on 2nd down.
+        _row(posteam="BBB", defteam="AAA", down=1, series=1, series_success=1, series_result="First down"),
+        _row(posteam="BBB", defteam="AAA", down=2, series=1, series_success=1, series_result="First down"),
+        # Series B: 1 play, defense returns it for a touchdown (no conversion).
+        _row(posteam="BBB", defteam="AAA", down=1, series=2, series_success=0, series_result="Opp touchdown"),
+        # --- Week 2: AAA offense vs CCC defense --------------------------
+        # Series 1: 1 play, converts for a touchdown on 1st down.
+        _row(
+            posteam="AAA",
+            defteam="CCC",
+            week=2,
+            down=1,
+            series=1,
+            series_success=1,
+            series_result="Touchdown",
+        ),
+    ]
+    return pl.DataFrame(rows)
+
+
+def test_series_weekly_grain_exact_rates() -> None:
+    df = calculate_nfl_series_conversion_rates(_synthetic_pbp(), weekly=True)
+
+    aaa_wk1 = df.filter((pl.col("season") == 2023) & (pl.col("team") == "AAA") & (pl.col("week") == 1)).row(
+        0, named=True
+    )
+    assert aaa_wk1["off_n"] == 4
+    assert aaa_wk1["off_scr"] == 0.5
+    assert aaa_wk1["off_scr_1st"] == 0.25
+    assert aaa_wk1["off_scr_2nd"] == 0.0
+    assert aaa_wk1["off_scr_3rd"] == 0.0
+    assert aaa_wk1["off_scr_4th"] == 0.25
+    assert aaa_wk1["off_1st"] == 0.25
+    assert aaa_wk1["off_td"] == 0.25
+    assert aaa_wk1["off_fg"] == 0.0
+    assert aaa_wk1["off_punt"] == 0.25
+    assert aaa_wk1["off_to"] == 0.25
+    # AAA defended BBB's 2-series offense in week 1 too.
+    assert aaa_wk1["def_n"] == 2
+    assert aaa_wk1["def_scr"] == 0.5
+    assert aaa_wk1["def_scr_2nd"] == 0.5
+    assert aaa_wk1["def_1st"] == 0.5
+    assert aaa_wk1["def_to"] == 0.5
+
+    aaa_wk2 = df.filter((pl.col("season") == 2023) & (pl.col("team") == "AAA") & (pl.col("week") == 2)).row(
+        0, named=True
+    )
+    assert aaa_wk2["off_n"] == 1
+    assert aaa_wk2["off_scr"] == 1.0
+    assert aaa_wk2["off_scr_1st"] == 1.0
+    assert aaa_wk2["off_td"] == 1.0
+    assert aaa_wk2["off_punt"] == 0.0
+
+    bbb_wk1 = df.filter((pl.col("season") == 2023) & (pl.col("team") == "BBB") & (pl.col("week") == 1)).row(
+        0, named=True
+    )
+    assert bbb_wk1["off_n"] == 2
+    assert bbb_wk1["off_scr"] == 0.5
+    assert bbb_wk1["off_scr_2nd"] == 0.5
+    assert bbb_wk1["off_1st"] == 0.5
+    assert bbb_wk1["off_to"] == 0.5
+    # BBB defended AAA's 4-series offense in week 1.
+    assert bbb_wk1["def_n"] == 4
+    assert bbb_wk1["def_scr"] == 0.5
+    assert bbb_wk1["def_scr_1st"] == 0.25
+    assert bbb_wk1["def_scr_4th"] == 0.25
+    assert bbb_wk1["def_1st"] == 0.25
+    assert bbb_wk1["def_td"] == 0.25
+    assert bbb_wk1["def_punt"] == 0.25
+    assert bbb_wk1["def_to"] == 0.25
+
+
+def test_series_season_grain_aggregates_across_weeks() -> None:
+    df = calculate_nfl_series_conversion_rates(_synthetic_pbp(), weekly=False)
+    assert "week" not in df.columns
+
+    aaa = df.filter((pl.col("season") == 2023) & (pl.col("team") == "AAA")).row(0, named=True)
+    # 4 series in week 1 + 1 series in week 2 = 5 total.
+    assert aaa["off_n"] == 5
+    assert aaa["off_scr"] == 0.6
+    assert aaa["off_scr_1st"] == 0.4
+    assert aaa["off_scr_4th"] == 0.2
+    assert aaa["off_1st"] == 0.2
+    assert aaa["off_td"] == 0.4
+    assert aaa["off_punt"] == 0.2
+    assert aaa["off_to"] == 0.2
+    assert aaa["off_fg"] == 0.0
+
+
+def test_series_empty_pbp_returns_zero_row_schema() -> None:
+    empty = pl.DataFrame(
+        schema={
+            "season": pl.Int64,
+            "week": pl.Int64,
+            "posteam": pl.Utf8,
+            "defteam": pl.Utf8,
+            "down": pl.Int64,
+            "series": pl.Int64,
+            "series_success": pl.Int64,
+            "series_result": pl.Utf8,
+        }
+    )
+    weekly = calculate_nfl_series_conversion_rates(empty, weekly=True)
+    assert weekly.height == 0
+    assert "week" in weekly.columns
+    assert "off_n" in weekly.columns
+    assert "def_to" in weekly.columns
+
+    season = calculate_nfl_series_conversion_rates(empty, weekly=False)
+    assert season.height == 0
+    assert "week" not in season.columns
+
+
+def test_series_return_as_pandas() -> None:
+    import pandas as pd
+
+    out = calculate_nfl_series_conversion_rates(_synthetic_pbp(), weekly=True, return_as_pandas=True)
+    assert isinstance(out, pd.DataFrame)
+    assert out.shape[0] > 0

--- a/tests/nfl/test_nfl_standings.py
+++ b/tests/nfl/test_nfl_standings.py
@@ -157,6 +157,27 @@ def test_standings_empty_games_returns_zero_row_schema() -> None:
     assert "seed" in out.columns
 
 
+def test_standings_empty_games_teams_none_never_hits_network() -> None:
+    # ``teams=None`` normally triggers a ``load_nfl_teams()`` network call, but
+    # the empty-games short-circuit must fire first so this stays offline-safe.
+    empty = pl.DataFrame(
+        schema={
+            "game_id": pl.Utf8,
+            "season": pl.Int64,
+            "game_type": pl.Utf8,
+            "week": pl.Int64,
+            "home_team": pl.Utf8,
+            "away_team": pl.Utf8,
+            "home_score": pl.Int64,
+            "away_score": pl.Int64,
+        }
+    )
+    out = calculate_nfl_standings(empty, teams=None)
+    assert out.height == 0
+    assert "div_rank" in out.columns
+    assert "seed" in out.columns
+
+
 def test_standings_return_as_pandas() -> None:
     import pandas as pd
 

--- a/tests/nfl/test_nfl_standings.py
+++ b/tests/nfl/test_nfl_standings.py
@@ -1,0 +1,165 @@
+"""Tests for :func:`calculate_nfl_standings`.
+
+A reduced, self-contained port of the win_pct -> head-to-head -> division
+record -> conference record tiebreaker ladder nflfastR delegates entirely to
+the external ``nflseedR`` package (``calculate_standings.R`` is a thin
+dispatch/reshape wrapper with no tiebreaker logic of its own -- see reference
+Sec 12). These tests inject a small synthetic ``teams`` frame (the
+``load_nfl_teams`` shape: ``team_abbr`` / ``team_conf`` / ``team_division``)
+so no network access is required.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+from sportsdataverse.nfl import calculate_nfl_standings
+
+
+def _teams() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "team_abbr": ["T1", "T2", "T3", "T4"],
+            "team_conf": ["T", "T", "T", "T"],
+            "team_division": ["TEST", "TEST", "TEST", "TEST"],
+        }
+    )
+
+
+def _games() -> pl.DataFrame:
+    # A 4-team round robin (one division): T1 and T2 both finish 2-1 and tied
+    # on win_pct, but T1 beat T2 head-to-head so T1 ranks ahead. T3 and T4 tie
+    # each other (0.5 win apiece).
+    rows = [
+        {
+            "game_id": "g1",
+            "season": 2024,
+            "game_type": "REG",
+            "week": 1,
+            "home_team": "T1",
+            "away_team": "T2",
+            "home_score": 24,
+            "away_score": 17,
+        },
+        {
+            "game_id": "g2",
+            "season": 2024,
+            "game_type": "REG",
+            "week": 2,
+            "home_team": "T1",
+            "away_team": "T3",
+            "home_score": 28,
+            "away_score": 10,
+        },
+        {
+            "game_id": "g3",
+            "season": 2024,
+            "game_type": "REG",
+            "week": 3,
+            "home_team": "T1",
+            "away_team": "T4",
+            "home_score": 14,
+            "away_score": 21,
+        },
+        {
+            "game_id": "g4",
+            "season": 2024,
+            "game_type": "REG",
+            "week": 4,
+            "home_team": "T2",
+            "away_team": "T4",
+            "home_score": 20,
+            "away_score": 13,
+        },
+        {
+            "game_id": "g5",
+            "season": 2024,
+            "game_type": "REG",
+            "week": 5,
+            "home_team": "T2",
+            "away_team": "T3",
+            "home_score": 17,
+            "away_score": 6,
+        },
+        {
+            "game_id": "g6",
+            "season": 2024,
+            "game_type": "REG",
+            "week": 6,
+            "home_team": "T3",
+            "away_team": "T4",
+            "home_score": 10,
+            "away_score": 10,
+        },
+    ]
+    return pl.DataFrame(rows)
+
+
+def test_standings_two_way_tie_broken_by_head_to_head() -> None:
+    df = calculate_nfl_standings(_games(), teams=_teams())
+
+    def _row(team: str) -> dict:  # type: ignore[no-untyped-def]
+        return df.filter(pl.col("team") == team).row(0, named=True)
+
+    t1, t2, t3, t4 = _row("T1"), _row("T2"), _row("T3"), _row("T4")
+
+    # T1 and T2 both go 2-1, tied on win_pct -- T1 beat T2 head-to-head.
+    assert t1["wins"] == 2
+    assert t1["losses"] == 1
+    assert t1["ties"] == 0
+    assert t1["win_pct"] == 2 / 3
+
+    assert t2["wins"] == 2
+    assert t2["losses"] == 1
+    assert t2["ties"] == 0
+    assert t2["win_pct"] == 2 / 3
+
+    # T3 vs T4 tie counts as 0.5 win apiece.
+    assert t3["wins"] == 0
+    assert t3["losses"] == 2
+    assert t3["ties"] == 1
+    assert t3["win_pct"] == 0.5 / 3
+
+    assert t4["wins"] == 1
+    assert t4["losses"] == 1
+    assert t4["ties"] == 1
+    assert t4["win_pct"] == 0.5
+
+    # Head-to-head breaks the T1/T2 tie: T1 ranks ahead of T2.
+    assert t1["div_rank"] == 1
+    assert t2["div_rank"] == 2
+    assert t4["div_rank"] == 3
+    assert t3["div_rank"] == 4
+
+    # Single division/conference in this synthetic league -> seed mirrors div_rank.
+    assert t1["seed"] == 1
+    assert t2["seed"] == 2
+    assert t4["seed"] == 3
+    assert t3["seed"] == 4
+
+
+def test_standings_empty_games_returns_zero_row_schema() -> None:
+    empty = pl.DataFrame(
+        schema={
+            "game_id": pl.Utf8,
+            "season": pl.Int64,
+            "game_type": pl.Utf8,
+            "week": pl.Int64,
+            "home_team": pl.Utf8,
+            "away_team": pl.Utf8,
+            "home_score": pl.Int64,
+            "away_score": pl.Int64,
+        }
+    )
+    out = calculate_nfl_standings(empty, teams=_teams())
+    assert out.height == 0
+    assert "div_rank" in out.columns
+    assert "seed" in out.columns
+
+
+def test_standings_return_as_pandas() -> None:
+    import pandas as pd
+
+    out = calculate_nfl_standings(_games(), teams=_teams(), return_as_pandas=True)
+    assert isinstance(out, pd.DataFrame)
+    assert out.shape[0] == 4

--- a/tests/nfl/test_nfl_stats_def_kicking.py
+++ b/tests/nfl/test_nfl_stats_def_kicking.py
@@ -1,0 +1,322 @@
+"""Tests for :func:`build_nfl_player_stats_def` / :func:`build_nfl_player_stats_kicking`.
+
+Faithful polars ports of nflfastR's deprecated ``calculate_player_stats_def`` /
+``calculate_player_stats_kicking`` (``aggregate_game_stats_def.R`` /
+``aggregate_game_stats_kicking.R``). These builders consume a caller-supplied
+play-by-play frame directly (unlike :func:`build_nfl_player_stats`, which loads
+its own PBP) -- so the tests build a small synthetic PBP frame in-process,
+no ``load_nfl_pbp`` monkeypatching required.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from sportsdataverse.nfl import (
+    build_nfl_player_stats_def,
+    build_nfl_player_stats_kicking,
+)
+
+
+def _synthetic_players() -> pl.DataFrame:
+    ids = ["DE1", "DE2", "LB1", "LB2", "CB1", "K1"]
+    return pl.DataFrame(
+        {
+            "gsis_id": ids,
+            "display_name": [f"{i} Display" for i in ids],
+            "short_name": [f"{i[0]}.{i[1:]}" for i in ids],
+            "position": ["DE", "DE", "LB", "LB", "CB", "K"],
+            "position_group": ["DL", "DL", "LB", "LB", "DB", "SPEC"],
+            "headshot": [f"u_{i}" for i in ids],
+        }
+    )
+
+
+@pytest.fixture(autouse=True)
+def _patch_players(monkeypatch):
+    import sportsdataverse.nfl.nfl_loaders as loaders
+
+    monkeypatch.setattr(loaders, "load_nfl_players", lambda *a, **k: _synthetic_players())
+
+
+def _base_row(**kw):  # type: ignore[no-untyped-def]
+    base = {
+        "game_id": "2023_01_AAA_BBB",
+        "season": 2023,
+        "week": 1,
+        "season_type": "REG",
+        "posteam": "AAA",
+        "defteam": "BBB",
+        "home_team": "AAA",
+        "away_team": "BBB",
+        "down": 1,
+        "play_type": "pass",
+        "yards_gained": 0,
+        "touchdown": 0,
+        "td_team": None,
+        "td_player_id": None,
+        "safety": 0,
+        "safety_player_id": None,
+        "fumble": 0,
+        "fumble_lost": 0,
+        "penalty": 0,
+        "penalty_team": None,
+        "penalty_player_id": None,
+        "penalty_yards": 0,
+        "interception": 0,
+        "interception_player_id": None,
+        "return_yards": 0,
+        "return_touchdown": 0,
+        "sack": 0,
+        "sack_player_id": None,
+        "half_sack_1_player_id": None,
+        "half_sack_2_player_id": None,
+        "qb_hit_1_player_id": None,
+        "qb_hit_2_player_id": None,
+        "pass_defense_1_player_id": None,
+        "pass_defense_2_player_id": None,
+        "solo_tackle_1_player_id": None,
+        "solo_tackle_2_player_id": None,
+        "assist_tackle_1_player_id": None,
+        "assist_tackle_2_player_id": None,
+        "tackle_with_assist_1_player_id": None,
+        "tackle_for_loss_1_player_id": None,
+        "tackle_for_loss_2_player_id": None,
+        "tackled_for_loss": 0,
+        "forced_fumble_player_1_player_id": None,
+        "forced_fumble_player_2_player_id": None,
+        "fumbled_1_team": None,
+        "fumbled_1_player_id": None,
+        "fumbled_2_team": None,
+        "fumbled_2_player_id": None,
+        "fumble_recovery_1_team": None,
+        "fumble_recovery_1_player_id": None,
+        "fumble_recovery_1_yards": 0,
+        "fumble_recovery_2_team": None,
+        "fumble_recovery_2_player_id": None,
+        "fumble_recovery_2_yards": 0,
+        "kicker_player_id": None,
+        "kicker_player_name": None,
+        "kick_distance": None,
+        "field_goal_attempt": 0,
+        "field_goal_result": None,
+        "extra_point_attempt": 0,
+        "extra_point_result": None,
+        "fixed_drive": 1,
+        "score_differential": 0,
+    }
+    base.update(kw)
+    return base
+
+
+def _def_pbp() -> pl.DataFrame:
+    """One week: split sack, solo+assist tackle, INT-return TD."""
+    rows = [
+        # AAA dropback, BBB splits a sack (DE1 + DE2 half each), -8 yards
+        _base_row(
+            play_type="pass",
+            down=1,
+            sack=1,
+            yards_gained=-8,
+            half_sack_1_player_id="DE1",
+            half_sack_2_player_id="DE2",
+        ),
+        # AAA run, BBB solo tackle (LB1) + assist (LB2)
+        _base_row(
+            play_type="run",
+            down=2,
+            yards_gained=3,
+            solo_tackle_1_player_id="LB1",
+            assist_tackle_1_player_id="LB2",
+        ),
+        # AAA pass intercepted by CB1, returned 45 yards for a TD (defteam scores)
+        _base_row(
+            play_type="pass",
+            down=3,
+            week=1,
+            interception=1,
+            interception_player_id="CB1",
+            return_yards=45,
+            return_touchdown=1,
+            touchdown=1,
+            td_team="BBB",
+            td_player_id="CB1",
+        ),
+        # A tackle-for-loss (separate from the sack play): LB1 stops the run for -2
+        _base_row(
+            play_type="run",
+            down=1,
+            yards_gained=-2,
+            tackled_for_loss=1,
+            tackle_for_loss_1_player_id="LB1",
+        ),
+        # A second week for LB1 (season-collapse exercise): another solo tackle
+        _base_row(
+            game_id="2023_02_AAA_BBB",
+            week=2,
+            play_type="run",
+            down=1,
+            yards_gained=4,
+            solo_tackle_1_player_id="LB1",
+        ),
+    ]
+    return pl.DataFrame(rows, infer_schema_length=None)
+
+
+def _kicking_pbp() -> pl.DataFrame:
+    """One week: 47-yard made FG, 52-yard missed FG, blocked PAT."""
+    rows = [
+        _base_row(
+            play_type="field_goal",
+            down=None,
+            field_goal_attempt=1,
+            field_goal_result="made",
+            kick_distance=47,
+            kicker_player_id="K1",
+            kicker_player_name="K.One",
+            fixed_drive=1,
+        ),
+        _base_row(
+            play_type="field_goal",
+            down=None,
+            field_goal_attempt=1,
+            field_goal_result="missed",
+            kick_distance=52,
+            kicker_player_id="K1",
+            kicker_player_name="K.One",
+            fixed_drive=2,
+        ),
+        _base_row(
+            play_type="extra_point",
+            down=None,
+            extra_point_attempt=1,
+            extra_point_result="blocked",
+            kicker_player_id="K1",
+            kicker_player_name="K.One",
+            fixed_drive=3,
+        ),
+        # A second week for K1 (season-collapse exercise): one made FG
+        _base_row(
+            game_id="2023_02_AAA_BBB",
+            week=2,
+            play_type="field_goal",
+            down=None,
+            field_goal_attempt=1,
+            field_goal_result="made",
+            kick_distance=30,
+            kicker_player_id="K1",
+            kicker_player_name="K.One",
+            fixed_drive=1,
+        ),
+    ]
+    return pl.DataFrame(rows, infer_schema_length=None)
+
+
+# ---------------------------------------------------------------------------
+# defense
+# ---------------------------------------------------------------------------
+
+
+def test_def_split_sack_half_credit():
+    df = build_nfl_player_stats_def(_def_pbp(), weekly=True)
+    de1 = df.filter(pl.col("player_id") == "DE1").to_dicts()[0]
+    de2 = df.filter(pl.col("player_id") == "DE2").to_dicts()[0]
+    assert de1["def_sacks"] == 0.5
+    assert de2["def_sacks"] == 0.5
+    assert de1["def_sack_yards"] == 4.0  # 0.5 * 8
+    assert de2["def_sack_yards"] == 4.0
+
+
+def test_def_solo_and_assist_tackle():
+    df = build_nfl_player_stats_def(_def_pbp(), weekly=True)
+    lb1_wk1 = df.filter((pl.col("player_id") == "LB1") & (pl.col("week") == 1)).to_dicts()[0]
+    lb2 = df.filter(pl.col("player_id") == "LB2").to_dicts()[0]
+    assert lb1_wk1["def_tackles_solo"] == 1
+    assert lb1_wk1["def_tackles"] == 1  # solo + tackle_with_assist (0 here)
+    assert lb2["def_tackle_assists"] == 1
+    assert lb1_wk1["def_tackles_for_loss"] == 1
+    assert lb1_wk1["def_tackles_for_loss_yards"] == 2
+
+
+def test_def_interception_return_td():
+    df = build_nfl_player_stats_def(_def_pbp(), weekly=True)
+    cb1 = df.filter(pl.col("player_id") == "CB1").to_dicts()[0]
+    assert cb1["def_interceptions"] == 1
+    assert cb1["def_interception_yards"] == 45
+    assert cb1["def_tds"] == 1
+    assert cb1["team"] == "BBB"
+
+
+def test_def_weekly_vs_season_collapse():
+    weekly = build_nfl_player_stats_def(_def_pbp(), weekly=True)
+    season = build_nfl_player_stats_def(_def_pbp(), weekly=False)
+
+    lb1_weekly_solo = weekly.filter(pl.col("player_id") == "LB1")["def_tackles_solo"].sum()
+    lb1_season = season.filter(pl.col("player_id") == "LB1").to_dicts()[0]
+    assert lb1_season["def_tackles_solo"] == lb1_weekly_solo == 2
+    assert lb1_season["games"] == 2
+    assert "week" not in season.columns
+    assert "season_type" not in season.columns
+    assert "games" in season.columns
+
+
+def test_def_empty_frame_schema():
+    empty_weekly = build_nfl_player_stats_def(pl.DataFrame(), weekly=True)
+    empty_season = build_nfl_player_stats_def(pl.DataFrame(), weekly=False)
+    assert empty_weekly.height == 0
+    assert empty_season.height == 0
+    assert "week" in empty_weekly.columns
+    assert "games" in empty_season.columns
+    assert "def_sacks" in empty_weekly.columns
+    assert "def_sacks" in empty_season.columns
+
+
+# ---------------------------------------------------------------------------
+# kicking
+# ---------------------------------------------------------------------------
+
+
+def test_kicking_made_missed_blocked_buckets():
+    df = build_nfl_player_stats_kicking(_kicking_pbp(), weekly=True)
+    wk1 = df.filter(pl.col("week") == 1).to_dicts()[0]
+    assert wk1["fg_made"] == 1
+    assert wk1["fg_missed"] == 1
+    assert wk1["fg_att"] == 2
+    assert wk1["fg_made_40_49"] == 1
+    assert wk1["fg_missed_50_59"] == 1
+    assert wk1["fg_long"] == 47
+    assert wk1["fg_pct"] == 0.5
+    assert wk1["pat_blocked"] == 1
+    assert wk1["pat_att"] == 1
+    assert wk1["fg_made_list"] == "47"
+    assert wk1["fg_missed_list"] == "52"
+
+
+def test_kicking_weekly_vs_season_collapse():
+    weekly = build_nfl_player_stats_kicking(_kicking_pbp(), weekly=True)
+    season = build_nfl_player_stats_kicking(_kicking_pbp(), weekly=False)
+
+    assert weekly.filter(pl.col("week") == 1)["fg_made"].sum() == 1
+    assert weekly.filter(pl.col("week") == 2)["fg_made"].sum() == 1
+
+    k1 = season.filter(pl.col("player_id") == "K1").to_dicts()[0]
+    assert k1["fg_made"] == 2
+    assert k1["fg_att"] == 3
+    assert k1["games"] == 2
+    assert "week" not in season.columns
+    assert "gwfg_distance" not in season.columns
+    assert "gwfg_distance_list" in season.columns
+    assert "gwfg_distance_list" not in weekly.columns
+    assert "gwfg_distance" in weekly.columns
+
+
+def test_kicking_empty_frame_schema():
+    empty_weekly = build_nfl_player_stats_kicking(pl.DataFrame(), weekly=True)
+    empty_season = build_nfl_player_stats_kicking(pl.DataFrame(), weekly=False)
+    assert empty_weekly.height == 0
+    assert empty_season.height == 0
+    assert "fg_made" in empty_weekly.columns
+    assert "games" in empty_season.columns
+    assert "gwfg_distance" in empty_weekly.columns
+    assert "gwfg_distance_list" in empty_season.columns

--- a/tests/nfl/test_nfl_stats_def_kicking.py
+++ b/tests/nfl/test_nfl_stats_def_kicking.py
@@ -256,6 +256,9 @@ def test_def_weekly_vs_season_collapse():
     lb1_season = season.filter(pl.col("player_id") == "LB1").to_dicts()[0]
     assert lb1_season["def_tackles_solo"] == lb1_weekly_solo == 2
     assert lb1_season["games"] == 2
+    # R's season grain groups on (player_id, team) only -- no season column.
+    assert "season" not in season.columns
+    assert "season" in weekly.columns
     assert "week" not in season.columns
     assert "season_type" not in season.columns
     assert "games" in season.columns
@@ -267,6 +270,8 @@ def test_def_empty_frame_schema():
     assert empty_weekly.height == 0
     assert empty_season.height == 0
     assert "week" in empty_weekly.columns
+    assert "season" in empty_weekly.columns
+    assert "season" not in empty_season.columns
     assert "games" in empty_season.columns
     assert "def_sacks" in empty_weekly.columns
     assert "def_sacks" in empty_season.columns
@@ -304,11 +309,26 @@ def test_kicking_weekly_vs_season_collapse():
     assert k1["fg_made"] == 2
     assert k1["fg_att"] == 3
     assert k1["games"] == 2
+    # R's season grain groups on (player_id, team) only -- no season column.
+    assert "season" not in season.columns
+    assert "season" in weekly.columns
     assert "week" not in season.columns
     assert "gwfg_distance" not in season.columns
     assert "gwfg_distance_list" in season.columns
     assert "gwfg_distance_list" not in weekly.columns
     assert "gwfg_distance" in weekly.columns
+
+    # Positive GWFG: week 2's lone made 30-yarder is the only FG on the
+    # team's final drive with score_differential in [-2, 0] (week 1's final
+    # drive ends on the PAT, so it never qualifies).
+    wk2 = weekly.filter(pl.col("week") == 2).to_dicts()[0]
+    assert wk2["gwfg_att"] == 1
+    assert wk2["gwfg_made"] == 1
+    assert wk2["gwfg_distance"] == [30.0]
+    assert weekly.filter(pl.col("week") == 1).to_dicts()[0]["gwfg_att"] == 0
+    assert k1["gwfg_att"] == 1
+    assert k1["gwfg_made"] == 1
+    assert k1["gwfg_distance_list"] == "30"
 
 
 def test_kicking_empty_frame_schema():
@@ -317,6 +337,8 @@ def test_kicking_empty_frame_schema():
     assert empty_weekly.height == 0
     assert empty_season.height == 0
     assert "fg_made" in empty_weekly.columns
+    assert "season" in empty_weekly.columns
+    assert "season" not in empty_season.columns
     assert "games" in empty_season.columns
     assert "gwfg_distance" in empty_weekly.columns
     assert "gwfg_distance_list" in empty_season.columns


### PR DESCRIPTION
## Summary

Track B of the nflfastR parity closure program: extends the `sportsdataverse/nfl` analysis surface with the nflfastR layers that were still missing. Every ported function is transcribed from a line-anchored porting reference against the nflfastR R source as of 2026-07-03 (reference + full SDD review ledger live in the companion nfl-data PR sportsdataverse/nfl-data#20).

## What's included

- **Air/YAC EPA-WPA family** (`ep_wp.py`): `air_epa`/`yac_epa`/`air_wpa`/`yac_wpa` + comp/raw variants and per-game running totals (24 cols + 10 totals), `vegas_home_wpa`, OT two-path airWP. The single-owner rule is preserved — all derivation lives in `ep_wp.py`, orchestrated by `enrich_nfl_pbp` in nflfastR order; every cumulative is `.over("game_id")`.
- **`clean_nfl_pbp`** (`nfl_clean.py`): nflfastR `clean_pbp` port — player names/ids, fantasy columns, team normalization, with the `rush_finder` R quirk replicated verbatim (10-case R oracle match).
- **Player-level defense + kicking stats** (`nfl_stats.py`): `build_nfl_player_stats_def` / `build_nfl_player_stats_kicking`, column-exact vs the reference (§9/§10) including split-sack half credit, TFL slot asymmetry, FG distance buckets, and GWFG detection; weekly and season grains.
- **Series conversion rates** (`nfl_series.py`): `calculate_nfl_series_conversion_rates`, including the R operator-precedence quirk re-derived correctly and documented.
- **Standings** (`nfl_standings_calc.py`): `calculate_nfl_standings` with win_pct → h2h → division → conference tiebreakers (ties = 0.5), per-season playoff seed counts (6 pre-2020 / 7 from 2020). Deeper nflseedR-style tiebreaking (SOV/SOS/common games) is deliberately out of scope.

## Notes

- The standings module is named `nfl_standings_calc.py` because a module named `nfl_standings.py` would shadow the released `nfl_api.nfl_standings()` NFL.com wrapper (caught in the final whole-branch review; the wrapper is verified intact).
- Codegen fully regenerated at branch head; drift gate (`generate.py --check`) exits 0; the four new functions are registered in the generated reference docs.

## Verification

- `tests/nfl` + `tests/codegen`: 516 passed / 49 skipped; mypy ratchet + ruff clean; no uv.lock churn.
- Full SDD review trail: each task passed an independent task-scoped review (Task 7 on the §9/§10 formula tables column-by-column), plus a final whole-branch review with fix waves applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new NFL stats and standings outputs for defensive players, kickers, series conversion rates, and team standings.
  * Expanded play-by-play enrichment with additional EPA/WPA outputs, including cumulative game totals and air/YAC splits.
  * Added a new play-by-play cleaning utility and team-name normalization support.

* **Documentation**
  * Updated NFL reference docs and package exports to surface the new helpers more clearly.

* **Tests**
  * Added coverage for the new stats, standings, cleaning, and EPA/WPA behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->