### PR TITLE
feat(hockey): wire all 20 live HockeyTech leagues into the callable surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@
     - [CFB — rule-era models + decision surfaces (0.0.68)](#cfb--rule-era-models--decision-surfaces-0068)
     - [MLB — Statcast (Baseball Savant) comprehensive surface (0.0.64+)](#mlb--statcast-baseball-savant-comprehensive-surface-0064)
     - [NBA / WNBA — stats.nba.com / stats.wnba.com stats API (0.0.72+)](#nba--wnba--statsnbacom--statswnbacom-stats-api-0072)
+    - [Hockey — HockeyTech multi-league (PWHL + 19 minor/junior) (0.0.72+)](#hockey--hockeytech-multi-league-pwhl--19-minorjunior-0072)
     - [HTTP / retry layer](#http--retry-layer)
     - [Polars version](#polars-version)
     - [Type hints](#type-hints)
@@ -653,6 +654,63 @@ wdf = wnba_stats.wnba_stats_leaguedashplayerstats()                    # WNBA
 ```
 
 See Also: [`nba_api`](https://github.com/swar/nba_api), [`hoopR`](https://hoopR.sportsdataverse.org), [`wehoop`](https://wehoop.sportsdataverse.org).
+
+### Hockey — HockeyTech multi-league (PWHL + 19 minor/junior) (0.0.72+)
+
+The HockeyTech/LeagueStat feed (one query-dispatched endpoint behind the PWHL
+and ~20 minor/junior league sites) is wired as **one shared core + N
+registry-driven league families**:
+
+- `sportsdataverse/hockeytech/` — the core: `_client.py` (JSONP-stripping HTTP
+  chokepoint `hockeytech_api`), `_leagues.py` (the `LEAGUES` registry +
+  `resolve_season_id`), `_family.py` (`build_family(league)` mints the 13 public
+  callables), `_parsers.py`, `_analytics.py`.
+- **The registry is the whole surface.** `build_family("echl")` returns
+  `echl_schedule`, `echl_pbp`, `echl_standings`, `echl_teams`,
+  `echl_team_roster`, `echl_player_stats`, `echl_leaders`, `echl_game_summary`,
+  `echl_game_shifts`, `echl_player_toi`, `echl_game_corsi`, `echl_season_id`,
+  `most_recent_echl_season`. Adding a league is a `LEAGUES` entry + a 4-line
+  `sportsdataverse/hockey/<lg>/__init__.py` (calls `build_family`) + 3 wiring
+  lines (`hockey/__init__.py` import, top-level `__init__.py` wildcard, and the
+  `_MOVED` back-compat entry). **No new parser code** — see below.
+- **20 leagues wired (all live-verified 2026-07-12):** `pwhl` (flagship, top-level
+  `sportsdataverse.pwhl` with a richer surface), `ahl`, `ohl`, `whl`, `qmjhl`, and
+  the 15 promoted 2026-07-12 — `echl`, `sphl`, `chl`, `ushl`, `bchl`, `ajhl`,
+  `sjhl`, `ojhl`, `cchl`, `gojhl`, `mhl`, `nojhl`, `vijhl`, `kijhl`, `mjhl`.
+
+```python
+import sportsdataverse as sdv
+sdv.echl_schedule(season=2026)             # flat namespace, one row per game
+sdv.ushl_standings(season=2025)            # one row per team
+from sportsdataverse.hockey.bchl import bchl_pbp   # per-league module
+```
+
+- **One parser fits every league.** `seasons` and `scorebar` row schemas are
+  byte-identical across all 20 (verified sweep); that uniformity is why one
+  `_parsers.py` drives every family and why the offline league-family tests reuse
+  the committed `pwhl_*` fixtures for all leagues.
+- **`league_id` = the standings query param**, not the scorebar row field (they
+  disagree — a scorebar row's `league_id` is a different namespace). Every
+  single-league client uses `league_id=1`; the CHL-cluster majors keep curated
+  ids (ahl=4, whl=7, qmjhl=6).
+- **`pbp_style`** is the coordinate-canvas dialect (`hockeytech_a` ≈ 850×400 /
+  `hockeytech_b` ≈ 600×300). New leagues default to `_b`; flip to `_a` only after
+  a `gameCenterPlayByPlay` coordinate-range probe shows the big canvas. Classify
+  by observed range, **not** pro/junior tier (ECHL is pro but small-canvas).
+- **Per-league PBP caveats:** `ushl` gamecenter ships goals/penalties/goalie
+  changes only (no coordinates); `mjhl`'s public key has no gamecenter access
+  (`<lg>_pbp`/`<lg>_game_summary` return empty — graceful, not an error).
+- **Keys are per-league and public** (shipped in each site's JS); no shared master
+  key. They rotate by *addition* — old generations keep working. Override any
+  league's key with env `SDV_<LEAGUE>_API_KEY` (wins for every view). PWHL's
+  `gameCenterPlayByPlay` historically needed a distinct key (`_PBP_KEY_OVERRIDES`).
+- **Envelope gotchas** live in `_client._strip_jsonp`: `modulekit` →
+  `{"SiteKit":…}`, `gc` → `{"GC":…}` and selects the view with **`tab=` not
+  `view=`**, `statviewfeed` → bare-paren JSONP. Errors are HTTP 200 with an
+  error-in-body sentinel — check bodies, not status.
+- Full API reference + the live/dead + schema accounting: `sdv-internal-refs/
+  hockeytech/` (`README.md`, `SCHEMAS.md`, `ACCOUNTING.md`, `hockeytech.openapi.yaml`
+  mirrored to `sdv-swagger/`).
 
 ### HTTP / retry layer
 

--- a/docs/docs/ajhl/_category_.json
+++ b/docs/docs/ajhl/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "AJHL",
+  "position": 49,
+  "collapsed": true
+}

--- a/docs/docs/ajhl/index.md
+++ b/docs/docs/ajhl/index.md
@@ -1,0 +1,15 @@
+---
+title: AJHL
+sidebar_label: AJHL
+---
+# AJHL (`sportsdataverse.ajhl`)
+
+| Reference | Functions | Base URL |
+|---|---:|---|
+| [Additional functions](reference/additional) | 14 | hand-written wrappers, loaders & helpers |
+
+## Examples
+
+Worked examples — executed notebooks rendered as pages (refreshed weekly against the live APIs):
+
+- [Quickstart](../tutorials/01_quickstart.md)

--- a/docs/docs/ajhl/reference/_category_.json
+++ b/docs/docs/ajhl/reference/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Reference",
+  "position": 1,
+  "collapsed": true
+}

--- a/docs/docs/ajhl/reference/additional.md
+++ b/docs/docs/ajhl/reference/additional.md
@@ -1,0 +1,171 @@
+---
+title: AJHL — additional Python functions
+sidebar_label: Additional functions
+sidebar_position: 50
+---
+# AJHL — additional Python functions
+
+Hand-written wrappers, loaders, and helpers in `sportsdataverse.ajhl`
+not covered by the generated API-endpoint reference above.
+
+## Utilities & helpers
+
+### `most_recent_ajhl_season() -> 'int'` {#most_recent_ajhl_season}
+
+Most-recent AJHL season as an end-year integer (max `season_yr`), or 2026.
+
+## Other
+
+### `ajhl_game_corsi(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#ajhl_game_corsi}
+
+Player-level on-ice Corsi and Fenwick for a single AJHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `ajhl_game_shifts(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#ajhl_game_shifts}
+
+Parsed shift stints for a single AJHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `ajhl_game_summary(game_id: 'int') -> 'dict'` {#ajhl_game_summary}
+
+AJHL game summary — dict of frames (game/goals/penalties/shots_by_period/three_stars).
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+
+### `ajhl_leaders(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#ajhl_leaders}
+
+AJHL statistical leaders for a given season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `ajhl_pbp(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#ajhl_pbp}
+
+AJHL play-by-play — one row per event, fully enriched.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `ajhl_player_stats(player_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#ajhl_player_stats}
+
+AJHL player season stats across all seasons.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `player_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `ajhl_player_toi(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#ajhl_player_toi}
+
+Per-player time-on-ice totals for a single AJHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `ajhl_schedule(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#ajhl_schedule}
+
+AJHL schedule — one row per game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `ajhl_season_id(return_as_pandas: 'bool' = False) -> 'Any'` {#ajhl_season_id}
+
+All AJHL seasons with end-year + game-type labels.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `ajhl_standings(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#ajhl_standings}
+
+AJHL standings — one row per team.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `ajhl_team_roster(team_id: 'int', season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#ajhl_team_roster}
+
+AJHL team roster for a given team + season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `team_id` | `int` |  |  |
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `ajhl_teams(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#ajhl_teams}
+
+AJHL teams for a given season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `build_family(league: 'str') -> 'dict[str, Any]'` {#build_family}
+
+Return a dict of public callables for *league*.
+
+All callables are fully independent closures over the single `league`
+string; none share mutable state.  The dict is ready to be spread into
+a module namespace via `globals().update(...)`.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `league` | `str` |  | HockeyTech league code: `"ahl"`, `"ohl"`, `"whl"`, or `"qmjhl"`. |
+
+**Returns**
+
+Keys are the public function names (e.g. `"ahl_schedule"`).

--- a/docs/docs/bchl/_category_.json
+++ b/docs/docs/bchl/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "BCHL",
+  "position": 48,
+  "collapsed": true
+}

--- a/docs/docs/bchl/index.md
+++ b/docs/docs/bchl/index.md
@@ -1,0 +1,15 @@
+---
+title: BCHL
+sidebar_label: BCHL
+---
+# BCHL (`sportsdataverse.bchl`)
+
+| Reference | Functions | Base URL |
+|---|---:|---|
+| [Additional functions](reference/additional) | 14 | hand-written wrappers, loaders & helpers |
+
+## Examples
+
+Worked examples — executed notebooks rendered as pages (refreshed weekly against the live APIs):
+
+- [Quickstart](../tutorials/01_quickstart.md)

--- a/docs/docs/bchl/reference/_category_.json
+++ b/docs/docs/bchl/reference/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Reference",
+  "position": 1,
+  "collapsed": true
+}

--- a/docs/docs/bchl/reference/additional.md
+++ b/docs/docs/bchl/reference/additional.md
@@ -1,0 +1,171 @@
+---
+title: BCHL — additional Python functions
+sidebar_label: Additional functions
+sidebar_position: 50
+---
+# BCHL — additional Python functions
+
+Hand-written wrappers, loaders, and helpers in `sportsdataverse.bchl`
+not covered by the generated API-endpoint reference above.
+
+## Utilities & helpers
+
+### `most_recent_bchl_season() -> 'int'` {#most_recent_bchl_season}
+
+Most-recent BCHL season as an end-year integer (max `season_yr`), or 2026.
+
+## Other
+
+### `bchl_game_corsi(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#bchl_game_corsi}
+
+Player-level on-ice Corsi and Fenwick for a single BCHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `bchl_game_shifts(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#bchl_game_shifts}
+
+Parsed shift stints for a single BCHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `bchl_game_summary(game_id: 'int') -> 'dict'` {#bchl_game_summary}
+
+BCHL game summary — dict of frames (game/goals/penalties/shots_by_period/three_stars).
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+
+### `bchl_leaders(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#bchl_leaders}
+
+BCHL statistical leaders for a given season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `bchl_pbp(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#bchl_pbp}
+
+BCHL play-by-play — one row per event, fully enriched.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `bchl_player_stats(player_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#bchl_player_stats}
+
+BCHL player season stats across all seasons.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `player_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `bchl_player_toi(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#bchl_player_toi}
+
+Per-player time-on-ice totals for a single BCHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `bchl_schedule(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#bchl_schedule}
+
+BCHL schedule — one row per game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `bchl_season_id(return_as_pandas: 'bool' = False) -> 'Any'` {#bchl_season_id}
+
+All BCHL seasons with end-year + game-type labels.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `bchl_standings(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#bchl_standings}
+
+BCHL standings — one row per team.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `bchl_team_roster(team_id: 'int', season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#bchl_team_roster}
+
+BCHL team roster for a given team + season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `team_id` | `int` |  |  |
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `bchl_teams(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#bchl_teams}
+
+BCHL teams for a given season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `build_family(league: 'str') -> 'dict[str, Any]'` {#build_family}
+
+Return a dict of public callables for *league*.
+
+All callables are fully independent closures over the single `league`
+string; none share mutable state.  The dict is ready to be spread into
+a module namespace via `globals().update(...)`.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `league` | `str` |  | HockeyTech league code: `"ahl"`, `"ohl"`, `"whl"`, or `"qmjhl"`. |
+
+**Returns**
+
+Keys are the public function names (e.g. `"ahl_schedule"`).

--- a/docs/docs/cchl/_category_.json
+++ b/docs/docs/cchl/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "CCHL",
+  "position": 52,
+  "collapsed": true
+}

--- a/docs/docs/cchl/index.md
+++ b/docs/docs/cchl/index.md
@@ -1,0 +1,15 @@
+---
+title: CCHL
+sidebar_label: CCHL
+---
+# CCHL (`sportsdataverse.cchl`)
+
+| Reference | Functions | Base URL |
+|---|---:|---|
+| [Additional functions](reference/additional) | 14 | hand-written wrappers, loaders & helpers |
+
+## Examples
+
+Worked examples — executed notebooks rendered as pages (refreshed weekly against the live APIs):
+
+- [Quickstart](../tutorials/01_quickstart.md)

--- a/docs/docs/cchl/reference/_category_.json
+++ b/docs/docs/cchl/reference/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Reference",
+  "position": 1,
+  "collapsed": true
+}

--- a/docs/docs/cchl/reference/additional.md
+++ b/docs/docs/cchl/reference/additional.md
@@ -1,0 +1,171 @@
+---
+title: CCHL — additional Python functions
+sidebar_label: Additional functions
+sidebar_position: 50
+---
+# CCHL — additional Python functions
+
+Hand-written wrappers, loaders, and helpers in `sportsdataverse.cchl`
+not covered by the generated API-endpoint reference above.
+
+## Utilities & helpers
+
+### `most_recent_cchl_season() -> 'int'` {#most_recent_cchl_season}
+
+Most-recent CCHL season as an end-year integer (max `season_yr`), or 2026.
+
+## Other
+
+### `build_family(league: 'str') -> 'dict[str, Any]'` {#build_family}
+
+Return a dict of public callables for *league*.
+
+All callables are fully independent closures over the single `league`
+string; none share mutable state.  The dict is ready to be spread into
+a module namespace via `globals().update(...)`.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `league` | `str` |  | HockeyTech league code: `"ahl"`, `"ohl"`, `"whl"`, or `"qmjhl"`. |
+
+**Returns**
+
+Keys are the public function names (e.g. `"ahl_schedule"`).
+
+### `cchl_game_corsi(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#cchl_game_corsi}
+
+Player-level on-ice Corsi and Fenwick for a single CCHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `cchl_game_shifts(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#cchl_game_shifts}
+
+Parsed shift stints for a single CCHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `cchl_game_summary(game_id: 'int') -> 'dict'` {#cchl_game_summary}
+
+CCHL game summary — dict of frames (game/goals/penalties/shots_by_period/three_stars).
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+
+### `cchl_leaders(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#cchl_leaders}
+
+CCHL statistical leaders for a given season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `cchl_pbp(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#cchl_pbp}
+
+CCHL play-by-play — one row per event, fully enriched.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `cchl_player_stats(player_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#cchl_player_stats}
+
+CCHL player season stats across all seasons.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `player_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `cchl_player_toi(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#cchl_player_toi}
+
+Per-player time-on-ice totals for a single CCHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `cchl_schedule(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#cchl_schedule}
+
+CCHL schedule — one row per game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `cchl_season_id(return_as_pandas: 'bool' = False) -> 'Any'` {#cchl_season_id}
+
+All CCHL seasons with end-year + game-type labels.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `cchl_standings(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#cchl_standings}
+
+CCHL standings — one row per team.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `cchl_team_roster(team_id: 'int', season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#cchl_team_roster}
+
+CCHL team roster for a given team + season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `team_id` | `int` |  |  |
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `cchl_teams(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#cchl_teams}
+
+CCHL teams for a given season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |

--- a/docs/docs/chl/_category_.json
+++ b/docs/docs/chl/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "CHL",
+  "position": 46,
+  "collapsed": true
+}

--- a/docs/docs/chl/index.md
+++ b/docs/docs/chl/index.md
@@ -1,0 +1,15 @@
+---
+title: CHL
+sidebar_label: CHL
+---
+# CHL (`sportsdataverse.chl`)
+
+| Reference | Functions | Base URL |
+|---|---:|---|
+| [Additional functions](reference/additional) | 14 | hand-written wrappers, loaders & helpers |
+
+## Examples
+
+Worked examples — executed notebooks rendered as pages (refreshed weekly against the live APIs):
+
+- [Quickstart](../tutorials/01_quickstart.md)

--- a/docs/docs/chl/reference/_category_.json
+++ b/docs/docs/chl/reference/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Reference",
+  "position": 1,
+  "collapsed": true
+}

--- a/docs/docs/chl/reference/additional.md
+++ b/docs/docs/chl/reference/additional.md
@@ -1,0 +1,171 @@
+---
+title: CHL — additional Python functions
+sidebar_label: Additional functions
+sidebar_position: 50
+---
+# CHL — additional Python functions
+
+Hand-written wrappers, loaders, and helpers in `sportsdataverse.chl`
+not covered by the generated API-endpoint reference above.
+
+## Utilities & helpers
+
+### `most_recent_chl_season() -> 'int'` {#most_recent_chl_season}
+
+Most-recent CHL season as an end-year integer (max `season_yr`), or 2026.
+
+## Other
+
+### `build_family(league: 'str') -> 'dict[str, Any]'` {#build_family}
+
+Return a dict of public callables for *league*.
+
+All callables are fully independent closures over the single `league`
+string; none share mutable state.  The dict is ready to be spread into
+a module namespace via `globals().update(...)`.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `league` | `str` |  | HockeyTech league code: `"ahl"`, `"ohl"`, `"whl"`, or `"qmjhl"`. |
+
+**Returns**
+
+Keys are the public function names (e.g. `"ahl_schedule"`).
+
+### `chl_game_corsi(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#chl_game_corsi}
+
+Player-level on-ice Corsi and Fenwick for a single CHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `chl_game_shifts(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#chl_game_shifts}
+
+Parsed shift stints for a single CHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `chl_game_summary(game_id: 'int') -> 'dict'` {#chl_game_summary}
+
+CHL game summary — dict of frames (game/goals/penalties/shots_by_period/three_stars).
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+
+### `chl_leaders(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#chl_leaders}
+
+CHL statistical leaders for a given season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `chl_pbp(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#chl_pbp}
+
+CHL play-by-play — one row per event, fully enriched.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `chl_player_stats(player_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#chl_player_stats}
+
+CHL player season stats across all seasons.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `player_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `chl_player_toi(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#chl_player_toi}
+
+Per-player time-on-ice totals for a single CHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `chl_schedule(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#chl_schedule}
+
+CHL schedule — one row per game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `chl_season_id(return_as_pandas: 'bool' = False) -> 'Any'` {#chl_season_id}
+
+All CHL seasons with end-year + game-type labels.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `chl_standings(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#chl_standings}
+
+CHL standings — one row per team.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `chl_team_roster(team_id: 'int', season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#chl_team_roster}
+
+CHL team roster for a given team + season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `team_id` | `int` |  |  |
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `chl_teams(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#chl_teams}
+
+CHL teams for a given season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |

--- a/docs/docs/echl/_category_.json
+++ b/docs/docs/echl/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "ECHL",
+  "position": 44,
+  "collapsed": true
+}

--- a/docs/docs/echl/index.md
+++ b/docs/docs/echl/index.md
@@ -1,0 +1,15 @@
+---
+title: ECHL
+sidebar_label: ECHL
+---
+# ECHL (`sportsdataverse.echl`)
+
+| Reference | Functions | Base URL |
+|---|---:|---|
+| [Additional functions](reference/additional) | 14 | hand-written wrappers, loaders & helpers |
+
+## Examples
+
+Worked examples — executed notebooks rendered as pages (refreshed weekly against the live APIs):
+
+- [Quickstart](../tutorials/01_quickstart.md)

--- a/docs/docs/echl/reference/_category_.json
+++ b/docs/docs/echl/reference/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Reference",
+  "position": 1,
+  "collapsed": true
+}

--- a/docs/docs/echl/reference/additional.md
+++ b/docs/docs/echl/reference/additional.md
@@ -1,0 +1,171 @@
+---
+title: ECHL — additional Python functions
+sidebar_label: Additional functions
+sidebar_position: 50
+---
+# ECHL — additional Python functions
+
+Hand-written wrappers, loaders, and helpers in `sportsdataverse.echl`
+not covered by the generated API-endpoint reference above.
+
+## Utilities & helpers
+
+### `most_recent_echl_season() -> 'int'` {#most_recent_echl_season}
+
+Most-recent ECHL season as an end-year integer (max `season_yr`), or 2026.
+
+## Other
+
+### `build_family(league: 'str') -> 'dict[str, Any]'` {#build_family}
+
+Return a dict of public callables for *league*.
+
+All callables are fully independent closures over the single `league`
+string; none share mutable state.  The dict is ready to be spread into
+a module namespace via `globals().update(...)`.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `league` | `str` |  | HockeyTech league code: `"ahl"`, `"ohl"`, `"whl"`, or `"qmjhl"`. |
+
+**Returns**
+
+Keys are the public function names (e.g. `"ahl_schedule"`).
+
+### `echl_game_corsi(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#echl_game_corsi}
+
+Player-level on-ice Corsi and Fenwick for a single ECHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `echl_game_shifts(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#echl_game_shifts}
+
+Parsed shift stints for a single ECHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `echl_game_summary(game_id: 'int') -> 'dict'` {#echl_game_summary}
+
+ECHL game summary — dict of frames (game/goals/penalties/shots_by_period/three_stars).
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+
+### `echl_leaders(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#echl_leaders}
+
+ECHL statistical leaders for a given season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `echl_pbp(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#echl_pbp}
+
+ECHL play-by-play — one row per event, fully enriched.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `echl_player_stats(player_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#echl_player_stats}
+
+ECHL player season stats across all seasons.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `player_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `echl_player_toi(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#echl_player_toi}
+
+Per-player time-on-ice totals for a single ECHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `echl_schedule(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#echl_schedule}
+
+ECHL schedule — one row per game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `echl_season_id(return_as_pandas: 'bool' = False) -> 'Any'` {#echl_season_id}
+
+All ECHL seasons with end-year + game-type labels.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `echl_standings(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#echl_standings}
+
+ECHL standings — one row per team.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `echl_team_roster(team_id: 'int', season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#echl_team_roster}
+
+ECHL team roster for a given team + season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `team_id` | `int` |  |  |
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `echl_teams(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#echl_teams}
+
+ECHL teams for a given season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |

--- a/docs/docs/gojhl/_category_.json
+++ b/docs/docs/gojhl/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "GOJHL",
+  "position": 53,
+  "collapsed": true
+}

--- a/docs/docs/gojhl/index.md
+++ b/docs/docs/gojhl/index.md
@@ -1,0 +1,15 @@
+---
+title: GOJHL
+sidebar_label: GOJHL
+---
+# GOJHL (`sportsdataverse.gojhl`)
+
+| Reference | Functions | Base URL |
+|---|---:|---|
+| [Additional functions](reference/additional) | 14 | hand-written wrappers, loaders & helpers |
+
+## Examples
+
+Worked examples — executed notebooks rendered as pages (refreshed weekly against the live APIs):
+
+- [Quickstart](../tutorials/01_quickstart.md)

--- a/docs/docs/gojhl/reference/_category_.json
+++ b/docs/docs/gojhl/reference/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Reference",
+  "position": 1,
+  "collapsed": true
+}

--- a/docs/docs/gojhl/reference/additional.md
+++ b/docs/docs/gojhl/reference/additional.md
@@ -1,0 +1,171 @@
+---
+title: GOJHL — additional Python functions
+sidebar_label: Additional functions
+sidebar_position: 50
+---
+# GOJHL — additional Python functions
+
+Hand-written wrappers, loaders, and helpers in `sportsdataverse.gojhl`
+not covered by the generated API-endpoint reference above.
+
+## Utilities & helpers
+
+### `most_recent_gojhl_season() -> 'int'` {#most_recent_gojhl_season}
+
+Most-recent GOJHL season as an end-year integer (max `season_yr`), or 2026.
+
+## Other
+
+### `build_family(league: 'str') -> 'dict[str, Any]'` {#build_family}
+
+Return a dict of public callables for *league*.
+
+All callables are fully independent closures over the single `league`
+string; none share mutable state.  The dict is ready to be spread into
+a module namespace via `globals().update(...)`.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `league` | `str` |  | HockeyTech league code: `"ahl"`, `"ohl"`, `"whl"`, or `"qmjhl"`. |
+
+**Returns**
+
+Keys are the public function names (e.g. `"ahl_schedule"`).
+
+### `gojhl_game_corsi(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#gojhl_game_corsi}
+
+Player-level on-ice Corsi and Fenwick for a single GOJHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `gojhl_game_shifts(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#gojhl_game_shifts}
+
+Parsed shift stints for a single GOJHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `gojhl_game_summary(game_id: 'int') -> 'dict'` {#gojhl_game_summary}
+
+GOJHL game summary — dict of frames (game/goals/penalties/shots_by_period/three_stars).
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+
+### `gojhl_leaders(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#gojhl_leaders}
+
+GOJHL statistical leaders for a given season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `gojhl_pbp(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#gojhl_pbp}
+
+GOJHL play-by-play — one row per event, fully enriched.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `gojhl_player_stats(player_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#gojhl_player_stats}
+
+GOJHL player season stats across all seasons.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `player_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `gojhl_player_toi(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#gojhl_player_toi}
+
+Per-player time-on-ice totals for a single GOJHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `gojhl_schedule(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#gojhl_schedule}
+
+GOJHL schedule — one row per game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `gojhl_season_id(return_as_pandas: 'bool' = False) -> 'Any'` {#gojhl_season_id}
+
+All GOJHL seasons with end-year + game-type labels.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `gojhl_standings(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#gojhl_standings}
+
+GOJHL standings — one row per team.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `gojhl_team_roster(team_id: 'int', season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#gojhl_team_roster}
+
+GOJHL team roster for a given team + season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `team_id` | `int` |  |  |
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `gojhl_teams(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#gojhl_teams}
+
+GOJHL teams for a given season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |

--- a/docs/docs/kijhl/_category_.json
+++ b/docs/docs/kijhl/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "KIJHL",
+  "position": 57,
+  "collapsed": true
+}

--- a/docs/docs/kijhl/index.md
+++ b/docs/docs/kijhl/index.md
@@ -1,0 +1,15 @@
+---
+title: KIJHL
+sidebar_label: KIJHL
+---
+# KIJHL (`sportsdataverse.kijhl`)
+
+| Reference | Functions | Base URL |
+|---|---:|---|
+| [Additional functions](reference/additional) | 14 | hand-written wrappers, loaders & helpers |
+
+## Examples
+
+Worked examples — executed notebooks rendered as pages (refreshed weekly against the live APIs):
+
+- [Quickstart](../tutorials/01_quickstart.md)

--- a/docs/docs/kijhl/reference/_category_.json
+++ b/docs/docs/kijhl/reference/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Reference",
+  "position": 1,
+  "collapsed": true
+}

--- a/docs/docs/kijhl/reference/additional.md
+++ b/docs/docs/kijhl/reference/additional.md
@@ -1,0 +1,171 @@
+---
+title: KIJHL — additional Python functions
+sidebar_label: Additional functions
+sidebar_position: 50
+---
+# KIJHL — additional Python functions
+
+Hand-written wrappers, loaders, and helpers in `sportsdataverse.kijhl`
+not covered by the generated API-endpoint reference above.
+
+## Utilities & helpers
+
+### `most_recent_kijhl_season() -> 'int'` {#most_recent_kijhl_season}
+
+Most-recent KIJHL season as an end-year integer (max `season_yr`), or 2026.
+
+## Other
+
+### `build_family(league: 'str') -> 'dict[str, Any]'` {#build_family}
+
+Return a dict of public callables for *league*.
+
+All callables are fully independent closures over the single `league`
+string; none share mutable state.  The dict is ready to be spread into
+a module namespace via `globals().update(...)`.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `league` | `str` |  | HockeyTech league code: `"ahl"`, `"ohl"`, `"whl"`, or `"qmjhl"`. |
+
+**Returns**
+
+Keys are the public function names (e.g. `"ahl_schedule"`).
+
+### `kijhl_game_corsi(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#kijhl_game_corsi}
+
+Player-level on-ice Corsi and Fenwick for a single KIJHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `kijhl_game_shifts(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#kijhl_game_shifts}
+
+Parsed shift stints for a single KIJHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `kijhl_game_summary(game_id: 'int') -> 'dict'` {#kijhl_game_summary}
+
+KIJHL game summary — dict of frames (game/goals/penalties/shots_by_period/three_stars).
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+
+### `kijhl_leaders(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#kijhl_leaders}
+
+KIJHL statistical leaders for a given season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `kijhl_pbp(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#kijhl_pbp}
+
+KIJHL play-by-play — one row per event, fully enriched.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `kijhl_player_stats(player_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#kijhl_player_stats}
+
+KIJHL player season stats across all seasons.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `player_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `kijhl_player_toi(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#kijhl_player_toi}
+
+Per-player time-on-ice totals for a single KIJHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `kijhl_schedule(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#kijhl_schedule}
+
+KIJHL schedule — one row per game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `kijhl_season_id(return_as_pandas: 'bool' = False) -> 'Any'` {#kijhl_season_id}
+
+All KIJHL seasons with end-year + game-type labels.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `kijhl_standings(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#kijhl_standings}
+
+KIJHL standings — one row per team.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `kijhl_team_roster(team_id: 'int', season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#kijhl_team_roster}
+
+KIJHL team roster for a given team + season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `team_id` | `int` |  |  |
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `kijhl_teams(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#kijhl_teams}
+
+KIJHL teams for a given season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |

--- a/docs/docs/mhl/_category_.json
+++ b/docs/docs/mhl/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "MHL",
+  "position": 54,
+  "collapsed": true
+}

--- a/docs/docs/mhl/index.md
+++ b/docs/docs/mhl/index.md
@@ -1,0 +1,15 @@
+---
+title: MHL
+sidebar_label: MHL
+---
+# MHL (`sportsdataverse.mhl`)
+
+| Reference | Functions | Base URL |
+|---|---:|---|
+| [Additional functions](reference/additional) | 14 | hand-written wrappers, loaders & helpers |
+
+## Examples
+
+Worked examples — executed notebooks rendered as pages (refreshed weekly against the live APIs):
+
+- [Quickstart](../tutorials/01_quickstart.md)

--- a/docs/docs/mhl/reference/_category_.json
+++ b/docs/docs/mhl/reference/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Reference",
+  "position": 1,
+  "collapsed": true
+}

--- a/docs/docs/mhl/reference/additional.md
+++ b/docs/docs/mhl/reference/additional.md
@@ -1,0 +1,171 @@
+---
+title: MHL — additional Python functions
+sidebar_label: Additional functions
+sidebar_position: 50
+---
+# MHL — additional Python functions
+
+Hand-written wrappers, loaders, and helpers in `sportsdataverse.mhl`
+not covered by the generated API-endpoint reference above.
+
+## Utilities & helpers
+
+### `most_recent_mhl_season() -> 'int'` {#most_recent_mhl_season}
+
+Most-recent MHL season as an end-year integer (max `season_yr`), or 2026.
+
+## Other
+
+### `build_family(league: 'str') -> 'dict[str, Any]'` {#build_family}
+
+Return a dict of public callables for *league*.
+
+All callables are fully independent closures over the single `league`
+string; none share mutable state.  The dict is ready to be spread into
+a module namespace via `globals().update(...)`.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `league` | `str` |  | HockeyTech league code: `"ahl"`, `"ohl"`, `"whl"`, or `"qmjhl"`. |
+
+**Returns**
+
+Keys are the public function names (e.g. `"ahl_schedule"`).
+
+### `mhl_game_corsi(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#mhl_game_corsi}
+
+Player-level on-ice Corsi and Fenwick for a single MHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `mhl_game_shifts(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#mhl_game_shifts}
+
+Parsed shift stints for a single MHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `mhl_game_summary(game_id: 'int') -> 'dict'` {#mhl_game_summary}
+
+MHL game summary — dict of frames (game/goals/penalties/shots_by_period/three_stars).
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+
+### `mhl_leaders(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#mhl_leaders}
+
+MHL statistical leaders for a given season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `mhl_pbp(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#mhl_pbp}
+
+MHL play-by-play — one row per event, fully enriched.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `mhl_player_stats(player_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#mhl_player_stats}
+
+MHL player season stats across all seasons.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `player_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `mhl_player_toi(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#mhl_player_toi}
+
+Per-player time-on-ice totals for a single MHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `mhl_schedule(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#mhl_schedule}
+
+MHL schedule — one row per game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `mhl_season_id(return_as_pandas: 'bool' = False) -> 'Any'` {#mhl_season_id}
+
+All MHL seasons with end-year + game-type labels.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `mhl_standings(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#mhl_standings}
+
+MHL standings — one row per team.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `mhl_team_roster(team_id: 'int', season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#mhl_team_roster}
+
+MHL team roster for a given team + season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `team_id` | `int` |  |  |
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `mhl_teams(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#mhl_teams}
+
+MHL teams for a given season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |

--- a/docs/docs/mjhl/_category_.json
+++ b/docs/docs/mjhl/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "MJHL",
+  "position": 58,
+  "collapsed": true
+}

--- a/docs/docs/mjhl/index.md
+++ b/docs/docs/mjhl/index.md
@@ -1,0 +1,15 @@
+---
+title: MJHL
+sidebar_label: MJHL
+---
+# MJHL (`sportsdataverse.mjhl`)
+
+| Reference | Functions | Base URL |
+|---|---:|---|
+| [Additional functions](reference/additional) | 14 | hand-written wrappers, loaders & helpers |
+
+## Examples
+
+Worked examples — executed notebooks rendered as pages (refreshed weekly against the live APIs):
+
+- [Quickstart](../tutorials/01_quickstart.md)

--- a/docs/docs/mjhl/reference/_category_.json
+++ b/docs/docs/mjhl/reference/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Reference",
+  "position": 1,
+  "collapsed": true
+}

--- a/docs/docs/mjhl/reference/additional.md
+++ b/docs/docs/mjhl/reference/additional.md
@@ -1,0 +1,171 @@
+---
+title: MJHL — additional Python functions
+sidebar_label: Additional functions
+sidebar_position: 50
+---
+# MJHL — additional Python functions
+
+Hand-written wrappers, loaders, and helpers in `sportsdataverse.mjhl`
+not covered by the generated API-endpoint reference above.
+
+## Utilities & helpers
+
+### `most_recent_mjhl_season() -> 'int'` {#most_recent_mjhl_season}
+
+Most-recent MJHL season as an end-year integer (max `season_yr`), or 2026.
+
+## Other
+
+### `build_family(league: 'str') -> 'dict[str, Any]'` {#build_family}
+
+Return a dict of public callables for *league*.
+
+All callables are fully independent closures over the single `league`
+string; none share mutable state.  The dict is ready to be spread into
+a module namespace via `globals().update(...)`.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `league` | `str` |  | HockeyTech league code: `"ahl"`, `"ohl"`, `"whl"`, or `"qmjhl"`. |
+
+**Returns**
+
+Keys are the public function names (e.g. `"ahl_schedule"`).
+
+### `mjhl_game_corsi(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#mjhl_game_corsi}
+
+Player-level on-ice Corsi and Fenwick for a single MJHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `mjhl_game_shifts(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#mjhl_game_shifts}
+
+Parsed shift stints for a single MJHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `mjhl_game_summary(game_id: 'int') -> 'dict'` {#mjhl_game_summary}
+
+MJHL game summary — dict of frames (game/goals/penalties/shots_by_period/three_stars).
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+
+### `mjhl_leaders(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#mjhl_leaders}
+
+MJHL statistical leaders for a given season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `mjhl_pbp(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#mjhl_pbp}
+
+MJHL play-by-play — one row per event, fully enriched.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `mjhl_player_stats(player_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#mjhl_player_stats}
+
+MJHL player season stats across all seasons.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `player_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `mjhl_player_toi(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#mjhl_player_toi}
+
+Per-player time-on-ice totals for a single MJHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `mjhl_schedule(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#mjhl_schedule}
+
+MJHL schedule — one row per game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `mjhl_season_id(return_as_pandas: 'bool' = False) -> 'Any'` {#mjhl_season_id}
+
+All MJHL seasons with end-year + game-type labels.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `mjhl_standings(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#mjhl_standings}
+
+MJHL standings — one row per team.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `mjhl_team_roster(team_id: 'int', season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#mjhl_team_roster}
+
+MJHL team roster for a given team + season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `team_id` | `int` |  |  |
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `mjhl_teams(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#mjhl_teams}
+
+MJHL teams for a given season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |

--- a/docs/docs/nojhl/_category_.json
+++ b/docs/docs/nojhl/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "NOJHL",
+  "position": 55,
+  "collapsed": true
+}

--- a/docs/docs/nojhl/index.md
+++ b/docs/docs/nojhl/index.md
@@ -1,0 +1,15 @@
+---
+title: NOJHL
+sidebar_label: NOJHL
+---
+# NOJHL (`sportsdataverse.nojhl`)
+
+| Reference | Functions | Base URL |
+|---|---:|---|
+| [Additional functions](reference/additional) | 14 | hand-written wrappers, loaders & helpers |
+
+## Examples
+
+Worked examples — executed notebooks rendered as pages (refreshed weekly against the live APIs):
+
+- [Quickstart](../tutorials/01_quickstart.md)

--- a/docs/docs/nojhl/reference/_category_.json
+++ b/docs/docs/nojhl/reference/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Reference",
+  "position": 1,
+  "collapsed": true
+}

--- a/docs/docs/nojhl/reference/additional.md
+++ b/docs/docs/nojhl/reference/additional.md
@@ -1,0 +1,171 @@
+---
+title: NOJHL — additional Python functions
+sidebar_label: Additional functions
+sidebar_position: 50
+---
+# NOJHL — additional Python functions
+
+Hand-written wrappers, loaders, and helpers in `sportsdataverse.nojhl`
+not covered by the generated API-endpoint reference above.
+
+## Utilities & helpers
+
+### `most_recent_nojhl_season() -> 'int'` {#most_recent_nojhl_season}
+
+Most-recent NOJHL season as an end-year integer (max `season_yr`), or 2026.
+
+## Other
+
+### `build_family(league: 'str') -> 'dict[str, Any]'` {#build_family}
+
+Return a dict of public callables for *league*.
+
+All callables are fully independent closures over the single `league`
+string; none share mutable state.  The dict is ready to be spread into
+a module namespace via `globals().update(...)`.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `league` | `str` |  | HockeyTech league code: `"ahl"`, `"ohl"`, `"whl"`, or `"qmjhl"`. |
+
+**Returns**
+
+Keys are the public function names (e.g. `"ahl_schedule"`).
+
+### `nojhl_game_corsi(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#nojhl_game_corsi}
+
+Player-level on-ice Corsi and Fenwick for a single NOJHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `nojhl_game_shifts(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#nojhl_game_shifts}
+
+Parsed shift stints for a single NOJHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `nojhl_game_summary(game_id: 'int') -> 'dict'` {#nojhl_game_summary}
+
+NOJHL game summary — dict of frames (game/goals/penalties/shots_by_period/three_stars).
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+
+### `nojhl_leaders(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#nojhl_leaders}
+
+NOJHL statistical leaders for a given season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `nojhl_pbp(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#nojhl_pbp}
+
+NOJHL play-by-play — one row per event, fully enriched.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `nojhl_player_stats(player_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#nojhl_player_stats}
+
+NOJHL player season stats across all seasons.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `player_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `nojhl_player_toi(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#nojhl_player_toi}
+
+Per-player time-on-ice totals for a single NOJHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `nojhl_schedule(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#nojhl_schedule}
+
+NOJHL schedule — one row per game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `nojhl_season_id(return_as_pandas: 'bool' = False) -> 'Any'` {#nojhl_season_id}
+
+All NOJHL seasons with end-year + game-type labels.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `nojhl_standings(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#nojhl_standings}
+
+NOJHL standings — one row per team.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `nojhl_team_roster(team_id: 'int', season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#nojhl_team_roster}
+
+NOJHL team roster for a given team + season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `team_id` | `int` |  |  |
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `nojhl_teams(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#nojhl_teams}
+
+NOJHL teams for a given season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |

--- a/docs/docs/odds/_category_.json
+++ b/docs/docs/odds/_category_.json
@@ -1,5 +1,5 @@
 {
   "label": "ODDS",
-  "position": 44,
+  "position": 59,
   "collapsed": true
 }

--- a/docs/docs/ojhl/_category_.json
+++ b/docs/docs/ojhl/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "OJHL",
+  "position": 51,
+  "collapsed": true
+}

--- a/docs/docs/ojhl/index.md
+++ b/docs/docs/ojhl/index.md
@@ -1,0 +1,15 @@
+---
+title: OJHL
+sidebar_label: OJHL
+---
+# OJHL (`sportsdataverse.ojhl`)
+
+| Reference | Functions | Base URL |
+|---|---:|---|
+| [Additional functions](reference/additional) | 14 | hand-written wrappers, loaders & helpers |
+
+## Examples
+
+Worked examples — executed notebooks rendered as pages (refreshed weekly against the live APIs):
+
+- [Quickstart](../tutorials/01_quickstart.md)

--- a/docs/docs/ojhl/reference/_category_.json
+++ b/docs/docs/ojhl/reference/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Reference",
+  "position": 1,
+  "collapsed": true
+}

--- a/docs/docs/ojhl/reference/additional.md
+++ b/docs/docs/ojhl/reference/additional.md
@@ -1,0 +1,171 @@
+---
+title: OJHL — additional Python functions
+sidebar_label: Additional functions
+sidebar_position: 50
+---
+# OJHL — additional Python functions
+
+Hand-written wrappers, loaders, and helpers in `sportsdataverse.ojhl`
+not covered by the generated API-endpoint reference above.
+
+## Utilities & helpers
+
+### `most_recent_ojhl_season() -> 'int'` {#most_recent_ojhl_season}
+
+Most-recent OJHL season as an end-year integer (max `season_yr`), or 2026.
+
+## Other
+
+### `build_family(league: 'str') -> 'dict[str, Any]'` {#build_family}
+
+Return a dict of public callables for *league*.
+
+All callables are fully independent closures over the single `league`
+string; none share mutable state.  The dict is ready to be spread into
+a module namespace via `globals().update(...)`.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `league` | `str` |  | HockeyTech league code: `"ahl"`, `"ohl"`, `"whl"`, or `"qmjhl"`. |
+
+**Returns**
+
+Keys are the public function names (e.g. `"ahl_schedule"`).
+
+### `ojhl_game_corsi(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#ojhl_game_corsi}
+
+Player-level on-ice Corsi and Fenwick for a single OJHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `ojhl_game_shifts(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#ojhl_game_shifts}
+
+Parsed shift stints for a single OJHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `ojhl_game_summary(game_id: 'int') -> 'dict'` {#ojhl_game_summary}
+
+OJHL game summary — dict of frames (game/goals/penalties/shots_by_period/three_stars).
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+
+### `ojhl_leaders(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#ojhl_leaders}
+
+OJHL statistical leaders for a given season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `ojhl_pbp(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#ojhl_pbp}
+
+OJHL play-by-play — one row per event, fully enriched.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `ojhl_player_stats(player_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#ojhl_player_stats}
+
+OJHL player season stats across all seasons.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `player_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `ojhl_player_toi(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#ojhl_player_toi}
+
+Per-player time-on-ice totals for a single OJHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `ojhl_schedule(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#ojhl_schedule}
+
+OJHL schedule — one row per game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `ojhl_season_id(return_as_pandas: 'bool' = False) -> 'Any'` {#ojhl_season_id}
+
+All OJHL seasons with end-year + game-type labels.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `ojhl_standings(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#ojhl_standings}
+
+OJHL standings — one row per team.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `ojhl_team_roster(team_id: 'int', season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#ojhl_team_roster}
+
+OJHL team roster for a given team + season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `team_id` | `int` |  |  |
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `ojhl_teams(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#ojhl_teams}
+
+OJHL teams for a given season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |

--- a/docs/docs/sjhl/_category_.json
+++ b/docs/docs/sjhl/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "SJHL",
+  "position": 50,
+  "collapsed": true
+}

--- a/docs/docs/sjhl/index.md
+++ b/docs/docs/sjhl/index.md
@@ -1,0 +1,15 @@
+---
+title: SJHL
+sidebar_label: SJHL
+---
+# SJHL (`sportsdataverse.sjhl`)
+
+| Reference | Functions | Base URL |
+|---|---:|---|
+| [Additional functions](reference/additional) | 14 | hand-written wrappers, loaders & helpers |
+
+## Examples
+
+Worked examples — executed notebooks rendered as pages (refreshed weekly against the live APIs):
+
+- [Quickstart](../tutorials/01_quickstart.md)

--- a/docs/docs/sjhl/reference/_category_.json
+++ b/docs/docs/sjhl/reference/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Reference",
+  "position": 1,
+  "collapsed": true
+}

--- a/docs/docs/sjhl/reference/additional.md
+++ b/docs/docs/sjhl/reference/additional.md
@@ -1,0 +1,171 @@
+---
+title: SJHL — additional Python functions
+sidebar_label: Additional functions
+sidebar_position: 50
+---
+# SJHL — additional Python functions
+
+Hand-written wrappers, loaders, and helpers in `sportsdataverse.sjhl`
+not covered by the generated API-endpoint reference above.
+
+## Utilities & helpers
+
+### `most_recent_sjhl_season() -> 'int'` {#most_recent_sjhl_season}
+
+Most-recent SJHL season as an end-year integer (max `season_yr`), or 2026.
+
+## Other
+
+### `build_family(league: 'str') -> 'dict[str, Any]'` {#build_family}
+
+Return a dict of public callables for *league*.
+
+All callables are fully independent closures over the single `league`
+string; none share mutable state.  The dict is ready to be spread into
+a module namespace via `globals().update(...)`.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `league` | `str` |  | HockeyTech league code: `"ahl"`, `"ohl"`, `"whl"`, or `"qmjhl"`. |
+
+**Returns**
+
+Keys are the public function names (e.g. `"ahl_schedule"`).
+
+### `sjhl_game_corsi(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#sjhl_game_corsi}
+
+Player-level on-ice Corsi and Fenwick for a single SJHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `sjhl_game_shifts(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#sjhl_game_shifts}
+
+Parsed shift stints for a single SJHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `sjhl_game_summary(game_id: 'int') -> 'dict'` {#sjhl_game_summary}
+
+SJHL game summary — dict of frames (game/goals/penalties/shots_by_period/three_stars).
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+
+### `sjhl_leaders(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#sjhl_leaders}
+
+SJHL statistical leaders for a given season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `sjhl_pbp(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#sjhl_pbp}
+
+SJHL play-by-play — one row per event, fully enriched.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `sjhl_player_stats(player_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#sjhl_player_stats}
+
+SJHL player season stats across all seasons.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `player_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `sjhl_player_toi(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#sjhl_player_toi}
+
+Per-player time-on-ice totals for a single SJHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `sjhl_schedule(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#sjhl_schedule}
+
+SJHL schedule — one row per game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `sjhl_season_id(return_as_pandas: 'bool' = False) -> 'Any'` {#sjhl_season_id}
+
+All SJHL seasons with end-year + game-type labels.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `sjhl_standings(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#sjhl_standings}
+
+SJHL standings — one row per team.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `sjhl_team_roster(team_id: 'int', season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#sjhl_team_roster}
+
+SJHL team roster for a given team + season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `team_id` | `int` |  |  |
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `sjhl_teams(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#sjhl_teams}
+
+SJHL teams for a given season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |

--- a/docs/docs/sphl/_category_.json
+++ b/docs/docs/sphl/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "SPHL",
+  "position": 45,
+  "collapsed": true
+}

--- a/docs/docs/sphl/index.md
+++ b/docs/docs/sphl/index.md
@@ -1,0 +1,15 @@
+---
+title: SPHL
+sidebar_label: SPHL
+---
+# SPHL (`sportsdataverse.sphl`)
+
+| Reference | Functions | Base URL |
+|---|---:|---|
+| [Additional functions](reference/additional) | 14 | hand-written wrappers, loaders & helpers |
+
+## Examples
+
+Worked examples — executed notebooks rendered as pages (refreshed weekly against the live APIs):
+
+- [Quickstart](../tutorials/01_quickstart.md)

--- a/docs/docs/sphl/reference/_category_.json
+++ b/docs/docs/sphl/reference/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Reference",
+  "position": 1,
+  "collapsed": true
+}

--- a/docs/docs/sphl/reference/additional.md
+++ b/docs/docs/sphl/reference/additional.md
@@ -1,0 +1,171 @@
+---
+title: SPHL — additional Python functions
+sidebar_label: Additional functions
+sidebar_position: 50
+---
+# SPHL — additional Python functions
+
+Hand-written wrappers, loaders, and helpers in `sportsdataverse.sphl`
+not covered by the generated API-endpoint reference above.
+
+## Utilities & helpers
+
+### `most_recent_sphl_season() -> 'int'` {#most_recent_sphl_season}
+
+Most-recent SPHL season as an end-year integer (max `season_yr`), or 2026.
+
+## Other
+
+### `build_family(league: 'str') -> 'dict[str, Any]'` {#build_family}
+
+Return a dict of public callables for *league*.
+
+All callables are fully independent closures over the single `league`
+string; none share mutable state.  The dict is ready to be spread into
+a module namespace via `globals().update(...)`.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `league` | `str` |  | HockeyTech league code: `"ahl"`, `"ohl"`, `"whl"`, or `"qmjhl"`. |
+
+**Returns**
+
+Keys are the public function names (e.g. `"ahl_schedule"`).
+
+### `sphl_game_corsi(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#sphl_game_corsi}
+
+Player-level on-ice Corsi and Fenwick for a single SPHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `sphl_game_shifts(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#sphl_game_shifts}
+
+Parsed shift stints for a single SPHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `sphl_game_summary(game_id: 'int') -> 'dict'` {#sphl_game_summary}
+
+SPHL game summary — dict of frames (game/goals/penalties/shots_by_period/three_stars).
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+
+### `sphl_leaders(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#sphl_leaders}
+
+SPHL statistical leaders for a given season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `sphl_pbp(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#sphl_pbp}
+
+SPHL play-by-play — one row per event, fully enriched.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `sphl_player_stats(player_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#sphl_player_stats}
+
+SPHL player season stats across all seasons.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `player_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `sphl_player_toi(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#sphl_player_toi}
+
+Per-player time-on-ice totals for a single SPHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `sphl_schedule(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#sphl_schedule}
+
+SPHL schedule — one row per game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `sphl_season_id(return_as_pandas: 'bool' = False) -> 'Any'` {#sphl_season_id}
+
+All SPHL seasons with end-year + game-type labels.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `sphl_standings(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#sphl_standings}
+
+SPHL standings — one row per team.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `sphl_team_roster(team_id: 'int', season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#sphl_team_roster}
+
+SPHL team roster for a given team + season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `team_id` | `int` |  |  |
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `sphl_teams(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#sphl_teams}
+
+SPHL teams for a given season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |

--- a/docs/docs/ushl/_category_.json
+++ b/docs/docs/ushl/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "USHL",
+  "position": 47,
+  "collapsed": true
+}

--- a/docs/docs/ushl/index.md
+++ b/docs/docs/ushl/index.md
@@ -1,0 +1,15 @@
+---
+title: USHL
+sidebar_label: USHL
+---
+# USHL (`sportsdataverse.ushl`)
+
+| Reference | Functions | Base URL |
+|---|---:|---|
+| [Additional functions](reference/additional) | 14 | hand-written wrappers, loaders & helpers |
+
+## Examples
+
+Worked examples — executed notebooks rendered as pages (refreshed weekly against the live APIs):
+
+- [Quickstart](../tutorials/01_quickstart.md)

--- a/docs/docs/ushl/reference/_category_.json
+++ b/docs/docs/ushl/reference/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Reference",
+  "position": 1,
+  "collapsed": true
+}

--- a/docs/docs/ushl/reference/additional.md
+++ b/docs/docs/ushl/reference/additional.md
@@ -1,0 +1,171 @@
+---
+title: USHL — additional Python functions
+sidebar_label: Additional functions
+sidebar_position: 50
+---
+# USHL — additional Python functions
+
+Hand-written wrappers, loaders, and helpers in `sportsdataverse.ushl`
+not covered by the generated API-endpoint reference above.
+
+## Utilities & helpers
+
+### `most_recent_ushl_season() -> 'int'` {#most_recent_ushl_season}
+
+Most-recent USHL season as an end-year integer (max `season_yr`), or 2026.
+
+## Other
+
+### `build_family(league: 'str') -> 'dict[str, Any]'` {#build_family}
+
+Return a dict of public callables for *league*.
+
+All callables are fully independent closures over the single `league`
+string; none share mutable state.  The dict is ready to be spread into
+a module namespace via `globals().update(...)`.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `league` | `str` |  | HockeyTech league code: `"ahl"`, `"ohl"`, `"whl"`, or `"qmjhl"`. |
+
+**Returns**
+
+Keys are the public function names (e.g. `"ahl_schedule"`).
+
+### `ushl_game_corsi(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#ushl_game_corsi}
+
+Player-level on-ice Corsi and Fenwick for a single USHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `ushl_game_shifts(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#ushl_game_shifts}
+
+Parsed shift stints for a single USHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `ushl_game_summary(game_id: 'int') -> 'dict'` {#ushl_game_summary}
+
+USHL game summary — dict of frames (game/goals/penalties/shots_by_period/three_stars).
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+
+### `ushl_leaders(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#ushl_leaders}
+
+USHL statistical leaders for a given season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `ushl_pbp(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#ushl_pbp}
+
+USHL play-by-play — one row per event, fully enriched.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `ushl_player_stats(player_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#ushl_player_stats}
+
+USHL player season stats across all seasons.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `player_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `ushl_player_toi(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#ushl_player_toi}
+
+Per-player time-on-ice totals for a single USHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `ushl_schedule(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#ushl_schedule}
+
+USHL schedule — one row per game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `ushl_season_id(return_as_pandas: 'bool' = False) -> 'Any'` {#ushl_season_id}
+
+All USHL seasons with end-year + game-type labels.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `ushl_standings(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#ushl_standings}
+
+USHL standings — one row per team.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `ushl_team_roster(team_id: 'int', season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#ushl_team_roster}
+
+USHL team roster for a given team + season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `team_id` | `int` |  |  |
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `ushl_teams(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#ushl_teams}
+
+USHL teams for a given season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |

--- a/docs/docs/vijhl/_category_.json
+++ b/docs/docs/vijhl/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "VIJHL",
+  "position": 56,
+  "collapsed": true
+}

--- a/docs/docs/vijhl/index.md
+++ b/docs/docs/vijhl/index.md
@@ -1,0 +1,15 @@
+---
+title: VIJHL
+sidebar_label: VIJHL
+---
+# VIJHL (`sportsdataverse.vijhl`)
+
+| Reference | Functions | Base URL |
+|---|---:|---|
+| [Additional functions](reference/additional) | 14 | hand-written wrappers, loaders & helpers |
+
+## Examples
+
+Worked examples — executed notebooks rendered as pages (refreshed weekly against the live APIs):
+
+- [Quickstart](../tutorials/01_quickstart.md)

--- a/docs/docs/vijhl/reference/_category_.json
+++ b/docs/docs/vijhl/reference/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Reference",
+  "position": 1,
+  "collapsed": true
+}

--- a/docs/docs/vijhl/reference/additional.md
+++ b/docs/docs/vijhl/reference/additional.md
@@ -1,0 +1,171 @@
+---
+title: VIJHL — additional Python functions
+sidebar_label: Additional functions
+sidebar_position: 50
+---
+# VIJHL — additional Python functions
+
+Hand-written wrappers, loaders, and helpers in `sportsdataverse.vijhl`
+not covered by the generated API-endpoint reference above.
+
+## Utilities & helpers
+
+### `most_recent_vijhl_season() -> 'int'` {#most_recent_vijhl_season}
+
+Most-recent VIJHL season as an end-year integer (max `season_yr`), or 2026.
+
+## Other
+
+### `build_family(league: 'str') -> 'dict[str, Any]'` {#build_family}
+
+Return a dict of public callables for *league*.
+
+All callables are fully independent closures over the single `league`
+string; none share mutable state.  The dict is ready to be spread into
+a module namespace via `globals().update(...)`.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `league` | `str` |  | HockeyTech league code: `"ahl"`, `"ohl"`, `"whl"`, or `"qmjhl"`. |
+
+**Returns**
+
+Keys are the public function names (e.g. `"ahl_schedule"`).
+
+### `vijhl_game_corsi(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#vijhl_game_corsi}
+
+Player-level on-ice Corsi and Fenwick for a single VIJHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `vijhl_game_shifts(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#vijhl_game_shifts}
+
+Parsed shift stints for a single VIJHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `vijhl_game_summary(game_id: 'int') -> 'dict'` {#vijhl_game_summary}
+
+VIJHL game summary — dict of frames (game/goals/penalties/shots_by_period/three_stars).
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+
+### `vijhl_leaders(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#vijhl_leaders}
+
+VIJHL statistical leaders for a given season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `vijhl_pbp(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#vijhl_pbp}
+
+VIJHL play-by-play — one row per event, fully enriched.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `vijhl_player_stats(player_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#vijhl_player_stats}
+
+VIJHL player season stats across all seasons.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `player_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `vijhl_player_toi(game_id: 'int', return_as_pandas: 'bool' = False) -> 'Any'` {#vijhl_player_toi}
+
+Per-player time-on-ice totals for a single VIJHL game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `int` |  |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `vijhl_schedule(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#vijhl_schedule}
+
+VIJHL schedule — one row per game.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `vijhl_season_id(return_as_pandas: 'bool' = False) -> 'Any'` {#vijhl_season_id}
+
+All VIJHL seasons with end-year + game-type labels.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `vijhl_standings(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#vijhl_standings}
+
+VIJHL standings — one row per team.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `vijhl_team_roster(team_id: 'int', season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#vijhl_team_roster}
+
+VIJHL team roster for a given team + season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `team_id` | `int` |  |  |
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |
+
+### `vijhl_teams(season: 'Optional[int]' = None, season_id: 'Optional[int]' = None, return_as_pandas: 'bool' = False) -> 'Any'` {#vijhl_teams}
+
+VIJHL teams for a given season.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `Optional[int]` | `None` |  |
+| `season_id` | `Optional[int]` | `None` |  |
+| `return_as_pandas` | `bool` | `False` |  |

--- a/sportsdataverse/__init__.py
+++ b/sportsdataverse/__init__.py
@@ -83,6 +83,21 @@ from sportsdataverse.baseball.college_baseball import *  # noqa: F401,F403,E402
 from sportsdataverse.baseball.college_softball import *  # noqa: F401,F403,E402
 from sportsdataverse.hockey.mch import *  # noqa: F401,F403,E402
 from sportsdataverse.hockey.wch import *  # noqa: F401,F403,E402
+from sportsdataverse.hockey.echl import *  # noqa: F401,F403,E402
+from sportsdataverse.hockey.sphl import *  # noqa: F401,F403,E402
+from sportsdataverse.hockey.chl import *  # noqa: F401,F403,E402
+from sportsdataverse.hockey.ushl import *  # noqa: F401,F403,E402
+from sportsdataverse.hockey.bchl import *  # noqa: F401,F403,E402
+from sportsdataverse.hockey.ajhl import *  # noqa: F401,F403,E402
+from sportsdataverse.hockey.sjhl import *  # noqa: F401,F403,E402
+from sportsdataverse.hockey.ojhl import *  # noqa: F401,F403,E402
+from sportsdataverse.hockey.cchl import *  # noqa: F401,F403,E402
+from sportsdataverse.hockey.gojhl import *  # noqa: F401,F403,E402
+from sportsdataverse.hockey.mhl import *  # noqa: F401,F403,E402
+from sportsdataverse.hockey.nojhl import *  # noqa: F401,F403,E402
+from sportsdataverse.hockey.vijhl import *  # noqa: F401,F403,E402
+from sportsdataverse.hockey.kijhl import *  # noqa: F401,F403,E402
+from sportsdataverse.hockey.mjhl import *  # noqa: F401,F403,E402
 
 # Top-level QoL helpers (0.0.51+).
 #   * find_team / find_athlete / find_event — name-to-ID resolvers
@@ -144,6 +159,21 @@ _MOVED = {
     "ohl": "hockey.ohl",
     "qmjhl": "hockey.qmjhl",
     "whl": "hockey.whl",
+    "echl": "hockey.echl",
+    "sphl": "hockey.sphl",
+    "chl": "hockey.chl",
+    "ushl": "hockey.ushl",
+    "bchl": "hockey.bchl",
+    "ajhl": "hockey.ajhl",
+    "sjhl": "hockey.sjhl",
+    "ojhl": "hockey.ojhl",
+    "cchl": "hockey.cchl",
+    "gojhl": "hockey.gojhl",
+    "mhl": "hockey.mhl",
+    "nojhl": "hockey.nojhl",
+    "vijhl": "hockey.vijhl",
+    "kijhl": "hockey.kijhl",
+    "mjhl": "hockey.mjhl",
     "ufl": "football.ufl",
     "xfl": "football.xfl",
     "cfl": "football.cfl",

--- a/sportsdataverse/hockey/__init__.py
+++ b/sportsdataverse/hockey/__init__.py
@@ -4,3 +4,10 @@ from __future__ import annotations
 # as an attribute on this container module (0.0.65+).
 from sportsdataverse.hockey import ahl, mch, ohl, qmjhl  # noqa: F401,E402
 from sportsdataverse.hockey import wch, whl  # noqa: F401,E402
+
+# HockeyTech leagues promoted from the recon registry to the callable surface
+# (2026-07-12) — all live-verified, one shared parser. See hockeytech/_leagues.py.
+from sportsdataverse.hockey import echl, sphl, chl  # noqa: F401,E402
+from sportsdataverse.hockey import ushl, bchl, ajhl, sjhl, ojhl  # noqa: F401,E402
+from sportsdataverse.hockey import cchl, gojhl, mhl, nojhl  # noqa: F401,E402
+from sportsdataverse.hockey import vijhl, kijhl, mjhl  # noqa: F401,E402

--- a/sportsdataverse/hockey/__init__.py
+++ b/sportsdataverse/hockey/__init__.py
@@ -2,12 +2,9 @@ from __future__ import annotations
 
 # Sub-league packages — imported so ``sportsdataverse.hockey.<leaf>`` is reachable
 # as an attribute on this container module (0.0.65+).
-from sportsdataverse.hockey import ahl, mch, ohl, qmjhl  # noqa: F401,E402
-from sportsdataverse.hockey import wch, whl  # noqa: F401,E402
-
-# HockeyTech leagues promoted from the recon registry to the callable surface
-# (2026-07-12) — all live-verified, one shared parser. See hockeytech/_leagues.py.
-from sportsdataverse.hockey import echl, sphl, chl  # noqa: F401,E402
-from sportsdataverse.hockey import ushl, bchl, ajhl, sjhl, ojhl  # noqa: F401,E402
-from sportsdataverse.hockey import cchl, gojhl, mhl, nojhl  # noqa: F401,E402
-from sportsdataverse.hockey import vijhl, kijhl, mjhl  # noqa: F401,E402
+from sportsdataverse.hockey import ahl, ajhl, bchl, cchl  # noqa: F401,E402
+from sportsdataverse.hockey import chl, echl, gojhl, kijhl  # noqa: F401,E402
+from sportsdataverse.hockey import mch, mhl, mjhl, nojhl  # noqa: F401,E402
+from sportsdataverse.hockey import ohl, ojhl, qmjhl, sjhl  # noqa: F401,E402
+from sportsdataverse.hockey import sphl, ushl, vijhl, wch  # noqa: F401,E402
+from sportsdataverse.hockey import whl  # noqa: F401,E402

--- a/sportsdataverse/hockey/ajhl/__init__.py
+++ b/sportsdataverse/hockey/ajhl/__init__.py
@@ -1,0 +1,9 @@
+"""sportsdataverse.ajhl -- live AJHL HockeyTech wrappers (core set + analytics)."""
+
+from __future__ import annotations
+
+from sportsdataverse.hockeytech._family import build_family
+
+_family = build_family("ajhl")
+globals().update(_family)
+__all__ = list(_family)

--- a/sportsdataverse/hockey/bchl/__init__.py
+++ b/sportsdataverse/hockey/bchl/__init__.py
@@ -1,0 +1,9 @@
+"""sportsdataverse.bchl -- live BCHL HockeyTech wrappers (core set + analytics)."""
+
+from __future__ import annotations
+
+from sportsdataverse.hockeytech._family import build_family
+
+_family = build_family("bchl")
+globals().update(_family)
+__all__ = list(_family)

--- a/sportsdataverse/hockey/cchl/__init__.py
+++ b/sportsdataverse/hockey/cchl/__init__.py
@@ -1,0 +1,9 @@
+"""sportsdataverse.cchl -- live CCHL HockeyTech wrappers (core set + analytics)."""
+
+from __future__ import annotations
+
+from sportsdataverse.hockeytech._family import build_family
+
+_family = build_family("cchl")
+globals().update(_family)
+__all__ = list(_family)

--- a/sportsdataverse/hockey/chl/__init__.py
+++ b/sportsdataverse/hockey/chl/__init__.py
@@ -1,0 +1,9 @@
+"""sportsdataverse.chl -- live CHL HockeyTech wrappers (core set + analytics)."""
+
+from __future__ import annotations
+
+from sportsdataverse.hockeytech._family import build_family
+
+_family = build_family("chl")
+globals().update(_family)
+__all__ = list(_family)

--- a/sportsdataverse/hockey/echl/__init__.py
+++ b/sportsdataverse/hockey/echl/__init__.py
@@ -1,0 +1,9 @@
+"""sportsdataverse.echl -- live ECHL HockeyTech wrappers (core set + analytics)."""
+
+from __future__ import annotations
+
+from sportsdataverse.hockeytech._family import build_family
+
+_family = build_family("echl")
+globals().update(_family)
+__all__ = list(_family)

--- a/sportsdataverse/hockey/gojhl/__init__.py
+++ b/sportsdataverse/hockey/gojhl/__init__.py
@@ -1,0 +1,9 @@
+"""sportsdataverse.gojhl -- live GOJHL HockeyTech wrappers (core set + analytics)."""
+
+from __future__ import annotations
+
+from sportsdataverse.hockeytech._family import build_family
+
+_family = build_family("gojhl")
+globals().update(_family)
+__all__ = list(_family)

--- a/sportsdataverse/hockey/kijhl/__init__.py
+++ b/sportsdataverse/hockey/kijhl/__init__.py
@@ -1,0 +1,9 @@
+"""sportsdataverse.kijhl -- live KIJHL HockeyTech wrappers (core set + analytics)."""
+
+from __future__ import annotations
+
+from sportsdataverse.hockeytech._family import build_family
+
+_family = build_family("kijhl")
+globals().update(_family)
+__all__ = list(_family)

--- a/sportsdataverse/hockey/mhl/__init__.py
+++ b/sportsdataverse/hockey/mhl/__init__.py
@@ -1,0 +1,9 @@
+"""sportsdataverse.mhl -- live MHL HockeyTech wrappers (core set + analytics)."""
+
+from __future__ import annotations
+
+from sportsdataverse.hockeytech._family import build_family
+
+_family = build_family("mhl")
+globals().update(_family)
+__all__ = list(_family)

--- a/sportsdataverse/hockey/mjhl/__init__.py
+++ b/sportsdataverse/hockey/mjhl/__init__.py
@@ -1,0 +1,9 @@
+"""sportsdataverse.mjhl -- live MJHL HockeyTech wrappers (core set + analytics)."""
+
+from __future__ import annotations
+
+from sportsdataverse.hockeytech._family import build_family
+
+_family = build_family("mjhl")
+globals().update(_family)
+__all__ = list(_family)

--- a/sportsdataverse/hockey/nojhl/__init__.py
+++ b/sportsdataverse/hockey/nojhl/__init__.py
@@ -1,0 +1,9 @@
+"""sportsdataverse.nojhl -- live NOJHL HockeyTech wrappers (core set + analytics)."""
+
+from __future__ import annotations
+
+from sportsdataverse.hockeytech._family import build_family
+
+_family = build_family("nojhl")
+globals().update(_family)
+__all__ = list(_family)

--- a/sportsdataverse/hockey/ojhl/__init__.py
+++ b/sportsdataverse/hockey/ojhl/__init__.py
@@ -1,0 +1,9 @@
+"""sportsdataverse.ojhl -- live OJHL HockeyTech wrappers (core set + analytics)."""
+
+from __future__ import annotations
+
+from sportsdataverse.hockeytech._family import build_family
+
+_family = build_family("ojhl")
+globals().update(_family)
+__all__ = list(_family)

--- a/sportsdataverse/hockey/sjhl/__init__.py
+++ b/sportsdataverse/hockey/sjhl/__init__.py
@@ -1,0 +1,9 @@
+"""sportsdataverse.sjhl -- live SJHL HockeyTech wrappers (core set + analytics)."""
+
+from __future__ import annotations
+
+from sportsdataverse.hockeytech._family import build_family
+
+_family = build_family("sjhl")
+globals().update(_family)
+__all__ = list(_family)

--- a/sportsdataverse/hockey/sphl/__init__.py
+++ b/sportsdataverse/hockey/sphl/__init__.py
@@ -1,0 +1,9 @@
+"""sportsdataverse.sphl -- live SPHL HockeyTech wrappers (core set + analytics)."""
+
+from __future__ import annotations
+
+from sportsdataverse.hockeytech._family import build_family
+
+_family = build_family("sphl")
+globals().update(_family)
+__all__ = list(_family)

--- a/sportsdataverse/hockey/ushl/__init__.py
+++ b/sportsdataverse/hockey/ushl/__init__.py
@@ -1,0 +1,9 @@
+"""sportsdataverse.ushl -- live USHL HockeyTech wrappers (core set + analytics)."""
+
+from __future__ import annotations
+
+from sportsdataverse.hockeytech._family import build_family
+
+_family = build_family("ushl")
+globals().update(_family)
+__all__ = list(_family)

--- a/sportsdataverse/hockey/vijhl/__init__.py
+++ b/sportsdataverse/hockey/vijhl/__init__.py
@@ -1,0 +1,9 @@
+"""sportsdataverse.vijhl -- live VIJHL HockeyTech wrappers (core set + analytics)."""
+
+from __future__ import annotations
+
+from sportsdataverse.hockeytech._family import build_family
+
+_family = build_family("vijhl")
+globals().update(_family)
+__all__ = list(_family)

--- a/sportsdataverse/hockeytech/_leagues.py
+++ b/sportsdataverse/hockeytech/_leagues.py
@@ -11,7 +11,28 @@ import os
 from dataclasses import dataclass
 from typing import Dict, Literal, Optional
 
-LeagueCode = Literal["pwhl", "ahl", "ohl", "whl", "qmjhl"]
+LeagueCode = Literal[
+    "pwhl",
+    "ahl",
+    "ohl",
+    "whl",
+    "qmjhl",
+    "echl",
+    "sphl",
+    "chl",
+    "ushl",
+    "bchl",
+    "ajhl",
+    "sjhl",
+    "ojhl",
+    "cchl",
+    "gojhl",
+    "mhl",
+    "nojhl",
+    "vijhl",
+    "kijhl",
+    "mjhl",
+]
 
 
 @dataclass(frozen=True)
@@ -30,11 +51,39 @@ _LSCLUSTER = "https://lscluster.hockeytech.com/feed/index.php"
 _LEAGUESTAT = "https://cluster.leaguestat.com/feed/index.php"
 
 LEAGUES: Dict[str, LeagueConfig] = {
+    # Verified live 2026-07-12 (all 20 respond on lscluster.hockeytech.com; seasons +
+    # scorebar schemas are byte-identical across every league). league_id for the
+    # single-league clients is 1 (standings-verified live); pbp_style for the leagues
+    # added in this pass defaults to "hockeytech_b" (small ~600x300 canvas — the
+    # junior/lower-pro majority; ECHL's small canvas was observed directly). Determine
+    # a league's true canvas with one gameCenterPlayByPlay coordinate-range probe and
+    # flip to "hockeytech_a" if it ships the ~850x400 canvas.
+    # -- flagship / already-shipped (league_id + pbp_style curated) --
     "pwhl": LeagueConfig("PWHL", "pwhl", "446521baf8c38984", 1, 0, _LSCLUSTER, "hockeytech_a", 600),
     "ahl": LeagueConfig("AHL", "ahl", "ccb91f29d6744675", 4, 3, _LSCLUSTER, "hockeytech_a", 300),
     "ohl": LeagueConfig("OHL", "ohl", "f1aa699db3d81487", 1, 1, _LSCLUSTER, "hockeytech_b", 300),
     "whl": LeagueConfig("WHL", "whl", "f1aa699db3d81487", 7, 0, _LSCLUSTER, "hockeytech_b", 300),
     "qmjhl": LeagueConfig("QMJHL", "lhjmq", "f322673b6bcae299", 6, 0, _LEAGUESTAT, "hockeytech_b", 300),
+    # -- professional / major (added 2026-07-12) --
+    "echl": LeagueConfig("ECHL", "echl", "2c2b89ea7345cae8", 1, 0, _LSCLUSTER, "hockeytech_b", 300),
+    "sphl": LeagueConfig("SPHL", "sphl", "8fa10d218c49ec96", 1, 0, _LSCLUSTER, "hockeytech_b", 300),
+    "chl": LeagueConfig("CHL", "chl", "ef96ea7d71574f2a", 1, 0, _LSCLUSTER, "hockeytech_b", 300),
+    # -- junior (added 2026-07-12) --
+    # ushl: gameCenterPlayByPlay ships goals/penalties/goalie-changes only, no coordinates.
+    "ushl": LeagueConfig("USHL", "ushl", "e828f89b243dc43f", 1, 0, _LSCLUSTER, "hockeytech_b", 300),
+    "bchl": LeagueConfig("BCHL", "bchl", "f3ed30007ad2124e", 1, 0, _LSCLUSTER, "hockeytech_b", 300),
+    "ajhl": LeagueConfig("AJHL", "ajhl", "cbe60a1d91c44ade", 1, 0, _LSCLUSTER, "hockeytech_b", 300),
+    "sjhl": LeagueConfig("SJHL", "sjhl", "2fb5c2e84bf3e4a8", 1, 0, _LSCLUSTER, "hockeytech_b", 300),
+    "ojhl": LeagueConfig("OJHL", "ojhl", "cce66dd6bebf4790", 1, 0, _LSCLUSTER, "hockeytech_b", 300),
+    "cchl": LeagueConfig("CCHL", "cchl", "b370f3e6c805baf3", 1, 0, _LSCLUSTER, "hockeytech_b", 300),
+    "gojhl": LeagueConfig("GOJHL", "gojhl", "34b10d4d34d7b59a", 1, 0, _LSCLUSTER, "hockeytech_b", 300),
+    "mhl": LeagueConfig("MHL", "mhl", "4a948e7faf5ee58d", 1, 0, _LSCLUSTER, "hockeytech_b", 300),
+    "nojhl": LeagueConfig("NOJHL", "nojhl", "c1375ff55168bd71", 1, 0, _LSCLUSTER, "hockeytech_b", 300),
+    "vijhl": LeagueConfig("VIJHL", "vijhl", "4f1a61df18906b61", 1, 0, _LSCLUSTER, "hockeytech_b", 300),
+    "kijhl": LeagueConfig("KIJHL", "kijhl", "2589e0f644b1bb71", 1, 0, _LSCLUSTER, "hockeytech_b", 300),
+    # mjhl: seasons/scorebar/standings work; its public key has NO gamecenter access,
+    # so <lg>_pbp / <lg>_game_summary come back empty for MJHL (graceful, not an error).
+    "mjhl": LeagueConfig("MJHL", "mjhl", "f894c324fe5fd8f0", 1, 0, _LSCLUSTER, "hockeytech_b", 300),
 }
 
 # gameCenterPlayByPlay uses a distinct key on the statviewfeed PBP view for PWHL

--- a/tests/hockeytech/test_league_families.py
+++ b/tests/hockeytech/test_league_families.py
@@ -19,7 +19,28 @@ import pytest
 
 from tests.conftest import load_fixture
 
-LEAGUES = ["ahl", "ohl", "whl", "qmjhl"]
+LEAGUES = [
+    "ahl",
+    "ohl",
+    "whl",
+    "qmjhl",
+    # promoted 2026-07-12 — same shared parser, driven by the pwhl_* fixtures
+    "echl",
+    "sphl",
+    "chl",
+    "ushl",
+    "bchl",
+    "ajhl",
+    "sjhl",
+    "ojhl",
+    "cchl",
+    "gojhl",
+    "mhl",
+    "nojhl",
+    "vijhl",
+    "kijhl",
+    "mjhl",
+]
 
 # HockeyTech ``view`` -> captured fixture stem. ``resolve_season_id`` fans out to
 # the ``seasons`` view, so every season-aware wrapper needs that mapping too.

--- a/tests/hockeytech/test_leagues.py
+++ b/tests/hockeytech/test_leagues.py
@@ -1,10 +1,44 @@
 from __future__ import annotations
 
 
-def test_leagues_registry_has_five_hockeytech_leagues():
+def test_leagues_registry_has_all_verified_hockeytech_leagues():
     from sportsdataverse.hockeytech import LEAGUES
 
-    assert set(LEAGUES) == {"pwhl", "ahl", "ohl", "whl", "qmjhl"}
+    assert set(LEAGUES) == {
+        "pwhl",
+        "ahl",
+        "ohl",
+        "whl",
+        "qmjhl",
+        "echl",
+        "sphl",
+        "chl",
+        "ushl",
+        "bchl",
+        "ajhl",
+        "sjhl",
+        "ojhl",
+        "cchl",
+        "gojhl",
+        "mhl",
+        "nojhl",
+        "vijhl",
+        "kijhl",
+        "mjhl",
+    }
+
+
+def test_new_leagues_use_single_league_client_defaults():
+    from sportsdataverse.hockeytech import LEAGUES
+
+    # The 15 leagues promoted 2026-07-12 are single-league clients: league_id=1,
+    # site_id=0, small-canvas pbp dialect (standings-verified live).
+    for lg in ("echl", "sphl", "chl", "ushl", "bchl", "cchl", "kijhl", "mjhl"):
+        cfg = LEAGUES[lg]
+        assert cfg.league_id == 1
+        assert cfg.site_id == 0
+        assert cfg.pbp_style == "hockeytech_b"
+        assert "lscluster.hockeytech.com" in cfg.base_url
 
 
 def test_pwhl_config_matches_known_values():

--- a/tests/test_namespace_backcompat.py
+++ b/tests/test_namespace_backcompat.py
@@ -50,7 +50,31 @@ def test_moved_map_matches_grouped_leagues():
 
     cfg = spec.load_leagues(Path("tools/codegen/endpoints/leagues.yaml"))
     grouped = {lg.prefix: f"{lg.group}.{lg.prefix}" for lg in cfg.leagues if lg.group}
-    hand_moved = {"ahl": "hockey.ahl", "ohl": "hockey.ohl", "qmjhl": "hockey.qmjhl", "whl": "hockey.whl"}
+    # Hand-wired HockeyTech leagues (not ESPN codegen leagues) live under hockey.*.
+    hand_moved = {
+        lg: f"hockey.{lg}"
+        for lg in (
+            "ahl",
+            "ohl",
+            "qmjhl",
+            "whl",
+            "echl",
+            "sphl",
+            "chl",
+            "ushl",
+            "bchl",
+            "ajhl",
+            "sjhl",
+            "ojhl",
+            "cchl",
+            "gojhl",
+            "mhl",
+            "nojhl",
+            "vijhl",
+            "kijhl",
+            "mjhl",
+        )
+    }
     expected = {**grouped, **hand_moved}
     assert sportsdataverse._MOVED == expected, (
         f"_MOVED drifted from grouped leagues.yaml: "

--- a/tools/codegen/generate.py
+++ b/tools/codegen/generate.py
@@ -1603,12 +1603,41 @@ def _container_init_body(group: str, members: list[str], has_ext: bool) -> str:
     return "\n".join(lines)
 
 
+# The hand-written HockeyTech junior/minor league modules under
+# ``sportsdataverse.hockey.*`` (PWHL is separate — it lives at the top level with a
+# richer loader surface). SINGLE SOURCE OF TRUTH: every codegen list that enumerates
+# these leagues references this, so promoting a league (a hockeytech/_leagues.py entry
+# + a hockey/<lg>/ module) only needs it added HERE — no per-list drift.
+_HOCKEYTECH_MODULE_LEAGUES = [
+    "ahl",
+    "ohl",
+    "whl",
+    "qmjhl",
+    "echl",
+    "sphl",
+    "chl",
+    "ushl",
+    "bchl",
+    "ajhl",
+    "sjhl",
+    "ojhl",
+    "cchl",
+    "gojhl",
+    "mhl",
+    "nojhl",
+    "vijhl",
+    "kijhl",
+    "mjhl",
+]
+
+
 def _container_groups(groups_map: dict[str, str]) -> dict[str, list[str]]:
     """Build group → sorted-members mapping from the prefix→group dict.
 
-    Includes HockeyTech hand-written modules (ahl/ohl/whl/qmjhl) under hockey.
+    Includes the hand-written HockeyTech modules (``_HOCKEYTECH_MODULE_LEAGUES``)
+    under hockey.
     """
-    _HOCKEYTECH = ["ahl", "ohl", "qmjhl", "whl"]
+    _HOCKEYTECH = _HOCKEYTECH_MODULE_LEAGUES
     result: dict[str, list[str]] = {}
     for prefix, group in groups_map.items():
         if not group:
@@ -1742,22 +1771,14 @@ _COVERAGE_LEAGUES = [
     "mlb",
     "nhl",
     "pwhl",
-    "ahl",
-    "ohl",
-    "whl",
-    "qmjhl",
+    *_HOCKEYTECH_MODULE_LEAGUES,  # ahl/ohl/whl/qmjhl + the promoted junior/minor leagues
     "odds",
 ]
 
 # Mapping from doc/coverage prefix to actual Python module path for leagues
 # whose module moved under a sport-group container (Task 5+).
 # All other leagues default to f"sportsdataverse.{prefix}".
-_LEAGUE_MODULE: dict[str, str] = {
-    "ahl": "hockey.ahl",
-    "ohl": "hockey.ohl",
-    "whl": "hockey.whl",
-    "qmjhl": "hockey.qmjhl",
-}
+_LEAGUE_MODULE: dict[str, str] = {lg: f"hockey.{lg}" for lg in _HOCKEYTECH_MODULE_LEAGUES}
 
 _COVERAGE_ALLOWLIST_FILE = ROOT / "tools" / "codegen" / "coverage_allowlist.yaml"
 
@@ -3127,7 +3148,7 @@ def _doc_leagues() -> list[str]:
     prefixes = [lg.prefix for lg in cfg.leagues]
     extra = sorted({ld.league for ld in rel.loaders} - set(prefixes))
     # HockeyTech junior leagues have hand-written modules but no ESPN/loader entries.
-    _HOCKEYTECH_EXTRA = ["ahl", "ohl", "whl", "qmjhl"]
+    _HOCKEYTECH_EXTRA = _HOCKEYTECH_MODULE_LEAGUES
     # Cross-sport hand-written modules that get their own docs scope but have no
     # ESPN/loader entries (e.g. the The Odds API wrappers in sportsdataverse.odds).
     _NONLEAGUE_EXTRA = ["odds"]


### PR DESCRIPTION
## What

Expand the HockeyTech `LEAGUES` registry from **5 → 20**, promoting the 15 leagues that were verified live in the recon (`sdv-internal-refs/hockeytech/`) but never wired into the callable surface: **ECHL, SPHL, CHL, USHL, BCHL, AJHL, SJHL, OJHL, CCHL, GOJHL, MHL, NOJHL, VIJHL, KIJHL, MJHL**.

A 2026-07-12 sweep confirmed **20/20 live** with **byte-identical `seasons`/`scorebar` schemas** across every league, so each new league mints its 13 `<lg>_*` wrappers via `build_family` with **no new parser code**.

```python
import sportsdataverse as sdv
sdv.echl_schedule(season=2026)      # one row per game
sdv.ushl_standings(season=2025)     # one row per team
sdv.bchl_pbp(game_id=9149)          # enriched play-by-play
```

## Details

- `league_id=1` for every single-league client (standings-verified via `statviewfeed/teams`); the scorebar-row `league_id` is a **different namespace** and must not be used for standings.
- New pbp leagues default `pbp_style="hockeytech_b"` (small ~600×300 canvas — the junior/lower-pro majority; ECHL's small canvas was observed directly). Flip to `_a` after a `gameCenterPlayByPlay` coordinate-range probe.
- **USHL** ships no pbp coordinates (goals/penalties/goalie changes only); **MJHL**'s public key has no gamecenter access (`<lg>_pbp`/`<lg>_game_summary` return empty, gracefully).
- Adds the previously-absent **"Hockey — HockeyTech multi-league"** section to `CLAUDE.md`.

## Tests

- `test_leagues` registry set 5→20; new single-league-defaults assertion.
- `test_league_families` parametrized over all 19 minor/junior leagues (shared `pwhl_*` fixtures).
- `test_namespace_backcompat` `hand_moved` set extended to the 19 hand-wired hockey leagues.
- **305 tests pass, ruff clean, uv.lock untouched.**

Full live/dead + schema accounting: `sdv-internal-refs/hockeytech/ACCOUNTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HockeyTech support for 15 additional hockey leagues spanning minor, junior, and professional competitions.
  * Exposed consistent access to schedules, play-by-play, standings, teams, rosters, player statistics, leaders, and advanced analytics across supported leagues.
  * Added league-specific configuration for seasons, scoring, overtime, and data access.

* **Documentation**
  * Added guidance covering supported leagues, available data, configuration, and known play-by-play considerations.

* **Compatibility**
  * Preserved legacy import paths while adding grouped hockey league access.

* **Tests**
  * Expanded automated coverage across the complete HockeyTech league registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->