### PR TITLE
refactor(_common): extract shared opponent-adjustment rating cores to sportsdataverse/_common (T7.2)

### DIFF
--- a/docs/docs/nfl/reference/additional.md
+++ b/docs/docs/nfl/reference/additional.md
@@ -8334,12 +8334,14 @@ sched.select(["id", "homeTeam_fullName", "awayTeam_fullName"]).head()
 
 Ridge-regress `resp_col` on offense + defense team indicators + HFA.
 
-League-agnostic (column names are arguments) so this is the single solver
-a T7.2 refactor can lift into common_ratings` to back both CFB and
-NFL. Builds the offense/defense-indicator + intercept + home design and
-solves the ridge normal equations `beta = (X'X + lam*R)^-1 X'y`. Only
-team coefficients are penalised; the intercept (and, unless
-`penalize_home`, the home term) is free.
+League-agnostic (column names are arguments): builds the full
+offense/defense-indicator + intercept + home design and solves the
+ridge normal equations `beta = (X'X + lam*R)^-1 X'y`. Only team
+coefficients are penalised; the intercept (and, unless
+`penalize_home`, the home term) is free. Moved verbatim (T7.2) from
+`sportsdataverse.nfl.nfl_ratings` -- NFL is currently the sole
+adopter of this exact dense-design encoding (CFB's ridge is the
+genuinely different `dropped_level_ridge`).
 
 **Parameters**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -290,6 +290,8 @@ warn_unused_ignores = true
 warn_redundant_casts = true
 files = [
     "sportsdataverse/_deprecation.py",
+    "sportsdataverse/_common/__init__.py",
+    "sportsdataverse/_common/ratings.py",
     "sportsdataverse/errors.py",
     "sportsdataverse/cfb/cfb_adjusted_epa.py",
     "sportsdataverse/cfb/cfb_advanced_constants.py",

--- a/sportsdataverse/_common/__init__.py
+++ b/sportsdataverse/_common/__init__.py
@@ -1,0 +1,10 @@
+"""Internal cross-league infrastructure (T7.2).
+
+Shared, league-agnostic rating-engine math that the per-sport prediction
+spines delegate into: NFL's dense-design opponent-adjusted ridge, CFB's
+dropped-level (``model.matrix``-style) opponent-adjusted ridge, and the
+MBB/NBA/WBB/WNBA iterative (KenPom-style) fixed-point opponent adjustment.
+
+**Internal** -- not re-exported at the top-level ``sportsdataverse`` package;
+per-sport wrappers import from here and keep their own public signatures.
+"""

--- a/sportsdataverse/_common/ratings.py
+++ b/sportsdataverse/_common/ratings.py
@@ -1,0 +1,317 @@
+"""Shared opponent-adjusted power-rating engines (T7.2).
+
+Three league-agnostic solvers, moved **verbatim** (byte-for-byte, same op
+order) out of their originating per-sport modules so ``sportsdataverse``
+hosts one copy instead of N divergent ones:
+
+* :func:`opponent_adjusted_ridge` -- NFL's dense-design-matrix ridge
+  (``sportsdataverse.nfl.nfl_ratings``): full offense/defense dummy encoding
+  + intercept + home indicator, solved via the normal equations.
+* :func:`dropped_level_ridge` -- CFB's ``model.matrix``-style ridge
+  (``sportsdataverse.cfb.cfb_adjusted_epa``): drops one reference level per
+  side and fits a standardized :class:`sklearn.linear_model.Ridge`. This is
+  a **genuinely different algorithm** from :func:`opponent_adjusted_ridge`
+  (different design encoding, different library, different regularization
+  convention) despite both solving "opponent-adjusted ridge" -- it is kept
+  as its own function rather than forced into one solver, per the T7.2
+  no-force-unification discipline.
+* :func:`iterative_opponent_adjust` -- the MBB/NBA (and, via those modules,
+  WBB/WNBA) KenPom-style fixed point: alternately re-estimates each team's
+  offense/defense from its opponents' *current* adjusted ratings and a
+  home-court term until convergence. Byte-identical across MBB and NBA
+  today; the only difference is whether the baseline (``avg``) is the
+  data's own mean (MBB) or a fitted external constant (NBA), which this
+  function takes as an optional parameter so both behaviors are preserved
+  exactly.
+
+Every per-sport caller retains its own public signature, its own league
+constants, and its own output column names -- only the pure numeric core
+moved. See each per-sport module for the byte-for-byte migration.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+
+__all__ = ["dropped_level_ridge", "iterative_opponent_adjust", "opponent_adjusted_ridge"]
+
+
+_RIDGE_OUTPUT_SCHEMA: dict[str, pl.PolarsDataType] = {
+    "team_id": pl.Utf8,
+    "off_coef": pl.Float64,
+    "def_coef": pl.Float64,
+}
+
+_ITER_SCHEMA: dict[str, pl.PolarsDataType] = {
+    "team_id": pl.Utf8,
+    "adj_off": pl.Float64,
+    "adj_def": pl.Float64,
+    "adj_net": pl.Float64,
+    "raw_off": pl.Float64,
+    "raw_def": pl.Float64,
+    "games": pl.Int64,
+}
+
+
+def opponent_adjusted_ridge(
+    plays: pl.DataFrame,
+    *,
+    off_col: str,
+    def_col: str,
+    home_col: str,
+    resp_col: str,
+    lam: float,
+    penalize_home: bool = False,
+) -> tuple[pl.DataFrame, float, float]:
+    """Ridge-regress ``resp_col`` on offense + defense team indicators + HFA.
+
+    League-agnostic (column names are arguments): builds the full
+    offense/defense-indicator + intercept + home design and solves the
+    ridge normal equations ``beta = (X'X + lam*R)^-1 X'y``. Only team
+    coefficients are penalised; the intercept (and, unless
+    ``penalize_home``, the home term) is free. Moved verbatim (T7.2) from
+    ``sportsdataverse.nfl.nfl_ratings`` -- NFL is currently the sole
+    adopter of this exact dense-design encoding (CFB's ridge is the
+    genuinely different :func:`dropped_level_ridge`).
+
+    Args:
+        plays: One row per play. Rows with a null ``off_col`` / ``def_col``
+            / ``resp_col`` must be filtered by the caller.
+        off_col: Column naming the offense (possession) team.
+        def_col: Column naming the defense team.
+        home_col: Column naming the home team (HFA indicator is
+            ``off_col == home_col``).
+        resp_col: Numeric response column (e.g. ``epa``).
+        lam: Ridge penalty applied to the team coefficients.
+        penalize_home: Also penalise the home-field coefficient
+            (default False).
+
+    Returns:
+        A ``(frame, intercept, home_coef)`` tuple: ``frame`` has one row per
+        team (``team_id`` Utf8, ``off_coef`` / ``def_coef`` Float64);
+        ``intercept`` is the league baseline; ``home_coef`` the fitted HFA
+        in response units. Zero-row frame + ``(0.0, 0.0)`` on empty input.
+
+    Example:
+        Quick start (via the NFL public re-export -- its sole adopter today)::
+
+            from sportsdataverse.nfl.nfl_ratings import opponent_adjusted_ridge
+            frame, intercept, hfa = opponent_adjusted_ridge(
+                plays, off_col="posteam", def_col="defteam",
+                home_col="home_team", resp_col="epa", lam=200.0,
+            )
+            frame.sort("off_coef", descending=True).head()
+    """
+    if plays.height == 0:
+        return pl.DataFrame(schema=_RIDGE_OUTPUT_SCHEMA), 0.0, 0.0
+    off = plays[off_col].cast(pl.Utf8)
+    dff = plays[def_col].cast(pl.Utf8)
+    teams = sorted(set(off.to_list()) | set(dff.to_list()))
+    idx = {t: i for i, t in enumerate(teams)}
+    n_t = len(teams)
+    n = plays.height
+    # columns: [off_0..off_{T-1}, def_0..def_{T-1}, intercept, home]
+    p = 2 * n_t + 2
+    X = np.zeros((n, p), dtype=float)
+    oi = np.array([idx[t] for t in off.to_list()])
+    di = np.array([idx[t] for t in dff.to_list()])
+    X[np.arange(n), oi] = 1.0
+    X[np.arange(n), n_t + di] = 1.0
+    X[:, 2 * n_t] = 1.0  # intercept
+    is_home = (off == plays[home_col].cast(pl.Utf8)).to_numpy().astype(float)
+    X[:, 2 * n_t + 1] = is_home  # HFA (offense is home)
+    y = plays[resp_col].cast(pl.Float64).to_numpy()
+    R = np.eye(p)
+    R[2 * n_t, 2 * n_t] = 0.0  # don't penalise intercept
+    if not penalize_home:
+        R[2 * n_t + 1, 2 * n_t + 1] = 0.0  # don't penalise HFA
+    beta = np.linalg.solve(X.T @ X + lam * R, X.T @ y)
+    frame = pl.DataFrame(
+        {
+            "team_id": teams,
+            "off_coef": beta[:n_t].astype(np.float64),
+            "def_coef": beta[n_t : 2 * n_t].astype(np.float64),
+        }
+    )
+    return frame, float(beta[2 * n_t]), float(beta[2 * n_t + 1])
+
+
+def dropped_level_ridge(clean: pl.DataFrame, ridge_lambda: float) -> tuple[pl.DataFrame, pl.DataFrame, float]:
+    """Fit the offense/defense ridge on competitive plays -> (offense, defense, intercept).
+
+    ``model.matrix``-style encoding: drops the first factor level per side
+    (offense, defense) and fits a standardized :class:`sklearn.linear_model.Ridge`,
+    then un-standardizes the coefficients. ``offense``/``defense`` carry one
+    row per *non-reference* team; ``intercept`` is the league baseline used
+    as the fallback strength for not-yet-seen teams in CFB's walk-forward
+    variant. Moved verbatim (T7.2) from
+    ``sportsdataverse.cfb.cfb_adjusted_epa._fit_opponent_ridge`` -- a
+    genuinely different algorithm from :func:`opponent_adjusted_ridge`
+    (dropped reference level + standardized sklearn fit vs. full-dummy
+    manual normal equations), kept as its own function rather than forced
+    into a false unification.
+
+    Args:
+        clean: Competitive-play frame with ``pos_team_id``, ``def_pos_team_id``,
+            ``hfa``, ``EPA`` columns (see ``cfb_adjusted_epa._prepare``).
+        ridge_lambda: Ridge penalty (glmnet-scale).
+
+    Returns:
+        ``(offense, defense, intercept)``: ``offense`` has ``team_id`` +
+        ``adjmodelOff``; ``defense`` has ``team_id`` + ``adjmodelDef``;
+        ``intercept`` is the fitted league baseline (float).
+
+    Raises:
+        ImportError: If ``scikit-learn`` is not installed.
+
+    Example:
+        Quick start::
+
+            from sportsdataverse._common.ratings import dropped_level_ridge
+            offense, defense, intercept = dropped_level_ridge(clean, 325.0)
+    """
+    try:
+        from sklearn.linear_model import Ridge
+    except ImportError as exc:  # pragma: no cover - optional dep guidance
+        raise ImportError(
+            "dropped_level_ridge requires scikit-learn. Install it with "
+            "`pip install sportsdataverse[models]` (or `pip install scikit-learn`)."
+        ) from exc
+
+    off_ids = sorted(clean["pos_team_id"].drop_nulls().unique().to_list())
+    def_ids = sorted(clean["def_pos_team_id"].drop_nulls().unique().to_list())
+    off_dummy, def_dummy = off_ids[1:], def_ids[1:]
+
+    pos = clean["pos_team_id"].to_numpy()
+    dfn = clean["def_pos_team_id"].to_numpy()
+    feats = [clean["hfa"].cast(pl.Float64).to_numpy().reshape(-1, 1)]
+    feats += [(pos == t).astype(float).reshape(-1, 1) for t in off_dummy]
+    feats += [(dfn == t).astype(float).reshape(-1, 1) for t in def_dummy]
+    x_mat = np.hstack(feats)
+    y = clean["EPA"].cast(pl.Float64).to_numpy()
+
+    # glmnet (1/2n)RSS + lambda/2||b||^2 with internal standardization vs sklearn
+    # RSS + alpha||b||^2: standardize X and scale alpha by n. Coefficients won't
+    # byte-match glmnet, but the relative team strengths correlate closely.
+    mu, sd = x_mat.mean(axis=0), x_mat.std(axis=0)
+    sd[sd == 0] = 1.0
+    model = Ridge(alpha=ridge_lambda * len(y), fit_intercept=True)
+    model.fit((x_mat - mu) / sd, y)
+    coef_std = model.coef_ / sd
+    intercept = float(model.intercept_ - (coef_std * mu).sum())
+    names = ["hfa"] + [f"pos_team_id{t}" for t in off_dummy] + [f"def_pos_team_id{t}" for t in def_dummy]
+    coef = dict(zip(names, coef_std))
+    offense = pl.DataFrame(
+        {"team_id": off_dummy, "adjmodelOff": [coef[f"pos_team_id{t}"] + intercept for t in off_dummy]}
+    )
+    defense = pl.DataFrame(
+        {"team_id": def_dummy, "adjmodelDef": [coef[f"def_pos_team_id{t}"] + intercept for t in def_dummy]}
+    )
+    return offense, defense, intercept
+
+
+def iterative_opponent_adjust(
+    game_eff: pl.DataFrame,
+    *,
+    team_col: str,
+    opp_col: str,
+    off_col: str,
+    def_col: str,
+    home_col: str,
+    neutral_col: str,
+    hfa: float,
+    baseline: float | None = None,
+    max_iter: int = 100,
+    tol: float = 1e-4,
+) -> pl.DataFrame:
+    """KenPom-style opponent-adjustment fixed point for one group of game rows.
+
+    Initialises ``adj_off = raw_off`` / ``adj_def = raw_def``, then
+    repeatedly recomputes each team's rating from its games with the
+    opponent's *current* adjusted rating and a home-court adjustment
+    removed, until the largest change is below ``tol``. Moved verbatim
+    (T7.2) from the identical inner ``_adjust_one_season`` loops in
+    ``sportsdataverse.mbb.mbb_team_ratings`` and
+    ``sportsdataverse.nba.nba_team_ratings`` (and, via those modules,
+    WBB/WNBA) -- the two were byte-identical except for column names and
+    where the baseline average comes from, which is why ``baseline`` is
+    optional here: pass ``None`` to compute it as the data's own mean
+    (MBB's behavior) or an explicit float to use a fitted external
+    constant (NBA's behavior). Callers group by season (or whatever the
+    per-league unit is) before calling this once per group.
+
+    Args:
+        game_eff: One row per (game, team) with ``team_col``, ``opp_col``,
+            ``off_col``, ``def_col``, ``home_col`` (boolean), ``neutral_col``
+            (boolean). Already restricted to one rating group (e.g. season).
+        team_col: Column naming the team.
+        opp_col: Column naming the opponent.
+        off_col: Column with the team's own-side per-game rate/efficiency.
+        def_col: Column with the team's against-side per-game rate/efficiency.
+        home_col: Boolean column, True when ``team_col`` is the home side.
+        neutral_col: Boolean column, True for a neutral-site game.
+        hfa: Home-court/field edge, split ``+-hfa/2``.
+        baseline: League-average baseline to adjust and converge toward. If
+            ``None`` (default), computed as the data's own ``off_col`` mean.
+        max_iter: Maximum fixed-point iterations.
+        tol: Convergence tolerance on the largest rating change.
+
+    Returns:
+        One row per team: ``team_id, adj_off, adj_def, adj_net, raw_off,
+        raw_def, games``. Empty input returns that schema with zero rows.
+
+    Example:
+        Quick start::
+
+            from sportsdataverse._common.ratings import iterative_opponent_adjust
+            out = iterative_opponent_adjust(
+                game_eff, team_col="team_id", opp_col="opp_team_id",
+                off_col="off_eff", def_col="def_eff", home_col="is_home",
+                neutral_col="neutral_site", hfa=3.0,
+            )
+    """
+    if game_eff.height == 0:
+        return pl.DataFrame(schema=_ITER_SCHEMA)
+    teams = game_eff[team_col].unique(maintain_order=True).to_list()
+    index = {t: i for i, t in enumerate(teams)}
+    n = len(teams)
+    ti = np.array([index[t] for t in game_eff[team_col].to_list()], dtype=np.int64)
+    oi = np.array([index[t] for t in game_eff[opp_col].to_list()], dtype=np.int64)
+    off = game_eff[off_col].to_numpy().astype(float)
+    dfn = game_eff[def_col].to_numpy().astype(float)
+    is_home = game_eff[home_col].to_numpy()
+    neutral = game_eff[neutral_col].to_numpy()
+
+    half = hfa / 2.0
+    loc_o = np.where(neutral, 0.0, np.where(is_home, half, -half))
+    loc_d = np.where(neutral, 0.0, np.where(is_home, -half, half))
+    avg = float(off.mean()) if baseline is None else float(baseline)
+
+    counts: np.ndarray = np.bincount(ti, minlength=n).astype(float)
+    raw_o = np.bincount(ti, weights=off, minlength=n) / counts
+    raw_d = np.bincount(ti, weights=dfn, minlength=n) / counts
+
+    adj_o, adj_d = raw_o.copy(), raw_d.copy()
+    for _ in range(max_iter):
+        contrib_o = off - (adj_d[oi] - avg) - loc_o
+        contrib_d = dfn - (adj_o[oi] - avg) - loc_d
+        new_o = np.bincount(ti, weights=contrib_o, minlength=n) / counts
+        new_d = np.bincount(ti, weights=contrib_d, minlength=n) / counts
+        delta = max(float(np.abs(new_o - adj_o).max()), float(np.abs(new_d - adj_d).max()))
+        adj_o, adj_d = new_o, new_d
+        if delta < tol:
+            break
+
+    return pl.DataFrame(
+        {
+            "team_id": teams,
+            "adj_off": adj_o,
+            "adj_def": adj_d,
+            "adj_net": adj_o - adj_d,
+            "raw_off": raw_o,
+            "raw_def": raw_d,
+            "games": counts.astype(np.int64),
+        },
+        schema=_ITER_SCHEMA,
+    )

--- a/sportsdataverse/cfb/cfb_adjusted_epa.py
+++ b/sportsdataverse/cfb/cfb_adjusted_epa.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal, overload
 
-import numpy as np
 import polars as pl
 
 if TYPE_CHECKING:
@@ -96,45 +95,15 @@ def _fit_opponent_ridge(clean: pl.DataFrame, ridge_lambda: float) -> tuple[pl.Da
     ``offense``/``defense`` carry one row per *non-reference* team (``model.matrix``
     drops the first factor level); ``intercept`` is the league baseline used as the
     fallback strength for not-yet-seen teams in the walk-forward variant.
+
+    Thin wrapper (T7.2): the pure ridge solve moved verbatim to
+    :func:`sportsdataverse._common.ratings.dropped_level_ridge`; this name
+    stays so existing internal imports (``cfb_ratings.py``,
+    ``cfb_adjusted_epa`` call sites) keep working unchanged.
     """
-    try:
-        from sklearn.linear_model import Ridge
-    except ImportError as exc:  # pragma: no cover - optional dep guidance
-        raise ImportError(
-            "cfb_adjusted_epa requires scikit-learn. Install it with "
-            "`pip install sportsdataverse[models]` (or `pip install scikit-learn`)."
-        ) from exc
+    from sportsdataverse._common.ratings import dropped_level_ridge
 
-    off_ids = sorted(clean["pos_team_id"].drop_nulls().unique().to_list())
-    def_ids = sorted(clean["def_pos_team_id"].drop_nulls().unique().to_list())
-    off_dummy, def_dummy = off_ids[1:], def_ids[1:]
-
-    pos = clean["pos_team_id"].to_numpy()
-    dfn = clean["def_pos_team_id"].to_numpy()
-    feats = [clean["hfa"].cast(pl.Float64).to_numpy().reshape(-1, 1)]
-    feats += [(pos == t).astype(float).reshape(-1, 1) for t in off_dummy]
-    feats += [(dfn == t).astype(float).reshape(-1, 1) for t in def_dummy]
-    x_mat = np.hstack(feats)
-    y = clean["EPA"].cast(pl.Float64).to_numpy()
-
-    # glmnet (1/2n)RSS + lambda/2||b||^2 with internal standardization vs sklearn
-    # RSS + alpha||b||^2: standardize X and scale alpha by n. Coefficients won't
-    # byte-match glmnet, but the relative team strengths correlate closely.
-    mu, sd = x_mat.mean(axis=0), x_mat.std(axis=0)
-    sd[sd == 0] = 1.0
-    model = Ridge(alpha=ridge_lambda * len(y), fit_intercept=True)
-    model.fit((x_mat - mu) / sd, y)
-    coef_std = model.coef_ / sd
-    intercept = float(model.intercept_ - (coef_std * mu).sum())
-    names = ["hfa"] + [f"pos_team_id{t}" for t in off_dummy] + [f"def_pos_team_id{t}" for t in def_dummy]
-    coef = dict(zip(names, coef_std))
-    offense = pl.DataFrame(
-        {"team_id": off_dummy, "adjmodelOff": [coef[f"pos_team_id{t}"] + intercept for t in off_dummy]}
-    )
-    defense = pl.DataFrame(
-        {"team_id": def_dummy, "adjmodelDef": [coef[f"def_pos_team_id{t}"] + intercept for t in def_dummy]}
-    )
-    return offense, defense, intercept
+    return dropped_level_ridge(clean, ridge_lambda)
 
 
 def _adjust_games(

--- a/sportsdataverse/mbb/mbb_team_ratings.py
+++ b/sportsdataverse/mbb/mbb_team_ratings.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import polars as pl
 
+from sportsdataverse._common.ratings import iterative_opponent_adjust
 from sportsdataverse.mbb.mbb_loaders import load_mbb_schedule, load_mbb_team_boxscore
 from sportsdataverse.mbb.mbb_prediction_constants import get_constants
 
@@ -128,49 +129,32 @@ _ADJ_SCHEMA = {
 
 
 def _adjust_one_season(sub: pl.DataFrame, season: int, hfa: float, max_iter: int, tol: float) -> pl.DataFrame:
-    """Fixed-point opponent adjustment for one season's game-efficiency rows."""
-    teams = sub["team_id"].unique(maintain_order=True).to_list()
-    index = {t: i for i, t in enumerate(teams)}
-    n = len(teams)
-    ti = np.array([index[t] for t in sub["team_id"].to_list()], dtype=np.int64)
-    oi = np.array([index[t] for t in sub["opp_team_id"].to_list()], dtype=np.int64)
-    off = sub["off_eff"].to_numpy().astype(float)
-    dfn = sub["def_eff"].to_numpy().astype(float)
-    is_home = sub["is_home"].to_numpy()
-    neutral = sub["neutral_site"].to_numpy()
+    """Fixed-point opponent adjustment for one season's game-efficiency rows.
 
-    half = hfa / 2.0
-    loc_o = np.where(neutral, 0.0, np.where(is_home, half, -half))
-    loc_d = np.where(neutral, 0.0, np.where(is_home, -half, half))
-    avg = float(off.mean())
-
-    counts: np.ndarray = np.bincount(ti, minlength=n).astype(float)
-    raw_o = np.bincount(ti, weights=off, minlength=n) / counts
-    raw_d = np.bincount(ti, weights=dfn, minlength=n) / counts
-
-    adj_o, adj_d = raw_o.copy(), raw_d.copy()
-    for _ in range(max_iter):
-        contrib_o = off - (adj_d[oi] - avg) - loc_o
-        contrib_d = dfn - (adj_o[oi] - avg) - loc_d
-        new_o = np.bincount(ti, weights=contrib_o, minlength=n) / counts
-        new_d = np.bincount(ti, weights=contrib_d, minlength=n) / counts
-        delta = max(float(np.abs(new_o - adj_o).max()), float(np.abs(new_d - adj_d).max()))
-        adj_o, adj_d = new_o, new_d
-        if delta < tol:
-            break
-
-    return pl.DataFrame(
-        {
-            "season": [season] * n,
-            "team_id": teams,
-            "adj_o": adj_o,
-            "adj_d": adj_d,
-            "adj_em": adj_o - adj_d,
-            "raw_o": raw_o,
-            "raw_d": raw_d,
-            "games": counts.astype(np.int64),
-        },
-        schema=_ADJ_SCHEMA,
+    Thin wrapper (T7.2): the fixed-point core moved verbatim to
+    :func:`sportsdataverse._common.ratings.iterative_opponent_adjust`
+    (``baseline=None`` reproduces this module's own data-mean average);
+    only the column rename to this module's public names stays local.
+    """
+    core = iterative_opponent_adjust(
+        sub,
+        team_col="team_id",
+        opp_col="opp_team_id",
+        off_col="off_eff",
+        def_col="def_eff",
+        home_col="is_home",
+        neutral_col="neutral_site",
+        hfa=hfa,
+        baseline=None,
+        max_iter=max_iter,
+        tol=tol,
+    )
+    return (
+        core.rename(
+            {"adj_off": "adj_o", "adj_def": "adj_d", "adj_net": "adj_em", "raw_off": "raw_o", "raw_def": "raw_d"}
+        )
+        .with_columns(pl.lit(season, dtype=pl.Int64).alias("season"))
+        .select("season", "team_id", "adj_o", "adj_d", "adj_em", "raw_o", "raw_d", "games")
     )
 
 

--- a/sportsdataverse/nba/nba_team_ratings.py
+++ b/sportsdataverse/nba/nba_team_ratings.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING, Literal, Union, overload
 import numpy as np
 import polars as pl
 
+from sportsdataverse._common.ratings import iterative_opponent_adjust
 from sportsdataverse.nba.nba_loaders import load_nba_schedule, load_nba_team_boxscore
 from sportsdataverse.nba.nba_prediction_constants import as_of_ratings_split, get_constants
 
@@ -158,48 +159,39 @@ _ADJ_SCHEMA = {
 def _adjust_one_season(
     sub: pl.DataFrame, season: int, hfa: float, avg: float, max_iter: int, tol: float
 ) -> pl.DataFrame:
-    """Fixed-point opponent adjustment for one season's game-efficiency rows."""
-    teams = sub["team_id"].unique(maintain_order=True).to_list()
-    index = {t: i for i, t in enumerate(teams)}
-    n = len(teams)
-    ti = np.array([index[t] for t in sub["team_id"].to_list()], dtype=np.int64)
-    oi = np.array([index[t] for t in sub["opp_team_id"].to_list()], dtype=np.int64)
-    off = sub["off_rtg"].to_numpy().astype(float)
-    dfn = sub["def_rtg"].to_numpy().astype(float)
-    is_home = sub["is_home"].to_numpy()
-    neutral = sub["neutral_site"].to_numpy()
+    """Fixed-point opponent adjustment for one season's game-efficiency rows.
 
-    half = hfa / 2.0
-    loc_o = np.where(neutral, 0.0, np.where(is_home, half, -half))
-    loc_d = np.where(neutral, 0.0, np.where(is_home, -half, half))
-
-    counts: np.ndarray = np.bincount(ti, minlength=n).astype(float)
-    raw_o = np.bincount(ti, weights=off, minlength=n) / counts
-    raw_d = np.bincount(ti, weights=dfn, minlength=n) / counts
-
-    adj_o, adj_d = raw_o.copy(), raw_d.copy()
-    for _ in range(max_iter):
-        contrib_o = off - (adj_d[oi] - avg) - loc_o
-        contrib_d = dfn - (adj_o[oi] - avg) - loc_d
-        new_o = np.bincount(ti, weights=contrib_o, minlength=n) / counts
-        new_d = np.bincount(ti, weights=contrib_d, minlength=n) / counts
-        delta = max(float(np.abs(new_o - adj_o).max()), float(np.abs(new_d - adj_d).max()))
-        adj_o, adj_d = new_o, new_d
-        if delta < tol:
-            break
-
-    return pl.DataFrame(
-        {
-            "season": [season] * n,
-            "team_id": teams,
-            "adj_off_rtg": adj_o,
-            "adj_def_rtg": adj_d,
-            "adj_net_rtg": adj_o - adj_d,
-            "raw_off_rtg": raw_o,
-            "raw_def_rtg": raw_d,
-            "games": counts.astype(np.int64),
-        },
-        schema=_ADJ_SCHEMA,
+    Thin wrapper (T7.2): the fixed-point core moved verbatim to
+    :func:`sportsdataverse._common.ratings.iterative_opponent_adjust`
+    (``baseline=avg`` reproduces this module's fitted-constant average, as
+    opposed to MBB's data-derived mean); only the column rename to this
+    module's public names stays local.
+    """
+    core = iterative_opponent_adjust(
+        sub,
+        team_col="team_id",
+        opp_col="opp_team_id",
+        off_col="off_rtg",
+        def_col="def_rtg",
+        home_col="is_home",
+        neutral_col="neutral_site",
+        hfa=hfa,
+        baseline=avg,
+        max_iter=max_iter,
+        tol=tol,
+    )
+    return (
+        core.rename(
+            {
+                "adj_off": "adj_off_rtg",
+                "adj_def": "adj_def_rtg",
+                "adj_net": "adj_net_rtg",
+                "raw_off": "raw_off_rtg",
+                "raw_def": "raw_def_rtg",
+            }
+        )
+        .with_columns(pl.lit(season, dtype=pl.Int64).alias("season"))
+        .select("season", "team_id", "adj_off_rtg", "adj_def_rtg", "adj_net_rtg", "raw_off_rtg", "raw_def_rtg", "games")
     )
 
 

--- a/sportsdataverse/nfl/nfl_ratings.py
+++ b/sportsdataverse/nfl/nfl_ratings.py
@@ -5,10 +5,10 @@ from :func:`sportsdataverse.nfl.nfl_loaders.load_nfl_pbp` (owned by
 ``ep_wp.py`` -- this module never re-scores plays), producing per-team
 offense / defense / special-teams components and ``adj_net``.
 
-The solver, :func:`opponent_adjusted_ridge`, is a self-contained pure
-function parameterized on column names so it is league-agnostic -- the
-designated T7.2 extraction target for a shared ``_common_ratings`` module
-backing both CFB and NFL.
+The solver, :func:`opponent_adjusted_ridge`, is re-exported from the
+league-agnostic shared core :mod:`sportsdataverse._common.ratings` (T7.2) --
+this module keeps its NFL-specific plumbing (loaders, competitive-play
+filter, ``RatingsConfig``) and delegates the pure ridge math inward.
 
 Non-market discipline (binding): nothing in this module reads
 ``spread_line`` / ``total_line`` / ``vegas_wp``; the competitive-play filter
@@ -20,21 +20,15 @@ from __future__ import annotations
 import datetime
 from typing import Literal, overload
 
-import numpy as np
 import pandas as pd
 import polars as pl
 
+from sportsdataverse._common.ratings import opponent_adjusted_ridge
 from sportsdataverse.nfl.nfl_loaders import load_nfl_pbp, load_nfl_schedule
 from sportsdataverse.nfl.nfl_prediction_constants import RatingsConfig, as_of_ratings_split
 
 __all__ = ["efficiency_ratings", "nfl_ratings", "opponent_adjusted_ridge", "special_teams_ratings"]
 
-
-_RIDGE_OUTPUT_SCHEMA: dict[str, pl.PolarsDataType] = {
-    "team_id": pl.Utf8,
-    "off_coef": pl.Float64,
-    "def_coef": pl.Float64,
-}
 
 _EFFICIENCY_OUTPUT_SCHEMA: dict[str, pl.PolarsDataType] = {
     "team_id": pl.Utf8,
@@ -48,87 +42,6 @@ _ST_OUTPUT_SCHEMA: dict[str, pl.PolarsDataType] = {
     "team_id": pl.Utf8,
     "adj_st_epa": pl.Float64,
 }
-
-
-def opponent_adjusted_ridge(
-    plays: pl.DataFrame,
-    *,
-    off_col: str,
-    def_col: str,
-    home_col: str,
-    resp_col: str,
-    lam: float,
-    penalize_home: bool = False,
-) -> tuple[pl.DataFrame, float, float]:
-    """Ridge-regress ``resp_col`` on offense + defense team indicators + HFA.
-
-    League-agnostic (column names are arguments) so this is the single solver
-    a T7.2 refactor can lift into ``_common_ratings`` to back both CFB and
-    NFL. Builds the offense/defense-indicator + intercept + home design and
-    solves the ridge normal equations ``beta = (X'X + lam*R)^-1 X'y``. Only
-    team coefficients are penalised; the intercept (and, unless
-    ``penalize_home``, the home term) is free.
-
-    Args:
-        plays: One row per play. Rows with a null ``off_col`` / ``def_col`` /
-            ``resp_col`` must be filtered by the caller.
-        off_col: Column naming the offense (possession) team.
-        def_col: Column naming the defense team.
-        home_col: Column naming the home team (HFA indicator is
-            ``off_col == home_col``).
-        resp_col: Numeric response column (e.g. ``epa``).
-        lam: Ridge penalty applied to the team coefficients.
-        penalize_home: Also penalise the home-field coefficient
-            (default False).
-
-    Returns:
-        A ``(frame, intercept, home_coef)`` tuple: ``frame`` has one row per
-        team (``team_id`` Utf8, ``off_coef`` / ``def_coef`` Float64);
-        ``intercept`` is the league baseline; ``home_coef`` the fitted HFA in
-        response units. Zero-row frame + ``(0.0, 0.0)`` on empty input.
-
-    Example:
-        Quick start::
-
-            from sportsdataverse.nfl.nfl_ratings import opponent_adjusted_ridge
-            frame, intercept, hfa = opponent_adjusted_ridge(
-                plays, off_col="posteam", def_col="defteam",
-                home_col="home_team", resp_col="epa", lam=200.0,
-            )
-            frame.sort("off_coef", descending=True).head()
-    """
-    if plays.height == 0:
-        return pl.DataFrame(schema=_RIDGE_OUTPUT_SCHEMA), 0.0, 0.0
-    off = plays[off_col].cast(pl.Utf8)
-    dff = plays[def_col].cast(pl.Utf8)
-    teams = sorted(set(off.to_list()) | set(dff.to_list()))
-    idx = {t: i for i, t in enumerate(teams)}
-    n_t = len(teams)
-    n = plays.height
-    # columns: [off_0..off_{T-1}, def_0..def_{T-1}, intercept, home]
-    p = 2 * n_t + 2
-    X = np.zeros((n, p), dtype=float)
-    oi = np.array([idx[t] for t in off.to_list()])
-    di = np.array([idx[t] for t in dff.to_list()])
-    X[np.arange(n), oi] = 1.0
-    X[np.arange(n), n_t + di] = 1.0
-    X[:, 2 * n_t] = 1.0  # intercept
-    is_home = (off == plays[home_col].cast(pl.Utf8)).to_numpy().astype(float)
-    X[:, 2 * n_t + 1] = is_home  # HFA (offense is home)
-    y = plays[resp_col].cast(pl.Float64).to_numpy()
-    R = np.eye(p)
-    R[2 * n_t, 2 * n_t] = 0.0  # don't penalise intercept
-    if not penalize_home:
-        R[2 * n_t + 1, 2 * n_t + 1] = 0.0  # don't penalise HFA
-    beta = np.linalg.solve(X.T @ X + lam * R, X.T @ y)
-    frame = pl.DataFrame(
-        {
-            "team_id": teams,
-            "off_coef": beta[:n_t].astype(np.float64),
-            "def_coef": beta[n_t : 2 * n_t].astype(np.float64),
-        }
-    )
-    return frame, float(beta[2 * n_t]), float(beta[2 * n_t + 1])
 
 
 def efficiency_ratings(plays: pl.DataFrame, *, config: RatingsConfig | None = None) -> pl.DataFrame:

--- a/tests/common/test_ratings_iterative.py
+++ b/tests/common/test_ratings_iterative.py
@@ -1,0 +1,102 @@
+"""Unit tests for the shared MBB/NBA iterative fixed point (T7.2).
+
+The per-league byte-for-byte regression against real data lives in each
+league's own ``test_*_team_ratings*`` suite, which re-runs unchanged after
+the retarget. These tests lock in the pure-function behavior directly,
+including the ``baseline=None`` (MBB: data-mean) vs ``baseline=<float>``
+(NBA: fitted constant) branch both leagues rely on.
+"""
+
+import polars as pl
+
+from sportsdataverse._common.ratings import iterative_opponent_adjust
+
+
+def _round_robin(base: float = 104.0) -> pl.DataFrame:
+    strength = {"A": 10.0, "B": 0.0, "C": -10.0}
+    rows = []
+    for t in "ABC":
+        for o in "ABC":
+            if t == o:
+                continue
+            rows.append((t, o, base + strength[t] - strength[o], base - strength[t] + strength[o], True, False))
+    return pl.DataFrame(rows, schema=["team_id", "opp_team_id", "off", "def", "is_home", "neutral_site"], orient="row")
+
+
+def test_empty_returns_schema() -> None:
+    out = iterative_opponent_adjust(
+        pl.DataFrame(
+            schema={
+                "team_id": pl.Utf8,
+                "opp_team_id": pl.Utf8,
+                "off": pl.Float64,
+                "def": pl.Float64,
+                "is_home": pl.Boolean,
+                "neutral_site": pl.Boolean,
+            }
+        ),
+        team_col="team_id",
+        opp_col="opp_team_id",
+        off_col="off",
+        def_col="def",
+        home_col="is_home",
+        neutral_col="neutral_site",
+        hfa=3.0,
+    )
+    assert out.columns == ["team_id", "adj_off", "adj_def", "adj_net", "raw_off", "raw_def", "games"]
+    assert out.height == 0
+
+
+def test_adj_net_ordering_with_data_derived_baseline() -> None:
+    """``baseline=None`` -- MBB's behavior (average computed from the data)."""
+    out = iterative_opponent_adjust(
+        _round_robin(),
+        team_col="team_id",
+        opp_col="opp_team_id",
+        off_col="off",
+        def_col="def",
+        home_col="is_home",
+        neutral_col="neutral_site",
+        hfa=3.0,
+        baseline=None,
+    ).sort("adj_net", descending=True)
+    assert out["team_id"].to_list() == ["A", "B", "C"]
+    assert out.filter(pl.col("team_id") == "A")["games"].item() == 2
+
+
+def test_adj_net_ordering_with_fitted_baseline() -> None:
+    """``baseline=<float>`` -- NBA's behavior (a fitted external constant)."""
+    out = iterative_opponent_adjust(
+        _round_robin(),
+        team_col="team_id",
+        opp_col="opp_team_id",
+        off_col="off",
+        def_col="def",
+        home_col="is_home",
+        neutral_col="neutral_site",
+        hfa=3.0,
+        baseline=104.0,
+    ).sort("adj_net", descending=True)
+    assert out["team_id"].to_list() == ["A", "B", "C"]
+
+
+def test_neutral_site_zeroes_home_edge() -> None:
+    rows = [
+        ("A", "B", 105.0, 103.0, True, True),
+        ("B", "A", 103.0, 105.0, False, True),
+    ]
+    game_eff = pl.DataFrame(
+        rows, schema=["team_id", "opp_team_id", "off", "def", "is_home", "neutral_site"], orient="row"
+    )
+    out = iterative_opponent_adjust(
+        game_eff,
+        team_col="team_id",
+        opp_col="opp_team_id",
+        off_col="off",
+        def_col="def",
+        home_col="is_home",
+        neutral_col="neutral_site",
+        hfa=10.0,  # a large hfa would visibly bias a non-neutral game; here it must not.
+        baseline=104.0,
+    )
+    assert out.height == 2

--- a/tests/common/test_ratings_iterative.py
+++ b/tests/common/test_ratings_iterative.py
@@ -80,23 +80,46 @@ def test_adj_net_ordering_with_fitted_baseline() -> None:
     assert out["team_id"].to_list() == ["A", "B", "C"]
 
 
-def test_neutral_site_zeroes_home_edge() -> None:
+def _venue_slate(neutral: bool) -> pl.DataFrame:
+    """A multi-game, venue-asymmetric slate where hfa genuinely moves the fit.
+
+    (A single balanced game is degenerate -- the fixed point returns the raw
+    values regardless of hfa, so it can't distinguish neutral-zeroing from a
+    no-op. This slate has unbalanced venues + a venue-flipped rematch, so the
+    hfa term actually bites when ``neutral`` is False -- see the teeth check in
+    ``test_neutral_site_zeroes_home_edge``.)
+    """
     rows = [
-        ("A", "B", 105.0, 103.0, True, True),
-        ("B", "A", 103.0, 105.0, False, True),
+        ("A", "B", 110.0, 95.0, True, neutral),
+        ("B", "A", 95.0, 110.0, False, neutral),
+        ("A", "C", 108.0, 90.0, True, neutral),
+        ("C", "A", 90.0, 108.0, False, neutral),
+        ("B", "C", 102.0, 98.0, True, neutral),
+        ("C", "B", 98.0, 102.0, False, neutral),
+        ("A", "B", 112.0, 96.0, False, neutral),  # rematch, venues flipped
+        ("B", "A", 96.0, 112.0, True, neutral),
     ]
-    game_eff = pl.DataFrame(
-        rows, schema=["team_id", "opp_team_id", "off", "def", "is_home", "neutral_site"], orient="row"
-    )
-    out = iterative_opponent_adjust(
-        game_eff,
+    return pl.DataFrame(rows, schema=["team_id", "opp_team_id", "off", "def", "is_home", "neutral_site"], orient="row")
+
+
+def test_neutral_site_zeroes_home_edge() -> None:
+    """On an all-neutral slate the hfa must drop out entirely: the fixed point
+    with a large hfa must be identical to the one with hfa=0 -- while the same
+    slate marked non-neutral must NOT (proving the equality has teeth)."""
+    kw = dict(
         team_col="team_id",
         opp_col="opp_team_id",
         off_col="off",
         def_col="def",
         home_col="is_home",
         neutral_col="neutral_site",
-        hfa=10.0,  # a large hfa would visibly bias a non-neutral game; here it must not.
-        baseline=104.0,
+        baseline=100.0,
     )
-    assert out.height == 2
+    # Teeth: on a real (non-neutral) slate a large hfa changes the fit.
+    assert not iterative_opponent_adjust(_venue_slate(False), hfa=10.0, **kw).equals(
+        iterative_opponent_adjust(_venue_slate(False), hfa=0.0, **kw)
+    )
+    # Property: on an all-neutral slate the hfa is zeroed out -> hfa=10 == hfa=0.
+    assert iterative_opponent_adjust(_venue_slate(True), hfa=10.0, **kw).equals(
+        iterative_opponent_adjust(_venue_slate(True), hfa=0.0, **kw)
+    )

--- a/tests/common/test_ratings_ridge.py
+++ b/tests/common/test_ratings_ridge.py
@@ -1,0 +1,94 @@
+"""Unit tests for the two shared ridge engines in ``sportsdataverse._common.ratings``.
+
+These lock in the pure-function behavior directly (the per-league
+byte-for-byte regression against real data lives in each league's own
+``test_*_ratings*`` suite, which re-runs unchanged after the T7.2 retarget).
+"""
+
+import numpy as np
+import polars as pl
+
+from sportsdataverse._common.ratings import dropped_level_ridge, opponent_adjusted_ridge
+
+
+def test_opponent_adjusted_ridge_empty_returns_schema() -> None:
+    frame, intercept, home = opponent_adjusted_ridge(
+        pl.DataFrame(schema={"o": pl.Utf8, "d": pl.Utf8, "h": pl.Utf8, "y": pl.Float64}),
+        off_col="o",
+        def_col="d",
+        home_col="h",
+        resp_col="y",
+        lam=10.0,
+    )
+    assert frame.columns == ["team_id", "off_coef", "def_coef"]
+    assert frame.height == 0
+    assert intercept == 0.0 and home == 0.0
+
+
+def test_opponent_adjusted_ridge_recovers_injected_offense_ordering() -> None:
+    rng = np.random.default_rng(0)
+    true_off = {"A": 0.20, "B": 0.0, "C": -0.20}
+    true_def = {"A": 0.0, "B": 0.05, "C": -0.05}
+    rows = []
+    for o in "ABC":
+        for d in "ABC":
+            if o == d:
+                continue
+            for h in (o, d):  # alternate home team so `h` isn't collinear with the intercept
+                for _ in range(40):
+                    rows.append((o, d, h, true_off[o] - true_def[d] + rng.normal(0, 0.02)))
+    plays = pl.DataFrame(rows, schema=["o", "d", "h", "y"], orient="row")
+    frame, _intercept, _home = opponent_adjusted_ridge(
+        plays, off_col="o", def_col="d", home_col="h", resp_col="y", lam=1.0
+    )
+    out = frame.sort("off_coef", descending=True)
+    assert out["team_id"].to_list()[0] == "A"
+    a_net = (
+        out.filter(pl.col("team_id") == "A")["off_coef"].item()
+        - out.filter(pl.col("team_id") == "A")["def_coef"].item()
+    )
+    c_net = (
+        out.filter(pl.col("team_id") == "C")["off_coef"].item()
+        - out.filter(pl.col("team_id") == "C")["def_coef"].item()
+    )
+    assert a_net > c_net
+
+
+def test_opponent_adjusted_ridge_home_edge_positive() -> None:
+    rows = []
+    for o in "AB":
+        for d in "AB":
+            if o == d:
+                continue
+            for h in (o, d):  # h==o -> offense is home; h==d -> defense is home
+                for _ in range(50):
+                    rows.append((o, d, h, 0.03 if h == o else 0.0))
+    plays = pl.DataFrame(rows, schema=["o", "d", "h", "y"], orient="row")
+    _frame, _intercept, home_coef = opponent_adjusted_ridge(
+        plays, off_col="o", def_col="d", home_col="h", resp_col="y", lam=1.0
+    )
+    assert 0.0 < home_coef < 0.06
+
+
+def test_dropped_level_ridge_drops_first_team_alphabetically() -> None:
+    rng = np.random.default_rng(1)
+    rows = []
+    teams = ["Alpha", "Beta", "Gamma"]
+    strength = {"Alpha": 0.15, "Beta": 0.0, "Gamma": -0.15}
+    for o in teams:
+        for d in teams:
+            if o == d:
+                continue
+            for _ in range(30):
+                rows.append((o, d, o, "N", strength[o] - strength[d] + rng.normal(0, 0.02), 1, 0))
+    clean = pl.DataFrame(
+        rows, schema=["pos_team_id", "def_pos_team_id", "pos_team", "home", "EPA", "pass", "rush"], orient="row"
+    ).with_columns(hfa=pl.lit(0))
+    offense, defense, intercept = dropped_level_ridge(clean, ridge_lambda=5.0)
+    # "Alpha" is the first sorted team_id -> dropped as the reference level.
+    assert "Alpha" not in offense["team_id"].to_list()
+    assert "Beta" in offense["team_id"].to_list() and "Gamma" in offense["team_id"].to_list()
+    beta_off = offense.filter(pl.col("team_id") == "Beta")["adjmodelOff"].item()
+    gamma_off = offense.filter(pl.col("team_id") == "Gamma")["adjmodelOff"].item()
+    assert beta_off > gamma_off
+    assert isinstance(intercept, float)


### PR DESCRIPTION
## T7.2 — Cross-League Infrastructure (shared rating cores)

Behavior-preserving extraction of the opponent-adjustment rating engines that ≥2 leagues had duplicated, into a new `sportsdataverse/_common/ratings.py`. Model-spine roadmap Tier 7.2 (the deliberately-last infra item, unblocked now that multiple ratings spines have merged). **This is a pure refactor — no shipped output changes.**

### Extracted to `sportsdataverse/_common/ratings.py`
- `opponent_adjusted_ridge` — dense full-dummy manual normal-equations (NFL)
- `dropped_level_ridge` — dropped-reference-level standardized `sklearn.Ridge` (CFB)
- `iterative_opponent_adjust(..., baseline=None|float)` — KenPom-style fixed point (MBB/NBA/WBB/WNBA)

The two ridge algorithms are **kept distinct, not force-unified** — they are genuinely different design encodings, libraries, and regularization conventions; merging them would change one league's numbers. NHL's `adjust_rate_opponent` (different init + built-in shrinkage → not byte-identical) is honestly scoped out as a documented follow-on and left untouched.

### Callers retargeted (behavior identical)
- `nfl/nfl_ratings.py` → re-exports the shared ridge
- `cfb/cfb_adjusted_epa.py` (`_fit_opponent_ridge` → thin wrapper over `dropped_level_ridge`)
- `mbb/mbb_team_ratings.py` + `nba/nba_team_ratings.py` (`_adjust_one_season` → delegates to `iterative_opponent_adjust`; WBB/WNBA inherit via re-export)

### Byte-for-byte preservation (the acceptance gate)
Full multi-league baseline `uv run pytest tests/mbb tests/wbb tests/cfb tests/nba tests/wnba tests/nfl tests/nhl -q` → **2720 passed / 175 skipped / 10 xfailed**; after the refactor → **2728 passed** (= 2720 + 8 new `tests/common` unit tests) **/ 175 skipped / 10 xfailed — identical**. No existing test changed, no public signature changed. Reviewed by `oracle-gate-reviewer`: every retargeted caller diffed old-vs-new line-by-line, wrappers confirmed to reconstruct each league's exact schema/column-order/dtypes; the MBB-vs-NBA baseline divergence is preserved via the optional `baseline` param. **No merge-blockers.** The 8 new `tests/common` tests pin the extracted functions' behavior (ordering recovery, HFA sign+bound, reference-level drop, and a teeth-checked neutral-site HFA-zeroing test). mypy clean (both new modules on the ratchet); `generate.py --check` clean.

## Summary by Sourcery

Extract shared opponent-adjustment rating cores into a new internal sportsdataverse._common.ratings module and retarget league-specific callers without changing public behavior or outputs.

Enhancements:
- Centralize NFL, CFB, and MBB/NBA/WBB/WNBA opponent-adjusted rating engines in sportsdataverse._common.ratings while keeping league-specific wrappers and schemas intact.
- Add an internal _common package for shared cross-league infrastructure without altering top-level exports.

Build:
- Register the new _common modules in pyproject.toml for type-checking and tooling.

Documentation:
- Update NFL documentation to describe opponent_adjusted_ridge as a shared league-agnostic solver now hosted in sportsdataverse._common.ratings.

Tests:
- Add common unit tests for the shared ridge and iterative opponent-adjustment cores to pin their behavior across leagues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added shared opponent-adjusted rating calculations supporting ridge-based and iterative methods across sports.
  - Preserved existing NFL, CFB, MBB, and NBA rating outputs while centralizing their adjustment logic.

- **Documentation**
  - Clarified the methodology and coefficient handling for opponent-adjusted NFL ratings.

- **Tests**
  - Added coverage for empty inputs, team rating accuracy, home-court effects, neutral venues, and reference-team handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->