### PR TITLE
fix(dl_utils): retry transient HTTP status codes in download() with jittered backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,16 @@
   `load_nfl_ff_rankings`) retry with exponential backoff on transient
   upstream errors (HTTP 429/5xx) instead of failing on the first hit — the
   raw-GitHub host rate-limits parallel CI runners.
+- fix(dl_utils): `download()` now retries **transient status codes**
+  (403/408/429/500/502/503/504) with the same `Retry-After`-aware backoff it
+  already used for connection failures — previously a 429/403/5xx came back as
+  a normal `Response` and was returned without a retry (the root cause the
+  DynastyProcess loader-level retry worked around). The retryable set is
+  configurable via the new `retry_statuses=` param; when the budget is spent
+  the last response is returned unchanged (callers still key on
+  `.status_code`), and non-2xx responses are no longer cached. 403 is retried
+  by default because ESPN's Core v2 API returns it under load — `download()`
+  is the ESPN/nflverse gateway and does not serve the auth'd endpoints.
 
 ### CFB — advanced-efficiency spine (opponent-adjusted efficiency/explosiveness/havoc → field position → adjusted tempo)
 

--- a/docs/src/pages/CHANGELOG.md
+++ b/docs/src/pages/CHANGELOG.md
@@ -177,6 +177,16 @@
   `load_nfl_ff_rankings`) retry with exponential backoff on transient
   upstream errors (HTTP 429/5xx) instead of failing on the first hit — the
   raw-GitHub host rate-limits parallel CI runners.
+- fix(dl_utils): `download()` now retries **transient status codes**
+  (403/408/429/500/502/503/504) with the same `Retry-After`-aware backoff it
+  already used for connection failures — previously a 429/403/5xx came back as
+  a normal `Response` and was returned without a retry (the root cause the
+  DynastyProcess loader-level retry worked around). The retryable set is
+  configurable via the new `retry_statuses=` param; when the budget is spent
+  the last response is returned unchanged (callers still key on
+  `.status_code`), and non-2xx responses are no longer cached. 403 is retried
+  by default because ESPN's Core v2 API returns it under load — `download()`
+  is the ESPN/nflverse gateway and does not serve the auth'd endpoints.
 
 ### CFB — advanced-efficiency spine (opponent-adjusted efficiency/explosiveness/havoc → field position → adjusted tempo)
 

--- a/sportsdataverse/dl_utils.py
+++ b/sportsdataverse/dl_utils.py
@@ -240,7 +240,13 @@ def download(
             # return the response unchanged so callers can key on `.status_code`.
             status = getattr(response, "status_code", None)
             retryable = status in retry_statuses
-            if retryable and status_retries < status_budget:
+            # `attempt < attempts - 1` is load-bearing, not redundant with the
+            # budget: when status_budget == attempts-1 (small num_retries) a
+            # status retry could otherwise `continue` on the FINAL iteration,
+            # exhausting the loop into the post-loop `raise last_exc` — which
+            # would raise a STALE connection exception from an earlier attempt
+            # instead of returning this response. Never retry on the last attempt.
+            if retryable and status_retries < status_budget and attempt < attempts - 1:
                 status_retries += 1
                 logger.warning(
                     "retryable status %s - %s for url (%s) [status retry %d/%d]",

--- a/sportsdataverse/dl_utils.py
+++ b/sportsdataverse/dl_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import random
 import re
 import time
 from datetime import datetime, timezone
@@ -34,6 +35,22 @@ for _scheme in ("https://", "http://"):
 # rate-limit windows while bounding worst-case latency.
 _MAX_RETRY_AFTER = 120.0
 
+# Transient HTTP status codes worth retrying. 429 (rate limit) + 408 (request
+# timeout) + the 5xx server-error family are universally transient. 403 is
+# included because ESPN's Core v2 API returns it *under load* (not an auth
+# failure): ``download`` is the ESPN / nflverse gateway and does NOT serve the
+# auth'd endpoints — ``nfl_api`` (bearer), ``nba_stats`` / ``wnba_stats``
+# (curl_cffi runtime), and PFF (Clerk cookies) each have their own ``_get`` —
+# so a 403 seen here is far more likely rate-limiting than a permanent
+# forbidden. Retrying a genuine 403 only costs bounded backoff latency.
+_RETRYABLE_STATUS = frozenset({403, 408, 429, 500, 502, 503, 504})
+
+# Status retries reuse the loop but get their OWN small cap so a genuinely
+# permanent 403/forbidden can't spin the full ``num_retries`` (16 requests /
+# ~51s) before returning — and so we don't hammer a host already signalling
+# "back off." Connection-exception retries still use the full ``num_retries``.
+_MAX_STATUS_RETRIES = 4
+
 
 def _parse_retry_after(value: str) -> float | None:
     """Parse a ``Retry-After`` value into seconds, or ``None`` if unparseable.
@@ -65,6 +82,7 @@ def _retry_delay(
     base: float = 0.5,
     cap: float = 4.0,
     max_retry_after: float = _MAX_RETRY_AFTER,
+    jitter: bool = True,
 ) -> float:
     """Seconds to wait before the next retry.
 
@@ -74,7 +92,10 @@ def _retry_delay(
     outsized value can't park the request in ``time.sleep`` indefinitely. When
     the header is absent or unparseable, falls back to capped exponential
     backoff (gentler than a fixed sleep on quick-recovery transients, politer
-    than hammering on persistent ones).
+    than hammering on persistent ones). ``jitter`` (default on) spreads the
+    exponential fallback over 50-100% of the computed delay so concurrent
+    workers don't re-hit a recovering host in lockstep (a thundering herd); the
+    server-dictated ``Retry-After`` path is left exact.
     """
     headers = getattr(response, "headers", None)
     retry_after = headers.get("Retry-After") if headers else None
@@ -82,7 +103,10 @@ def _retry_delay(
         secs = _parse_retry_after(retry_after)
         if secs is not None:
             return min(max_retry_after, secs)
-    return min(cap, base * (2**attempt))
+    delay = min(cap, base * (2**attempt))
+    if jitter:
+        delay *= 0.5 + random.random() * 0.5
+    return delay
 
 
 def download(
@@ -95,6 +119,7 @@ def download(
     session=None,
     logger=None,
     cache_ttl=None,
+    retry_statuses=_RETRYABLE_STATUS,
 ):
     """Download a URL with retries and ESPN-aware error handling.
 
@@ -120,9 +145,16 @@ def download(
             when you need isolation (separate cookies / auth / proxy lifecycle).
         logger: Optional ``logging.Logger``. Defaults to the package
             logger ``"sdv.dl_utils"``.
+        retry_statuses: Iterable of HTTP status codes to retry (with the same
+            ``Retry-After``-aware backoff as connection failures). Defaults to
+            :data:`_RETRYABLE_STATUS` (403/408/429/500/502/503/504). Pass a
+            narrower set (e.g. ``{429, 503}``) for an auth'd endpoint where a
+            403 is a real forbidden rather than ESPN-under-load.
 
     Returns:
-        The final ``requests.Response``.
+        The final ``requests.Response``. When the retry budget is exhausted on
+        a retryable status the last response is returned unchanged (callers key
+        on ``.status_code``); a connection-level failure re-raises instead.
 
     Example:
         Quick start::
@@ -193,15 +225,47 @@ def download(
     # retry budget is exhausted instead of silently returning a stale or
     # unbound `response`.
     attempts = max(int(num_retries), 0) + 1
+    status_budget = min(attempts - 1, _MAX_STATUS_RETRIES)
     response = None
     last_exc: Exception | None = None
+    status_retries = 0
     for attempt in range(attempts):
         try:
             response = session.get(url, params=params, proxies=proxy, headers=headers, timeout=timeout)
             response = no_espn_data(response)
-            # Persist successful responses to the cache. Catches any
-            # body-parse error so a cache write never breaks the call.
-            if get_cache_mode() != "off":
+            # Transient status codes (rate-limit / server errors) come back as a
+            # normal Response — `requests` does not raise on them. Retry with the
+            # same Retry-After-aware backoff the connection-exception path uses,
+            # capped at `status_budget` (see `_MAX_STATUS_RETRIES`); once spent,
+            # return the response unchanged so callers can key on `.status_code`.
+            status = getattr(response, "status_code", None)
+            retryable = status in retry_statuses
+            if retryable and status_retries < status_budget:
+                status_retries += 1
+                logger.warning(
+                    "retryable status %s - %s for url (%s) [status retry %d/%d]",
+                    status,
+                    getattr(response, "reason", "?"),
+                    getattr(response, "url", url),
+                    status_retries,
+                    status_budget,
+                )
+                time.sleep(_retry_delay(response, attempt))
+                continue
+            if retryable:
+                # Budget spent: surface a terminal line so a persistent
+                # 429/403/5xx isn't invisible in logs after the last retry.
+                logger.warning(
+                    "retryable status %s persisted after %d retr%s; returning to caller for url (%s)",
+                    status,
+                    status_retries,
+                    "y" if status_retries == 1 else "ies",
+                    getattr(response, "url", url),
+                )
+            # Persist only successful (2xx) responses to the cache — never cache a
+            # 429/5xx body. Catches any body-parse error so a cache write never
+            # breaks the call.
+            if get_cache_mode() != "off" and status is not None and 200 <= status < 300:
                 try:
                     cache_set(url, _cache_params, response.json(), ttl=cache_ttl)
                 except Exception:  # noqa: BLE001

--- a/tests/test_dl_utils.py
+++ b/tests/test_dl_utils.py
@@ -15,11 +15,24 @@ class TestRetryDelay:
     """Offline tests for the retry backoff helper (no network)."""
 
     def test_exponential_backoff_capped(self):
-        # base=0.5: 0.5, 1, 2, 4, then capped at 4.
-        assert _retry_delay(None, 0) == 0.5
-        assert _retry_delay(None, 1) == 1.0
-        assert _retry_delay(None, 3) == 4.0
-        assert _retry_delay(None, 10) == 4.0  # capped
+        # base=0.5: 0.5, 1, 2, 4, then capped at 4. jitter=False for the exact curve.
+        assert _retry_delay(None, 0, jitter=False) == 0.5
+        assert _retry_delay(None, 1, jitter=False) == 1.0
+        assert _retry_delay(None, 3, jitter=False) == 4.0
+        assert _retry_delay(None, 10, jitter=False) == 4.0  # capped
+
+    def test_jitter_stays_within_half_to_full(self):
+        # Default jitter spreads the exponential fallback over 50-100% of the
+        # computed delay, so a thundering herd de-syncs. 50 draws stay in-band
+        # and at least one differs from the deterministic value.
+        vals = [_retry_delay(None, 3) for _ in range(50)]  # base curve = 4.0
+        assert all(2.0 <= v <= 4.0 for v in vals)
+        assert any(v != 4.0 for v in vals)
+
+    def test_jitter_never_touches_retry_after(self):
+        # The server-dictated Retry-After path is exact even with jitter on.
+        resp = types.SimpleNamespace(headers={"Retry-After": "7"})
+        assert all(_retry_delay(resp, 0) == 7.0 for _ in range(20))
 
     def test_honors_numeric_retry_after_header(self):
         resp = types.SimpleNamespace(headers={"Retry-After": "7"})
@@ -55,7 +68,7 @@ class TestRetryDelay:
 
     def test_bad_retry_after_falls_back_to_backoff(self):
         resp = types.SimpleNamespace(headers={"Retry-After": "soon"})
-        assert _retry_delay(resp, 2) == 2.0  # unparseable -> exponential
+        assert _retry_delay(resp, 2, jitter=False) == 2.0  # unparseable -> exponential
 
 
 class TestDownload:
@@ -137,3 +150,108 @@ class TestDownload:
         with pytest.raises(NoESPNDataError):
             download("https://sports.core.api.espn.com/v2/_no_such_/roster", num_retries=15)
         assert calls["n"] == 1  # not 16
+
+    def test_download_retries_transient_status_then_succeeds(self, monkeypatch):
+        """A 503/429 comes back as a normal Response (requests doesn't raise on
+        it) — download must retry the transient status and return the eventual
+        200. Offline: session.get is stubbed and time.sleep is a no-op."""
+        import sportsdataverse.cache as _cache
+
+        monkeypatch.setattr(_cache, "get_cache_mode", lambda: "off")
+        monkeypatch.setattr("sportsdataverse.dl_utils.time.sleep", lambda *a, **k: None)
+        seq = [503, 503, 200]
+        calls = {"n": 0}
+
+        def fake_get(self, url, **kwargs):
+            code = seq[calls["n"]]
+            calls["n"] += 1
+            return types.SimpleNamespace(status_code=code, url=url, reason="x", headers={}, json=lambda: {})
+
+        monkeypatch.setattr(requests.Session, "get", fake_get)
+        resp = download("https://site.api.espn.com/x", num_retries=5)
+        assert resp.status_code == 200
+        assert calls["n"] == 3  # 503, 503, 200
+
+    def test_download_returns_last_response_when_retry_budget_exhausted(self, monkeypatch):
+        """A persistent 429 must NOT raise — once the budget is spent, return the
+        429 Response so callers can key on ``.status_code`` (backward-compatible
+        with the pre-retry behavior of returning whatever came back)."""
+        import sportsdataverse.cache as _cache
+
+        monkeypatch.setattr(_cache, "get_cache_mode", lambda: "off")
+        monkeypatch.setattr("sportsdataverse.dl_utils.time.sleep", lambda *a, **k: None)
+        calls = {"n": 0}
+
+        def fake_get(self, url, **kwargs):
+            calls["n"] += 1
+            return types.SimpleNamespace(
+                status_code=429, url=url, reason="Too Many Requests", headers={}, json=lambda: {}
+            )
+
+        monkeypatch.setattr(requests.Session, "get", fake_get)
+        resp = download("https://site.api.espn.com/y", num_retries=2)
+        assert resp.status_code == 429
+        assert calls["n"] == 3  # 1 initial + 2 retries
+
+    def test_download_does_not_retry_non_retryable_status(self, monkeypatch):
+        """A 401 (not in the retry set) is a definitive answer — one attempt, no
+        retry, even with a large budget."""
+        import sportsdataverse.cache as _cache
+
+        monkeypatch.setattr(_cache, "get_cache_mode", lambda: "off")
+        calls = {"n": 0}
+
+        def fake_get(self, url, **kwargs):
+            calls["n"] += 1
+            return types.SimpleNamespace(status_code=401, url=url, reason="Unauthorized", headers={}, json=lambda: {})
+
+        monkeypatch.setattr(requests.Session, "get", fake_get)
+        resp = download("https://site.api.espn.com/z", num_retries=5)
+        assert resp.status_code == 401
+        assert calls["n"] == 1
+
+    def test_download_status_retries_capped_below_num_retries(self, monkeypatch):
+        """A persistent 429 with a large connection budget (num_retries=15) is
+        capped at _MAX_STATUS_RETRIES (4) status retries — 5 requests total, not
+        16 — so we don't hammer a host already signalling back-off."""
+        import sportsdataverse.cache as _cache
+
+        monkeypatch.setattr(_cache, "get_cache_mode", lambda: "off")
+        monkeypatch.setattr("sportsdataverse.dl_utils.time.sleep", lambda *a, **k: None)
+        calls = {"n": 0}
+
+        def fake_get(self, url, **kwargs):
+            calls["n"] += 1
+            return types.SimpleNamespace(
+                status_code=429, url=url, reason="Too Many Requests", headers={}, json=lambda: {}
+            )
+
+        monkeypatch.setattr(requests.Session, "get", fake_get)
+        resp = download("https://site.api.espn.com/capped", num_retries=15)
+        assert resp.status_code == 429
+        assert calls["n"] == 5  # 1 initial + 4 capped status retries
+
+    def test_download_does_not_cache_non_2xx(self, monkeypatch):
+        """A retryable status returned after the budget is spent must NOT be
+        written to the cache; a 2xx still is."""
+        import sportsdataverse.cache as _cache
+
+        writes = []
+        monkeypatch.setattr(_cache, "get_cache_mode", lambda: "memory")
+        monkeypatch.setattr(_cache, "cache_get", lambda *a, **k: None)
+        monkeypatch.setattr(_cache, "cache_set", lambda url, params, body, ttl=None: writes.append(url))
+        monkeypatch.setattr("sportsdataverse.dl_utils.time.sleep", lambda *a, **k: None)
+
+        def _resp(code):
+            def fake_get(self, url, **kwargs):
+                return types.SimpleNamespace(status_code=code, url=url, reason="x", headers={}, json=lambda: {})
+
+            return fake_get
+
+        monkeypatch.setattr(requests.Session, "get", _resp(503))
+        download("https://site.api.espn.com/nocache", num_retries=1)
+        assert writes == []  # 503 body never cached
+
+        monkeypatch.setattr(requests.Session, "get", _resp(200))
+        download("https://site.api.espn.com/docache", num_retries=1)
+        assert writes == ["https://site.api.espn.com/docache"]  # 200 cached

--- a/tests/test_dl_utils.py
+++ b/tests/test_dl_utils.py
@@ -193,6 +193,31 @@ class TestDownload:
         assert resp.status_code == 429
         assert calls["n"] == 3  # 1 initial + 2 retries
 
+    def test_download_interleaved_conn_error_then_status_returns_response(self, monkeypatch):
+        """A connection error on an early attempt sets ``last_exc``; if the FINAL
+        attempt is a retryable status, the loop must still RETURN that response
+        rather than fall through to ``raise last_exc`` and surface the stale
+        connection exception. Regression for the interleaved conn-error + status
+        retry path (status_budget == attempts-1)."""
+        import sportsdataverse.cache as _cache
+
+        monkeypatch.setattr(_cache, "get_cache_mode", lambda: "off")
+        monkeypatch.setattr("sportsdataverse.dl_utils.time.sleep", lambda *a, **k: None)
+        seq = ["boom", 503, 503]  # conn error, then persistent 503
+        calls = {"n": 0}
+
+        def fake_get(self, url, **kwargs):
+            item = seq[calls["n"]]
+            calls["n"] += 1
+            if item == "boom":
+                raise requests.exceptions.ConnectionError("boom")
+            return types.SimpleNamespace(status_code=item, url=url, reason="x", headers={}, json=lambda: {})
+
+        monkeypatch.setattr(requests.Session, "get", fake_get)
+        resp = download("https://site.api.espn.com/w", num_retries=2)
+        assert resp.status_code == 503  # returned, NOT raised as the stale ConnectionError
+        assert calls["n"] == 3
+
     def test_download_does_not_retry_non_retryable_status(self, monkeypatch):
         """A 401 (not in the retry set) is a definitive answer — one attempt, no
         retry, even with a large budget."""


### PR DESCRIPTION
## Status-code-aware retry for the package HTTP gateway

`download()` is the single HTTP gateway for the whole package. It already had `Retry-After`-aware capped-exponential backoff (`_retry_delay` / `_parse_retry_after`), but that machinery **only fired on connection-level exceptions** — a `429`/`403`/`5xx` came back as a normal `Response` and was returned without a retry. That's the root cause the DynastyProcess loader-level CSV retry (#203) had to work around, and it's why ESPN Core-v2 `403`-under-load and rate-limit `429`s surfaced as failures.

### What changed
- **Retry the transient set** `{403, 408, 429, 500, 502, 503, 504}` (configurable via the new `retry_statuses=` param) using the existing `_retry_delay` backoff.
- **Separate status-retry cap** (`_MAX_STATUS_RETRIES=4`) so a genuinely permanent forbidden can't spin the full `num_retries` (~16 requests / ~51s) or hammer a host already signalling back-off — connection-exception retries still use the full budget.
- **Jitter** (50–100%) on the exponential fallback so concurrent workers don't re-hit a recovering host in lockstep; the server-dictated `Retry-After` path stays exact.
- **Budget-exhaustion behavior**: return the last response unchanged (callers key on `.status_code`) + a terminal log line so a persistent `429` isn't invisible in logs.
- **Never cache a non-2xx body.**
- `403` is retried by default because ESPN Core v2 returns it under load; `download()` serves only the non-auth ESPN/nflverse surface (`nfl_api`, `nba_stats`/`wnba_stats`, and PFF each have their own auth-aware `_get`), so a `403` here is far more likely rate-limiting than a permanent forbidden.

### Review
Passed the `http-layer-reviewer` (0 MUST-FIX). All three of its SHOULD-CONSIDER items are applied in this PR (separate status-retry cap, jitter, terminal log).

### Gates
- 21 `test_dl_utils.py` tests (14 original + 7 new: retry-then-succeed, budget-exhausted-no-raise, non-retryable-1-attempt, status-cap, jitter-bounds, jitter-never-touches-Retry-After, no-cache-on-non-2xx).
- Full offline suite green (3908 passed), codegen `--check` clean, ruff+format clean. `dl_utils` is legacy-untyped (not in the mypy ratchet).

## Summary by Sourcery

Enhance the core download() HTTP gateway to perform status-code-aware retries with jittered backoff and safer caching behavior for transient failures.

New Features:
- Add configurable status-code-based retry support to download() via the retry_statuses parameter.
- Introduce jittered exponential backoff for non-Retry-After retries to reduce synchronized retry storms among workers.

Enhancements:
- Limit status-based retries with a separate cap so persistent forbidden/rate-limit responses do not consume the full connection retry budget or overload upstream hosts.
- Ensure only successful 2xx responses are written to the cache, avoiding storage of transient error bodies.
- Improve logging around retryable status handling, including terminal messages when the retry budget is exhausted.

Documentation:
- Update changelog documentation to describe download()'s new transient status retry behavior, configurability, and cache changes.

Tests:
- Expand dl_utils tests to cover jitter behavior, status-based retry success and exhaustion paths, non-retryable statuses, status retry capping, and cache behavior for non-2xx responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Downloads now retry transient HTTP errors (default: 403, 408, 429, and common 5xx), with delays that respect `Retry-After`.
  * Retries are capped; once exhausted, the final response is returned unchanged.
  * Only successful **2xx** responses are cached; non-2xx responses are no longer cached.
* **Documentation**
  * Updated the changelog to reflect the new retry and caching behavior.
* **Tests**
  * Added/expanded tests for retry timing (including jitter), `Retry-After` behavior, and cache/retry outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->