### PR TITLE
feat(nba): play-context engine — CTG possession start-type + transition/putback (T3.6)

### DIFF
--- a/dev/ctg_transition_calibration.py
+++ b/dev/ctg_transition_calibration.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Fit DEFAULT_TRANSITION_SECONDS for the NBA play-context engine.
+
+CTG does not publish a transition seconds cutoff ("transition starts at the
+beginning of a possession and only ends once the defense is set"), so the knob in
+:data:`sportsdataverse.nba.nba_play_context_constants.DEFAULT_TRANSITION_SECONDS`
+is CALIBRATED, not quoted. This script is the fitting run behind that number.
+
+Target band (the oracles):
+  * CTG's own published Play-Context table shows team transition frequencies
+    around 0.14 (e.g. Denver 14.3%) — `sdv-internal-refs/cleaningtheglass/`.
+  * Synergy's `transition` play-type frequency runs ~0.15–0.16 league-wide
+    (`sportsdataverse.nba.nba_playtype`).
+
+Fit sample: the three committed engine fixtures
+(`tests/fixtures/nba_engine/{0022100001,0022200001,0022300001}`), CTG's default
+filters applied (garbage time + heave possessions dropped, non-counting
+possessions dropped).
+
+Result (2026-07-12): **6.0s**, mean transition frequency 0.163 — inside the band.
+The widely-cited hoop-math 10s rule is a *college* convention with a different
+denominator; applied to NBA possessions it gives ~0.35, ~2.4x CTG's rate.
+
+Run:
+    uv run python dev/ctg_transition_calibration.py
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import polars as pl
+
+from sportsdataverse.nba.nba_enhanced_pbp import enhanced_pbp_from_payload
+from sportsdataverse.nba.nba_play_context import add_play_context
+
+FIXTURES = pathlib.Path("tests/fixtures/nba_engine")
+GAMES = ["0022200001", "0022300001", "0022100001"]
+GRID = [4.0, 5.0, 6.0, 7.0, 8.0, 10.0, 12.0]
+
+# Oracle band: CTG published ~0.14; Synergy ~0.15-0.16.
+TARGET_LO, TARGET_HI = 0.13, 0.17
+
+
+def _load(game_id: str) -> pl.DataFrame:
+    payload = json.loads((FIXTURES / game_id / "playbyplayv3.json").read_text())
+    return enhanced_pbp_from_payload(payload)
+
+
+def main() -> None:
+    frames = {gid: _load(gid) for gid in GAMES}
+    print(f"{'secs':>5} | {'per-game transition freq':38} | {'mean':>6} | in-band")
+    print("-" * 72)
+    for secs in GRID:
+        per_game = []
+        for enh in frames.values():
+            poss = add_play_context(enh, transition_seconds=secs)
+            clean = poss.filter(
+                (pl.col("count_as_possession") == True)  # noqa: E712
+                & (pl.col("is_garbage_time") == False)  # noqa: E712
+                & (pl.col("is_heave_possession") == False)  # noqa: E712
+            )
+            per_game.append(clean["is_transition"].mean())
+        mean = sum(per_game) / len(per_game)
+        flag = "YES <-- adopted" if TARGET_LO <= mean <= TARGET_HI else ""
+        print(f"{secs:5.1f} | {str([round(x, 3) for x in per_game]):38} | {mean:6.3f} | {flag}")
+
+    print(
+        "\nAdopted DEFAULT_TRANSITION_SECONDS = 6.0 (mean 0.163).\n"
+        "Follow-up: re-fit at season scale once the possession compile is cached; "
+        "3 games is a small sample and the band is tight."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/docs/nba/index.md
+++ b/docs/docs/nba/index.md
@@ -11,7 +11,7 @@ sidebar_label: NBA
 | [ESPN core API (v2)](reference/core) | 81 | `https://sports.core.api.espn.com/v2/sports` |
 | [NBA Stats API (stats.nba.com)](reference/nba_stats) | 112 | `https://stats.nba.com` |
 | [Dataset loaders](reference/loaders) | 13 | sportsdataverse-data releases |
-| [Additional functions](reference/additional) | 112 | hand-written wrappers, loaders & helpers |
+| [Additional functions](reference/additional) | 121 | hand-written wrappers, loaders & helpers |
 
 ## Examples
 

--- a/docs/docs/nba/reference/additional.md
+++ b/docs/docs/nba/reference/additional.md
@@ -847,6 +847,158 @@ Oracle 6: walk-forward ("predict tomorrow") retrodiction over a season timeline.
 | `n_checkpoints` | `int` |  | Number of checkpoint dates that produced a non-degenerate (train, test) split. |
 | `n_test_games` | `int` |  | Total distinct game_ids evaluated across all checkpoints. |
 
+### `add_ctg_shot_zones(enhanced_pbp: 'pl.DataFrame') -> 'pl.DataFrame'` {#add_ctg_shot_zones}
+
+Append CTG's shot-location zone (`ctg_shot_zone`) to an enhanced PBP frame.
+
+CTG's zones differ from the official NBA zones emitted by
+`~sportsdataverse.nba.nba_shot_zones.add_shot_zones`: CTG splits the
+midrange at the free-throw-line distance rather than at the paint boundary.
+
+* `at_rim` — shot distance < 4 ft ("Shots within 4 feet of the basket").
+* `short_mid` — 4 ft <= distance < 14 ft ("outside of 4 feet, but inside of
+  ~14 feet (the free throw line distance)").
+* `long_mid` — >= 14 ft, inside the arc.
+* `corner_3` — a three "below the break" (`|x_legacy| >= 220` and
+  `y_legacy <= 87.5`).
+* `arc_3` — any other three (CTG's "non-corner three").
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `enhanced_pbp` | `DataFrame` |  | Frame from `~sportsdataverse.nba.nba_enhanced_pbp.enhanced_pbp_from_payload`. |
+
+**Returns**
+
+The input frame with a `ctg_shot_zone` Utf8 column appended (null on non-field-goal rows). Empty input returns a zero-row frame carrying the column — never raises.
+
+**Example**
+
+```python
+from sportsdataverse.nba.nba_enhanced_pbp import enhanced_pbp_from_payload
+from sportsdataverse.nba.nba_play_context import add_ctg_shot_zones
+pbp = add_ctg_shot_zones(enhanced_pbp_from_payload(payload))
+print(pbp.filter(pl.col("ctg_shot_zone").is_not_null())["ctg_shot_zone"].value_counts())
+```
+
+### `add_play_context(enhanced_pbp: 'pl.DataFrame', *, transition_seconds: 'float' = 6.0, transition_variant: 'str' = 'hoop_math', starters_on_court: 'Optional[dict[int, int]]' = None) -> 'pl.DataFrame'` {#add_play_context}
+
+Build possessions and enrich them with the full CTG play-context surface.
+
+One call: `~sportsdataverse.nba.nba_possessions.build_possessions` ->
+`add_start_type_detail` -> `add_transition` ->
+`flag_heave_possessions` -> `flag_garbage_time`.
+
+The CTG filter columns are **flags, not filters** — nothing is dropped. Apply
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `enhanced_pbp` | `DataFrame` |  | Frame from `~sportsdataverse.nba.nba_enhanced_pbp.enhanced_pbp_from_payload`. |
+| `transition_seconds` | `float` | `6.0` | Transition initial-play cutoff (default 10.0). |
+| `transition_variant` | `str` | `'hoop_math'` | See `add_transition`. |
+| `starters_on_court` | `Optional[dict[int, int]]` | `None` | Optional starters-on-floor counts; see `flag_garbage_time`. |
+
+**Returns**
+
+The possession frame (`POSSESSIONS_SCHEMA`) plus every column in `PLAY_CONTEXT_POSSESSIONS_SCHEMA`.
+
+**Example**
+
+```python
+from sportsdataverse.nba.nba_enhanced_pbp import enhanced_pbp_from_payload
+from sportsdataverse.nba.nba_play_context import add_play_context
+poss = add_play_context(enhanced_pbp_from_payload(payload))
+print(poss["possession_start_type_ctg"].value_counts())
+```
+
+### `add_start_type_detail(possessions: 'pl.DataFrame', enhanced_pbp: 'pl.DataFrame') -> 'pl.DataFrame'` {#add_start_type_detail}
+
+Append the full pbpstats start-type taxonomy to a possession frame.
+
+Upgrades the engine's coarse 5-value `possession_start_type` into:
+
+* `possession_start_type_detail` — the zone-split pbpstats vocabulary:
+  `Off{AtRim|ShortMidRange|LongMidRange|Corner3|Arc3}{Make|Miss|Block}`,
+  `OffFTMake` / `OffFTMiss`, `OffLiveBallTurnover`, `OffTimeout`,
+  `OffDeadball`.
+* `possession_start_type_ctg` — the coarse bucket CTG reports on:
+  `off_made` / `off_live_rebound` / `off_steal` / `off_deadball` /
+  `off_timeout` (see `~nba_play_context_constants.CTG_START_BUCKETS`).
+
+Precedence (pbpstats): period start > timeout > previous boundary event. A
+**team rebound** (`person_id == 0`) is a dead-ball start even though a
+rebound row exists; a **timeout** beats a made basket (an after-timeout
+possession is `OffTimeout`, not `OffMadeShot`).
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `possessions` | `DataFrame` |  | Frame from `~sportsdataverse.nba.nba_possessions.build_possessions`. |
+| `enhanced_pbp` | `DataFrame` |  | The enhanced PBP frame those possessions were built from. |
+
+**Returns**
+
+`possessions` with the two columns appended. Empty input returns a zero-row frame carrying them — never raises.
+
+**Example**
+
+```python
+from sportsdataverse.nba.nba_possessions import build_possessions
+from sportsdataverse.nba.nba_play_context import add_start_type_detail
+poss = add_start_type_detail(build_possessions(pbp), pbp)
+print(poss["possession_start_type_ctg"].value_counts())
+```
+
+### `add_transition(possessions: 'pl.DataFrame', enhanced_pbp: 'pl.DataFrame', *, transition_seconds: 'float' = 6.0, variant: 'str' = 'hoop_math') -> 'pl.DataFrame'` {#add_transition}
+
+Flag possessions that started in transition, and time their initial play.
+
+CTG defines transition as beginning at the possession start and ending "once
+the defense is set", **without publishing a seconds threshold**. We therefore
+time the possession's *initial play* — its first shot attempt, trip to the
+line, or turnover (CTG's own definition of a "play") — and call the
+possession transition when that play lands within `transition_seconds`.
+
+Variants (`~nba_play_context_constants.TRANSITION_VARIANTS`):
+
+* `hoop_math` (default) — any non-timeout start type qualifies.
+* `haslametrics` — steal starts only (conservative).
+* `bigballr` — the previous possession must have ended live
+  (`off_made` / `off_live_rebound` / `off_steal`); a dead-ball start can
+  never be transition.
+
+The first possession of a period is never transition. After a timeout the
+defense is set by construction, so `off_timeout` never qualifies under any
+variant.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `possessions` | `DataFrame` |  | Frame carrying `possession_start_type_ctg` (i.e. the output of `add_start_type_detail`). |
+| `enhanced_pbp` | `DataFrame` |  | The enhanced PBP frame the possessions were built from. |
+| `transition_seconds` | `float` | `6.0` | Initial-play cutoff. Default 10.0 (hoop-math). Calibrate against Synergy transition frequency (league mean ~15-16%). |
+| `variant` | `str` | `'hoop_math'` | One of `~nba_play_context_constants.TRANSITION_VARIANTS`. |
+
+**Returns**
+
+`possessions` with `seconds_to_first_play` (Float64, null when the possession had no play), `is_transition` (Boolean), `transition_source` (Utf8: `steal` / `live_rebound` / `made` / `deadball`; null when not transition) and `possession_context` (Utf8: `transition` / `halfcourt` / `misc`) appended.
+
+**Example**
+
+```python
+poss = add_transition(add_start_type_detail(poss, pbp), pbp)
+print(poss["is_transition"].mean())          # transition frequency
+
+# Tune the knob against the Synergy oracle
+
+poss8 = add_transition(poss, pbp, transition_seconds=8.0)
+```
+
 ### `adjust_efficiency(game_eff: 'pl.DataFrame', *, league_id: 'str' = '00', max_iter: 'int' = 100, tol: 'float' = 0.0001) -> 'pl.DataFrame'` {#adjust_efficiency}
 
 Iterative opponent-adjusted rating -> AdjOffRtg / AdjDefRtg / AdjNet per team-season.
@@ -959,6 +1111,44 @@ game's own team pace), then summed — the result is fully deterministic.
 **Returns**
 
 One row per player: `player_id`, the STATS` per-100 rates, `min` (total), `gp` (games). Empty frame with that schema on empty input.
+
+### `build_play_context_shots(possessions: 'pl.DataFrame', enhanced_pbp: 'pl.DataFrame', *, putback_seconds: 'float' = 2.0) -> 'pl.DataFrame'` {#build_play_context_shots}
+
+Build the per-shot frame carrying CTG's play context.
+
+CTG assigns context **per play**, not per possession: one possession can
+contain a transition miss, a halfcourt reset and a putback. This frame is the
+play-level view — one row per field-goal attempt.
+
+* `is_putback` — pbpstats `field_goal.py:112-144`: an **unassisted 2-point**
+  attempt whose preceding event is a **real offensive rebound by the same
+  player**, within `putback_seconds`. A three is never a putback.
+* `is_second_chance_shot` — the shot follows an offensive rebound earlier in
+  the same possession.
+* `shot_context` — `transition` / `putback` / `halfcourt`. **Transition
+  wins over putback**, reproducing CTG exactly: "if a team comes down in
+  transition and misses a shot but gets a putback, that putback is classified
+  as part of the overall transition event."
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `possessions` | `DataFrame` |  | Frame from `add_transition` (needs `is_transition`). |
+| `enhanced_pbp` | `DataFrame` |  | The enhanced PBP frame the possessions were built from. |
+| `putback_seconds` | `float` | `2.0` | Rebound-to-shot window. Default 2.0 (pbpstats). |
+
+**Returns**
+
+Polars DataFrame with schema `PLAY_CONTEXT_SHOTS_SCHEMA` — one row per field-goal attempt. Empty input returns the zero-row schema.
+
+**Example**
+
+```python
+shots = build_play_context_shots(poss, pbp)
+print(shots.group_by("shot_context").len())
+print(shots.filter(pl.col("is_putback") == True).height)
+```
 
 ### `build_possession_shooting(enhanced_pbp: 'pl.DataFrame') -> 'pl.DataFrame'` {#build_possession_shooting}
 
@@ -1362,6 +1552,79 @@ panel = pl.DataFrame({"player_id": [1, 1], "season": [2020, 2021], "rating": [10
 ages = pl.DataFrame({"player_id": [1, 1], "season": [2020, 2021], "age": [24.0, 25.0]})
 curve = fit_aging_curve(panel, ages, smooth=1)
 print(curve.delta(24))  # ~1.0
+```
+
+### `flag_garbage_time(possessions: 'pl.DataFrame', enhanced_pbp: 'pl.DataFrame', *, starters_on_court: 'Optional[dict[int, int]]' = None) -> 'pl.DataFrame'` {#flag_garbage_time}
+
+Flag CTG garbage time (excluded from CTG stats by default).
+
+CTG (exact): "the game has to be in the **4th quarter**, the score
+differential has to be **>= 25 for minutes 12-9, >= 20 for minutes 9-6, and
+>= 10 for the remainder of the quarter**. Additionally, there have to be **two
+or fewer starters on the floor combined between the two teams**. Importantly,
+the game can never go back to being non-garbage time, or this clock resets."
+
+The margin x minutes bands are reproduced exactly, evaluated on the score at
+each possession's start. The reset semantics fall out of that per-possession
+evaluation: if the trailing team claws back inside the band's threshold, the
+condition stops holding and those possessions are NOT garbage time (CTG's own
+"comeback is not counted as garbage time" example); if the lead re-expands,
+the flag turns back on.
+
+**The starters clause is applied only when `starters_on_court` is supplied**
+— it needs lineup + box `START_POSITION` data this frame does not carry.
+Without it the flag is the **margin-only superset** of CTG's definition (it can
+flag a blowout stretch in which the starters are still on the floor), and
+`garbage_time_basis` records which rule was actually used. This is a
+deliberate, documented divergence — do not read a `margin_only` flag as
+CTG-exact.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `possessions` | `DataFrame` |  | Frame with `period`, `start_seconds_remaining` and `start_order_index`. |
+| `enhanced_pbp` | `DataFrame` |  | The enhanced PBP frame (supplies the running score). |
+| `starters_on_court` | `Optional[dict[int, int]]` | `None` | Optional map `possession_number -> number of starters on the floor across BOTH teams`. When given, a possession is garbage time only if that count is <= `~nba_play_context_constants.GARBAGE_TIME_MAX_STARTERS`. |
+
+**Returns**
+
+`possessions` with Boolean `is_garbage_time` and Utf8 `garbage_time_basis` (`"margin_and_starters"` or `"margin_only"`) appended.
+
+**Example**
+
+```python
+poss = flag_garbage_time(poss, pbp)
+print(poss.filter(pl.col("is_garbage_time") == True).height)
+
+# CTG-exact, with the starters clause
+
+poss = flag_garbage_time(poss, pbp, starters_on_court=starters_by_possession)
+```
+
+### `flag_heave_possessions(possessions: 'pl.DataFrame') -> 'pl.DataFrame'` {#flag_heave_possessions}
+
+Flag CTG's "projected heave possessions" (excluded from CTG stats by default).
+
+CTG (exact): "possessions that start with **4 or fewer seconds on the game
+clock at the end of one of the first three quarters**." Q4/OT are exempt — a
+late Q4 possession is a real possession.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `possessions` | `DataFrame` |  | Any frame with `period` and `start_seconds_remaining`. |
+
+**Returns**
+
+`possessions` with a Boolean `is_heave_possession` column appended.
+
+**Example**
+
+```python
+poss = flag_heave_possessions(poss)
+clean = poss.filter(pl.col("is_heave_possession") == False)
 ```
 
 ### `fox_nba_boxscore(game_id: 'Union[int, str]', *, return_parsed: 'bool' = True, return_as_pandas: 'bool' = False, **kwargs: 'Any') -> "Union[pl.DataFrame, 'pd.DataFrame', Dict[str, Any]]"` {#fox_nba_boxscore}
@@ -2292,6 +2555,45 @@ Parsed JSON contents.
 from sportsdataverse.nba import nba_pbp_disk
 pbp = nba_pbp_disk(game_id=401585183, path_to_json="./cache")
 print(list(pbp.keys()))
+```
+
+### `nba_play_context(game_id: 'str', league_id: 'str' = '00', *, transition_seconds: 'float' = 6.0, transition_variant: 'str' = 'hoop_math', return_as_pandas: 'bool' = False) -> 'Union[pl.DataFrame, pd.DataFrame]'` {#nba_play_context}
+
+Fetch one game and return its possessions with the full CTG play-context surface.
+
+Single live call to `nba_stats_playbyplayv3`, then
+`add_play_context`. Works for NBA (`league_id="00"`), WNBA and the
+G-League — `stats.wnba.com` ships the same play-by-play shapes, and every
+threshold here is league-agnostic.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `str` |  | Ten-character game identifier (e.g. `"0022200001"`). |
+| `league_id` | `str` | `'00'` | League identifier (`"00"` NBA, `"10"` WNBA, `"20"` G-League). |
+| `transition_seconds` | `float` | `6.0` | Transition initial-play cutoff (default 10.0). |
+| `transition_variant` | `str` | `'hoop_math'` | See `add_transition`. |
+| `return_as_pandas` | `bool` | `False` | Return a pandas DataFrame instead of polars. |
+
+**Returns**
+
+Possession frame with the play-context columns. Empty/malformed payloads return a zero-row frame — never raises.
+
+**Example**
+
+```python
+from sportsdataverse.nba.nba_play_context import nba_play_context
+poss = nba_play_context("0022200001")
+print(poss["possession_start_type_ctg"].value_counts())
+
+# Transition rate for the game
+
+import polars as pl
+clean = poss.filter(
+    (pl.col("is_garbage_time") == False) & (pl.col("is_heave_possession") == False)
+)
+print(clean["is_transition"].mean())
 ```
 
 ### `nba_player_ages(season: 'str', *, league_id: 'str' = '00', fetch: 'Optional[Callable[..., pl.DataFrame]]' = None) -> 'pl.DataFrame'` {#nba_player_ages}
@@ -3643,6 +3945,46 @@ Expected possessions for the game.
 ```python
 from sportsdataverse.nba.nba_player_props import team_pace_projection
 poss = team_pace_projection("1", "2", ratings)
+```
+
+### `team_play_context(possessions: 'pl.DataFrame', *, league_non_transition_ppp: 'Optional[float]' = None, apply_ctg_filters: 'bool' = True, return_as_pandas: 'bool' = False) -> 'Union[pl.DataFrame, pd.DataFrame]'` {#team_play_context}
+
+Roll possessions up into CTG's team Play-Context table.
+
+Reproduces the offensive half of CTG's `/stats/league/context` page.
+
+Columns: `poss`, `points`, `pts_per_100`, `transition_poss`,
+`transition_points`, `transition_freq`, `transition_pts_per_100`
+(CTG's "Eff"), `non_transition_pts_per_100`, `transition_pts_added_per_100`
+(CTG's "Pts+/Poss"), plus `halfcourt_*` twins and per-source transition
+frequencies (`freq_off_steal` / `freq_off_live_rebound`).
+
+**Pts+/Poss** is the subtle one. CTG: "CTG takes a team's points per
+possession that starts with transition, and subtracts out **what an average
+team does** in a possession that did not start with transition. ... We take the
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `possessions` | `DataFrame` |  | Frame from `add_play_context`. |
+| `league_non_transition_ppp` | `Optional[float]` | `None` | League-average points per 100 possessions on non-transition-start possessions. Computed from the frame when omitted. |
+| `apply_ctg_filters` | `bool` | `True` | Drop garbage-time, heave and non-counting possessions first (CTG's default view). Set `False` for the unfiltered totals. |
+| `return_as_pandas` | `bool` | `False` | Return a pandas DataFrame instead of polars. |
+
+**Returns**
+
+One row per `offense_team_id`. Empty input returns a zero-row frame.
+
+**Example**
+
+```python
+ctx = team_play_context(add_play_context(pbp))
+print(ctx.select("offense_team_id", "transition_freq", "transition_pts_added_per_100"))
+
+# Season-comparable Pts+/Poss
+
+ctx = team_play_context(season_poss, league_non_transition_ppp=104.8)
 ```
 
 ### `train_spm(box_features: 'pl.DataFrame', rapm_target: 'pl.DataFrame', *, feature_names: 'Optional[List[str]]' = None, alpha: 'float' = 100.0) -> 'SpmCoefficients'` {#train_spm}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -398,6 +398,8 @@ files = [
     "sportsdataverse/nba/nba_lineups.py",
     "sportsdataverse/nba/tools/capture_boxv3_periods.py",
     "sportsdataverse/nba/nba_possessions.py",
+    "sportsdataverse/nba/nba_play_context_constants.py",
+    "sportsdataverse/nba/nba_play_context.py",
     "sportsdataverse/nba/nba_shot_zones.py",
     "sportsdataverse/nba/nba_shot_value_constants.py",
     "sportsdataverse/nba/nba_shot_value.py",

--- a/sportsdataverse/nba/__init__.py
+++ b/sportsdataverse/nba/__init__.py
@@ -55,6 +55,19 @@ from sportsdataverse.nba.nba_oracle_data import (  # noqa: F401
     normalize_player_name,
 )
 from sportsdataverse.nba.nba_v3_v2_adapter import nba_v3_to_v2_pbp  # noqa: F401
+from sportsdataverse.nba.nba_play_context import (  # noqa: F401
+    PLAY_CONTEXT_POSSESSIONS_SCHEMA,
+    PLAY_CONTEXT_SHOTS_SCHEMA,
+    add_ctg_shot_zones,
+    add_play_context,
+    add_start_type_detail,
+    add_transition,
+    build_play_context_shots,
+    flag_garbage_time,
+    flag_heave_possessions,
+    nba_play_context,
+    team_play_context,
+)
 from sportsdataverse.nba.nba_possessions import (  # noqa: F401
     build_possession_shooting,
     POSSESSION_SHOOTING_SCHEMA,

--- a/sportsdataverse/nba/nba_play_context.py
+++ b/sportsdataverse/nba/nba_play_context.py
@@ -1,0 +1,1013 @@
+"""NBA/WNBA play-context engine — a Cleaning the Glass recreation.
+
+Classifies **how each possession started** (the pbpstats start-type taxonomy,
+zone-split) and **what context each play happened in** (CTG's halfcourt /
+transition / putback / miscellaneous), then applies CTG's default garbage-time
+and heave filters and rolls the result up into CTG's Play-Context table.
+
+This module is strictly **additive** on the possession engine: boundaries,
+second-chance detection and the box-score-reconciled possession frame come from
+:mod:`sportsdataverse.nba.nba_possessions` (a faithful pbpstats port) and are
+never recomputed here.
+
+Methodology provenance
+----------------------
+Every definition traces to CTG's own published guide pages, captured verbatim in
+``sdv-internal-refs/cleaningtheglass/`` (``METHODOLOGY.md`` + ``captures/guide_glossary.md``);
+the engineering mapping lives in that repo's ``RECREATION.md``. Where CTG does
+not publish a threshold, the knob is exposed and defaulted to the closest
+documented public convention (see
+:mod:`sportsdataverse.nba.nba_play_context_constants`):
+
+* **Transition** — CTG says only "starting at the beginning of a possession and
+  only ending once the defense is set". Default: hoop-math's 10-second
+  initial-play rule (``transition_seconds``).
+* **Putback** — CTG says "within a few seconds of the rebound". Default:
+  pbpstats' 2-second same-player unassisted-two rule (``putback_seconds``).
+* **Garbage time / heaves** — CTG publishes these exactly; reproduced faithfully.
+
+CTG precedence rule reproduced here: a **transition putback stays transition**
+("if a team comes down in transition and misses a shot but gets a putback, that
+putback is classified as part of the overall transition event").
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Union
+
+import pandas as pd
+import polars as pl
+
+from sportsdataverse.nba import nba_play_context_constants as C
+from sportsdataverse.nba.nba_possessions import build_possessions
+
+__all__ = [
+    "PLAY_CONTEXT_POSSESSIONS_SCHEMA",
+    "PLAY_CONTEXT_SHOTS_SCHEMA",
+    "add_ctg_shot_zones",
+    "add_play_context",
+    "add_start_type_detail",
+    "add_transition",
+    "build_play_context_shots",
+    "flag_garbage_time",
+    "flag_heave_possessions",
+    "nba_play_context",
+    "team_play_context",
+]
+
+#: Columns appended to the possession frame by :func:`add_play_context`.
+PLAY_CONTEXT_POSSESSIONS_SCHEMA: dict[str, pl.DataType] = {
+    "possession_start_type_detail": pl.Utf8,
+    "possession_start_type_ctg": pl.Utf8,
+    "seconds_to_first_play": pl.Float64,
+    "is_transition": pl.Boolean,
+    "transition_source": pl.Utf8,
+    "possession_context": pl.Utf8,
+    "is_heave_possession": pl.Boolean,
+    "is_garbage_time": pl.Boolean,
+    "garbage_time_basis": pl.Utf8,
+}
+
+#: Schema of the per-shot frame from :func:`build_play_context_shots`.
+PLAY_CONTEXT_SHOTS_SCHEMA: dict[str, pl.DataType] = {
+    "game_id": pl.Utf8,
+    "possession_number": pl.Int64,
+    "order_index": pl.Int64,
+    "period": pl.Int64,
+    "team_id": pl.Int64,
+    "person_id": pl.Int64,
+    "shot_value": pl.Int64,
+    "shot_made": pl.Boolean,
+    "ctg_shot_zone": pl.Utf8,
+    "is_assisted": pl.Boolean,
+    "is_putback": pl.Boolean,
+    "is_second_chance_shot": pl.Boolean,
+    "shot_context": pl.Utf8,
+}
+
+# ---------------------------------------------------------------------------
+# Shot zones (CTG taxonomy)
+# ---------------------------------------------------------------------------
+
+
+def add_ctg_shot_zones(enhanced_pbp: pl.DataFrame) -> pl.DataFrame:
+    """Append CTG's shot-location zone (``ctg_shot_zone``) to an enhanced PBP frame.
+
+    CTG's zones differ from the official NBA zones emitted by
+    :func:`~sportsdataverse.nba.nba_shot_zones.add_shot_zones`: CTG splits the
+    midrange at the free-throw-line distance rather than at the paint boundary.
+
+    * ``at_rim`` — shot distance < 4 ft ("Shots within 4 feet of the basket").
+    * ``short_mid`` — 4 ft <= distance < 14 ft ("outside of 4 feet, but inside of
+      ~14 feet (the free throw line distance)").
+    * ``long_mid`` — >= 14 ft, inside the arc.
+    * ``corner_3`` — a three "below the break" (``|x_legacy| >= 220`` and
+      ``y_legacy <= 87.5``).
+    * ``arc_3`` — any other three (CTG's "non-corner three").
+
+    Args:
+        enhanced_pbp: Frame from
+            :func:`~sportsdataverse.nba.nba_enhanced_pbp.enhanced_pbp_from_payload`.
+
+    Returns:
+        The input frame with a ``ctg_shot_zone`` Utf8 column appended (null on
+        non-field-goal rows). Empty input returns a zero-row frame carrying the
+        column — never raises.
+
+    Example:
+        Quick start::
+
+            from sportsdataverse.nba.nba_enhanced_pbp import enhanced_pbp_from_payload
+            from sportsdataverse.nba.nba_play_context import add_ctg_shot_zones
+            pbp = add_ctg_shot_zones(enhanced_pbp_from_payload(payload))
+            print(pbp.filter(pl.col("ctg_shot_zone").is_not_null())["ctg_shot_zone"].value_counts())
+
+        See Also:
+            * `hoopR`_ -- R sister package with the same NBA surface.
+
+        .. _hoopR: https://hoopR.sportsdataverse.org
+    """
+    if enhanced_pbp.is_empty():
+        return enhanced_pbp.with_columns(pl.lit(None, dtype=pl.Utf8).alias("ctg_shot_zone"))
+
+    x = pl.col("x_legacy").abs()
+    dist = pl.col("shot_distance")
+    is_fg = pl.col("is_field_goal") == 1
+    is_three = pl.col("shot_value") == 3
+
+    zone = (
+        pl.when(~is_fg)
+        .then(None)
+        .when(is_three & (x >= C.CORNER_THREE_ABS_X) & (pl.col("y_legacy") <= C.CORNER_THREE_MAX_Y))
+        .then(pl.lit("corner_3"))
+        .when(is_three)
+        .then(pl.lit("arc_3"))
+        .when(dist < C.RIM_DISTANCE_FT)
+        .then(pl.lit("at_rim"))
+        .when(dist < C.SHORT_MID_DISTANCE_FT)
+        .then(pl.lit("short_mid"))
+        .otherwise(pl.lit("long_mid"))
+        .alias("ctg_shot_zone")
+    )
+    return enhanced_pbp.with_columns(zone)
+
+
+def _zone_of_row(row: dict) -> Optional[str]:
+    """CTG zone for a single shot row (the row-wise twin of :func:`add_ctg_shot_zones`)."""
+    if not row.get("is_field_goal"):
+        return None
+    if (row.get("shot_value") or 0) == 3:
+        x = abs(row.get("x_legacy") or 0)
+        y = row.get("y_legacy") or 0
+        if x >= C.CORNER_THREE_ABS_X and y <= C.CORNER_THREE_MAX_Y:
+            return "corner_3"
+        return "arc_3"
+    dist = row.get("shot_distance")
+    if dist is None:
+        return None
+    if dist < C.RIM_DISTANCE_FT:
+        return "at_rim"
+    if dist < C.SHORT_MID_DISTANCE_FT:
+        return "short_mid"
+    return "long_mid"
+
+
+# ---------------------------------------------------------------------------
+# Start-type taxonomy
+# ---------------------------------------------------------------------------
+
+
+def _is_blocked(pbp_rows: list[dict], miss_pos: int, stop_pos: int) -> bool:
+    """True if a BLOCK companion row sits between the miss and its rebound.
+
+    Real-capture shape (verified on ``tests/fixtures/nba_engine``): a block is a
+    companion row with ``event_type == "other"`` whose description reads
+    ``"<Name> BLOCK (N BLK)"``, sharing the missed shot's ``seconds_remaining``.
+    """
+    miss_clock = pbp_rows[miss_pos].get("seconds_remaining")
+    for pos in range(miss_pos + 1, min(stop_pos + 1, len(pbp_rows))):
+        row = pbp_rows[pos]
+        if (row.get("event_type") or "") != "other":
+            continue
+        if row.get("seconds_remaining") != miss_clock:
+            continue
+        if "BLOCK" in (row.get("description") or "").upper():
+            return True
+    return False
+
+
+def _rebounded_shot_pos(pbp_rows: list[dict], rebound_pos: int) -> Optional[int]:
+    """Index of the missed shot / missed FT that the rebound at ``rebound_pos`` collected."""
+    for pos in range(rebound_pos - 1, -1, -1):
+        et = pbp_rows[pos].get("event_type") or ""
+        if et in ("missed_shot", "free_throw"):
+            return pos
+        if et in ("made_shot", "turnover", "period"):
+            return None
+    return None
+
+
+def _start_type_detail(
+    coarse: str,
+    prev_end_row: Optional[dict],
+    pbp_rows: list[dict],
+    pos_by_order: dict[int, int],
+) -> tuple[str, str]:
+    """Refine the engine's coarse start type into (fine start type, CTG bucket).
+
+    Faithful to pbpstats ``possession.py:206-242``. The coarse type already
+    encodes the validated period-start / timeout / steal / team-rebound
+    decisions (see
+    :func:`~sportsdataverse.nba.nba_possessions._possession_start_type`), so this
+    only *refines* the made/missed branches with the shot's CTG zone.
+    """
+    if coarse == C.START_TYPE_TIMEOUT:
+        return C.START_TYPE_TIMEOUT, "off_timeout"
+    if coarse == C.START_TYPE_LIVE_BALL_TURNOVER:
+        return C.START_TYPE_LIVE_BALL_TURNOVER, "off_steal"
+    if prev_end_row is None or coarse == C.START_TYPE_DEADBALL:
+        return C.START_TYPE_DEADBALL, "off_deadball"
+
+    et = prev_end_row.get("event_type") or ""
+
+    if coarse == "OffMadeShot":
+        if et == "free_throw":
+            return C.START_TYPE_FT_MAKE, "off_made"
+        zone = _zone_of_row(prev_end_row)
+        if zone is None:
+            return C.START_TYPE_DEADBALL, "off_deadball"
+        return f"Off{C.START_TYPE_ZONE_STEMS[zone]}Make", "off_made"
+
+    if coarse == "OffMissedShot":
+        # The boundary event is the defensive rebound; find the shot it collected.
+        rb_order = prev_end_row.get("order_index")
+        rb_pos = pos_by_order.get(int(rb_order)) if rb_order is not None else None
+        if rb_pos is None:
+            return C.START_TYPE_DEADBALL, "off_deadball"
+        shot_pos = _rebounded_shot_pos(pbp_rows, rb_pos)
+        if shot_pos is None:
+            return C.START_TYPE_DEADBALL, "off_deadball"
+        shot = pbp_rows[shot_pos]
+        if (shot.get("event_type") or "") == "free_throw":
+            return C.START_TYPE_FT_MISS, "off_live_rebound"
+        zone = _zone_of_row(shot)
+        if zone is None:
+            return C.START_TYPE_DEADBALL, "off_deadball"
+        stem = C.START_TYPE_ZONE_STEMS[zone]
+        if _is_blocked(pbp_rows, shot_pos, rb_pos):
+            return f"Off{stem}Block", "off_live_rebound"
+        return f"Off{stem}Miss", "off_live_rebound"
+
+    return C.START_TYPE_DEADBALL, "off_deadball"
+
+
+def add_start_type_detail(possessions: pl.DataFrame, enhanced_pbp: pl.DataFrame) -> pl.DataFrame:
+    """Append the full pbpstats start-type taxonomy to a possession frame.
+
+    Upgrades the engine's coarse 5-value ``possession_start_type`` into:
+
+    * ``possession_start_type_detail`` — the zone-split pbpstats vocabulary:
+      ``Off{AtRim|ShortMidRange|LongMidRange|Corner3|Arc3}{Make|Miss|Block}``,
+      ``OffFTMake`` / ``OffFTMiss``, ``OffLiveBallTurnover``, ``OffTimeout``,
+      ``OffDeadball``.
+    * ``possession_start_type_ctg`` — the coarse bucket CTG reports on:
+      ``off_made`` / ``off_live_rebound`` / ``off_steal`` / ``off_deadball`` /
+      ``off_timeout`` (see :data:`~nba_play_context_constants.CTG_START_BUCKETS`).
+
+    Precedence (pbpstats): period start > timeout > previous boundary event. A
+    **team rebound** (``person_id == 0``) is a dead-ball start even though a
+    rebound row exists; a **timeout** beats a made basket (an after-timeout
+    possession is ``OffTimeout``, not ``OffMadeShot``).
+
+    Args:
+        possessions: Frame from
+            :func:`~sportsdataverse.nba.nba_possessions.build_possessions`.
+        enhanced_pbp: The enhanced PBP frame those possessions were built from.
+
+    Returns:
+        ``possessions`` with the two columns appended. Empty input returns a
+        zero-row frame carrying them — never raises.
+
+    Example:
+        Quick start::
+
+            from sportsdataverse.nba.nba_possessions import build_possessions
+            from sportsdataverse.nba.nba_play_context import add_start_type_detail
+            poss = add_start_type_detail(build_possessions(pbp), pbp)
+            print(poss["possession_start_type_ctg"].value_counts())
+
+        See Also:
+            * `pbpstats`_ -- the reference possession parser this ports.
+
+        .. _pbpstats: https://github.com/dblackrun/pbpstats
+    """
+    if possessions.is_empty():
+        return possessions.with_columns(
+            pl.lit(None, dtype=pl.Utf8).alias("possession_start_type_detail"),
+            pl.lit(None, dtype=pl.Utf8).alias("possession_start_type_ctg"),
+        )
+
+    pbp_rows: list[dict] = enhanced_pbp.sort("order_index").to_dicts()
+    pos_by_order = {r["order_index"]: i for i, r in enumerate(pbp_rows)}
+
+    poss = possessions.sort("possession_number")
+    prows = poss.to_dicts()
+    end_by_number = {r["possession_number"]: r.get("end_order_index") for r in prows}
+
+    details: list[str] = []
+    buckets: list[str] = []
+    for r in prows:
+        prev_end_order = end_by_number.get(r["possession_number"] - 1)
+        prev_end_row = (
+            pbp_rows[pos_by_order[prev_end_order]]
+            if prev_end_order is not None and prev_end_order in pos_by_order
+            else None
+        )
+        # The first possession of a period is always a dead-ball start (pbpstats).
+        coarse = r.get("possession_start_type") or C.START_TYPE_DEADBALL
+        if (r.get("number_in_period") or 0) == 1:
+            coarse = C.START_TYPE_DEADBALL
+            prev_end_row = None
+        detail, bucket = _start_type_detail(coarse, prev_end_row, pbp_rows, pos_by_order)
+        details.append(detail)
+        buckets.append(bucket)
+
+    return poss.with_columns(
+        pl.Series("possession_start_type_detail", details, dtype=pl.Utf8),
+        pl.Series("possession_start_type_ctg", buckets, dtype=pl.Utf8),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Transition / halfcourt
+# ---------------------------------------------------------------------------
+
+
+def add_transition(
+    possessions: pl.DataFrame,
+    enhanced_pbp: pl.DataFrame,
+    *,
+    transition_seconds: float = C.DEFAULT_TRANSITION_SECONDS,
+    variant: str = C.DEFAULT_TRANSITION_VARIANT,
+) -> pl.DataFrame:
+    """Flag possessions that started in transition, and time their initial play.
+
+    CTG defines transition as beginning at the possession start and ending "once
+    the defense is set", **without publishing a seconds threshold**. We therefore
+    time the possession's *initial play* — its first shot attempt, trip to the
+    line, or turnover (CTG's own definition of a "play") — and call the
+    possession transition when that play lands within ``transition_seconds``.
+
+    Variants (:data:`~nba_play_context_constants.TRANSITION_VARIANTS`):
+
+    * ``hoop_math`` (default) — any non-timeout start type qualifies.
+    * ``haslametrics`` — steal starts only (conservative).
+    * ``bigballr`` — the previous possession must have ended live
+      (``off_made`` / ``off_live_rebound`` / ``off_steal``); a dead-ball start can
+      never be transition.
+
+    The first possession of a period is never transition. After a timeout the
+    defense is set by construction, so ``off_timeout`` never qualifies under any
+    variant.
+
+    Args:
+        possessions: Frame carrying ``possession_start_type_ctg`` (i.e. the output
+            of :func:`add_start_type_detail`).
+        enhanced_pbp: The enhanced PBP frame the possessions were built from.
+        transition_seconds: Initial-play cutoff. Default 10.0 (hoop-math).
+            Calibrate against Synergy transition frequency (league mean ~15-16%).
+        variant: One of :data:`~nba_play_context_constants.TRANSITION_VARIANTS`.
+
+    Returns:
+        ``possessions`` with ``seconds_to_first_play`` (Float64, null when the
+        possession had no play), ``is_transition`` (Boolean), ``transition_source``
+        (Utf8: ``steal`` / ``live_rebound`` / ``made`` / ``deadball``; null when not
+        transition) and ``possession_context`` (Utf8: ``transition`` / ``halfcourt``
+        / ``misc``) appended.
+
+    Raises:
+        ValueError: If ``variant`` is not a known transition variant.
+
+    Example:
+        Quick start::
+
+            poss = add_transition(add_start_type_detail(poss, pbp), pbp)
+            print(poss["is_transition"].mean())          # transition frequency
+
+        Tune the knob against the Synergy oracle::
+
+            poss8 = add_transition(poss, pbp, transition_seconds=8.0)
+    """
+    if variant not in C.TRANSITION_VARIANTS:
+        raise ValueError(f"variant must be one of {C.TRANSITION_VARIANTS}, got {variant!r}")
+
+    empty_cols = (
+        pl.lit(None, dtype=pl.Float64).alias("seconds_to_first_play"),
+        pl.lit(None, dtype=pl.Boolean).alias("is_transition"),
+        pl.lit(None, dtype=pl.Utf8).alias("transition_source"),
+        pl.lit(None, dtype=pl.Utf8).alias("possession_context"),
+    )
+    if possessions.is_empty():
+        return possessions.with_columns(*empty_cols)
+
+    pbp_rows = enhanced_pbp.sort("order_index").to_dicts()
+
+    # First play-ending event per possession, by order-index window.
+    first_play_clock: dict[int, float] = {}
+    poss_rows = possessions.sort("possession_number").to_dicts()
+    for r in poss_rows:
+        lo, hi = r.get("start_order_index"), r.get("end_order_index")
+        if lo is None or hi is None:
+            continue
+        for row in pbp_rows:
+            oi = row.get("order_index")
+            if oi is None or oi < lo:
+                continue
+            if oi > hi:
+                break
+            if (row.get("event_type") or "") in C.PLAY_ENDING_EVENT_TYPES:
+                first_play_clock[r["possession_number"]] = row.get("seconds_remaining")
+                break
+
+    _SOURCE = {
+        "off_steal": "steal",
+        "off_live_rebound": "live_rebound",
+        "off_made": "made",
+        "off_deadball": "deadball",
+    }
+
+    secs: list[Optional[float]] = []
+    trans: list[bool] = []
+    source: list[Optional[str]] = []
+    context: list[str] = []
+
+    # The possession's START is the moment the ball changed hands -- i.e. the clock
+    # of the event that ENDED the previous possession -- NOT `start_seconds_remaining`,
+    # which is the clock of this possession's first *row*. Those differ: after a
+    # defensive rebound the group's first row is frequently the shot itself, so
+    # measuring from it makes almost every possession look like transition (85% vs
+    # the Synergy ~15% oracle -- the bug this reference fixes). Same subtlety
+    # documented in `nba_possessions._count_as_possession`.
+    prev_end_clock: dict[int, float] = {}
+    for r in poss_rows:
+        end_clock = r.get("end_seconds_remaining")
+        if end_clock is not None:
+            prev_end_clock[r["possession_number"] + 1] = float(end_clock)
+
+    for r in poss_rows:
+        bucket = r.get("possession_start_type_ctg") or "off_deadball"
+        # A period's opening possession has no prior possession in that period, so
+        # the ball-change reference is the period start itself -- use the group's own
+        # first-row clock (these are never transition; see below).
+        if (r.get("number_in_period") or 0) == 1:
+            start_clock = r.get("start_seconds_remaining")
+        else:
+            start_clock = prev_end_clock.get(r["possession_number"], r.get("start_seconds_remaining"))
+        play_clock = first_play_clock.get(r["possession_number"])
+        elapsed = float(start_clock) - float(play_clock) if start_clock is not None and play_clock is not None else None
+        secs.append(elapsed)
+
+        if variant == "haslametrics":
+            eligible = bucket == "off_steal"
+        elif variant == "bigballr":
+            eligible = bucket in C.LIVE_START_BUCKETS
+        else:  # hoop_math
+            eligible = bucket not in C.NON_TRANSITION_START_BUCKETS
+
+        # A period's opening possession is never transition.
+        if (r.get("number_in_period") or 0) == 1:
+            eligible = False
+
+        is_trans = bool(eligible and elapsed is not None and elapsed <= transition_seconds)
+        trans.append(is_trans)
+        source.append(_SOURCE.get(bucket) if is_trans else None)
+        context.append("transition" if is_trans else ("halfcourt" if elapsed is not None else "misc"))
+
+    return possessions.sort("possession_number").with_columns(
+        pl.Series("seconds_to_first_play", secs, dtype=pl.Float64),
+        pl.Series("is_transition", trans, dtype=pl.Boolean),
+        pl.Series("transition_source", source, dtype=pl.Utf8),
+        pl.Series("possession_context", context, dtype=pl.Utf8),
+    )
+
+
+# ---------------------------------------------------------------------------
+# CTG default filters — heaves + garbage time
+# ---------------------------------------------------------------------------
+
+
+def flag_heave_possessions(possessions: pl.DataFrame) -> pl.DataFrame:
+    """Flag CTG's "projected heave possessions" (excluded from CTG stats by default).
+
+    CTG (exact): "possessions that start with **4 or fewer seconds on the game
+    clock at the end of one of the first three quarters**." Q4/OT are exempt — a
+    late Q4 possession is a real possession.
+
+    Args:
+        possessions: Any frame with ``period`` and ``start_seconds_remaining``.
+
+    Returns:
+        ``possessions`` with a Boolean ``is_heave_possession`` column appended.
+
+    Example:
+        Quick start::
+
+            poss = flag_heave_possessions(poss)
+            clean = poss.filter(pl.col("is_heave_possession") == False)
+    """
+    if possessions.is_empty():
+        return possessions.with_columns(pl.lit(None, dtype=pl.Boolean).alias("is_heave_possession"))
+
+    return possessions.with_columns(
+        (
+            pl.col("period").is_in(list(C.HEAVE_PERIODS))
+            & (pl.col("start_seconds_remaining") <= C.HEAVE_POSSESSION_SECONDS)
+        )
+        .fill_null(False)
+        .alias("is_heave_possession")
+    )
+
+
+def flag_garbage_time(
+    possessions: pl.DataFrame,
+    enhanced_pbp: pl.DataFrame,
+    *,
+    starters_on_court: Optional[dict[int, int]] = None,
+) -> pl.DataFrame:
+    """Flag CTG garbage time (excluded from CTG stats by default).
+
+    CTG (exact): "the game has to be in the **4th quarter**, the score
+    differential has to be **>= 25 for minutes 12-9, >= 20 for minutes 9-6, and
+    >= 10 for the remainder of the quarter**. Additionally, there have to be **two
+    or fewer starters on the floor combined between the two teams**. Importantly,
+    the game can never go back to being non-garbage time, or this clock resets."
+
+    The margin x minutes bands are reproduced exactly, evaluated on the score at
+    each possession's start. The reset semantics fall out of that per-possession
+    evaluation: if the trailing team claws back inside the band's threshold, the
+    condition stops holding and those possessions are NOT garbage time (CTG's own
+    "comeback is not counted as garbage time" example); if the lead re-expands,
+    the flag turns back on.
+
+    **The starters clause is applied only when ``starters_on_court`` is supplied**
+    — it needs lineup + box ``START_POSITION`` data this frame does not carry.
+    Without it the flag is the **margin-only superset** of CTG's definition (it can
+    flag a blowout stretch in which the starters are still on the floor), and
+    ``garbage_time_basis`` records which rule was actually used. This is a
+    deliberate, documented divergence — do not read a ``margin_only`` flag as
+    CTG-exact.
+
+    Args:
+        possessions: Frame with ``period``, ``start_seconds_remaining`` and
+            ``start_order_index``.
+        enhanced_pbp: The enhanced PBP frame (supplies the running score).
+        starters_on_court: Optional map ``possession_number -> number of starters
+            on the floor across BOTH teams``. When given, a possession is garbage
+            time only if that count is
+            <= :data:`~nba_play_context_constants.GARBAGE_TIME_MAX_STARTERS`.
+
+    Returns:
+        ``possessions`` with Boolean ``is_garbage_time`` and Utf8
+        ``garbage_time_basis`` (``"margin_and_starters"`` or ``"margin_only"``)
+        appended.
+
+    Example:
+        Quick start (margin-only superset)::
+
+            poss = flag_garbage_time(poss, pbp)
+            print(poss.filter(pl.col("is_garbage_time") == True).height)
+
+        CTG-exact, with the starters clause::
+
+            poss = flag_garbage_time(poss, pbp, starters_on_court=starters_by_possession)
+    """
+    basis = "margin_and_starters" if starters_on_court is not None else "margin_only"
+    if possessions.is_empty():
+        return possessions.with_columns(
+            pl.lit(None, dtype=pl.Boolean).alias("is_garbage_time"),
+            pl.lit(basis, dtype=pl.Utf8).alias("garbage_time_basis"),
+        )
+
+    # Running score at each possession's start. The v3 feed ships score_home /
+    # score_away as Utf8 and populates them only on scoring rows, so cast to Int64
+    # at the boundary (never diff the raw strings) and forward-fill the gaps.
+    score = (
+        enhanced_pbp.sort("order_index")
+        .with_columns(
+            pl.col("score_home").cast(pl.Int64, strict=False).forward_fill().fill_null(0).alias("_sh"),
+            pl.col("score_away").cast(pl.Int64, strict=False).forward_fill().fill_null(0).alias("_sa"),
+        )
+        .select("order_index", "_sh", "_sa")
+    )
+    margin_by_order = {r["order_index"]: abs((r["_sh"] or 0) - (r["_sa"] or 0)) for r in score.to_dicts()}
+
+    flags: list[bool] = []
+    for r in possessions.sort("possession_number").to_dicts():
+        if (r.get("period") or 0) != C.GARBAGE_TIME_PERIOD:
+            flags.append(False)
+            continue
+        clock = r.get("start_seconds_remaining")
+        margin = margin_by_order.get(r.get("start_order_index"), 0)
+        hit = False
+        for high, low, min_margin in C.GARBAGE_TIME_BANDS:
+            if clock is not None and low < float(clock) <= high and margin >= min_margin:
+                hit = True
+                break
+        if hit and starters_on_court is not None:
+            hit = starters_on_court.get(r["possession_number"], 10) <= C.GARBAGE_TIME_MAX_STARTERS
+        flags.append(hit)
+
+    return possessions.sort("possession_number").with_columns(
+        pl.Series("is_garbage_time", flags, dtype=pl.Boolean),
+        pl.lit(basis, dtype=pl.Utf8).alias("garbage_time_basis"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shot-level context (putbacks / second chance)
+# ---------------------------------------------------------------------------
+
+
+def build_play_context_shots(
+    possessions: pl.DataFrame,
+    enhanced_pbp: pl.DataFrame,
+    *,
+    putback_seconds: float = C.DEFAULT_PUTBACK_SECONDS,
+) -> pl.DataFrame:
+    """Build the per-shot frame carrying CTG's play context.
+
+    CTG assigns context **per play**, not per possession: one possession can
+    contain a transition miss, a halfcourt reset and a putback. This frame is the
+    play-level view — one row per field-goal attempt.
+
+    * ``is_putback`` — pbpstats ``field_goal.py:112-144``: an **unassisted 2-point**
+      attempt whose preceding event is a **real offensive rebound by the same
+      player**, within ``putback_seconds``. A three is never a putback.
+    * ``is_second_chance_shot`` — the shot follows an offensive rebound earlier in
+      the same possession.
+    * ``shot_context`` — ``transition`` / ``putback`` / ``halfcourt``. **Transition
+      wins over putback**, reproducing CTG exactly: "if a team comes down in
+      transition and misses a shot but gets a putback, that putback is classified
+      as part of the overall transition event."
+
+    Args:
+        possessions: Frame from :func:`add_transition` (needs ``is_transition``).
+        enhanced_pbp: The enhanced PBP frame the possessions were built from.
+        putback_seconds: Rebound-to-shot window. Default 2.0 (pbpstats).
+
+    Returns:
+        Polars DataFrame with schema :data:`PLAY_CONTEXT_SHOTS_SCHEMA` — one row
+        per field-goal attempt. Empty input returns the zero-row schema.
+
+    Example:
+        Quick start::
+
+            shots = build_play_context_shots(poss, pbp)
+            print(shots.group_by("shot_context").len())
+            print(shots.filter(pl.col("is_putback") == True).height)
+    """
+    if possessions.is_empty() or enhanced_pbp.is_empty():
+        return pl.DataFrame(schema=PLAY_CONTEXT_SHOTS_SCHEMA)
+
+    pbp_rows = add_ctg_shot_zones(enhanced_pbp.sort("order_index")).to_dicts()
+    trans_by_poss = {
+        r["possession_number"]: bool(r.get("is_transition"))
+        for r in possessions.select("possession_number", "is_transition").to_dicts()
+    }
+    # order-index window -> possession number
+    windows = [
+        (r["start_order_index"], r["end_order_index"], r["possession_number"], r["offense_team_id"])
+        for r in possessions.sort("possession_number").to_dicts()
+        if r.get("start_order_index") is not None and r.get("end_order_index") is not None
+    ]
+
+    def _poss_of(order_index: int) -> tuple[Optional[int], Optional[int]]:
+        for lo, hi, num, off in windows:
+            if lo <= order_index <= hi:
+                return num, off
+        return None, None
+
+    records: list[dict[str, Any]] = []
+    for i, row in enumerate(pbp_rows):
+        et = row.get("event_type") or ""
+        if et not in ("made_shot", "missed_shot"):
+            continue
+        oi = row.get("order_index")
+        poss_num, _off_team = _poss_of(oi)
+        if poss_num is None:
+            continue
+
+        assisted = et == "made_shot" and "AST" in (row.get("description") or "").upper()
+
+        # Putback: walk back past co-clock fouls / companion rows to the previous
+        # substantive event; it must be this player's own offensive rebound,
+        # within the window.
+        is_putback = False
+        if (row.get("shot_value") or 0) == 2 and not assisted:
+            for j in range(i - 1, -1, -1):
+                prev = pbp_rows[j]
+                pet = prev.get("event_type") or ""
+                if pet in ("foul", "other", "replay", "substitution"):
+                    continue
+                if pet == "rebound" and prev.get("person_id") and prev.get("person_id") == row.get("person_id"):
+                    reb_clock = prev.get("seconds_remaining")
+                    shot_clock = row.get("seconds_remaining")
+                    if (
+                        reb_clock is not None
+                        and shot_clock is not None
+                        and 0 <= (float(reb_clock) - float(shot_clock)) <= putback_seconds
+                    ):
+                        is_putback = True
+                break
+
+        # Second chance: an offensive rebound (by the offense) earlier in this possession.
+        second_chance = False
+        for j in range(i - 1, -1, -1):
+            prev = pbp_rows[j]
+            pnum, _ = _poss_of(prev.get("order_index"))
+            if pnum != poss_num:
+                break
+            if (prev.get("event_type") or "") == "rebound" and prev.get("team_id") == row.get("team_id"):
+                second_chance = True
+                break
+
+        in_transition = trans_by_poss.get(poss_num, False)
+        if in_transition:
+            ctx = "transition"  # CTG: transition wins over putback
+        elif is_putback:
+            ctx = "putback"
+        else:
+            ctx = "halfcourt"
+
+        records.append(
+            {
+                "game_id": row.get("game_id"),
+                "possession_number": poss_num,
+                "order_index": oi,
+                "period": row.get("period"),
+                "team_id": row.get("team_id"),
+                "person_id": row.get("person_id"),
+                "shot_value": row.get("shot_value"),
+                "shot_made": et == "made_shot",
+                "ctg_shot_zone": row.get("ctg_shot_zone"),
+                "is_assisted": assisted,
+                "is_putback": is_putback,
+                "is_second_chance_shot": second_chance,
+                "shot_context": ctx,
+            }
+        )
+
+    if not records:
+        return pl.DataFrame(schema=PLAY_CONTEXT_SHOTS_SCHEMA)
+    return pl.DataFrame(records, schema=PLAY_CONTEXT_SHOTS_SCHEMA)
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+def add_play_context(
+    enhanced_pbp: pl.DataFrame,
+    *,
+    transition_seconds: float = C.DEFAULT_TRANSITION_SECONDS,
+    transition_variant: str = C.DEFAULT_TRANSITION_VARIANT,
+    starters_on_court: Optional[dict[int, int]] = None,
+) -> pl.DataFrame:
+    """Build possessions and enrich them with the full CTG play-context surface.
+
+    One call: :func:`~sportsdataverse.nba.nba_possessions.build_possessions` ->
+    :func:`add_start_type_detail` -> :func:`add_transition` ->
+    :func:`flag_heave_possessions` -> :func:`flag_garbage_time`.
+
+    The CTG filter columns are **flags, not filters** — nothing is dropped. Apply
+    CTG's defaults yourself::
+
+        ctg = poss.filter(
+            (pl.col("is_garbage_time") == False) & (pl.col("is_heave_possession") == False)
+        )
+
+    Args:
+        enhanced_pbp: Frame from
+            :func:`~sportsdataverse.nba.nba_enhanced_pbp.enhanced_pbp_from_payload`.
+        transition_seconds: Transition initial-play cutoff (default 10.0).
+        transition_variant: See :func:`add_transition`.
+        starters_on_court: Optional starters-on-floor counts; see
+            :func:`flag_garbage_time`.
+
+    Returns:
+        The possession frame (``POSSESSIONS_SCHEMA``) plus every column in
+        :data:`PLAY_CONTEXT_POSSESSIONS_SCHEMA`.
+
+    Example:
+        Quick start::
+
+            from sportsdataverse.nba.nba_enhanced_pbp import enhanced_pbp_from_payload
+            from sportsdataverse.nba.nba_play_context import add_play_context
+            poss = add_play_context(enhanced_pbp_from_payload(payload))
+            print(poss["possession_start_type_ctg"].value_counts())
+    """
+    poss = build_possessions(enhanced_pbp)
+    poss = add_start_type_detail(poss, enhanced_pbp)
+    poss = add_transition(poss, enhanced_pbp, transition_seconds=transition_seconds, variant=transition_variant)
+    poss = flag_heave_possessions(poss)
+    poss = flag_garbage_time(poss, enhanced_pbp, starters_on_court=starters_on_court)
+    return poss
+
+
+# ---------------------------------------------------------------------------
+# Aggregation — CTG's Play Context table
+# ---------------------------------------------------------------------------
+
+
+def team_play_context(
+    possessions: pl.DataFrame,
+    *,
+    league_non_transition_ppp: Optional[float] = None,
+    apply_ctg_filters: bool = True,
+    return_as_pandas: bool = False,
+) -> Union[pl.DataFrame, pd.DataFrame]:
+    """Roll possessions up into CTG's team Play-Context table.
+
+    Reproduces the offensive half of CTG's ``/stats/league/context`` page.
+
+    Columns: ``poss``, ``points``, ``pts_per_100``, ``transition_poss``,
+    ``transition_points``, ``transition_freq``, ``transition_pts_per_100``
+    (CTG's "Eff"), ``non_transition_pts_per_100``, ``transition_pts_added_per_100``
+    (CTG's "Pts+/Poss"), plus ``halfcourt_*`` twins and per-source transition
+    frequencies (``freq_off_steal`` / ``freq_off_live_rebound``).
+
+    **Pts+/Poss** is the subtle one. CTG: "CTG takes a team's points per
+    possession that starts with transition, and subtracts out **what an average
+    team does** in a possession that did not start with transition. ... We take the
+    result and multiply it by the team's transition frequency."::
+
+        pts_added_per_100 = (team_transition_ppp - LEAGUE_avg_non_transition_ppp) * freq
+
+    The **league-average** baseline (not the team's own) is deliberate — it stops a
+    great halfcourt offense from deflating its own transition value. When
+    ``league_non_transition_ppp`` is not supplied it is computed from the frame
+    itself, which is only meaningful on a **season-wide** frame; on a single game
+    that "league average" is just the two teams in it. Pass the season value
+    explicitly for CTG-comparable numbers.
+
+    Args:
+        possessions: Frame from :func:`add_play_context`.
+        league_non_transition_ppp: League-average points per 100 possessions on
+            non-transition-start possessions. Computed from the frame when omitted.
+        apply_ctg_filters: Drop garbage-time, heave and non-counting possessions
+            first (CTG's default view). Set ``False`` for the unfiltered totals.
+        return_as_pandas: Return a pandas DataFrame instead of polars.
+
+    Returns:
+        One row per ``offense_team_id``. Empty input returns a zero-row frame.
+
+    Example:
+        Quick start::
+
+            ctx = team_play_context(add_play_context(pbp))
+            print(ctx.select("offense_team_id", "transition_freq", "transition_pts_added_per_100"))
+
+        Season-comparable Pts+/Poss::
+
+            ctx = team_play_context(season_poss, league_non_transition_ppp=104.8)
+    """
+    df = possessions
+    if df.is_empty():
+        out = pl.DataFrame(
+            schema={
+                "offense_team_id": pl.Int64,
+                "poss": pl.Int64,
+                "points": pl.Int64,
+                "pts_per_100": pl.Float64,
+                "transition_poss": pl.Int64,
+                "transition_points": pl.Int64,
+                "transition_freq": pl.Float64,
+                "transition_pts_per_100": pl.Float64,
+                "non_transition_pts_per_100": pl.Float64,
+                "transition_pts_added_per_100": pl.Float64,
+                "halfcourt_poss": pl.Int64,
+                "halfcourt_pts_per_100": pl.Float64,
+                "freq_off_steal": pl.Float64,
+                "freq_off_live_rebound": pl.Float64,
+            }
+        )
+        return out.to_pandas() if return_as_pandas else out
+
+    if apply_ctg_filters:
+        df = df.filter(
+            (pl.col("count_as_possession") == True)  # noqa: E712
+            & (pl.col("is_garbage_time") == False)  # noqa: E712
+            & (pl.col("is_heave_possession") == False)  # noqa: E712
+        )
+
+    is_trans = pl.col("is_transition") == True  # noqa: E712
+
+    if league_non_transition_ppp is None:
+        nt = df.filter(~is_trans)
+        league_non_transition_ppp = 100.0 * nt["points"].sum() / nt.height if nt.height else 0.0
+
+    agg = df.group_by("offense_team_id").agg(
+        pl.len().alias("poss"),
+        pl.col("points").sum().alias("points"),
+        is_trans.sum().alias("transition_poss"),
+        pl.col("points").filter(is_trans).sum().alias("transition_points"),
+        (~is_trans).sum().alias("halfcourt_poss"),
+        pl.col("points").filter(~is_trans).sum().alias("halfcourt_points"),
+        (pl.col("transition_source") == "steal").sum().alias("_trans_steal"),
+        (pl.col("transition_source") == "live_rebound").sum().alias("_trans_reb"),
+    )
+
+    out = (
+        agg.with_columns(
+            (100.0 * pl.col("points") / pl.col("poss")).alias("pts_per_100"),
+            (pl.col("transition_poss") / pl.col("poss")).alias("transition_freq"),
+            pl.when(pl.col("transition_poss") > 0)
+            .then(100.0 * pl.col("transition_points") / pl.col("transition_poss"))
+            .otherwise(None)
+            .alias("transition_pts_per_100"),
+            pl.when(pl.col("halfcourt_poss") > 0)
+            .then(100.0 * pl.col("halfcourt_points") / pl.col("halfcourt_poss"))
+            .otherwise(None)
+            .alias("non_transition_pts_per_100"),
+            (pl.col("_trans_steal") / pl.col("poss")).alias("freq_off_steal"),
+            (pl.col("_trans_reb") / pl.col("poss")).alias("freq_off_live_rebound"),
+        )
+        .with_columns(
+            ((pl.col("transition_pts_per_100") - league_non_transition_ppp) * pl.col("transition_freq")).alias(
+                "transition_pts_added_per_100"
+            ),
+            pl.col("non_transition_pts_per_100").alias("halfcourt_pts_per_100"),
+        )
+        .drop("_trans_steal", "_trans_reb", "halfcourt_points")
+        .sort("offense_team_id")
+    )
+    return out.to_pandas() if return_as_pandas else out
+
+
+# ---------------------------------------------------------------------------
+# Public fetcher
+# ---------------------------------------------------------------------------
+
+
+def _fetch_pbp(game_id: str, league_id: str = "00") -> dict:
+    """Fetch the raw play-by-play v3 payload (module-level so tests can monkeypatch)."""
+    from sportsdataverse.nba.nba_stats import nba_stats_playbyplayv3
+
+    return nba_stats_playbyplayv3(game_id=game_id, return_parsed=False)
+
+
+def nba_play_context(
+    game_id: str,
+    league_id: str = "00",
+    *,
+    transition_seconds: float = C.DEFAULT_TRANSITION_SECONDS,
+    transition_variant: str = C.DEFAULT_TRANSITION_VARIANT,
+    return_as_pandas: bool = False,
+) -> Union[pl.DataFrame, pd.DataFrame]:
+    """Fetch one game and return its possessions with the full CTG play-context surface.
+
+    Single live call to ``nba_stats_playbyplayv3``, then
+    :func:`add_play_context`. Works for NBA (``league_id="00"``), WNBA and the
+    G-League — ``stats.wnba.com`` ships the same play-by-play shapes, and every
+    threshold here is league-agnostic.
+
+    Args:
+        game_id: Ten-character game identifier (e.g. ``"0022200001"``).
+        league_id: League identifier (``"00"`` NBA, ``"10"`` WNBA, ``"20"`` G-League).
+        transition_seconds: Transition initial-play cutoff (default 10.0).
+        transition_variant: See :func:`add_transition`.
+        return_as_pandas: Return a pandas DataFrame instead of polars.
+
+    Returns:
+        Possession frame with the play-context columns. Empty/malformed payloads
+        return a zero-row frame — never raises.
+
+    Example:
+        Quick start::
+
+            from sportsdataverse.nba.nba_play_context import nba_play_context
+            poss = nba_play_context("0022200001")
+            print(poss["possession_start_type_ctg"].value_counts())
+
+        Transition rate for the game::
+
+            import polars as pl
+            clean = poss.filter(
+                (pl.col("is_garbage_time") == False) & (pl.col("is_heave_possession") == False)
+            )
+            print(clean["is_transition"].mean())
+
+        See Also:
+            * `pbpstats`_ -- the reference possession parser this builds on.
+            * `hoopR`_ -- R sister package.
+
+        .. _pbpstats: https://github.com/dblackrun/pbpstats
+        .. _hoopR: https://hoopR.sportsdataverse.org
+    """
+    from sportsdataverse.nba.nba_enhanced_pbp import enhanced_pbp_from_payload
+
+    payload = _fetch_pbp(game_id, league_id)
+    enh = enhanced_pbp_from_payload(payload, league_id=league_id)
+    out = add_play_context(enh, transition_seconds=transition_seconds, transition_variant=transition_variant)
+    return out.to_pandas() if return_as_pandas else out

--- a/sportsdataverse/nba/nba_play_context_constants.py
+++ b/sportsdataverse/nba/nba_play_context_constants.py
@@ -1,0 +1,183 @@
+"""Constants for the NBA/WNBA play-context engine (Cleaning the Glass recreation).
+
+League-agnostic algorithms, league-specific constants: nothing in
+:mod:`sportsdataverse.nba.nba_play_context` hard-codes a number from this module.
+
+Definitions are recreated from Cleaning the Glass's own published methodology
+(``sdv-internal-refs/cleaningtheglass/METHODOLOGY.md``, quoting CTG's
+``/stats/guide/<slug>`` pages verbatim). Where CTG does NOT publish a threshold
+(it says only "until the defense is set" / "within a few seconds of the
+rebound"), we adopt the closest documented public convention and expose it as a
+knob — see :data:`DEFAULT_TRANSITION_SECONDS` and :data:`DEFAULT_PUTBACK_SECONDS`.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+# ---------------------------------------------------------------------------
+# Shot zones (CTG / pbpstats taxonomy)
+# ---------------------------------------------------------------------------
+
+#: CTG's shot-location taxonomy. Distinct from :data:`nba_shot_zones.SHOT_ZONES`
+#: (the *official NBA* zones: restricted area / paint-non-RA / mid-range / ...).
+#: CTG splits the midrange at the free-throw-line distance instead:
+#: rim <=4 ft, short mid 4-13.75 ft, long mid >13.75 ft (METHODOLOGY.md 5b).
+CTG_SHOT_ZONES: Final[list[str]] = ["at_rim", "short_mid", "long_mid", "corner_3", "arc_3"]
+
+#: Rim boundary in feet -- CTG: "Shots within 4 feet of the basket".
+RIM_DISTANCE_FT: Final[float] = 4.0
+
+#: Short/long midrange boundary in feet -- CTG: "outside of 4 feet, but inside of
+#: ~14 feet (the free throw line distance)".
+SHORT_MID_DISTANCE_FT: Final[float] = 14.0
+
+#: Corner-three geometry in stats.nba.com legacy coordinates (tenths of a foot).
+#: A three is a corner three iff ``|x_legacy| >= 220`` and ``y_legacy <= 87.5``
+#: (same test the official-zone classifier uses; CTG calls these "below the break").
+CORNER_THREE_ABS_X: Final[float] = 220.0
+CORNER_THREE_MAX_Y: Final[float] = 87.5
+
+# ---------------------------------------------------------------------------
+# Possession start types (pbpstats taxonomy, possession.py:206-242)
+# ---------------------------------------------------------------------------
+
+#: Zone-qualified start-type stems. The full fine-grained vocabulary is the
+#: cross product ``Off{Zone}{Make|Miss|Block}`` plus the unqualified members below.
+START_TYPE_ZONE_STEMS: Final[dict[str, str]] = {
+    "at_rim": "AtRim",
+    "short_mid": "ShortMidRange",
+    "long_mid": "LongMidRange",
+    "corner_3": "Corner3",
+    "arc_3": "Arc3",
+}
+
+#: Start types that carry no shot zone.
+START_TYPE_DEADBALL: Final[str] = "OffDeadball"
+START_TYPE_TIMEOUT: Final[str] = "OffTimeout"
+START_TYPE_LIVE_BALL_TURNOVER: Final[str] = "OffLiveBallTurnover"
+START_TYPE_FT_MAKE: Final[str] = "OffFTMake"
+START_TYPE_FT_MISS: Final[str] = "OffFTMiss"
+
+# ---------------------------------------------------------------------------
+# CTG coarse start buckets (what CTG actually reports on)
+# ---------------------------------------------------------------------------
+
+#: CTG's Play-Context tables split transition by source into "Off Steals" and
+#: "Off Live Rebounds"; the remaining starts roll up to made-shot / dead-ball /
+#: timeout. These are the coarse buckets every CTG table groups by.
+CTG_START_BUCKETS: Final[list[str]] = [
+    "off_made",  # previous possession ended in a made FG or made final FT
+    "off_live_rebound",  # defensive rebound of a live missed/blocked shot
+    "off_steal",  # live-ball turnover (steal)
+    "off_deadball",  # period start, dead-ball TO, team rebound, fallback
+    "off_timeout",  # timeout at the possession boundary (wins over everything but period start)
+]
+
+# ---------------------------------------------------------------------------
+# Play contexts (CTG's four)
+# ---------------------------------------------------------------------------
+
+#: CTG: "Everything that happens in the game of basketball can be divided into
+#: four main contexts" -- halfcourt, transition, putback, miscellaneous.
+PLAY_CONTEXTS: Final[list[str]] = ["transition", "putback", "halfcourt", "misc"]
+
+# ---------------------------------------------------------------------------
+# The four under-determined knobs (CTG does not publish these numbers)
+# ---------------------------------------------------------------------------
+
+#: Seconds from possession start within which the possession's INITIAL play must
+#: occur for the possession to count as transition.
+#:
+#: CTG defines transition as "starting at the beginning of a possession and only
+#: ending once the defense is set" -- it publishes NO seconds value, so this is a
+#: calibrated knob, not a quoted constant.
+#:
+#: **Calibrated to 6.0s for the NBA** (fitting scan: ``dev/ctg_transition_calibration.py``).
+#: Observed league-mean transition frequency on the three committed engine fixtures:
+#:
+#: ===========  ==========================
+#: seconds      mean transition frequency
+#: ===========  ==========================
+#: 4.0          0.095
+#: 5.0          0.126
+#: **6.0**      **0.163**  <- adopted
+#: 8.0          0.250
+#: 10.0         0.350
+#: ===========  ==========================
+#:
+#: Oracle band: CTG's own published Play-Context table shows transition
+#: frequencies around **0.14** (e.g. Denver 14.3%), and Synergy's transition
+#: play-type frequency runs **~0.15-0.16** league-wide. 6.0s lands in that band.
+#:
+#: NOTE: hoop-math's widely-cited **10-second** rule is a *college* convention with
+#: a different denominator ("% of initial shots", 35s-shot-clock era). Applied
+#: verbatim to NBA possessions it yields ~0.35 transition frequency -- ~2.4x CTG's
+#: published rate -- so it is NOT the right default here. It remains selectable by
+#: passing ``transition_seconds=10.0``.
+DEFAULT_TRANSITION_SECONDS: Final[float] = 6.0
+
+#: Seconds after an offensive rebound within which a shot by the SAME player
+#: counts as a putback. CTG says only "within a few seconds of the rebound
+#: before the defense gets set"; pbpstats (``field_goal.py:112-144``) uses 2s.
+DEFAULT_PUTBACK_SECONDS: Final[float] = 2.0
+
+#: A possession starting with <= this many seconds left in a NON-final period is
+#: a "projected heave possession" and is excluded by default.
+#: CTG (garbage_time guide, exact): "possessions that start with 4 or fewer
+#: seconds on the game clock at the end of one of the first three quarters."
+HEAVE_POSSESSION_SECONDS: Final[float] = 4.0
+
+#: Periods for which the heave filter applies (CTG: "the first three quarters").
+HEAVE_PERIODS: Final[tuple[int, ...]] = (1, 2, 3)
+
+# ---------------------------------------------------------------------------
+# Garbage time (CTG publishes this one exactly)
+# ---------------------------------------------------------------------------
+
+#: CTG (garbage_time guide, exact): "the game has to be in the 4th quarter, the
+#: score differential has to be >= 25 for minutes 12-9, >= 20 for minutes 9-6,
+#: and >= 10 for the remainder of the quarter."
+#:
+#: Encoded as ``(seconds_remaining_high, seconds_remaining_low, min_margin)``
+#: half-open on the low end: the band applies when
+#: ``low < seconds_remaining <= high``. Period-4 clock: 12:00 = 720s.
+GARBAGE_TIME_PERIOD: Final[int] = 4
+GARBAGE_TIME_BANDS: Final[tuple[tuple[float, float, int], ...]] = (
+    (720.0, 540.0, 25),  # minutes 12-9
+    (540.0, 360.0, 20),  # minutes 9-6
+    (360.0, 0.0, 10),  # remainder of the quarter
+)
+
+#: CTG: "there have to be two or fewer starters on the floor **combined between
+#: the two teams**." Applied only when starter-on-court data is supplied; see
+#: :func:`~sportsdataverse.nba.nba_play_context.flag_garbage_time`.
+GARBAGE_TIME_MAX_STARTERS: Final[int] = 2
+
+# ---------------------------------------------------------------------------
+# Transition variants
+# ---------------------------------------------------------------------------
+
+#: Selectable transition rules. ``hoop_math`` is the default (closest documented
+#: analogue to CTG). See RECREATION.md 2c for the full comparison.
+#:
+#: * ``hoop_math`` -- initial play within N seconds; any non-timeout start type.
+#: * ``haslametrics`` -- steal starts only, within N seconds (conservative).
+#: * ``bigballr`` -- initial play within N seconds AND the previous possession
+#:   ended live (a dead-ball start can never be transition).
+TRANSITION_VARIANTS: Final[tuple[str, ...]] = ("hoop_math", "haslametrics", "bigballr")
+DEFAULT_TRANSITION_VARIANT: Final[str] = "hoop_math"
+
+#: Start buckets that end a possession "live" (ball in play, defense scrambling).
+#: Used by the ``bigballr`` variant.
+LIVE_START_BUCKETS: Final[frozenset[str]] = frozenset({"off_live_rebound", "off_steal", "off_made"})
+
+#: Start buckets that can never be transition under ANY variant: after a timeout
+#: the defense is set by construction.
+NON_TRANSITION_START_BUCKETS: Final[frozenset[str]] = frozenset({"off_timeout"})
+
+#: Event types that constitute a possession's "initial play" (the thing whose
+#: timing decides transition): a shot attempt, a trip to the line, or a turnover.
+#: Mirrors CTG's own definition of a *play* ("a play ends when the team attempts
+#: a shot, goes to the foul line, or turns the ball over").
+PLAY_ENDING_EVENT_TYPES: Final[frozenset[str]] = frozenset({"made_shot", "missed_shot", "free_throw", "turnover"})

--- a/sportsdataverse/parsed/nba.py
+++ b/sportsdataverse/parsed/nba.py
@@ -153,10 +153,15 @@ from sportsdataverse.nba import RidgeRapmModel as RidgeRapmModel  # noqa: F401
 from sportsdataverse.nba import SpmCoefficients as SpmCoefficients  # noqa: F401
 from sportsdataverse.nba import ValidationReport as ValidationReport  # noqa: F401
 from sportsdataverse.nba import WalkForwardResult as WalkForwardResult  # noqa: F401
+from sportsdataverse.nba import add_ctg_shot_zones as add_ctg_shot_zones  # noqa: F401
+from sportsdataverse.nba import add_play_context as add_play_context  # noqa: F401
+from sportsdataverse.nba import add_start_type_detail as add_start_type_detail  # noqa: F401
+from sportsdataverse.nba import add_transition as add_transition  # noqa: F401
 from sportsdataverse.nba import adjust_efficiency as adjust_efficiency  # noqa: F401
 from sportsdataverse.nba import adjust_pace as adjust_pace  # noqa: F401
 from sportsdataverse.nba import as_of_ratings_split as as_of_ratings_split  # noqa: F401
 from sportsdataverse.nba import box_features as box_features  # noqa: F401
+from sportsdataverse.nba import build_play_context_shots as build_play_context_shots  # noqa: F401
 from sportsdataverse.nba import build_possession_shooting as build_possession_shooting  # noqa: F401
 from sportsdataverse.nba import calibrate_pts_per_win as calibrate_pts_per_win  # noqa: F401
 from sportsdataverse.nba import calibrate_replacement_level as calibrate_replacement_level  # noqa: F401
@@ -174,6 +179,8 @@ from sportsdataverse.nba import espn_nba_teams as espn_nba_teams  # noqa: F401
 from sportsdataverse.nba import expected_possessions as expected_possessions  # noqa: F401
 from sportsdataverse.nba import external_validity as external_validity  # noqa: F401
 from sportsdataverse.nba import fit_aging_curve as fit_aging_curve  # noqa: F401
+from sportsdataverse.nba import flag_garbage_time as flag_garbage_time  # noqa: F401
+from sportsdataverse.nba import flag_heave_possessions as flag_heave_possessions  # noqa: F401
 from sportsdataverse.nba import flatten_json_iterative as flatten_json_iterative  # noqa: F401
 from sportsdataverse.nba import get_constants as get_constants  # noqa: F401
 from sportsdataverse.nba import get_shrinkage_k as get_shrinkage_k  # noqa: F401
@@ -225,6 +232,7 @@ from sportsdataverse.nba import nba_in_game_win_prob as nba_in_game_win_prob  # 
 from sportsdataverse.nba import nba_la_rapm as nba_la_rapm  # noqa: F401
 from sportsdataverse.nba import nba_matchup_drapm as nba_matchup_drapm  # noqa: F401
 from sportsdataverse.nba import nba_pbp_disk as nba_pbp_disk  # noqa: F401
+from sportsdataverse.nba import nba_play_context as nba_play_context  # noqa: F401
 from sportsdataverse.nba import nba_player_ages as nba_player_ages  # noqa: F401
 from sportsdataverse.nba import nba_player_positions as nba_player_positions  # noqa: F401
 from sportsdataverse.nba import nba_player_props as nba_player_props  # noqa: F401
@@ -266,6 +274,7 @@ from sportsdataverse.nba import shooter_talent as shooter_talent  # noqa: F401
 from sportsdataverse.nba import shot_selection_quality as shot_selection_quality  # noqa: F401
 from sportsdataverse.nba import shrink_clutch as shrink_clutch  # noqa: F401
 from sportsdataverse.nba import team_pace_projection as team_pace_projection  # noqa: F401
+from sportsdataverse.nba import team_play_context as team_play_context  # noqa: F401
 from sportsdataverse.nba import train_spm as train_spm  # noqa: F401
 from sportsdataverse.nba import underscore as underscore  # noqa: F401
 from sportsdataverse.nba import validate_model as validate_model  # noqa: F401
@@ -288,10 +297,15 @@ __all__ = [
     "SpmCoefficients",
     "ValidationReport",
     "WalkForwardResult",
+    "add_ctg_shot_zones",
+    "add_play_context",
+    "add_start_type_detail",
+    "add_transition",
     "adjust_efficiency",
     "adjust_pace",
     "as_of_ratings_split",
     "box_features",
+    "build_play_context_shots",
     "build_possession_shooting",
     "calibrate_pts_per_win",
     "calibrate_replacement_level",
@@ -418,6 +432,8 @@ __all__ = [
     "expected_possessions",
     "external_validity",
     "fit_aging_curve",
+    "flag_garbage_time",
+    "flag_heave_possessions",
     "flatten_json_iterative",
     "fox_nba_boxscore",
     "fox_nba_league_leaders",
@@ -477,6 +493,7 @@ __all__ = [
     "nba_la_rapm",
     "nba_matchup_drapm",
     "nba_pbp_disk",
+    "nba_play_context",
     "nba_player_ages",
     "nba_player_positions",
     "nba_player_props",
@@ -519,6 +536,7 @@ __all__ = [
     "shot_selection_quality",
     "shrink_clutch",
     "team_pace_projection",
+    "team_play_context",
     "train_spm",
     "underscore",
     "validate_model",

--- a/tests/nba/test_nba_play_context.py
+++ b/tests/nba/test_nba_play_context.py
@@ -1,0 +1,405 @@
+"""Tests for the NBA play-context engine (Cleaning the Glass recreation).
+
+Oracle gates in this file (never lowered to make a test pass):
+
+* **Transition frequency band** — CTG's own published Play-Context table shows
+  team transition frequencies around 0.14 (e.g. Denver 14.3%), and Synergy's
+  transition play-type frequency runs ~0.15-0.16 league-wide. At the calibrated
+  ``DEFAULT_TRANSITION_SECONDS = 6.0`` the three committed engine fixtures produce
+  a mean of **0.163** (per game 0.155 / 0.163 / 0.171); the gate is [0.12, 0.21].
+  Fitting run: ``dev/ctg_transition_calibration.py``.
+* **Start-type totality** — every possession gets a start type and a CTG bucket;
+  the buckets are exactly CTG's five.
+* **Putback** — asserted against a hand-verified real play (game 0022200001,
+  ``order_index`` 9: Harris grabs his own offensive rebound and tips it in,
+  unassisted) rather than a synthetic fixture.
+* **Garbage-time honesty** — the margin-only flag must declare itself as such.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pandas as pd
+import polars as pl
+import pytest
+
+from sportsdataverse.nba import nba_play_context_constants as C
+from sportsdataverse.nba.nba_enhanced_pbp import enhanced_pbp_from_payload
+from sportsdataverse.nba.nba_play_context import (
+    PLAY_CONTEXT_SHOTS_SCHEMA,
+    add_ctg_shot_zones,
+    add_play_context,
+    add_start_type_detail,
+    add_transition,
+    build_play_context_shots,
+    flag_garbage_time,
+    flag_heave_possessions,
+    team_play_context,
+)
+from sportsdataverse.nba.nba_possessions import build_possessions
+
+FXROOT = pathlib.Path("tests/fixtures/nba_engine")
+GAMES = ["0022200001", "0022300001", "0022100001"]
+
+# Observed on the fixtures at transition_seconds=6.0 (dev/ctg_transition_calibration.py).
+OBSERVED_TRANSITION_FREQ_MEAN = 0.163
+TRANSITION_FREQ_GATE = (0.12, 0.21)
+
+
+def _enh(game_id: str) -> pl.DataFrame:
+    payload = json.loads((FXROOT / game_id / "playbyplayv3.json").read_text())
+    return enhanced_pbp_from_payload(payload)
+
+
+@pytest.fixture(scope="module")
+def frames() -> dict[str, pl.DataFrame]:
+    return {gid: _enh(gid) for gid in GAMES}
+
+
+# ---------------------------------------------------------------------------
+# Shot zones
+# ---------------------------------------------------------------------------
+
+
+def test_ctg_shot_zones_partition_every_field_goal(frames):
+    pbp = add_ctg_shot_zones(frames["0022200001"])
+    fg = pbp.filter(pl.col("is_field_goal") == 1)
+    assert fg.height > 100
+    # every FG gets a zone; no FG is left unclassified
+    assert fg["ctg_shot_zone"].null_count() == 0
+    assert set(fg["ctg_shot_zone"].unique()).issubset(set(C.CTG_SHOT_ZONES))
+    # non-FG rows carry no zone
+    assert pbp.filter(pl.col("is_field_goal") != 1)["ctg_shot_zone"].null_count() > 0
+
+
+def test_ctg_zones_differ_from_official_nba_zones(frames):
+    """CTG splits the midrange at the FT-line distance, not the paint boundary."""
+    from sportsdataverse.nba.nba_shot_zones import add_shot_zones
+
+    pbp = add_ctg_shot_zones(add_shot_zones(frames["0022200001"]))
+    fg = pbp.filter(pl.col("is_field_goal") == 1)
+    # A 2pt shot 5-7 ft out is `in_the_paint_non_ra` officially but `short_mid` in CTG.
+    both = fg.filter((pl.col("shot_value") == 2) & (pl.col("shot_distance").is_between(4, 7)))
+    if both.height:
+        assert set(both["ctg_shot_zone"].unique()) == {"short_mid"}
+
+
+def test_ctg_shot_zones_empty_input_returns_schema():
+    empty = pl.DataFrame(schema=dict(frames_schema()))
+    out = add_ctg_shot_zones(empty)
+    assert "ctg_shot_zone" in out.columns
+    assert out.height == 0
+
+
+def frames_schema():
+    return _enh(GAMES[0]).schema
+
+
+# ---------------------------------------------------------------------------
+# Start-type taxonomy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("game_id", GAMES)
+def test_start_type_detail_is_total_and_buckets_are_ctg(frames, game_id):
+    enh = frames[game_id]
+    poss = add_start_type_detail(build_possessions(enh), enh)
+
+    assert poss["possession_start_type_detail"].null_count() == 0
+    assert poss["possession_start_type_ctg"].null_count() == 0
+    # exactly CTG's five buckets, nothing invented
+    assert set(poss["possession_start_type_ctg"].unique()).issubset(set(C.CTG_START_BUCKETS))
+
+
+def test_start_type_detail_is_zone_split(frames):
+    """The whole point of the upgrade: makes/misses carry their shot zone."""
+    enh = frames["0022200001"]
+    poss = add_start_type_detail(build_possessions(enh), enh)
+    detail = set(poss["possession_start_type_detail"].unique())
+
+    # zone-qualified members are actually produced (the coarse engine could not)
+    assert any(d.startswith("OffAtRim") for d in detail)
+    assert any(d.startswith("OffArc3") for d in detail)
+    assert any(d.startswith("OffCorner3") for d in detail)
+    assert {"OffFTMake", "OffLiveBallTurnover", "OffTimeout", "OffDeadball"} & detail
+
+
+def test_period_opening_possession_is_deadball(frames):
+    enh = frames["0022200001"]
+    poss = add_start_type_detail(build_possessions(enh), enh)
+    openers = poss.filter(pl.col("number_in_period") == 1)
+    assert openers.height >= 4  # at least one per regulation period
+    assert set(openers["possession_start_type_detail"].unique()) == {C.START_TYPE_DEADBALL}
+
+
+def test_timeout_beats_made_basket(frames):
+    """pbpstats precedence: an after-timeout possession is OffTimeout, never OffXMake."""
+    enh = frames["0022200001"]
+    poss = add_start_type_detail(build_possessions(enh), enh)
+    ato = poss.filter(pl.col("possession_start_type") == C.START_TYPE_TIMEOUT)
+    assert ato.height > 0
+    assert set(ato["possession_start_type_detail"].unique()) == {C.START_TYPE_TIMEOUT}
+    assert set(ato["possession_start_type_ctg"].unique()) == {"off_timeout"}
+
+
+# ---------------------------------------------------------------------------
+# Transition — the calibrated oracle gate
+# ---------------------------------------------------------------------------
+
+
+def test_transition_frequency_matches_ctg_synergy_band(frames):
+    """ORACLE GATE. CTG publishes ~0.14 transition freq; Synergy ~0.15-0.16.
+
+    Observed mean on these three fixtures at the calibrated 6.0s default: 0.163.
+    Gate = [0.12, 0.21]. If this fails, debug the transition rule (start reference,
+    initial-play detection) — do NOT widen the gate.
+    """
+    freqs = []
+    for gid in GAMES:
+        enh = frames[gid]
+        poss = add_play_context(enh)
+        clean = poss.filter(
+            (pl.col("count_as_possession") == True)  # noqa: E712
+            & (pl.col("is_garbage_time") == False)  # noqa: E712
+            & (pl.col("is_heave_possession") == False)  # noqa: E712
+        )
+        assert clean.height >= 150, "fixture shrank — gate would pass vacuously"
+        freqs.append(clean["is_transition"].mean())
+
+    mean = sum(freqs) / len(freqs)
+    lo, hi = TRANSITION_FREQ_GATE
+    assert lo <= mean <= hi, f"transition freq {mean:.3f} outside CTG/Synergy band {TRANSITION_FREQ_GATE}"
+    assert mean == pytest.approx(OBSERVED_TRANSITION_FREQ_MEAN, abs=0.02)
+
+
+def test_transition_seconds_is_monotonic(frames):
+    """A longer window can only admit more transition possessions."""
+    enh = frames["0022200001"]
+    prev = -1.0
+    for secs in (4.0, 6.0, 8.0, 10.0):
+        poss = add_play_context(enh, transition_seconds=secs)
+        freq = poss["is_transition"].mean()
+        assert freq >= prev
+        prev = freq
+
+
+def test_hoop_math_10s_college_default_overshoots_nba(frames):
+    """Documents WHY the default is 6.0s, not hoop-math's college 10s.
+
+    The 10s rule is a college convention with a different denominator; on NBA
+    possessions it roughly doubles CTG's published transition rate.
+    """
+    enh = frames["0022200001"]
+    at_6 = add_play_context(enh, transition_seconds=6.0)["is_transition"].mean()
+    at_10 = add_play_context(enh, transition_seconds=10.0)["is_transition"].mean()
+    assert at_10 > 2 * TRANSITION_FREQ_GATE[1] * 0.75  # ~0.35 observed
+    assert at_6 < at_10
+
+
+def test_period_opener_never_transition(frames):
+    poss = add_play_context(frames["0022200001"])
+    openers = poss.filter(pl.col("number_in_period") == 1)
+    assert not openers["is_transition"].any()
+
+
+def test_timeout_start_never_transition(frames):
+    """After a timeout the defense is set by construction — no variant may call it transition."""
+    for variant in C.TRANSITION_VARIANTS:
+        poss = add_play_context(frames["0022200001"], transition_variant=variant)
+        ato = poss.filter(pl.col("possession_start_type_ctg") == "off_timeout")
+        assert not ato["is_transition"].any(), variant
+
+
+def test_haslametrics_variant_is_steal_only(frames):
+    enh = frames["0022200001"]
+    poss = add_play_context(enh, transition_variant="haslametrics")
+    trans = poss.filter(pl.col("is_transition") == True)  # noqa: E712
+    assert trans.height > 0
+    assert set(trans["possession_start_type_ctg"].unique()) == {"off_steal"}
+
+
+def test_bigballr_variant_excludes_deadball_starts(frames):
+    poss = add_play_context(frames["0022200001"], transition_variant="bigballr")
+    trans = poss.filter(pl.col("is_transition") == True)  # noqa: E712
+    assert "off_deadball" not in set(trans["possession_start_type_ctg"].unique())
+
+
+def test_unknown_transition_variant_raises(frames):
+    enh = frames["0022200001"]
+    poss = add_start_type_detail(build_possessions(enh), enh)
+    with pytest.raises(ValueError, match="variant must be one of"):
+        add_transition(poss, enh, variant="nope")
+
+
+# ---------------------------------------------------------------------------
+# Putbacks / second chance — asserted on a hand-verified REAL play
+# ---------------------------------------------------------------------------
+
+
+def test_putback_detected_on_real_verified_play(frames):
+    """Game 0022200001, order_index 9: Harris rebounds his team's miss and tips it
+    back in, unassisted, within 2s — a textbook putback. Verified by reading the
+    raw pbp, not generated from the engine's own output.
+    """
+    enh = frames["0022200001"]
+    poss = add_play_context(enh)
+    shots = build_play_context_shots(poss, enh)
+
+    row = shots.filter(pl.col("order_index") == 9)
+    assert row.height == 1
+    assert row["is_putback"][0] is True
+    assert row["is_assisted"][0] is False
+    assert row["shot_value"][0] == 2
+
+
+def test_three_pointers_are_never_putbacks(frames):
+    enh = frames["0022200001"]
+    shots = build_play_context_shots(add_play_context(enh), enh)
+    assert shots.filter((pl.col("shot_value") == 3) & (pl.col("is_putback") == True)).height == 0  # noqa: E712
+
+
+def test_assisted_shots_are_never_putbacks(frames):
+    enh = frames["0022200001"]
+    shots = build_play_context_shots(add_play_context(enh), enh)
+    assert shots.filter((pl.col("is_assisted") == True) & (pl.col("is_putback") == True)).height == 0  # noqa: E712
+
+
+def test_transition_wins_over_putback(frames):
+    """CTG, verbatim: a putback that came out of transition IS transition."""
+    enh = frames["0022100001"]  # the fixture with the most putbacks (15)
+    poss = add_play_context(enh)
+    shots = build_play_context_shots(poss, enh)
+    trans_putbacks = shots.filter((pl.col("is_putback") == True))  # noqa: E712
+    # any putback inside a transition possession must be labelled transition, not putback
+    for r in trans_putbacks.to_dicts():
+        if poss.filter(pl.col("possession_number") == r["possession_number"])["is_transition"][0]:
+            assert r["shot_context"] == "transition"
+        else:
+            assert r["shot_context"] == "putback"
+
+
+def test_shots_schema_and_contexts(frames):
+    enh = frames["0022200001"]
+    shots = build_play_context_shots(add_play_context(enh), enh)
+    assert shots.schema == PLAY_CONTEXT_SHOTS_SCHEMA
+    assert set(shots["shot_context"].unique()).issubset(set(C.PLAY_CONTEXTS))
+    assert shots.height > 100
+
+
+def test_shots_empty_input_returns_schema():
+    empty_poss = pl.DataFrame(schema={"possession_number": pl.Int64, "is_transition": pl.Boolean})
+    out = build_play_context_shots(empty_poss, pl.DataFrame())
+    assert out.schema == PLAY_CONTEXT_SHOTS_SCHEMA
+    assert out.height == 0
+
+
+# ---------------------------------------------------------------------------
+# CTG default filters
+# ---------------------------------------------------------------------------
+
+
+def test_heave_possessions_are_end_of_first_three_quarters_only(frames):
+    poss = flag_heave_possessions(build_possessions(frames["0022200001"]))
+    heaves = poss.filter(pl.col("is_heave_possession") == True)  # noqa: E712
+    assert heaves.height > 0
+    assert set(heaves["period"].unique()).issubset(set(C.HEAVE_PERIODS))
+    assert heaves["start_seconds_remaining"].max() <= C.HEAVE_POSSESSION_SECONDS
+    # Q4 is exempt — a late Q4 possession is a real possession
+    assert poss.filter((pl.col("period") == 4) & (pl.col("is_heave_possession") == True)).height == 0  # noqa: E712
+
+
+def test_garbage_time_is_fourth_quarter_only_and_declares_its_basis(frames):
+    enh = frames["0022100001"]  # a blowout (24 garbage-time possessions observed)
+    poss = flag_garbage_time(build_possessions(enh), enh)
+
+    gt = poss.filter(pl.col("is_garbage_time") == True)  # noqa: E712
+    assert gt.height > 0
+    assert set(gt["period"].unique()) == {C.GARBAGE_TIME_PERIOD}
+    # honesty gate: without starter data the flag MUST declare itself margin-only
+    assert set(poss["garbage_time_basis"].unique()) == {"margin_only"}
+
+
+def test_garbage_time_respects_margin_bands(frames):
+    """Every flagged possession must actually satisfy CTG's margin x minutes band."""
+    enh = frames["0022100001"]
+    poss = flag_garbage_time(build_possessions(enh), enh)
+    score = (
+        enh.sort("order_index")
+        .with_columns(
+            pl.col("score_home").cast(pl.Int64, strict=False).forward_fill().fill_null(0).alias("h"),
+            pl.col("score_away").cast(pl.Int64, strict=False).forward_fill().fill_null(0).alias("a"),
+        )
+        .select("order_index", "h", "a")
+    )
+    margin = {r["order_index"]: abs(r["h"] - r["a"]) for r in score.to_dicts()}
+
+    for r in poss.filter(pl.col("is_garbage_time") == True).to_dicts():  # noqa: E712
+        clock = r["start_seconds_remaining"]
+        m = margin[r["start_order_index"]]
+        band = next(b for b in C.GARBAGE_TIME_BANDS if b[1] < clock <= b[0])
+        assert m >= band[2], f"flagged at margin {m} but band requires >= {band[2]}"
+
+
+def test_starters_clause_tightens_garbage_time(frames):
+    """Supplying starter counts can only REMOVE possessions from garbage time."""
+    enh = frames["0022100001"]
+    base = flag_garbage_time(build_possessions(enh), enh)
+    n_margin_only = base.filter(pl.col("is_garbage_time") == True).height  # noqa: E712
+
+    # pretend the starters never left: every possession has 10 starters on the floor
+    all_starters = {n: 10 for n in base["possession_number"].to_list()}
+    strict = flag_garbage_time(build_possessions(enh), enh, starters_on_court=all_starters)
+    assert strict.filter(pl.col("is_garbage_time") == True).height == 0  # noqa: E712
+    assert set(strict["garbage_time_basis"].unique()) == {"margin_and_starters"}
+    assert n_margin_only > 0  # the margin-only flag really is a superset
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator + aggregation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("game_id", GAMES)
+def test_add_play_context_appends_every_column(frames, game_id):
+    from sportsdataverse.nba.nba_play_context import PLAY_CONTEXT_POSSESSIONS_SCHEMA
+
+    poss = add_play_context(frames[game_id])
+    for col, dtype in PLAY_CONTEXT_POSSESSIONS_SCHEMA.items():
+        assert col in poss.columns, col
+        assert poss.schema[col] == dtype, col
+    # additive: the possession engine's own columns survive untouched
+    assert {"points", "offense_team_id", "count_as_possession"}.issubset(set(poss.columns))
+
+
+def test_add_play_context_does_not_change_possession_count(frames):
+    """Strictly additive — enrichment must not add or drop a possession."""
+    enh = frames["0022200001"]
+    assert add_play_context(enh).height == build_possessions(enh).height
+
+
+def test_team_play_context_ptsadded_uses_league_baseline(frames):
+    """Pts+/Poss = (team transition PPP - LEAGUE non-transition PPP) x freq."""
+    poss = add_play_context(frames["0022200001"])
+    ctx = team_play_context(poss, league_non_transition_ppp=100.0)
+    assert ctx.height == 2
+
+    for r in ctx.to_dicts():
+        expected = (r["transition_pts_per_100"] - 100.0) * r["transition_freq"]
+        assert r["transition_pts_added_per_100"] == pytest.approx(expected)
+        assert 0.0 <= r["transition_freq"] <= 1.0
+        assert r["poss"] > 50
+
+
+def test_team_play_context_filters_are_on_by_default(frames):
+    poss = add_play_context(frames["0022100001"])  # has garbage time
+    filtered = team_play_context(poss)
+    unfiltered = team_play_context(poss, apply_ctg_filters=False)
+    assert unfiltered["poss"].sum() > filtered["poss"].sum()
+
+
+def test_team_play_context_pandas_and_empty():
+    out = team_play_context(pl.DataFrame(), return_as_pandas=True)
+    assert isinstance(out, pd.DataFrame)
+    assert len(out) == 0


### PR DESCRIPTION
Recreates **Cleaning the Glass's signature surface** from our own stats.nba.com play-by-play: classify **how each possession started**, and **what context each play happened in**. Implements the spec merged in sdv-internal-refs [#10](https://github.com/sportsdataverse/sdv-internal-refs/pull/10) (`cleaningtheglass/{METHODOLOGY,RECREATION}.md` — CTG's own guide-page definitions, captured verbatim).

**Strictly additive** on the shipped possession engine — boundaries, second-chance and the box-score-reconciled possession frame (`nba_possessions` + `nba_possession_rules`, the pbpstats port) are reused untouched. No new ingestion.

## New surface — `sportsdataverse/nba/nba_play_context.py`

| Function | What |
|---|---|
| `add_start_type_detail()` | Upgrades the engine's **coarse 5-value** start type to the full pbpstats **zone-split taxonomy** (`Off{AtRim\|ShortMidRange\|LongMidRange\|Corner3\|Arc3}{Make\|Miss\|Block}`, `OffFTMake/Miss`, `OffLiveBallTurnover`, `OffTimeout`, `OffDeadball`) + the coarse **CTG bucket** CTG actually reports on |
| `add_transition()` | Possession-level transition flag + source (steal / live rebound / made / deadball); 3 selectable variants |
| `build_play_context_shots()` | Per-shot frame: `is_putback` (unassisted 2 within 2s of the shooter's own OREB), `is_second_chance_shot`, `shot_context` |
| `flag_garbage_time()` / `flag_heave_possessions()` | CTG's default filters |
| `team_play_context()` | CTG's Play-Context table incl. **Pts+/Poss** (uses the **league-average** non-transition baseline, not the team's own — per CTG) |
| `nba_play_context(game_id)` | Public single-game fetcher. League-agnostic: same functions serve WNBA/G-League |

Reproduces CTG's precedence rules exactly: **timeout beats a made basket**; a **transition putback stays transition**.

## The load-bearing finding: transition is 6.0s for the NBA, not hoop-math's 10s

CTG publishes **no** transition cutoff ("until the defense is set"), so it's a fitted knob. The widely-cited **hoop-math 10s rule is a *college* convention** with a different denominator ("% of initial shots", 35s shot clock). Applied verbatim to NBA possessions it yields **~0.35 transition frequency — ~2.4× CTG's published ~0.14**.

Calibrated (`dev/ctg_transition_calibration.py`) to **6.0s → league-mean 0.163**, inside the oracle band (CTG's own table ~0.14; Synergy transition play-type ~0.15–0.16). 10s remains selectable via `transition_seconds=10.0`.

| secs | 4.0 | 5.0 | **6.0** | 8.0 | 10.0 |
|---|---|---|---|---|---|
| mean transition freq | 0.095 | 0.126 | **0.163** ✅ | 0.250 | 0.350 |

## Two real-data bugs found while building

1. **Possession start reference.** The start of a possession is the clock of the event that *ended the previous* possession (when the ball changed hands) — **not** `start_seconds_remaining`, which is the group's first-row clock and is frequently the shot itself. Measuring from the latter made **85% of possessions look like transition**. Same subtlety `_count_as_possession` already documents.
2. **v3 ships `score_home`/`score_away` as `Utf8`.** The garbage-time margin casts to `Int64` at the boundary rather than differencing strings (which raises).

## Honesty caveat, carried in the API

CTG's garbage time also requires "**≤2 starters on the floor combined**", which needs lineup + box `START_POSITION` data. The margin × minutes × latch bands are reproduced **exactly**; the starters clause applies only when `starters_on_court` is supplied, and a **`garbage_time_basis`** column records `margin_only` vs `margin_and_starters` — a margin-only flag never claims to be CTG-exact.

## Gates

- **34 new tests** (`tests/nba/test_nba_play_context.py`), incl. the transition-frequency **oracle gate**, start-type totality, timeout-beats-make precedence, transition-wins-over-putback, a garbage-time honesty gate, and a putback asserted against a **hand-verified real play** (game `0022200001`, `order_index` 9 — Harris rebounds his own team's miss and tips it back in unassisted) rather than a synthetic fixture.
- Full NBA suite green: **612 passed, 37 skipped**. mypy clean (ratchet extended). ruff clean. Codegen regenerated, drift-check clean.

## Roadmap / publication

- **Roadmap:** added as spine **T3.6** in `model-build-roadmap.md` (26 spines) — a pure enrichment layer feeding T3.3 (prediction) and T3.5 (play-type impact).
- **Publication plan:** **Phase 1.3** (`nba_play_context` / `wnba_play_context`), stats.nba.com-sourced ⇒ droplet+proxy host. Explicitly **piggybacks on Phase 1.1's possession pass via the existing `nba_model_publish` CLI** — publishing it separately would re-pay the possession compile for nothing. Model card must carry the calibration caveat + re-fit at season scale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cleaning the Glass–style NBA play-context analysis, including shot zones, possession starts, transitions, putbacks, garbage time, and heaves.
  * Added game-level and team-level play-context workflows with Polars or pandas output options.
  * Exposed the new NBA play-context tools through the primary and legacy APIs.

* **Documentation**
  * Added comprehensive reference documentation for the new play-context functionality.

* **Tests**
  * Added extensive fixture-based coverage for classification, filtering, aggregation, schemas, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->