### PR TITLE
feat(nba,wnba): CTG play-context A-track — WNBA sibling, player/lineup tables, 99.5% start-type oracle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Unreleased](#unreleased)
+  - [NBA / WNBA — CTG play context (T3.6): possession/shot/lineup/player tables + start-type oracle](#nba--wnba--ctg-play-context-t36-possessionshotlineupplayer-tables--start-type-oracle)
   - [Fixes](#fixes)
   - [Dependencies](#dependencies)
   - [Release utilities — `sportsdataverse.release` (sportsdataversedata R-package port)](#release-utilities--sportsdataverserelease-sportsdataversedata-r-package-port)
@@ -173,6 +174,32 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Unreleased
+
+### NBA / WNBA — CTG play context (T3.6): possession/shot/lineup/player tables + start-type oracle
+
+- **`nba_play_context` / `wnba_play_context`** — Cleaning the Glass recreation on
+  the shipped possession engine. Per-possession context (`possession_start_type`
+  coarse family + `possession_start_type_detail` zone-split + the five
+  `possession_start_type_ctg` buckets, `is_transition` / `transition_source`,
+  `seconds_to_first_play`, `is_garbage_time` / `garbage_time_basis`,
+  `is_heave_possession`) and per-shot context (`ctg_shot_zone`, `is_putback`,
+  `is_second_chance_shot`, `shot_context`). `wnba_play_context` is a real shim
+  (`wnba_engine`), byte-identical to the NBA core on WNBA fixtures.
+- **`lineup_play_context` / `player_play_context`** — on/off possessions + points
+  per 5-man unit and per player, sharing one aggregation core; the OFF side is
+  derived by subtraction so the on/off split is exact by construction.
+- **`starters_on_court_counts`** — implements CTG's garbage-time "<=2 starters on
+  floor" clause; when starter data is joined `garbage_time_basis` upgrades from
+  `margin_only` to `margin+starters` (containment-verified against margin-only).
+- **Faithful pbpstats possession start-type** — boundary-only timeout detection
+  (a port of `possession_has_timeout` / `previous_possession_has_timeout`, incl.
+  the asymmetric FT-sandwich technical carve-out), exact CTG shot-zone boundaries
+  from the legacy coordinates (the v3 `shot_distance` column is `Int64`, rounded
+  to whole feet), and a `team_id == 0` team-rebound discriminator (the v3 feed
+  stuffs the team id into `person_id`). Validated like-for-like against
+  pbpstats-live: **99.50% coarse `possession_start_type` agreement (592/595)**
+  across the committed fixtures (`test_nba_play_context_oracle.py`, gated on
+  `SDV_PBPSTATS_ROOT`).
 
 ### Fixes
 

--- a/docs/docs/nba/index.md
+++ b/docs/docs/nba/index.md
@@ -11,7 +11,7 @@ sidebar_label: NBA
 | [ESPN core API (v2)](reference/core) | 81 | `https://sports.core.api.espn.com/v2/sports` |
 | [NBA Stats API (stats.nba.com)](reference/nba_stats) | 112 | `https://stats.nba.com` |
 | [Dataset loaders](reference/loaders) | 13 | sportsdataverse-data releases |
-| [Additional functions](reference/additional) | 121 | hand-written wrappers, loaders & helpers |
+| [Additional functions](reference/additional) | 124 | hand-written wrappers, loaders & helpers |
 
 ## Examples
 

--- a/docs/docs/nba/reference/additional.md
+++ b/docs/docs/nba/reference/additional.md
@@ -1879,6 +1879,42 @@ pbp = load_nba_pbp([2024]).filter(pl.col("game_id") == 401585828)
 feats = in_game_features(pbp, 0.62)
 ```
 
+### `lineup_play_context(possessions: 'pl.DataFrame', *, min_poss: 'int' = 0, league_non_transition_ppp: 'Optional[float]' = None, apply_ctg_filters: 'bool' = True, return_as_pandas: 'bool' = False) -> 'Union[pl.DataFrame, pd.DataFrame]'` {#lineup_play_context}
+
+Roll possessions up into a per-5-man-lineup Play-Context table.
+
+The lineup analogue of `team_play_context`: same metric columns, grouped
+by the five players on the floor **for the offense**. Lineups are identified by
+`lineup_id` — the five player ids sorted ascending and hyphen-joined — so the
+same five players always land in the same bucket regardless of slot order.
+
+Requires the `off_player_1..5` columns from
+`~sportsdataverse.nba.nba_possessions.attach_possession_lineups`
+(which passes the play-context columns through, so the two compose in either
+order).
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `possessions` | `DataFrame` |  | Frame from `add_play_context` **with lineups attached**. |
+| `min_poss` | `int` | `0` | Drop lineups below this possession count (CTG's tables carry a minimum; 0 keeps everything, which is what the partition identity needs). |
+| `league_non_transition_ppp` | `Optional[float]` | `None` | Pts+/Poss baseline; see `team_play_context`. |
+| `apply_ctg_filters` | `bool` | `True` | Drop garbage-time / heave / non-counting possessions first. |
+| `return_as_pandas` | `bool` | `False` | Return a pandas DataFrame instead of polars. |
+
+**Returns**
+
+One row per (team, lineup) with `LINEUP_PLAY_CONTEXT_SCHEMA`. Empty input returns a zero-row frame with that schema.
+
+**Example**
+
+```python
+poss = attach_possession_lineups(add_play_context(enh), oncourt, enh, home_team_id=home)
+lu = lineup_play_context(poss, min_poss=25)
+print(lu.sort("pts_per_100", descending=True).head())
+```
+
 ### `luck_adjusted_response(possessions: 'pl.DataFrame', shooting: 'pl.DataFrame', player_rates: 'Optional[dict[int, tuple[float, float]]]' = None, *, fg3_k: 'float' = 100.0, ft_k: 'float' = 50.0) -> 'pl.DataFrame'` {#luck_adjusted_response}
 
 Attach a per-possession `la_points` expected-points response.
@@ -3365,6 +3401,53 @@ assert normalize_player_name("Nikola Jokić") == normalize_player_name("Nikola J
 assert normalize_player_name("Gary Trent Jr.") == normalize_player_name("Gary Trent")
 ```
 
+### `player_play_context(possessions: 'pl.DataFrame', *, league_non_transition_ppp: 'Optional[float]' = None, apply_ctg_filters: 'bool' = True, return_as_pandas: 'bool' = False) -> 'Union[pl.DataFrame, pd.DataFrame]'` {#player_play_context}
+
+Per-player offensive On/Off Play-Context table (CTG's On/Off page, offense half).
+
+For each player: their team's offensive play-context **with them on the floor**
+(`on_*`), **without them** (`off_*`), and the on-minus-off difference
+(`diff_*`) — which is the number CTG actually displays.
+
+The OFF side is derived by **subtraction** (team total minus on-court), not by a
+second scan. That is deliberate: it makes the partition exact by construction —
+`on_poss + off_poss == team_poss` and the same for points — so a leak (a
+double-counted possession, a dropped lineup slot) is impossible to hide. The
+test suite asserts that identity directly.
+
+Like CTG's on/off, this is a **raw** split: no luck adjustment, no opponent
+adjustment, no minutes threshold. It is a descriptive difference, not a causal
+estimate — for that, use the RAPM surface
+(`~sportsdataverse.nba.nba_rapm.nba_rapm`).
+
+Requires `off_player_1..5` from
+`~sportsdataverse.nba.nba_possessions.attach_possession_lineups`.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `possessions` | `DataFrame` |  | Frame from `add_play_context` **with lineups attached**. |
+| `league_non_transition_ppp` | `Optional[float]` | `None` | Pts+/Poss baseline; see `team_play_context`. One baseline is shared across the on and off sides so the diffs are comparable. |
+| `apply_ctg_filters` | `bool` | `True` | Drop garbage-time / heave / non-counting possessions first. |
+| `return_as_pandas` | `bool` | `False` | Return a pandas DataFrame instead of polars. |
+
+**Returns**
+
+One row per (player, team) with `PLAYER_PLAY_CONTEXT_SCHEMA`. Empty input returns a zero-row frame with that schema.
+
+**Example**
+
+```python
+poss = attach_possession_lineups(add_play_context(enh), oncourt, enh, home_team_id=home)
+onoff = player_play_context(poss)
+print(onoff.sort("diff_pts_per_100", descending=True).head())
+
+# Who makes their team run?
+
+print(onoff.sort("diff_transition_freq", descending=True).head())
+```
+
 ### `player_rates(box_logs: 'pl.DataFrame') -> 'pl.DataFrame'` {#player_rates}
 
 Per-player per-minute rate stats from box logs.
@@ -3921,6 +4004,33 @@ factor `k_i = τ² / (τ² + σ²_i)` and `clutch_skill_shrunk = k_i · delta_i`
 ```python
 from sportsdataverse.nba.nba_clutch import clutch_delta, shrink_clutch
 skill = shrink_clutch(clutch_delta(clutch_frame, baseline_frame))
+```
+
+### `starters_on_court_counts(possessions: 'pl.DataFrame', starters: 'dict[int, list[int]]') -> 'dict[int, int]'` {#starters_on_court_counts}
+
+Count, per possession, how many **starters** are on the floor across BOTH teams.
+
+This supplies the second half of CTG's garbage-time rule — "there have to be
+**two or fewer starters on the floor combined between the two teams**" — which
+`flag_garbage_time` cannot evaluate on its own (the possession frame does
+not carry who is on the floor).
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `possessions` | `DataFrame` |  | Possession frame with the ten on-court columns `off_player_1..5` **and** `def_player_1..5` (from `~sportsdataverse.nba.nba_possessions.attach_possession_lineups`). |
+| `starters` | `dict[int, list[int]]` |  | `{team_id: [player_id, ...]}` — e.g. from `~sportsdataverse.nba.nba_lineups._starters_from_boxscore_v3`. Player ids are matched across both teams' starting fives, so the offense/defense split of the lineup columns does not matter. |
+
+**Returns**
+
+`{possession_number: starters_on_floor}`, each value in `0..10`. An **empty** *starters* map yields all-zero counts, which would make CTG's `<= 2` clause vacuously true and flag every margin-qualifying possession. The counts are reported honestly rather than guessed — do not pass an empty map and then read the result as CTG-exact.
+
+**Example**
+
+```python
+counts = starters_on_court_counts(poss, _starters_from_boxscore_v3(box))
+print(max(counts.values()))  # 10 at the opening tip
 ```
 
 ### `team_pace_projection(home_team_id: 'str', away_team_id: 'str', ratings: 'pl.DataFrame', *, league_id: 'str' = '00') -> 'float'` {#team_pace_projection}

--- a/docs/docs/wnba/index.md
+++ b/docs/docs/wnba/index.md
@@ -11,7 +11,7 @@ sidebar_label: WNBA
 | [ESPN core API (v2)](reference/core) | 80 | `https://sports.core.api.espn.com/v2/sports` |
 | [WNBA Stats API (stats.wnba.com)](reference/wnba_stats) | 95 | `https://stats.wnba.com` |
 | [Dataset loaders](reference/loaders) | 21 | sportsdataverse-data releases |
-| [Additional functions](reference/additional) | 47 | hand-written wrappers, loaders & helpers |
+| [Additional functions](reference/additional) | 48 | hand-written wrappers, loaders & helpers |
 
 ## Examples
 

--- a/docs/docs/wnba/reference/additional.md
+++ b/docs/docs/wnba/reference/additional.md
@@ -1075,7 +1075,7 @@ Two caveats worth stating plainly:
 
 **Returns**
 
-The possession frame (`POSSESSIONS_SCHEMA`) plus `~sportsdataverse.nba.nba_play_context.PLAY_CONTEXT_POSSESSIONS_SCHEMA`. Empty or malformed payloads return a zero-row frame — never raises.
+The possession frame (`POSSESSIONS_SCHEMA`) plus `~sportsdataverse.nba.nba_play_context.PLAY_CONTEXT_POSSESSIONS_SCHEMA`. Empty or malformed payloads return a zero-row frame — never raises on payload content.
 
 **Example**
 

--- a/docs/docs/wnba/reference/additional.md
+++ b/docs/docs/wnba/reference/additional.md
@@ -1039,6 +1039,61 @@ _No description available._
 | `game_id` |  |  |  |
 | `path_to_json` |  |  |  |
 
+### `wnba_play_context(game_id: 'str', *, transition_seconds: 'float' = 6.0, transition_variant: 'str' = 'hoop_math', return_as_pandas: 'bool' = False) -> 'Union[pl.DataFrame, pd.DataFrame]'` {#wnba_play_context}
+
+Return a WNBA game's possessions with the full CTG play-context surface.
+
+WNBA sibling of
+`~sportsdataverse.nba.nba_play_context.nba_play_context` — the
+Cleaning the Glass recreation (possession start-type taxonomy + the
+halfcourt / transition / putback contexts + CTG's garbage-time and heave
+filters). One network call (`playbyplayv3` on `stats.wnba.com`); every
+transformation is done by the league-agnostic
+`~sportsdataverse.nba.nba_play_context.add_play_context` core, so
+there is **no WNBA-specific classification logic** to drift.
+
+Two caveats worth stating plainly:
+
+* **CTG is NBA-only.** There is no published WNBA play-context table to
+  calibrate against, so `transition_seconds` inherits the NBA's fitted
+  6.0 s default. The WNBA fixtures land inside the NBA's transition-frequency
+  gate at that value (`tests/wnba/test_wnba_play_context_shim.py`), which
+  is a sanity check on the shared engine — not evidence that 6.0 s is the
+  *right* WNBA cutoff. Re-fit it if a WNBA oracle ever appears.
+* Shot-zone boundaries are league-agnostic (feet from the rim), and the
+  corner-three test uses the same legacy coordinates, which the WNBA feed
+  also ships.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `game_id` | `str` |  | WNBA game identifier (e.g. `"1022400001"`). |
+| `transition_seconds` | `float` | `6.0` | Transition initial-play cutoff, in seconds. |
+| `transition_variant` | `str` | `'hoop_math'` | See `~sportsdataverse.nba.nba_play_context.add_transition`. |
+| `return_as_pandas` | `bool` | `False` | Return a pandas DataFrame instead of polars. |
+
+**Returns**
+
+The possession frame (`POSSESSIONS_SCHEMA`) plus `~sportsdataverse.nba.nba_play_context.PLAY_CONTEXT_POSSESSIONS_SCHEMA`. Empty or malformed payloads return a zero-row frame — never raises.
+
+**Example**
+
+```python
+from sportsdataverse.wnba.wnba_engine import wnba_play_context
+poss = wnba_play_context("1022400001")
+print(poss["possession_start_type_ctg"].value_counts())
+
+# Transition rate (CTG's default filtered view)
+
+import polars as pl
+clean = poss.filter(
+    (pl.col("is_garbage_time") == False)  # noqa: E712
+    & (pl.col("is_heave_possession") == False)  # noqa: E712
+)
+print(clean["is_transition"].mean())
+```
+
 ### `wnba_player_props(season: 'int', game_id: 'str', home_team_id: 'str', away_team_id: 'str', *, league_id: 'str' = '00', return_as_pandas: 'bool' = False) -> 'Union[pl.DataFrame, pd.DataFrame]'` {#wnba_player_props}
 
 WNBA player props (league_id='10'). See sportsdataverse.nba.nba_player_props.nba_player_props.

--- a/docs/src/pages/CHANGELOG.md
+++ b/docs/src/pages/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Unreleased](#unreleased)
+  - [NBA / WNBA — CTG play context (T3.6): possession/shot/lineup/player tables + start-type oracle](#nba--wnba--ctg-play-context-t36-possessionshotlineupplayer-tables--start-type-oracle)
   - [Fixes](#fixes)
   - [Dependencies](#dependencies)
   - [Release utilities — `sportsdataverse.release` (sportsdataversedata R-package port)](#release-utilities--sportsdataverserelease-sportsdataversedata-r-package-port)
@@ -173,6 +174,32 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Unreleased
+
+### NBA / WNBA — CTG play context (T3.6): possession/shot/lineup/player tables + start-type oracle
+
+- **`nba_play_context` / `wnba_play_context`** — Cleaning the Glass recreation on
+  the shipped possession engine. Per-possession context (`possession_start_type`
+  coarse family + `possession_start_type_detail` zone-split + the five
+  `possession_start_type_ctg` buckets, `is_transition` / `transition_source`,
+  `seconds_to_first_play`, `is_garbage_time` / `garbage_time_basis`,
+  `is_heave_possession`) and per-shot context (`ctg_shot_zone`, `is_putback`,
+  `is_second_chance_shot`, `shot_context`). `wnba_play_context` is a real shim
+  (`wnba_engine`), byte-identical to the NBA core on WNBA fixtures.
+- **`lineup_play_context` / `player_play_context`** — on/off possessions + points
+  per 5-man unit and per player, sharing one aggregation core; the OFF side is
+  derived by subtraction so the on/off split is exact by construction.
+- **`starters_on_court_counts`** — implements CTG's garbage-time "<=2 starters on
+  floor" clause; when starter data is joined `garbage_time_basis` upgrades from
+  `margin_only` to `margin+starters` (containment-verified against margin-only).
+- **Faithful pbpstats possession start-type** — boundary-only timeout detection
+  (a port of `possession_has_timeout` / `previous_possession_has_timeout`, incl.
+  the asymmetric FT-sandwich technical carve-out), exact CTG shot-zone boundaries
+  from the legacy coordinates (the v3 `shot_distance` column is `Int64`, rounded
+  to whole feet), and a `team_id == 0` team-rebound discriminator (the v3 feed
+  stuffs the team id into `person_id`). Validated like-for-like against
+  pbpstats-live: **99.50% coarse `possession_start_type` agreement (592/595)**
+  across the committed fixtures (`test_nba_play_context_oracle.py`, gated on
+  `SDV_PBPSTATS_ROOT`).
 
 ### Fixes
 

--- a/sportsdataverse/nba/__init__.py
+++ b/sportsdataverse/nba/__init__.py
@@ -56,8 +56,10 @@ from sportsdataverse.nba.nba_oracle_data import (  # noqa: F401
 )
 from sportsdataverse.nba.nba_v3_v2_adapter import nba_v3_to_v2_pbp  # noqa: F401
 from sportsdataverse.nba.nba_play_context import (  # noqa: F401
+    LINEUP_PLAY_CONTEXT_SCHEMA,
     PLAY_CONTEXT_POSSESSIONS_SCHEMA,
     PLAY_CONTEXT_SHOTS_SCHEMA,
+    PLAYER_PLAY_CONTEXT_SCHEMA,
     add_ctg_shot_zones,
     add_play_context,
     add_start_type_detail,
@@ -65,7 +67,9 @@ from sportsdataverse.nba.nba_play_context import (  # noqa: F401
     build_play_context_shots,
     flag_garbage_time,
     flag_heave_possessions,
+    lineup_play_context,
     nba_play_context,
+    player_play_context,
     team_play_context,
 )
 from sportsdataverse.nba.nba_possessions import (  # noqa: F401

--- a/sportsdataverse/nba/__init__.py
+++ b/sportsdataverse/nba/__init__.py
@@ -70,6 +70,7 @@ from sportsdataverse.nba.nba_play_context import (  # noqa: F401
     lineup_play_context,
     nba_play_context,
     player_play_context,
+    starters_on_court_counts,
     team_play_context,
 )
 from sportsdataverse.nba.nba_possessions import (  # noqa: F401

--- a/sportsdataverse/nba/nba_play_context.py
+++ b/sportsdataverse/nba/nba_play_context.py
@@ -56,6 +56,7 @@ __all__ = [
     "lineup_play_context",
     "nba_play_context",
     "player_play_context",
+    "starters_on_court_counts",
     "team_play_context",
 ]
 
@@ -1018,6 +1019,78 @@ def _context_rates(counts: pl.DataFrame, league_non_transition_ppp: float) -> pl
         )
         .drop("_trans_steal", "_trans_reb", "halfcourt_points")
     )
+
+
+def starters_on_court_counts(
+    possessions: pl.DataFrame,
+    starters: dict[int, list[int]],
+) -> dict[int, int]:
+    """Count, per possession, how many **starters** are on the floor across BOTH teams.
+
+    This supplies the second half of CTG's garbage-time rule — "there have to be
+    **two or fewer starters on the floor combined between the two teams**" — which
+    :func:`flag_garbage_time` cannot evaluate on its own (the possession frame does
+    not carry who is on the floor).
+
+    Feed the result straight back in::
+
+        poss = attach_possession_lineups(build_possessions(enh), oncourt, enh, home_team_id=home)
+        counts = starters_on_court_counts(poss, _starters_from_boxscore_v3(box))
+        ctx = add_play_context(enh, starters_on_court=counts)   # now CTG-exact
+
+    The possession numbering is stable for a given enhanced-PBP frame, so counts
+    derived from a lineup-attached frame key correctly into a frame rebuilt from the
+    same PBP.
+
+    Args:
+        possessions: Possession frame with the ten on-court columns
+            ``off_player_1..5`` **and** ``def_player_1..5`` (from
+            :func:`~sportsdataverse.nba.nba_possessions.attach_possession_lineups`).
+        starters: ``{team_id: [player_id, ...]}`` — e.g. from
+            :func:`~sportsdataverse.nba.nba_lineups._starters_from_boxscore_v3`.
+            Player ids are matched across both teams' starting fives, so the
+            offense/defense split of the lineup columns does not matter.
+
+    Returns:
+        ``{possession_number: starters_on_floor}``, each value in ``0..10``.
+
+        An **empty** *starters* map yields all-zero counts, which would make CTG's
+        ``<= 2`` clause vacuously true and flag every margin-qualifying possession.
+        The counts are reported honestly rather than guessed — do not pass an empty
+        map and then read the result as CTG-exact.
+
+    Raises:
+        ValueError: when the ``off_player_*`` / ``def_player_*`` columns are absent.
+
+    Example:
+        Quick start::
+
+            counts = starters_on_court_counts(poss, _starters_from_boxscore_v3(box))
+            print(max(counts.values()))  # 10 at the opening tip
+    """
+    def_cols = [f"def_player_{i}" for i in range(1, 6)]
+    missing = [c for c in _OFF_PLAYER_COLS + def_cols if c not in possessions.columns]
+    if missing:
+        raise ValueError(
+            f"missing on-court columns {missing}: pass a frame through "
+            "nba_possessions.attach_possession_lineups() first"
+        )
+    if possessions.is_empty():
+        return {}
+
+    # One flat set of starter ids: a player is a starter or they are not, and the
+    # offense/defense column split says nothing about which team they start for.
+    starter_ids = {int(pid) for ids in starters.values() for pid in ids}
+
+    counted = possessions.select(
+        "possession_number",
+        pl.concat_list(_OFF_PLAYER_COLS + def_cols)
+        .list.set_intersection(pl.lit(sorted(starter_ids), dtype=pl.List(pl.Int64)))
+        .list.len()
+        .cast(pl.Int64)
+        .alias("n_starters"),
+    )
+    return dict(zip(counted["possession_number"].to_list(), counted["n_starters"].to_list()))
 
 
 def _require_lineups(df: pl.DataFrame) -> None:

--- a/sportsdataverse/nba/nba_play_context.py
+++ b/sportsdataverse/nba/nba_play_context.py
@@ -1030,8 +1030,18 @@ def _context_rates(counts: pl.DataFrame, league_non_transition_ppp: float) -> pl
     """Turn :func:`_context_counts` output into the CTG metric columns."""
     return (
         counts.with_columns(
-            (100.0 * pl.col("points") / pl.col("poss")).alias("pts_per_100"),
-            (pl.col("transition_poss") / pl.col("poss")).alias("transition_freq"),
+            # poss can be 0 on the subtraction-derived OFF side (a player who never
+            # sits: off_poss = team_poss - on_poss = 0). Guard every poss-denominator
+            # rate to a null rather than emit inf/NaN into the output (and into the
+            # on-minus-off diff). Matches the transition/halfcourt guards below.
+            pl.when(pl.col("poss") > 0)
+            .then(100.0 * pl.col("points") / pl.col("poss"))
+            .otherwise(None)
+            .alias("pts_per_100"),
+            pl.when(pl.col("poss") > 0)
+            .then(pl.col("transition_poss") / pl.col("poss"))
+            .otherwise(None)
+            .alias("transition_freq"),
             pl.when(pl.col("transition_poss") > 0)
             .then(100.0 * pl.col("transition_points") / pl.col("transition_poss"))
             .otherwise(None)
@@ -1040,8 +1050,14 @@ def _context_rates(counts: pl.DataFrame, league_non_transition_ppp: float) -> pl
             .then(100.0 * pl.col("halfcourt_points") / pl.col("halfcourt_poss"))
             .otherwise(None)
             .alias("non_transition_pts_per_100"),
-            (pl.col("_trans_steal") / pl.col("poss")).alias("freq_off_steal"),
-            (pl.col("_trans_reb") / pl.col("poss")).alias("freq_off_live_rebound"),
+            pl.when(pl.col("poss") > 0)
+            .then(pl.col("_trans_steal") / pl.col("poss"))
+            .otherwise(None)
+            .alias("freq_off_steal"),
+            pl.when(pl.col("poss") > 0)
+            .then(pl.col("_trans_reb") / pl.col("poss"))
+            .otherwise(None)
+            .alias("freq_off_live_rebound"),
         )
         .with_columns(
             ((pl.col("transition_pts_per_100") - league_non_transition_ppp) * pl.col("transition_freq")).alias(

--- a/sportsdataverse/nba/nba_play_context.py
+++ b/sportsdataverse/nba/nba_play_context.py
@@ -42,6 +42,8 @@ from sportsdataverse.nba import nba_play_context_constants as C
 from sportsdataverse.nba.nba_possessions import build_possessions
 
 __all__ = [
+    "LINEUP_PLAY_CONTEXT_SCHEMA",
+    "PLAYER_PLAY_CONTEXT_SCHEMA",
     "PLAY_CONTEXT_POSSESSIONS_SCHEMA",
     "PLAY_CONTEXT_SHOTS_SCHEMA",
     "add_ctg_shot_zones",
@@ -51,7 +53,9 @@ __all__ = [
     "build_play_context_shots",
     "flag_garbage_time",
     "flag_heave_possessions",
+    "lineup_play_context",
     "nba_play_context",
+    "player_play_context",
     "team_play_context",
 ]
 
@@ -67,6 +71,61 @@ PLAY_CONTEXT_POSSESSIONS_SCHEMA: dict[str, pl.DataType] = {
     "is_garbage_time": pl.Boolean,
     "garbage_time_basis": pl.Utf8,
 }
+
+#: The Play-Context metric columns every rollup emits (team / lineup / player-on-off).
+#: Kept in one place so the three tables cannot drift apart.
+_CONTEXT_METRIC_SCHEMA: dict[str, pl.DataType] = {
+    "poss": pl.Int64,
+    "points": pl.Int64,
+    "pts_per_100": pl.Float64,
+    "transition_poss": pl.Int64,
+    "transition_points": pl.Int64,
+    "transition_freq": pl.Float64,
+    "transition_pts_per_100": pl.Float64,
+    "non_transition_pts_per_100": pl.Float64,
+    "transition_pts_added_per_100": pl.Float64,
+    "halfcourt_poss": pl.Int64,
+    "halfcourt_pts_per_100": pl.Float64,
+    "freq_off_steal": pl.Float64,
+    "freq_off_live_rebound": pl.Float64,
+}
+
+#: Schema of :func:`lineup_play_context` — one row per 5-man offensive lineup.
+LINEUP_PLAY_CONTEXT_SCHEMA: dict[str, pl.DataType] = {
+    "offense_team_id": pl.Int64,
+    "lineup_id": pl.Utf8,
+    **{f"off_player_{i}": pl.Int64 for i in range(1, 6)},
+    **_CONTEXT_METRIC_SCHEMA,
+}
+
+#: Schema of :func:`player_play_context` — the offensive half of CTG's On/Off page.
+#: ``on_*`` = the team's offense with the player on the floor, ``off_*`` = without
+#: them, ``diff_*`` = on minus off (the number CTG actually shows).
+PLAYER_PLAY_CONTEXT_SCHEMA: dict[str, pl.DataType] = {
+    "player_id": pl.Int64,
+    "offense_team_id": pl.Int64,
+    "on_poss": pl.Int64,
+    "off_poss": pl.Int64,
+    "on_points": pl.Int64,
+    "off_points": pl.Int64,
+    "on_pts_per_100": pl.Float64,
+    "off_pts_per_100": pl.Float64,
+    "diff_pts_per_100": pl.Float64,
+    "on_transition_freq": pl.Float64,
+    "off_transition_freq": pl.Float64,
+    "diff_transition_freq": pl.Float64,
+    "on_transition_pts_per_100": pl.Float64,
+    "off_transition_pts_per_100": pl.Float64,
+    "diff_transition_pts_per_100": pl.Float64,
+    "on_halfcourt_pts_per_100": pl.Float64,
+    "off_halfcourt_pts_per_100": pl.Float64,
+    "diff_halfcourt_pts_per_100": pl.Float64,
+    "on_transition_pts_added_per_100": pl.Float64,
+    "off_transition_pts_added_per_100": pl.Float64,
+}
+
+#: The offensive lineup columns :func:`attach_possession_lineups` appends.
+_OFF_PLAYER_COLS: list[str] = [f"off_player_{i}" for i in range(1, 6)]
 
 #: Schema of the per-shot frame from :func:`build_play_context_shots`.
 PLAY_CONTEXT_SHOTS_SCHEMA: dict[str, pl.DataType] = {
@@ -874,52 +933,70 @@ def team_play_context(
     """
     df = possessions
     if df.is_empty():
-        out = pl.DataFrame(
-            schema={
-                "offense_team_id": pl.Int64,
-                "poss": pl.Int64,
-                "points": pl.Int64,
-                "pts_per_100": pl.Float64,
-                "transition_poss": pl.Int64,
-                "transition_points": pl.Int64,
-                "transition_freq": pl.Float64,
-                "transition_pts_per_100": pl.Float64,
-                "non_transition_pts_per_100": pl.Float64,
-                "transition_pts_added_per_100": pl.Float64,
-                "halfcourt_poss": pl.Int64,
-                "halfcourt_pts_per_100": pl.Float64,
-                "freq_off_steal": pl.Float64,
-                "freq_off_live_rebound": pl.Float64,
-            }
-        )
+        out = pl.DataFrame(schema={"offense_team_id": pl.Int64, **_CONTEXT_METRIC_SCHEMA})
         return out.to_pandas() if return_as_pandas else out
 
-    if apply_ctg_filters:
-        df = df.filter(
-            (pl.col("count_as_possession") == True)  # noqa: E712
-            & (pl.col("is_garbage_time") == False)  # noqa: E712
-            & (pl.col("is_heave_possession") == False)  # noqa: E712
-        )
+    df = _ctg_filtered(df) if apply_ctg_filters else df
+    league_non_transition_ppp = _league_non_transition_ppp(df, league_non_transition_ppp)
+    out = _context_rates(_context_counts(df, ["offense_team_id"]), league_non_transition_ppp).sort("offense_team_id")
+    return out.to_pandas() if return_as_pandas else out
 
-    is_trans = pl.col("is_transition") == True  # noqa: E712
 
-    if league_non_transition_ppp is None:
-        nt = df.filter(~is_trans)
-        league_non_transition_ppp = 100.0 * nt["points"].sum() / nt.height if nt.height else 0.0
+# ---------------------------------------------------------------------------
+# Shared aggregation core — team / lineup / player all roll up the same way
+# ---------------------------------------------------------------------------
 
-    agg = df.group_by("offense_team_id").agg(
-        pl.len().alias("poss"),
-        pl.col("points").sum().alias("points"),
-        is_trans.sum().alias("transition_poss"),
-        pl.col("points").filter(is_trans).sum().alias("transition_points"),
-        (~is_trans).sum().alias("halfcourt_poss"),
-        pl.col("points").filter(~is_trans).sum().alias("halfcourt_points"),
-        (pl.col("transition_source") == "steal").sum().alias("_trans_steal"),
-        (pl.col("transition_source") == "live_rebound").sum().alias("_trans_reb"),
+
+def _ctg_filtered(df: pl.DataFrame) -> pl.DataFrame:
+    """CTG's default view: drop garbage time, heaves, and non-counting possessions."""
+    return df.filter(
+        (pl.col("count_as_possession") == True)  # noqa: E712
+        & (pl.col("is_garbage_time") == False)  # noqa: E712
+        & (pl.col("is_heave_possession") == False)  # noqa: E712
     )
 
-    out = (
-        agg.with_columns(
+
+def _league_non_transition_ppp(df: pl.DataFrame, supplied: Optional[float]) -> float:
+    """The Pts+/Poss baseline: league-average PPP on non-transition-start possessions.
+
+    Computed from the frame when not supplied — only meaningful on a season-wide
+    frame (on a single game the "league" is just the two teams in it). Every
+    rollup in one call shares ONE baseline, so on/off diffs stay comparable.
+    """
+    if supplied is not None:
+        return supplied
+    nt = df.filter(pl.col("is_transition") == False)  # noqa: E712
+    return 100.0 * nt["points"].sum() / nt.height if nt.height else 0.0
+
+
+def _context_counts(df: pl.DataFrame, by: list[str]) -> pl.DataFrame:
+    """Raw (additive) play-context counts grouped by *by*.
+
+    Counts only — no rates. Keeping the additive layer separate is what lets
+    :func:`player_play_context` derive the OFF side by simple subtraction
+    (team total - on-court), which is exactly what makes the on/off partition
+    identity exact rather than approximate.
+    """
+    is_trans = pl.col("is_transition") == True  # noqa: E712
+    # Every count is cast to Int64 explicitly: pl.len() and Boolean.sum() are UInt32,
+    # which (a) disagrees with the declared zero-row schema and (b) would wrap on the
+    # subtraction that derives the OFF side in player_play_context.
+    return df.group_by(by).agg(
+        pl.len().cast(pl.Int64).alias("poss"),
+        pl.col("points").sum().cast(pl.Int64).alias("points"),
+        is_trans.sum().cast(pl.Int64).alias("transition_poss"),
+        pl.col("points").filter(is_trans).sum().cast(pl.Int64).alias("transition_points"),
+        (~is_trans).sum().cast(pl.Int64).alias("halfcourt_poss"),
+        pl.col("points").filter(~is_trans).sum().cast(pl.Int64).alias("halfcourt_points"),
+        (pl.col("transition_source") == "steal").sum().cast(pl.Int64).alias("_trans_steal"),
+        (pl.col("transition_source") == "live_rebound").sum().cast(pl.Int64).alias("_trans_reb"),
+    )
+
+
+def _context_rates(counts: pl.DataFrame, league_non_transition_ppp: float) -> pl.DataFrame:
+    """Turn :func:`_context_counts` output into the CTG metric columns."""
+    return (
+        counts.with_columns(
             (100.0 * pl.col("points") / pl.col("poss")).alias("pts_per_100"),
             (pl.col("transition_poss") / pl.col("poss")).alias("transition_freq"),
             pl.when(pl.col("transition_poss") > 0)
@@ -940,8 +1017,201 @@ def team_play_context(
             pl.col("non_transition_pts_per_100").alias("halfcourt_pts_per_100"),
         )
         .drop("_trans_steal", "_trans_reb", "halfcourt_points")
-        .sort("offense_team_id")
     )
+
+
+def _require_lineups(df: pl.DataFrame) -> None:
+    """Fail loudly when the 5v5 lineup columns are absent.
+
+    Without ``off_player_1..5`` a lineup/player rollup would silently degenerate
+    (an empty group key, or every possession attributed to one bucket), which is
+    worse than an error — so this raises rather than returning a plausible-looking
+    wrong answer.
+    """
+    missing = [c for c in _OFF_PLAYER_COLS if c not in df.columns]
+    if missing:
+        raise ValueError(
+            f"missing lineup columns {missing}: pass a frame through "
+            "nba_possessions.attach_possession_lineups() before a lineup/player rollup"
+        )
+
+
+def lineup_play_context(
+    possessions: pl.DataFrame,
+    *,
+    min_poss: int = 0,
+    league_non_transition_ppp: Optional[float] = None,
+    apply_ctg_filters: bool = True,
+    return_as_pandas: bool = False,
+) -> Union[pl.DataFrame, pd.DataFrame]:
+    """Roll possessions up into a per-5-man-lineup Play-Context table.
+
+    The lineup analogue of :func:`team_play_context`: same metric columns, grouped
+    by the five players on the floor **for the offense**. Lineups are identified by
+    ``lineup_id`` — the five player ids sorted ascending and hyphen-joined — so the
+    same five players always land in the same bucket regardless of slot order.
+
+    Requires the ``off_player_1..5`` columns from
+    :func:`~sportsdataverse.nba.nba_possessions.attach_possession_lineups`
+    (which passes the play-context columns through, so the two compose in either
+    order).
+
+    Args:
+        possessions: Frame from :func:`add_play_context` **with lineups attached**.
+        min_poss: Drop lineups below this possession count (CTG's tables carry a
+            minimum; 0 keeps everything, which is what the partition identity needs).
+        league_non_transition_ppp: Pts+/Poss baseline; see :func:`team_play_context`.
+        apply_ctg_filters: Drop garbage-time / heave / non-counting possessions first.
+        return_as_pandas: Return a pandas DataFrame instead of polars.
+
+    Returns:
+        One row per (team, lineup) with :data:`LINEUP_PLAY_CONTEXT_SCHEMA`.
+        Empty input returns a zero-row frame with that schema.
+
+    Raises:
+        ValueError: when the ``off_player_*`` columns are missing.
+
+    Example:
+        Quick start::
+
+            poss = attach_possession_lineups(add_play_context(enh), oncourt, enh, home_team_id=home)
+            lu = lineup_play_context(poss, min_poss=25)
+            print(lu.sort("pts_per_100", descending=True).head())
+    """
+    _require_lineups(possessions)
+    if possessions.is_empty():
+        out = pl.DataFrame(schema=LINEUP_PLAY_CONTEXT_SCHEMA)
+        return out.to_pandas() if return_as_pandas else out
+
+    df = _ctg_filtered(possessions) if apply_ctg_filters else possessions
+    league_non_transition_ppp = _league_non_transition_ppp(df, league_non_transition_ppp)
+
+    # Sort the five ids NUMERICALLY, then cast the list's inner dtype to Utf8 to join.
+    # (Casting to Utf8 before sorting would order them lexicographically -- "10" < "9" --
+    # which still yields a stable key but scrambles the off_player_* ids parsed back out.)
+    df = df.with_columns(
+        pl.concat_list(_OFF_PLAYER_COLS).list.sort().cast(pl.List(pl.Utf8)).list.join("-").alias("lineup_id")
+    )
+    counts = _context_counts(df, ["offense_team_id", "lineup_id"])
+    out = _context_rates(counts, league_non_transition_ppp)
+
+    # re-attach the five ids (sorted, so they line up with lineup_id)
+    ids = out["lineup_id"].str.split("-")
+    out = out.with_columns([ids.list.get(i).cast(pl.Int64).alias(f"off_player_{i + 1}") for i in range(5)])
+    if min_poss > 0:
+        out = out.filter(pl.col("poss") >= min_poss)
+    out = out.select(list(LINEUP_PLAY_CONTEXT_SCHEMA)).sort(["offense_team_id", "poss"], descending=[False, True])
+    return out.to_pandas() if return_as_pandas else out
+
+
+def player_play_context(
+    possessions: pl.DataFrame,
+    *,
+    league_non_transition_ppp: Optional[float] = None,
+    apply_ctg_filters: bool = True,
+    return_as_pandas: bool = False,
+) -> Union[pl.DataFrame, pd.DataFrame]:
+    """Per-player offensive On/Off Play-Context table (CTG's On/Off page, offense half).
+
+    For each player: their team's offensive play-context **with them on the floor**
+    (``on_*``), **without them** (``off_*``), and the on-minus-off difference
+    (``diff_*``) — which is the number CTG actually displays.
+
+    The OFF side is derived by **subtraction** (team total minus on-court), not by a
+    second scan. That is deliberate: it makes the partition exact by construction —
+    ``on_poss + off_poss == team_poss`` and the same for points — so a leak (a
+    double-counted possession, a dropped lineup slot) is impossible to hide. The
+    test suite asserts that identity directly.
+
+    Like CTG's on/off, this is a **raw** split: no luck adjustment, no opponent
+    adjustment, no minutes threshold. It is a descriptive difference, not a causal
+    estimate — for that, use the RAPM surface
+    (:func:`~sportsdataverse.nba.nba_rapm.nba_rapm`).
+
+    Requires ``off_player_1..5`` from
+    :func:`~sportsdataverse.nba.nba_possessions.attach_possession_lineups`.
+
+    Args:
+        possessions: Frame from :func:`add_play_context` **with lineups attached**.
+        league_non_transition_ppp: Pts+/Poss baseline; see :func:`team_play_context`.
+            One baseline is shared across the on and off sides so the diffs are
+            comparable.
+        apply_ctg_filters: Drop garbage-time / heave / non-counting possessions first.
+        return_as_pandas: Return a pandas DataFrame instead of polars.
+
+    Returns:
+        One row per (player, team) with :data:`PLAYER_PLAY_CONTEXT_SCHEMA`.
+        Empty input returns a zero-row frame with that schema.
+
+    Raises:
+        ValueError: when the ``off_player_*`` columns are missing.
+
+    Example:
+        Quick start::
+
+            poss = attach_possession_lineups(add_play_context(enh), oncourt, enh, home_team_id=home)
+            onoff = player_play_context(poss)
+            print(onoff.sort("diff_pts_per_100", descending=True).head())
+
+        Who makes their team run?::
+
+            print(onoff.sort("diff_transition_freq", descending=True).head())
+    """
+    _require_lineups(possessions)
+    if possessions.is_empty():
+        out = pl.DataFrame(schema=PLAYER_PLAY_CONTEXT_SCHEMA)
+        return out.to_pandas() if return_as_pandas else out
+
+    df = _ctg_filtered(possessions) if apply_ctg_filters else possessions
+    league_ppp = _league_non_transition_ppp(df, league_non_transition_ppp)
+
+    keep = ["game_id", "possession_number", "offense_team_id", "points", "is_transition", "transition_source"]
+    long = (
+        df.select(keep + _OFF_PLAYER_COLS)
+        .unpivot(index=keep, on=_OFF_PLAYER_COLS, variable_name="_slot", value_name="player_id")
+        .drop_nulls("player_id")
+        # a player occupying two slots of the same possession would double-count
+        .unique(subset=["game_id", "possession_number", "player_id"])
+    )
+
+    on_counts = _context_counts(long, ["offense_team_id", "player_id"])
+    team_counts = _context_counts(df, ["offense_team_id"])
+
+    count_cols = [
+        "poss",
+        "points",
+        "transition_poss",
+        "transition_points",
+        "halfcourt_poss",
+        "halfcourt_points",
+        "_trans_steal",
+        "_trans_reb",
+    ]
+    off_counts = on_counts.join(team_counts, on="offense_team_id", how="inner", suffix="_team").select(
+        "offense_team_id",
+        "player_id",
+        *[(pl.col(f"{c}_team") - pl.col(c)).alias(c) for c in count_cols],
+    )
+
+    on_rates = _context_rates(on_counts, league_ppp)
+    off_rates = _context_rates(off_counts, league_ppp)
+
+    metric_cols = [c for c in _CONTEXT_METRIC_SCHEMA if c not in ("halfcourt_points",)]
+    out = on_rates.join(
+        off_rates.rename({c: f"off_{c}" for c in metric_cols}),
+        on=["offense_team_id", "player_id"],
+        how="inner",
+    ).rename({c: f"on_{c}" for c in metric_cols})
+
+    out = out.with_columns(
+        (pl.col("on_pts_per_100") - pl.col("off_pts_per_100")).alias("diff_pts_per_100"),
+        (pl.col("on_transition_freq") - pl.col("off_transition_freq")).alias("diff_transition_freq"),
+        (pl.col("on_transition_pts_per_100") - pl.col("off_transition_pts_per_100")).alias(
+            "diff_transition_pts_per_100"
+        ),
+        (pl.col("on_halfcourt_pts_per_100") - pl.col("off_halfcourt_pts_per_100")).alias("diff_halfcourt_pts_per_100"),
+    )
+    out = out.select(list(PLAYER_PLAY_CONTEXT_SCHEMA)).sort(["offense_team_id", "on_poss"], descending=[False, True])
     return out.to_pandas() if return_as_pandas else out
 
 

--- a/sportsdataverse/nba/nba_play_context.py
+++ b/sportsdataverse/nba/nba_play_context.py
@@ -191,7 +191,6 @@ def add_ctg_shot_zones(enhanced_pbp: pl.DataFrame) -> pl.DataFrame:
         return enhanced_pbp.with_columns(pl.lit(None, dtype=pl.Utf8).alias("ctg_shot_zone"))
 
     x = pl.col("x_legacy").abs()
-    dist = pl.col("shot_distance")
     is_fg = pl.col("is_field_goal") == 1
     is_three = pl.col("shot_value") == 3
 
@@ -202,14 +201,47 @@ def add_ctg_shot_zones(enhanced_pbp: pl.DataFrame) -> pl.DataFrame:
         .then(pl.lit("corner_3"))
         .when(is_three)
         .then(pl.lit("arc_3"))
-        .when(dist < C.RIM_DISTANCE_FT)
+        .when(_shot_distance_ft() < C.RIM_DISTANCE_FT)
         .then(pl.lit("at_rim"))
-        .when(dist < C.SHORT_MID_DISTANCE_FT)
+        .when(_shot_distance_ft() < C.SHORT_MID_DISTANCE_FT)
         .then(pl.lit("short_mid"))
         .otherwise(pl.lit("long_mid"))
         .alias("ctg_shot_zone")
     )
     return enhanced_pbp.with_columns(zone)
+
+
+def _shot_distance_ft() -> pl.Expr:
+    """Exact shot distance in feet, from the legacy coordinates.
+
+    **Do not use the v3 ``shot_distance`` column for zone boundaries.** It is
+    ``Int64`` — the feed rounds distance to whole feet — so a shot released 3.6 ft
+    from the rim is reported as ``4`` and falls on the wrong side of CTG's 4-foot
+    ``at_rim`` boundary. The legacy coordinates are exact (tenths of a foot, rim at
+    the origin), so ``sqrt(x^2 + y^2) / 10`` recovers the true distance.
+
+    Measured against the pbpstats-live oracle (which reads the decimal distance off
+    the CDN feed), the rounded column mis-binned every 3.5-3.9 ft shot as
+    ``short_mid`` — 8 of the 22 residual start-type mismatches on the three
+    committed fixtures, all in the single most important zone.
+
+    Falls back to the rounded column only when a coordinate is null.
+    """
+    coord = ((pl.col("x_legacy").cast(pl.Float64) ** 2 + pl.col("y_legacy").cast(pl.Float64) ** 2).sqrt()) / 10.0
+    return (
+        pl.when(pl.col("x_legacy").is_null() | pl.col("y_legacy").is_null())
+        .then(pl.col("shot_distance").cast(pl.Float64))
+        .otherwise(coord)
+    )
+
+
+def _row_distance_ft(row: dict) -> Optional[float]:
+    """Row-wise twin of :func:`_shot_distance_ft` (exact distance from coordinates)."""
+    x, y = row.get("x_legacy"), row.get("y_legacy")
+    if x is None or y is None:
+        d = row.get("shot_distance")
+        return float(d) if d is not None else None
+    return ((float(x) ** 2 + float(y) ** 2) ** 0.5) / 10.0
 
 
 def _zone_of_row(row: dict) -> Optional[str]:
@@ -222,7 +254,7 @@ def _zone_of_row(row: dict) -> Optional[str]:
         if x >= C.CORNER_THREE_ABS_X and y <= C.CORNER_THREE_MAX_Y:
             return "corner_3"
         return "arc_3"
-    dist = row.get("shot_distance")
+    dist = _row_distance_ft(row)
     if dist is None:
         return None
     if dist < C.RIM_DISTANCE_FT:

--- a/sportsdataverse/nba/nba_possessions.py
+++ b/sportsdataverse/nba/nba_possessions.py
@@ -359,16 +359,25 @@ def _possession_start_type(
     def _clock(row: dict) -> float:
         return float(row.get("seconds_remaining") or 0.0)
 
-    def _is_ft_sandwich(nxt: Optional[dict], timeout_clock: float) -> bool:
+    def _is_ft_sandwich(nxt: Optional[dict], timeout_clock: float, *, exclude_technical: bool) -> bool:
         """pbpstats: skip a timeout that sits before/between the FTs of one trip.
 
-        A *technical* FT does NOT trigger the exclusion (pbpstats checks
-        ``not next_event.is_technical_ft``), so a timeout before a technical FT
-        still counts as a real timeout.
+        pbpstats applies this exclusion ASYMMETRICALLY (``possession.py``):
+
+        * ``possession_has_timeout`` (154-159) checks
+          ``and not next_event.is_technical_ft`` -- a timeout before a same-clock
+          *technical* FT is NOT a sandwich, so it still counts as a real timeout.
+        * ``previous_possession_has_timeout`` (185-189) omits that clause -- a
+          same-clock FT of ANY kind (technical included) IS a sandwich and
+          suppresses the timeout.
+
+        ``exclude_technical`` selects between the two: ``True`` for the
+        current-possession call (technical FT is not a sandwich), ``False`` for
+        the previous-possession call (any same-clock FT is a sandwich).
         """
         if nxt is None or (nxt.get("event_type") or "") != "free_throw":
             return False
-        if is_technical_ft_row(nxt):
+        if exclude_technical and is_technical_ft_row(nxt):
             return False
         return _clock(nxt) == timeout_clock
 
@@ -379,7 +388,9 @@ def _possession_start_type(
                 continue
             # the event after a boundary timeout is the first row of THIS possession
             nxt = rows[i + 1] if i + 1 < len(rows) else (cur_rows[0] if cur_rows else None)
-            if not _is_ft_sandwich(nxt, _clock(r)):
+            # previous-possession sandwich test: any same-clock FT suppresses (no
+            # technical carve-out -- pbpstats possession.py:185-189).
+            if not _is_ft_sandwich(nxt, _clock(r), exclude_technical=False):
                 return True
         return False
 
@@ -390,11 +401,16 @@ def _possession_start_type(
             clock = _clock(r)
             if clock != end_time:
                 nxt = rows[i + 1] if i + 1 < len(rows) else None
-                if not _is_ft_sandwich(nxt, clock):
+                # current-possession sandwich test keeps pbpstats' technical carve-out.
+                if not _is_ft_sandwich(nxt, clock, exclude_technical=True):
                     return True
             else:
                 # timeout at the end of the possession: only a same-clock turnover
-                # after it means the timeout actually started the next possession
+                # after it means the timeout actually started the next possession.
+                # pbpstats also requires ``not is_no_turnover`` here (possession.py:169-173),
+                # but that guards a stats_nba "No Turnover" placeholder event; the v3/cdn
+                # feed types turnovers by actionType and emits no such row, so the plain
+                # event_type test is exact for this feed.
                 for later in rows[i + 1 :]:
                     if (later.get("event_type") or "") == "turnover" and _clock(later) == clock:
                         return True

--- a/sportsdataverse/nba/nba_possessions.py
+++ b/sportsdataverse/nba/nba_possessions.py
@@ -320,10 +320,28 @@ def _possession_start_type(
     """Coarse pbpstats ``possession_start_type`` (``possession.py:206-242``; no shot-type buckets).
 
     ``OffDeadball``: period start / team rebound / dead-ball turnover /
-    unresolved. ``OffTimeout``: a timeout event in the previous OR current
-    possession's rows. ``OffMadeShot`` / ``OffMissedShot``: prior boundary was
-    a made shot-or-FT / a player defensive rebound. ``OffLiveBallTurnover``:
-    prior boundary was a steal.
+    unresolved. ``OffTimeout``: a timeout at the possession boundary (see below).
+    ``OffMadeShot`` / ``OffMissedShot``: prior boundary was a made shot-or-FT /
+    a player defensive rebound. ``OffLiveBallTurnover``: prior boundary was a steal.
+
+    **Timeout rule (pbpstats ``possession_has_timeout`` /
+    ``previous_possession_has_timeout``, ``possession.py:146-191``).** A timeout
+    does NOT unconditionally make the next possession ``OffTimeout``; only a
+    timeout *at the boundary* does. Faithfully:
+
+    * **Previous possession** — counts only when the timeout's clock equals THIS
+      possession's start time (i.e. it was called as the ball changed hands), and
+      the timeout is not sandwiched before a same-clock non-technical free throw.
+    * **Current possession** — a timeout not at the possession's end time counts
+      (again excluding the FT sandwich); a timeout AT the end time counts only if a
+      real turnover follows at the same clock (call timeout, then turn it over).
+
+    The earlier "any timeout row anywhere in either possession" shortcut
+    over-fired: a timeout called mid-possession, far from either boundary, wrongly
+    relabelled the next possession ``OffTimeout`` and erased its real start type.
+    Measured against the pbpstats-live oracle on the three committed fixtures, that
+    accounted for the largest single mismatch family (~20 possessions/game); see
+    ``tests/nba/test_nba_play_context_oracle.py``.
 
     Real-fixture verification note: the v3 feed's ``"STEAL"`` text does NOT
     live on the ``Turnover``-type row's own ``description`` (verified against
@@ -338,18 +356,72 @@ def _possession_start_type(
     ``prev_end_row``'s own description.
     """
 
-    def _has_timeout(rows: Optional[list[dict]]) -> bool:
-        return any((r.get("event_type") or "") == "timeout" for r in rows or [])
+    def _clock(row: dict) -> float:
+        return float(row.get("seconds_remaining") or 0.0)
+
+    def _is_ft_sandwich(nxt: Optional[dict], timeout_clock: float) -> bool:
+        """pbpstats: skip a timeout that sits before/between the FTs of one trip.
+
+        A *technical* FT does NOT trigger the exclusion (pbpstats checks
+        ``not next_event.is_technical_ft``), so a timeout before a technical FT
+        still counts as a real timeout.
+        """
+        if nxt is None or (nxt.get("event_type") or "") != "free_throw":
+            return False
+        if is_technical_ft_row(nxt):
+            return False
+        return _clock(nxt) == timeout_clock
+
+    def _previous_possession_has_timeout(rows: Optional[list[dict]], start_time: float) -> bool:
+        rows = rows or []
+        for i, r in enumerate(rows):
+            if (r.get("event_type") or "") != "timeout" or _clock(r) != start_time:
+                continue
+            # the event after a boundary timeout is the first row of THIS possession
+            nxt = rows[i + 1] if i + 1 < len(rows) else (cur_rows[0] if cur_rows else None)
+            if not _is_ft_sandwich(nxt, _clock(r)):
+                return True
+        return False
+
+    def _possession_has_timeout(rows: list[dict], end_time: float) -> bool:
+        for i, r in enumerate(rows):
+            if (r.get("event_type") or "") != "timeout":
+                continue
+            clock = _clock(r)
+            if clock != end_time:
+                nxt = rows[i + 1] if i + 1 < len(rows) else None
+                if not _is_ft_sandwich(nxt, clock):
+                    return True
+            else:
+                # timeout at the end of the possession: only a same-clock turnover
+                # after it means the timeout actually started the next possession
+                for later in rows[i + 1 :]:
+                    if (later.get("event_type") or "") == "turnover" and _clock(later) == clock:
+                        return True
+        return False
 
     if prev_end_row is None:
         return "OffDeadball"
-    if _has_timeout(prev_rows) or _has_timeout(cur_rows):
-        return "OffTimeout"
+    if cur_rows:
+        start_time = _clock(cur_rows[0])
+        end_time = _clock(cur_rows[-1])
+        if _possession_has_timeout(cur_rows, end_time) or _previous_possession_has_timeout(prev_rows, start_time):
+            return "OffTimeout"
     et = prev_end_row.get("event_type") or ""
     if et in ("made_shot", "free_throw"):
         return "OffMadeShot"
     if et == "rebound":
-        return "OffMissedShot" if (prev_end_row.get("person_id") or 0) else "OffDeadball"
+        # pbpstats calls a TEAM rebound a dead-ball start (``player1_id == 0``,
+        # possession.py:225-227). On the v3 feed a team rebound does NOT set
+        # ``person_id`` to 0 -- it stuffs the TEAM id into ``person_id`` and sets
+        # ``team_id`` to 0 (e.g. action 109 of 0022100001: "Nets Rebound",
+        # person_id=1610612751, team_id=0). So ``person_id != 0`` is NOT a
+        # player test: it is true for every team rebound too, which mislabelled
+        # them ``OffMissedShot``. ``team_id`` is the reliable discriminator --
+        # verified across all three committed fixtures: every ``team_id == 0``
+        # rebound carries a team id in ``person_id`` (20/19/19) and every
+        # ``team_id != 0`` rebound carries a real player id (98/67/75).
+        return "OffMissedShot" if int(prev_end_row.get("team_id") or 0) != 0 else "OffDeadball"
     if et == "turnover":
         has_steal = any("steal" in (r.get("description") or "").casefold() for r in cur_rows or [])
         return "OffLiveBallTurnover" if has_steal else "OffDeadball"

--- a/sportsdataverse/parsed/nba.py
+++ b/sportsdataverse/parsed/nba.py
@@ -193,6 +193,7 @@ from sportsdataverse.nba import helper_nba_pickcenter as helper_nba_pickcenter  
 from sportsdataverse.nba import helper_nba_roster_items as helper_nba_roster_items  # noqa: F401
 from sportsdataverse.nba import helper_nba_team_items as helper_nba_team_items  # noqa: F401
 from sportsdataverse.nba import in_game_features as in_game_features  # noqa: F401
+from sportsdataverse.nba import lineup_play_context as lineup_play_context  # noqa: F401
 from sportsdataverse.nba import load_darko_dpm as load_darko_dpm  # noqa: F401
 from sportsdataverse.nba import load_dunks_threes_stats as load_dunks_threes_stats  # noqa: F401
 from sportsdataverse.nba import load_epm as load_epm  # noqa: F401
@@ -256,6 +257,7 @@ from sportsdataverse.nba import nba_war as nba_war  # noqa: F401
 from sportsdataverse.nba import normalize_player_name as normalize_player_name  # noqa: F401
 from sportsdataverse.nba import normalize_team_roster_columns as normalize_team_roster_columns  # noqa: F401
 from sportsdataverse.nba import parse_nba_stats_result_sets as parse_nba_stats_result_sets  # noqa: F401
+from sportsdataverse.nba import player_play_context as player_play_context  # noqa: F401
 from sportsdataverse.nba import player_rates as player_rates  # noqa: F401
 from sportsdataverse.nba import players_on_court_from_pbp as players_on_court_from_pbp  # noqa: F401
 from sportsdataverse.nba import players_on_court_from_quarter_boxscores as players_on_court_from_quarter_boxscores  # noqa: F401
@@ -273,6 +275,7 @@ from sportsdataverse.nba import scoreboard_event_parsing as scoreboard_event_par
 from sportsdataverse.nba import shooter_talent as shooter_talent  # noqa: F401
 from sportsdataverse.nba import shot_selection_quality as shot_selection_quality  # noqa: F401
 from sportsdataverse.nba import shrink_clutch as shrink_clutch  # noqa: F401
+from sportsdataverse.nba import starters_on_court_counts as starters_on_court_counts  # noqa: F401
 from sportsdataverse.nba import team_pace_projection as team_pace_projection  # noqa: F401
 from sportsdataverse.nba import team_play_context as team_play_context  # noqa: F401
 from sportsdataverse.nba import train_spm as train_spm  # noqa: F401
@@ -454,6 +457,7 @@ __all__ = [
     "helper_nba_roster_items",
     "helper_nba_team_items",
     "in_game_features",
+    "lineup_play_context",
     "load_darko_dpm",
     "load_dunks_threes_stats",
     "load_epm",
@@ -518,6 +522,7 @@ __all__ = [
     "normalize_player_name",
     "normalize_team_roster_columns",
     "parse_nba_stats_result_sets",
+    "player_play_context",
     "player_rates",
     "players_on_court_from_pbp",
     "players_on_court_from_quarter_boxscores",
@@ -535,6 +540,7 @@ __all__ = [
     "shooter_talent",
     "shot_selection_quality",
     "shrink_clutch",
+    "starters_on_court_counts",
     "team_pace_projection",
     "team_play_context",
     "train_spm",

--- a/sportsdataverse/parsed/wnba.py
+++ b/sportsdataverse/parsed/wnba.py
@@ -206,6 +206,7 @@ from sportsdataverse.wnba import wnba_in_game_win_prob as wnba_in_game_win_prob 
 from sportsdataverse.wnba import wnba_matchup_drapm as wnba_matchup_drapm  # noqa: F401
 from sportsdataverse.wnba import wnba_on_court as wnba_on_court  # noqa: F401
 from sportsdataverse.wnba import wnba_pbp_disk as wnba_pbp_disk  # noqa: F401
+from sportsdataverse.wnba import wnba_play_context as wnba_play_context  # noqa: F401
 from sportsdataverse.wnba import wnba_player_props as wnba_player_props  # noqa: F401
 from sportsdataverse.wnba import wnba_playtype_ratings as wnba_playtype_ratings  # noqa: F401
 from sportsdataverse.wnba import wnba_possessions as wnba_possessions  # noqa: F401
@@ -410,6 +411,7 @@ __all__ = [
     "wnba_matchup_drapm",
     "wnba_on_court",
     "wnba_pbp_disk",
+    "wnba_play_context",
     "wnba_player_props",
     "wnba_playtype_ratings",
     "wnba_possessions",

--- a/sportsdataverse/wnba/__init__.py
+++ b/sportsdataverse/wnba/__init__.py
@@ -30,6 +30,7 @@ from sportsdataverse.wnba.wnba_draft import espn_wnba_draft  # noqa: E402,F401
 from sportsdataverse.wnba.wnba_engine import (  # noqa: F401
     wnba_enhanced_pbp,
     wnba_on_court,
+    wnba_play_context,
     wnba_possessions,
     wnba_rapm_from_games,
 )

--- a/sportsdataverse/wnba/wnba_engine.py
+++ b/sportsdataverse/wnba/wnba_engine.py
@@ -13,6 +13,7 @@ Public surface
 - :func:`wnba_enhanced_pbp`   — normalised play-by-play frame
 - :func:`wnba_on_court`       — 10-player rotation-keyed frame (home+away ×5)
 - :func:`wnba_possessions`    — possession-level stint matrix (off+def ×5)
+- :func:`wnba_play_context`   — possessions + the CTG play-context surface
 - :func:`wnba_rapm_from_games` — per-player RAPM over a list of games
 """
 
@@ -23,7 +24,9 @@ from typing import Sequence, Union
 import pandas as pd
 import polars as pl
 
+from sportsdataverse.nba import nba_play_context_constants as C
 from sportsdataverse.nba.nba_enhanced_pbp import enhanced_pbp_from_payload
+from sportsdataverse.nba.nba_play_context import add_play_context
 from sportsdataverse.nba.nba_lineups import (
     boxscore_home_away,
     parse_rotation_resultsets,
@@ -256,6 +259,79 @@ def wnba_possessions(
     )
     poss = attach_possession_lineups(build_possessions(enh), oc, enh, home_team_id=home)
     return poss.to_pandas() if return_as_pandas else poss
+
+
+def wnba_play_context(
+    game_id: str,
+    *,
+    transition_seconds: float = C.DEFAULT_TRANSITION_SECONDS,
+    transition_variant: str = C.DEFAULT_TRANSITION_VARIANT,
+    return_as_pandas: bool = False,
+) -> Union[pl.DataFrame, pd.DataFrame]:
+    """Return a WNBA game's possessions with the full CTG play-context surface.
+
+    WNBA sibling of
+    :func:`~sportsdataverse.nba.nba_play_context.nba_play_context` — the
+    Cleaning the Glass recreation (possession start-type taxonomy + the
+    halfcourt / transition / putback contexts + CTG's garbage-time and heave
+    filters). One network call (``playbyplayv3`` on ``stats.wnba.com``); every
+    transformation is done by the league-agnostic
+    :func:`~sportsdataverse.nba.nba_play_context.add_play_context` core, so
+    there is **no WNBA-specific classification logic** to drift.
+
+    Two caveats worth stating plainly:
+
+    * **CTG is NBA-only.** There is no published WNBA play-context table to
+      calibrate against, so ``transition_seconds`` inherits the NBA's fitted
+      6.0 s default. The WNBA fixtures land inside the NBA's transition-frequency
+      gate at that value (``tests/wnba/test_wnba_play_context_shim.py``), which
+      is a sanity check on the shared engine — not evidence that 6.0 s is the
+      *right* WNBA cutoff. Re-fit it if a WNBA oracle ever appears.
+    * Shot-zone boundaries are league-agnostic (feet from the rim), and the
+      corner-three test uses the same legacy coordinates, which the WNBA feed
+      also ships.
+
+    Args:
+        game_id: WNBA game identifier (e.g. ``"1022400001"``).
+        transition_seconds: Transition initial-play cutoff, in seconds.
+        transition_variant: See
+            :func:`~sportsdataverse.nba.nba_play_context.add_transition`.
+        return_as_pandas: Return a pandas DataFrame instead of polars.
+
+    Returns:
+        The possession frame (``POSSESSIONS_SCHEMA``) plus
+        :data:`~sportsdataverse.nba.nba_play_context.PLAY_CONTEXT_POSSESSIONS_SCHEMA`.
+        Empty or malformed payloads return a zero-row frame — never raises.
+
+    Example:
+        Quick start::
+
+            from sportsdataverse.wnba.wnba_engine import wnba_play_context
+            poss = wnba_play_context("1022400001")
+            print(poss["possession_start_type_ctg"].value_counts())
+
+        Transition rate (CTG's default filtered view)::
+
+            import polars as pl
+            clean = poss.filter(
+                (pl.col("is_garbage_time") == False)  # noqa: E712
+                & (pl.col("is_heave_possession") == False)  # noqa: E712
+            )
+            print(clean["is_transition"].mean())
+
+        See Also:
+            * `wehoop`_ — WNBA/WBB data in R
+            * `nba_play_context`_ — NBA sibling function
+
+        .. _wehoop: https://wehoop.sportsdataverse.org
+        .. _nba_play_context: sportsdataverse.nba.nba_play_context.nba_play_context
+    """
+    out = add_play_context(
+        _enhanced(game_id),
+        transition_seconds=transition_seconds,
+        transition_variant=transition_variant,
+    )
+    return out.to_pandas() if return_as_pandas else out
 
 
 def _fetch_possessions(game_id: str) -> pl.DataFrame:

--- a/sportsdataverse/wnba/wnba_engine.py
+++ b/sportsdataverse/wnba/wnba_engine.py
@@ -301,7 +301,14 @@ def wnba_play_context(
     Returns:
         The possession frame (``POSSESSIONS_SCHEMA``) plus
         :data:`~sportsdataverse.nba.nba_play_context.PLAY_CONTEXT_POSSESSIONS_SCHEMA`.
-        Empty or malformed payloads return a zero-row frame — never raises.
+        Empty or malformed payloads return a zero-row frame — never raises on payload
+        content.
+
+    Raises:
+        ValueError: when *transition_variant* is not one of
+            :data:`~sportsdataverse.nba.nba_play_context_constants.TRANSITION_VARIANTS`
+            (propagated from
+            :func:`~sportsdataverse.nba.nba_play_context.add_transition`).
 
     Example:
         Quick start::

--- a/tests/nba/test_nba_play_context.py
+++ b/tests/nba/test_nba_play_context.py
@@ -76,12 +76,16 @@ def test_ctg_shot_zones_partition_every_field_goal(frames):
 
 def test_ctg_zones_differ_from_official_nba_zones(frames):
     """CTG splits the midrange at the FT-line distance, not the paint boundary."""
+    from sportsdataverse.nba.nba_play_context import _shot_distance_ft
     from sportsdataverse.nba.nba_shot_zones import add_shot_zones
 
     pbp = add_ctg_shot_zones(add_shot_zones(frames["0022200001"]))
     fg = pbp.filter(pl.col("is_field_goal") == 1)
-    # A 2pt shot 5-7 ft out is `in_the_paint_non_ra` officially but `short_mid` in CTG.
-    both = fg.filter((pl.col("shot_value") == 2) & (pl.col("shot_distance").is_between(4, 7)))
+    # A 2pt shot 4-7 ft out is `in_the_paint_non_ra` officially but `short_mid` in CTG.
+    # Select on the EXACT coordinate distance the classifier uses, not the rounded
+    # v3 ``shot_distance`` column — a shot the feed rounds to 4 ft can truly be 3.6 ft
+    # (correctly ``at_rim``), so the rounded column straddles the 4-foot rim boundary.
+    both = fg.filter((pl.col("shot_value") == 2) & _shot_distance_ft().is_between(4, 7))
     if both.height:
         assert set(both["ctg_shot_zone"].unique()) == {"short_mid"}
 

--- a/tests/nba/test_nba_play_context_aggregations.py
+++ b/tests/nba/test_nba_play_context_aggregations.py
@@ -1,0 +1,207 @@
+"""Player + lineup play-context aggregations (CTG's on/off and lineup tables).
+
+These roll the possession-level play-context frame up two more ways than
+:func:`team_play_context` does:
+
+* :func:`lineup_play_context` — one row per 5-man **offensive** lineup.
+* :func:`player_play_context` — one row per player, with the team's offensive
+  context **with them on the floor vs off it**, and the on-minus-off difference.
+  This is the offensive half of CTG's player On/Off page.
+
+Both consume a possession frame that has been through
+:func:`~sportsdataverse.nba.nba_possessions.attach_possession_lineups`, so they
+need the ``off_player_1..5`` columns.
+
+The load-bearing gate here is an **exact partition identity**, not a
+correlation: for every player, ``on_poss + off_poss`` must equal their team's
+total possessions. A player is either on the floor for a team possession or they
+are not — there is no third bucket, so any leak (double-counted possession,
+dropped null lineup slot, wrong team attribution) breaks the identity exactly.
+Points partition the same way.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pandas as pd
+import polars as pl
+import pytest
+
+from sportsdataverse.nba.nba_enhanced_pbp import enhanced_pbp_from_payload
+from sportsdataverse.nba.nba_lineups import (
+    boxscore_home_away,
+    parse_rotation_resultsets,
+    players_on_court_from_rotation,
+)
+from sportsdataverse.nba.nba_play_context import (
+    LINEUP_PLAY_CONTEXT_SCHEMA,
+    PLAYER_PLAY_CONTEXT_SCHEMA,
+    add_play_context,
+    lineup_play_context,
+    player_play_context,
+    team_play_context,
+)
+from sportsdataverse.nba.nba_possessions import attach_possession_lineups
+
+FXROOT = pathlib.Path("tests/fixtures/nba_engine")
+GAMES = ["0022100001", "0022200001", "0022300001"]
+
+
+def _ctx_with_lineups(game_id: str) -> pl.DataFrame:
+    """Possessions + play context + the 5v5 lineup columns (offline, committed fixtures).
+
+    ``attach_possession_lineups`` passes non-possession columns straight through,
+    so the play-context enrichment and the lineup attach compose in either order;
+    this is the natural one (enrich, then attach).
+    """
+    fx = FXROOT / game_id
+    enh = enhanced_pbp_from_payload(json.loads((fx / "playbyplayv3.json").read_text()))
+    home, away = boxscore_home_away(json.loads((fx / "boxscoretraditionalv3.json").read_text()))
+    oncourt = players_on_court_from_rotation(
+        enh,
+        parse_rotation_resultsets(json.loads((fx / "gamerotation.json").read_text())),
+        home_team_id=home,
+        away_team_id=away,
+    )
+    return attach_possession_lineups(add_play_context(enh), oncourt, enh, home_team_id=home)
+
+
+@pytest.fixture(scope="module")
+def frames() -> dict[str, pl.DataFrame]:
+    return {g: _ctx_with_lineups(g) for g in GAMES}
+
+
+# ---------------------------------------------------------------------------
+# Lineup table
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("game_id", GAMES)
+def test_lineup_schema_and_nonempty(frames, game_id: str) -> None:
+    out = lineup_play_context(frames[game_id])
+    assert out.height > 0
+    for col, dtype in LINEUP_PLAY_CONTEXT_SCHEMA.items():
+        assert col in out.columns, f"missing {col}"
+        assert out.schema[col] == dtype, f"{col}: {out.schema[col]} != {dtype}"
+
+
+@pytest.mark.parametrize("game_id", GAMES)
+def test_lineup_possessions_partition_the_team(frames, game_id: str) -> None:
+    """PARTITION IDENTITY: every team possession belongs to exactly one lineup."""
+    ctx = frames[game_id]
+    lineups = lineup_play_context(ctx, min_poss=0)
+    team = team_play_context(ctx)
+
+    by_team = lineups.group_by("offense_team_id").agg(
+        pl.col("poss").sum().alias("poss"), pl.col("points").sum().alias("points")
+    )
+    joined = team.join(by_team, on="offense_team_id", how="inner", suffix="_lineups")
+    assert joined.height == team.height >= 2, "lineup rollup lost a team"
+    assert (joined["poss"] == joined["poss_lineups"]).all(), "lineup possessions do not partition the team's"
+    assert (joined["points"] == joined["points_lineups"]).all(), "lineup points do not partition the team's"
+
+
+def test_lineup_min_poss_filter(frames) -> None:
+    ctx = frames[GAMES[0]]
+    assert lineup_play_context(ctx, min_poss=10).height < lineup_play_context(ctx, min_poss=0).height
+    assert (lineup_play_context(ctx, min_poss=10)["poss"] >= 10).all()
+
+
+# ---------------------------------------------------------------------------
+# Player on/off table
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("game_id", GAMES)
+def test_player_schema_and_nonempty(frames, game_id: str) -> None:
+    out = player_play_context(frames[game_id])
+    assert out.height > 0
+    for col, dtype in PLAYER_PLAY_CONTEXT_SCHEMA.items():
+        assert col in out.columns, f"missing {col}"
+        assert out.schema[col] == dtype, f"{col}: {out.schema[col]} != {dtype}"
+
+
+@pytest.mark.parametrize("game_id", GAMES)
+def test_player_on_off_partitions_the_team(frames, game_id: str) -> None:
+    """THE GATE. on_poss + off_poss == the player's team's possessions, exactly.
+
+    A player is either on the floor for a team's offensive possession or they are
+    not. Any leak — a possession counted for both, a null lineup slot silently
+    dropped, a player attributed to the wrong team — breaks this identity. Points
+    partition identically.
+    """
+    ctx = frames[game_id]
+    players = player_play_context(ctx)
+    team = team_play_context(ctx).select("offense_team_id", "poss", "points")
+
+    joined = players.join(team, on="offense_team_id", how="inner", suffix="_team")
+    assert joined.height == players.height, "a player is attributed to a team not in the team table"
+    assert joined.height >= 16, f"only {joined.height} player rows — fixture shrunk?"
+
+    assert (joined["on_poss"] + joined["off_poss"] == joined["poss"]).all(), (
+        "on_poss + off_poss != team poss — the on/off split leaks"
+    )
+    assert (joined["on_points"] + joined["off_points"] == joined["points"]).all(), (
+        "on_points + off_points != team points"
+    )
+
+
+@pytest.mark.parametrize("game_id", GAMES)
+def test_player_diff_is_on_minus_off(frames, game_id: str) -> None:
+    p = player_play_context(frames[game_id]).filter((pl.col("on_poss") > 0) & (pl.col("off_poss") > 0))
+    assert p.height > 0
+    got = p["diff_pts_per_100"].to_list()
+    want = [a - b for a, b in zip(p["on_pts_per_100"].to_list(), p["off_pts_per_100"].to_list())]
+    assert got == pytest.approx(want)
+
+
+@pytest.mark.parametrize("game_id", GAMES)
+def test_player_transition_freq_is_a_rate(frames, game_id: str) -> None:
+    p = player_play_context(frames[game_id]).filter(pl.col("on_poss") > 0)
+    assert ((p["on_transition_freq"] >= 0.0) & (p["on_transition_freq"] <= 1.0)).all()
+
+
+# ---------------------------------------------------------------------------
+# Contracts
+# ---------------------------------------------------------------------------
+
+
+def test_missing_lineup_columns_raises_not_silently_wrong(frames) -> None:
+    """Without off_player_1..5 these tables are meaningless — fail loudly."""
+    no_lineups = frames[GAMES[0]].drop([f"off_player_{i}" for i in range(1, 6)])
+    with pytest.raises(ValueError, match="off_player"):
+        lineup_play_context(no_lineups)
+    with pytest.raises(ValueError, match="off_player"):
+        player_play_context(no_lineups)
+
+
+def test_empty_input_returns_documented_schema() -> None:
+    empty = pl.DataFrame(schema={**{f"off_player_{i}": pl.Int64 for i in range(1, 6)}})
+    for fn, schema in (
+        (lineup_play_context, LINEUP_PLAY_CONTEXT_SCHEMA),
+        (player_play_context, PLAYER_PLAY_CONTEXT_SCHEMA),
+    ):
+        out = fn(empty)
+        assert out.height == 0
+        assert list(out.columns) == list(schema)
+
+
+def test_pandas_flag(frames) -> None:
+    assert isinstance(lineup_play_context(frames[GAMES[0]], return_as_pandas=True), pd.DataFrame)
+    assert isinstance(player_play_context(frames[GAMES[0]], return_as_pandas=True), pd.DataFrame)
+
+
+def test_team_count_dtypes_match_the_empty_schema(frames) -> None:
+    """REGRESSION. ``pl.len()`` / ``Boolean.sum()`` are UInt32, so before the explicit
+    Int64 cast in ``_context_counts`` the team table returned UInt32 counts on real
+    data while its zero-row branch declared Int64 — the same frame had two schemas
+    depending on whether it had rows. The subtraction that derives the OFF side in
+    ``player_play_context`` would also wrap on an unsigned type.
+    """
+    populated = team_play_context(frames[GAMES[0]])
+    empty = team_play_context(frames[GAMES[0]].clear())
+    for col in ("poss", "points", "transition_poss", "transition_points", "halfcourt_poss"):
+        assert populated.schema[col] == pl.Int64, f"{col} is {populated.schema[col]}, want Int64"
+        assert populated.schema[col] == empty.schema[col], f"{col}: populated/empty schema disagree"

--- a/tests/nba/test_nba_play_context_aggregations.py
+++ b/tests/nba/test_nba_play_context_aggregations.py
@@ -38,6 +38,7 @@ from sportsdataverse.nba.nba_lineups import (
 from sportsdataverse.nba.nba_play_context import (
     LINEUP_PLAY_CONTEXT_SCHEMA,
     PLAYER_PLAY_CONTEXT_SCHEMA,
+    _context_rates,
     add_play_context,
     lineup_play_context,
     player_play_context,
@@ -205,3 +206,29 @@ def test_team_count_dtypes_match_the_empty_schema(frames) -> None:
     for col in ("poss", "points", "transition_poss", "transition_points", "halfcourt_poss"):
         assert populated.schema[col] == pl.Int64, f"{col} is {populated.schema[col]}, want Int64"
         assert populated.schema[col] == empty.schema[col], f"{col}: populated/empty schema disagree"
+
+
+def test_zero_poss_rates_are_null_not_nan() -> None:
+    """A zero-possession group (the subtraction-derived OFF side of a player who never
+    sits: off_poss = team_poss - on_poss = 0) must yield NULL rates, not inf/NaN.
+
+    NaN would poison the on-minus-off diff and any downstream aggregation. Guards the
+    poss-denominator branch in ``_context_rates``.
+    """
+    zero = pl.DataFrame(
+        {
+            "offense_team_id": [1],
+            "poss": [0],
+            "points": [0],
+            "transition_poss": [0],
+            "transition_points": [0],
+            "halfcourt_poss": [0],
+            "halfcourt_points": [0],
+            "_trans_steal": [0],
+            "_trans_reb": [0],
+        }
+    )
+    rates = _context_rates(zero, league_non_transition_ppp=1.0)
+    for col in ("pts_per_100", "transition_freq", "freq_off_steal", "freq_off_live_rebound"):
+        val = rates[col][0]
+        assert val is None, f"{col} = {val!r}, want None (not inf/NaN)"

--- a/tests/nba/test_nba_play_context_garbage_time.py
+++ b/tests/nba/test_nba_play_context_garbage_time.py
@@ -1,0 +1,162 @@
+"""CTG's garbage-time definition, including the "<=2 starters on the floor" clause.
+
+CTG (verbatim): "the game has to be in the **4th quarter**, the score differential
+has to be **>= 25 for minutes 12-9, >= 20 for minutes 9-6, and >= 10 for the
+remainder of the quarter**. Additionally, there have to be **two or fewer starters
+on the floor combined between the two teams**."
+
+The margin x minutes half is computable from the possession frame alone and shipped
+already. The starters half needs the 10 on-court players and each team's starting
+five, which is what :func:`starters_on_court_counts` supplies.
+
+The load-bearing property is **containment**: the full rule (margin AND starters) is
+a strict subset of the margin-only rule. Adding a conjunct can only ever *remove*
+possessions from the flag — so if the "full" rule ever flags a possession the
+margin-only rule did not, the implementation is wrong. That is asserted directly,
+which is a much stronger check than eyeballing a count.
+
+The clause is **not cosmetic**. Observed on the three committed fixtures
+(margin-only -> margin+starters garbage-time possessions):
+
+===========  ===========  ================
+game         margin-only  margin+starters
+===========  ===========  ================
+0022100001            24                11
+0022200001            21                 0
+0022300001             0                 0
+===========  ===========  ================
+
+0022200001 is the case CTG's second conjunct exists for: the score ran far enough
+ahead to satisfy the margin band while both coaches still had their starters on the
+floor — i.e. not garbage time at all. Without the clause the margin-only superset
+over-flags by up to 21 possessions in a single game, and those possessions are
+exactly the competitive ones you least want silently dropped from the default view.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import polars as pl
+import pytest
+
+from sportsdataverse.nba.nba_enhanced_pbp import enhanced_pbp_from_payload
+from sportsdataverse.nba.nba_lineups import (
+    _starters_from_boxscore_v3,
+    boxscore_home_away,
+    parse_rotation_resultsets,
+    players_on_court_from_rotation,
+)
+from sportsdataverse.nba.nba_play_context import (
+    add_play_context,
+    flag_garbage_time,
+    starters_on_court_counts,
+)
+from sportsdataverse.nba.nba_possessions import attach_possession_lineups, build_possessions
+
+FXROOT = pathlib.Path("tests/fixtures/nba_engine")
+GAMES = ["0022100001", "0022200001", "0022300001"]
+
+
+def _parts(game_id: str):
+    fx = FXROOT / game_id
+    enh = enhanced_pbp_from_payload(json.loads((fx / "playbyplayv3.json").read_text()))
+    box = json.loads((fx / "boxscoretraditionalv3.json").read_text())
+    home, away = boxscore_home_away(box)
+    oncourt = players_on_court_from_rotation(
+        enh,
+        parse_rotation_resultsets(json.loads((fx / "gamerotation.json").read_text())),
+        home_team_id=home,
+        away_team_id=away,
+    )
+    poss = attach_possession_lineups(build_possessions(enh), oncourt, enh, home_team_id=home)
+    return enh, poss, _starters_from_boxscore_v3(box)
+
+
+@pytest.fixture(scope="module")
+def parts() -> dict:
+    return {g: _parts(g) for g in GAMES}
+
+
+@pytest.mark.parametrize("game_id", GAMES)
+def test_starter_counts_are_in_range(parts, game_id: str) -> None:
+    _enh, poss, starters = parts[game_id]
+    counts = starters_on_court_counts(poss, starters)
+    assert len(counts) == poss.height
+    assert set(counts) == set(poss["possession_number"].to_list())
+    assert all(0 <= v <= 10 for v in counts.values()), "starters-on-floor outside 0..10"
+
+
+@pytest.mark.parametrize("game_id", GAMES)
+def test_opening_possession_has_all_ten_starters(parts, game_id: str) -> None:
+    """The tip-off possession is, by definition, 10 starters on the floor.
+
+    This is the check that catches a wrong-team attribution: if the offense/defense
+    player columns were mapped to the wrong teams' starter sets, the opening count
+    would not be 10.
+    """
+    _enh, poss, starters = parts[game_id]
+    counts = starters_on_court_counts(poss, starters)
+    first = poss.filter(pl.col("period") == 1).sort("possession_number")["possession_number"][0]
+    assert counts[first] == 10, f"{game_id}: opening possession had {counts[first]} starters, expected 10"
+
+
+@pytest.mark.parametrize("game_id", GAMES)
+def test_full_rule_is_a_subset_of_margin_only(parts, game_id: str) -> None:
+    """CONTAINMENT GATE. margin AND starters can only ever be a SUBSET of margin alone."""
+    enh, poss, starters = parts[game_id]
+    counts = starters_on_court_counts(poss, starters)
+
+    margin_only = flag_garbage_time(poss, enh)
+    full = flag_garbage_time(poss, enh, starters_on_court=counts)
+
+    assert margin_only["garbage_time_basis"].unique().to_list() == ["margin_only"]
+    assert full["garbage_time_basis"].unique().to_list() == ["margin_and_starters"]
+
+    m = set(margin_only.filter(pl.col("is_garbage_time"))["possession_number"].to_list())
+    f = set(full.filter(pl.col("is_garbage_time"))["possession_number"].to_list())
+    assert f <= m, f"{game_id}: full rule flagged possessions margin-only did not: {sorted(f - m)}"
+
+
+@pytest.mark.parametrize("game_id", GAMES)
+def test_full_rule_never_flags_a_possession_with_three_plus_starters(parts, game_id: str) -> None:
+    """The clause itself: <=2 starters combined, or it is not garbage time."""
+    enh, poss, starters = parts[game_id]
+    counts = starters_on_court_counts(poss, starters)
+    full = flag_garbage_time(poss, enh, starters_on_court=counts)
+    for pn in full.filter(pl.col("is_garbage_time"))["possession_number"].to_list():
+        assert counts[pn] <= 2, f"possession {pn} flagged garbage with {counts[pn]} starters on floor"
+
+
+def test_add_play_context_threads_the_starters_clause(parts) -> None:
+    """The clause reaches the one-call surface (add_play_context), not just the flagger."""
+    enh, poss, starters = parts[GAMES[0]]
+    counts = starters_on_court_counts(poss, starters)
+
+    default = add_play_context(enh)
+    exact = add_play_context(enh, starters_on_court=counts)
+
+    assert default["garbage_time_basis"].unique().to_list() == ["margin_only"]
+    assert exact["garbage_time_basis"].unique().to_list() == ["margin_and_starters"]
+    assert int(exact["is_garbage_time"].sum()) <= int(default["is_garbage_time"].sum())
+
+
+def test_missing_lineup_columns_raises(parts) -> None:
+    _enh, poss, starters = parts[GAMES[0]]
+    with pytest.raises(ValueError, match="def_player"):
+        starters_on_court_counts(poss.drop([f"def_player_{i}" for i in range(1, 6)]), starters)
+
+
+def test_empty_starters_map_yields_zero_counts(parts) -> None:
+    """A malformed/empty box must not silently produce a CTG-exact-looking flag.
+
+    With no starters known, every possession has 0 starters on the floor, which
+    would make the <=2 clause vacuously true and flag EVERY margin-qualifying
+    possession as garbage time. The counts are honest (all zero); the caller is
+    responsible for not passing an empty map — so this test documents the
+    behaviour rather than pretending it is safe.
+    """
+    _enh, poss, _starters = parts[GAMES[0]]
+    counts = starters_on_court_counts(poss, {})
+    assert set(counts.values()) == {0}

--- a/tests/nba/test_nba_play_context_oracle.py
+++ b/tests/nba/test_nba_play_context_oracle.py
@@ -1,0 +1,132 @@
+"""Task 4: the pbpstats-live possession *start-type* oracle round-trip.
+
+Like-for-like gate on the coarse possession start type. sdv's
+:func:`~sportsdataverse.nba.nba_possessions.build_possessions` attaches a coarse
+``possession_start_type`` (the five pbpstats families: ``OffDeadball`` /
+``OffTimeout`` / ``OffMadeShot`` / ``OffMissedShot`` / ``OffLiveBallTurnover``, no
+shot-type buckets). pbpstats' own ``possession_start_type`` is finer
+(``OffFTMake``, ``OffArc3Miss``, ...); :func:`_coarsen` folds it down to the same
+five families so the two are directly comparable. Both engines are fed from the
+SAME committed cdn fixture (``tests/fixtures/nba_engine/{gid}/cdn_playbyplay.json``
++ ``cdn_boxscore.json``).
+
+Alignment is by possession END action number — the intersection of the two
+engines' possession boundaries. Phase A verified the cdn feed's ``actionNumber``
+equals the v3 ``action_number`` 1-to-1, so END numbers are directly comparable;
+possessions whose boundary only one engine emits (the S1/S2 artifacts the
+possession oracle classifies) cannot be paired and are excluded from the rate.
+
+Gate (floors from OBSERVED values — never lowered to make a test pass):
+
+* per-game agreement ``>= 0.98`` (observed 0.99502 / 0.98953 / 1.00000)
+* total agreement    ``>= 0.99`` (observed 592/595 = 0.99496)
+
+The three residuals are pinned EXACTLY in :data:`EXPECTED_RESIDUALS` (an equality,
+not a floor): any NEW disagreement fails the gate. Each is a pbpstats-live
+possession-boundary artifact around a timeout/FT sequence — the same S2 family the
+possession oracle (``test_nba_possession_oracle.py``) already classifies — NOT an
+sdv start-type bug. sdv follows pbpstats' OWN documented ``possession_start_type``
+rule (``possession.py:206-242``); the disagreement is downstream of pbpstats-live's
+possession *segmentation* differing from sdv's, which shifts the coarse start type
+of the possession on the far side of the divergent boundary. In every residual sdv
+is on the side pbpstats' documented rule prescribes (e.g. end_action 494 / 578:
+sdv ``OffMadeShot`` because the possession does not start at the timeout's clock,
+while pbpstats-live reaches ``OffTimeout`` only via its shifted boundary).
+
+Gated on ``SDV_PBPSTATS_ROOT`` (a local https://github.com/dblackrun/pbpstats
+checkout; pbpstats is NOT a project dependency). Unset → every test skips cleanly;
+no workflow sets it. The pbpstats client plumbing + committed-fixture transport is
+reused from :mod:`tests.nba.test_nba_possession_oracle`.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from typing import Any, Dict, List, Set, Tuple
+
+import polars as pl
+import pytest
+
+from sportsdataverse.nba.nba_possessions import build_possessions
+from tests.nba.test_nba_possession_oracle import GAMES, _enh, _pbpstats_possessions
+
+#: Observed shared-boundary count per game. Min-size guard: a shrunken / partial
+#: re-capture must FAIL, not vacuously pass a rate check on a handful of rows.
+OBSERVED_SHARED: Dict[str, int] = {"0022100001": 201, "0022200001": 191, "0022300001": 203}
+
+PER_GAME_FLOOR = 0.98
+TOTAL_FLOOR = 0.99
+
+#: The classified start-type residuals, pinned exactly (equality, not a floor):
+#: game_id -> {possession END action number: (sdv_coarse, oracle_fine)}. Games
+#: absent default to no residuals (exact agreement). See the module docstring for
+#: the classification — every entry is a pbpstats-live boundary artifact, not an
+#: sdv bug.
+EXPECTED_RESIDUALS: Dict[str, Dict[int, Tuple[str, str]]] = {
+    "0022100001": {494: ("OffMadeShot", "OffTimeout")},
+    "0022200001": {70: ("OffMissedShot", "OffDeadball"), 578: ("OffMadeShot", "OffTimeout")},
+    "0022300001": {},
+}
+
+
+def _coarsen(fine: str) -> str:
+    """pbpstats fine ``possession_start_type`` → sdv's five coarse families."""
+    if fine.endswith("Make"):
+        return "OffMadeShot"
+    if fine.endswith("Miss") or fine.endswith("Block"):
+        return "OffMissedShot"
+    return fine  # OffDeadball / OffTimeout / OffLiveBallTurnover pass through
+
+
+def _sdv_start_types(enhanced: pl.DataFrame, sdv: pl.DataFrame) -> Dict[int, str]:
+    """{possession END action number: sdv coarse start type} (end_order_index → action_number)."""
+    idx: Dict[int, int] = dict(zip(enhanced["order_index"].to_list(), enhanced["action_number"].to_list()))
+    return {idx[i]: t for i, t in zip(sdv["end_order_index"].to_list(), sdv["possession_start_type"].to_list())}
+
+
+def _compare(game_id: str, tmp_path: pathlib.Path) -> Tuple[Set[int], Dict[int, Tuple[str, str]]]:
+    """Shared END boundaries and the coarse start-type disagreements on them.
+
+    ``disagree`` maps each disagreeing END action number to ``(sdv_coarse,
+    oracle_fine)`` so a failure message names the pbpstats fine type that moved.
+    """
+    enhanced = _enh(game_id)
+    sdv_map = _sdv_start_types(enhanced, build_possessions(enhanced))
+    oracle: List[Any] = _pbpstats_possessions(game_id, tmp_path)
+    orc_fine: Dict[int, str] = {p.events[-1].event_num: p.possession_start_type for p in oracle}
+    shared = set(sdv_map) & set(orc_fine)
+    disagree = {k: (sdv_map[k], orc_fine[k]) for k in shared if sdv_map[k] != _coarsen(orc_fine[k])}
+    return shared, disagree
+
+
+@pytest.mark.parametrize("game_id", GAMES)
+def test_start_type_agreement_meets_floor(game_id: str, tmp_path: pathlib.Path) -> None:
+    """Per-game coarse start-type agreement clears the floor, residuals pinned exactly."""
+    shared, disagree = _compare(game_id, tmp_path)
+
+    assert len(shared) >= OBSERVED_SHARED[game_id], {
+        "game_id": game_id,
+        "shared": len(shared),
+        "expected_at_least": OBSERVED_SHARED[game_id],
+    }
+    rate = (len(shared) - len(disagree)) / len(shared)
+    assert rate >= PER_GAME_FLOOR, {"game_id": game_id, "rate": rate, "floor": PER_GAME_FLOOR}
+    # Exact — any start-type disagreement NOT in the classified set fails here.
+    assert disagree == EXPECTED_RESIDUALS[game_id], {
+        "game_id": game_id,
+        "unexpected": {k: v for k, v in disagree.items() if k not in EXPECTED_RESIDUALS[game_id]},
+        "missing": {k: v for k, v in EXPECTED_RESIDUALS[game_id].items() if k not in disagree},
+    }
+
+
+def test_total_start_type_agreement_meets_floor(tmp_path: pathlib.Path) -> None:
+    """Aggregate coarse start-type agreement over all three fixtures clears the total floor."""
+    tot_shared = tot_disagree = 0
+    for game_id in GAMES:
+        shared, disagree = _compare(game_id, tmp_path)
+        tot_shared += len(shared)
+        tot_disagree += len(disagree)
+
+    assert tot_shared >= sum(OBSERVED_SHARED.values()), {"total_shared": tot_shared}
+    rate = (tot_shared - tot_disagree) / tot_shared
+    assert rate >= TOTAL_FLOOR, {"total_rate": rate, "floor": TOTAL_FLOOR, "shared": tot_shared}

--- a/tests/nba/test_nba_play_context_oracle.py
+++ b/tests/nba/test_nba_play_context_oracle.py
@@ -23,15 +23,23 @@ Gate (floors from OBSERVED values — never lowered to make a test pass):
 
 The three residuals are pinned EXACTLY in :data:`EXPECTED_RESIDUALS` (an equality,
 not a floor): any NEW disagreement fails the gate. Each is a pbpstats-live
-possession-boundary artifact around a timeout/FT sequence — the same S2 family the
-possession oracle (``test_nba_possession_oracle.py``) already classifies — NOT an
-sdv start-type bug. sdv follows pbpstats' OWN documented ``possession_start_type``
-rule (``possession.py:206-242``); the disagreement is downstream of pbpstats-live's
-possession *segmentation* differing from sdv's, which shifts the coarse start type
-of the possession on the far side of the divergent boundary. In every residual sdv
-is on the side pbpstats' documented rule prescribes (e.g. end_action 494 / 578:
-sdv ``OffMadeShot`` because the possession does not start at the timeout's clock,
-while pbpstats-live reaches ``OffTimeout`` only via its shifted boundary).
+possession-*segmentation* artifact — the same S2 family the possession oracle
+(``test_nba_possession_oracle.py``) already classifies — NOT an sdv start-type bug.
+sdv follows pbpstats' OWN documented ``possession_start_type`` rule
+(``possession.py:206-242``); the disagreement is downstream of pbpstats-live
+drawing a possession boundary where sdv does not, which changes the previous-
+possession-ending event and hence the coarse start type. In every residual sdv is
+on the side pbpstats' documented rule prescribes. Two sub-mechanisms:
+
+* **end_action 494 / 578** (sdv ``OffMadeShot`` vs oracle ``OffTimeout``): sdv's
+  possession does not start at the timeout's clock, so its documented boundary-
+  timeout rule yields no timeout; pbpstats-live reaches ``OffTimeout`` only via a
+  shifted boundary around the timeout/FT sequence.
+* **end_action 70** (sdv ``OffMissedShot`` vs oracle ``OffDeadball``): pbpstats-live
+  ends the previous possession at a personal foul (a dead-ball event, event 64), so
+  its previous-possession-ending event is a ``Foul`` → ``OffDeadball``; sdv's prior
+  boundary is the defensive rebound → ``OffMissedShot``. A foul-boundary segmentation
+  difference, not the timeout family.
 
 Gated on ``SDV_PBPSTATS_ROOT`` (a local https://github.com/dblackrun/pbpstats
 checkout; pbpstats is NOT a project dependency). Unset → every test skips cleanly;

--- a/tests/nba/test_nba_possessions.py
+++ b/tests/nba/test_nba_possessions.py
@@ -924,19 +924,22 @@ def test_start_type_ft_sandwich_technical_asymmetry():
     ``exclude_technical``; not exercised by the committed fixtures.
     """
     made = {"event_type": "made_shot", "seconds_remaining": 100.0}
+    timeout = {"event_type": "timeout", "seconds_remaining": 90.0}
     tech_ft = {"event_type": "free_throw", "sub_type": "Free Throw Technical", "seconds_remaining": 90.0}
 
-    # PREVIOUS-possession boundary timeout, then this possession opens on a
-    # same-clock technical FT → sandwich → suppressed → falls through to OffMadeShot.
-    prev_rows = [made, {"event_type": "timeout", "seconds_remaining": 90.0}]
+    # PREVIOUS-possession boundary timeout, then this possession opens on a same-clock
+    # technical FT → sandwich → timeout suppressed. Production invariant:
+    # prev_end_row IS the previous group's last row (build_possessions:758), so here it
+    # is the timeout itself. pbpstats' previous_possession_ending_event skips only
+    # Substitutions (not Timeouts), so a suppressed boundary timeout falls through to
+    # OffDeadball — NOT the made shot before it. Under the pre-fix code the technical FT
+    # was wrongly treated as "not a sandwich", so the timeout counted → OffTimeout; this
+    # assertion discriminates the fix.
+    prev_rows = [made, timeout]
     cur_rows = [tech_ft, {"event_type": "made_shot", "seconds_remaining": 80.0}]
-    assert _possession_start_type(made, prev_rows, cur_rows) == "OffMadeShot"
+    assert _possession_start_type(timeout, prev_rows, cur_rows) == "OffDeadball"
 
     # CURRENT-possession timeout before a same-clock technical FT → carve-out
-    # retained → still OffTimeout.
-    cur_rows_to = [
-        {"event_type": "timeout", "seconds_remaining": 90.0},
-        tech_ft,
-        {"event_type": "made_shot", "seconds_remaining": 80.0},
-    ]
+    # retained (possession_has_timeout keeps `and not is_technical_ft`) → OffTimeout.
+    cur_rows_to = [timeout, tech_ft, {"event_type": "made_shot", "seconds_remaining": 80.0}]
     assert _possession_start_type(made, [made], cur_rows_to) == "OffTimeout"

--- a/tests/nba/test_nba_possessions.py
+++ b/tests/nba/test_nba_possessions.py
@@ -24,6 +24,7 @@ from sportsdataverse.nba.nba_possessions import (
     POSSESSION_SHOOTING_SCHEMA,
     POSSESSIONS_SCHEMA,
     _is_last_ft,
+    _possession_start_type,
     attach_possession_lineups,
     build_possession_shooting,
     build_possessions,
@@ -905,3 +906,37 @@ def test_new_possession_columns(game_id):
     not_counted = poss.filter(pl.col("count_as_possession") == False)  # noqa: E712
     for r in not_counted.to_dicts():
         assert r["start_seconds_remaining"] <= 2.0, r
+
+
+def test_start_type_ft_sandwich_technical_asymmetry():
+    """pbpstats applies the FT-sandwich technical carve-out asymmetrically.
+
+    A boundary timeout followed by a same-clock *technical* FT:
+
+    * as the PREVIOUS possession's boundary → suppressed (any same-clock FT is a
+      sandwich; pbpstats ``previous_possession_has_timeout``, possession.py:185-189
+      has no technical clause) → the start type falls through, NOT ``OffTimeout``.
+    * inside the CURRENT possession → still counts (pbpstats
+      ``possession_has_timeout``, possession.py:154-159, keeps
+      ``and not is_technical_ft``) → ``OffTimeout``.
+
+    Regression guard for the parity fix that split ``_is_ft_sandwich`` by
+    ``exclude_technical``; not exercised by the committed fixtures.
+    """
+    made = {"event_type": "made_shot", "seconds_remaining": 100.0}
+    tech_ft = {"event_type": "free_throw", "sub_type": "Free Throw Technical", "seconds_remaining": 90.0}
+
+    # PREVIOUS-possession boundary timeout, then this possession opens on a
+    # same-clock technical FT → sandwich → suppressed → falls through to OffMadeShot.
+    prev_rows = [made, {"event_type": "timeout", "seconds_remaining": 90.0}]
+    cur_rows = [tech_ft, {"event_type": "made_shot", "seconds_remaining": 80.0}]
+    assert _possession_start_type(made, prev_rows, cur_rows) == "OffMadeShot"
+
+    # CURRENT-possession timeout before a same-clock technical FT → carve-out
+    # retained → still OffTimeout.
+    cur_rows_to = [
+        {"event_type": "timeout", "seconds_remaining": 90.0},
+        tech_ft,
+        {"event_type": "made_shot", "seconds_remaining": 80.0},
+    ]
+    assert _possession_start_type(made, [made], cur_rows_to) == "OffTimeout"

--- a/tests/wnba/test_wnba_play_context_shim.py
+++ b/tests/wnba/test_wnba_play_context_shim.py
@@ -1,0 +1,131 @@
+"""Offline tests for the WNBA play-context shim (``wnba_engine.wnba_play_context``).
+
+The shim is a thin binding of the league-agnostic
+:func:`sportsdataverse.nba.nba_play_context.add_play_context` core onto the
+``stats.wnba.com`` fetcher — so the tests prove two things:
+
+1. **Delegation is byte-identical.** ``wnba_play_context(gid)`` must equal
+   ``add_play_context(enhanced_pbp)`` on the same fixture. If it ever diverges,
+   a WNBA-specific code path has been introduced, which is exactly what the
+   shim exists to prevent.
+
+2. **The oracle gate holds on WNBA data.** The transition-frequency gate is
+   re-run at the SAME band as the NBA (``[0.12, 0.21]``, see
+   ``tests/nba/test_nba_play_context.py``) — the sibling-league parity rule from
+   the model-spine skill: identical thresholds, sibling fixtures. CTG is
+   NBA-only, so there is no published WNBA transition rate; the band is
+   inherited from the NBA calibration and is a *sanity* gate on the shared
+   engine, not a WNBA-specific claim.
+
+No network: the module-level ``_fetch_*`` helpers are monkeypatched to the
+committed ``tests/fixtures/wnba_engine`` payloads.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pandas as pd
+import polars as pl
+import pytest
+
+import sportsdataverse.wnba.wnba_engine as W
+from sportsdataverse.nba.nba_enhanced_pbp import enhanced_pbp_from_payload
+from sportsdataverse.nba.nba_play_context import (
+    PLAY_CONTEXT_POSSESSIONS_SCHEMA,
+    add_play_context,
+)
+
+FXR = pathlib.Path("tests/fixtures/wnba_engine")
+GAMES = ["1022400001", "1022400003"]
+
+#: Same band as the NBA gate (tests/nba/test_nba_play_context.py). Sibling-league
+#: parity: identical thresholds on the sibling's fixtures.
+TRANSITION_FREQ_GATE = (0.12, 0.21)
+
+#: Observed on the two committed WNBA fixtures at the NBA-calibrated 6.0s default:
+#: 0.167 (1022400001) and 0.160 (1022400003) -> mean 0.163. That is the SAME mean
+#: the three NBA fixtures produce (0.163), which is the substantive finding here:
+#: the transition knob fitted on the NBA transfers to the WNBA unchanged. The knob
+#: is steep either way (WNBA scan: 4s=0.07, 6s=0.16, 8s=0.24, 10s=0.32), so this
+#: agreement is not an artifact of a flat region.
+OBSERVED_WNBA_TRANSITION_FREQ_MEAN = 0.163
+
+
+def _patch(monkeypatch, gid: str) -> None:
+    fx = FXR / gid
+    monkeypatch.setattr(W, "_fetch_pbp", lambda g: json.loads((fx / "playbyplayv3.json").read_text()))
+
+
+def _enh(gid: str) -> pl.DataFrame:
+    payload = json.loads((FXR / gid / "playbyplayv3.json").read_text())
+    return enhanced_pbp_from_payload(payload, league_id="10")
+
+
+@pytest.mark.parametrize("gid", GAMES)
+def test_shim_emits_the_play_context_columns(monkeypatch, gid: str) -> None:
+    _patch(monkeypatch, gid)
+    out = W.wnba_play_context(gid)
+    assert isinstance(out, pl.DataFrame)
+    assert out.height > 0
+    for col, dtype in PLAY_CONTEXT_POSSESSIONS_SCHEMA.items():
+        assert col in out.columns, f"missing play-context column {col}"
+        assert out.schema[col] == dtype, f"{col}: {out.schema[col]} != {dtype}"
+
+
+@pytest.mark.parametrize("gid", GAMES)
+def test_shim_delegates_to_the_nba_core(monkeypatch, gid: str) -> None:
+    """The shim must add NO WNBA-specific logic — output equals the core's."""
+    _patch(monkeypatch, gid)
+    shim = W.wnba_play_context(gid)
+    core = add_play_context(_enh(gid))
+    assert shim.equals(core)
+
+
+@pytest.mark.parametrize("gid", GAMES)
+def test_shim_pandas_flag(monkeypatch, gid: str) -> None:
+    _patch(monkeypatch, gid)
+    assert isinstance(W.wnba_play_context(gid, return_as_pandas=True), pd.DataFrame)
+
+
+def test_transition_frequency_gate_on_wnba_fixtures(monkeypatch) -> None:
+    """ORACLE GATE (sibling-league parity, identical NBA thresholds).
+
+    Never lower this gate to make it pass — debug the engine instead. If WNBA
+    genuinely runs at a different transition rate than the NBA, that is a
+    *finding* to record and calibrate (a WNBA ``transition_seconds``), not a
+    reason to widen the band.
+    """
+    freqs = []
+    for gid in GAMES:
+        _patch(monkeypatch, gid)
+        poss = W.wnba_play_context(gid)
+        clean = poss.filter(
+            (pl.col("count_as_possession") == True)  # noqa: E712
+            & (pl.col("is_garbage_time") == False)  # noqa: E712
+            & (pl.col("is_heave_possession") == False)  # noqa: E712
+        )
+        assert clean.height >= 150, f"{gid}: only {clean.height} clean possessions — fixture shrunk?"
+        freqs.append(clean["is_transition"].mean())
+
+    mean = sum(freqs) / len(freqs)
+    lo, hi = TRANSITION_FREQ_GATE
+    assert lo <= mean <= hi, (
+        f"WNBA transition freq {mean:.3f} outside the NBA band {TRANSITION_FREQ_GATE} (per-game {freqs})"
+    )
+    assert mean == pytest.approx(OBSERVED_WNBA_TRANSITION_FREQ_MEAN, abs=0.02)
+
+
+@pytest.mark.parametrize("gid", GAMES)
+def test_start_types_are_the_full_taxonomy(monkeypatch, gid: str) -> None:
+    """The zone-split taxonomy must actually resolve on WNBA shot coordinates."""
+    _patch(monkeypatch, gid)
+    poss = W.wnba_play_context(gid)
+    detail = set(poss["possession_start_type_detail"].drop_nulls().to_list())
+    # at least one zone-qualified start type resolved (not everything collapsing
+    # to OffDeadball — which is what a coordinate/zone failure would look like)
+    zoned = {s for s in detail if s.endswith(("Make", "Miss", "Block")) and s not in ("OffFTMake", "OffFTMiss")}
+    assert zoned, f"{gid}: no zone-qualified start types — shot-zone classification failed on WNBA coords"
+    buckets = set(poss["possession_start_type_ctg"].drop_nulls().to_list())
+    assert {"off_made", "off_live_rebound"} <= buckets, f"{gid}: CTG buckets missing: {buckets}"


### PR DESCRIPTION
## CTG play-context — A-track (T3.6)

Completes the Cleaning the Glass play-context recreation on the shipped possession engine: WNBA sibling, player/lineup on-off tables, the garbage-time starters clause, and a pbpstats-live start-type oracle gate that surfaced three real engine bugs.

### What's here

- **`wnba_play_context`** (`wnba/wnba_engine.py`) — a real shim, byte-identical to the NBA core on WNBA fixtures; the `6.0s` transition knob transfers cross-league unchanged (WNBA mean 0.163, identical to the NBA fixture mean).
- **`lineup_play_context` / `player_play_context`** — on/off possessions + points per 5-man unit and per player, sharing one aggregation core. The OFF side is derived by **subtraction**, so `on + off == team` is exact by construction (the gate is that identity).
- **`starters_on_court_counts`** — implements CTG's garbage-time "≤2 starters on floor" clause. With starter data joined, `garbage_time_basis` upgrades `margin_only` → `margin+starters` (containment-verified: the full rule is a strict subset of margin-only; opening possession has all 10 starters).
- **Faithful pbpstats possession start-type** — three engine bugs found by driving the pbpstats-live start-type oracle (coarse `possession_start_type` agreement **91.26% → 99.50%**):
  1. **Timeout over-fired** — only a *boundary* timeout now yields `OffTimeout`, a faithful port of pbpstats `possession_has_timeout` / `previous_possession_has_timeout` (`possession.py:146-191`), including the **asymmetric** FT-sandwich technical carve-out (kept for the current-possession test, omitted for the previous-possession test — matching pbpstats exactly).
  2. **`v3 shot_distance` is `Int64`** (feed rounds to whole feet) — CTG rim/short-mid zone boundaries now use exact distance from the legacy coordinates (`sqrt(x²+y²)/10`), so a 3.6 ft shot no longer mis-bins as a 4 ft `short_mid`.
  3. **`v3` team rebounds stuff the team id into `person_id`** and set `team_id=0` — so `person_id != 0` mislabelled every team rebound `OffMissedShot`; `team_id == 0` is the reliable dead-ball discriminator (verified across all three fixtures: 20/19/19 team vs 98/67/75 player rebounds, zero exceptions).

### Oracle gate

`tests/nba/test_nba_play_context_oracle.py` (gated on `SDV_PBPSTATS_ROOT`; skips cleanly — no workflow sets it) compares sdv's coarse `possession_start_type` against pbpstats-live's own, coarsened to the same five families, aligned by possession END action number:

- per-game agreement **≥ 0.98** (observed 0.99502 / 0.98953 / 1.00000)
- total agreement **≥ 0.99** (observed **592/595 = 0.99496**)
- floors set from observed values (never lowered); a per-game min-shared guard prevents a shrunken re-capture from passing vacuously; the **3 residuals are pinned exactly** (equality, not a floor) — each a classified pbpstats-live *segmentation* artifact (two timeout-boundary, one personal-foul dead-ball boundary), not an sdv start-type bug.

### Gates

- Full `tests/nba tests/wnba`: **713 passed, 64 skipped, 0 failed**
- mypy clean (touched modules already in the ratchet); ruff clean; codegen drift `--check` clean; `uv.lock` untouched
- Reviewed by the plugin's `oracle-gate-reviewer`, `port-parity-reviewer`, and `polars-1x-reviewer` — the port-parity reviewer caught the FT-sandwich technical asymmetry (fixed here with a direct unit test), no other blocking findings.

### Follow-up (deliberately NOT in this PR)

`nba_shot_zones.add_shot_zones` — the **official NBA** zone classifier — has the **same rounded-distance bug**: `restricted_area` tests `shot_distance < 4` on the same `Int64` column. Left untouched here because it feeds the shot-value models, which carry their own oracle gates; silently shifting a model input outside this PR's scope would be wrong. Worth a separate issue to migrate it to exact coordinate distance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NBA CTG play-context outputs for offense 5-man lineups, on/off player splits, and starters-on-court counts.
  * Added WNBA play-context support with configurable transition settings and optional pandas output.

* **Improvements**
  * Refined shot-zone classification using more accurate shot-distance boundaries.
  * Improved possession start-type labeling (including timeout/FT sandwiched boundaries and rebound handling) and enhanced CTG garbage-time starter evaluation.

* **Bug Fixes**
  * Prevented zero-possession rate outputs from returning NaN/infinite values.

* **Documentation**
  * Updated NBA/WNBA reference docs and the unreleased changelog with the new capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->