### PR TITLE
fix(baseball): replace filler column descriptions with real detail

### DIFF
--- a/tools/codegen/manual_column_descriptions.yaml
+++ b/tools/codegen/manual_column_descriptions.yaml
@@ -8361,8 +8361,8 @@ leverage_index:
   score_diff_bucket: home minus away score, clipped to [-6, 6].
   leverage_index: Mean absolute win-probability swing from this state, normalized to a 1.0 league average.
 college_baseball_state:
-  game_id: ESPN event id.
-  inning: Inning number.
+  game_id: ESPN event id of the game the play belongs to (Utf8; joins to the summary/schedule frames).
+  inning: Inning number the plate appearance occurs in (1-9 regulation baseball, 1-7 softball; extras continue the count).
   half: Half-inning ("top" or "bottom").
   base_state: 3-char base occupancy code before the PA ("_" = empty, "1"/"2"/"3" = occupied), e.g. "1_3" for runners on first and third.
   outs: Outs before the PA (0-2).
@@ -8377,7 +8377,7 @@ college_baseball_re24:
   run_expectancy: Empirical mean runs scored from this state through the end of the half-inning (RE24).
   n: Number of plate appearances observed starting in this base-out state.
 college_baseball_wpa:
-  game_id: ESPN event id.
+  game_id: ESPN event id of the game the play belongs to (Utf8; joins to the summary/schedule frames).
   play_seq: Game-global sequential plate-appearance order.
   re_before: RE24 of the base-out state before the PA.
   re_after: RE24 of the base-out state after the PA.


### PR DESCRIPTION
## Summary

`college_baseball_state.game_id`, `college_baseball_state.inning`, and `college_baseball_wpa.game_id` had generic one-line filler descriptions (`"ESPN event id."`, `"Inning number."`) that fail `test_no_filler_descriptions`. Replaced with descriptions carrying actual semantic content (join target, valid ranges by sport).

Pre-existing on `main` — unrelated to any other in-flight PR, discovered because it blocks the codegen test suite on every branch.

## Type of change

- [x] Bug fix (non-breaking)

## Test plan

- [x] `uv run pytest tests/codegen/test_manual_descriptions.py::test_no_filler_descriptions` passes
- [x] `uv run python tools/codegen/generate.py --check` — no drift (docs-only change)

## Checklist

- [x] I have NOT included AI agents as commit co-authors