### PR TITLE
feat(nba): thread a proxy seam through nba_possessions + compile_nba_season

### DIFF
--- a/docs/docs/nba/reference/additional.md
+++ b/docs/docs/nba/reference/additional.md
@@ -1094,7 +1094,7 @@ from sportsdataverse.nba.nba_clutch import clutch_delta
 d = clutch_delta(clutch_frame, baseline_frame)
 ```
 
-### `compile_nba_season(season: 'int', season_type: 'str' = 'Regular Season', *, resume: 'bool' = True, cache_dir: 'Optional[str]' = None, delay_s: 'float' = 0.6, lineup_source: 'str' = 'auto', return_as_pandas: 'bool' = False) -> 'Union[pl.DataFrame, pd.DataFrame]'` {#compile_nba_season}
+### `compile_nba_season(season: 'int', season_type: 'str' = 'Regular Season', *, resume: 'bool' = True, cache_dir: 'Optional[str]' = None, delay_s: 'float' = 0.6, lineup_source: 'str' = 'auto', proxy_provider: 'Optional[Callable[[], Optional[str]]]' = None, return_as_pandas: 'bool' = False) -> 'Union[pl.DataFrame, pd.DataFrame]'` {#compile_nba_season}
 
 Compile a full season's possession stint matrix (cached + resumable + throttled).
 
@@ -1115,6 +1115,7 @@ frame is tagged with a `season` column.
 | `cache_dir` | `Optional[str]` | `None` | Cache root; defaults to `SDV_PY_NBA_CACHE_DIR` or `~/.sdv_py_nba_cache/possessions`. |
 | `delay_s` | `float` | `0.6` | Seconds to sleep after each live fetch (rate-limit throttle). |
 | `lineup_source` | `str` | `'auto'` | Which on-court lineup producer to use — `"auto"` (default; tries rotation then falls back to pbp), `"rotation"` (gamerotation endpoint only), or `"pbp"` (pbp-derived, no gamerotation fetch — useful when the gamerotation endpoint is throttled or unavailable). |
+| `proxy_provider` | `Optional[Callable[[], Optional[str]]]` | `None` | Optional zero-arg callable returning a proxy URL (or `None`). **Called once per game**, so a rotating pool spreads a season's fetches across many exit IPs rather than hammering `stats.nba.com` from one address. `stats.nba.com` *hangs* rather than errors on datacenter/cloud IPs, so an unattended host (CI, a droplet) MUST supply one — a proxied request is judged on the proxy's exit IP, which is what makes such a host viable at all. Any `() -> str \| None` works; a round-robin pool's `.next` matches the signature directly:: compile_nba_season(2023, proxy_provider=round_robin.next) |
 | `return_as_pandas` | `bool` | `False` | Return pandas instead of polars. |
 
 **Returns**

--- a/sportsdataverse/nba/nba_possessions.py
+++ b/sportsdataverse/nba/nba_possessions.py
@@ -978,51 +978,54 @@ def attach_possession_lineups(
 # ---------------------------------------------------------------------------
 
 
-def _fetch_pbp(game_id: str, league_id: str = "00") -> dict:
+def _fetch_pbp(game_id: str, league_id: str = "00", *, proxy_url: Optional[str] = None) -> dict:
     """Fetch raw play-by-play v3 payload from stats.nba.com.
 
     Args:
         game_id: Ten-character NBA game identifier.
         league_id: League identifier (accepted for API symmetry; not forwarded
             to ``nba_stats_playbyplayv3`` which does not expose it).
+        proxy_url: Optional proxy URL forwarded to the underlying transport.
 
     Returns:
         Raw ``dict`` from ``nba_stats_playbyplayv3``.
     """
     from sportsdataverse.nba.nba_stats import nba_stats_playbyplayv3
 
-    return nba_stats_playbyplayv3(game_id=game_id, return_parsed=False)
+    return nba_stats_playbyplayv3(game_id=game_id, return_parsed=False, proxy_url=proxy_url)
 
 
-def _fetch_rotation(game_id: str, league_id: str = "00") -> dict:
+def _fetch_rotation(game_id: str, league_id: str = "00", *, proxy_url: Optional[str] = None) -> dict:
     """Fetch raw gamerotation payload from stats.nba.com.
 
     Args:
         game_id: Ten-character NBA game identifier.
         league_id: League identifier (default ``"00"`` for NBA).
+        proxy_url: Optional proxy URL forwarded to the underlying transport.
 
     Returns:
         Raw ``dict`` from ``nba_stats_gamerotation``.
     """
     from sportsdataverse.nba.nba_stats import nba_stats_gamerotation
 
-    return nba_stats_gamerotation(game_id=game_id, league_id=league_id, return_parsed=False)
+    return nba_stats_gamerotation(game_id=game_id, league_id=league_id, return_parsed=False, proxy_url=proxy_url)
 
 
-def _fetch_box(game_id: str, league_id: str = "00") -> dict:
+def _fetch_box(game_id: str, league_id: str = "00", *, proxy_url: Optional[str] = None) -> dict:
     """Fetch raw boxscore traditional v3 payload from stats.nba.com.
 
     Args:
         game_id: Ten-character NBA game identifier.
         league_id: League identifier (accepted for API symmetry; not forwarded
             to ``nba_stats_boxscoretraditionalv3`` which does not expose it).
+        proxy_url: Optional proxy URL forwarded to the underlying transport.
 
     Returns:
         Raw ``dict`` from ``nba_stats_boxscoretraditionalv3``.
     """
     from sportsdataverse.nba.nba_stats import nba_stats_boxscoretraditionalv3
 
-    return nba_stats_boxscoretraditionalv3(game_id=game_id, return_parsed=False)
+    return nba_stats_boxscoretraditionalv3(game_id=game_id, return_parsed=False, proxy_url=proxy_url)
 
 
 def _fetch_box_periods(
@@ -1090,6 +1093,7 @@ def nba_possessions(
     *,
     lineup_source: str = "auto",
     period_boxscores: Optional[Dict[int, dict]] = None,
+    proxy_url: Optional[str] = None,
     return_as_pandas: bool = False,
 ) -> Union[pl.DataFrame, pd.DataFrame]:
     """Fetch and build the possession-level lineup stint matrix for a single game.
@@ -1145,6 +1149,12 @@ def nba_possessions(
             quarter_box step). When ``None`` (default) and quarter_box is
             reached, :func:`_fetch_box_periods` fetches it. Ignored for
             ``"rotation"``/``"pbp"``.
+        proxy_url: Optional proxy URL forwarded to every network call this
+            function makes (pbp, rotation, box, and the per-period boxes).
+            ``stats.nba.com`` hangs rather than errors on datacenter/cloud
+            IPs, so an unattended host (CI, a droplet) MUST supply a proxy;
+            see :func:`~sportsdataverse.nba.nba_season_compile.compile_nba_season`'s
+            ``proxy_provider`` to rotate one per game across a season.
         return_as_pandas: If ``True``, return a :class:`pandas.DataFrame`
             instead of :class:`polars.DataFrame`.
 
@@ -1205,8 +1215,8 @@ def nba_possessions(
     if lineup_source not in ("auto", "rotation", "pbp", "quarter_box"):
         raise ValueError(f"lineup_source must be 'auto'|'rotation'|'pbp'|'quarter_box', got {lineup_source!r}")
 
-    raw_pbp = _fetch_pbp(game_id, league_id)
-    raw_box = _fetch_box(game_id, league_id)
+    raw_pbp = _fetch_pbp(game_id, league_id, proxy_url=proxy_url)
+    raw_box = _fetch_box(game_id, league_id, proxy_url=proxy_url)
     enh = enhanced_pbp_from_payload(raw_pbp, league_id=league_id)
     home, away = boxscore_home_away(raw_box)
 
@@ -1214,7 +1224,7 @@ def nba_possessions(
         return players_on_court_from_pbp(enh, raw_box, home_team_id=home, away_team_id=away), "pbp"
 
     def _from_rotation() -> "tuple[pl.DataFrame, str]":
-        raw_rot = _fetch_rotation(game_id, league_id)
+        raw_rot = _fetch_rotation(game_id, league_id, proxy_url=proxy_url)
         rot = parse_rotation_resultsets(raw_rot)
         oc = players_on_court_from_rotation(enh, rot, home_team_id=home, away_team_id=away)
         if oc.is_empty():
@@ -1234,7 +1244,7 @@ def nba_possessions(
         pb = period_boxscores
         if pb is None:
             n_periods = int(enh["period"].max() or 0) if not enh.is_empty() else 0
-            pb = _fetch_box_periods(game_id, n_periods, league_id=league_id)
+            pb = _fetch_box_periods(game_id, n_periods, league_id=league_id, proxy_url=proxy_url)
         oc = players_on_court_from_quarter_boxscores(enh, pb, raw_box, home_team_id=home, away_team_id=away)
         if oc.is_empty():
             raise ValueError("quarter_box produced empty on-court frame")

--- a/sportsdataverse/nba/nba_season_compile.py
+++ b/sportsdataverse/nba/nba_season_compile.py
@@ -11,7 +11,7 @@ import logging
 import os
 import time
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Callable, List, Optional, Union
 
 import pandas as pd
 import polars as pl
@@ -68,7 +68,13 @@ def _game_ids_for_season(season: int, season_type: str) -> List[str]:
     return _season_game_index(season, season_type)["game_id"].to_list()
 
 
-def _fetch_possessions(game_id: str, league_id: str, *, lineup_source: str = "auto") -> pl.DataFrame:
+def _fetch_possessions(
+    game_id: str,
+    league_id: str,
+    *,
+    lineup_source: str = "auto",
+    proxy_url: Optional[str] = None,
+) -> pl.DataFrame:
     """Fetch one game's possession+lineup frame (monkeypatchable).
 
     Args:
@@ -78,13 +84,15 @@ def _fetch_possessions(game_id: str, league_id: str, *, lineup_source: str = "au
             (default; tries rotation then falls back to pbp), ``"rotation"``
             (gamerotation endpoint only), or ``"pbp"`` (pbp-derived, no
             gamerotation fetch).
+        proxy_url: Optional proxy URL forwarded to every underlying
+            ``stats.nba.com`` call for this game.
 
     Returns:
         Possession stint matrix as a polars DataFrame.
     """
     from .nba_possessions import nba_possessions
 
-    return nba_possessions(game_id, league_id, lineup_source=lineup_source)
+    return nba_possessions(game_id, league_id, lineup_source=lineup_source, proxy_url=proxy_url)
 
 
 def compile_nba_season(
@@ -95,6 +103,7 @@ def compile_nba_season(
     cache_dir: Optional[str] = None,
     delay_s: float = 0.6,
     lineup_source: str = "auto",
+    proxy_provider: Optional[Callable[[], Optional[str]]] = None,
     return_as_pandas: bool = False,
 ) -> Union[pl.DataFrame, pd.DataFrame]:
     """Compile a full season's possession stint matrix (cached + resumable + throttled).
@@ -118,6 +127,18 @@ def compile_nba_season(
             (gamerotation endpoint only), or ``"pbp"`` (pbp-derived, no
             gamerotation fetch — useful when the gamerotation endpoint is
             throttled or unavailable).
+        proxy_provider: Optional zero-arg callable returning a proxy URL (or
+            ``None``). **Called once per game**, so a rotating pool spreads a
+            season's fetches across many exit IPs rather than hammering
+            ``stats.nba.com`` from one address. ``stats.nba.com`` *hangs*
+            rather than errors on datacenter/cloud IPs, so an unattended host
+            (CI, a droplet) MUST supply one — a proxied request is judged on
+            the proxy's exit IP, which is what makes such a host viable at all.
+            Any ``() -> str | None`` works; a round-robin pool's ``.next``
+            matches the signature directly::
+
+                compile_nba_season(2023, proxy_provider=round_robin.next)
+
         return_as_pandas: Return pandas instead of polars.
 
     Returns:
@@ -174,7 +195,14 @@ def compile_nba_season(
 
         # --- live fetch (throttle only on successful fetches, not failures) ---
         try:
-            poss = _fetch_possessions(gid, _LEAGUE_ID, lineup_source=lineup_source)
+            # Called PER GAME so a pool (e.g. RoundRobin.next) rotates the exit IP
+            # across the season instead of hammering stats.nba.com from one address.
+            poss = _fetch_possessions(
+                gid,
+                _LEAGUE_ID,
+                lineup_source=lineup_source,
+                proxy_url=proxy_provider() if proxy_provider is not None else None,
+            )
         except Exception as exc:
             _LOG.warning("skip game %s (%d/%d): fetch failed: %s", gid, i, total, exc)
             continue

--- a/tests/nba/test_nba_possessions.py
+++ b/tests/nba/test_nba_possessions.py
@@ -452,12 +452,14 @@ def test_nba_possessions_offline(monkeypatch: pytest.MonkeyPatch) -> None:
     import sportsdataverse.nba.nba_possessions as P
 
     g = "0022200001"
-    monkeypatch.setattr(P, "_fetch_pbp", lambda gid, lg: json.loads((FXROOT / g / "playbyplayv3.json").read_text()))
     monkeypatch.setattr(
-        P, "_fetch_rotation", lambda gid, lg: json.loads((FXROOT / g / "gamerotation.json").read_text())
+        P, "_fetch_pbp", lambda gid, lg, **kw: json.loads((FXROOT / g / "playbyplayv3.json").read_text())
     )
     monkeypatch.setattr(
-        P, "_fetch_box", lambda gid, lg: json.loads((FXROOT / g / "boxscoretraditionalv3.json").read_text())
+        P, "_fetch_rotation", lambda gid, lg, **kw: json.loads((FXROOT / g / "gamerotation.json").read_text())
+    )
+    monkeypatch.setattr(
+        P, "_fetch_box", lambda gid, lg, **kw: json.loads((FXROOT / g / "boxscoretraditionalv3.json").read_text())
     )
 
     df = P.nba_possessions(g)
@@ -546,8 +548,10 @@ def _install_fixture_fetchers(
     quarter_box_raises: bool = False,
 ) -> dict[str, int]:
     root = FXROOT / game_id
-    monkeypatch.setattr(npm, "_fetch_pbp", lambda g, lg: json.loads((root / "playbyplayv3.json").read_text()))
-    monkeypatch.setattr(npm, "_fetch_box", lambda g, lg: json.loads((root / "boxscoretraditionalv3.json").read_text()))
+    monkeypatch.setattr(npm, "_fetch_pbp", lambda g, lg, **kw: json.loads((root / "playbyplayv3.json").read_text()))
+    monkeypatch.setattr(
+        npm, "_fetch_box", lambda g, lg, **kw: json.loads((root / "boxscoretraditionalv3.json").read_text())
+    )
 
     def _box_periods(g: str, n: int, **kwargs: object) -> dict[int, dict]:
         # Stubbed so "auto"'s quarter_box step (interposed between rotation and
@@ -560,7 +564,7 @@ def _install_fixture_fetchers(
     monkeypatch.setattr(npm, "_fetch_box_periods", _box_periods)
     calls: dict[str, int] = {"rotation": 0}
 
-    def _rot(g: str, lg: str) -> dict:
+    def _rot(g: str, lg: str, **kw: object) -> dict:
         calls["rotation"] += 1
         if rotation_raises:
             raise RuntimeError("gamerotation throttled")

--- a/tests/nba/test_nba_season_compile.py
+++ b/tests/nba/test_nba_season_compile.py
@@ -42,7 +42,7 @@ def test_compile_dedups_gameids_and_tags_season(tmp_path, monkeypatch):
     )
     calls = []
 
-    def fake_fetch(gid, league_id, *, lineup_source: str = "auto"):
+    def fake_fetch(gid, league_id, *, lineup_source: str = "auto", proxy_url=None):
         calls.append(gid)
         return _poss(gid)
 
@@ -59,13 +59,13 @@ def test_compile_resume_skips_cached(tmp_path, monkeypatch):
         "_season_game_index",
         lambda s, st: _idx(["001", "002"], [datetime.date(2023, 10, 24), datetime.date(2023, 10, 25)]),
     )
-    monkeypatch.setattr(C, "_fetch_possessions", lambda gid, lid, *, lineup_source="auto": _poss(gid))
+    monkeypatch.setattr(C, "_fetch_possessions", lambda gid, lid, *, lineup_source="auto", proxy_url=None: _poss(gid))
     C.compile_nba_season(2023, cache_dir=str(tmp_path), delay_s=0.0)  # warm cache
     calls = []
     monkeypatch.setattr(
         C,
         "_fetch_possessions",
-        lambda gid, lid, *, lineup_source="auto": (calls.append(gid), _poss(gid))[1],
+        lambda gid, lid, *, lineup_source="auto", proxy_url=None: (calls.append(gid), _poss(gid))[1],
     )
     C.compile_nba_season(2023, cache_dir=str(tmp_path), delay_s=0.0)  # all cached
     assert calls == []  # nothing re-fetched
@@ -81,7 +81,7 @@ def test_compile_best_effort_skips_failing_game(tmp_path, monkeypatch):
         ),
     )
 
-    def fetch(gid, lid, *, lineup_source: str = "auto"):
+    def fetch(gid, lid, *, lineup_source: str = "auto", proxy_url=None):
         if gid == "bad":
             raise RuntimeError("api boom")
         return _poss(gid)
@@ -95,6 +95,69 @@ def test_compile_never_raises_on_no_games(tmp_path, monkeypatch):
     monkeypatch.setattr(C, "_season_game_index", lambda s, st: _idx([], []))
     out = C.compile_nba_season(2023, cache_dir=str(tmp_path), delay_s=0.0)
     assert out.is_empty() and "season" in out.columns
+
+
+# ---------------------------------------------------------------------------
+# proxy_provider: stats.nba.com HANGS (not errors) on datacenter IPs, so an
+# unattended host must proxy. The provider is called PER GAME so a pool rotates
+# the exit IP across a season instead of burning one address.
+# ---------------------------------------------------------------------------
+
+
+def test_compile_rotates_proxy_once_per_game(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        C,
+        "_season_game_index",
+        lambda s, st: _idx(
+            ["001", "002", "003"],
+            [datetime.date(2023, 10, 24), datetime.date(2023, 10, 25), datetime.date(2023, 10, 26)],
+        ),
+    )
+    pool = iter(["http://p1:1", "http://p2:2", "http://p3:3"])
+    seen: list[str | None] = []
+
+    def fetch(gid, lid, *, lineup_source="auto", proxy_url=None):
+        seen.append(proxy_url)  # the URL must actually REACH the fetcher
+        return _poss(gid)
+
+    monkeypatch.setattr(C, "_fetch_possessions", fetch)
+    C.compile_nba_season(2023, cache_dir=str(tmp_path), delay_s=0.0, proxy_provider=lambda: next(pool))
+    # one distinct proxy per game -- not one proxy reused for the whole season
+    assert seen == ["http://p1:1", "http://p2:2", "http://p3:3"]
+
+
+def test_compile_without_proxy_provider_passes_none(tmp_path, monkeypatch):
+    """Default (no provider) must stay a plain unproxied fetch -- back-compat."""
+    monkeypatch.setattr(C, "_season_game_index", lambda s, st: _idx(["001"], [datetime.date(2023, 10, 24)]))
+    seen: list[str | None] = []
+
+    def fetch(gid, lid, *, lineup_source="auto", proxy_url=None):
+        seen.append(proxy_url)
+        return _poss(gid)
+
+    monkeypatch.setattr(C, "_fetch_possessions", fetch)
+    C.compile_nba_season(2023, cache_dir=str(tmp_path), delay_s=0.0)
+    assert seen == [None]
+
+
+def test_nba_possessions_threads_proxy_to_every_fetcher(monkeypatch):
+    """proxy_url must reach ALL the network calls -- a missed one silently deanonymizes."""
+    from sportsdataverse.nba import nba_possessions as P
+
+    got: dict[str, str | None] = {}
+
+    def _pbp(game_id, league_id="00", *, proxy_url=None):
+        got["pbp"] = proxy_url
+        return json.loads(pathlib.Path("tests/fixtures/nba_engine/0022300001/playbyplayv3.json").read_text())
+
+    def _box(game_id, league_id="00", *, proxy_url=None):
+        got["box"] = proxy_url
+        return json.loads(pathlib.Path("tests/fixtures/nba_engine/0022300001/boxscoretraditionalv3.json").read_text())
+
+    monkeypatch.setattr(P, "_fetch_pbp", _pbp)
+    monkeypatch.setattr(P, "_fetch_box", _box)
+    P.nba_possessions("0022300001", lineup_source="pbp", proxy_url="http://proxy:9")
+    assert got == {"pbp": "http://proxy:9", "box": "http://proxy:9"}
 
 
 # ---------------------------------------------------------------------------
@@ -121,7 +184,9 @@ def test_compile_attaches_game_date(monkeypatch, tmp_path):
     from sportsdataverse.nba import nba_season_compile as mod
 
     monkeypatch.setattr(mod, "_season_game_index", lambda s, st: _fake_index())
-    monkeypatch.setattr(mod, "_fetch_possessions", lambda gid, lid, lineup_source="auto": _fixture_poss())
+    monkeypatch.setattr(
+        mod, "_fetch_possessions", lambda gid, lid, lineup_source="auto", proxy_url=None: _fixture_poss()
+    )
     out = mod.compile_nba_season(2023, cache_dir=str(tmp_path), delay_s=0.0)
     assert out.schema["game_date"] == pl.Date
     assert out["game_date"].null_count() == 0
@@ -154,7 +219,9 @@ def test_compile_missing_game_date_raises(monkeypatch, tmp_path):
         schema={"game_id": pl.Utf8, "game_date": pl.Date},
     )
     monkeypatch.setattr(mod, "_season_game_index", lambda s, st: bad_index)
-    monkeypatch.setattr(mod, "_fetch_possessions", lambda gid, lid, lineup_source="auto": _fixture_poss())
+    monkeypatch.setattr(
+        mod, "_fetch_possessions", lambda gid, lid, lineup_source="auto", proxy_url=None: _fixture_poss()
+    )
     with pytest.raises(ValueError, match="game_date"):
         mod.compile_nba_season(2023, cache_dir=str(tmp_path), delay_s=0.0)
 


### PR DESCRIPTION
## The bug: a seam that exists at both ends, but not in the middle

`stats.nba.com` **hangs** (rather than errors) on datacenter/cloud IPs, so any
unattended host — CI, a droplet — must route through a proxy. Today it **cannot**:

- the `nba_stats` wrappers already accept `proxy_url` ✅
- `_fetch_box_periods` already forwards `proxy_url` ✅
- …but `nba_possessions` has **no proxy parameter** and never passes one down ❌

So the capability is unreachable from any caller, and `_fetch_box_periods`' proxy support
is **dead code** — `nba_possessions` calls it without a proxy. The mitigation exists only
in docstrings ("droplet + proxy host"); the call chain cannot express it.

This blocks the NBA model-publish backfill (`hoopR-nba-stats-data`), which has a working
`RoundRobin` pool it has no way to hand to `compile_nba_season`.

## Changes — all additive, keyword-only, default `None` = current behavior exactly

- `_fetch_pbp` / `_fetch_rotation` / `_fetch_box` gain `proxy_url` and forward it
  (matching `_fetch_box_periods`, which already did).
- `nba_possessions` gains `proxy_url` and threads it to **all four** fetchers. A missed one
  would silently deanonymize part of a game — pbp through the proxy while the boxscore
  leaks the host's real IP.
- `compile_nba_season` gains `proxy_provider: Callable[[], str | None]`, invoked **once per
  game**, so a pool rotates the exit IP across a season instead of hammering stats.nba.com
  from one address for ~1,200 games. `RoundRobin.next` already matches the signature:

  ```python
  compile_nba_season(2023, proxy_provider=round_robin.next)
  ```

A callable rather than a `proxy_url: str` because a static URL pins an entire multi-season
backfill to one exit IP, which is how you burn it.

## Verified against the live pool — not just typechecked

```
[1/5] exit_ip=154.81.56.81  -> stats.nba.com OK (504 actions) in 546ms
[2/5] exit_ip=31.14.9.145   -> OK (504 actions) in 411ms
[3/5] exit_ip=31.14.9.221   -> OK (504 actions) in 288ms
[4/5] exit_ip=31.14.9.205   -> OK (504 actions) in 268ms
[5/5] exit_ip=31.14.9.185   -> OK (504 actions) in 308ms
[control] direct, no proxy  -> OK (504 actions) in 233ms
```

5/5 proxied calls returned the **identical** 504-action payload, exit IP != local IP,
latency on par with direct.

## Tests

New: the proxy rotates **once per game** (not one URL reused for a season); the default
(no provider) still passes `None`; `proxy_url` reaches **every** fetcher.

The `_fetch_*` test doubles were updated to accept the new kwarg rather than having the
call sites conditionally omit it — a fake whose signature drifts from the real seam is how
a test keeps passing against code that cannot run.

`581 passed / 37 skipped`; ruff clean; codegen regenerated and `--check` current.

## Consumer

`hoopR-nba-stats-data#11` wires this up. That repo floats on `sportsdataverse@main`, so it
picks this up with no pin bump.