### PR TITLE
fix(ci): use uv run for the sdv-codegen commit-stage hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,7 +118,7 @@ repos:
       # (.github/workflows/codegen.yml).
       - id: sdv-codegen
         name: codegen drift check (generated wrappers in sync with metadata)
-        entry: python tools/codegen/generate.py --check
+        entry: uv run python tools/codegen/generate.py --check
         language: system
         files: ^tools/codegen/(endpoints|schemas|templates)/.*$
         pass_filenames: false


### PR DESCRIPTION
## Summary
- The commit-stage `sdv-codegen` pre-commit hook invoked bare `python`, which resolves outside the project's uv-managed venv and lacks `jinja2` -- causing `ModuleNotFoundError` whenever a commit touches `tools/codegen/{endpoints,schemas,templates}/*`.
- The pre-push variant of the same check (`codegen-drift-prepush`) already correctly uses `uv run python`; this aligns the commit-stage hook to match.

## Test plan
- [x] Manually ran `uv run python tools/codegen/generate.py --check` -- passes cleanly (uv resolves its own venv regardless of what bare `python` points to)
- [x] Reproduced the original failure via the bare `python tools/codegen/generate.py --check` invocation on this environment

## Summary by Sourcery

CI:
- Update the sdv-codegen pre-commit hook to invoke code generation via `uv run python` instead of bare `python` to match other CI checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the code-generation check to run through the project’s standard command runner, keeping the validation flow aligned with the current environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->