### PR TITLE
fix(nfl): retry DynastyProcess CSV loaders with backoff on transient 429/5xx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Unreleased](#unreleased)
+  - [Fixes](#fixes)
   - [NFL — scheme & special teams spine (play-call model → game script → kicker/punter value → line grades)](#nfl--scheme--special-teams-spine-play-call-model-%E2%86%92-game-script-%E2%86%92-kickerpunter-value-%E2%86%92-line-grades)
   - [NFL — projection & draft spine (player projections → usage shares → availability → draft model)](#nfl--projection--draft-spine-player-projections-%E2%86%92-usage-shares-%E2%86%92-availability-%E2%86%92-draft-model)
   - [NFL — ratings & market spine (power ratings → win prob → spread/total → player props)](#nfl--ratings--market-spine-power-ratings-%E2%86%92-win-prob-%E2%86%92-spreadtotal-%E2%86%92-player-props)
@@ -167,6 +168,13 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Unreleased
+
+### Fixes
+
+- fix(nfl): the DynastyProcess CSV loaders (`load_nfl_ff_playerids`,
+  `load_nfl_ff_rankings`) retry with exponential backoff on transient
+  upstream errors (HTTP 429/5xx) instead of failing on the first hit — the
+  raw-GitHub host rate-limits parallel CI runners.
 
 ### NFL — scheme & special teams spine (play-call model → game script → kicker/punter value → line grades)
 

--- a/docs/src/pages/CHANGELOG.md
+++ b/docs/src/pages/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Unreleased](#unreleased)
+  - [Fixes](#fixes)
   - [NFL — scheme & special teams spine (play-call model → game script → kicker/punter value → line grades)](#nfl--scheme--special-teams-spine-play-call-model-%E2%86%92-game-script-%E2%86%92-kickerpunter-value-%E2%86%92-line-grades)
   - [NFL — projection & draft spine (player projections → usage shares → availability → draft model)](#nfl--projection--draft-spine-player-projections-%E2%86%92-usage-shares-%E2%86%92-availability-%E2%86%92-draft-model)
   - [NFL — ratings & market spine (power ratings → win prob → spread/total → player props)](#nfl--ratings--market-spine-power-ratings-%E2%86%92-win-prob-%E2%86%92-spreadtotal-%E2%86%92-player-props)
@@ -167,6 +168,13 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Unreleased
+
+### Fixes
+
+- fix(nfl): the DynastyProcess CSV loaders (`load_nfl_ff_playerids`,
+  `load_nfl_ff_rankings`) retry with exponential backoff on transient
+  upstream errors (HTTP 429/5xx) instead of failing on the first hit — the
+  raw-GitHub host rate-limits parallel CI runners.
 
 ### NFL — scheme & special teams spine (play-call model → game script → kicker/punter value → line grades)
 

--- a/sportsdataverse/nfl/nfl_loaders.py
+++ b/sportsdataverse/nfl/nfl_loaders.py
@@ -1500,6 +1500,26 @@ def load_nfl_trades(return_as_pandas=False) -> pl.DataFrame:
     )
 
 
+def _read_csv_retry(url: str, *, attempts: int = 4, **kwargs) -> pl.DataFrame:
+    """``pl.read_csv`` with exponential backoff on transient upstream errors.
+
+    The DynastyProcess raw-GitHub CSVs rate-limit CI runners (the parallel
+    test matrix triggers HTTP 429); a short backoff clears it. Non-transient
+    errors and the final attempt re-raise unchanged.
+    """
+    import time
+    import urllib.error
+
+    for attempt in range(attempts):
+        try:
+            return pl.read_csv(url, **kwargs)
+        except urllib.error.HTTPError as exc:
+            if exc.code not in (429, 500, 502, 503, 504) or attempt == attempts - 1:
+                raise
+            time.sleep(2.0 * 2**attempt)
+    raise AssertionError("unreachable")
+
+
 @cached_loader
 def load_nfl_ff_playerids(return_as_pandas=False) -> pl.DataFrame:
     """Load fantasy football player IDs from DynastyProcess.com
@@ -1533,9 +1553,11 @@ def load_nfl_ff_playerids(return_as_pandas=False) -> pl.DataFrame:
         .. _nflverse: https://nflverse.nflverse.com
     """
     return (
-        pl.read_csv(NFL_FF_PLAYERIDS_URL, null_values=["NA", "NULL", ""]).to_pandas(use_pyarrow_extension_array=True)
+        _read_csv_retry(NFL_FF_PLAYERIDS_URL, null_values=["NA", "NULL", ""]).to_pandas(
+            use_pyarrow_extension_array=True
+        )
         if return_as_pandas
-        else pl.read_csv(NFL_FF_PLAYERIDS_URL, null_values=["NA", "NULL", ""])
+        else _read_csv_retry(NFL_FF_PLAYERIDS_URL, null_values=["NA", "NULL", ""])
     )
 
 
@@ -1599,9 +1621,9 @@ def load_nfl_ff_rankings(
         raise ValueError("type/kind must be one of 'draft', 'week', 'all'")
 
     if effective == "draft":
-        data = pl.read_csv(NFL_FF_RANKINGS_DRAFT_URL, null_values=["NA", "NULL", ""])
+        data = _read_csv_retry(NFL_FF_RANKINGS_DRAFT_URL, null_values=["NA", "NULL", ""])
     elif effective == "week":
-        data = pl.read_csv(NFL_FF_RANKINGS_WEEK_URL, null_values=["NA", "NULL", ""])
+        data = _read_csv_retry(NFL_FF_RANKINGS_WEEK_URL, null_values=["NA", "NULL", ""])
     else:  # all
         data = pl.read_parquet(NFL_FF_RANKINGS_ALL_URL, use_pyarrow=True, columns=None)
 

--- a/tests/nfl/test_nfl_loaders_aliases.py
+++ b/tests/nfl/test_nfl_loaders_aliases.py
@@ -357,3 +357,40 @@ def test_nflreadpy_style_import_block_compiles():
     assert len(callables) == 25
     for fn in callables:
         assert callable(fn)
+
+
+def test_read_csv_retry_backs_off_transient_429(monkeypatch):
+    import urllib.error
+
+    from sportsdataverse.nfl import nfl_loaders
+
+    calls = {"n": 0}
+
+    def flaky_read_csv(url, **kwargs):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise urllib.error.HTTPError(url, 429, "Too Many Requests", None, None)
+        return pl.DataFrame({"ok": [1]})
+
+    sleeps: list = []
+    monkeypatch.setattr(nfl_loaders.pl, "read_csv", flaky_read_csv)
+    monkeypatch.setattr("time.sleep", lambda s: sleeps.append(s))
+    out = nfl_loaders._read_csv_retry("https://example.com/x.csv")
+    assert out["ok"].to_list() == [1]
+    assert calls["n"] == 3 and len(sleeps) == 2
+    assert sleeps == [2.0, 4.0]  # exponential backoff
+
+
+def test_read_csv_retry_reraises_non_transient(monkeypatch):
+    import urllib.error
+
+    import pytest as _pytest
+
+    from sportsdataverse.nfl import nfl_loaders
+
+    def notfound(url, **kwargs):
+        raise urllib.error.HTTPError(url, 404, "Not Found", None, None)
+
+    monkeypatch.setattr(nfl_loaders.pl, "read_csv", notfound)
+    with _pytest.raises(urllib.error.HTTPError):
+        nfl_loaders._read_csv_retry("https://example.com/x.csv")


### PR DESCRIPTION
## Summary

The DynastyProcess raw-GitHub CSVs behind `load_nfl_ff_playerids` / `load_nfl_ff_rankings` rate-limit CI runners — the parallel pytest matrix hit HTTP 429 on **five separate jobs across the last four PRs** (#192, #193 ×2, #199, #201), each costing a full rerun cycle. This adds a small `_read_csv_retry` helper (4 attempts, exponential backoff, transient-only: 429/500/502/503/504; non-transient errors and the final attempt re-raise unchanged) and routes the three CSV call sites through it.

## Test plan

- Two new offline tests pin the contract: backoff sequence on transient 429 (2s → 4s, succeeds on attempt 3) and immediate re-raise on non-transient 404
- `tests/nfl/test_nfl_loaders_aliases.py`: 33 passed; ruff clean; `generate.py --check` clean (no public-surface change)

## Summary by Sourcery

Add transient-aware retry with exponential backoff to DynastyProcess NFL CSV loaders to reduce CI flakiness from upstream rate limiting.

Bug Fixes:
- Ensure DynastyProcess-based NFL fantasy CSV loaders retry on transient HTTP 429/5xx responses instead of failing immediately.

Enhancements:
- Introduce a shared CSV-read helper that centralizes retry and backoff behavior for NFL loader endpoints.

Documentation:
- Document the new NFL loader fix in both the main changelog and the docs changelog under an Unreleased Fixes section.

Tests:
- Add offline tests that verify the retry/backoff behavior on transient 429 responses and immediate re-raise on non-transient 404 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fantasy football data downloads now retry automatically on temporary server and rate-limit errors, reducing failed loads during upstream interruptions.
  * The affected CSV-based rankings/player ID imports are now more resilient and less likely to break on the first request.

* **Tests**
  * Added coverage for retry behavior, including successful recovery from transient errors and immediate failure for non-retryable responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->