### PR TITLE
refactor(_common): extract shared validation-metrics module across 7 leagues (T7.2 remaining)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -295,6 +295,7 @@ warn_redundant_casts = true
 files = [
     "sportsdataverse/_deprecation.py",
     "sportsdataverse/_common/__init__.py",
+    "sportsdataverse/_common/metrics.py",
     "sportsdataverse/_common/ratings.py",
     "sportsdataverse/errors.py",
     "sportsdataverse/cfb/cfb_adjusted_epa.py",

--- a/sportsdataverse/_common/metrics.py
+++ b/sportsdataverse/_common/metrics.py
@@ -1,0 +1,163 @@
+"""League-agnostic validation metrics + the as-of leakage split (T7.2).
+
+These six helpers were duplicated verbatim across every per-sport
+``*_prediction_constants`` / ``*_projection_constants`` module (Brier / log-loss /
+Spearman / MAE / calibration table + the leakage-boundary date split). They are
+extracted here so the identical implementation lives exactly once; the per-sport
+modules re-export these names (redundant-alias re-export) and keep their own
+league-specific constants.
+
+**Internal** -- not re-exported at the top-level ``sportsdataverse`` package;
+per-sport modules import from here.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import numpy as np
+import polars as pl
+from scipy.stats import rankdata
+
+
+def brier_score(y_true: np.ndarray, p_pred: np.ndarray) -> float:
+    """Mean squared error between predicted probabilities and binary outcomes.
+
+    Args:
+        y_true: Array of binary outcomes (0/1).
+        p_pred: Array of predicted probabilities in [0, 1].
+
+    Returns:
+        The Brier score (0.0 is a perfect forecast).
+
+    Example:
+        Quick start::
+
+            import numpy as np
+            from sportsdataverse._common.metrics import brier_score
+            brier_score(np.array([1, 0]), np.array([0.9, 0.1]))
+    """
+    return float(np.mean((np.asarray(p_pred, dtype=float) - np.asarray(y_true, dtype=float)) ** 2))
+
+
+def log_loss_score(y_true: np.ndarray, p_pred: np.ndarray, eps: float = 1e-15) -> float:
+    """Binary cross-entropy loss between predicted probabilities and outcomes.
+
+    Args:
+        y_true: Array of binary outcomes (0/1).
+        p_pred: Array of predicted probabilities in [0, 1].
+        eps: Clipping bound to avoid ``log(0)``.
+
+    Returns:
+        The mean log loss.
+
+    Example:
+        Quick start::
+
+            import numpy as np
+            from sportsdataverse._common.metrics import log_loss_score
+            log_loss_score(np.array([1, 0]), np.array([0.9, 0.1]))
+    """
+    p = np.clip(np.asarray(p_pred, dtype=float), eps, 1 - eps)
+    y = np.asarray(y_true, dtype=float)
+    return float(-np.mean(y * np.log(p) + (1 - y) * np.log(1 - p)))
+
+
+def spearman_corr(a: np.ndarray, b: np.ndarray) -> float:
+    """Spearman rank correlation between two arrays.
+
+    Args:
+        a: First array of values.
+        b: Second array of values (same length as ``a``).
+
+    Returns:
+        The Spearman rank correlation coefficient.
+
+    Example:
+        Quick start::
+
+            import numpy as np
+            from sportsdataverse._common.metrics import spearman_corr
+            spearman_corr(np.array([1, 2, 3]), np.array([3, 1, 2]))
+    """
+    ra, rb = rankdata(a), rankdata(b)
+    return float(np.corrcoef(ra, rb)[0, 1])
+
+
+def mae(a: np.ndarray, b: np.ndarray) -> float:
+    """Mean absolute error between two arrays.
+
+    Args:
+        a: First array of values.
+        b: Second array of values (same length as ``a``).
+
+    Returns:
+        The mean absolute error.
+
+    Example:
+        Quick start::
+
+            import numpy as np
+            from sportsdataverse._common.metrics import mae
+            mae(np.array([1.0, 2.0]), np.array([1.5, 2.5]))
+    """
+    return float(np.mean(np.abs(np.asarray(a, dtype=float) - np.asarray(b, dtype=float))))
+
+
+def calibration_table(y_true: np.ndarray, p_pred: np.ndarray, n_bins: int = 10) -> pl.DataFrame:
+    """Bucket predicted probabilities into bins and compare to actual outcome rates.
+
+    Args:
+        y_true: Array of binary outcomes (0/1).
+        p_pred: Array of predicted probabilities in [0, 1].
+        n_bins: Number of equal-width probability bins.
+
+    Returns:
+        A ``polars.DataFrame`` with columns ``bin_mid``, ``mean_pred``,
+        ``mean_actual``, ``n`` (one row per non-empty bin).
+
+    Example:
+        Quick start::
+
+            import numpy as np
+            from sportsdataverse._common.metrics import calibration_table
+            calibration_table(np.array([1, 0, 1, 0]), np.array([0.9, 0.1, 0.8, 0.2]))
+    """
+    df = pl.DataFrame(
+        {
+            "y": np.asarray(y_true, dtype=float),
+            "p": np.asarray(p_pred, dtype=float),
+        }
+    )
+    df = df.with_columns((pl.col("p").clip(0.0, 0.9999) * n_bins).floor().cast(pl.Int64).alias("bin"))
+    return (
+        df.group_by("bin")
+        .agg(
+            pl.col("p").mean().alias("mean_pred"),
+            pl.col("y").mean().alias("mean_actual"),
+            pl.len().alias("n"),
+        )
+        .sort("bin")
+        .with_columns(((pl.col("bin") + 0.5) / n_bins).alias("bin_mid"))
+        .select("bin_mid", "mean_pred", "mean_actual", "n")
+    )
+
+
+def as_of_ratings_split(results: pl.DataFrame, cutoff_date: datetime.date) -> pl.DataFrame:
+    """Filter a results frame to games strictly before a cutoff date (leakage boundary).
+
+    Args:
+        results: A ``polars.DataFrame`` with a ``date`` column.
+        cutoff_date: Games on or after this date are excluded.
+
+    Returns:
+        A ``polars.DataFrame`` containing only rows with ``date < cutoff_date``.
+
+    Example:
+        Quick start::
+
+            import datetime as dt
+            from sportsdataverse._common.metrics import as_of_ratings_split
+            as_of_ratings_split(results, dt.date(2023, 9, 8))
+    """
+    return results.filter(pl.col("date") < cutoff_date)

--- a/sportsdataverse/cfb/cfb_prediction_constants.py
+++ b/sportsdataverse/cfb/cfb_prediction_constants.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
-import datetime
 from dataclasses import dataclass
 
-import numpy as np
-import polars as pl
-from scipy.stats import rankdata
+from sportsdataverse._common.metrics import (
+    as_of_ratings_split as as_of_ratings_split,
+    brier_score as brier_score,
+    calibration_table as calibration_table,
+    log_loss_score as log_loss_score,
+    mae as mae,
+    spearman_corr as spearman_corr,
+)
 
 
 @dataclass
@@ -137,146 +141,3 @@ def get_constants(era: str = "modern") -> PredictConfig:
     except KeyError:
         valid = ", ".join(sorted(CFB_CONSTANTS))
         raise ValueError(f"Unknown era {era!r}; valid eras are: {valid}") from None
-
-
-def as_of_ratings_split(results: pl.DataFrame, cutoff_date: datetime.date) -> pl.DataFrame:
-    """Filter a results frame to games strictly before a cutoff date (leakage boundary).
-
-    Args:
-        results: A ``polars.DataFrame`` with a ``date`` column.
-        cutoff_date: Games on or after this date are excluded.
-
-    Returns:
-        A ``polars.DataFrame`` containing only rows with ``date < cutoff_date``.
-
-    Example:
-        Quick start::
-
-            import datetime as dt
-            from sportsdataverse.cfb.cfb_prediction_constants import as_of_ratings_split
-            as_of_ratings_split(results, dt.date(2023, 9, 8))
-    """
-    return results.filter(pl.col("date") < cutoff_date)
-
-
-def brier_score(y_true: np.ndarray, p_pred: np.ndarray) -> float:
-    """Mean squared error between predicted probabilities and binary outcomes.
-
-    Args:
-        y_true: Array of binary outcomes (0/1).
-        p_pred: Array of predicted probabilities in [0, 1].
-
-    Returns:
-        The Brier score (0.0 is a perfect forecast).
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.cfb.cfb_prediction_constants import brier_score
-            brier_score(np.array([1, 0]), np.array([0.9, 0.1]))
-    """
-    return float(np.mean((np.asarray(p_pred, dtype=float) - np.asarray(y_true, dtype=float)) ** 2))
-
-
-def log_loss_score(y_true: np.ndarray, p_pred: np.ndarray, eps: float = 1e-15) -> float:
-    """Binary cross-entropy loss between predicted probabilities and outcomes.
-
-    Args:
-        y_true: Array of binary outcomes (0/1).
-        p_pred: Array of predicted probabilities in [0, 1].
-        eps: Clipping bound to avoid ``log(0)``.
-
-    Returns:
-        The mean log loss.
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.cfb.cfb_prediction_constants import log_loss_score
-            log_loss_score(np.array([1, 0]), np.array([0.9, 0.1]))
-    """
-    p = np.clip(np.asarray(p_pred, dtype=float), eps, 1 - eps)
-    y = np.asarray(y_true, dtype=float)
-    return float(-np.mean(y * np.log(p) + (1 - y) * np.log(1 - p)))
-
-
-def spearman_corr(a: np.ndarray, b: np.ndarray) -> float:
-    """Spearman rank correlation between two arrays.
-
-    Args:
-        a: First array of values.
-        b: Second array of values (same length as ``a``).
-
-    Returns:
-        The Spearman rank correlation coefficient.
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.cfb.cfb_prediction_constants import spearman_corr
-            spearman_corr(np.array([1, 2, 3]), np.array([3, 1, 2]))
-    """
-    ra, rb = rankdata(a), rankdata(b)
-    return float(np.corrcoef(ra, rb)[0, 1])
-
-
-def mae(a: np.ndarray, b: np.ndarray) -> float:
-    """Mean absolute error between two arrays.
-
-    Args:
-        a: First array of values.
-        b: Second array of values (same length as ``a``).
-
-    Returns:
-        The mean absolute error.
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.cfb.cfb_prediction_constants import mae
-            mae(np.array([1.0, 2.0]), np.array([1.5, 2.5]))
-    """
-    return float(np.mean(np.abs(np.asarray(a, dtype=float) - np.asarray(b, dtype=float))))
-
-
-def calibration_table(y_true: np.ndarray, p_pred: np.ndarray, n_bins: int = 10) -> pl.DataFrame:
-    """Bucket predicted probabilities into bins and compare to actual outcome rates.
-
-    Args:
-        y_true: Array of binary outcomes (0/1).
-        p_pred: Array of predicted probabilities in [0, 1].
-        n_bins: Number of equal-width probability bins.
-
-    Returns:
-        A ``polars.DataFrame`` with columns ``bin_mid``, ``mean_pred``,
-        ``mean_actual``, ``n`` (one row per non-empty bin).
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.cfb.cfb_prediction_constants import calibration_table
-            calibration_table(np.array([1, 0, 1, 0]), np.array([0.9, 0.1, 0.8, 0.2]))
-    """
-    df = pl.DataFrame(
-        {
-            "y": np.asarray(y_true, dtype=float),
-            "p": np.asarray(p_pred, dtype=float),
-        }
-    )
-    df = df.with_columns((pl.col("p").clip(0.0, 0.9999) * n_bins).floor().cast(pl.Int64).alias("bin"))
-    return (
-        df.group_by("bin")
-        .agg(
-            pl.col("p").mean().alias("mean_pred"),
-            pl.col("y").mean().alias("mean_actual"),
-            pl.len().alias("n"),
-        )
-        .sort("bin")
-        .with_columns(((pl.col("bin") + 0.5) / n_bins).alias("bin_mid"))
-        .select("bin_mid", "mean_pred", "mean_actual", "n")
-    )

--- a/sportsdataverse/cfb/cfb_projection_constants.py
+++ b/sportsdataverse/cfb/cfb_projection_constants.py
@@ -19,6 +19,11 @@ import numpy as np
 import polars as pl
 from scipy.optimize import minimize
 from scipy.stats import rankdata
+from sportsdataverse._common.metrics import (
+    brier_score as brier_score,
+    mae as mae,
+    spearman_corr as spearman_corr,
+)
 
 
 @dataclass(frozen=True)
@@ -99,17 +104,6 @@ def get_constants(division: str = "fbs") -> ProjectionConstants:
     return DIVISION_CONSTANTS[key]
 
 
-def spearman_corr(a: np.ndarray, b: np.ndarray) -> float:
-    """Spearman rank correlation between two arrays."""
-    ra, rb = rankdata(a), rankdata(b)
-    return float(np.corrcoef(ra, rb)[0, 1])
-
-
-def mae(a: np.ndarray, b: np.ndarray) -> float:
-    """Mean absolute error between two arrays."""
-    return float(np.mean(np.abs(np.asarray(a, float) - np.asarray(b, float))))
-
-
 def rmse(a: np.ndarray, b: np.ndarray) -> float:
     """Root-mean-squared error between two arrays."""
     return float(np.sqrt(np.mean((np.asarray(a, float) - np.asarray(b, float)) ** 2)))
@@ -133,11 +127,6 @@ def roc_auc(y_true: np.ndarray, score: np.ndarray) -> float:
     order = rankdata(s)
     auc = (order[y == 1].sum() - n_pos * (n_pos + 1) / 2.0) / (n_pos * n_neg)
     return float(auc)
-
-
-def brier_score(y_true: np.ndarray, p_pred: np.ndarray) -> float:
-    """Mean squared error between predicted probabilities and binary outcomes."""
-    return float(np.mean((np.asarray(p_pred, float) - np.asarray(y_true, float)) ** 2))
 
 
 def as_of_season_split(df: pl.DataFrame, cutoff_season: int, *, season_col: str = "season") -> pl.DataFrame:

--- a/sportsdataverse/mbb/mbb_prediction_constants.py
+++ b/sportsdataverse/mbb/mbb_prediction_constants.py
@@ -14,12 +14,16 @@ split (:func:`as_of_ratings_split`).
 
 from __future__ import annotations
 
-import datetime
 from dataclasses import dataclass
 
-import numpy as np
-import polars as pl
-from scipy.stats import rankdata
+from sportsdataverse._common.metrics import (
+    as_of_ratings_split as as_of_ratings_split,
+    brier_score as brier_score,
+    calibration_table as calibration_table,
+    log_loss_score as log_loss_score,
+    mae as mae,
+    spearman_corr as spearman_corr,
+)
 
 __all__ = [
     "LEAGUE_CONSTANTS",
@@ -133,153 +137,3 @@ def get_constants(league: str) -> LeagueConstants:
         return LEAGUE_CONSTANTS[league]
     except KeyError:
         raise ValueError(f"Unknown league {league!r}; expected one of {sorted(LEAGUE_CONSTANTS)}") from None
-
-
-def as_of_ratings_split(results: pl.DataFrame, cutoff_date: datetime.date) -> pl.DataFrame:
-    """Return only games strictly before ``cutoff_date`` (the leakage boundary).
-
-    Predictive backtests must rate a game using only games that finished before
-    it — this split enforces that as-of-date rule so no future information leaks
-    into a game's own prediction.
-
-    Args:
-        results: A frame with a ``date`` column of dtype ``pl.Date``.
-        cutoff_date: The date of the game being predicted; games on or after it
-            are dropped.
-
-    Returns:
-        The subset of ``results`` with ``date < cutoff_date``.
-
-    Example:
-        Quick start::
-
-            from sportsdataverse.mbb.mbb_prediction_constants import as_of_ratings_split
-            prior = as_of_ratings_split(results, some_game_date)
-    """
-    return results.filter(pl.col("date") < cutoff_date)
-
-
-def brier_score(y_true: np.ndarray, p_pred: np.ndarray) -> float:
-    """Mean squared error between binary outcomes and predicted probabilities.
-
-    Args:
-        y_true: Array of realized binary outcomes (0/1).
-        p_pred: Array of predicted probabilities in ``[0, 1]``.
-
-    Returns:
-        The Brier score (lower is better; 0.0 is perfect).
-
-    Example:
-        Perfect predictions score zero::
-
-            import numpy as np
-            from sportsdataverse.mbb.mbb_prediction_constants import brier_score
-            brier_score(np.array([1, 0]), np.array([1.0, 0.0]))
-    """
-    return float(np.mean((np.asarray(p_pred, dtype=float) - np.asarray(y_true, dtype=float)) ** 2))
-
-
-def log_loss_score(y_true: np.ndarray, p_pred: np.ndarray, eps: float = 1e-15) -> float:
-    """Binary cross-entropy (log loss) between outcomes and probabilities.
-
-    Args:
-        y_true: Array of realized binary outcomes (0/1).
-        p_pred: Array of predicted probabilities in ``[0, 1]``.
-        eps: Clipping bound to keep the log finite at 0/1.
-
-    Returns:
-        The mean log loss (lower is better).
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.mbb.mbb_prediction_constants import log_loss_score
-            log_loss_score(np.array([1, 0]), np.array([0.9, 0.1]))
-    """
-    p = np.clip(np.asarray(p_pred, dtype=float), eps, 1 - eps)
-    y = np.asarray(y_true, dtype=float)
-    return float(-np.mean(y * np.log(p) + (1 - y) * np.log(1 - p)))
-
-
-def spearman_corr(a: np.ndarray, b: np.ndarray) -> float:
-    """Spearman rank correlation between two arrays.
-
-    Args:
-        a: First array.
-        b: Second array (same length as ``a``).
-
-    Returns:
-        The Spearman rank-correlation coefficient in ``[-1, 1]``.
-
-    Example:
-        A monotonic relationship scores 1.0::
-
-            import numpy as np
-            from sportsdataverse.mbb.mbb_prediction_constants import spearman_corr
-            spearman_corr(np.array([1.0, 2.0, 3.0]), np.array([10.0, 20.0, 30.0]))
-    """
-    ra, rb = rankdata(a), rankdata(b)
-    return float(np.corrcoef(ra, rb)[0, 1])
-
-
-def mae(a: np.ndarray, b: np.ndarray) -> float:
-    """Mean absolute error between two arrays.
-
-    Args:
-        a: First array.
-        b: Second array (same length as ``a``).
-
-    Returns:
-        The mean absolute error.
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.mbb.mbb_prediction_constants import mae
-            mae(np.array([1.0, 2.0]), np.array([1.5, 2.5]))
-    """
-    return float(np.mean(np.abs(np.asarray(a, dtype=float) - np.asarray(b, dtype=float))))
-
-
-def calibration_table(y_true: np.ndarray, p_pred: np.ndarray, n_bins: int = 10) -> pl.DataFrame:
-    """Bin predicted probabilities and compare mean-predicted vs mean-actual.
-
-    Args:
-        y_true: Array of realized binary outcomes (0/1).
-        p_pred: Array of predicted probabilities in ``[0, 1]``.
-        n_bins: Number of equal-width probability bins.
-
-    Returns:
-        A ``polars.DataFrame`` with columns ``bin_mid``, ``mean_pred``,
-        ``mean_actual``, ``n`` (one row per non-empty bin, sorted ascending).
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.mbb.mbb_prediction_constants import calibration_table
-            y = np.random.default_rng(0).integers(0, 2, 200)
-            p = np.random.default_rng(1).random(200)
-            calibration_table(y, p, n_bins=10)
-    """
-    df = pl.DataFrame(
-        {
-            "y": np.asarray(y_true, dtype=float),
-            "p": np.asarray(p_pred, dtype=float),
-        }
-    )
-    df = df.with_columns((pl.col("p").clip(0.0, 0.9999) * n_bins).floor().cast(pl.Int64).alias("bin"))
-    out = (
-        df.group_by("bin")
-        .agg(
-            pl.col("p").mean().alias("mean_pred"),
-            pl.col("y").mean().alias("mean_actual"),
-            pl.len().alias("n"),
-        )
-        .sort("bin")
-        .with_columns(((pl.col("bin") + 0.5) / n_bins).alias("bin_mid"))
-        .select("bin_mid", "mean_pred", "mean_actual", "n")
-    )
-    return out

--- a/sportsdataverse/mlb/mlb_game_state_constants.py
+++ b/sportsdataverse/mlb/mlb_game_state_constants.py
@@ -20,9 +20,13 @@ from __future__ import annotations
 import time
 from typing import Any, List
 
-import numpy as np
 import polars as pl
-from scipy.stats import rankdata
+from sportsdataverse._common.metrics import (
+    brier_score as brier_score,
+    calibration_table as calibration_table,
+    mae as mae,
+    spearman_corr as spearman_corr,
+)
 
 #: Smyth-Patriot "pythagenpat" run-environment-adaptive exponent (Task 4.1).
 PYTHAGENPAT_EXPONENT: float = 0.287
@@ -47,99 +51,6 @@ _PBP_SCHEMA = {
     "matchup_post_on_second_id": pl.Utf8,
     "matchup_post_on_third_id": pl.Utf8,
 }
-
-
-def mae(a: "np.ndarray", b: "np.ndarray") -> float:
-    """Mean absolute error between two same-length arrays.
-
-    Args:
-        a: First array (e.g. predictions).
-        b: Second array (e.g. observed values).
-
-    Returns:
-        The mean of ``|a - b|`` as a plain Python ``float``.
-
-    Example:
-        Quick start::
-
-            from sportsdataverse.mlb.mlb_game_state_constants import mae
-            mae([1.0, 2.0], [1.5, 2.5])
-    """
-    return float(np.mean(np.abs(np.asarray(a, dtype=float) - np.asarray(b, dtype=float))))
-
-
-def spearman_corr(a: "np.ndarray", b: "np.ndarray") -> float:
-    """Spearman rank correlation between two same-length arrays.
-
-    Args:
-        a: First array.
-        b: Second array.
-
-    Returns:
-        The Pearson correlation of the rank-transformed arrays, as a
-        plain Python ``float``.
-
-    Example:
-        Quick start::
-
-            from sportsdataverse.mlb.mlb_game_state_constants import spearman_corr
-            spearman_corr([1, 2, 3], [9, 8, 10])
-    """
-    return float(np.corrcoef(rankdata(a), rankdata(b))[0, 1])
-
-
-def brier_score(y_true: "np.ndarray", p_pred: "np.ndarray") -> float:
-    """Brier score (mean squared error of a probability forecast).
-
-    Args:
-        y_true: Binary outcomes (0/1).
-        p_pred: Predicted probabilities in ``[0, 1]``.
-
-    Returns:
-        The mean of ``(p_pred - y_true) ** 2`` as a plain Python ``float``.
-
-    Example:
-        Quick start::
-
-            from sportsdataverse.mlb.mlb_game_state_constants import brier_score
-            brier_score([1, 0], [0.75, 0.25])
-    """
-    return float(np.mean((np.asarray(p_pred, dtype=float) - np.asarray(y_true, dtype=float)) ** 2))
-
-
-def calibration_table(y_true: "np.ndarray", p_pred: "np.ndarray", n_bins: int = 10) -> pl.DataFrame:
-    """Bucket predicted probabilities into deciles and compare to realized rate.
-
-    Args:
-        y_true: Binary outcomes (0/1).
-        p_pred: Predicted probabilities in ``[0, 1]``.
-        n_bins: Number of equal-width probability buckets (default 10).
-
-    Returns:
-        pl.DataFrame: one row per non-empty bucket.
-
-        | Column | Type | Description |
-        |---|---|---|
-        | bin_mid | Float64 | Bucket midpoint probability |
-        | mean_pred | Float64 | Mean predicted probability in the bucket |
-        | mean_actual | Float64 | Realized outcome rate in the bucket |
-        | n | UInt32 | Row count in the bucket |
-
-    Example:
-        Quick start::
-
-            from sportsdataverse.mlb.mlb_game_state_constants import calibration_table
-            calibration_table([1, 0, 1, 1], [0.8, 0.2, 0.6, 0.9])
-    """
-    df = pl.DataFrame({"y": np.asarray(y_true, dtype=float), "p": np.asarray(p_pred, dtype=float)})
-    df = df.with_columns((pl.col("p").clip(0.0, 0.9999) * n_bins).floor().cast(pl.Int64).alias("bin"))
-    return (
-        df.group_by("bin")
-        .agg(pl.col("p").mean().alias("mean_pred"), pl.col("y").mean().alias("mean_actual"), pl.len().alias("n"))
-        .sort("bin")
-        .with_columns(((pl.col("bin") + 0.5) / n_bins).alias("bin_mid"))
-        .select("bin_mid", "mean_pred", "mean_actual", "n")
-    )
 
 
 def collect_statsapi_pbp(game_pks: List[int], *, sleep: float = 0.0) -> pl.DataFrame:

--- a/sportsdataverse/mlb/mlb_hitting_constants.py
+++ b/sportsdataverse/mlb/mlb_hitting_constants.py
@@ -17,13 +17,18 @@ Methodology references (cited, not copied):
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Optional
+from typing import Callable, Optional
 
 import numpy as np
 import polars as pl
-from scipy.stats import rankdata
 
 from sportsdataverse.mlb.mlb_statcast_extra import mlb_statcast_search
+from sportsdataverse._common.metrics import (
+    brier_score as brier_score,
+    calibration_table as calibration_table,
+    mae as mae,
+    spearman_corr as spearman_corr,
+)
 
 
 @dataclass(frozen=True)
@@ -168,102 +173,6 @@ def as_of_seasons_split(player_seasons: pl.DataFrame, target_season: int) -> pl.
             as_of_seasons_split(ps, target_season=2023)
     """
     return player_seasons.filter(pl.col("season") < target_season)
-
-
-def spearman_corr(a: "np.ndarray[Any, Any]", b: "np.ndarray[Any, Any]") -> float:
-    """Spearman rank correlation between two arrays.
-
-    Args:
-        a: First array of values.
-        b: Second array of values (same length as ``a``).
-
-    Returns:
-        The Spearman rank correlation coefficient.
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.mlb.mlb_hitting_constants import spearman_corr
-
-            spearman_corr(np.array([1.0, 2.0, 3.0]), np.array([10.0, 20.0, 30.0]))
-    """
-    ra, rb = rankdata(a), rankdata(b)
-    return float(np.corrcoef(ra, rb)[0, 1])
-
-
-def mae(a: "np.ndarray[Any, Any]", b: "np.ndarray[Any, Any]") -> float:
-    """Mean absolute error between two arrays.
-
-    Args:
-        a: First array of values.
-        b: Second array of values (same length as ``a``).
-
-    Returns:
-        The mean absolute difference ``mean(abs(a - b))``.
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.mlb.mlb_hitting_constants import mae
-
-            mae(np.array([1.0, 2.0]), np.array([1.5, 2.5]))
-    """
-    return float(np.mean(np.abs(np.asarray(a, dtype=float) - np.asarray(b, dtype=float))))
-
-
-def brier_score(y_true: "np.ndarray[Any, Any]", p_pred: "np.ndarray[Any, Any]") -> float:
-    """Brier score (mean squared error of a probability forecast).
-
-    Args:
-        y_true: Binary outcome array (0/1).
-        p_pred: Predicted probability array (same length as ``y_true``).
-
-    Returns:
-        The Brier score ``mean((p_pred - y_true) ** 2)``.
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.mlb.mlb_hitting_constants import brier_score
-
-            brier_score(np.array([1, 0]), np.array([0.75, 0.25]))
-    """
-    return float(np.mean((np.asarray(p_pred, dtype=float) - np.asarray(y_true, dtype=float)) ** 2))
-
-
-def calibration_table(y_true: "np.ndarray[Any, Any]", p_pred: "np.ndarray[Any, Any]", n_bins: int = 10) -> pl.DataFrame:
-    """Bin predicted probabilities and compare mean predicted vs. mean actual.
-
-    Args:
-        y_true: Binary outcome array (0/1).
-        p_pred: Predicted probability array (same length as ``y_true``).
-        n_bins: Number of equal-width probability bins.
-
-    Returns:
-        A polars DataFrame with columns ``bin_mid``, ``mean_pred``,
-        ``mean_actual``, ``n`` -- one row per non-empty bin.
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.mlb.mlb_hitting_constants import calibration_table
-
-            rng = np.random.default_rng(0)
-            calibration_table(rng.integers(0, 2, 200), rng.random(200), n_bins=10)
-    """
-    df = pl.DataFrame({"y": np.asarray(y_true, dtype=float), "p": np.asarray(p_pred, dtype=float)})
-    df = df.with_columns((pl.col("p").clip(0.0, 0.9999) * n_bins).floor().cast(pl.Int64).alias("bin"))
-    return (
-        df.group_by("bin")
-        .agg(pl.col("p").mean().alias("mean_pred"), pl.col("y").mean().alias("mean_actual"), pl.len().alias("n"))
-        .sort("bin")
-        .with_columns(((pl.col("bin") + 0.5) / n_bins).alias("bin_mid"))
-        .select("bin_mid", "mean_pred", "mean_actual", "n")
-    )
 
 
 def pull_statcast_season(

--- a/sportsdataverse/mlb/mlb_pitching_constants.py
+++ b/sportsdataverse/mlb/mlb_pitching_constants.py
@@ -21,7 +21,11 @@ from typing import Dict, List
 
 import numpy as np
 import polars as pl
-from scipy.stats import rankdata
+from sportsdataverse._common.metrics import (
+    calibration_table as calibration_table,
+    mae as mae,
+    spearman_corr as spearman_corr,
+)
 
 # --- bundled-artifact paths (Phase 2 / Phase 3 write these .ubj files) ---
 STUFF_PLUS_ARTIFACT = "mlb_stuff_plus.ubj"
@@ -59,27 +63,6 @@ COMMAND_LEAGUE_MEAN_RV: float = -0.0009078294970095158
 COMMAND_LEAGUE_SD_RV: float = 0.0403415784239769
 
 
-def spearman_corr(a: np.ndarray, b: np.ndarray) -> float:
-    """Spearman rank correlation between two equal-length arrays.
-
-    Args:
-        a: First array.
-        b: Second array (same length as ``a``).
-
-    Returns:
-        float: The Spearman rank correlation coefficient in ``[-1, 1]``.
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.mlb.mlb_pitching_constants import spearman_corr
-            spearman_corr(np.array([1.0, 2.0, 3.0]), np.array([10.0, 20.0, 30.0]))
-    """
-    ra, rb = rankdata(a), rankdata(b)
-    return float(np.corrcoef(ra, rb)[0, 1])
-
-
 def rmse(a: np.ndarray, b: np.ndarray) -> float:
     """Root-mean-squared error between two equal-length arrays.
 
@@ -100,59 +83,6 @@ def rmse(a: np.ndarray, b: np.ndarray) -> float:
     a = np.asarray(a, dtype=float)
     b = np.asarray(b, dtype=float)
     return float(np.sqrt(np.mean((a - b) ** 2)))
-
-
-def mae(a: np.ndarray, b: np.ndarray) -> float:
-    """Mean absolute error between two equal-length arrays.
-
-    Args:
-        a: Predicted (or first) array.
-        b: Actual (or second) array (same length as ``a``).
-
-    Returns:
-        float: The MAE.
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.mlb.mlb_pitching_constants import mae
-            mae(np.array([1.0, 2.0]), np.array([1.5, 2.5]))
-    """
-    a = np.asarray(a, dtype=float)
-    b = np.asarray(b, dtype=float)
-    return float(np.mean(np.abs(a - b)))
-
-
-def calibration_table(y_true: np.ndarray, p_pred: np.ndarray, n_bins: int = 10) -> pl.DataFrame:
-    """Bin predicted probabilities and compare to observed outcome rate per bin.
-
-    Args:
-        y_true: Binary (0/1) outcome array.
-        p_pred: Predicted probability array (same length as ``y_true``).
-        n_bins: Number of equal-width probability bins (default 10).
-
-    Returns:
-        polars.DataFrame: Columns ``bin_mid``, ``mean_pred``, ``mean_actual``,
-        ``n`` — one row per non-empty bin (at most ``n_bins`` rows).
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.mlb.mlb_pitching_constants import calibration_table
-            rng = np.random.default_rng(0)
-            calibration_table(rng.integers(0, 2, 200), rng.random(200), n_bins=10)
-    """
-    df = pl.DataFrame({"y": np.asarray(y_true, dtype=float), "p": np.asarray(p_pred, dtype=float)})
-    df = df.with_columns((pl.col("p").clip(0.0, 0.9999) * n_bins).floor().cast(pl.Int64).alias("bin"))
-    return (
-        df.group_by("bin")
-        .agg(pl.col("p").mean().alias("mean_pred"), pl.col("y").mean().alias("mean_actual"), pl.len().alias("n"))
-        .sort("bin")
-        .with_columns(((pl.col("bin") + 0.5) / n_bins).alias("bin_mid"))
-        .select("bin_mid", "mean_pred", "mean_actual", "n")
-    )
 
 
 def as_of_split(pitches: pl.DataFrame, cutoff_date: dt.date, *, date_col: str = "game_date") -> pl.DataFrame:

--- a/sportsdataverse/mlb/mlb_run_values.py
+++ b/sportsdataverse/mlb/mlb_run_values.py
@@ -31,9 +31,12 @@ from typing import Any, List, Union
 
 import numpy as np
 import polars as pl
-from scipy.stats import rankdata
 
 from sportsdataverse.mlb.mlb_statcast_extra import mlb_statcast_search
+from sportsdataverse._common.metrics import (
+    mae as mae,
+    spearman_corr as spearman_corr,
+)
 
 #: Documented linear-weight fallback (used only when ``delta_run_exp`` is
 #: absent from the feed -- pre-2015 seasons / MiLB). Values follow Tango,
@@ -67,48 +70,6 @@ def pearson_corr(a: "np.ndarray", b: "np.ndarray") -> float:
     arr_a = np.asarray(a, dtype=float)
     arr_b = np.asarray(b, dtype=float)
     return float(np.corrcoef(arr_a, arr_b)[0, 1])
-
-
-def spearman_corr(a: "np.ndarray", b: "np.ndarray") -> float:
-    """Spearman rank correlation between two 1-D arrays.
-
-    Args:
-        a: First sample array.
-        b: Second sample array, same length as ``a``.
-
-    Returns:
-        float: Spearman's rho (Pearson correlation of the ranks).
-
-    Example:
-        Quick start::
-
-            from sportsdataverse.mlb.mlb_run_values import spearman_corr
-            rho = spearman_corr(mine["oaa"].to_numpy(), sav["outs_above_average"].to_numpy())
-    """
-    arr_a = np.asarray(a, dtype=float)
-    arr_b = np.asarray(b, dtype=float)
-    return float(np.corrcoef(rankdata(arr_a), rankdata(arr_b))[0, 1])
-
-
-def mae(a: "np.ndarray", b: "np.ndarray") -> float:
-    """Mean absolute error between two 1-D arrays.
-
-    Args:
-        a: Predicted / modeled array.
-        b: Reference / observed array, same length as ``a``.
-
-    Returns:
-        float: ``mean(abs(a - b))``.
-
-    Example:
-        Quick start::
-
-            from sportsdataverse.mlb.mlb_run_values import mae
-            gap = mae(deciles["mean_pred"].to_numpy(), deciles["mean_actual"].to_numpy())
-    """
-    arr_a = np.asarray(a, dtype=float)
-    arr_b = np.asarray(b, dtype=float)
-    return float(np.mean(np.abs(arr_a - arr_b)))
 
 
 _COUNT_RV_SCHEMA = {"balls": pl.Int64, "strikes": pl.Int64, "strike_run_value": pl.Float64}

--- a/sportsdataverse/nba/nba_draft_constants.py
+++ b/sportsdataverse/nba/nba_draft_constants.py
@@ -27,51 +27,15 @@ from dataclasses import dataclass, field
 import numpy as np
 import polars as pl
 from scipy.stats import rankdata
+from sportsdataverse._common.metrics import (
+    calibration_table as calibration_table,
+    mae as mae,
+    spearman_corr as spearman_corr,
+)
 
 # ---------------------------------------------------------------------------
 # Metrics
 # ---------------------------------------------------------------------------
-
-
-def spearman_corr(a: np.ndarray, b: np.ndarray) -> float:
-    """Spearman rank correlation between two 1-D arrays.
-
-    Args:
-        a: First array.
-        b: Second array, same length as ``a``.
-
-    Returns:
-        Spearman's rho as a plain ``float``.
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.nba.nba_draft_constants import spearman_corr
-            spearman_corr(np.array([1.0, 2.0, 3.0]), np.array([10.0, 20.0, 15.0]))
-    """
-    ra, rb = rankdata(a), rankdata(b)
-    return float(np.corrcoef(ra, rb)[0, 1])
-
-
-def mae(a: np.ndarray, b: np.ndarray) -> float:
-    """Mean absolute error between two 1-D arrays.
-
-    Args:
-        a: First array (e.g. predictions).
-        b: Second array (e.g. realized values), same length as ``a``.
-
-    Returns:
-        Mean absolute error as a plain ``float``.
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.nba.nba_draft_constants import mae
-            mae(np.array([1.0, 2.0]), np.array([1.5, 2.5]))
-    """
-    return float(np.mean(np.abs(np.asarray(a, dtype=float) - np.asarray(b, dtype=float))))
 
 
 def auc(y_true: np.ndarray, p_pred: np.ndarray) -> float:
@@ -99,38 +63,6 @@ def auc(y_true: np.ndarray, p_pred: np.ndarray) -> float:
         return 0.5
     r = rankdata(p)
     return float((r[y == 1].sum() - pos.size * (pos.size + 1) / 2) / (pos.size * neg.size))
-
-
-def calibration_table(y_true: np.ndarray, p_pred: np.ndarray, n_bins: int = 10) -> pl.DataFrame:
-    """Bin predicted probabilities and compare mean-predicted vs mean-actual.
-
-    Args:
-        y_true: Binary or fractional ground-truth outcomes in ``[0, 1]``.
-        p_pred: Predicted probabilities/rates in ``[0, 1]``.
-        n_bins: Number of equal-width probability bins.
-
-    Returns:
-        Frame ``bin_mid:Float64, mean_pred:Float64, mean_actual:Float64, n:Int64``,
-        one row per non-empty bin (``height <= n_bins``).
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.nba.nba_draft_constants import calibration_table
-            y = np.random.default_rng(0).integers(0, 2, 200)
-            p = np.random.default_rng(1).random(200)
-            calibration_table(y, p, n_bins=10)
-    """
-    df = pl.DataFrame({"y": np.asarray(y_true, dtype=float), "p": np.asarray(p_pred, dtype=float)})
-    df = df.with_columns((pl.col("p").clip(0.0, 0.9999) * n_bins).floor().cast(pl.Int64).alias("bin"))
-    return (
-        df.group_by("bin")
-        .agg(pl.col("p").mean().alias("mean_pred"), pl.col("y").mean().alias("mean_actual"), pl.len().alias("n"))
-        .sort("bin")
-        .with_columns(((pl.col("bin") + 0.5) / n_bins).alias("bin_mid"))
-        .select("bin_mid", "mean_pred", "mean_actual", "n")
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/sportsdataverse/nba/nba_playtype_constants.py
+++ b/sportsdataverse/nba/nba_playtype_constants.py
@@ -11,9 +11,12 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 import numpy as np
-from scipy.stats import rankdata
 
 from sportsdataverse.nba.nba_rapm import DEFAULT_RAPM_ALPHAS
+from sportsdataverse._common.metrics import (
+    mae as mae,
+    spearman_corr as spearman_corr,
+)
 
 #: Synergy's canonical 11 play types (``play_type_nullable`` values), pinned from a
 #: live ``nba_stats_synergyplaytypes`` capture (2023-24 season) -- note ``PRRollMan``
@@ -53,47 +56,6 @@ class PlaytypeConfig:
     ft_points_per_trip: float = 1.53
     min_matchup_poss: float = 25.0
     ridge_alphas: np.ndarray = field(default_factory=lambda: np.asarray(DEFAULT_RAPM_ALPHAS))
-
-
-def spearman_corr(a: np.ndarray, b: np.ndarray) -> float:
-    """Spearman rank correlation between two equal-length arrays.
-
-    Args:
-        a: First array.
-        b: Second array, same length as *a*.
-
-    Returns:
-        The Pearson correlation of the rank-transformed arrays.
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.nba.nba_playtype_constants import spearman_corr
-            spearman_corr(np.array([1, 2, 3]), np.array([10, 20, 30]))
-    """
-    ra, rb = rankdata(a), rankdata(b)
-    return float(np.corrcoef(ra, rb)[0, 1])
-
-
-def mae(a: np.ndarray, b: np.ndarray) -> float:
-    """Mean absolute error between two equal-length arrays.
-
-    Args:
-        a: First array.
-        b: Second array, same length as *a*.
-
-    Returns:
-        ``mean(abs(a - b))``.
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.nba.nba_playtype_constants import mae
-            mae(np.array([1.0, 2.0]), np.array([1.5, 2.5]))
-    """
-    return float(np.mean(np.abs(np.asarray(a, dtype=float) - np.asarray(b, dtype=float))))
 
 
 def sum_consistency_residual(parts: np.ndarray, whole: np.ndarray) -> float:

--- a/sportsdataverse/nba/nba_prediction_constants.py
+++ b/sportsdataverse/nba/nba_prediction_constants.py
@@ -26,12 +26,16 @@ implements them standalone per the T3.3 plan (mirroring MBB names).
 
 from __future__ import annotations
 
-import datetime
 from dataclasses import dataclass
 
-import numpy as np
-import polars as pl
-from scipy.stats import rankdata
+from sportsdataverse._common.metrics import (
+    as_of_ratings_split as as_of_ratings_split,
+    brier_score as brier_score,
+    calibration_table as calibration_table,
+    log_loss_score as log_loss_score,
+    mae as mae,
+    spearman_corr as spearman_corr,
+)
 
 __all__ = [
     "LEAGUE_CONSTANTS",
@@ -137,152 +141,3 @@ def get_constants(league_id: str) -> LeagueConstants:
         return LEAGUE_CONSTANTS[league_id]
     except KeyError:
         raise ValueError(f"unknown league_id {league_id!r}; expected one of {sorted(LEAGUE_CONSTANTS)}") from None
-
-
-def as_of_ratings_split(results: pl.DataFrame, cutoff_date: datetime.date) -> pl.DataFrame:
-    """Return only games strictly before ``cutoff_date`` (the leakage boundary).
-
-    Predictive backtests must rate a game using only games that finished
-    before it -- this split enforces that as-of-date rule so no future
-    information leaks into a game's own prediction.
-
-    Args:
-        results: A frame with a ``date`` column of dtype ``pl.Date``.
-        cutoff_date: The date of the game being predicted; games on or after
-            it are dropped.
-
-    Returns:
-        The subset of ``results`` with ``date < cutoff_date``.
-
-    Example:
-        Quick start::
-
-            from sportsdataverse.nba.nba_prediction_constants import as_of_ratings_split
-            prior = as_of_ratings_split(results, some_game_date)
-    """
-    return results.filter(pl.col("date") < cutoff_date)
-
-
-def brier_score(y_true: np.ndarray, p_pred: np.ndarray) -> float:
-    """Mean squared error between binary outcomes and predicted probabilities.
-
-    Args:
-        y_true: Array of realized binary outcomes (0/1).
-        p_pred: Array of predicted probabilities in ``[0, 1]``.
-
-    Returns:
-        The Brier score (lower is better; 0.0 is perfect).
-
-    Example:
-        Perfect predictions score zero::
-
-            import numpy as np
-            from sportsdataverse.nba.nba_prediction_constants import brier_score
-            brier_score(np.array([1, 0]), np.array([1.0, 0.0]))
-    """
-    return float(np.mean((np.asarray(p_pred, dtype=float) - np.asarray(y_true, dtype=float)) ** 2))
-
-
-def log_loss_score(y_true: np.ndarray, p_pred: np.ndarray, eps: float = 1e-15) -> float:
-    """Binary cross-entropy (log loss) between outcomes and probabilities.
-
-    Args:
-        y_true: Array of realized binary outcomes (0/1).
-        p_pred: Array of predicted probabilities in ``[0, 1]``.
-        eps: Clipping bound to keep the log finite at 0/1.
-
-    Returns:
-        The mean log loss (lower is better).
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.nba.nba_prediction_constants import log_loss_score
-            log_loss_score(np.array([1, 0]), np.array([0.9, 0.1]))
-    """
-    p = np.clip(np.asarray(p_pred, dtype=float), eps, 1 - eps)
-    y = np.asarray(y_true, dtype=float)
-    return float(-np.mean(y * np.log(p) + (1 - y) * np.log(1 - p)))
-
-
-def spearman_corr(a: np.ndarray, b: np.ndarray) -> float:
-    """Spearman rank correlation between two arrays.
-
-    Args:
-        a: First array.
-        b: Second array (same length as ``a``).
-
-    Returns:
-        The Spearman rank-correlation coefficient in ``[-1, 1]``.
-
-    Example:
-        A monotonic relationship scores 1.0::
-
-            import numpy as np
-            from sportsdataverse.nba.nba_prediction_constants import spearman_corr
-            spearman_corr(np.array([1.0, 2.0, 3.0]), np.array([10.0, 20.0, 30.0]))
-    """
-    ra, rb = rankdata(a), rankdata(b)
-    return float(np.corrcoef(ra, rb)[0, 1])
-
-
-def mae(a: np.ndarray, b: np.ndarray) -> float:
-    """Mean absolute error between two arrays.
-
-    Args:
-        a: First array.
-        b: Second array (same length as ``a``).
-
-    Returns:
-        The mean absolute error.
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.nba.nba_prediction_constants import mae
-            mae(np.array([1.0, 2.0]), np.array([1.5, 2.5]))
-    """
-    return float(np.mean(np.abs(np.asarray(a, dtype=float) - np.asarray(b, dtype=float))))
-
-
-def calibration_table(y_true: np.ndarray, p_pred: np.ndarray, n_bins: int = 10) -> pl.DataFrame:
-    """Bin predicted probabilities and compare mean-predicted vs mean-actual.
-
-    Args:
-        y_true: Array of realized binary outcomes (0/1).
-        p_pred: Array of predicted probabilities in ``[0, 1]``.
-        n_bins: Number of equal-width probability bins.
-
-    Returns:
-        A ``polars.DataFrame`` with columns ``bin_mid``, ``mean_pred``,
-        ``mean_actual``, ``n`` (one row per non-empty bin, sorted ascending).
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.nba.nba_prediction_constants import calibration_table
-            y = np.random.default_rng(0).integers(0, 2, 200)
-            p = np.random.default_rng(1).random(200)
-            calibration_table(y, p, n_bins=10)
-    """
-    df = pl.DataFrame(
-        {
-            "y": np.asarray(y_true, dtype=float),
-            "p": np.asarray(p_pred, dtype=float),
-        }
-    )
-    df = df.with_columns((pl.col("p").clip(0.0, 0.9999) * n_bins).floor().cast(pl.Int64).alias("bin"))
-    return (
-        df.group_by("bin")
-        .agg(
-            pl.col("p").mean().alias("mean_pred"),
-            pl.col("y").mean().alias("mean_actual"),
-            pl.len().alias("n"),
-        )
-        .sort("bin")
-        .with_columns(((pl.col("bin") + 0.5) / n_bins).alias("bin_mid"))
-        .select("bin_mid", "mean_pred", "mean_actual", "n")
-    )

--- a/sportsdataverse/nba/nba_shot_value_constants.py
+++ b/sportsdataverse/nba/nba_shot_value_constants.py
@@ -13,6 +13,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import numpy as np
+from sportsdataverse._common.metrics import (
+    mae as mae,
+)
 
 
 def points_calibration_error(exp_points: np.ndarray, actual_points: np.ndarray) -> float:
@@ -57,25 +60,6 @@ def split_half_reliability(first_half: np.ndarray, second_half: np.ndarray) -> f
     if a.size < 2:
         return float("nan")
     return float(np.corrcoef(a, b)[0, 1])
-
-
-def mae(a: np.ndarray, b: np.ndarray) -> float:
-    """Mean absolute error between two aligned arrays.
-
-    Args:
-        a: First array.
-        b: Second array.
-
-    Returns:
-        ``mean(|a − b|)``.
-
-    Example:
-        Quick start::
-
-            from sportsdataverse.nba.nba_shot_value_constants import mae
-            mae(np.array([1.0, 2.0]), np.array([1.5, 2.5]))
-    """
-    return float(np.mean(np.abs(np.asarray(a, dtype=float) - np.asarray(b, dtype=float))))
 
 
 def pps(points: np.ndarray, attempts: np.ndarray) -> float:

--- a/sportsdataverse/nfl/nfl_ngs_constants.py
+++ b/sportsdataverse/nfl/nfl_ngs_constants.py
@@ -13,7 +13,10 @@ from typing import Optional, Tuple
 
 import numpy as np
 import polars as pl
-from scipy.stats import rankdata
+from sportsdataverse._common.metrics import (
+    mae as mae,
+    spearman_corr as spearman_corr,
+)
 
 RECEIVER_POSITIONS: Tuple[str, ...] = ("WR", "TE", "RB", "FB")
 # Separation-OE ridge penalty. A sweep over lambda {0.1, 1, 10} x min_targets
@@ -185,17 +188,6 @@ def expected_separation_ridge(
     pen[0, 0] = 0.0  # do not penalize intercept
     beta = np.linalg.solve(feature_matrix.T @ weighted + pen, weighted.T @ y)
     return feature_matrix @ beta, beta
-
-
-def spearman_corr(a: np.ndarray, b: np.ndarray) -> float:
-    """Spearman rank correlation of two same-length vectors."""
-    ra, rb = rankdata(a), rankdata(b)
-    return float(np.corrcoef(ra, rb)[0, 1])
-
-
-def mae(a: np.ndarray, b: np.ndarray) -> float:
-    """Mean absolute error between two same-length vectors."""
-    return float(np.mean(np.abs(np.asarray(a, dtype=float) - np.asarray(b, dtype=float))))
 
 
 def next_season_stability(

--- a/sportsdataverse/nfl/nfl_prediction_constants.py
+++ b/sportsdataverse/nfl/nfl_prediction_constants.py
@@ -13,9 +13,14 @@ import datetime as dt
 from dataclasses import dataclass, field
 from typing import Dict
 
-import numpy as np
 import polars as pl
-from scipy.stats import rankdata
+from sportsdataverse._common.metrics import (
+    brier_score as brier_score,
+    calibration_table as calibration_table,
+    log_loss_score as log_loss_score,
+    mae as mae,
+    spearman_corr as spearman_corr,
+)
 
 
 @dataclass(frozen=True)
@@ -222,123 +227,3 @@ def as_of_ratings_split(
             past = as_of_ratings_split(results, dt.date(2023, 11, 1))
     """
     return results.filter(pl.col(date_col) < cutoff_date)
-
-
-def brier_score(y_true: np.ndarray, p_pred: np.ndarray) -> float:
-    """Mean squared error between predicted probabilities and binary outcomes.
-
-    Args:
-        y_true: Binary outcomes (0/1).
-        p_pred: Predicted probabilities in ``[0, 1]``.
-
-    Returns:
-        The Brier score (lower is better; 0.0 is perfect).
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.nfl.nfl_prediction_constants import brier_score
-            brier_score(np.array([1, 0]), np.array([0.75, 0.25]))
-    """
-    return float(np.mean((np.asarray(p_pred, float) - np.asarray(y_true, float)) ** 2))
-
-
-def log_loss_score(y_true: np.ndarray, p_pred: np.ndarray, eps: float = 1e-15) -> float:
-    """Binary cross-entropy between predicted probabilities and outcomes.
-
-    Args:
-        y_true: Binary outcomes (0/1).
-        p_pred: Predicted probabilities in ``[0, 1]`` (clipped by ``eps``).
-        eps: Clip bound keeping ``log`` finite.
-
-    Returns:
-        The mean negative log-likelihood (lower is better).
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.nfl.nfl_prediction_constants import log_loss_score
-            log_loss_score(np.array([1, 0]), np.array([0.9, 0.1]))
-    """
-    p = np.clip(np.asarray(p_pred, float), eps, 1 - eps)
-    y = np.asarray(y_true, float)
-    return float(-np.mean(y * np.log(p) + (1 - y) * np.log(1 - p)))
-
-
-def spearman_corr(a: np.ndarray, b: np.ndarray) -> float:
-    """Spearman rank correlation between two vectors.
-
-    Args:
-        a: First vector.
-        b: Second vector (same length).
-
-    Returns:
-        The rank correlation in ``[-1, 1]``.
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.nfl.nfl_prediction_constants import spearman_corr
-            spearman_corr(np.array([1.0, 2.0, 3.0]), np.array([10.0, 20.0, 30.0]))
-    """
-    ra, rb = rankdata(a), rankdata(b)
-    return float(np.corrcoef(ra, rb)[0, 1])
-
-
-def mae(a: np.ndarray, b: np.ndarray) -> float:
-    """Mean absolute error between two vectors.
-
-    Args:
-        a: First vector.
-        b: Second vector (same length).
-
-    Returns:
-        The mean absolute difference.
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.nfl.nfl_prediction_constants import mae
-            mae(np.array([1.0, 2.0]), np.array([1.5, 2.5]))
-    """
-    return float(np.mean(np.abs(np.asarray(a, float) - np.asarray(b, float))))
-
-
-def calibration_table(y_true: np.ndarray, p_pred: np.ndarray, n_bins: int = 10) -> pl.DataFrame:
-    """Bucket predictions into probability bins and compare to realized rates.
-
-    Args:
-        y_true: Binary outcomes (0/1).
-        p_pred: Predicted probabilities in ``[0, 1]``.
-        n_bins: Number of equal-width probability bins.
-
-    Returns:
-        pl.DataFrame: One row per non-empty bin with columns ``bin_mid``
-        (Float64), ``mean_pred`` (Float64), ``mean_actual`` (Float64), ``n``
-        (Int64/UInt32 count).
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.nfl.nfl_prediction_constants import calibration_table
-            tbl = calibration_table(np.array([1, 0, 1, 1]), np.array([0.9, 0.2, 0.7, 0.6]))
-            print(tbl.shape)
-    """
-    df = pl.DataFrame({"y": np.asarray(y_true, float), "p": np.asarray(p_pred, float)})
-    df = df.with_columns((pl.col("p").clip(0.0, 0.9999) * n_bins).floor().cast(pl.Int64).alias("bin"))
-    return (
-        df.group_by("bin")
-        .agg(
-            pl.col("p").mean().alias("mean_pred"),
-            pl.col("y").mean().alias("mean_actual"),
-            pl.len().alias("n"),
-        )
-        .sort("bin")
-        .with_columns(((pl.col("bin") + 0.5) / n_bins).alias("bin_mid"))
-        .select("bin_mid", "mean_pred", "mean_actual", "n")
-    )

--- a/sportsdataverse/nfl/nfl_projection_constants.py
+++ b/sportsdataverse/nfl/nfl_projection_constants.py
@@ -14,7 +14,12 @@ from typing import Dict, Tuple
 
 import numpy as np
 import polars as pl
-from scipy.stats import rankdata
+from sportsdataverse._common.metrics import (
+    brier_score as brier_score,
+    log_loss_score as log_loss_score,
+    mae as mae,
+    spearman_corr as spearman_corr,
+)
 
 # ---------------------------------------------------------------------------
 # Scoring formats
@@ -180,90 +185,6 @@ class ProjectionConfig:
     team_games: int = 17
     min_realized_games: int = 8
     scoring: Dict[str, float] = field(default_factory=lambda: dict(SCORING_PPR))
-
-
-def spearman_corr(a: np.ndarray, b: np.ndarray) -> float:
-    """Spearman rank correlation between two 1-D arrays.
-
-    Args:
-        a (np.ndarray): First array.
-        b (np.ndarray): Second array, same length as ``a``.
-
-    Returns:
-        float: Spearman correlation in ``[-1, 1]``.
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.nfl.nfl_projection_constants import spearman_corr
-            spearman_corr(np.array([1.0, 2.0, 3.0]), np.array([2.0, 4.0, 9.0]))
-    """
-    ra, rb = rankdata(a), rankdata(b)
-    return float(np.corrcoef(ra, rb)[0, 1])
-
-
-def mae(a: np.ndarray, b: np.ndarray) -> float:
-    """Mean absolute error between two arrays.
-
-    Args:
-        a (np.ndarray): Predictions.
-        b (np.ndarray): Targets, same length as ``a``.
-
-    Returns:
-        float: Mean of ``|a - b|``.
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.nfl.nfl_projection_constants import mae
-            mae(np.array([1.0, 2.0]), np.array([1.5, 2.5]))
-    """
-    return float(np.mean(np.abs(np.asarray(a, dtype=float) - np.asarray(b, dtype=float))))
-
-
-def brier_score(y_true: np.ndarray, p_pred: np.ndarray) -> float:
-    """Brier score (mean squared error of probabilities).
-
-    Args:
-        y_true (np.ndarray): Binary outcomes in ``{0, 1}``.
-        p_pred (np.ndarray): Predicted probabilities in ``[0, 1]``.
-
-    Returns:
-        float: Mean of ``(p_pred - y_true) ** 2`` (lower is better).
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.nfl.nfl_projection_constants import brier_score
-            brier_score(np.array([1, 0]), np.array([0.75, 0.25]))
-    """
-    return float(np.mean((np.asarray(p_pred, dtype=float) - np.asarray(y_true, dtype=float)) ** 2))
-
-
-def log_loss_score(y_true: np.ndarray, p_pred: np.ndarray, eps: float = 1e-15) -> float:
-    """Binary log loss (cross-entropy) with probability clipping.
-
-    Args:
-        y_true (np.ndarray): Binary outcomes in ``{0, 1}``.
-        p_pred (np.ndarray): Predicted probabilities in ``[0, 1]``.
-        eps (float): Clip bound keeping probabilities in ``[eps, 1 - eps]``.
-
-    Returns:
-        float: Mean negative log-likelihood (lower is better).
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.nfl.nfl_projection_constants import log_loss_score
-            log_loss_score(np.array([1, 0]), np.array([0.9, 0.1]))
-    """
-    p = np.clip(np.asarray(p_pred, dtype=float), eps, 1 - eps)
-    y = np.asarray(y_true, dtype=float)
-    return float(-np.mean(y * np.log(p) + (1 - y) * np.log(1 - p)))
 
 
 def calibration_table(y_true: np.ndarray, p_pred: np.ndarray, n_bins: int = 10) -> pl.DataFrame:

--- a/sportsdataverse/nfl/nfl_scheme_constants.py
+++ b/sportsdataverse/nfl/nfl_scheme_constants.py
@@ -16,53 +16,16 @@ from typing import Dict
 import numpy as np
 import polars as pl
 from scipy.stats import rankdata
+from sportsdataverse._common.metrics import (
+    brier_score as brier_score,
+    log_loss_score as log_loss_score,
+    mae as mae,
+    spearman_corr as spearman_corr,
+)
 
 # --------------------------------------------------------------------------- #
 # validation metrics (numpy-only, no sklearn)
 # --------------------------------------------------------------------------- #
-
-
-def brier_score(y_true: np.ndarray, p_pred: np.ndarray) -> float:
-    """Mean squared error between binary outcomes and predicted probabilities.
-
-    Args:
-        y_true: Binary outcome array (0/1).
-        p_pred: Predicted probability array, same length.
-
-    Returns:
-        The Brier score (lower is better).
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.nfl.nfl_scheme_constants import brier_score
-            brier_score(np.array([1, 0]), np.array([0.75, 0.25]))
-    """
-    return float(np.mean((np.asarray(p_pred, dtype=float) - np.asarray(y_true, dtype=float)) ** 2))
-
-
-def log_loss_score(y_true: np.ndarray, p_pred: np.ndarray, eps: float = 1e-15) -> float:
-    """Binary cross-entropy of predicted probabilities against outcomes.
-
-    Args:
-        y_true: Binary outcome array (0/1).
-        p_pred: Predicted probability array, same length.
-        eps: Probability clip to avoid log(0).
-
-    Returns:
-        Mean negative log-likelihood (lower is better).
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.nfl.nfl_scheme_constants import log_loss_score
-            log_loss_score(np.array([1, 0]), np.array([0.9, 0.1]))
-    """
-    y = np.asarray(y_true, dtype=float)
-    p = np.clip(np.asarray(p_pred, dtype=float), eps, 1.0 - eps)
-    return float(-np.mean(y * np.log(p) + (1.0 - y) * np.log(1.0 - p)))
 
 
 def auc_score(y_true: np.ndarray, p_pred: np.ndarray) -> float:
@@ -89,47 +52,6 @@ def auc_score(y_true: np.ndarray, p_pred: np.ndarray) -> float:
         return float("nan")
     ranks = rankdata(np.asarray(p_pred, dtype=float))
     return float((ranks[y == 1].sum() - n_pos * (n_pos + 1) / 2.0) / (n_pos * n_neg))
-
-
-def spearman_corr(a: np.ndarray, b: np.ndarray) -> float:
-    """Spearman rank correlation between two arrays.
-
-    Args:
-        a: First array.
-        b: Second array, same length.
-
-    Returns:
-        Rank correlation in [-1, 1].
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.nfl.nfl_scheme_constants import spearman_corr
-            spearman_corr(np.array([1.0, 2.0, 3.0]), np.array([2.0, 4.0, 6.0]))
-    """
-    ra, rb = rankdata(a), rankdata(b)
-    return float(np.corrcoef(ra, rb)[0, 1])
-
-
-def mae(a: np.ndarray, b: np.ndarray) -> float:
-    """Mean absolute error between two arrays.
-
-    Args:
-        a: First array.
-        b: Second array, same length.
-
-    Returns:
-        Mean of ``|a - b|``.
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.nfl.nfl_scheme_constants import mae
-            mae(np.array([1.0, 2.0]), np.array([1.5, 2.5]))
-    """
-    return float(np.mean(np.abs(np.asarray(a, dtype=float) - np.asarray(b, dtype=float))))
 
 
 def calibration_table(y_true: np.ndarray, p_pred: np.ndarray, n_bins: int = 10) -> pl.DataFrame:

--- a/sportsdataverse/nhl/nhl_player_impact_constants.py
+++ b/sportsdataverse/nhl/nhl_player_impact_constants.py
@@ -28,10 +28,12 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-import polars as pl
 import scipy.sparse as sp
 from scipy.sparse.linalg import cg
-from scipy.stats import rankdata
+from sportsdataverse._common.metrics import (
+    calibration_table as calibration_table,
+    spearman_corr as spearman_corr,
+)
 
 __all__ = [
     "ImpactConfig",
@@ -244,58 +246,6 @@ def team_fullname_to_abbr(name: str) -> str | None:
             team_fullname_to_abbr("Buffalo Sabres")  # "BUF"
     """
     return NHL_TEAM_FULLNAME_TO_ABBR.get(name)
-
-
-def spearman_corr(a: np.ndarray, b: np.ndarray) -> float:
-    """Spearman rank correlation between two 1-D arrays (no scipy.stats.spearmanr dep).
-
-    Args:
-        a: first sample.
-        b: second sample, same length as ``a``.
-
-    Returns:
-        The Pearson correlation of the rank-transformed samples.
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.nhl.nhl_player_impact_constants import spearman_corr
-            spearman_corr(np.array([1, 2, 3]), np.array([3, 6, 9]))  # 1.0
-    """
-    ra, rb = rankdata(a), rankdata(b)
-    return float(np.corrcoef(ra, rb)[0, 1])
-
-
-def calibration_table(y_true: np.ndarray, p_pred: np.ndarray, n_bins: int = 10) -> pl.DataFrame:
-    """Bucket predicted probabilities into ``n_bins`` and compare to the realized rate.
-
-    Args:
-        y_true: binary outcomes (0/1), e.g. ``event_type == "GOAL"``.
-        p_pred: predicted probabilities, e.g. per-shot ``xg``.
-        n_bins: number of equal-width probability bins.
-
-    Returns:
-        polars.DataFrame: ``bin_mid:Float64, mean_pred:Float64, mean_actual:Float64,
-        n:Int64`` -- reliability tracks the diagonal (``mean_actual`` monotone in
-        ``bin_mid``) when the model is well-calibrated.
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.nhl.nhl_player_impact_constants import calibration_table
-            tbl = calibration_table(np.array([0, 1, 1, 0]), np.array([0.1, 0.8, 0.6, 0.2]))
-    """
-    df = pl.DataFrame({"y": np.asarray(y_true, float), "p": np.asarray(p_pred, float)})
-    df = df.with_columns((pl.col("p").clip(0.0, 0.9999) * n_bins).floor().cast(pl.Int64).alias("bin"))
-    return (
-        df.group_by("bin")
-        .agg(pl.col("p").mean().alias("mean_pred"), pl.col("y").mean().alias("mean_actual"), pl.len().alias("n"))
-        .sort("bin")
-        .with_columns(((pl.col("bin") + 0.5) / n_bins).alias("bin_mid"))
-        .select("bin_mid", "mean_pred", "mean_actual", "n")
-    )
 
 
 def weighted_ridge(X: Any, y: np.ndarray, w: np.ndarray, lam: float) -> np.ndarray:

--- a/sportsdataverse/nhl/nhl_prediction_constants.py
+++ b/sportsdataverse/nhl/nhl_prediction_constants.py
@@ -45,134 +45,14 @@ from __future__ import annotations
 import datetime as _dt
 from dataclasses import dataclass
 
-import numpy as np
 import polars as pl
-from scipy.stats import rankdata
-
-
-def brier_score(y_true: np.ndarray, p_pred: np.ndarray) -> float:
-    """Mean squared error between predicted probability and binary outcome.
-
-    Args:
-        y_true: binary outcomes (0/1).
-        p_pred: predicted probabilities in [0, 1].
-
-    Returns:
-        The Brier score (lower is better; 0.0 is a perfect forecast).
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.nhl.nhl_prediction_constants import brier_score
-            brier_score(np.array([1, 0]), np.array([0.8, 0.2]))
-    """
-    return float(np.mean((np.asarray(p_pred, dtype=float) - np.asarray(y_true, dtype=float)) ** 2))
-
-
-def log_loss_score(y_true: np.ndarray, p_pred: np.ndarray, eps: float = 1e-15) -> float:
-    """Binary log-loss (cross-entropy) between predicted probability and outcome.
-
-    Args:
-        y_true: binary outcomes (0/1).
-        p_pred: predicted probabilities in [0, 1].
-        eps: clipping floor/ceiling to avoid ``log(0)``.
-
-    Returns:
-        The mean log-loss (lower is better).
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.nhl.nhl_prediction_constants import log_loss_score
-            log_loss_score(np.array([1, 0]), np.array([0.8, 0.2]))
-    """
-    p = np.clip(np.asarray(p_pred, dtype=float), eps, 1 - eps)
-    y = np.asarray(y_true, dtype=float)
-    return float(-np.mean(y * np.log(p) + (1 - y) * np.log(1 - p)))
-
-
-def spearman_corr(a: np.ndarray, b: np.ndarray) -> float:
-    """Spearman rank correlation between two arrays.
-
-    Args:
-        a: first array.
-        b: second array (same length as ``a``).
-
-    Returns:
-        The Spearman rank correlation coefficient in [-1, 1].
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.nhl.nhl_prediction_constants import spearman_corr
-            spearman_corr(np.array([1.0, 2.0, 3.0]), np.array([3.0, 1.0, 2.0]))
-    """
-    ra, rb = rankdata(a), rankdata(b)
-    return float(np.corrcoef(ra, rb)[0, 1])
-
-
-def mae(a: np.ndarray, b: np.ndarray) -> float:
-    """Mean absolute error between two arrays.
-
-    Args:
-        a: first array (e.g. predicted values).
-        b: second array (e.g. observed values).
-
-    Returns:
-        The mean absolute difference ``mean(|a - b|)``.
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.nhl.nhl_prediction_constants import mae
-            mae(np.array([1.0, 2.0]), np.array([1.5, 2.5]))
-    """
-    return float(np.mean(np.abs(np.asarray(a, dtype=float) - np.asarray(b, dtype=float))))
-
-
-def calibration_table(y_true: np.ndarray, p_pred: np.ndarray, n_bins: int = 10) -> pl.DataFrame:
-    """Bucket predicted probabilities into ``n_bins`` and compare to realized rate.
-
-    Args:
-        y_true: binary outcomes (0/1).
-        p_pred: predicted probabilities in [0, 1].
-        n_bins: number of equal-width probability bins.
-
-    Returns:
-        A polars DataFrame with one row per non-empty bin.
-
-        |col_name    |type   |
-        |:-----------|:------|
-        |bin_mid     |Float64|
-        |mean_pred   |Float64|
-        |mean_actual |Float64|
-        |n           |Int64  |
-
-    Example:
-        Quick start::
-
-            import numpy as np
-            from sportsdataverse.nhl.nhl_prediction_constants import calibration_table
-            rng = np.random.default_rng(0)
-            calibration_table(rng.integers(0, 2, 200), rng.random(200))
-    """
-    df = pl.DataFrame({"y": np.asarray(y_true, dtype=float), "p": np.asarray(p_pred, dtype=float)})
-    df = df.with_columns((pl.col("p").clip(0.0, 0.9999) * n_bins).floor().cast(pl.Int64).alias("bin"))
-    return (
-        df.group_by("bin")
-        .agg(
-            pl.col("p").mean().alias("mean_pred"),
-            pl.col("y").mean().alias("mean_actual"),
-            pl.len().alias("n"),
-        )
-        .sort("bin")
-        .with_columns(((pl.col("bin") + 0.5) / n_bins).alias("bin_mid"))
-        .select("bin_mid", "mean_pred", "mean_actual", "n")
-    )
+from sportsdataverse._common.metrics import (
+    brier_score as brier_score,
+    calibration_table as calibration_table,
+    log_loss_score as log_loss_score,
+    mae as mae,
+    spearman_corr as spearman_corr,
+)
 
 
 def as_of_ratings_split(df: pl.DataFrame, cutoff_date: _dt.date, *, date_col: str = "date") -> pl.DataFrame:

--- a/tests/common/test_metrics.py
+++ b/tests/common/test_metrics.py
@@ -1,0 +1,87 @@
+"""Behavioral pins for the shared validation metrics (T7.2 `_common.metrics`)."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import numpy as np
+import polars as pl
+
+from sportsdataverse._common.metrics import (
+    as_of_ratings_split,
+    brier_score,
+    calibration_table,
+    log_loss_score,
+    mae,
+    spearman_corr,
+)
+
+
+def test_brier_perfect_is_zero():
+    assert brier_score(np.array([1, 0, 1, 0]), np.array([1.0, 0.0, 1.0, 0.0])) == 0.0
+
+
+def test_brier_matches_manual():
+    # (0.75-1)^2 + (0.25-0)^2 = 0.0625 + 0.0625 -> mean 0.0625
+    assert abs(brier_score(np.array([1, 0]), np.array([0.75, 0.25])) - 0.0625) < 1e-12
+
+
+def test_brier_accepts_python_lists():
+    assert abs(brier_score([1, 0], [0.9, 0.1]) - 0.01) < 1e-12
+
+
+def test_log_loss_matches_manual():
+    # -mean( ln(0.9) , ln(0.9) ) = -ln(0.9)
+    got = log_loss_score(np.array([1, 0]), np.array([0.9, 0.1]))
+    assert abs(got - (-np.log(0.9))) < 1e-9
+
+
+def test_log_loss_clips_extremes():
+    # p=1.0 for y=0 would be inf without eps clipping; assert finite + large
+    got = log_loss_score(np.array([0, 1]), np.array([1.0, 0.0]))
+    assert np.isfinite(got) and got > 30.0
+
+
+def test_spearman_monotonic_is_one():
+    assert abs(spearman_corr(np.array([1.0, 2.0, 3.0, 4.0]), np.array([10.0, 20.0, 30.0, 40.0])) - 1.0) < 1e-12
+
+
+def test_spearman_reversed_is_minus_one():
+    assert abs(spearman_corr(np.array([1, 2, 3, 4]), np.array([4, 3, 2, 1])) + 1.0) < 1e-12
+
+
+def test_spearman_uses_ranks_not_values():
+    # rank correlation is invariant to monotone transform of one variable
+    a = np.array([1.0, 2.0, 3.0, 4.0])
+    assert abs(spearman_corr(a, a**3) - 1.0) < 1e-12
+
+
+def test_mae_manual():
+    assert abs(mae(np.array([1.0, 2.0]), np.array([1.5, 2.5])) - 0.5) < 1e-12
+
+
+def test_calibration_table_schema_and_dtypes():
+    y = np.array([1, 0, 1, 0, 1, 0])
+    p = np.array([0.95, 0.05, 0.85, 0.15, 0.55, 0.45])
+    tbl = calibration_table(y, p, n_bins=10)
+    assert tbl.columns == ["bin_mid", "mean_pred", "mean_actual", "n"]
+    # `n` is pl.len() -> UInt32 (schema is load-bearing for byte-for-byte migration)
+    assert tbl.schema["n"] == pl.UInt32
+    assert tbl.height <= 10
+
+
+def test_calibration_table_bins_and_actuals():
+    # two perfectly-separated buckets
+    y = np.array([0, 0, 1, 1])
+    p = np.array([0.05, 0.05, 0.95, 0.95])
+    tbl = calibration_table(y, p, n_bins=10).sort("bin_mid")
+    assert tbl["mean_actual"].to_list() == [0.0, 1.0]
+    assert tbl["n"].to_list() == [2, 2]
+
+
+def test_as_of_split_strict_less_than():
+    df = pl.DataFrame(
+        {"game_id": ["a", "b", "c"], "date": [dt.date(2024, 1, 1), dt.date(2024, 1, 5), dt.date(2024, 1, 9)]}
+    )
+    out = as_of_ratings_split(df, dt.date(2024, 1, 5))
+    assert out["game_id"].to_list() == ["a"]  # same-day and later excluded

--- a/tests/common/test_migration_regression.py
+++ b/tests/common/test_migration_regression.py
@@ -1,0 +1,85 @@
+"""Byte-for-byte migration gate (T7.2): every per-sport metric symbol that was
+routed through ``_common.metrics`` must BE the shared object (redundant-alias
+re-export), guaranteeing identical behavior to the pre-refactor inline copy.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+import sportsdataverse._common.metrics as core
+
+# module -> metric names re-exported from _common.metrics (mirrors the migration)
+MIGRATED = {
+    "sportsdataverse.cfb.cfb_prediction_constants": [
+        "brier_score",
+        "log_loss_score",
+        "spearman_corr",
+        "mae",
+        "calibration_table",
+        "as_of_ratings_split",
+    ],
+    "sportsdataverse.cfb.cfb_projection_constants": ["brier_score", "spearman_corr", "mae"],
+    "sportsdataverse.mbb.mbb_prediction_constants": [
+        "brier_score",
+        "log_loss_score",
+        "spearman_corr",
+        "mae",
+        "calibration_table",
+        "as_of_ratings_split",
+    ],
+    "sportsdataverse.nba.nba_prediction_constants": [
+        "brier_score",
+        "log_loss_score",
+        "spearman_corr",
+        "mae",
+        "calibration_table",
+        "as_of_ratings_split",
+    ],
+    "sportsdataverse.nba.nba_draft_constants": ["spearman_corr", "mae", "calibration_table"],
+    "sportsdataverse.nba.nba_playtype_constants": ["spearman_corr", "mae"],
+    "sportsdataverse.nba.nba_shot_value_constants": ["mae"],
+    "sportsdataverse.nfl.nfl_prediction_constants": [
+        "brier_score",
+        "log_loss_score",
+        "spearman_corr",
+        "mae",
+        "calibration_table",
+    ],
+    "sportsdataverse.nfl.nfl_projection_constants": ["brier_score", "log_loss_score", "spearman_corr", "mae"],
+    "sportsdataverse.nfl.nfl_scheme_constants": ["brier_score", "log_loss_score", "spearman_corr", "mae"],
+    "sportsdataverse.nfl.nfl_ngs_constants": ["spearman_corr", "mae"],
+    "sportsdataverse.nhl.nhl_prediction_constants": [
+        "brier_score",
+        "log_loss_score",
+        "spearman_corr",
+        "mae",
+        "calibration_table",
+    ],
+    "sportsdataverse.nhl.nhl_player_impact_constants": ["spearman_corr", "calibration_table"],
+    "sportsdataverse.mlb.mlb_game_state_constants": ["brier_score", "spearman_corr", "mae", "calibration_table"],
+    "sportsdataverse.mlb.mlb_hitting_constants": ["brier_score", "spearman_corr", "mae", "calibration_table"],
+    "sportsdataverse.mlb.mlb_pitching_constants": ["spearman_corr", "mae", "calibration_table"],
+    "sportsdataverse.mlb.mlb_run_values": ["spearman_corr", "mae"],
+}
+
+
+@pytest.mark.parametrize("modname,names", list(MIGRATED.items()), ids=list(MIGRATED))
+def test_reexport_is_shared_object(modname, names):
+    mod = importlib.import_module(modname)
+    for nm in names:
+        assert getattr(mod, nm) is getattr(core, nm), f"{modname}.{nm} is not the shared _common.metrics object"
+
+
+def test_distinct_impls_were_left_alone():
+    # nhl_microstat spearman has an n<2 guard; nfl_projection/nfl_scheme calibration_table
+    # casts n->Int64 -- these are mathematically/schema distinct and must NOT be re-exports.
+    from sportsdataverse.nhl import nhl_microstat_constants as micro
+    from sportsdataverse.nfl import nfl_projection_constants as proj
+    from sportsdataverse.nfl import nfl_scheme_constants as scheme
+
+    assert micro.spearman_corr is not core.spearman_corr
+    assert proj.calibration_table is not core.calibration_table
+    assert scheme.calibration_table is not core.calibration_table


### PR DESCRIPTION
## T7.2 (remaining) — shared validation metrics

Continues the cross-league infra consolidation (#211 did the rating cores). The validation metrics — Brier, log-loss, Spearman, MAE, calibration-table — were **duplicated in all 7 leagues' constants modules**. This extracts the identical core into `sportsdataverse/_common/metrics.py` and retargets every league to it.

### What moved
- New `sportsdataverse/_common/metrics.py` (+ unit test `tests/common/test_metrics.py` pinning behavior) — the ≥2-caller shared metrics.
- **17 modules across cfb / mbb / nba / wnba / nfl / nhl / mlb** retargeted to import from `_common`; ~1,400 lines of duplication deleted (+182 / −1399 net in the retarget commit).
- `tests/common/test_migration_regression.py` — asserts each league's metrics match post-migration.

### Behavior preservation (the gate)
Full 7-league suite `tests/mbb tests/wbb tests/cfb tests/nba tests/wnba tests/nfl tests/nhl tests/mlb` → **2903 passed / 179 skipped / 10 xfailed — identical to baseline.** No existing test changed; only the extracted core was unified (metrics that differed across leagues in edge-case handling were NOT force-unified). `_common/metrics.py` added to the mypy ratchet.

Scope note: single-caller helpers were deliberately left in place (no speculative extraction, per the roadmap's ≥2-caller rule).

## Summary by Sourcery

Extract shared validation metric helpers into a league-agnostic _common module and update all affected sport-specific constants modules to re-export them, reducing duplication while preserving behavior.

Enhancements:
- Introduce sportsdataverse._common.metrics with shared implementations of Brier score, log-loss, Spearman correlation, MAE, calibration table, and as-of ratings split.
- Refactor prediction/projection and other constants modules across cfb, mbb, nba, wnba, nfl, nhl, and mlb to import and re-export metrics from the new common module instead of maintaining local copies.
- Add regression and behavior-pin tests ensuring that all migrated league-specific metric symbols reference the shared implementations and remain byte-for-byte compatible.

Build:
- Include the new _common/metrics module in the mypy configuration file list for type-checking.

Tests:
- Add unit tests for the shared metrics module to pin numerical behavior and calibration table schema.
- Add a migration regression test that verifies each league’s re-exported metrics are the same shared objects and that intentionally distinct implementations remain separate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared validation metrics for classification, ranking, regression, calibration, and date-based data splitting.
  * Improved invalid league selection errors by listing valid options.

* **Refactor**
  * Standardized metric behavior across sports while preserving existing public access points.

* **Tests**
  * Added coverage for metric calculations, calibration output, date boundaries, and cross-sport consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->