### PR TITLE
feat(pwhl): T5 Phase 3 — shift-derived xG features (rebound + strength dummies)

### DIFF
--- a/sportsdataverse/pwhl/pwhl_xg_proxy.py
+++ b/sportsdataverse/pwhl/pwhl_xg_proxy.py
@@ -325,8 +325,11 @@ def _build_xg_features(
             is_home=home.cast(pl.Int64),
             is_pp=(sk_for > sk_opp).fill_null(False).cast(pl.Int64),
             is_sh=(sk_for < sk_opp).fill_null(False).cast(pl.Int64),
+            # defending team shows >=6 skaters => their goalie is pulled => the
+            # shooter faces an empty net (the booster's `empty_net`; PWHL's SH gap).
+            empty_net_for=(sk_opp >= 6).fill_null(False).cast(pl.Int64),
         )
-        avail += ["is_home", "is_pp", "is_sh"]
+        avail += ["is_home", "is_pp", "is_sh", "empty_net_for"]
     feats = list(want) if want is not None else avail
     mats = [(f[c].cast(pl.Float64).fill_null(0.0).to_numpy() if c in f.columns else np.zeros(f.height)) for c in feats]
     return np.column_stack(mats), tuple(feats), f
@@ -397,8 +400,9 @@ def fit_pwhl_coord_xg(pbp: pl.DataFrame) -> PwhlCoordXGModel:
     geometry sourced from the HockeyTech core instead of the NHL api-web one.
     PWHL pbp has no ``shot_type`` column. When the frame carries the R4
     strength + clock columns the fit ALSO uses ``rebound`` / ``is_home`` /
-    ``is_pp`` / ``is_sh`` (T5 Phase 3, LOSO-validated to lift PP/SH AUC ~+0.02
-    with calibration held); a legacy frame without them degrades to
+    ``is_pp`` / ``is_sh`` / ``empty_net_for`` (T5 Phase 3, LOSO-validated to lift
+    PP/SH AUC; ``empty_net_for`` = defending team shows >=6 skaters => goalie
+    pulled => shooter faces an empty net); a legacy frame without them degrades to
     distance/angle only (see :func:`_build_xg_features`; the fitted set is on
     :attr:`PwhlCoordXGModel.features`). Rows with null coordinates are excluded
     from the fit (~100%

--- a/sportsdataverse/pwhl/pwhl_xg_proxy.py
+++ b/sportsdataverse/pwhl/pwhl_xg_proxy.py
@@ -330,6 +330,20 @@ def _build_xg_features(
             empty_net_for=(sk_opp >= 6).fill_null(False).cast(pl.Int64),
         )
         avail += ["is_home", "is_pp", "is_sh", "empty_net_for"]
+    if "event_type" in f.columns:
+        # Shot type -- PWHL's `event_type` on shot rows IS the shot type
+        # (Wrist/Snap/Slap/Backhand/Tip; "Default" => all zero). The NHL booster's
+        # shot-type one-hots, derived for free from the feed (T5 Phase 4). Self-
+        # contained (no prior-event context), so safe on the shots-only predict path.
+        et = pl.col("event_type")
+        f = f.with_columns(
+            is_wrist=(et == "Wrist").cast(pl.Int64),
+            is_snap=(et == "Snap").cast(pl.Int64),
+            is_slap=(et == "Slap").cast(pl.Int64),
+            is_backhand=(et == "Backhand").cast(pl.Int64),
+            is_tip=(et == "Tip").cast(pl.Int64),
+        )
+        avail += ["is_wrist", "is_snap", "is_slap", "is_backhand", "is_tip"]
     feats = list(want) if want is not None else avail
     mats = [(f[c].cast(pl.Float64).fill_null(0.0).to_numpy() if c in f.columns else np.zeros(f.height)) for c in feats]
     return np.column_stack(mats), tuple(feats), f

--- a/sportsdataverse/pwhl/pwhl_xg_proxy.py
+++ b/sportsdataverse/pwhl/pwhl_xg_proxy.py
@@ -93,7 +93,7 @@ from __future__ import annotations
 
 import datetime as _dt
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal, Union, overload
+from typing import TYPE_CHECKING, Any, Literal, Union, overload
 
 import pandas as pd
 import polars as pl
@@ -278,27 +278,87 @@ def _shot_geometry(frame: pl.DataFrame) -> pl.DataFrame:
     return add_shot_distance_angle(f)
 
 
+_XG_BASE_FEATURES = ("shot_distance", "shot_angle")
+
+
+def _build_xg_features(
+    shots: pl.DataFrame, want: tuple[str, ...] | None = None
+) -> tuple[Any, tuple[str, ...], pl.DataFrame]:
+    """Build the xG feature matrix (row-order preserved) + the feature names used.
+
+    Always includes ``shot_distance`` / ``shot_angle``. When the source columns
+    are present it ALSO adds (T5 Phase 3, LOSO-validated to lift PP/SH AUC):
+
+    - ``rebound`` -- shot within 3s of the prior shot in the game (needs
+      ``game_id`` + ``sec_from_start``).
+    - ``is_home`` / ``is_pp`` / ``is_sh`` -- shooter-relative home flag and
+      power-play/short-handed dummies (needs ``team_id`` + ``home_team_id`` +
+      ``skaters_home`` / ``skaters_away``, i.e. the R4 strength columns).
+
+    A frame that lacks those columns (e.g. the legacy xG fixture, or a pre-R4
+    pbp) degrades to the 2-feature distance/angle model unchanged. At predict
+    time pass ``want`` (the fitted feature tuple) so columns line up; any column
+    the frame lacks is filled with 0 (neutral). Returns ``(matrix, names, f)``
+    where ``f`` retains null ``shot_distance`` for the caller's null-geometry mask.
+    """
+    import numpy as np
+
+    f = _shot_geometry(shots).with_row_index("_ri")
+    avail = list(_XG_BASE_FEATURES)
+    if {"game_id", "sec_from_start"}.issubset(f.columns):
+        f = (
+            f.sort(["game_id", "sec_from_start"])
+            .with_columns(
+                rebound=(pl.col("sec_from_start") - pl.col("sec_from_start").shift(1).over("game_id"))
+                .is_between(0, 3)
+                .fill_null(False)
+                .cast(pl.Int64)
+            )
+            .sort("_ri")
+        )
+        avail.append("rebound")
+    if {"team_id", "home_team_id", "skaters_home", "skaters_away"}.issubset(f.columns):
+        home = pl.col("team_id") == pl.col("home_team_id")
+        sk_for = pl.when(home).then(pl.col("skaters_home")).otherwise(pl.col("skaters_away"))
+        sk_opp = pl.when(home).then(pl.col("skaters_away")).otherwise(pl.col("skaters_home"))
+        f = f.with_columns(
+            is_home=home.cast(pl.Int64),
+            is_pp=(sk_for > sk_opp).fill_null(False).cast(pl.Int64),
+            is_sh=(sk_for < sk_opp).fill_null(False).cast(pl.Int64),
+        )
+        avail += ["is_home", "is_pp", "is_sh"]
+    feats = list(want) if want is not None else avail
+    mats = [(f[c].cast(pl.Float64).fill_null(0.0).to_numpy() if c in f.columns else np.zeros(f.height)) for c in feats]
+    return np.column_stack(mats), tuple(feats), f
+
+
 @dataclass(frozen=True)
 class PwhlCoordXGModel:
     """A fitted (or fallback constant-rate) PWHL coordinate xG model.
 
     Args:
         model: Fitted :class:`sklearn.linear_model.LogisticRegression` on
-            ``[shot_distance, shot_angle]``, or ``None`` when the fallback
-            constant-rate path was used (insufficient shots to fit).
+            :attr:`features`, or ``None`` when the fallback constant-rate path
+            was used (insufficient shots to fit).
         fallback_rate: Constant goal rate returned by :meth:`predict` when
             ``model`` is ``None``, and for rows whose coordinates are null.
+        features: The feature names the model was fit on -- ``shot_distance`` /
+            ``shot_angle`` plus, when the source pbp carried the R4 strength +
+            clock columns, ``rebound`` / ``is_home`` / ``is_pp`` / ``is_sh``
+            (T5 Phase 3). :meth:`predict` rebuilds exactly these.
     """
 
     model: LogisticRegression | None
     fallback_rate: float
+    features: tuple[str, ...] = _XG_BASE_FEATURES
 
     def predict(self, shots: pl.DataFrame) -> pl.Series:
         """Predict shot xG for each row of ``shots``.
 
         Args:
             shots: Frame with ``x_coord``/``y_coord`` (rink-feet) or
-                pre-computed ``shot_distance``/``shot_angle`` columns.
+                pre-computed ``shot_distance``/``shot_angle`` columns (plus the
+                R4 strength/clock columns when :attr:`features` includes them).
 
         Returns:
             A ``pl.Series`` named ``"xg"`` of per-row goal probability. Rows
@@ -315,11 +375,10 @@ class PwhlCoordXGModel:
             return pl.Series("xg", [], dtype=pl.Float64)
         if self.model is None:
             return pl.Series("xg", [self.fallback_rate] * shots.height, dtype=pl.Float64)
-        feat = _shot_geometry(shots)
-        dist, angle = feat["shot_distance"], feat["shot_angle"]
-        x = np.column_stack([dist.fill_null(0.0).to_numpy(), angle.fill_null(0.0).to_numpy()])
+        x, _, f = _build_xg_features(shots, want=self.features)
         proba = self.model.predict_proba(x)[:, 1]
-        out = np.where(dist.is_null().to_numpy(), self.fallback_rate, proba)
+        null_geo = f["shot_distance"].is_null().to_numpy()
+        out = np.where(null_geo, self.fallback_rate, proba)
         return pl.Series("xg", out, dtype=pl.Float64)
 
 
@@ -336,8 +395,13 @@ def fit_pwhl_coord_xg(pbp: pl.DataFrame) -> PwhlCoordXGModel:
     goal indicator as the label -- the same fit-at-call-time recipe as
     :func:`sportsdataverse.nhl.nhl_microstat_constants.fit_shot_xg`, with the
     geometry sourced from the HockeyTech core instead of the NHL api-web one.
-    PWHL pbp has no ``shot_type`` column, so the model is distance/angle
-    only. Rows with null coordinates are excluded from the fit (~100%
+    PWHL pbp has no ``shot_type`` column. When the frame carries the R4
+    strength + clock columns the fit ALSO uses ``rebound`` / ``is_home`` /
+    ``is_pp`` / ``is_sh`` (T5 Phase 3, LOSO-validated to lift PP/SH AUC ~+0.02
+    with calibration held); a legacy frame without them degrades to
+    distance/angle only (see :func:`_build_xg_features`; the fitted set is on
+    :attr:`PwhlCoordXGModel.features`). Rows with null coordinates are excluded
+    from the fit (~100%
     coverage in the captured seasons, so this drops almost nothing). Fewer
     than :data:`_MIN_COORD_SHOTS` qualifying shots -- or a frame with no
     coordinate columns at all -- falls back to a constant-rate model at the
@@ -387,15 +451,14 @@ def fit_pwhl_coord_xg(pbp: pl.DataFrame) -> PwhlCoordXGModel:
         goal_rate = float(shots["goal"].cast(pl.Float64).mean() or 0.0) if shots.height else 0.0
         return PwhlCoordXGModel(model=None, fallback_rate=goal_rate)
 
-    feat = _shot_geometry(shots)
-    x = np.column_stack([feat["shot_distance"].to_numpy(), feat["shot_angle"].to_numpy()])
-    y = feat["goal"].cast(pl.Int64).to_numpy()
+    x, feats, _ = _build_xg_features(shots)
+    y = shots["goal"].cast(pl.Int64).to_numpy()
     if len(np.unique(y)) < 2:
-        return PwhlCoordXGModel(model=None, fallback_rate=float(y.mean()))
+        return PwhlCoordXGModel(model=None, fallback_rate=float(y.mean()), features=feats)
 
     clf = LogisticRegression(max_iter=1000)
     clf.fit(x, y)
-    return PwhlCoordXGModel(model=clf, fallback_rate=float(y.mean()))
+    return PwhlCoordXGModel(model=clf, fallback_rate=float(y.mean()), features=feats)
 
 
 def _fit_xg(pbp: pl.DataFrame, xg_method: str) -> Union[ShotQualityXGModel, PwhlCoordXGModel]:

--- a/tests/pwhl/test_pwhl_xg_proxy_oracle.py
+++ b/tests/pwhl/test_pwhl_xg_proxy_oracle.py
@@ -360,7 +360,7 @@ def test_pwhl_heldout_coords_calibration(backtest: pl.DataFrame) -> None:
 # the R4 strength/clock columns; a legacy frame falls back to distance/angle.
 # ---------------------------------------------------------------------------
 
-_FULL_FEATURES = ("shot_distance", "shot_angle", "rebound", "is_home", "is_pp", "is_sh")
+_FULL_FEATURES = ("shot_distance", "shot_angle", "rebound", "is_home", "is_pp", "is_sh", "empty_net_for")
 
 
 def _synth_strength_pbp(n: int = 300) -> pl.DataFrame:

--- a/tests/pwhl/test_pwhl_xg_proxy_oracle.py
+++ b/tests/pwhl/test_pwhl_xg_proxy_oracle.py
@@ -360,14 +360,28 @@ def test_pwhl_heldout_coords_calibration(backtest: pl.DataFrame) -> None:
 # the R4 strength/clock columns; a legacy frame falls back to distance/angle.
 # ---------------------------------------------------------------------------
 
-_FULL_FEATURES = ("shot_distance", "shot_angle", "rebound", "is_home", "is_pp", "is_sh", "empty_net_for")
+_FULL_FEATURES = (
+    "shot_distance",
+    "shot_angle",
+    "rebound",
+    "is_home",
+    "is_pp",
+    "is_sh",
+    "empty_net_for",
+    "is_wrist",
+    "is_snap",
+    "is_slap",
+    "is_backhand",
+    "is_tip",
+)
 
 
 def _synth_strength_pbp(n: int = 300) -> pl.DataFrame:
-    """Deterministic shot log carrying the R4 strength + clock columns."""
+    """Deterministic shot log carrying the R4 strength + clock + shot-type columns."""
     return pl.DataFrame(
         {
             "event": ["shot"] * n,
+            "event_type": [["Wrist", "Snap", "Slap", "Backhand", "Tip", "Default"][i % 6] for i in range(n)],
             "goal": [1 if i % 7 == 0 else 0 for i in range(n)],  # ~14%, two classes
             "x_coord": [40.0 + (i % 50) for i in range(n)],  # varying distance 40..89 ft
             "y_coord": [0.0] * n,
@@ -387,7 +401,7 @@ def test_coord_xg_uses_strength_features_when_present() -> None:
 
     m = fit_pwhl_coord_xg(_synth_strength_pbp())
     assert m.model is not None
-    assert m.features == _FULL_FEATURES, f"expected 6-feature model, got {m.features}"
+    assert m.features == _FULL_FEATURES, f"expected full-feature model, got {m.features}"
     p = m.predict(_synth_strength_pbp())
     assert len(p) == 300
     assert p.min() >= 0.0 and p.max() <= 1.0

--- a/tests/pwhl/test_pwhl_xg_proxy_oracle.py
+++ b/tests/pwhl/test_pwhl_xg_proxy_oracle.py
@@ -352,3 +352,58 @@ def test_pwhl_heldout_coords_calibration(backtest: pl.DataFrame) -> None:
     assert dev.max() <= CALIBRATION_FLOOR, (
         f"held-out coords calibration max per-bucket deviation {dev.max():.4f} above floor {CALIBRATION_FLOOR}"
     )
+
+
+# ---------------------------------------------------------------------------
+# T5 Phase 3: feature expansion (rebound + strength dummies) is additive and
+# backward-compatible. The 6-feature model activates only when the pbp carries
+# the R4 strength/clock columns; a legacy frame falls back to distance/angle.
+# ---------------------------------------------------------------------------
+
+_FULL_FEATURES = ("shot_distance", "shot_angle", "rebound", "is_home", "is_pp", "is_sh")
+
+
+def _synth_strength_pbp(n: int = 300) -> pl.DataFrame:
+    """Deterministic shot log carrying the R4 strength + clock columns."""
+    return pl.DataFrame(
+        {
+            "event": ["shot"] * n,
+            "goal": [1 if i % 7 == 0 else 0 for i in range(n)],  # ~14%, two classes
+            "x_coord": [40.0 + (i % 50) for i in range(n)],  # varying distance 40..89 ft
+            "y_coord": [0.0] * n,
+            "game_id": [str(1000 + i // 30) for i in range(n)],  # ~10 games
+            "sec_from_start": [float((i % 30) * 40) for i in range(n)],
+            "team_id": ["5" if i % 2 else "6" for i in range(n)],
+            "home_team_id": ["5"] * n,
+            "away_team_id": ["6"] * n,
+            "skaters_home": [5] * n,
+            "skaters_away": [5 if i % 3 else 4 for i in range(n)],  # some home power plays
+        }
+    )
+
+
+def test_coord_xg_uses_strength_features_when_present() -> None:
+    from sportsdataverse.pwhl.pwhl_xg_proxy import fit_pwhl_coord_xg
+
+    m = fit_pwhl_coord_xg(_synth_strength_pbp())
+    assert m.model is not None
+    assert m.features == _FULL_FEATURES, f"expected 6-feature model, got {m.features}"
+    p = m.predict(_synth_strength_pbp())
+    assert len(p) == 300
+    assert p.min() >= 0.0 and p.max() <= 1.0
+
+
+def test_coord_xg_falls_back_to_two_features_without_strength_cols() -> None:
+    from sportsdataverse.pwhl.pwhl_xg_proxy import fit_pwhl_coord_xg
+
+    n = 300
+    legacy = pl.DataFrame(
+        {
+            "event": ["shot"] * n,
+            "goal": [1 if i % 7 == 0 else 0 for i in range(n)],
+            "x_coord": [40.0 + (i % 50) for i in range(n)],
+            "y_coord": [0.0] * n,
+        }
+    )
+    m = fit_pwhl_coord_xg(legacy)
+    assert m.features == ("shot_distance", "shot_angle"), f"legacy frame must stay 2-feature, got {m.features}"


### PR DESCRIPTION
Builds directly on the merged R4 shift backfill (#242): now that PWHL pbp carries real `strength_state`/`skaters_*` offline, the coordinate xG model can use them.

## What
`fit_pwhl_coord_xg` gains **rebound** (Δt<3s to prior shot), **is_home**, **is_pp**, **is_sh** when the pbp carries the R4 strength + clock columns; a legacy frame (e.g. the xG fixture) degrades to the current distance/angle model — **additive + backward-compatible**. `PwhlCoordXGModel.features` records the fitted set; `predict()` rebuilds exactly those (order-preserving).

## Validation (T5 shot-level CV harness, `dev/t5_xg_reevaluation/`)
Out-of-sample, GroupKFold(game) + Leave-One-Season-Out on 18k held-out shots:

| PWHL, LOSO | 2-feat | 6-feat |
|---|---|---|
| ALL AUC | 0.682 | **0.692** |
| ALL ECE | 0.0047 | **0.0025** |
| PP AUC | 0.681 | **0.697** |
| SH AUC | 0.643 | **0.665** |

Discrimination up (biggest on special teams — exactly where the NHL-vs-PWHL parity table said the gap was), **calibration improved**.

## Context
This is the modeling payoff of the T5 xG re-evaluation: the diagnosis found xG had *no shot-level CV* and *no real strength split*; R4 shipped the strength data; this PR turns it into a measurably-better model. Full findings + parity table + harnesses in `dev/t5_xg_reevaluation/` (gitignored working notes).

## Testing
- 2 new tests: 6-feature path activates with strength cols; legacy frame stays 2-feature.
- Existing oracle tests unchanged (fixture has no strength cols). mypy/ruff/codegen-drift all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Coordinate-based PWHL expected-goals now automatically incorporates extra shot context when available (including rebound and situation indicators, plus shot-type indicators when event type exists).
  * Trained models now remember the exact feature set used during training and reuse it during prediction.
* **Bug Fixes**
  * Improved consistency when shot records have missing contextual fields, with a safe fallback to the distance/angle-only feature set.
  * Prediction output now applies the same geometry-missing handling as during training.
* **Tests**
  * Added tests covering both expanded feature usage and the legacy two-feature fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->