### PR TITLE
fix(pwhl): read the games-in-data-repo manifest from the csv asset when parquet is absent

### DIFF
--- a/sportsdataverse/_codegen_runtime.py
+++ b/sportsdataverse/_codegen_runtime.py
@@ -82,6 +82,22 @@ def _read_release_parquet(url: str) -> Optional[pl.DataFrame]:
         raise
 
 
+def _read_release_csv(url: str) -> Optional[pl.DataFrame]:
+    """Read a release CSV; return ``None`` on 404 / missing asset.
+
+    The CSV counterpart of :func:`_read_release_parquet`, for release tags whose
+    producer publishes an asset in csv/rds but not parquet. Same narrow
+    missing-asset classification, same re-raise-everything-else contract.
+    """
+    try:
+        return pl.read_csv(url)
+    except Exception as e:  # noqa: BLE001 -- classify fetch/parse failures
+        msg = str(e).lower()
+        if any(tok in msg for tok in ("404", "not found", "no such")):
+            return None
+        raise
+
+
 def format_nhl_season(season: Any) -> Optional[str]:
     """Normalize an NHL season to the 8-digit ``"20242025"`` form the api-web host wants.
 

--- a/sportsdataverse/pwhl/pwhl_loaders_extra.py
+++ b/sportsdataverse/pwhl/pwhl_loaders_extra.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import polars as pl
 
-from sportsdataverse._codegen_runtime import _read_release_parquet, cli_warn
+from sportsdataverse._codegen_runtime import _read_release_csv, _read_release_parquet, cli_warn
 from sportsdataverse.pwhl.pwhl_loaders import (
     load_pwhl_goalie_boxscores,
     load_pwhl_player_boxscores,
@@ -89,15 +89,21 @@ def load_pwhl_games(return_as_pandas: bool = False):
             load_pwhl_games()
     """
     primary = "https://github.com/sportsdataverse/sportsdataverse-data/releases/download/pwhl_schedules/pwhl_games_in_data_repo.parquet"
+    # The pwhl_schedules release publishes this manifest as csv + rds only -- unlike
+    # nhl_schedules, which also ships parquet. Read the csv when the parquet is absent
+    # rather than degrading to an empty frame.
+    primary_csv = "https://github.com/sportsdataverse/sportsdataverse-data/releases/download/pwhl_schedules/pwhl_games_in_data_repo.csv"
     fallback = (
         "https://raw.githubusercontent.com/sportsdataverse/fastRhockey-data/main/pwhl/pwhl_games_in_data_repo.parquet"
     )
 
     df = _read_release_parquet(primary)
     if df is None:
+        df = _read_release_csv(primary_csv)
+    if df is None:
         df = _read_release_parquet(fallback)
     if df is None:
-        cli_warn("load_pwhl_games: manifest parquet not found at primary or fallback URL")
+        cli_warn("load_pwhl_games: manifest not found at primary (parquet/csv) or fallback URL")
         df = pl.DataFrame()
 
     return df.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else df


### PR DESCRIPTION
Fixes the two live-suite failures currently red on `main` (since #246 / `a33581e7`):

```
FAILED tests/test_loader_parity.py::test_load_pwhl_games_returns_nonempty_dataframe
FAILED tests/test_loader_parity.py::test_load_pwhl_games_pandas_flag
```

## Root cause

`load_pwhl_games()` reads `pwhl_games_in_data_repo.parquet`, but the `pwhl_schedules` release publishes that manifest as **csv + rds only** — there is no parquet variant. The raw `fastRhockey-data` fallback path 404s as well, so both reads missed and the loader degraded to an empty frame.

```
pwhl_schedules assets:   pwhl_games_in_data_repo.{rds,csv}      <- no .parquet
nhl_schedules assets:    nhl_games_in_data_repo.{rds,csv,parquet}
```

`load_nhl_games()` uses the identical code path and is fine, because its release *does* ship parquet — which is why only the PWHL tests were red.

This failed silently: a missing release asset is indistinguishable from "no games yet" once it is swallowed into a zero-row DataFrame. The only thing that caught it was the test asserting `height > 0`.

## Fix

Add a 404-safe `_read_release_csv()` next to the existing `_read_release_parquet()` in `_codegen_runtime` — same narrow missing-asset classification, same re-raise-everything-else contract — and read the csv asset when the parquet is absent.

Deliberately **not** hand-uploading a parquet to the release instead: the producer regenerates that manifest as games are added, so a manually-uploaded asset would silently go stale. Publishing parquet from the PWHL producer (to match the NHL producer) remains a reasonable follow-up; this makes the loader correct either way.

## Verification

```
load_pwhl_games()                      -> (320, 29)   polars
load_pwhl_games(return_as_pandas=True) -> (320, 29)   pandas

SDV_PY_LIVE_TESTS=1 pytest tests/pwhl/ tests/test_loader_parity.py   -> 76 passed
uv run mypy                                                          -> 295 files, clean
uv run ruff check sportsdataverse/                                   -> clean
uv run python tools/codegen/generate.py --check                      -> current
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PWHL game data loading by supporting CSV manifests when the primary Parquet asset is unavailable.
  * Added a fallback sequence to improve resilience when loading game data from alternate sources.
  * Updated warnings to more accurately describe data-loading failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->