### PR TITLE
fix(codegen): recombine colon-split Returns code spans in reference docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,15 @@
   `load_nfl_ff_rankings`) retry with exponential backoff on transient
   upstream errors (HTTP 429/5xx) instead of failing on the first hit — the
   raw-GitHub host rate-limits parallel CI runners.
+- fix(codegen): reference-doc **Returns** prose no longer mangles docstrings
+  whose return description is an inline `col: dtype, ...` code span.
+  `docstring_parser` splits a Google-style `Returns:` body on the first colon,
+  so a colon *inside* the span was mistaken for the type/description separator —
+  dropping the leading column/key and leaving a stray unbalanced backtick. The
+  renderer now recombines the mis-split fragment (only when the parsed type
+  contains a backtick, so legit Google types like `pl.DataFrame` are untouched),
+  fixing ~15 rendered Returns across the cfb/mbb/wbb/nba/nfl/mlb/wnba reference
+  pages.
 - fix(dl_utils): `download()` now retries **transient status codes**
   (403/408/429/500/502/503/504) with the same `Retry-After`-aware backoff it
   already used for connection failures — previously a 429/403/5xx came back as

--- a/docs/docs/cfb/reference/additional.md
+++ b/docs/docs/cfb/reference/additional.md
@@ -657,7 +657,7 @@ Load the bundled EP-by-yardline curve (no network, no first-use download).
 
 **Returns**
 
-Int64 (1..99), ep: Float64``.
+`yardline_own: Int64 (1..99), ep: Float64`.
 
 | col_name | type | description |
 |---|---|---|
@@ -1260,7 +1260,7 @@ simplification).
 
 **Returns**
 
-..., "games": ...}`` — updated frames, mirroring nflseedR's returned list.
+`{"teams": ..., "games": ...}` — updated frames, mirroring nflseedR's returned list.
 
 | col_name | type | description |
 |---|---|---|
@@ -1301,7 +1301,7 @@ year's eligible players.
 
 **Returns**
 
-..., "teams": ...}` — players: `draft_year` (Int64), `team_id` / `player_id` / `player_name` (Utf8), `draft_prob` (Float64); teams: `draft_year`, `team_id`, `proj_draft_picks`` (Float64, the sum of member draft probabilities). Zero-row (typed) frames when no data is available.
+`{"players": ..., "teams": ...}` — players: `draft_year` (Int64), `team_id` / `player_id` / `player_name` (Utf8), `draft_prob` (Float64); teams: `draft_year`, `team_id`, `proj_draft_picks` (Float64, the sum of member draft probabilities). Zero-row (typed) frames when no data is available.
 
 **Example**
 
@@ -2294,7 +2294,7 @@ interpolated onto the full 1..99 grid.
 
 **Returns**
 
-Int64 (1..99), ep: Float64`` -- monotone non-decreasing. Empty input returns a zero-row frame.
+`yardline_own: Int64 (1..99), ep: Float64` -- monotone non-decreasing. Empty input returns a zero-row frame.
 
 | col_name | type | description |
 |---|---|---|

--- a/docs/docs/mbb/reference/additional.md
+++ b/docs/docs/mbb/reference/additional.md
@@ -3113,7 +3113,7 @@ see `PLAN-phase2.md`'s self-review notes.
 
 **Returns**
 
-float, "Adj_ORtgPlus": float, "Usage_Bonus": float, "SoS_Bonus": float}`` -- keys kept TS-verbatim (see module docstring's naming-convention note).
+`{"Adj_ORtg": float, "Adj_ORtgPlus": float, "Usage_Bonus": float, "SoS_Bonus": float}` -- keys kept TS-verbatim (see module docstring's naming-convention note).
 
 ### `build_strength_adjusted_stats(teams: 'Sequence[TeamDetail]', *, max_iterations: 'int' = 100, tolerance: 'float' = 1e-06) -> 'StrengthAdjustedResult'` {#build_strength_adjusted_stats}
 
@@ -4145,7 +4145,7 @@ contribute. An empty accumulator yields `0`.
 
 **Returns**
 
-{"league_off": float, "league_def": float}}``.
+`{field: {"league_off": float, "league_def": float}}`.
 
 **Example**
 
@@ -4179,7 +4179,7 @@ skipped.
 
 **Returns**
 
-{"avg_opp_def": float, "avg_opp_off": float}}``.
+`{field: {"avg_opp_def": float, "avg_opp_off": float}}`.
 
 **Example**
 
@@ -4803,7 +4803,7 @@ Off/def stat-key names for a field (`fieldKeys`, `ts:77-79`).
 
 **Returns**
 
-f"off_{field}", "def": f"def_{field}"}``.
+`{"off": f"off_{field}", "def": f"def_{field}"}`.
 
 **Example**
 
@@ -5595,7 +5595,7 @@ scoped to one team's games; empty -> `0`.
 
 **Returns**
 
-float, "def": float}``.
+`{"off": float, "def": float}`.
 
 **Example**
 
@@ -6255,7 +6255,7 @@ input list) is deleted as a side effect while building the roster --
 
 **Returns**
 
-{code: id}, "players": [...], "error_code": ...}`. Each entry in `players` is `{"playerId", "playerCode", "teammates", "on", "off", "replacement"}` -- `on`/`off` are finished `LineupStatSet` averages (or, for a player who's always ON, an all-zero `off`); `replacement` is `None` unless `inc_replacement=True``.
+`{"playerMap": {code: id}, "players": [...], "error_code": ...}`. Each entry in `players` is `{"playerId", "playerCode", "teammates", "on", "off", "replacement"}` -- `on`/`off` are finished `LineupStatSet` averages (or, for a player who's always ON, an all-zero `off`); `replacement` is `None` unless `inc_replacement=True`.
 
 **Example**
 
@@ -8324,7 +8324,7 @@ consecutive seasons.
 
 **Returns**
 
-Utf8, from_team_id:Utf8, to_team_id:Utf8, from_season:Int64, to_season:Int64`` -- a player transferring twice appears twice.
+`player_id: Utf8, from_team_id:Utf8, to_team_id:Utf8, from_season:Int64, to_season:Int64` -- a player transferring twice appears twice.
 
 **Example**
 

--- a/docs/docs/mlb/reference/additional.md
+++ b/docs/docs/mlb/reference/additional.md
@@ -1083,7 +1083,7 @@ Score pitches with the bundled Command+/Location+ (②) run-value model.
 
 **Returns**
 
-`pitcher`, `pitch_type`, `location_rv_hat`, `command_plus`. `level="pitcher"`: `pitcher`, `location_rv_hat`, `command_plus` (per-pitcher mean). Empty input returns a zero-row frame with the documented schema.
+`level="pitch"`: `pitcher`, `pitch_type`, `location_rv_hat`, `command_plus`. `level="pitcher"`: `pitcher`, `location_rv_hat`, `command_plus` (per-pitcher mean). Empty input returns a zero-row frame with the documented schema.
 
 | col_name | type | description |
 |---|---|---|

--- a/docs/docs/nba/reference/additional.md
+++ b/docs/docs/nba/reference/additional.md
@@ -1685,7 +1685,7 @@ aggregates `Σfgm/Σfga` across players within each bucket.
 
 **Returns**
 
-frame, "shot_clock": frame}` each with rows per `bucket` (`bucket, fga, fgm, fg_pct``). Missing result sets return the zero-row schema.
+`{"defender": frame, "shot_clock": frame}` each with rows per `bucket` (`bucket, fga, fgm, fg_pct`). Missing result sets return the zero-row schema.
 
 **Example**
 
@@ -1840,7 +1840,7 @@ Fetch per-player and per-team game logs for a season (bulk, one call each).
 
 **Returns**
 
-<per-player-game logs>, "team": <per-team-game logs>}`` as snake-cased polars frames.
+`{"player": <per-player-game logs>, "team": <per-team-game logs>}` as snake-cased polars frames.
 
 **Example**
 
@@ -1867,7 +1867,7 @@ Faithful BPM 2.0 per player, at season or single-game granularity.
 
 **Returns**
 
-frame with `player_id`, `obpm`, `dbpm`, `bpm`, `min`, `gp` (Int64 player_id/gp, Float64 obpm/dbpm/bpm/min). `"game"`: the same columns prefixed with `game_id` (Utf8), one row per (game_id, player_id). Empty (that schema) input -> zero-row frame with the same schema; never raises on empty.
+`"season"`: frame with `player_id`, `obpm`, `dbpm`, `bpm`, `min`, `gp` (Int64 player_id/gp, Float64 obpm/dbpm/bpm/min). `"game"`: the same columns prefixed with `game_id` (Utf8), one row per (game_id, player_id). Empty (that schema) input -> zero-row frame with the same schema; never raises on empty.
 
 **Example**
 

--- a/docs/docs/nfl/reference/additional.md
+++ b/docs/docs/nfl/reference/additional.md
@@ -6127,7 +6127,7 @@ via the returned `teams` frame.
 
 **Returns**
 
-teams, "games": games}`` with updated ELO ratings and filled results.
+`{"teams": teams, "games": games}` with updated ELO ratings and filled results.
 
 | col_name | type | description |
 |---|---|---|

--- a/docs/docs/wbb/reference/additional.md
+++ b/docs/docs/wbb/reference/additional.md
@@ -3232,7 +3232,7 @@ see `PLAN-phase2.md`'s self-review notes.
 
 **Returns**
 
-float, "Adj_ORtgPlus": float, "Usage_Bonus": float, "SoS_Bonus": float}`` -- keys kept TS-verbatim (see module docstring's naming-convention note).
+`{"Adj_ORtg": float, "Adj_ORtgPlus": float, "Usage_Bonus": float, "SoS_Bonus": float}` -- keys kept TS-verbatim (see module docstring's naming-convention note).
 
 ### `build_strength_adjusted_stats(teams: 'Sequence[TeamDetail]', *, max_iterations: 'int' = 100, tolerance: 'float' = 1e-06) -> 'StrengthAdjustedResult'` {#build_strength_adjusted_stats}
 
@@ -4264,7 +4264,7 @@ contribute. An empty accumulator yields `0`.
 
 **Returns**
 
-{"league_off": float, "league_def": float}}``.
+`{field: {"league_off": float, "league_def": float}}`.
 
 **Example**
 
@@ -4298,7 +4298,7 @@ skipped.
 
 **Returns**
 
-{"avg_opp_def": float, "avg_opp_off": float}}``.
+`{field: {"avg_opp_def": float, "avg_opp_off": float}}`.
 
 **Example**
 
@@ -4868,7 +4868,7 @@ Off/def stat-key names for a field (`fieldKeys`, `ts:77-79`).
 
 **Returns**
 
-f"off_{field}", "def": f"def_{field}"}``.
+`{"off": f"off_{field}", "def": f"def_{field}"}`.
 
 **Example**
 
@@ -5474,7 +5474,7 @@ scoped to one team's games; empty -> `0`.
 
 **Returns**
 
-float, "def": float}``.
+`{"off": float, "def": float}`.
 
 **Example**
 
@@ -6134,7 +6134,7 @@ input list) is deleted as a side effect while building the roster --
 
 **Returns**
 
-{code: id}, "players": [...], "error_code": ...}`. Each entry in `players` is `{"playerId", "playerCode", "teammates", "on", "off", "replacement"}` -- `on`/`off` are finished `LineupStatSet` averages (or, for a player who's always ON, an all-zero `off`); `replacement` is `None` unless `inc_replacement=True``.
+`{"playerMap": {code: id}, "players": [...], "error_code": ...}`. Each entry in `players` is `{"playerId", "playerCode", "teammates", "on", "off", "replacement"}` -- `on`/`off` are finished `LineupStatSet` averages (or, for a player who's always ON, an all-zero `off`); `replacement` is `None` unless `inc_replacement=True`.
 
 **Example**
 
@@ -7559,7 +7559,7 @@ consecutive seasons.
 
 **Returns**
 
-Utf8, from_team_id:Utf8, to_team_id:Utf8, from_season:Int64, to_season:Int64`` -- a player transferring twice appears twice.
+`player_id: Utf8, from_team_id:Utf8, to_team_id:Utf8, from_season:Int64, to_season:Int64` -- a player transferring twice appears twice.
 
 **Example**
 

--- a/docs/docs/wnba/reference/additional.md
+++ b/docs/docs/wnba/reference/additional.md
@@ -480,7 +480,7 @@ aggregates `Σfgm/Σfga` across players within each bucket.
 
 **Returns**
 
-frame, "shot_clock": frame}` each with rows per `bucket` (`bucket, fga, fgm, fg_pct``). Missing result sets return the zero-row schema.
+`{"defender": frame, "shot_clock": frame}` each with rows per `bucket` (`bucket, fga, fgm, fg_pct`). Missing result sets return the zero-row schema.
 
 **Example**
 

--- a/docs/src/pages/CHANGELOG.md
+++ b/docs/src/pages/CHANGELOG.md
@@ -177,6 +177,15 @@
   `load_nfl_ff_rankings`) retry with exponential backoff on transient
   upstream errors (HTTP 429/5xx) instead of failing on the first hit — the
   raw-GitHub host rate-limits parallel CI runners.
+- fix(codegen): reference-doc **Returns** prose no longer mangles docstrings
+  whose return description is an inline `col: dtype, ...` code span.
+  `docstring_parser` splits a Google-style `Returns:` body on the first colon,
+  so a colon *inside* the span was mistaken for the type/description separator —
+  dropping the leading column/key and leaving a stray unbalanced backtick. The
+  renderer now recombines the mis-split fragment (only when the parsed type
+  contains a backtick, so legit Google types like `pl.DataFrame` are untouched),
+  fixing ~15 rendered Returns across the cfb/mbb/wbb/nba/nfl/mlb/wnba reference
+  pages.
 - fix(dl_utils): `download()` now retries **transient status codes**
   (403/408/429/500/502/503/504) with the same `Retry-After`-aware backoff it
   already used for connection failures — previously a 429/403/5xx came back as

--- a/tests/codegen/test_render.py
+++ b/tests/codegen/test_render.py
@@ -1,4 +1,5 @@
 import ast
+import types
 
 from tools.codegen import generate, render
 
@@ -28,3 +29,31 @@ def test_generated_modules_are_valid_python_with_all_and_defs():
         assert "__all__" in src
         for fn in funcs:
             assert f'"{fn}"' in src, f"{fn} missing from __all__ in {name}"
+
+
+def test_returns_prose_recombines_colon_split_code_span():
+    """docstring_parser splits a Returns body on the first colon; when that
+    colon is INSIDE an inline code span (``col: dtype, ...``) it mis-splits,
+    leaving type_name a dangling ``col`` fragment. The renderer must recombine
+    so no unbalanced reST literal (a stray ``) survives. Regression for the
+    load_fp_curve / mbb / wbb mangled Returns fragments."""
+    ds = types.SimpleNamespace(
+        type_name="``yardline_own",
+        description="Int64 (1..99), ep: Float64`` -- monotone non-decreasing.",
+    )
+    out = generate._returns_prose(ds)
+    assert "``" not in out  # no unbalanced reST double-backtick literal survives
+    assert "`yardline_own: Int64 (1..99), ep: Float64`" in out
+    assert "monotone non-decreasing" in out  # descriptive tail preserved
+
+
+def test_returns_prose_leaves_plain_type_split_untouched():
+    """A legit Google ``type: description`` (no backtick in the type) keeps the
+    prior behavior — description only, no spurious recombination."""
+    ds = types.SimpleNamespace(type_name="pl.DataFrame", description="A tidy frame.")
+    assert generate._returns_prose(ds) == "A tidy frame."
+
+
+def test_returns_prose_empty_inputs_yield_empty_string():
+    assert generate._returns_prose(None) == ""
+    assert generate._returns_prose(types.SimpleNamespace(type_name=None, description="")) == ""

--- a/tools/codegen/generate.py
+++ b/tools/codegen/generate.py
@@ -2445,6 +2445,28 @@ def _normalize_rst(text: str) -> str:
     return out
 
 
+def _returns_prose(ds_returns) -> str:
+    """Reconstruct Returns prose from a ``docstring_parser`` DocstringReturns.
+
+    ``docstring_parser`` splits a Google-style ``Returns:`` body on the first
+    colon into ``(type_name, description)``. When the body is an inline code
+    span like ``col: dtype, ...``, the colon INSIDE the span is mistaken for
+    the type/description separator — leaving ``type_name`` a dangling ``col``
+    fragment (with an unbalanced backtick) and ``description`` the remainder,
+    which :func:`_normalize_rst` then cannot pair (emitting a stray trailing
+    ``\\`\\``). Legit Google return types (``pl.DataFrame``, ``dict[str, X]``)
+    never contain a backtick, so recombine ONLY in that mis-split case, then
+    normalise reST -> markdown. Empty / ``None`` input yields ``""``.
+    """
+    if ds_returns is None or not getattr(ds_returns, "description", None):
+        return ""
+    desc = ds_returns.description
+    tname = (getattr(ds_returns, "type_name", None) or "").strip()
+    if "`" in tname:
+        desc = f"{tname}: {desc}"
+    return _normalize_rst(" ".join(desc.split()))
+
+
 def _clean_long(text: str) -> str:
     """Defensive truncation of a docstring's long-description prose.
 
@@ -2832,7 +2854,7 @@ def _doc_view(obj) -> dict:
     long = _clean_long(ds_long or "")
     returns = ""
     if ds_returns is not None and ds_returns.description:
-        returns = _normalize_rst(" ".join(ds_returns.description.split()))
+        returns = _returns_prose(ds_returns)
     elif fb["returns"]:
         returns = fb["returns"]
     raw_example = ds_examples[0].description if ds_examples and ds_examples[0].description else ""


### PR DESCRIPTION
## Reference-doc `Returns` prose mangled inline code spans

`docstring_parser` splits a Google-style `Returns:` body on the first colon into `(type_name, description)`. When the return description is an inline code span like `` `col: dtype, ...` ``, the colon *inside* the span was mistaken for the `type: description` separator — the leading column/key was captured into `type_name` (which the renderer dropped) and the description became an unbalanced fragment that `_normalize_rst` couldn't pair, rendering a **stray trailing double-backtick**.

Examples of the mangled output this fixes:
- `Int64 (1..99), ep: Float64` + stray `` `` `` → `` `yardline_own: Int64 (1..99), ep: Float64` `` (`load_fp_curve`)
- `{"league_off": float, ...}}` + stray `` `` `` → `` `{field: {"league_off": float, ...}}` `` (mbb/wbb strength)
- `proj_draft_picks` rendered with an inner stray `` `` `` → balanced

### Fix
Extract `_returns_prose(ds_returns)`, which recombines `type_name + ": " + description` **only when the parsed `type_name` contains a backtick** — legit Google return types (`pl.DataFrame`, `dict[str, X]`) never do, so they're untouched and there's zero collateral drift. Then normalize reST → markdown as before.

Regenerating fixes **~15 rendered `Returns`** across the **cfb / mbb / wbb / nba / nfl / mlb / wnba** reference pages (every diff restores a dropped leading token and balances the backticks — no regressions).

### Gates
- 3 new unit tests in `tests/codegen/test_render.py` (mis-split recombine, legit-type untouched, empty inputs); codegen `--check` clean.

## Summary by Sourcery

Fix rendering of reference-doc Returns sections when docstring return descriptions use inline `col: dtype, ...` code spans, and regenerate affected docs accordingly.

Bug Fixes:
- Ensure Returns prose recombines colon-split inline code spans only when the parsed type name contains backticks, preventing dropped keys and stray backticks in rendered reference docs.

Enhancements:
- Introduce a dedicated helper for constructing normalized Returns prose from parsed docstring returns metadata.

Documentation:
- Regenerate and correct ~15 Returns sections across cfb, mbb, wbb, nba, nfl, mlb, and wnba reference pages to show complete inline code spans and balanced backticks.
- Document the Returns rendering fix in both the main CHANGELOG and the docs site CHANGELOG.

Tests:
- Add unit tests covering recombination of colon-split inline code spans, preserving behavior for plain type/description splits, and handling empty Returns inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected rendering of Google-style `Returns:` documentation containing colons inside inline code.
  * Prevented missing leading keys or columns and unbalanced backticks in generated reference pages.

* **Documentation**
  * Improved return-value examples and inline formatting across CFB, MBB, MLB, NBA, NFL, WBB, and WNBA references.
  * Clarified documented output schemas for several helper functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->