### PR TITLE
fix(validation): heal Null-vs-String dtype divergence in multi-file parquet read

### DIFF
--- a/tests/contracts/test_registry.py
+++ b/tests/contracts/test_registry.py
@@ -1,3 +1,6 @@
+import polars as pl
+import pytest
+
 from tools.validation.registry import DatasetSpec, load_thresholds
 
 
@@ -102,3 +105,24 @@ def test_expected_constant_columns_defaults_and_threads() -> None:
     )
     _frame, ctx = _resolve_spec(spec)
     assert ctx.expected_constant_columns == ("season", "division")
+
+
+def test_read_parquet_glob_heals_null_vs_string_dtype_divergence(tmp_path) -> None:
+    # A sparse column all-null in one season's file (polars -> Null dtype) but
+    # String in another. pl.read_parquet's strict multi-file concat rejects this
+    # (SchemaError: incoming String != target Null); _read_parquet_glob must heal
+    # it by supertyping to String. This is the nfl_model_pbp validation crash.
+    from tools.validation.registry import _read_parquet_glob
+
+    pl.DataFrame({"game_id": [1], "sparse": [None]}).write_parquet(tmp_path / "s2020.parquet")
+    pl.DataFrame({"game_id": [2], "sparse": ["x"]}).write_parquet(tmp_path / "s2021.parquet")
+    glob = str(tmp_path / "s*.parquet")
+
+    # Strict read raises — proves the fixture reproduces the crash the fix targets.
+    with pytest.raises(pl.exceptions.SchemaError):
+        pl.read_parquet(glob)
+
+    frame = _read_parquet_glob(glob)
+    assert frame.height == 2
+    assert frame.schema["sparse"] == pl.String
+    assert set(frame["game_id"].to_list()) == {1, 2}

--- a/tools/codegen/manual_column_descriptions.yaml
+++ b/tools/codegen/manual_column_descriptions.yaml
@@ -8361,8 +8361,8 @@ leverage_index:
   score_diff_bucket: home minus away score, clipped to [-6, 6].
   leverage_index: Mean absolute win-probability swing from this state, normalized to a 1.0 league average.
 college_baseball_state:
-  game_id: ESPN event id.
-  inning: Inning number.
+  game_id: ESPN event id for the game (join key to the schedule).
+  inning: Inning number of the plate appearance (1-based).
   half: Half-inning ("top" or "bottom").
   base_state: 3-char base occupancy code before the PA ("_" = empty, "1"/"2"/"3" = occupied), e.g. "1_3" for runners on first and third.
   outs: Outs before the PA (0-2).
@@ -8377,7 +8377,7 @@ college_baseball_re24:
   run_expectancy: Empirical mean runs scored from this state through the end of the half-inning (RE24).
   n: Number of plate appearances observed starting in this base-out state.
 college_baseball_wpa:
-  game_id: ESPN event id.
+  game_id: ESPN event id for the game (join key to the schedule).
   play_seq: Game-global sequential plate-appearance order.
   re_before: RE24 of the base-out state before the PA.
   re_after: RE24 of the base-out state after the PA.

--- a/tools/validation/registry.py
+++ b/tools/validation/registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import glob as _glob
 import json
 import os
 from dataclasses import dataclass, field
@@ -109,6 +110,36 @@ def load_schema(name: str) -> dict[str, str]:
     return json.loads(path.read_text())
 
 
+def _read_parquet_glob(glob_expanded: str) -> pl.DataFrame:
+    """Read a (possibly multi-file) parquet glob into one frame.
+
+    ``pl.read_parquet`` concatenates a multi-file glob with a *strict* vertical
+    concat that rejects per-file dtype divergence: a sparse column that is
+    all-null in one season's file (polars writes it as ``Null`` dtype) but
+    ``String`` in another raises ``SchemaError``. Fall back to a relaxed concat
+    that supertypes the diverging columns (``Null`` + ``String`` -> ``String``).
+
+    ``vertical_relaxed`` still errors if the column *sets* differ across files,
+    so the ``schema_contract`` check keeps its teeth — this only heals dtype
+    divergence, it does not paper over a genuinely missing/extra column.
+
+    Args:
+        glob_expanded: A parquet path or glob (env vars already expanded).
+
+    Returns:
+        The concatenated frame.
+
+    Raises:
+        FileNotFoundError: If the glob matches no files (propagated from the
+            strict read, before the relaxed fallback is reached).
+    """
+    try:
+        return pl.read_parquet(glob_expanded)
+    except pl.exceptions.SchemaError:
+        paths = sorted(_glob.glob(glob_expanded))
+        return pl.concat((pl.read_parquet(p) for p in paths), how="vertical_relaxed")
+
+
 def _resolve_spec(spec: DatasetSpec, release: str | None = None) -> tuple[pl.DataFrame, CheckContext]:
     """Resolve a DatasetSpec to its frame and check context.
 
@@ -126,7 +157,7 @@ def _resolve_spec(spec: DatasetSpec, release: str | None = None) -> tuple[pl.Dat
         FileNotFoundError: If the resolved parquet glob matches no files.
     """
     glob_expanded = os.path.expandvars(spec.parquet_glob)
-    frame = pl.read_parquet(glob_expanded)
+    frame = _read_parquet_glob(glob_expanded)
     ctx = CheckContext(
         domain=spec.domain,
         dataset=spec.name,


### PR DESCRIPTION
Fixes the `nfl_model_pbp` validation-cron crash (`polars SchemaError: assist_tackle_3_player_id incoming String != target Null`) surfaced by the run-ingest rollout.

## Root cause
`_resolve_spec` reads the dataset's multi-season glob via `pl.read_parquet(glob)`, which does a **strict** vertical concat. A sparse column that is all-null in one season's file (polars writes it as `Null` dtype) but `String` in another fails the concat.

## Fix
New `_read_parquet_glob`: try the fast native read; on `SchemaError`, fall back to `pl.concat(..., how="vertical_relaxed")` which supertypes the diverging columns (`Null`+`String`→`String`). `vertical_relaxed` still errors on differing column **sets**, so the `schema_contract` check keeps catching genuinely missing/extra columns — this only heals dtype divergence.

## Test
`test_read_parquet_glob_heals_null_vs_string_dtype_divergence` writes two parquets with a `Null`-vs-`String` sparse column, asserts strict `pl.read_parquet` raises (reproducing the crash), and that `_read_parquet_glob` heals it to `String`. Full `tests/contracts/test_registry.py` green (10/10), ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parquet dataset loading when files contain compatible differences between null and string column types.
  * Dataset validation now continues successfully in these cases while still detecting missing or unexpected columns.
  * Added regression coverage to verify reliable multi-file parquet reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->