### PR TITLE
fix(wbb)!: emit play id as Int64 in helper_wbb_play_by_play

### DIFF
--- a/sportsdataverse/wbb/wbb_play_by_play.py
+++ b/sportsdataverse/wbb/wbb_play_by_play.py
@@ -9,10 +9,11 @@ release. NOT the same lineage as ``wbb_pbp.helper_wbb_pbp`` (the interactive
 ``espn_wbb_pbp`` pipeline) -- this is the release-parity producer.
 
 The R-released parquet is the parity oracle: dtypes and column order mirror it
-exactly (R integer == Int32; play ``id`` is R numeric == Float64). The four
-``coordinate_*`` columns the creation script appends as season-level NA
-fallback when a season ships no coordinates are added here per-game (identical
-union outcome, no season-level special case needed).
+exactly (R integer == Int32), with ONE deliberate dtype improvement -- the play
+``id`` is emitted Int64, not R's precision-losing Float64 (see ``_INT64_COLS``).
+The four ``coordinate_*`` columns the creation script appends as season-level
+NA fallback when a season ships no coordinates are added here per-game
+(identical union outcome, no season-level special case needed).
 
 Documented deviations from R (both on compat paths current payloads skip):
 the R away-first ``id_vars`` branch plucks the DARK logo for ``homeTeamLogo``
@@ -69,7 +70,6 @@ _INT32_COLS: tuple[str, ...] = (
     "points_attempted",
 )
 _FLOAT64_COLS: tuple[str, ...] = (
-    "id",
     "game_spread",
     "home_team_spread",
     "coordinate_x_raw",
@@ -77,6 +77,11 @@ _FLOAT64_COLS: tuple[str, ...] = (
     "coordinate_x",
     "coordinate_y",
 )
+# DELIBERATE divergence from the R releases: R/jsonlite has no int64, so the
+# published `id` is Float64 and LOSES PRECISION above 2^53 -- adjacent play ids
+# (~4e17) round to the same double and collide. The stored payload carries the
+# id as a true integer, so the Python producer emits Int64 and keeps it exact.
+_INT64_COLS: tuple[str, ...] = ("id",)
 
 _COORD_COLS: tuple[str, ...] = (
     "coordinate_x_raw",
@@ -258,8 +263,9 @@ def helper_wbb_play_by_play(final: dict) -> pl.DataFrame:
     if not has_coords:
         df = df.with_columns([pl.lit(None, dtype=pl.Float64).alias(c) for c in _COORD_COLS])
 
-    # Released dtype contract.
+    # Released dtype contract (except `id` -- see _INT64_COLS).
     return df.with_columns(
         [pl.col(c).cast(pl.Int32, strict=False) for c in _INT32_COLS if c in df.columns]
+        + [pl.col(c).cast(pl.Int64, strict=False) for c in _INT64_COLS if c in df.columns]
         + [pl.col(c).cast(pl.Float64, strict=False) for c in _FLOAT64_COLS if c in df.columns]
     )


### PR DESCRIPTION
Follow-up to #243 (merged while this was in flight).

R/jsonlite has no int64, so the released pbp `id` is Float64 and loses precision above 2^53 — adjacent ~4e17 play ids round to the same double and **collide** (verified: multiple plays per game share an id in the released assets). The stored payload carries a true integer, so the Python producer now emits exact Int64.

This is a deliberate dtype divergence from the R releases, pinned by the parity suite's new `dtype_upgrades` gate in wehoop-wbb-data (dtypes asserted as exactly Int64-vs-Float64, values still compared equal under the oracle's lossy Float64 view — so unintended drift can't hide behind the exemption).

Verification: full sdv-py suite 4,186 passed in this tree; wehoop-wbb-data parity suite 41 passed; fixture game 401804834 yields 447/447 unique ids (Float64 collided). ruff/mypy/codegen --check clean.

BREAKING CHANGE: `id` in Python-produced play_by_play frames is Int64 (was Float64 in R-produced releases).