### PR TITLE
fix(pwhl)!: correct the xG even-strength filter + add pre-shot movement features

### DIFF
--- a/sportsdataverse/pwhl/pwhl_xg_proxy.py
+++ b/sportsdataverse/pwhl/pwhl_xg_proxy.py
@@ -336,7 +336,12 @@ def _add_preshot_context(pbp: pl.DataFrame) -> pl.DataFrame:
     f = pbp.with_row_index("_ri")
     seq = (
         f.filter(is_play)
-        .sort(["game_id", "sec_from_start"])
+        # `_ri` (feed order) is the final tie-break: polars' sort is NOT stable by
+        # default, and the feed's clock is 1s-granular, so events tied in the same
+        # second would otherwise flip which row counts as "prior" between runs --
+        # non-deterministic movement features. Feed order is the right tie-break:
+        # within a second it IS the chronological order.
+        .sort(["game_id", "sec_from_start", "_ri"])
         .with_columns(
             _pe=pl.col("event").shift(1).over("game_id"),
             _px=pl.col("x_coord").shift(1).over("game_id"),
@@ -393,7 +398,11 @@ def _build_xg_features(
     avail = list(_XG_BASE_FEATURES)
     if {"game_id", "sec_from_start"}.issubset(f.columns):
         f = (
-            f.sort(["game_id", "sec_from_start"])
+            # `_ri` (feed order) is the final sort key for the same reason as in
+            # `_add_preshot_context`: polars' sort is unstable and the clock is
+            # 1s-granular, so without it the "prior shot" of a rebound flips
+            # between runs on tied timestamps.
+            f.sort(["game_id", "sec_from_start", "_ri"])
             .with_columns(
                 rebound=(pl.col("sec_from_start") - pl.col("sec_from_start").shift(1).over("game_id"))
                 .is_between(0, 3)

--- a/sportsdataverse/pwhl/pwhl_xg_proxy.py
+++ b/sportsdataverse/pwhl/pwhl_xg_proxy.py
@@ -280,6 +280,92 @@ def _shot_geometry(frame: pl.DataFrame) -> pl.DataFrame:
 
 _XG_BASE_FEATURES = ("shot_distance", "shot_angle")
 
+#: Real on-ice PLAY events, in feed order. The pre-shot-context sequence is
+#: restricted to these: PWHL emits a coordless DUPLICATE `goal` row alongside the
+#: scoring `shot` (plus `goalie_change` / shootout rows), so an unfiltered
+#: `shift(1)` would make every goal its own "prior event" -- a target leak that
+#: inflates held-out AUC from 0.707 to 0.755. Do not widen without re-checking that.
+_PLAY_EVENTS = ("faceoff", "shot", "blocked_shot", "hit", "penalty")
+
+#: Pre-shot movement features (T5 Phase 4). Added by :func:`_add_preshot_context`,
+#: which needs the FULL pbp; :func:`_build_xg_features` only reads them.
+_XG_MOVE_FEATURES = (
+    "last_shot",
+    "last_faceoff",
+    "last_hit",
+    "last_blocked",
+    "last_penalty",
+    "time_since_last",
+    "distance_from_last",
+    "last_x",
+    "last_y",
+)
+
+_MOVE_CONTEXT_INPUTS = ("game_id", "sec_from_start", "event", "x_coord", "y_coord")
+_NO_PRIOR_SECONDS = 999.0  # first play of a game: "nothing happened recently"
+_NO_PRIOR_DISTANCE = 200.0  # first play of a game: "far from anything" (rink is 200ft)
+
+#: Even-strength `strength_state` values (home-vs-away skater counts, R4).
+_EV_STRENGTH_STATES = ("5v5", "4v4", "3v3")
+
+
+def _add_preshot_context(pbp: pl.DataFrame) -> pl.DataFrame:
+    """Append pre-shot movement context columns (:data:`_XG_MOVE_FEATURES`) to a pbp.
+
+    Must be handed the **FULL** pbp (not a shots-only frame): the features describe
+    what happened *before* each shot, so they need the surrounding event sequence.
+    Call it before filtering to shots; the columns then ride along on the shot rows
+    into both :func:`_build_xg_features` and :meth:`PwhlCoordXGModel.predict`.
+
+    Idempotent (returns the frame unchanged if the columns are already present), and
+    a no-op on frames that can't support the features:
+
+    - missing any of :data:`_MOVE_CONTEXT_INPUTS`, or
+    - **shots-only frames** (the legacy xG fixture) -- there every shot's "prior
+      event" would be another shot, a degenerate feature set. Callers degrade to the
+      shot-local features instead.
+
+    The sequence is restricted to :data:`_PLAY_EVENTS` -- see that constant for the
+    goal-duplicate target leak this guards against.
+    """
+    if set(_XG_MOVE_FEATURES).issubset(pbp.columns) or not set(_MOVE_CONTEXT_INPUTS).issubset(pbp.columns):
+        return pbp
+    is_play = pl.col("event").is_in(_PLAY_EVENTS)
+    if pbp.filter(is_play & (pl.col("event") != "shot")).height == 0:
+        return pbp
+    f = pbp.with_row_index("_ri")
+    seq = (
+        f.filter(is_play)
+        .sort(["game_id", "sec_from_start"])
+        .with_columns(
+            _pe=pl.col("event").shift(1).over("game_id"),
+            _px=pl.col("x_coord").shift(1).over("game_id"),
+            _py=pl.col("y_coord").shift(1).over("game_id"),
+            _ps=pl.col("sec_from_start").shift(1).over("game_id"),
+        )
+    )
+    pe = pl.col("_pe")
+    ctx = seq.select(
+        "_ri",
+        last_shot=(pe == "shot").fill_null(False).cast(pl.Int64),
+        last_faceoff=(pe == "faceoff").fill_null(False).cast(pl.Int64),
+        last_hit=(pe == "hit").fill_null(False).cast(pl.Int64),
+        last_blocked=(pe == "blocked_shot").fill_null(False).cast(pl.Int64),
+        last_penalty=(pe == "penalty").fill_null(False).cast(pl.Int64),
+        time_since_last=(pl.col("sec_from_start") - pl.col("_ps"))
+        .cast(pl.Float64)
+        .fill_null(_NO_PRIOR_SECONDS)
+        .clip(0.0, _NO_PRIOR_SECONDS),
+        distance_from_last=(
+            ((pl.col("x_coord") - pl.col("_px")) ** 2 + (pl.col("y_coord") - pl.col("_py")) ** 2).sqrt()
+        )
+        .cast(pl.Float64)
+        .fill_null(_NO_PRIOR_DISTANCE),
+        last_x=pl.col("_px").cast(pl.Float64).fill_null(0.0),
+        last_y=pl.col("_py").cast(pl.Float64).fill_null(0.0),
+    )
+    return f.join(ctx, on="_ri", how="left").sort("_ri").drop("_ri")
+
 
 def _build_xg_features(
     shots: pl.DataFrame, want: tuple[str, ...] | None = None
@@ -344,6 +430,11 @@ def _build_xg_features(
             is_tip=(et == "Tip").cast(pl.Int64),
         )
         avail += ["is_wrist", "is_snap", "is_slap", "is_backhand", "is_tip"]
+    if set(_XG_MOVE_FEATURES).issubset(f.columns):
+        # Pre-shot movement (T5 Phase 4) -- already computed by _add_preshot_context
+        # on the FULL pbp (it cannot be derived here: a shots-only frame has no
+        # prior-event context). Read only.
+        avail += list(_XG_MOVE_FEATURES)
     feats = list(want) if want is not None else avail
     mats = [(f[c].cast(pl.Float64).fill_null(0.0).to_numpy() if c in f.columns else np.zeros(f.height)) for c in feats]
     return np.column_stack(mats), tuple(feats), f
@@ -412,13 +503,23 @@ def fit_pwhl_coord_xg(pbp: pl.DataFrame) -> PwhlCoordXGModel:
     goal indicator as the label -- the same fit-at-call-time recipe as
     :func:`sportsdataverse.nhl.nhl_microstat_constants.fit_shot_xg`, with the
     geometry sourced from the HockeyTech core instead of the NHL api-web one.
-    PWHL pbp has no ``shot_type`` column. When the frame carries the R4
-    strength + clock columns the fit ALSO uses ``rebound`` / ``is_home`` /
-    ``is_pp`` / ``is_sh`` / ``empty_net_for`` (T5 Phase 3, LOSO-validated to lift
-    PP/SH AUC; ``empty_net_for`` = defending team shows >=6 skaters => goalie
-    pulled => shooter faces an empty net); a legacy frame without them degrades to
-    distance/angle only (see :func:`_build_xg_features`; the fitted set is on
-    :attr:`PwhlCoordXGModel.features`). Rows with null coordinates are excluded
+    The feature set grows with what the frame carries (all LOSO-validated; the
+    fitted set is on :attr:`PwhlCoordXGModel.features`, and a frame missing any
+    group simply degrades -- see :func:`_build_xg_features`):
+
+    - **R4 strength + clock columns** -> ``rebound`` / ``is_home`` / ``is_pp`` /
+      ``is_sh`` / ``empty_net_for`` (T5 Phase 3; ``empty_net_for`` = defending team
+      shows >=6 skaters => goalie pulled => shooter faces an empty net).
+    - **``event_type``** -> the shot-type one-hots ``is_wrist`` / ``is_snap`` /
+      ``is_slap`` / ``is_backhand`` / ``is_tip``. PWHL has no ``shot_type`` column,
+      but ``event_type`` on a shot row IS the shot type (T5 Phase 4).
+    - **A full pbp (not a shots-only frame)** -> the pre-shot movement features
+      (:data:`_XG_MOVE_FEATURES`), derived here by :func:`_add_preshot_context`
+      before the shot filter. Pass the FULL pbp to get them; note that
+      :meth:`PwhlCoordXGModel.predict` then also needs frames carrying those
+      columns (:func:`pwhl_team_game_xg_rates` handles this for you).
+
+    Rows with null coordinates are excluded
     from the fit (~100%
     coverage in the captured seasons, so this drops almost nothing). Fewer
     than :data:`_MIN_COORD_SHOTS` qualifying shots -- or a frame with no
@@ -458,6 +559,9 @@ def fit_pwhl_coord_xg(pbp: pl.DataFrame) -> PwhlCoordXGModel:
         return PwhlCoordXGModel(model=None, fallback_rate=0.0)
     if "goal" not in pbp.columns:
         raise ValueError("fit_pwhl_coord_xg requires a 'goal' column (load_pwhl_pbp shape)")
+    # Pre-shot movement context must be derived BEFORE narrowing to shots (it needs
+    # the surrounding event sequence); the columns then ride along on the shot rows.
+    pbp = _add_preshot_context(pbp)
     shots = pbp.filter(pl.col("event") == "shot") if "event" in pbp.columns else pbp
     if not {"x_coord", "y_coord"}.issubset(pbp.columns):
         # No coordinate columns at all: an honest constant-rate model at the
@@ -526,8 +630,13 @@ def pwhl_team_game_xg_rates(
             as-is regardless of method. Shot rows with null coordinates
             contribute :class:`PwhlCoordXGModel`'s fallback rate (handled
             inside its ``predict``, not here).
-        even_strength_only: Best-effort filter excluding shots with
-            ``power_play == 1`` (see the module docstring's coverage caveat).
+        even_strength_only: Best-effort even-strength filter. When the pbp carries
+            the R4 shift-derived ``strength_state`` / ``strength_state_valid``
+            columns it drops only CONFIDENTLY non-even shots (a valid state outside
+            ``5v5`` / ``4v4`` / ``3v3``); rows whose strength is null or invalid are
+            kept, so a shift-tracking gap never silently deletes a shot. A pre-R4
+            frame falls back to the legacy penalty-window-inferred ``power_play == 1``
+            exclusion (see the module docstring's coverage caveat).
 
     Raises:
         ValueError: If ``xg_method`` is not ``"coords"`` or ``"quality"``.
@@ -568,13 +677,30 @@ def pwhl_team_game_xg_rates(
         return pl.DataFrame(schema=GAME_RATES_SCHEMA)
 
     model = xg_model if xg_model is not None else _fit_xg(pbp, xg_method)
-    shots = pbp.filter(pl.col("event") == "shot")
-    if even_strength_only and "power_play" in shots.columns:
-        # Best-effort even-strength filter (see module docstring): exclude only
-        # confidently-tagged power-play shots. Nulls (the majority, sparse
-        # tagging) are KEPT -- `!= 1` alone would drop them (null comparisons
-        # are null, and filter() excludes null), so null is filled to 0 first.
-        shots = shots.filter(pl.col("power_play").fill_null(0) != 1)
+    # Context BEFORE the shot filter: the movement features need the surrounding
+    # event sequence, which a shots-only frame no longer has.
+    shots = _add_preshot_context(pbp).filter(pl.col("event") == "shot")
+    if even_strength_only and {"strength_state", "strength_state_valid"}.issubset(shots.columns):
+        # R4 shift-derived strength: drop only CONFIDENTLY non-even shots (a valid
+        # state with unequal skater counts). Null / invalid strength keeps the row,
+        # same best-effort philosophy as the legacy power_play path below -- a
+        # shift-tracking gap shouldn't silently delete a shot.
+        non_even = (
+            (pl.col("strength_state_valid") == True) & (pl.col("strength_state").is_in(_EV_STRENGTH_STATES) == False)
+        ).fill_null(False)
+        shots = shots.filter(non_even == False)
+    elif even_strength_only and "power_play" in shots.columns:
+        # Legacy pre-R4 fallback: penalty-window-inferred `power_play` (sparse; see
+        # the module docstring's coverage caveat). Exclude only confidently-tagged
+        # power-play shots. Nulls (the majority) are KEPT -- comparing to null yields
+        # null and filter() drops those rows, so null is filled first.
+        #
+        # Compared AS STRING: load_pwhl_pbp ships `power_play` as Utf8 ("0"/"1"/null),
+        # not an int. The old numeric form (`fill_null(0) != 1`) raised ComputeError
+        # ("cannot compare string with numeric type") on every real pbp frame -- it
+        # only survived tests because the mini fixture hand-builds it as Int32. The
+        # cast handles both.
+        shots = shots.filter(pl.col("power_play").cast(pl.Utf8).fill_null("0") != "1")
     if shots.height == 0:
         return pl.DataFrame(schema=GAME_RATES_SCHEMA)
 

--- a/tests/pwhl/test_pwhl_xg_proxy_oracle.py
+++ b/tests/pwhl/test_pwhl_xg_proxy_oracle.py
@@ -396,6 +396,165 @@ def _synth_strength_pbp(n: int = 300) -> pl.DataFrame:
     )
 
 
+_MOVE_FEATURES = (
+    "last_shot",
+    "last_faceoff",
+    "last_hit",
+    "last_blocked",
+    "last_penalty",
+    "time_since_last",
+    "distance_from_last",
+    "last_x",
+    "last_y",
+)
+
+
+def _synth_full_pbp(n: int = 300) -> pl.DataFrame:
+    """Full-pbp shape: a real PLAY event before each shot, plus PWHL's coordless
+    DUPLICATE ``goal`` row -- emitted immediately BEFORE the scoring shot, so an
+    unguarded ``shift(1)`` would pick it up as that shot's "prior event" (the leak).
+    """
+    rows: list[dict[str, object]] = []
+    for i in range(n):
+        common: dict[str, object] = {
+            "game_id": str(1000 + i // 30),  # ~10 games
+            "home_team_id": "5",
+            "away_team_id": "6",
+            "skaters_home": 5,
+            "skaters_away": 5 if i % 3 else 4,  # some home power plays
+        }
+        t = float((i % 30) * 40)
+        scored = i % 7 == 0  # ~14%, two classes
+        rows.append(
+            {
+                **common,
+                "event": "faceoff" if i % 2 else "hit",
+                "event_type": "Default",
+                "goal": 0,
+                "x_coord": 20.0,
+                "y_coord": 5.0,
+                "sec_from_start": t - 5.0,
+                "team_id": "5",
+            }
+        )
+        if scored:
+            rows.append(
+                {
+                    **common,
+                    "event": "goal",
+                    "event_type": "Default",
+                    "goal": 1,
+                    "x_coord": None,
+                    "y_coord": None,
+                    "sec_from_start": t,
+                    "team_id": "5",
+                }
+            )
+        rows.append(
+            {
+                **common,
+                "event": "shot",
+                "event_type": ["Wrist", "Snap", "Slap", "Backhand", "Tip", "Default"][i % 6],
+                "goal": 1 if scored else 0,
+                "x_coord": 40.0 + (i % 50),  # varying distance 40..89 ft
+                "y_coord": 0.0,
+                "sec_from_start": t,
+                "team_id": "5" if i % 2 else "6",
+            }
+        )
+    return pl.DataFrame(rows)
+
+
+def test_coord_xg_adds_movement_features_on_full_pbp() -> None:
+    from sportsdataverse.pwhl.pwhl_xg_proxy import fit_pwhl_coord_xg
+
+    m = fit_pwhl_coord_xg(_synth_full_pbp())
+    assert m.model is not None
+    assert m.features == _FULL_FEATURES + _MOVE_FEATURES, f"expected movement features, got {m.features}"
+
+
+def test_preshot_context_excludes_duplicate_goal_rows() -> None:
+    """The leak guard: a scoring shot's "prior event" must be the real prior PLAY,
+    not PWHL's coordless duplicate ``goal`` row (a perfect goal tell -- it inflated
+    held-out AUC 0.707 -> 0.755 before the ``_PLAY_EVENTS`` filter).
+    """
+    from sportsdataverse.pwhl.pwhl_xg_proxy import _add_preshot_context
+
+    ctx = _add_preshot_context(_synth_full_pbp()).filter(pl.col("event") == "shot")
+    assert ctx.filter(pl.col("goal") == 1).height > 0, "synth frame must contain goals to test the leak"
+    # Every shot is preceded by a faceoff or a hit, 5s and 20ft-x away -- including
+    # the scoring ones. If the `goal` dupe leaked in, goal shots would show neither
+    # (and inherit its null coords as last_x=0).
+    assert ((ctx["last_faceoff"] + ctx["last_hit"]) == 1).all()
+    assert (ctx["time_since_last"] == 5.0).all()
+    assert (ctx["last_x"] == 20.0).all()
+    assert (ctx["last_shot"] == 0).all()
+
+
+def test_preshot_context_noop_on_shots_only_frame_and_idempotent() -> None:
+    from sportsdataverse.pwhl.pwhl_xg_proxy import _add_preshot_context
+
+    # A shots-only frame has no prior-event context (every "prior" would be a shot):
+    # no-op, so the caller degrades to the shot-local features.
+    shots = _synth_strength_pbp()
+    assert _add_preshot_context(shots).columns == shots.columns
+    # Idempotent -- fit() and pwhl_team_game_xg_rates() may both call it.
+    once = _add_preshot_context(_synth_full_pbp())
+    assert _add_preshot_context(once).columns == once.columns
+
+
+def _mini_strength_pbp() -> pl.DataFrame:
+    """One game: a 5v5 shot, a valid 5v4 power-play shot, and a null-strength shot."""
+    return pl.DataFrame(
+        {
+            "game_id": [1, 1, 1],
+            "event": ["shot"] * 3,
+            "team_id": [10, 10, 10],
+            "goal": [False, False, False],
+            "x_coord": [85.0, 30.0, 60.0],
+            "y_coord": [0.0, -10.0, 5.0],
+            "strength_state": ["5v5", "5v4", None],
+            "strength_state_valid": [True, True, None],
+        }
+    )
+
+
+def test_even_strength_filter_prefers_shift_derived_strength_state() -> None:
+    """R4 `strength_state` governs when present: drop the CONFIDENTLY non-even shot,
+    keep the null-strength one (a shift-tracking gap must not delete a shot).
+    """
+    model = _distance_only_model()
+    pbp, sched = _mini_strength_pbp(), _mini_sched()
+    ev = pwhl_team_game_xg_rates(pbp, sched, xg_model=model, even_strength_only=True)
+    everything = pwhl_team_game_xg_rates(pbp, sched, xg_model=model, even_strength_only=False)
+    tor_ev = ev.filter(pl.col("team") == "Toronto")["xgf"][0]
+    tor_all = everything.filter(pl.col("team") == "Toronto")["xgf"][0]
+    # Exactly the 5v4 shot is dropped -- so the null-strength shot was KEPT.
+    dropped = model.predict(pl.DataFrame({"x_coord": [30.0], "y_coord": [-10.0]}))[0]
+    assert tor_all - tor_ev == pytest.approx(dropped, abs=1e-9)
+
+
+def test_even_strength_filter_handles_string_power_play_on_prer4_frame() -> None:
+    """Regression: load_pwhl_pbp ships `power_play` as Utf8 ("0"/"1"/null), not int.
+    The old numeric filter (`fill_null(0) != 1`) raised ComputeError on every real
+    frame; it only passed tests because `_mini_pbp` hand-builds it as Int32.
+    """
+    model = _distance_only_model()
+    # Pre-R4 shape (no strength_state) with the feed's real String power_play.
+    pbp = (
+        _mini_strength_pbp()
+        .drop("strength_state", "strength_state_valid")
+        .with_columns(power_play=pl.Series(["0", "1", None], dtype=pl.Utf8))
+    )
+    ev = pwhl_team_game_xg_rates(pbp, _mini_sched(), xg_model=model, even_strength_only=True)
+    everything = pwhl_team_game_xg_rates(pbp, _mini_sched(), xg_model=model, even_strength_only=False)
+    tor_ev = ev.filter(pl.col("team") == "Toronto")["xgf"][0]
+    tor_all = everything.filter(pl.col("team") == "Toronto")["xgf"][0]
+    # Only the "1" shot is dropped -- the null-tagged one is KEPT (sparse tagging).
+    dropped = model.predict(pl.DataFrame({"x_coord": [30.0], "y_coord": [-10.0]}))[0]
+    assert tor_all - tor_ev == pytest.approx(dropped, abs=1e-9)
+
+
 def test_coord_xg_uses_strength_features_when_present() -> None:
     from sportsdataverse.pwhl.pwhl_xg_proxy import fit_pwhl_coord_xg
 


### PR DESCRIPTION
Completes the T5 NHL/PWHL xG parity work. Follows #242 (shifts) and #246 (strength + shot-type features).

## The bug (shipped, crashing)

`pwhl_team_game_xg_rates(even_strength_only=True)` — **the default** — raised `ComputeError` on **every real `load_pwhl_pbp` frame**:

```
ComputeError: cannot compare string with numeric type (i32)
  [(col("power_play").fill_null(["0"])) != (dyn int: 1)]
```

`load_pwhl_pbp` ships `power_play` as **Utf8** (`"0"`/`"1"`/null); the filter compared it to an int. It passed CI only because the mini fixture hand-builds `power_play` as `Int32`. Fixed (compared as string) and regression-tested with the feed's real dtype.

## Filter parity with NHL

The user ask was to bring the xG shot population to parity. Audited:

- **Blocked shots — already at parity.** NHL trains on `_UNBLOCKED = [SHOT, MISSED_SHOT, GOAL]` (`nhl_xg.py:87`); PWHL's `event == "shot"` already excludes `blocked_shot`. No change.
- **Missed shots — genuinely absent from PWHL.** Every `shot_quality` value is "…on net": a non-goal PWHL shot is a *save*, not a miss. Not inferable; a real population difference vs NHL (misses are the easy negatives) and part of the residual AUC gap.
- **`shot_quality` is a leak, not a feature** — its tiers contain the outcome ("Quality goal"). Excluded. `scoring_chance` = distance < 25ft, redundant.
- **Even strength** now uses the R4 shift-derived `strength_state` when present, superseding the sparse penalty-window `power_play` heuristic — which tagged power-play shots only and **missed short-handed shots entirely**. On 2025: `strength_state` excludes 1,508 non-even shots (26.6%) vs `power_play`'s 919 (16.2%). Null/invalid strength **keeps** the row, so a shift-tracking gap never silently deletes a shot.

## Pre-shot movement features

`_add_preshot_context` runs on the **full pbp before the shot filter**, so the columns ride along onto the shot rows — `predict()` receives a shots-only frame and cannot derive them itself. Idempotent, and a no-op on shots-only frames (where every "prior event" would be another shot).

**Target leak caught and guarded:** PWHL emits a coordless **duplicate `goal` row** alongside each scoring shot. An unguarded `shift(1)` makes every goal its own "prior event" — and since that row has null coords, goal shots got a unique `distance_from_last=200, last_x=0` signature. Held-out AUC inflated to **0.755**. Restricting the sequence to real play events (`faceoff/shot/blocked_shot/hit/penalty`) gives the honest **0.707**. Regression-tested: the synthetic frame places the dupe immediately before its shot, so removing the guard fails the test.

## Results (LOSO, 2024–2026, 18,031 shots)

| | #246 (12 feat) | this PR (21 feat) |
|---|---|---|
| ALL AUC | 0.694 | **0.707** |
| PP AUC | 0.704 | **0.714** |
| SH AUC | 0.677 | **0.692** |
| ECE | 0.0040 | **0.0013** |

## Verification

40/40 `tests/pwhl` pass (5 new: movement features, leak guard, shots-only no-op + idempotence, strength-state EV filter, String-`power_play` regression). mypy + ruff + codegen drift green. Real-data end-to-end: 21-feature fit, `pwhl_team_game_xg_rates(2025)` → (180, 11).

## BREAKING

`pwhl_team_game_xg_rates` `xgf`/`xga` change: the default even-strength filter previously crashed on real frames, and on the hand-built shape under-filtered by missing short-handed shots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced PWHL coordinate expected-goals to include pre-shot movement context (recent play timing/location and last-event indicators) when available.
* **Bug Fixes**
  * Prevented duplicated/non-on-ice goal entries from polluting the prior-event context used for shot modeling.
  * Improved even-strength and power-play shot filtering for legacy data types and tied prior-event selection.
* **Tests**
  * Added synthetic full-PBP scenarios, movement-feature enrichment checks, leak-guard and idempotency coverage, plus even-strength/power-play regression tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->