### PR TITLE
chore(phf): cut PHF dataset URLs over to dedicated release tags

### DIFF
--- a/sportsdataverse/config.py
+++ b/sportsdataverse/config.py
@@ -25,10 +25,14 @@ NHL_TEAM_BOX_URL = SDVRELEASES + "nhl_team_boxscores/team_box_{season}.parquet"
 NHL_TEAM_SCHEDULE_URL = SDVRELEASES + "nhl_schedules/nhl_schedule_{season}.parquet"
 NHL_TEAM_LOGO_URL = f"{SGITHUB}fastRhockey-data/main/nhl/nhl_teams_colors_logos.csv"
 
-PHF_BASE_URL = SGITHUB + "fastRhockey-data/main/phf/pbp/parquet/play_by_play_{season}.parquet"
-PHF_PLAYER_BOX_URL = SGITHUB + "fastRhockey-data/main/phf/player_box/parquet/player_box_{season}.parquet"
-PHF_TEAM_BOX_URL = SGITHUB + "fastRhockey-data/main/phf/team_box/parquet/team_box_{season}.parquet"
-PHF_TEAM_SCHEDULE_URL = SGITHUB + "fastRhockey-data/main/phf/schedules/parquet/phf_schedule_{season}.parquet"
+# PHF (Premier Hockey Federation) is a frozen dataset -- the league ceased
+# operations in June 2023. Assets were migrated from the fastRhockey-data git
+# tree into dedicated release tags (2026-07-11): seasons 2016-2023, except pbp
+# which covers 2016 + 2020-2023 (2017-2019 pbp was never published upstream).
+PHF_BASE_URL = SDVRELEASES + "phf_pbp/play_by_play_{season}.parquet"
+PHF_PLAYER_BOX_URL = SDVRELEASES + "phf_player_boxscores/player_box_{season}.parquet"
+PHF_TEAM_BOX_URL = SDVRELEASES + "phf_team_boxscores/team_box_{season}.parquet"
+PHF_TEAM_SCHEDULE_URL = SDVRELEASES + "phf_schedules/phf_schedule_{season}.parquet"
 
 MBB_BASE_URL = SDVRELEASES + "espn_mens_college_basketball_pbp/play_by_play_{season}.parquet"
 MBB_TEAM_BOX_URL = SDVRELEASES + "espn_mens_college_basketball_team_boxscores/team_box_{season}.parquet"


### PR DESCRIPTION
## Summary
- PHF datasets migrated into dedicated `sportsdataverse-data` release tags, mirroring the `pwhl_*` convention: `phf_pbp` (5 assets), `phf_player_boxscores` (8), `phf_team_boxscores` (8), `phf_schedules` (8) — 29 assets total, uploaded per-file from the `fastRhockey-data` git tree.
- `sportsdataverse/config.py` `PHF_*` constants now point at the release URLs instead of `raw.githubusercontent.com` tree paths. The git tree remains in place (the R `fastRhockey` package still reads it).
- PHF is a frozen dataset: league ceased operations June 2023. Coverage 2016–2023; pbp covers 2016 + 2020–2023 (2017–2019 pbp was never published upstream — permanent gap, noted in the release notes and config comment).

## Notes
- The `PHF_*` constants currently have no consuming `load_phf_*` loaders in sdv-py (they didn't survive the NHL module rewrite); re-adding PHF loaders against these tags is a separate follow-up if wanted.

## Verification
- All 4 release URLs serve readable parquet (e.g. `phf_pbp/play_by_play_2023.parquet` → 13,524×79; `PHF_BASE_URL.format(season=2022)` → 10,960×78).
- `ruff check` + `ruff format --check` clean; `tools/codegen/generate.py --check` green; `uv.lock` untouched.

## Summary by Sourcery

Enhancements:
- Document PHF as a frozen dataset with historical coverage details in the configuration comments.