### PR TITLE
refactor(nfl): deprecate calculate_nfl_standings toward nfl_season_standings

### DIFF
--- a/sportsdataverse/nfl/nfl_standings_calc.py
+++ b/sportsdataverse/nfl/nfl_standings_calc.py
@@ -20,10 +20,17 @@ coinflip, so results are reproducible.
 The one piece of nflfastR-specific domain knowledge preserved verbatim here is
 the 2020 playoff-format cutover: seasons 1999-2019 default to
 ``playoff_seeds=6``, seasons >= 2020 default to ``playoff_seeds=7``.
+
+.. deprecated::
+    :func:`sportsdataverse.nfl.nfl_season_standings` (a faithful polars port of
+    the full ``nflseedR`` engine -- common games, strength of victory, strength
+    of schedule, draft order) supersedes this reduced ladder. ``calculate_nfl_standings``
+    remains for back-compat and emits a ``DeprecationWarning``.
 """
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, Any, Literal, overload
 
 import polars as pl
@@ -313,7 +320,21 @@ def calculate_nfl_standings(
     .. _nflfastR: https://www.nflfastr.com
     .. _nflseedR: https://github.com/nflverse/nflseedR
     .. _nflreadpy: https://github.com/nflverse/nflreadpy
+
+    .. deprecated::
+        Prefer :func:`sportsdataverse.nfl.nfl_season_standings`, a faithful
+        polars port of the full ``nflseedR`` tiebreaker engine (common games,
+        strength of victory, strength of schedule, draft order) that this
+        bounded four-tier ladder only approximates. This function remains for
+        back-compat and emits a ``DeprecationWarning``.
     """
+    warnings.warn(
+        "calculate_nfl_standings is a reduced (four-tier) tiebreaker ladder; "
+        "prefer nfl_season_standings for the faithful full-nflseedR engine "
+        "(SOV/SOS/common-games/draft-order).",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     if tiebreaker_depth not in (1, 2, 3):
         raise ValueError(f"Invalid tiebreaker_depth {tiebreaker_depth!r}; expected 1, 2, or 3.")
 

--- a/tests/nfl/test_nfl_standings.py
+++ b/tests/nfl/test_nfl_standings.py
@@ -12,8 +12,14 @@ so no network access is required.
 from __future__ import annotations
 
 import polars as pl
+import pytest
 
 from sportsdataverse.nfl import calculate_nfl_standings
+
+# calculate_nfl_standings is deprecated in favor of nfl_season_standings; the
+# behavior tests below still exercise the reduced ladder, so silence the
+# DeprecationWarning here (a dedicated test asserts it still fires).
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
 
 
 def _teams() -> pl.DataFrame:
@@ -184,3 +190,9 @@ def test_standings_return_as_pandas() -> None:
     out = calculate_nfl_standings(_games(), teams=_teams(), return_as_pandas=True)
     assert isinstance(out, pd.DataFrame)
     assert out.shape[0] == 4
+
+
+@pytest.mark.filterwarnings("default::DeprecationWarning")
+def test_standings_emits_deprecation_pointing_to_season_standings() -> None:
+    with pytest.warns(DeprecationWarning, match="nfl_season_standings"):
+        calculate_nfl_standings(_games(), teams=_teams())


### PR DESCRIPTION
Reconciles the two NFL standings functions that landed close together on main:

- **`calculate_nfl_standings`** (nflfastR-parity program, #169) — by its own docstring a *reduced* four-tier tiebreaker ladder (win_pct → head-to-head → division → conference), explicitly stopping short of the full nflseedR ladder ("out of scope … YAGNI per the task brief").
- **`nfl_season_standings`** (seedR port, #171) — the *faithful superset*: a full polars port of nflseedR's engine (common games, strength of victory, strength of schedule, draft order).

Rather than maintain two functions with overlapping purpose, this deprecates the reduced one toward the faithful one:
- `calculate_nfl_standings` now emits a `DeprecationWarning` naming `nfl_season_standings` as the successor, and both its module + function docstrings carry a `.. deprecated::` cross-reference. **It still works** for back-compat (unchanged output).
- Existing behavior tests silence the warning at module scope; a new test asserts the deprecation fires and names the successor.

`tests/nfl/test_nfl_standings.py`: 5 passed. Codegen drift gate clean (native-fn docstrings feed runtime help, not the generated reference).

## Summary by Sourcery

Deprecate the reduced calculate_nfl_standings helper in favor of the full nfl_season_standings engine while preserving backward-compatible behavior.

Enhancements:
- Add deprecation notices and runtime warning guiding users from calculate_nfl_standings to nfl_season_standings.
- Document the relationship between the reduced tiebreaker ladder and the full nflseedR-based implementation.

Tests:
- Silence deprecation warnings in existing NFL standings tests and add a dedicated test asserting the deprecation warning and successor reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `calculate_nfl_standings` now shows a clear deprecation warning when used, guiding users to the newer standings function.
  * Existing standings tests were updated to ignore the warning so normal results remain unchanged.

* **Tests**
  * Added coverage to confirm the deprecation warning appears with the expected replacement guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->