### PR TITLE
ci(validation): ingest validation-cron runs into the platform run tracker

### DIFF
--- a/.github/workflows/validation-cron.yml
+++ b/.github/workflows/validation-cron.yml
@@ -373,6 +373,7 @@ jobs:
                     tags: ["validation-cron"]
                   }') || { echo "::warning::${ds} — could not build ingest payload"; continue; }
             code=$(curl -sS -o resp_ingest.txt -w '%{http_code}' -X POST "$url" \
+              --connect-timeout 10 --max-time 30 \
               -H "Authorization: Bearer ${PLATFORM_INGEST_TOKEN}" \
               -H "Content-Type: application/json" \
               --data "$payload" || echo 000)

--- a/.github/workflows/validation-cron.yml
+++ b/.github/workflows/validation-cron.yml
@@ -312,6 +312,78 @@ jobs:
             }
 
       # -----------------------------------------------------------------------
+      # Ingest one platform run per validated dataset (exemplar CI run-ingest;
+      # payload contract: sdv-web frontend/SETUP-platform.md). Each of the six
+      # harness checks maps to one gate: observed = ERROR-finding count for
+      # that check, threshold 0, comparison lte. Skips a dataset whose release
+      # download was unavailable (an empty findings file would read as a
+      # perfect run), skips entirely when the org secret is absent (forks),
+      # and never fails the cron on ingest errors.
+      # -----------------------------------------------------------------------
+      - name: Ingest runs to platform
+        if: always()
+        env:
+          PLATFORM_INGEST_TOKEN: ${{ secrets.PLATFORM_INGEST_TOKEN }}
+          CFB_AVAILABLE: ${{ steps.dl_cfb.outputs.available }}
+          NFL_AVAILABLE: ${{ steps.dl_nfl.outputs.available }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GIT_REPO: ${{ github.repository }}
+          GIT_BRANCH: ${{ github.ref_name }}
+          GIT_SHA: ${{ github.sha }}
+        run: |
+          if [ -z "${PLATFORM_INGEST_TOKEN}" ]; then
+            echo "::notice::PLATFORM_INGEST_TOKEN not set — skipping platform run ingest"
+            exit 0
+          fi
+          url="${SDV_PLATFORM_URL:-https://www.sportsdataverse.org}/api/platform/runs"
+          today=$(date -u +%F)
+          for spec in "cfb_model_pbp cfb ${CFB_AVAILABLE}" "nfl_model_pbp nfl ${NFL_AVAILABLE}"; do
+            set -- $spec
+            ds="$1"; sport="$2"; available="${3:-false}"
+            if [ "$available" != "true" ]; then
+              echo "::notice::${ds} — dataset skipped this run; not ingesting"
+              continue
+            fi
+            payload=$(jq -n \
+              --arg model_id "$ds" --arg sport "$sport" \
+              --arg run_name "validation-cron ${today}" \
+              --arg run_url "${RUN_URL}" \
+              --arg repo "${GIT_REPO}" --arg branch "${GIT_BRANCH}" --arg sha "${GIT_SHA}" \
+              --slurpfile findings "findings_${ds}.json" '
+                ($findings[0] // []) as $f
+                | ([$f[] | select(.severity == "error")] | length) as $err
+                | (["schema_contract", "extraction", "numeric_parity", "sweep",
+                    "boundary_leakage", "constant_column"] + [$f[].check] | unique) as $checks
+                | {
+                    model_id: $model_id,
+                    sport: $sport,
+                    run_name: $run_name,
+                    status: (if $err > 0 then "failed" else "completed" end),
+                    metrics: {
+                      findings_total: ($f | length),
+                      findings_error: $err,
+                      findings_warn: ([$f[] | select(.severity == "warn")] | length)
+                    },
+                    gates: [ $checks[] as $c
+                      | ([$f[] | select(.check == $c and .severity == "error")] | length) as $n
+                      | { name: $c, threshold: 0, observed: $n,
+                          comparison: "lte", passed: ($n == 0) } ],
+                    artifacts: [ { name: "GitHub Actions run", url: $run_url } ],
+                    git: { repo: $repo, branch: $branch, sha: $sha },
+                    tags: ["validation-cron"]
+                  }') || { echo "::warning::${ds} — could not build ingest payload"; continue; }
+            code=$(curl -sS -o resp_ingest.txt -w '%{http_code}' -X POST "$url" \
+              -H "Authorization: Bearer ${PLATFORM_INGEST_TOKEN}" \
+              -H "Content-Type: application/json" \
+              --data "$payload" || echo 000)
+            if [ "$code" -ge 200 ] && [ "$code" -lt 300 ]; then
+              echo "::notice::${ds} — platform run ingested (HTTP ${code})"
+            else
+              echo "::warning::${ds} — platform run ingest failed (HTTP ${code}): $(head -c 300 resp_ingest.txt 2>/dev/null)"
+            fi
+          done
+
+      # -----------------------------------------------------------------------
       # Upload findings JSON for inspection (always — even on skip)
       # -----------------------------------------------------------------------
       - name: Upload findings artifacts


### PR DESCRIPTION
## Summary

Adds the exemplar CI run-ingest to `validation-cron.yml`: after the findings
aggregation, one platform run per validated dataset is POSTed to
`https://www.sportsdataverse.org/api/platform/runs` with the org-wide
`PLATFORM_INGEST_TOKEN` Actions secret, so weekly dataset-health runs land in
the members-only Models/Eval tracker (payload contract:
sdv-web `frontend/SETUP-platform.md`).

Mapping (per dataset — `cfb_model_pbp`, `nfl_model_pbp`):

- **gates[]** — one gate per harness check (`schema_contract`, `extraction`,
  `numeric_parity`, `sweep`, `boundary_leakage`, `constant_column`, plus any
  dynamic check present in findings, e.g. the `run_error` crash sentinel):
  `observed` = ERROR-finding count for that check, `threshold` 0,
  `comparison: lte` — so a check passes iff it produced zero ERROR findings.
  WARN-only findings do not fail a gate (they surface in `metrics`).
- **status** — `failed` iff any ERROR finding (same definition the drift-issue
  step uses), else `completed`.
- **metrics** — `findings_total` / `findings_error` / `findings_warn`.
- **artifacts** — link back to the Actions run; **git** — repo/branch/sha.

Safety rails:

- A dataset whose release download was unavailable is **not** ingested — an
  empty findings file would masquerade as a perfect run.
- Skips silently when `PLATFORM_INGEST_TOKEN` is absent (forks).
- Ingest failures log a `::warning::` and never fail the cron.

## Verification

- Workflow YAML parses; step ordering preserved (aggregation → ingest → artifact upload).
- jq payload builder exercised locally for both the drift case (status
  `failed`, `run_error` + `schema_contract` gates failing, warn-only checks
  passing) and the clean case (`completed`, 6/6 gates pass).
- Both payloads validated against the **real** `modelRunSchema` zod schema in
  sdv-web (`lib/platform/schemas.ts`) — parse OK.
- Prod route probed: `POST /api/platform/runs` with an invalid bearer → 401
  (route live, auth enforced, no redirect loss on `www`).

Post-merge: dispatch `validation-cron` once via `workflow_dispatch` and
confirm the `::notice::… platform run ingested (HTTP 2xx)` log lines + the two
runs appearing on `/platform/models`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated ingestion of dataset validation results into the platform.
  * Reports finding totals, errors, warnings, gate statuses, and overall run status.
  * Skips unavailable datasets and safely bypasses ingestion when credentials are not configured.
  * Provides notices for successful submissions and warnings when ingestion fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->