### PR TITLE
fix(validation): build run_error sentinel with jq so it is valid JSON

### DIFF
--- a/.github/workflows/validation-cron.yml
+++ b/.github/workflows/validation-cron.yml
@@ -116,10 +116,16 @@ jobs:
           # If the CLI crashed (non-zero exit), inject a run_error sentinel so
           # the aggregation step surfaces this as an ERROR finding rather than
           # treating a missing/truncated findings file as a clean zero-finding run.
+          # Build with jq so the log tail (a Python traceback with embedded
+          # quotes/newlines) is escaped into valid JSON — a printf-interpolated
+          # sentinel is malformed and gets silently swallowed by the aggregation
+          # step's JSON.parse AND the platform-ingest jq.
           if [ "${exit_code}" -ne 0 ]; then
             log_tail=$(tail -c 500 validate_cfb.log 2>/dev/null || true)
-            printf '[{"check":"run_error","severity":"error","message":"cfb_model_pbp validation CLI exited %s: %s"}]\n' \
-              "${exit_code}" "${log_tail}" > findings_cfb_model_pbp.json
+            jq -n --arg code "${exit_code}" --arg log "${log_tail}" \
+              '[{check: "run_error", severity: "error", dataset: "cfb_model_pbp",
+                 message: ("cfb_model_pbp validation CLI exited " + $code + ": " + $log)}]' \
+              > findings_cfb_model_pbp.json
           fi
 
       - name: Skip cfb_model_pbp (no data)
@@ -172,10 +178,16 @@ jobs:
           # If the CLI crashed (non-zero exit), inject a run_error sentinel so
           # the aggregation step surfaces this as an ERROR finding rather than
           # treating a missing/truncated findings file as a clean zero-finding run.
+          # Build with jq so the log tail (a Python traceback with embedded
+          # quotes/newlines) is escaped into valid JSON — a printf-interpolated
+          # sentinel is malformed and gets silently swallowed by the aggregation
+          # step's JSON.parse AND the platform-ingest jq.
           if [ "${exit_code}" -ne 0 ]; then
             log_tail=$(tail -c 500 validate_nfl.log 2>/dev/null || true)
-            printf '[{"check":"run_error","severity":"error","message":"nfl_model_pbp validation CLI exited %s: %s"}]\n' \
-              "${exit_code}" "${log_tail}" > findings_nfl_model_pbp.json
+            jq -n --arg code "${exit_code}" --arg log "${log_tail}" \
+              '[{check: "run_error", severity: "error", dataset: "nfl_model_pbp",
+                 message: ("nfl_model_pbp validation CLI exited " + $code + ": " + $log)}]' \
+              > findings_nfl_model_pbp.json
           fi
 
       - name: Skip nfl_model_pbp (no data)

--- a/.github/workflows/validation-cron.yml
+++ b/.github/workflows/validation-cron.yml
@@ -123,7 +123,8 @@ jobs:
           if [ "${exit_code}" -ne 0 ]; then
             log_tail=$(tail -c 500 validate_cfb.log 2>/dev/null || true)
             jq -n --arg code "${exit_code}" --arg log "${log_tail}" \
-              '[{check: "run_error", severity: "error", dataset: "cfb_model_pbp",
+              '[{check: "run_error", severity: "error", domain: "cfb",
+                 dataset: "cfb_model_pbp", needs_judgment: false,
                  message: ("cfb_model_pbp validation CLI exited " + $code + ": " + $log)}]' \
               > findings_cfb_model_pbp.json
           fi
@@ -185,7 +186,8 @@ jobs:
           if [ "${exit_code}" -ne 0 ]; then
             log_tail=$(tail -c 500 validate_nfl.log 2>/dev/null || true)
             jq -n --arg code "${exit_code}" --arg log "${log_tail}" \
-              '[{check: "run_error", severity: "error", dataset: "nfl_model_pbp",
+              '[{check: "run_error", severity: "error", domain: "nfl",
+                 dataset: "nfl_model_pbp", needs_judgment: false,
                  message: ("nfl_model_pbp validation CLI exited " + $code + ": " + $log)}]' \
               > findings_nfl_model_pbp.json
           fi


### PR DESCRIPTION
## Summary

Follow-up to #227. The `Run validation` steps inject a `run_error` sentinel
finding when the validation CLI crashes, built with `printf` that interpolates
the log tail (`tail -c 500` of the CLI's stderr — a Python traceback with
embedded `"` and newlines) **directly into a JSON string literal**. The result
is **malformed JSON**, which is silently swallowed by both consumers:

- the aggregation `github-script` step's `JSON.parse` throws → caught →
  "treating as no findings" → **a validation crash never opens a drift issue**;
- the platform-ingest jq (#227) fails to slurp it → "could not build payload"
  → **the crashed run is never ingested**.

Both defeat the sentinel's entire purpose ("surface this as an ERROR finding").

Fix: build the sentinel with `jq -n --arg`, which escapes the log tail into
valid JSON. `jq` is pre-installed on GitHub-hosted runners and already used by
the ingest step in #227.

## How it surfaced

The post-merge `validation-cron` dispatch (run
[29185604732](https://github.com/sportsdataverse/sportsdataverse-py/actions/runs/29185604732)):

- `cfb_model_pbp` — **platform run ingested (HTTP 201)** ✅
- `nfl_model_pbp` — **could not build ingest payload** ⚠️ — the CLI had crashed
  (`SchemaError: assist_tackle_3_player_id: String != Null`) and its malformed
  sentinel broke the jq.

The underlying `nfl_model_pbp` `SchemaError` is a **separate pre-existing
validation-harness bug** (schema-contract check against a `Null`-typed target
column on the published parquet) — tracked separately, not fixed here.

## Verification

- Reproduced the malformed sentinel from the real crash traceback → invalid
  JSON (jq parse error at col 169).
- New jq sentinel from the same traceback → **valid JSON**.
- Ingest jq now builds a `status: failed` payload from it (findings_error 1,
  `run_error` gate `observed 1 / passed false`), and it **passes sdv-web's real
  `modelRunSchema`** zod validation.
- Workflow YAML parses; both `Run validation` steps updated identically.

## Summary by Sourcery

Ensure validation-cron workflows emit valid JSON sentinel findings when the validation CLI crashes so downstream aggregation and ingest steps correctly surface run errors.

Bug Fixes:
- Build run_error sentinel findings with jq to properly escape traceback logs into valid JSON for cfb_model_pbp runs.
- Build run_error sentinel findings with jq to properly escape traceback logs into valid JSON for nfl_model_pbp runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation error reporting when the CLI crashes, ensuring crash logs that include quotes or line breaks are captured without breaking the generated JSON.
  * Enhanced validation findings with additional context fields (e.g., domain/dataset/needs judgment) and a more reliable message that includes the exit code and escaped log tail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->