### PR TITLE
fix(mbb,wbb): publish-safe possessions — fix_cross_game_leak + fix_technicals flags (default correct, faithful-R behind flags)

### DIFF
--- a/docs/docs/mbb/reference/additional.md
+++ b/docs/docs/mbb/reference/additional.md
@@ -7434,7 +7434,7 @@ df_pd = ncaa_mbb_player_stats(pbp, multi_games=True, simple=True, return_as_pand
 season.filter(pl.col("mins") > 50).sort("pts", descending=True).head()
 ```
 
-### `ncaa_mbb_possessions(pbp: 'pl.DataFrame', *, simple: 'bool' = False, return_as_pandas: 'bool' = False) -> 'Union[pl.DataFrame, pd.DataFrame]'` {#ncaa_mbb_possessions}
+### `ncaa_mbb_possessions(pbp: 'pl.DataFrame', *, simple: 'bool' = False, fix_cross_game_leak: 'bool' = True, return_as_pandas: 'bool' = False) -> 'Union[pl.DataFrame, pd.DataFrame]'` {#ncaa_mbb_possessions}
 
 Aggregate bigballR-contract play-by-play into one row per possession.
 
@@ -7451,6 +7451,7 @@ given lineup always occupies the same columns.
 |---|---|---|---|
 | `pbp` | `DataFrame` |  | Play-by-play frame in the sdv-py 35-column snake_case bigballR contract (`parse_ncaa_bb_game_pbp` output). May span multiple games; rows must be in scrape order. |
 | `simple` | `bool` | `False` | When True, return only the 17-column possession/points frame (`all_functions.R:3687-3694`) with lineups in on-court order. When False (default), return the full 28-column frame with per-possession context columns and alpha-sorted lineups. |
+| `fix_cross_game_leak` | `bool` | `True` | When True (default, and the CORRECT behavior), window the `start_event_type` lag with `.over("game_id")` so a game's first possession has a null start event instead of inheriting the PREVIOUS game's last event. When False, reproduce R's ungrouped `dplyr::lag` (`all_functions.R:3698`) and its cross-game leak. Parity tests pass False. Ignored when `simple=True` (that variant emits no `start_event_type`). |
 | `return_as_pandas` | `bool` | `False` | Return a `pandas.DataFrame` instead of polars. |
 
 **Returns**

--- a/docs/docs/wbb/reference/additional.md
+++ b/docs/docs/wbb/reference/additional.md
@@ -6608,14 +6608,14 @@ stats = ncaa_wbb_player_stats(pbp)
 print(stats.shape)
 ```
 
-### `ncaa_wbb_possessions(pbp: 'pl.DataFrame', *, simple: 'bool' = False, return_as_pandas: 'bool' = False) -> "Union[pl.DataFrame, 'pd.DataFrame']"` {#ncaa_wbb_possessions}
+### `ncaa_wbb_possessions(pbp: 'pl.DataFrame', *, simple: 'bool' = False, fix_cross_game_leak: 'bool' = True, return_as_pandas: 'bool' = False) -> "Union[pl.DataFrame, 'pd.DataFrame']"` {#ncaa_wbb_possessions}
 
 Aggregate WBB play-by-play into one row per possession (wbigballR `get_possessions`).
 
 Pure delegation to
 `sportsdataverse.mbb.mbb_ncaa_possession_seg.ncaa_mbb_possessions`
-— see it for the algorithm, the 28/17-column contracts, and the faithful
-ungrouped-lag quirk.
+— see it for the algorithm, the 28/17-column contracts, and the fixed-vs-
+faithful flag convention.
 
 **Parameters**
 
@@ -6623,6 +6623,7 @@ ungrouped-lag quirk.
 |---|---|---|---|
 | `pbp` | `DataFrame` |  | Play-by-play frame in the sdv-py 35-column snake_case bigballR contract (`ncaa_wbb_game_pbp` output). |
 | `simple` | `bool` | `False` | Return only the 17-column possession/points frame. |
+| `fix_cross_game_leak` | `bool` | `True` | When True (default, and the CORRECT behavior), window the `start_event_type` lag with `.over("game_id")` so a game's first possession does not inherit the previous game's last event. When False, reproduce R's ungrouped `dplyr::lag` (`all_functions.R:3698`). Parity tests pass False. |
 | `return_as_pandas` | `bool` | `False` | Return a pandas DataFrame instead of polars. |
 
 **Returns**
@@ -6635,6 +6636,10 @@ One row per possession.
 from sportsdataverse.wbb.wbb_ncaa_possession_seg import ncaa_wbb_possessions
 poss = ncaa_wbb_possessions(pbp)
 print(poss.shape)
+
+# Faithful (R-buggy) start-event lag
+
+poss = ncaa_wbb_possessions(pbp, fix_cross_game_leak=False)
 ```
 
 ### `ncaa_wbb_shot_locations(game_ids: 'Sequence[object]', *, fetcher: 'Optional[Any]' = None, return_as_pandas: 'bool' = False) -> "Union[pl.DataFrame, 'pd.DataFrame']"` {#ncaa_wbb_shot_locations}

--- a/sportsdataverse/mbb/mbb_ncaa_game_pbp.py
+++ b/sportsdataverse/mbb/mbb_ncaa_game_pbp.py
@@ -15,6 +15,29 @@ The core is generalized over a ``period_model`` knob —
 Deliberate R-faithful quirks are marked with ``ponytail:`` comments citing the
 R line they reproduce; the 11 fork-skew fixes from the divergence spec are
 adopted (the bigballR side already carries all that apply here).
+
+**Technical / flagrant fouls (``fix_technicals``, default True).** The R chain
+has no technical or flagrant rules, so a made technical free throw flips
+``poss_team`` — a possession change that never happened
+(``dev/bigballr_port/possession_engine_reconciliation.md`` BUG-3). The fix
+ports the semantics of hoop-explorer's ``bad_fouls`` /
+``offsetting_tech_or_flagrant`` (``mbb_ncaa_possessions.calculate_stats``):
+free throws sharing a clock reading with a technical / flagrant foul are inert
+— no switch, no corrective flip, no and-1 — which also nets offsetting double
+technicals to zero. Pass ``fix_technicals=False`` for faithful R output (the
+parity tests do).
+
+**This rule is UN-ADJUDICATED.** Two committed fixtures do exercise it (1613299
+carries a coach technical, 6479639 a flagrant — 2 and 1 phantom possessions
+respectively), but their R oracle encodes the BUGGY chain, so no oracle can
+score the fixed output: there is no ground truth for the correct behavior. The
+rule is a code-read port of hoop-explorer's, pinned by constructed sequences in
+``tests/mbb/test_mbb_ncaa_technical_possessions.py``. Re-validate it against a
+refereed capture when one exists.
+
+Dropping a phantom possession also drops a possession BOUNDARY, so the lineup
+walk-forward can re-home a substitution and ``sub_deviate`` can move — expected
+downstream of the fix, not a second change.
 """
 
 from __future__ import annotations
@@ -169,6 +192,113 @@ _V2_EVENT_MAP: "tuple[tuple[tuple[str, ...], str], ...]" = (
     (("coachchallenge outofbounds",), "Challenge (Out of Bounds)"),
     (("coachchallenge goal",), "Challenge (Interference)"),
 )
+
+#: Technical / flagrant foul detector, run over the RAW ``event_description``.
+#: bigballR's event vocabulary has no technical or flagrant type — the V2 map
+#: folds ``"foul technical ..."`` / ``"foul personal flagrant ..."`` into the
+#: generic ``"Commits Foul"`` (:3204) and V1 spells them out in the description
+#: — so the raw text is the only signal either format preserves.
+_BAD_FOUL_RE = re.compile(r"(?i)technical|flagrant")
+
+
+def _is_bad_foul(row: "dict[str, Any]") -> bool:
+    """True when the event is a technical / flagrant foul (BUG-3 detector)."""
+    desc = row.get("event_description")
+    return desc is not None and _BAD_FOUL_RE.search(desc) is not None
+
+
+def _is_bad_ft(row: "dict[str, Any]", bad_secs: "set[int]") -> bool:
+    """True for a free throw awarded by a technical / flagrant foul.
+
+    A bad-foul FT is one sharing a clock reading with a technical / flagrant
+    foul — the same "concurrent clump" grouping hoop-explorer uses
+    (``mbb_ncaa_possessions.calculate_stats``). Such an FT neither ends nor
+    transfers possession, so the chain must treat it as inert.
+    """
+    return row["event_type"] == "Free Throw" and row["game_seconds"] in bad_secs
+
+
+def _stamp_possessions(
+    rows: "list[dict[str, Any]]",
+    home_team: Optional[str],
+    away_team: Optional[str],
+    *,
+    fix_technicals: bool = True,
+) -> None:
+    """Stamp ``poss_num`` / ``poss_team`` onto arranged pbp rows, in place.
+
+    bigballR's sequential possession chain (``all_functions.R:380-436``),
+    reset per period: a defensive rebound, a turnover, a made FG (unless it's
+    an and-1) or a made FT with nothing following it arms a switch, which
+    takes effect at the next distinct clock reading; an event by the wrong
+    team corrects the chain immediately.
+
+    Args:
+        rows: Arranged event rows (post assist-merge), each carrying
+            ``period``, ``game_seconds``, ``event_team``, ``event_type``,
+            ``event_result`` and ``event_description``. Mutated in place.
+        home_team: Home team name, as it appears in ``event_team``.
+        away_team: Away team name, as it appears in ``event_team``.
+        fix_technicals: See :func:`parse_ncaa_bb_game_pbp`. True (default)
+            makes technical / flagrant free throws inert; False reproduces
+            bigballR, which has no technical / flagrant rules at all.
+    """
+    poss_num = 0
+    max_period = rows[-1]["period"] if rows else 0
+    for i in range(1, max_period + 1):
+        prs = [r for r in rows if r["period"] == i]
+        if not prs:
+            # ponytail: R's 1:max loop would error on an empty period table;
+            # real pages carry rows in every period.
+            continue
+        # BUG-3 fix: clock readings carrying a technical/flagrant foul. Every
+        # Free Throw at one of these readings is a bad-foul FT and is INERT for
+        # the chain (see _BAD_FOUL_RE + the `fix_technicals` docs).
+        bad_secs: "set[int]" = {r["game_seconds"] for r in prs if _is_bad_foul(r)} if fix_technicals else set()
+        first_non_sub = next((r for r in prs if r["event_type"] not in _SUB_TYPES), None)
+        poss_team = first_non_sub["event_team"] if first_non_sub is not None else None
+        other_team = away_team if poss_team == home_team else home_team
+        poss_switch = False
+        poss_num += 1
+        for j, r in enumerate(prs):
+            team = r["event_team"]
+            typ = r["event_type"]
+            result = r["event_result"]
+            seconds = r["game_seconds"]
+            bad_ft = _is_bad_ft(r, bad_secs)
+            swap = poss_switch and seconds != prs[max(j - 1, 0)]["game_seconds"]
+            if swap:
+                poss_num += 1
+                poss_team, other_team = other_team, poss_team
+                poss_switch = False
+            # R precedence: (shot & wrong team) | (turnover & wrong team) (:410).
+            # A bad-foul FT is shot by whoever was fouled, not by whoever has
+            # the ball, so it must NOT trigger the corrective re-sync flip.
+            if not bad_ft and ((result is not None and team != poss_team) or (typ == "Turnover" and poss_team != team)):
+                poss_num += 1 - (1 if swap else 0)
+                poss_team, other_team = other_team, poss_team
+                poss_switch = False
+            and_one = any(
+                x["event_type"] == "Free Throw" and not _is_bad_ft(x, bad_secs)
+                for x in prs
+                if x["game_seconds"] == seconds
+            )
+            nxt = prs[j + 1] if j + 1 < len(prs) else None
+            next_reb = nxt is not None and (
+                nxt["event_type"] == "Defensive Rebound"
+                or (nxt["event_type"] == "Free Throw" and not _is_bad_ft(nxt, bad_secs))
+            )
+            if (
+                typ in ("Defensive Rebound", "Turnover")
+                or (typ in _FG_TYPES and result == "made" and not and_one)
+                # A made bad-foul FT does not end the possession (the ball goes
+                # back to whoever had it) — hoop-explorer's `bad_fouls` term.
+                or (typ == "Free Throw" and result == "made" and not next_reb and not bad_ft)
+            ):
+                poss_switch = True
+            r["poss_num"] = poss_num
+            r["poss_team"] = poss_team
+
 
 _Row = "dict[str, Any]"
 
@@ -520,6 +650,7 @@ def parse_ncaa_bb_game_pbp(
     game_id: str,
     *,
     period_model: "tuple[int, int, int]" = _MBB_PERIOD_MODEL,
+    fix_technicals: bool = True,
 ) -> pl.DataFrame:
     """Parse one stats.ncaa.org play-by-play page (bigballR ``scrape_game``).
 
@@ -536,6 +667,15 @@ def parse_ncaa_bb_game_pbp(
         period_model: ``(n_regulation_periods, regulation_period_seconds,
             overtime_period_seconds)``. MBB ``(2, 1200, 300)`` (the bigballR
             hardcoded model), WBB quarters ``(4, 600, 300)``.
+        fix_technicals: When True (default, and the CORRECT behavior), free
+            throws awarded by a technical or flagrant foul are inert in the
+            possession chain: they neither end nor transfer possession, and
+            they cannot pose as an and-1. When False, reproduce bigballR's
+            faithful behavior (``all_functions.R:380-436`` has no technical /
+            flagrant rules at all, so a made technical FT sets
+            ``poss_switch`` and flips ``poss_team``, inventing a possession
+            change that never happened). Parity tests pass False. Same
+            spirit as ``mbb_ncaa_lineups.fix_tip_in``.
 
     Returns:
         A 35-column polars frame, one row per event in bigballR's arranged
@@ -713,47 +853,7 @@ def parse_ncaa_bb_game_pbp(
         r["shot_value"] = _SHOT_VALUES.get(r["event_type"])
 
     # -- possession counting (R :380-436) --------------------------------------
-    poss_num = 0
-    max_period = rows[-1]["period"]
-    for i in range(1, max_period + 1):
-        prs = [r for r in rows if r["period"] == i]
-        if not prs:
-            # ponytail: R's 1:max loop would error on an empty period table;
-            # real pages carry rows in every period.
-            continue
-        first_non_sub = next((r for r in prs if r["event_type"] not in _SUB_TYPES), None)
-        poss_team = first_non_sub["event_team"] if first_non_sub is not None else None
-        other_team = away_team if poss_team == home_team else home_team
-        poss_switch = False
-        poss_num += 1
-        for j, r in enumerate(prs):
-            team = r["event_team"]
-            typ = r["event_type"]
-            result = r["event_result"]
-            seconds = r["game_seconds"]
-            swap = poss_switch and seconds != prs[max(j - 1, 0)]["game_seconds"]
-            if swap:
-                poss_num += 1
-                poss_team, other_team = other_team, poss_team
-                poss_switch = False
-            # R precedence: (shot & wrong team) | (turnover & wrong team) (:410)
-            if (result is not None and team != poss_team) or (typ == "Turnover" and poss_team != team):
-                poss_num += 1 - (1 if swap else 0)
-                poss_team, other_team = other_team, poss_team
-                poss_switch = False
-            and_one = any(x["event_type"] == "Free Throw" for x in prs if x["game_seconds"] == seconds)
-            next_reb = j + 1 < len(prs) and prs[j + 1]["event_type"] in (
-                "Defensive Rebound",
-                "Free Throw",
-            )
-            if (
-                typ in ("Defensive Rebound", "Turnover")
-                or (typ in _FG_TYPES and result == "made" and not and_one)
-                or (typ == "Free Throw" and result == "made" and not next_reb)
-            ):
-                poss_switch = True
-            r["poss_num"] = poss_num
-            r["poss_team"] = poss_team
+    _stamp_possessions(rows, home_team, away_team, fix_technicals=fix_technicals)
 
     # -- possession validity + Poss_Length + isTransition (R :438-462) ---------
     last_type: "dict[int, Optional[str]]" = {}

--- a/sportsdataverse/mbb/mbb_ncaa_possession_seg.py
+++ b/sportsdataverse/mbb/mbb_ncaa_possession_seg.py
@@ -14,6 +14,20 @@ detection from raw pbp). ``ncaa_mbb_possessions`` here does NOT detect
 possessions — it only segments/groups by the possession keys bigballR
 stamped upstream. Do not merge the two.
 
+Fixed R bugs (flags default to the CORRECT behavior; the parity tests pass the
+faithful value — same convention as ``mbb_ncaa_lineups.fix_tip_in``):
+
+* ``fix_cross_game_leak`` — R's ``End = dplyr::lag(Event_Type)``
+  (``all_functions.R:3698``) runs UNGROUPED, so in a multi-game frame every
+  game's possession #1 inherits the PREVIOUS game's last event as its
+  ``start_event_type`` (``dev/bigballr_port/possession_engine_reconciliation.md``
+  BUG-4). The fix windows the lag with ``.over("game_id")``.
+
+The technical/flagrant possession rule (BUG-3) is NOT here — it lives in the
+chain that stamps ``poss_num`` / ``poss_team``
+(``mbb_ncaa_game_pbp.parse_ncaa_bb_game_pbp``, ``fix_technicals=``); this
+module only groups by the keys that chain already stamped.
+
 Deliberate deviations from the R output (documented, semantics preserved):
 
 * R's full variant round-trips every row through ``apply()`` (chr coercion),
@@ -184,6 +198,7 @@ def ncaa_mbb_possessions(
     pbp: pl.DataFrame,
     *,
     simple: bool = ...,
+    fix_cross_game_leak: bool = ...,
     return_as_pandas: Literal[False] = ...,
 ) -> pl.DataFrame: ...
 
@@ -193,6 +208,7 @@ def ncaa_mbb_possessions(
     pbp: pl.DataFrame,
     *,
     simple: bool = ...,
+    fix_cross_game_leak: bool = ...,
     return_as_pandas: Literal[True],
 ) -> pd.DataFrame: ...
 
@@ -202,12 +218,14 @@ def ncaa_mbb_possessions(
     pbp: pl.DataFrame,
     *,
     simple: bool = False,
+    fix_cross_game_leak: bool = True,
     return_as_pandas: bool = False,
 ) -> Union[pl.DataFrame, pd.DataFrame]: ...
 def ncaa_mbb_possessions(
     pbp: pl.DataFrame,
     *,
     simple: bool = False,
+    fix_cross_game_leak: bool = True,
     return_as_pandas: bool = False,
 ) -> Union[pl.DataFrame, pd.DataFrame]:
     """Aggregate bigballR-contract play-by-play into one row per possession.
@@ -227,6 +245,13 @@ def ncaa_mbb_possessions(
             (``all_functions.R:3687-3694``) with lineups in on-court order.
             When False (default), return the full 28-column frame with
             per-possession context columns and alpha-sorted lineups.
+        fix_cross_game_leak: When True (default, and the CORRECT behavior),
+            window the ``start_event_type`` lag with ``.over("game_id")`` so a
+            game's first possession has a null start event instead of
+            inheriting the PREVIOUS game's last event. When False, reproduce
+            R's ungrouped ``dplyr::lag`` (``all_functions.R:3698``) and its
+            cross-game leak. Parity tests pass False. Ignored when
+            ``simple=True`` (that variant emits no ``start_event_type``).
         return_as_pandas: Return a ``pandas.DataFrame`` instead of polars.
 
     Returns:
@@ -264,12 +289,15 @@ def ncaa_mbb_possessions(
         schema: pl.Schema = POSSESSIONS_SIMPLE_SCHEMA
     else:
         keys = list(_KEYS_FULL)
-        # Faithful to R: `End = dplyr::lag(Event_Type)` at all_functions.R:3698
-        # runs UNGROUPED over the whole frame, so `start_event_type` of a
-        # game's first possession leaks the previous game's last event type in
-        # multi-game frames (null only on the very first row). Do NOT add
-        # .over("game_id") — oracle parity depends on the leak.
-        df = pbp.with_columns(pl.col("event_type").shift(1).alias("_end"))
+        # BUG-4: R's `End = dplyr::lag(Event_Type)` (all_functions.R:3698) runs
+        # UNGROUPED over the whole frame, so in a multi-game frame each game's
+        # first possession leaks the PREVIOUS game's last event type (null only
+        # on the very first row). fix_cross_game_leak=False reproduces that —
+        # oracle parity depends on the leak.
+        end = pl.col("event_type").shift(1)
+        if fix_cross_game_leak:
+            end = end.over("game_id")
+        df = pbp.with_columns(end.alias("_end"))
         is_shot = pl.col("event_type").is_in(SHOT_TYPES)
         aggs = [
             pl.col("home_score").first(),

--- a/sportsdataverse/wbb/wbb_ncaa_possession_seg.py
+++ b/sportsdataverse/wbb/wbb_ncaa_possession_seg.py
@@ -26,23 +26,35 @@ def ncaa_wbb_possessions(
     pbp: pl.DataFrame,
     *,
     simple: bool = False,
+    fix_cross_game_leak: bool = True,
     return_as_pandas: bool = False,
 ) -> Union[pl.DataFrame, "pd.DataFrame"]:
     """Aggregate WBB play-by-play into one row per possession (wbigballR ``get_possessions``).
 
     Pure delegation to
     :func:`sportsdataverse.mbb.mbb_ncaa_possession_seg.ncaa_mbb_possessions`
-    — see it for the algorithm, the 28/17-column contracts, and the faithful
-    ungrouped-lag quirk.
+    — see it for the algorithm, the 28/17-column contracts, and the fixed-vs-
+    faithful flag convention.
 
     Args:
         pbp: Play-by-play frame in the sdv-py 35-column snake_case bigballR
             contract (``ncaa_wbb_game_pbp`` output).
         simple: Return only the 17-column possession/points frame.
+        fix_cross_game_leak: When True (default, and the CORRECT behavior),
+            window the ``start_event_type`` lag with ``.over("game_id")`` so a
+            game's first possession does not inherit the previous game's last
+            event. When False, reproduce R's ungrouped ``dplyr::lag``
+            (``all_functions.R:3698``). Parity tests pass False.
         return_as_pandas: Return a pandas DataFrame instead of polars.
 
     Returns:
         One row per possession.
+
+    Note:
+        The technical/flagrant possession rule is applied UPSTREAM, in the
+        chain that stamps ``poss_num`` / ``poss_team`` — see
+        :func:`sportsdataverse.mbb.mbb_ncaa_game_pbp.parse_ncaa_bb_game_pbp`'s
+        ``fix_technicals`` flag (``ncaa_wbb_game_pbp`` inherits it).
 
     Example:
         Quick start::
@@ -50,9 +62,14 @@ def ncaa_wbb_possessions(
             from sportsdataverse.wbb.wbb_ncaa_possession_seg import ncaa_wbb_possessions
             poss = ncaa_wbb_possessions(pbp)
             print(poss.shape)
+
+        Faithful (R-buggy) start-event lag::
+
+            poss = ncaa_wbb_possessions(pbp, fix_cross_game_leak=False)
     """
     return ncaa_mbb_possessions(
         pbp,
         simple=simple,
+        fix_cross_game_leak=fix_cross_game_leak,
         return_as_pandas=return_as_pandas,
     )

--- a/tests/mbb/test_mbb_ncaa_game_pbp_parity.py
+++ b/tests/mbb/test_mbb_ncaa_game_pbp_parity.py
@@ -11,6 +11,12 @@ Fixture games (see ``tests/fixtures/ncaa/bigballr/README.md``):
 * 6479639 — close regulation game
 * 6479592 — 1 OT
 * 1613299 — 2019-era markup (older event vocabulary, same V2 comma grammar)
+
+Parity runs in FAITHFUL mode (``fix_technicals=False``): the shipped default
+fixes bigballR's missing technical/flagrant possession rules (BUG-3), which
+moves ``poss_num`` / ``poss_team`` on 1613299 (a coach technical) and 6479639
+(a flagrant). The fixed-mode behavior is pinned by
+``tests/mbb/test_mbb_ncaa_technical_possessions.py``.
 """
 
 from __future__ import annotations
@@ -37,7 +43,7 @@ def _fixture_html(game_id: str) -> str:
 
 @pytest.mark.parametrize("game_id", GAMES["mbb"])
 def test_mbb_pbp_parity(game_id: str, oracle: pl.DataFrame) -> None:
-    got = parse_ncaa_bb_game_pbp(_fixture_html(game_id), game_id)
+    got = parse_ncaa_bb_game_pbp(_fixture_html(game_id), game_id, fix_technicals=False)
     exp = oracle.filter(pl.col("game_id") == game_id)
 
     assert got.columns == list(PBP_SCHEMA)

--- a/tests/mbb/test_mbb_ncaa_possession_seg_parity.py
+++ b/tests/mbb/test_mbb_ncaa_possession_seg_parity.py
@@ -4,8 +4,11 @@ Input is the oracle play_by_play renamed to the sdv-py contract — the exact
 rows R's ``get_possessions`` (``all_functions.R:3686-3745``) consumed — so
 this isolates the segmenter transform from scrape logic. The transform is
 called ONCE over the concatenated multi-game frame, matching how the oracle
-was generated: the ungrouped ``startEventType`` lag (``all_functions.R:3698``)
-leaks across game boundaries by design and the parity assertions cover it.
+was generated — and in FAITHFUL mode (``fix_cross_game_leak=False``), because
+R's ungrouped ``startEventType`` lag (``all_functions.R:3698``) leaks across
+game boundaries. The shipped default fixes that leak (BUG-4); parity is
+asserted against the faithful mode, and the fixed-vs-faithful delta is pinned
+by ``test_faithful_mode_leaks_across_games_fixed_mode_does_not``.
 
 Row order is deterministic (dplyr emits groups sorted by the group keys; the
 keys are unique per row), so rows are compared in order without re-sorting.
@@ -56,7 +59,7 @@ def pbp() -> pl.DataFrame:
 
 
 def test_full_parity(pbp: pl.DataFrame) -> None:
-    got = ncaa_mbb_possessions(pbp)
+    got = ncaa_mbb_possessions(pbp, fix_cross_game_leak=False)
     exp = load_expected("possessions", POSSESSION_SEG_SCHEMA, LEAGUE)
     assert_frame_parity(got, exp, POSSESSION_SEG_SCHEMA)
 
@@ -67,13 +70,26 @@ def test_simple_parity(pbp: pl.DataFrame) -> None:
     assert_frame_parity(got, exp, POSSESSIONS_SIMPLE_SCHEMA)
 
 
-def test_start_event_type_leaks_across_games(pbp: pl.DataFrame) -> None:
-    """The ungrouped lag (all_functions.R:3698) is ported faithfully."""
-    got = ncaa_mbb_possessions(pbp)
-    first_per_game = got.group_by("game_id", maintain_order=True).first()
-    # Exactly one game (the first in pbp order) starts with a null; the other
-    # games' first possessions inherit the previous game's last event type.
-    assert first_per_game["start_event_type"].null_count() == 1
+def test_faithful_mode_leaks_across_games_fixed_mode_does_not(pbp: pl.DataFrame) -> None:
+    """BUG-4: the ungrouped lag (all_functions.R:3698) leaks; the fix windows it.
+
+    Faithful mode (``fix_cross_game_leak=False``) reproduces R: only the very
+    first row of the whole frame gets a null ``start_event_type``, so every
+    OTHER game's possession #1 inherits the previous game's last event type.
+    The default (fixed) mode nulls each game's first possession instead.
+    """
+    n_games = pbp["game_id"].n_unique()
+    assert n_games > 1, "leak is only observable in a multi-game frame"
+
+    faithful = ncaa_mbb_possessions(pbp, fix_cross_game_leak=False)
+    first_faithful = faithful.group_by("game_id", maintain_order=True).first()
+    assert first_faithful["start_event_type"].null_count() == 1
+
+    fixed = ncaa_mbb_possessions(pbp)
+    first_fixed = fixed.group_by("game_id", maintain_order=True).first()
+    assert first_fixed["start_event_type"].null_count() == n_games
+    # Nothing else moves: only start_event_type differs between the modes.
+    assert fixed.drop("start_event_type").equals(faithful.drop("start_event_type"))
 
 
 def test_return_as_pandas(pbp: pl.DataFrame) -> None:

--- a/tests/mbb/test_mbb_ncaa_technical_possessions.py
+++ b/tests/mbb/test_mbb_ncaa_technical_possessions.py
@@ -1,0 +1,192 @@
+"""BUG-3: technical / flagrant free throws must not move the possession chain.
+
+bigballR's chain (``all_functions.R:380-436``) has no technical or flagrant
+rules, so a made technical FT — an event by the team that does NOT have the
+ball — both triggers the corrective re-sync flip and arms ``poss_switch``,
+inventing a possession change that never happened. ``fix_technicals=True``
+(the shipped default) makes bad-foul FTs inert; ``fix_technicals=False``
+reproduces R (the pbp parity tests use it).
+
+# no fixture ORACLE covers a technical — constructed frames pin the rule
+Two committed fixtures do carry a bad foul (1613299 a coach technical, 6479639
+a flagrant) and both are asserted below — but the R oracle for them encodes the
+BUGGY chain, so it cannot adjudicate the fixed output. There is no ground truth
+for the correct behavior. The constructed sequences below are hand-built from
+the event contract ``_stamp_possessions`` consumes; they pin the intended
+semantics, they do not prove them against a refereed capture. Re-validate when
+one exists.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import polars as pl
+import pytest
+
+from sportsdataverse.mbb.mbb_ncaa_game_pbp import _stamp_possessions, parse_ncaa_bb_game_pbp
+from tests.mbb._bigballr_oracle import HTML_DIR
+
+HOME = "Illinois"
+AWAY = "Purdue"
+
+
+def _ev(
+    seconds: int,
+    team: str,
+    event_type: str,
+    result: Optional[str] = None,
+    desc: str = "",
+) -> "dict[str, Any]":
+    return {
+        "period": 1,
+        "game_seconds": seconds,
+        "event_team": team,
+        "event_type": event_type,
+        "event_result": result,
+        "event_description": desc or f"{team} {event_type}",
+    }
+
+
+def _stamp(rows: "list[dict[str, Any]]", *, fix_technicals: bool) -> "list[dict[str, Any]]":
+    _stamp_possessions(rows, HOME, AWAY, fix_technicals=fix_technicals)
+    return rows
+
+
+def _technical_sequence() -> "list[dict[str, Any]]":
+    """Illinois inbounds; Purdue's coach is whistled for a technical, Illinois
+    makes both technical FTs, then Illinois scores in the run of play."""
+    return [
+        _ev(10, HOME, "Two Point Jumper", "missed"),
+        _ev(12, HOME, "Offensive Rebound"),
+        # Purdue technical; Illinois shoots two and keeps the ball.
+        _ev(20, AWAY, "Commits Foul", None, "SMITH,JOHN foul technical classa"),
+        _ev(20, HOME, "Free Throw", "made", "JONES,MIKE freethrow 1of2 made (2)"),
+        _ev(20, HOME, "Free Throw", "made", "JONES,MIKE freethrow 2of2 made (3)"),
+        _ev(30, HOME, "Layup", "made"),
+        _ev(40, AWAY, "Three Point Jumper", "missed"),
+        _ev(42, HOME, "Defensive Rebound"),
+    ]
+
+
+def test_made_technical_ft_does_not_flip_poss_team() -> None:
+    rows = _stamp(_technical_sequence(), fix_technicals=True)
+    ft_rows = [r for r in rows if r["event_type"] == "Free Throw"]
+
+    # The technical FTs belong to the possession that was already in progress.
+    assert [r["poss_team"] for r in ft_rows] == [HOME, HOME]
+    assert {r["poss_num"] for r in ft_rows} == {rows[0]["poss_num"]}
+    # The made Layup (the real possession-ender) still hands the ball to Purdue.
+    assert rows[-2]["poss_team"] == AWAY  # Purdue's missed three
+    assert rows[-1]["poss_team"] == AWAY
+
+
+def test_technical_sequence_possession_count_unchanged_by_the_technical() -> None:
+    """The technical adds no possession: the fixed chain counts exactly the
+    possessions the run of play produces (Illinois, then Purdue)."""
+    fixed = _stamp(_technical_sequence(), fix_technicals=True)
+    assert len({r["poss_num"] for r in fixed}) == 2
+    assert [r["poss_team"] for r in fixed] == [HOME] * 6 + [AWAY] * 2
+
+    # Faithful R: the made technical FT flips the ball to Illinois' opponent
+    # (corrective re-sync is a no-op here since Illinois shot it) and arms the
+    # switch, so the chain manufactures extra possessions.
+    faithful = _stamp(_technical_sequence(), fix_technicals=False)
+    assert len({r["poss_num"] for r in faithful}) > 2
+
+
+def test_offsetting_double_technical_does_not_flip_poss_team() -> None:
+    """Both benches get a technical at the same clock; each shoots one FT.
+    Offsetting techs net to zero (hoop-explorer ``offsetting_tech_or_flagrant``)
+    — the possession in progress survives both."""
+    rows = _stamp(
+        [
+            _ev(10, HOME, "Two Point Jumper", "missed"),
+            _ev(12, HOME, "Offensive Rebound"),
+            _ev(20, AWAY, "Commits Foul", None, "SMITH,JOHN foul technical classa"),
+            _ev(20, HOME, "Commits Foul", None, "DOE,JANE foul technical classa"),
+            _ev(20, HOME, "Free Throw", "made", "JONES,MIKE freethrow 1of1 made (2)"),
+            _ev(20, AWAY, "Free Throw", "made", "ROE,RICH freethrow 1of1 made (2)"),
+            _ev(30, HOME, "Layup", "made"),
+        ],
+        fix_technicals=True,
+    )
+    assert [r["poss_team"] for r in rows] == [HOME] * 7
+    assert len({r["poss_num"] for r in rows}) == 1
+
+
+def test_ordinary_and_one_still_works() -> None:
+    """Guard: the fix must not disarm the ordinary and-1 rule (a made FG plus a
+    shooting-foul FT at the same clock is ONE possession, no switch at the FG)."""
+    rows = _stamp(
+        [
+            _ev(10, HOME, "Layup", "made"),
+            _ev(10, AWAY, "Commits Foul", None, "SMITH,JOHN foul personal"),
+            _ev(10, HOME, "Free Throw", "made", "JONES,MIKE freethrow 1of1 made (3)"),
+            _ev(20, AWAY, "Two Point Jumper", "missed"),
+            _ev(22, HOME, "Defensive Rebound"),
+        ],
+        fix_technicals=True,
+    )
+    assert [r["poss_team"] for r in rows[:3]] == [HOME] * 3
+    assert len({r["poss_num"] for r in rows[:3]}) == 1
+    # the and-1 FT ends the possession -> Purdue gets the next one
+    assert rows[3]["poss_team"] == AWAY
+
+
+@pytest.mark.parametrize(
+    ("game_id", "bad_foul", "faithful_poss", "fixed_poss"),
+    [
+        # "Team, foul coachTechnical classa;2freethrow" — 2 phantom possessions
+        ("1613299", "coach technical", 141, 139),
+        # "Kylan Boswell, foul personal flagrant1;2freethrow;" — 1 phantom
+        ("6479639", "flagrant", 142, 141),
+    ],
+)
+def test_bad_foul_fixture_games_drop_phantom_possessions(
+    game_id: str, bad_foul: str, faithful_poss: int, fixed_poss: int
+) -> None:
+    """Real-data check: the two MBB fixtures carrying a bad foul (there is no
+    oracle for the FIXED output — R has the bug — so this pins the delta, not
+    the truth). The fix only ever REMOVES possessions the technical/flagrant FTs
+    manufactured; the parsed events themselves are untouched.
+
+    The lineup columns and ``sub_deviate`` may also move: the lineup walk places
+    substitutions at possession boundaries, so dropping a phantom boundary can
+    re-home a sub. That is downstream of the fix, not a separate change.
+    """
+    html = (HTML_DIR / f"pbp_{game_id}.html").read_text(encoding="utf-8")
+    fixed = parse_ncaa_bb_game_pbp(html, game_id)
+    faithful = parse_ncaa_bb_game_pbp(html, game_id, fix_technicals=False)
+
+    assert fixed.height == faithful.height
+    assert faithful["poss_num"].max() == faithful_poss, f"{bad_foul}: faithful count drifted"
+    assert fixed["poss_num"].max() == fixed_poss, f"{bad_foul}: fixed count drifted"
+    # the parsed event stream is identical — only the chain's reading of it moves
+    events = [
+        "game_id",
+        "period",
+        "clock",
+        "game_seconds",
+        "home_score",
+        "away_score",
+        "event_team",
+        "event_description",
+        "player_1",
+        "player_2",
+        "event_type",
+        "event_result",
+        "shot_value",
+        "event_length",
+    ]
+    assert fixed.select(events).equals(faithful.select(events))
+
+
+def test_games_without_bad_fouls_are_identical_in_both_modes() -> None:
+    """No technical, no flagrant -> the flag is a no-op."""
+    for game_id in ("6470186", "6479592"):
+        html = (HTML_DIR / f"pbp_{game_id}.html").read_text(encoding="utf-8")
+        fixed = parse_ncaa_bb_game_pbp(html, game_id)
+        faithful = parse_ncaa_bb_game_pbp(html, game_id, fix_technicals=False)
+        assert isinstance(fixed, pl.DataFrame)
+        assert fixed.equals(faithful), f"game {game_id} moved without a bad foul"

--- a/tests/wbb/test_wbb_ncaa_game_pbp_parity.py
+++ b/tests/wbb/test_wbb_ncaa_game_pbp_parity.py
@@ -57,8 +57,10 @@ def oracle() -> pl.DataFrame:
 
 
 def _parse(game_id: str) -> pl.DataFrame:
+    """Parse in FAITHFUL mode — the shipped default fixes bigballR's missing
+    technical/flagrant possession rules (BUG-3), which the R oracle lacks."""
     html = (HTML_DIR / f"pbp_{game_id}.html").read_text(encoding="utf-8")
-    return parse_ncaa_bb_game_pbp(html, game_id, period_model=WBB_PERIOD_MODEL)
+    return parse_ncaa_bb_game_pbp(html, game_id, period_model=WBB_PERIOD_MODEL, fix_technicals=False)
 
 
 @pytest.mark.parametrize("game_id", GAMES["wbb"])

--- a/tests/wbb/test_wbb_ncaa_possession_seg_parity.py
+++ b/tests/wbb/test_wbb_ncaa_possession_seg_parity.py
@@ -36,7 +36,7 @@ def pbp() -> pl.DataFrame:
 
 
 def test_full_parity(pbp: pl.DataFrame) -> None:
-    got = ncaa_mbb_possessions(pbp)
+    got = ncaa_mbb_possessions(pbp, fix_cross_game_leak=False)
     exp = load_expected("possessions", POSSESSION_SEG_SCHEMA, LEAGUE)
     assert_frame_parity(got, exp, POSSESSION_SEG_SCHEMA)
 
@@ -47,8 +47,14 @@ def test_simple_parity(pbp: pl.DataFrame) -> None:
     assert_frame_parity(got, exp, POSSESSIONS_SIMPLE_SCHEMA)
 
 
-def test_start_event_type_leaks_across_games(pbp: pl.DataFrame) -> None:
-    """Faithful ungrouped lag: exactly one null start_event_type frame-wide."""
-    got = ncaa_mbb_possessions(pbp)
-    first_per_game = got.group_by("game_id", maintain_order=True).first()
-    assert first_per_game["start_event_type"].null_count() == 1
+def test_faithful_mode_leaks_across_games_fixed_mode_does_not(pbp: pl.DataFrame) -> None:
+    """BUG-4: faithful ungrouped lag leaks (one null frame-wide); the fix nulls per game."""
+    n_games = pbp["game_id"].n_unique()
+    assert n_games > 1, "leak is only observable in a multi-game frame"
+
+    faithful = ncaa_mbb_possessions(pbp, fix_cross_game_leak=False)
+    assert faithful.group_by("game_id", maintain_order=True).first()["start_event_type"].null_count() == 1
+
+    fixed = ncaa_mbb_possessions(pbp)
+    assert fixed.group_by("game_id", maintain_order=True).first()["start_event_type"].null_count() == n_games
+    assert fixed.drop("start_event_type").equals(faithful.drop("start_event_type"))


### PR DESCRIPTION
## Summary

Two publish-safety fixes to the NCAA possessions engine (bigballR family, `#251`), gating both behind flags whose **default is the correct behavior** and whose faithful-R behavior is opt-in (`False`). This lets the parity oracles keep asserting against the buggy R chain while the published datasets get the corrected output.

## Fixes

**1. Cross-game possession leak (`fix_cross_game_leak`, default `True`)**
An ungrouped `shift(1)` in the possession-segmentation walk leaked the last play of one game into the first possession of the next when frames are concatenated. Grouping the shift per game closes the leak. Faithful-R (ungrouped) is behind the flag for parity tests.

**2. Technical / flagrant free throws (`fix_technicals`, default `True`)**
The R chain has no technical/flagrant rules, so a made technical free throw flips `poss_team` — a possession change that never happened (`possession_engine_reconciliation.md` BUG-3). The fix ports hoop-explorer's `bad_fouls` / `offsetting_tech_or_flagrant` semantics (`mbb_ncaa_possessions.calculate_stats`): free throws sharing a clock reading with a technical/flagrant foul are inert — no switch, no corrective flip, no and-1 — which also nets offsetting double technicals to zero. Pass `fix_technicals=False` for faithful R output.

⚠️ **`fix_technicals` is UN-ADJUDICATED.** Two committed fixtures exercise it (1613299 coach technical → 2 phantom possessions; 6479639 flagrant → 1), but their R oracle encodes the buggy chain, so no oracle can score the fixed output — there is no ground truth for the correct behavior. The rule is a code-read port of hoop-explorer's, pinned by constructed sequences in `tests/mbb/test_mbb_ncaa_technical_possessions.py`. Re-validate against a refereed capture when one exists.

Dropping a phantom possession also drops a possession *boundary*, so the lineup walk-forward can re-home a substitution and `sub_deviate` can move — expected downstream of the fix, not a second change.

## Why flags (default-correct, faithful-R opt-in)

The R golden-master oracles from the port assert byte-for-byte against the upstream (buggy) chain. Flipping the default to correct while keeping `False` faithful means the published data is right *and* the parity suite still guards the port fidelity.

## Verification

- 45 tests pass (parity suites re-parameterized to pass `fix_*=False`; new `test_mbb_ncaa_technical_possessions.py` covers the corrected path).
- `mypy` strict ratchet + `ruff` clean.
- Regenerated reference docs (`docs/docs/{mbb,wbb}/reference/additional.md`) included; codegen drift check passes.
- `uv.lock` untouched.
- Full pre-push CI-parity gate ran on push (mypy + codegen `--check` + `test_id_conventions` + validation contracts).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added controls for correcting cross-game possession boundaries in men’s and women’s NCAA basketball data, enabled by default.
  * Added controls for handling technical and flagrant foul free throws during possession assignment, with corrected behavior enabled by default.
  * Users can still select legacy behavior for compatibility.

* **Bug Fixes**
  * Prevented possessions from incorrectly carrying over between games.
  * Prevented technical free throws from creating phantom possession changes.

* **Documentation**
  * Updated reference documentation and examples for the new options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->