### PR TITLE
fix(codegen): write LF explicitly in all codegen/capture writers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,11 @@
 
 ### Fixes
 
+- fix(codegen): all codegen/capture writers now emit LF explicitly
+  (`newline="\n"`), matching `generate.py`'s convention. On Windows the
+  text-mode default translated `\n` to CRLF, so every codegen-test run (which
+  re-runs the pff / 247 site-pages generators) left ~65 endpoint + schema
+  YAMLs dirty with line-ending-only churn against the LF-normalized index.
 - feat(nfl): PFF Premium auth can now **auto-refresh from a saved Playwright
   `storage_state`**. Point `SDV_PY_PFF_STORAGE_STATE` at a `storage_state` JSON
   captured once from a headed login and `pff_runtime` replays it headlessly so

--- a/docs/src/pages/CHANGELOG.md
+++ b/docs/src/pages/CHANGELOG.md
@@ -174,6 +174,11 @@
 
 ### Fixes
 
+- fix(codegen): all codegen/capture writers now emit LF explicitly
+  (`newline="\n"`), matching `generate.py`'s convention. On Windows the
+  text-mode default translated `\n` to CRLF, so every codegen-test run (which
+  re-runs the pff / 247 site-pages generators) left ~65 endpoint + schema
+  YAMLs dirty with line-ending-only churn against the LF-normalized index.
 - feat(nfl): PFF Premium auth can now **auto-refresh from a saved Playwright
   `storage_state`**. Point `SDV_PY_PFF_STORAGE_STATE` at a `storage_state` JSON
   captured once from a headed login and `pff_runtime` replays it headlessly so

--- a/tools/codegen/build_espn_rename_map.py
+++ b/tools/codegen/build_espn_rename_map.py
@@ -174,9 +174,13 @@ def main() -> int:
         md.insert(3, f"| {prefix} | {g} | {e} | {rn} | {rv} | {k} |")
 
     out = ROOT / "docs" / "superpowers" / "specs" / "espn-r-naming-worksheet.md"
-    out.write_text("\n".join(md) + "\n", encoding="utf-8")
+    out.write_text("\n".join(md) + "\n", encoding="utf-8", newline="\n")
     ymap = ROOT / "tools" / "codegen" / "espn_rename_map.suggested.yaml"
-    ymap.write_text(yaml.safe_dump({"rename": dict(sorted(suggested.items()))}, sort_keys=False, width=100), "utf-8")
+    ymap.write_text(
+        yaml.safe_dump({"rename": dict(sorted(suggested.items()))}, sort_keys=False, width=100),
+        "utf-8",
+        newline="\n",
+    )
     print("totals (league: gen/exact/rename/review/keep):")
     for prefix, t in totals.items():
         print(f"  {prefix}: {t}")

--- a/tools/codegen/build_r_col_descriptions.py
+++ b/tools/codegen/build_r_col_descriptions.py
@@ -441,7 +441,7 @@ def main() -> None:
     )
 
     OUTPUT.parent.mkdir(parents=True, exist_ok=True)
-    OUTPUT.write_text(header + yaml_str, encoding="utf-8")
+    OUTPUT.write_text(header + yaml_str, encoding="utf-8", newline="\n")
     print(f"\nWrote {OUTPUT}")
 
 

--- a/tools/codegen/build_r_exports.py
+++ b/tools/codegen/build_r_exports.py
@@ -84,7 +84,7 @@ def main() -> None:
         "#   python tools/codegen/build_r_exports.py\n"
     )
     yaml_str = yaml.dump(out, allow_unicode=True, default_flow_style=False, sort_keys=True, width=120)
-    OUTPUT.write_text(header + yaml_str, encoding="utf-8")
+    OUTPUT.write_text(header + yaml_str, encoding="utf-8", newline="\n")
     print(f"\nWrote {OUTPUT}")
 
 

--- a/tools/codegen/extract.py
+++ b/tools/codegen/extract.py
@@ -412,7 +412,9 @@ def schema_from_parser(parser_name: str, payload: dict, description: str = "") -
 
 
 def write_yaml(obj, path: Path) -> None:
-    Path(path).write_text(yaml.safe_dump(obj, sort_keys=False, width=120, allow_unicode=True), encoding="utf-8")
+    Path(path).write_text(
+        yaml.safe_dump(obj, sort_keys=False, width=120, allow_unicode=True), encoding="utf-8", newline="\n"
+    )
 
 
 def main() -> int:

--- a/tools/codegen/extract_releases.py
+++ b/tools/codegen/extract_releases.py
@@ -84,7 +84,7 @@ def build_manifest() -> dict:
 
 def write_manifest(path: Path) -> dict:
     doc = build_manifest()
-    path.write_text(yaml.safe_dump(doc, sort_keys=False, width=100, allow_unicode=True), encoding="utf-8")
+    path.write_text(yaml.safe_dump(doc, sort_keys=False, width=100, allow_unicode=True), encoding="utf-8", newline="\n")
     return doc
 
 

--- a/tools/codegen/fetch_packages.py
+++ b/tools/codegen/fetch_packages.py
@@ -29,7 +29,7 @@ def fetch() -> list[dict]:
         }
         for p in items
     ]
-    DEST.write_text(json.dumps(pkgs, indent=2) + "\n", encoding="utf-8")
+    DEST.write_text(json.dumps(pkgs, indent=2) + "\n", encoding="utf-8", newline="\n")
     print(f"wrote {len(pkgs)} packages -> {DEST}")
     return pkgs
 

--- a/tools/codegen/gen_nba_stats.py
+++ b/tools/codegen/gen_nba_stats.py
@@ -113,7 +113,7 @@ def _endpoint_entry(ep: dict, stem: str, default_league: str, parser_name: str) 
 
 def _write_yaml(path: Path, obj: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as fh:
+    with path.open("w", encoding="utf-8", newline="\n") as fh:
         yaml.safe_dump(obj, fh, sort_keys=True, default_flow_style=False, allow_unicode=True)
 
 

--- a/tools/codegen/gen_on3.py
+++ b/tools/codegen/gen_on3.py
@@ -231,7 +231,7 @@ def _usable_ops(spec: dict) -> List[Tuple[str, dict]]:
 
 def _write_yaml(path: Path, obj: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as fh:
+    with path.open("w", encoding="utf-8", newline="\n") as fh:
         yaml.safe_dump(obj, fh, sort_keys=True, default_flow_style=False, allow_unicode=True)
 
 

--- a/tools/codegen/gen_pff.py
+++ b/tools/codegen/gen_pff.py
@@ -195,7 +195,7 @@ def build() -> tuple[dict, Dict[str, dict]]:
 
 def _write_yaml(path: Path, obj: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as fh:
+    with path.open("w", encoding="utf-8", newline="\n") as fh:
         yaml.safe_dump(obj, fh, sort_keys=True, default_flow_style=False, allow_unicode=True)
 
 

--- a/tools/codegen/gen_sports247_site_pages.py
+++ b/tools/codegen/gen_sports247_site_pages.py
@@ -91,7 +91,7 @@ def _schema_name(ref: str | None, short: str) -> str:
 
 def _write_yaml(path: Path, obj: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as fh:
+    with path.open("w", encoding="utf-8", newline="\n") as fh:
         yaml.safe_dump(obj, fh, sort_keys=True, default_flow_style=False, allow_unicode=True)
 
 


### PR DESCRIPTION
## Kills the ~65-file line-ending churn

On Windows, text-mode file writes translate `\n` → CRLF. `generate.py`'s writers already pass `newline="\n"`, but the `gen_*` generator scripts (pff, 247 site-pages, on3, nba_stats) and the capture/build tools (`extract`, `extract_releases`, `build_espn_rename_map`, `build_r_exports`, `build_r_col_descriptions`, `fetch_packages`) did not.

**Effect:** every codegen-test run (`tests/codegen/test_gen_pff.py` / `test_gen_sports247_site_pages.py` re-run the generators) rewrote ~65 endpoint + returns-schema YAMLs with CRLF, leaving permanent line-ending-only churn against the LF-normalized index (`.gitattributes` pins `* text=auto eol=lf`). This has polluted `git status` in essentially every dev session on Windows.

### Change
`newline="\n"` added to all 11 write sites across 10 `tools/codegen/*.py` scripts — dev-side tooling only; no package code, no generated-output content changes.

### Verified
- All 10 files parse + ruff clean.
- **Empirical churn proof:** from a clean tree, running the four generator test files (11 tests, all pass) now leaves the tree clean — previously this dirtied ~65 YAMLs.
- Codegen `--check` runs in the pre-push hook + CI as usual.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized generated YAML, JSON, and markdown files to use LF line endings across platforms.
  * Prevented Windows-specific line-ending changes from creating unnecessary differences in regenerated files.
  * Improved consistency and byte-identical output for code generation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->