### PR TITLE
feat(mbb,wbb): NCAA LineupStatSet producer — stage-2 rate-minting port (connects college RAPM/lineup models to real data)

### DIFF
--- a/docs/docs/mbb/index.md
+++ b/docs/docs/mbb/index.md
@@ -10,7 +10,7 @@ sidebar_label: MBB
 | [ESPN web API (v3)](reference/web) | 5 | `https://site.web.api.espn.com/apis/common/v3/sports` |
 | [ESPN core API (v2)](reference/core) | 86 | `https://sports.core.api.espn.com/v2/sports` |
 | [Dataset loaders](reference/loaders) | 11 | sportsdataverse-data releases |
-| [Additional functions](reference/additional) | 300 | hand-written wrappers, loaders & helpers |
+| [Additional functions](reference/additional) | 302 | hand-written wrappers, loaders & helpers |
 
 ## Examples
 

--- a/docs/docs/mbb/reference/additional.md
+++ b/docs/docs/mbb/reference/additional.md
@@ -6249,6 +6249,72 @@ still-negative possession count is clamped to 0.
 
 New lineup copies with clamped `num_possessions`.
 
+### `lineup_stats_bucket(ev: 'LineupEvent', *, avg_eff: 'float' = 100.0, opponent_baselines: 'Optional[dict[str, float]]' = None, doc_count: 'int' = 1) -> 'LineupStatSet'` {#lineup_stats_bucket}
+
+Assemble one lineup's full 254-field `{value}` bucket.
+
+`lineup_stats_bucket` is the Python entry point for stage 2 of the port (see the
+module docstring) -- the faithful composition of this module's factories in the order
+`commonLineupAggregations.ts` (572-line ES aggregation) issues them: `sum` (
+sum_fields`) -> merge the play-type `pts`/`poss` bucket_script (
+play_type_pts_poss`) -> mint every other rate bucket_script (
+all_rate_fields`) -> the SOS-adjusted-efficiency bucket_script (
+adj_fields`).
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `ev` | `LineupEvent` |  | One already-summed lineup event (`team_stats`/`opponent_stats` populated by stage 1, `~sportsdataverse.mbb.mbb_ncaa_lineup_enrich.enrich_lineup`). |
+| `avg_eff` | `float` | `100.0` | League-average efficiency passed through to adj_fields`. |
+| `opponent_baselines` | `Optional[dict[str, float]]` | `None` | SOS baseline lookup passed through to adj_fields`; only `None` (no baselines) is implemented. |
+| `doc_count` | `int` | `1` | The ES `doc_count` for this bucket (number of raw events folded in). |
+
+**Returns**
+
+The full bucket: every `total_*`/rate/adj field wrapped in `{"value": <float>}`, plus the structural keys `key`, `players_array`, `doc_count` (bare, unwrapped).
+
+**Example**
+
+```python
+from sportsdataverse.mbb.mbb_ncaa_lineup_aggregation import lineup_stats_bucket
+
+bucket = lineup_stats_bucket(enriched_event, doc_count=7)
+bucket["off_ppp"]["value"]
+```
+
+### `lineup_stats_buckets(evs: 'list[LineupEvent]', *, avg_eff: 'float' = 100.0, opponent_baselines: 'Optional[dict[str, float]]' = None) -> 'list[LineupStatSet]'` {#lineup_stats_buckets}
+
+Group events by lineup, fold each group's stats, and mint one bucket per lineup.
+
+Python entry point for the ES `terms` aggregation over `key` (grouping by
+bucket_key`) that feeds each lineup's docs into
+`commonLineupAggregations.ts`'s `sum` aggs -- see
+`cbb-on-off-analyzer/src/utils/es-queries/commonLineupAggregations.ts`. This
+is the list-form producer the `LineupStatSet` consumers (`mbb_lineup_stats`)
+read from; `lineup_stats_bucket` handles a single already-folded event.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `evs` | `list[LineupEvent]` |  | Raw per-possession-chunk lineup events (`team_stats`/`opponent_stats` populated by stage 1, `~sportsdataverse.mbb.mbb_ncaa_lineup_enrich .enrich_lineup`), one lineup's floor time possibly split across many events. |
+| `avg_eff` | `float` | `100.0` | League-average efficiency passed through to each bucket. |
+| `opponent_baselines` | `Optional[dict[str, float]]` | `None` | SOS baseline lookup passed through to each bucket; only `None` (no baselines) is implemented (see adj_fields`). |
+
+**Returns**
+
+One `LineupStatSet` per distinct lineup (bucket_key`), in first-seen order, with `doc_count` set to that lineup's event count.
+
+**Example**
+
+```python
+from sportsdataverse.mbb.mbb_ncaa_lineup_aggregation import lineup_stats_buckets
+
+buckets = lineup_stats_buckets(enriched_events)
+buckets[0]["off_poss"]["value"]
+```
+
 ### `lineup_to_team_report(lineup_report: 'LineupStatSet', inc_replacement: 'bool' = False, regress_diffs: 'float' = 0.0, rep_on_off_diag_mode: 'int' = 0) -> 'LineupStatSet'` {#lineup_to_team_report}
 
 Build per-player on/off splits out of a team's lineups.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -496,6 +496,7 @@ files = [
     "sportsdataverse/mbb/mbb_ncaa_shot_parser.py",
     "sportsdataverse/mbb/mbb_ncaa_pbp_glue.py",
     "sportsdataverse/mbb/mbb_ncaa_strength.py",
+    "sportsdataverse/mbb/mbb_ncaa_lineup_aggregation.py",
     "sportsdataverse/wbb/wbb_lineup_stats.py",
     "sportsdataverse/wbb/wbb_ratings.py",
     "sportsdataverse/wbb/wbb_luck.py",

--- a/sportsdataverse/mbb/__init__.py
+++ b/sportsdataverse/mbb/__init__.py
@@ -13,6 +13,7 @@ from sportsdataverse.mbb.mbb_ncaa_data_quality import *
 from sportsdataverse.mbb.mbb_ncaa_events import *
 from sportsdataverse.mbb.mbb_ncaa_fetch import *
 from sportsdataverse.mbb.mbb_ncaa_html import *
+from sportsdataverse.mbb.mbb_ncaa_lineup_aggregation import *
 from sportsdataverse.mbb.mbb_ncaa_lineup_enrich import *
 from sportsdataverse.mbb.mbb_ncaa_models import *
 from sportsdataverse.mbb.mbb_ncaa_names import *

--- a/sportsdataverse/mbb/mbb_ncaa_lineup_aggregation.py
+++ b/sportsdataverse/mbb/mbb_ncaa_lineup_aggregation.py
@@ -86,3 +86,86 @@ def _sum_fields(s: LineupEventStats, dst: str, prefix: str, suffix: str) -> dict
         put("pts", float(s.pts))
         put("poss", float(s.num_possessions))
     return out
+
+
+# (shotType stems used by both the shot-rate and eFG tables) — T3, commonAverageAggs.ts:291-397
+_SHOT_RATE_TYPES = ("2p", "3p", "2prim", "2pmid")
+_ASSIST_DIST_TYPES = ("rim", "mid", "3p")
+
+
+def _rate(
+    out: dict[str, dict[str, float]],
+    totals: dict[str, float],
+    dst: str,
+    name: str,
+    top: str,
+    bottom: str,
+    factor: float = 1.0,
+) -> None:
+    # ponytail: guarded rate formula, commonAverageAggs.ts:81-99 -- (num>0)?factor*num/den:0.
+    # `out` takes an explicit param (vs. a closure) so Task 5's scramble_/trans_ loop can
+    # reuse this directly instead of re-deriving a nested closure per prefix.
+    num = totals.get(f"total_{dst}_{top}", 0.0)
+    den = totals.get(f"total_{dst}_{bottom}", 0.0)
+    # ponytail: guard den==0 too (num>0 alone can still divide by zero when the
+    # denominator field is absent/zero, e.g. a partial totals dict in tests).
+    out[f"{dst}_{name}"] = {"value": factor * num / den if num > 0 and den > 0 else 0.0}
+
+
+def _rate_table(prefix: str) -> list[tuple[str, float, str, str]]:
+    # T3 rate tuples (name, factor, top, bottom); top/bottom are total_* stems sans "total_{dst}_".
+    p = prefix
+    table: list[tuple[str, float, str, str]] = []
+    for st in _SHOT_RATE_TYPES:
+        table.append((f"{p}{st}", 1.0, f"{p}{st}_made", f"{p}{st}_attempts"))
+        table.append((f"{p}{st}_ast", 1.0, f"{p}{st}_ast", f"{p}{st}_made"))
+    table.extend(
+        [
+            (f"{p}ft", 1.0, f"{p}ftm", f"{p}fta"),
+            (f"{p}ftr", 1.0, f"{p}fta", f"{p}fga"),
+            (f"{p}2primr", 1.0, f"{p}2prim_attempts", f"{p}fga"),
+            (f"{p}2pmidr", 1.0, f"{p}2pmid_attempts", f"{p}fga"),
+            (f"{p}3pr", 1.0, f"{p}3p_attempts", f"{p}fga"),
+            (f"{p}assist", 1.0, f"{p}assist", f"{p}fgm"),
+            (f"{p}ppp", 100.0, f"{p}pts", f"{p}poss"),
+            (f"{p}to", 1.0, f"{p}to", f"{p}poss"),
+        ]
+    )
+    return table
+
+
+def _efg(totals: dict[str, float], dst: str, prefix: str) -> dict[str, dict[str, float]]:
+    # ponytail: eFG special-case, commonAverageAggs.ts:429-437 -- threes weighted 1.5x.
+    fga = totals.get(f"total_{dst}_{prefix}fga", 0.0)
+    made2 = totals.get(f"total_{dst}_{prefix}2p_made", 0.0)
+    made3 = totals.get(f"total_{dst}_{prefix}3p_made", 0.0)
+    value = (1.0 * made2 + 1.5 * made3) / fga if fga > 0 else 0.0
+    return {f"{dst}_{prefix}efg": {"value": value}}
+
+
+def _orb(totals: dict[str, float], oppo_totals: dict[str, float], dst: str) -> dict[str, dict[str, float]]:
+    # ponytail: orb rate special-case, commonAverageAggs.ts:414-422 -- cross-side drb
+    # (off's orb rate is denominated against the opponent's drb, not off's own drb).
+    oppo_dst = "def" if dst == "off" else "off"
+    var_orb = totals.get(f"total_{dst}_orb", 0.0)
+    var_drb = oppo_totals.get(f"total_{oppo_dst}_drb", 0.0)
+    value = var_orb / (var_orb + var_drb) if var_orb > 0 else 0.0
+    return {f"{dst}_orb": {"value": value}}
+
+
+def _rate_fields(
+    totals: dict[str, float],
+    dst: str,
+    prefix: str,
+    oppo_totals: dict[str, float],
+) -> dict[str, dict[str, float]]:
+    out: dict[str, dict[str, float]] = {}
+    for name, factor, top, bottom in _rate_table(prefix):
+        _rate(out, totals, dst, name, top, bottom, factor)
+    out.update(_efg(totals, dst, prefix))
+    # orb + assist-distribution rates are cross-side/base-only per T3 -- prefix "" only.
+    if prefix == "":
+        out.update(_orb(totals, oppo_totals, dst))
+        for st in _ASSIST_DIST_TYPES:
+            _rate(out, totals, dst, f"ast_{st}", f"ast_{st}", "assist")
+    return out

--- a/sportsdataverse/mbb/mbb_ncaa_lineup_aggregation.py
+++ b/sportsdataverse/mbb/mbb_ncaa_lineup_aggregation.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
-from .mbb_ncaa_models import LineupEvent, ShotClockStats
+from .mbb_ncaa_models import LineupEvent, LineupEventStats, ShotClockStats
 
 LineupStatSet = dict[str, Any]
 
@@ -34,3 +34,55 @@ def _bucket_key(ev: LineupEvent) -> str:
 
 def _players_array(ev: LineupEvent) -> dict:
     return {"hits": {"hits": [{"_source": {"players": [{"code": p.code, "id": p.id} for p in ev.players]}}]}}
+
+
+# (name, attribute-path-tuple)  — ponytail: commonShotAggs/commonMiscAggs, .ts:31-78
+_SHOT_SRC = {  # emitted-stem -> (fg-attr) ; each expands to _attempts/_made/_ast
+    "2prim": "fg_rim",
+    "2pmid": "fg_mid",
+    "2p": "fg_2p",
+    "3p": "fg_3p",
+}
+_MISC_SRC = {  # emitted-stem -> attr-path-on-stats
+    "fga": ("fg", "attempts"),
+    "fgm": ("fg", "made"),
+    "ftm": ("ft", "made"),
+    "fta": ("ft", "attempts"),
+    "to": ("to",),
+    "assist": ("assist",),
+    "orb": ("orb",),
+    "drb": ("drb",),
+    "blk": ("blk",),
+    "stl": ("stl",),
+    "foul": ("foul",),
+}
+_ASSIST_SRC = {"ast_rim": "ast_rim", "ast_mid": "ast_mid", "ast_3p": "ast_3p"}
+
+
+def _sum_fields(s: LineupEventStats, dst: str, prefix: str, suffix: str) -> dict[str, float]:
+    out: dict[str, float] = {}
+
+    def put(stem: str, val: float) -> None:
+        out[f"total_{dst}_{prefix}{stem}"] = val
+
+    # shots: attempts/made/ast for each shot type
+    for stem, fg_attr in _SHOT_SRC.items():
+        fg = getattr(s, fg_attr)
+        put(f"{stem}_attempts", _leaf(fg.attempts, suffix))
+        put(f"{stem}_made", _leaf(fg.made, suffix))
+        put(f"{stem}_ast", _leaf(fg.ast, suffix))
+    # misc scalars-by-clock
+    for stem, path in _MISC_SRC.items():
+        node: Any = s
+        for a in path:
+            node = getattr(node, a)
+        put(stem, _leaf(node, suffix))
+    # assist counts
+    for stem, ai_attr in _ASSIST_SRC.items():
+        ai = getattr(s, ai_attr)
+        put(stem, _leaf(ai.counts if ai is not None else None, suffix))
+    # pts/poss are scalar totals (prefix "" here; scramble_/trans_ handled in Task 6)
+    if prefix == "":
+        put("pts", float(s.pts))
+        put("poss", float(s.num_possessions))
+    return out

--- a/sportsdataverse/mbb/mbb_ncaa_lineup_aggregation.py
+++ b/sportsdataverse/mbb/mbb_ncaa_lineup_aggregation.py
@@ -14,9 +14,11 @@ from .mbb_ncaa_models import LineupEvent, LineupEventStats, ShotClockStats
 
 LineupStatSet = dict[str, Any]
 
-# ponytail: __all__ omitted -- lineup_stats_bucket/lineup_stats_buckets (the
-# public entry points) land in a later task; this task ships only the
-# underscore-prefixed accessors + the LineupStatSet alias.
+__all__ = ["LineupStatSet", "lineup_stats_bucket"]
+
+# ponytail: lineup_stats_buckets (the list-form public entry point) lands in
+# a later task (group-by producer); this task ships the single-lineup
+# assembler `lineup_stats_bucket`.
 
 
 def _leaf(stat: Optional[ShotClockStats], suffix: str) -> float:
@@ -289,3 +291,99 @@ def _adj_fields(
         f"{dst}_adj_ppp": {"value": ppp},
         f"{dst}_adj_opp": {"value": avg_eff},
     }
+
+
+_T1_SUFFIXES = {"": ".total", "scramble_": ".orb", "trans_": ".early"}  # ts:31-78 shot-bucket suffix map.
+
+
+def lineup_stats_bucket(
+    ev: LineupEvent,
+    *,
+    avg_eff: float = 100.0,
+    opponent_baselines: Optional[dict[str, float]] = None,
+    doc_count: int = 1,
+) -> LineupStatSet:
+    """Assemble one lineup's full 254-field ``{value}`` bucket.
+
+    ``lineup_stats_bucket`` is the Python entry point for stage 2 of the port (see the
+    module docstring) -- the faithful composition of this module's factories in the order
+    ``commonLineupAggregations.ts`` (572-line ES aggregation) issues them: ``sum`` (
+    :func:`_sum_fields`) -> merge the play-type ``pts``/``poss`` bucket_script (
+    :func:`_play_type_pts_poss`) -> mint every other rate bucket_script (
+    :func:`_all_rate_fields`) -> the SOS-adjusted-efficiency bucket_script (
+    :func:`_adj_fields`).
+
+    Args:
+        ev: One already-summed lineup event (``team_stats``/``opponent_stats`` populated by
+            stage 1, :func:`~sportsdataverse.mbb.mbb_ncaa_lineup_enrich.enrich_lineup`).
+        avg_eff: League-average efficiency passed through to :func:`_adj_fields`.
+        opponent_baselines: SOS baseline lookup passed through to :func:`_adj_fields`; only
+            ``None`` (no baselines) is implemented.
+        doc_count: The ES ``doc_count`` for this bucket (number of raw events folded in).
+
+    Returns:
+        The full bucket: every ``total_*``/rate/adj field wrapped in ``{"value": <float>}``,
+        plus the structural keys ``key``, ``players_array``, ``doc_count`` (bare, unwrapped).
+
+    Example:
+        Quick start::
+
+            from sportsdataverse.mbb.mbb_ncaa_lineup_aggregation import lineup_stats_bucket
+
+            bucket = lineup_stats_bucket(enriched_event, doc_count=7)
+            bucket["off_ppp"]["value"]
+
+    See Also:
+        * `cbb-on-off-analyzer <https://github.com/Alex-At-Home/cbb-on-off-analyzer>`_ --
+          ``src/utils/es-queries/commonLineupAggregations.ts``, this function's TS source.
+    """
+    off_totals_by_prefix = {
+        prefix: _sum_fields(ev.team_stats, dst="off", prefix=prefix, suffix=suffix)
+        for prefix, suffix in _T1_SUFFIXES.items()
+    }
+    def_totals_by_prefix = {
+        prefix: _sum_fields(ev.opponent_stats, dst="def", prefix=prefix, suffix=suffix)
+        for prefix, suffix in _T1_SUFFIXES.items()
+    }
+
+    # Fold the play-type pts/poss bucket_script in BEFORE minting rates -- _all_rate_fields
+    # reads total_{dst}_{scramble_,trans_}{pts,poss} out of these same dicts.
+    play_type = _play_type_pts_poss(off_totals_by_prefix, def_totals_by_prefix)
+    for dst, totals_by_prefix in (("off", off_totals_by_prefix), ("def", def_totals_by_prefix)):
+        for prefix in _PLAY_TYPE_PREFIXES:
+            for stem in ("pts", "poss"):
+                key = f"total_{dst}_{prefix}{stem}"
+                totals_by_prefix[prefix][key] = play_type[key]
+
+    off_rates = _all_rate_fields(off_totals_by_prefix, "off", def_totals_by_prefix)
+    def_rates = _all_rate_fields(def_totals_by_prefix, "def", off_totals_by_prefix)
+
+    off_adj = _adj_fields(
+        pts=off_totals_by_prefix[""]["total_off_pts"],
+        poss=off_totals_by_prefix[""]["total_off_poss"],
+        dst="off",
+        opponent_baselines=opponent_baselines,
+        avg_eff=avg_eff,
+    )
+    def_adj = _adj_fields(
+        pts=def_totals_by_prefix[""]["total_def_pts"],
+        poss=def_totals_by_prefix[""]["total_def_poss"],
+        dst="def",
+        opponent_baselines=opponent_baselines,
+        avg_eff=avg_eff,
+    )
+
+    bucket: LineupStatSet = {
+        "key": _bucket_key(ev),
+        "players_array": _players_array(ev),
+        "doc_count": doc_count,
+    }
+    for totals_by_prefix in (off_totals_by_prefix, def_totals_by_prefix):
+        for totals in totals_by_prefix.values():
+            for stem, value in totals.items():
+                bucket[stem] = {"value": value}
+    bucket.update(off_rates)
+    bucket.update(def_rates)
+    bucket.update(off_adj)
+    bucket.update(def_adj)
+    return bucket

--- a/sportsdataverse/mbb/mbb_ncaa_lineup_aggregation.py
+++ b/sportsdataverse/mbb/mbb_ncaa_lineup_aggregation.py
@@ -45,6 +45,9 @@ _SHOT_SRC = {  # emitted-stem -> (fg-attr) ; each expands to _attempts/_made/_as
     "2p": "fg_2p",
     "3p": "fg_3p",
 }
+# ponytail: fga/fgm/ftm/fta/to/assist are minted for every prefix ("" / scramble_ /
+# trans_) -- plan.md T2. orb/drb/blk/stl/foul are ".total only" (base-prefix-only in
+# practice: the fixture has no total_{off,def}_{scramble,trans}_{orb,drb,blk,stl,foul}).
 _MISC_SRC = {  # emitted-stem -> attr-path-on-stats
     "fga": ("fg", "attempts"),
     "fgm": ("fg", "made"),
@@ -52,13 +55,15 @@ _MISC_SRC = {  # emitted-stem -> attr-path-on-stats
     "fta": ("ft", "attempts"),
     "to": ("to",),
     "assist": ("assist",),
+}
+_MISC_SRC_BASE_ONLY = {  # emitted-stem -> attr-path-on-stats, prefix "" only
     "orb": ("orb",),
     "drb": ("drb",),
     "blk": ("blk",),
     "stl": ("stl",),
     "foul": ("foul",),
 }
-_ASSIST_SRC = {"ast_rim": "ast_rim", "ast_mid": "ast_mid", "ast_3p": "ast_3p"}
+_ASSIST_SRC = {"ast_rim": "ast_rim", "ast_mid": "ast_mid", "ast_3p": "ast_3p"}  # prefix "" only
 
 
 def _sum_fields(s: LineupEventStats, dst: str, prefix: str, suffix: str) -> dict[str, float]:
@@ -73,16 +78,23 @@ def _sum_fields(s: LineupEventStats, dst: str, prefix: str, suffix: str) -> dict
         put(f"{stem}_attempts", _leaf(fg.attempts, suffix))
         put(f"{stem}_made", _leaf(fg.made, suffix))
         put(f"{stem}_ast", _leaf(fg.ast, suffix))
-    # misc scalars-by-clock
+    # misc scalars-by-clock (all prefixes)
     for stem, path in _MISC_SRC.items():
         node: Any = s
         for a in path:
             node = getattr(node, a)
         put(stem, _leaf(node, suffix))
-    # assist counts
-    for stem, ai_attr in _ASSIST_SRC.items():
-        ai = getattr(s, ai_attr)
-        put(stem, _leaf(ai.counts if ai is not None else None, suffix))
+    # misc scalars-by-clock (base prefix only -- ponytail: see _MISC_SRC_BASE_ONLY note)
+    if prefix == "":
+        for stem, path in _MISC_SRC_BASE_ONLY.items():
+            node = s
+            for a in path:
+                node = getattr(node, a)
+            put(stem, _leaf(node, suffix))
+        # assist counts (base prefix only)
+        for stem, ai_attr in _ASSIST_SRC.items():
+            ai = getattr(s, ai_attr)
+            put(stem, _leaf(ai.counts if ai is not None else None, suffix))
     # pts/poss are scalar totals (prefix "" here; scramble_/trans_ handled in Task 6)
     if prefix == "":
         put("pts", float(s.pts))
@@ -293,6 +305,36 @@ def _adj_fields(
     }
 
 
+def _def_3p_opp_field(
+    def_3p_rate: float, opponent_baselines: Optional[dict[str, float]]
+) -> dict[str, dict[str, float]]:
+    """``def_3p_opp`` -- externally opponent-adjusted 3P%, commonLineupAggregations.ts:461-474.
+
+    DEF-side only (the fixture's off bucket has no ``off_3p_opp`` counterpart). TS sources
+    this from an external ``vs_3p`` opponent-baseline lookup this port has no data source
+    for yet -- same divergence class as :func:`_adj_fields`.
+
+    ponytail: no-baseline fallback -- with ``opponent_baselines is None`` we can't compute
+    the real opponent-weighted 3P%, so fall back to the lineup's own raw ``def_3p`` rate
+    (already computed by :func:`_rate_fields`) rather than fabricating a value. Task 8 only
+    pins the field NAME onto the 254-key parity set, not this VALUE against the
+    baseline-minted fixture number.
+
+    Args:
+        def_3p_rate: The already-computed ``def_3p`` raw rate value (fallback source).
+        opponent_baselines: SOS baseline lookup; only ``None`` is implemented.
+
+    Returns:
+        ``{"def_3p_opp": {"value": ...}}``.
+
+    Raises:
+        NotImplementedError: If ``opponent_baselines`` is not ``None``.
+    """
+    if opponent_baselines is not None:
+        raise NotImplementedError("_def_3p_opp_field: opponent_baselines vs_3p branch not yet ported")
+    return {"def_3p_opp": {"value": def_3p_rate}}
+
+
 _T1_SUFFIXES = {"": ".total", "scramble_": ".orb", "trans_": ".early"}  # ts:31-78 shot-bucket suffix map.
 
 
@@ -386,4 +428,11 @@ def lineup_stats_bucket(
     bucket.update(def_rates)
     bucket.update(off_adj)
     bucket.update(def_adj)
+    # ponytail: off_poss/def_poss are a bare re-exposure of the base-prefix total (not a
+    # ratio) -- ts sums the same leaf into a top-level agg name alongside the bucket_script
+    # rates. duration_mins is a straight passthrough of the LineupEvent field.
+    bucket["off_poss"] = {"value": off_totals_by_prefix[""]["total_off_poss"]}
+    bucket["def_poss"] = {"value": def_totals_by_prefix[""]["total_def_poss"]}
+    bucket["duration_mins"] = {"value": ev.duration_mins}
+    bucket.update(_def_3p_opp_field(def_rates["def_3p"]["value"], opponent_baselines))
     return bucket

--- a/sportsdataverse/mbb/mbb_ncaa_lineup_aggregation.py
+++ b/sportsdataverse/mbb/mbb_ncaa_lineup_aggregation.py
@@ -185,3 +185,107 @@ def _all_rate_fields(
     for prefix in _PREFIXES:
         out.update(_rate_fields(totals_by_prefix[prefix], dst, prefix, oppo_totals_by_prefix[prefix]))
     return out
+
+
+_PLAY_TYPE_PREFIXES = ("scramble_", "trans_")  # ponytail: `_.drop(typePrefixes)` == everything but "".
+
+
+def _play_type_pts_poss(
+    off_totals_by_prefix: dict[str, dict[str, float]],
+    def_totals_by_prefix: dict[str, dict[str, float]],
+) -> dict[str, float]:
+    """``total_{dst}_{scramble_,trans_}pts`` / ``poss`` -- commonLineupAggregations.ts:342-380.
+
+    The base (prefix "") pts/poss totals are plain scalar sums already emitted by
+    ``_sum_fields`` (see its ``if prefix == ""`` branch); TS only bucket-scripts pts/poss
+    for the *other* typePrefixes (``_.drop(typePrefixes)`` == ``scramble_``/``trans_``),
+    hence this function's narrower scope.
+
+    Takes both sides' per-prefix totals (not one dst at a time, unlike ``_rate_fields``)
+    because the ``poss`` script's rebound_pct term cross-references the *opposite* dst's
+    BASE (prefix "") ``drb`` total (``total_${oppoDstPrefix}_drb``, ts:368) -- same
+    cross-side convention as this module's ``_orb`` helper.
+
+    Args:
+        off_totals_by_prefix: ``{"": {...}, "scramble_": {...}, "trans_": {...}}`` totals
+            for ``dst="off"`` (as returned by ``_sum_fields`` per prefix).
+        def_totals_by_prefix: same shape for ``dst="def"``.
+
+    Returns:
+        Flat ``total_{off,def}_{scramble_,trans_}{pts,poss}`` dict (8 keys).
+    """
+    out: dict[str, float] = {}
+    sides = {"off": (off_totals_by_prefix, def_totals_by_prefix), "def": (def_totals_by_prefix, off_totals_by_prefix)}
+    for dst, (totals_by_prefix, oppo_totals_by_prefix) in sides.items():
+        oppo_dst = "def" if dst == "off" else "off"
+        # ponytail: var_orb/var_drb are always the BASE (prefix "") totals, ts:367-368 --
+        # not re-derived per scramble_/trans_ typePrefix.
+        var_orb = totals_by_prefix[""].get(f"total_{dst}_orb", 0.0)
+        var_drb = oppo_totals_by_prefix[""].get(f"total_{oppo_dst}_drb", 0.0)
+        rebound_pct = var_orb / (var_orb + var_drb) if var_orb > 0 else 0.0
+        for prefix in _PLAY_TYPE_PREFIXES:
+            t = totals_by_prefix.get(prefix, {})
+            made3p = t.get(f"total_{dst}_{prefix}3p_made", 0.0)
+            made2p = t.get(f"total_{dst}_{prefix}2p_made", 0.0)
+            ftm = t.get(f"total_{dst}_{prefix}ftm", 0.0)
+            out[f"total_{dst}_{prefix}pts"] = 3.0 * made3p + 2.0 * made2p + ftm
+
+            fga = t.get(f"total_{dst}_{prefix}fga", 0.0)
+            fgm = t.get(f"total_{dst}_{prefix}fgm", 0.0)
+            fta = t.get(f"total_{dst}_{prefix}fta", 0.0)
+            to = t.get(f"total_{dst}_{prefix}to", 0.0)
+            fg_missed = fga - fgm  # ts:371 `def fgM = params.fga - params.fgm;`
+            out[f"total_{dst}_{prefix}poss"] = fgm + (1.0 - rebound_pct) * fg_missed + 0.475 * fta + to
+    return out
+
+
+def _adj_fields(
+    pts: float,
+    poss: float,
+    dst: str,
+    opponent_baselines: Optional[dict[str, float]],
+    avg_eff: float = 100.0,
+) -> dict[str, dict[str, float]]:
+    """``{dst}_adj_ppp`` / ``{dst}_adj_opp`` -- commonLineupAggregations.ts:443-502.
+
+    ``opponent_baselines is None`` is the only branch this port implements: TS's
+    ``properAdjEffCalc`` (hardcoded ``true``, ts:169) weighted_avg/SOS branch needs a
+    per-opponent baseline lookup (``calculateAdjEff``'s ES ``weighted_avg`` over
+    opponent efficiency) this port has no data source for yet.
+
+    ponytail: the returned value is a *faithful degenerate case* of TS's own
+    bucket_script fallback (ts:503-522: ``(var_adj_opp > 0) ? var_ppp*avgEff/var_adj_opp
+    : avgEff``), not an invented formula -- with no SOS data, ``adj_opp := avg_eff``
+    (can't compute the real weighted-avg), so
+    ``adj_ppp = var_ppp*avgEff/avgEff == var_ppp`` (raw ppp). Confirmed against the
+    analyzer's own adj_ppp *read*-site coalesce (not the query builder):
+    ``cbb-on-off-analyzer/src/utils/stats/LineupUtils.ts:1161``
+    ``const off_adj_ppp = lineup.off_adj_ppp?.value || avgEff;`` -- the consumer already
+    falls back to ``avgEff`` whenever the stored value is falsy/zero, so returning raw
+    ppp here (or ``0.0`` under the zero-poss guard) composes correctly with that
+    read-site; it does not contradict it.
+
+    Args:
+        pts: Total points for this dst/prefix bucket.
+        poss: Total possessions for this dst/prefix bucket.
+        dst: ``"off"`` or ``"def"``.
+        opponent_baselines: SOS baseline lookup; only ``None`` (no baselines) is
+            implemented.
+        avg_eff: League-average efficiency (points per 100 possessions) used as the
+            fallback constant. Defaults to ``100.0``.
+
+    Returns:
+        ``{f"{dst}_adj_ppp": {"value": ...}, f"{dst}_adj_opp": {"value": ...}}``.
+
+    Raises:
+        NotImplementedError: If ``opponent_baselines`` is not ``None`` -- the real
+            SOS-adjusted branch isn't ported yet; raising avoids silently returning the
+            degenerate fallback to a caller that expects real adjustment.
+    """
+    if opponent_baselines is not None:
+        raise NotImplementedError("_adj_fields: opponent_baselines SOS branch (TS properAdjEffCalc) not yet ported")
+    ppp = 100.0 * pts / poss if poss > 0 else 0.0
+    return {
+        f"{dst}_adj_ppp": {"value": ppp},
+        f"{dst}_adj_opp": {"value": avg_eff},
+    }

--- a/sportsdataverse/mbb/mbb_ncaa_lineup_aggregation.py
+++ b/sportsdataverse/mbb/mbb_ncaa_lineup_aggregation.py
@@ -169,3 +169,19 @@ def _rate_fields(
         for st in _ASSIST_DIST_TYPES:
             _rate(out, totals, dst, f"ast_{st}", f"ast_{st}", "assist")
     return out
+
+
+_PREFIXES = ("", "scramble_", "trans_")
+
+
+def _all_rate_fields(
+    totals_by_prefix: dict[str, dict[str, float]],
+    dst: str,
+    oppo_totals_by_prefix: dict[str, dict[str, float]],
+) -> dict[str, dict[str, float]]:
+    # ponytail: prefix loop over base/scramble_/trans_ families, commonLineupAggregations.ts:181-282.
+    # orb + assist-dist gating already lives in `_rate_fields` (prefix == "" only); no special-casing here.
+    out: dict[str, dict[str, float]] = {}
+    for prefix in _PREFIXES:
+        out.update(_rate_fields(totals_by_prefix[prefix], dst, prefix, oppo_totals_by_prefix[prefix]))
+    return out

--- a/sportsdataverse/mbb/mbb_ncaa_lineup_aggregation.py
+++ b/sportsdataverse/mbb/mbb_ncaa_lineup_aggregation.py
@@ -8,17 +8,16 @@ See dev/bigballr_port/lineup_aggregation_design.md.
 
 from __future__ import annotations
 
+from dataclasses import replace
+from functools import reduce
 from typing import Any, Optional
 
+from .mbb_ncaa_lineup_enrich import sum_event_stats
 from .mbb_ncaa_models import LineupEvent, LineupEventStats, ShotClockStats
 
 LineupStatSet = dict[str, Any]
 
-__all__ = ["LineupStatSet", "lineup_stats_bucket"]
-
-# ponytail: lineup_stats_buckets (the list-form public entry point) lands in
-# a later task (group-by producer); this task ships the single-lineup
-# assembler `lineup_stats_bucket`.
+__all__ = ["LineupStatSet", "lineup_stats_bucket", "lineup_stats_buckets"]
 
 
 def _leaf(stat: Optional[ShotClockStats], suffix: str) -> float:
@@ -436,3 +435,60 @@ def lineup_stats_bucket(
     bucket["duration_mins"] = {"value": ev.duration_mins}
     bucket.update(_def_3p_opp_field(def_rates["def_3p"]["value"], opponent_baselines))
     return bucket
+
+
+def lineup_stats_buckets(
+    evs: list[LineupEvent],
+    *,
+    avg_eff: float = 100.0,
+    opponent_baselines: Optional[dict[str, float]] = None,
+) -> list[LineupStatSet]:
+    """Group events by lineup, fold each group's stats, and mint one bucket per lineup.
+
+    Python entry point for the ES ``terms`` aggregation over ``key`` (grouping by
+    :func:`_bucket_key`) that feeds each lineup's docs into
+    ``commonLineupAggregations.ts``'s ``sum`` aggs -- see
+    ``cbb-on-off-analyzer/src/utils/es-queries/commonLineupAggregations.ts``. This
+    is the list-form producer the ``LineupStatSet`` consumers (``mbb_lineup_stats``)
+    read from; :func:`lineup_stats_bucket` handles a single already-folded event.
+
+    Args:
+        evs: Raw per-possession-chunk lineup events (``team_stats``/``opponent_stats``
+            populated by stage 1, :func:`~sportsdataverse.mbb.mbb_ncaa_lineup_enrich
+            .enrich_lineup`), one lineup's floor time possibly split across many events.
+        avg_eff: League-average efficiency passed through to each bucket.
+        opponent_baselines: SOS baseline lookup passed through to each bucket; only
+            ``None`` (no baselines) is implemented (see :func:`_adj_fields`).
+
+    Returns:
+        One :data:`LineupStatSet` per distinct lineup (:func:`_bucket_key`), in
+        first-seen order, with ``doc_count`` set to that lineup's event count.
+
+    Example:
+        Quick start::
+
+            from sportsdataverse.mbb.mbb_ncaa_lineup_aggregation import lineup_stats_buckets
+
+            buckets = lineup_stats_buckets(enriched_events)
+            buckets[0]["off_poss"]["value"]
+
+    See Also:
+        * `cbb-on-off-analyzer <https://github.com/Alex-At-Home/cbb-on-off-analyzer>`_ --
+          ``src/utils/es-queries/commonLineupAggregations.ts``, the ``terms``-agg-per-lineup
+          concept this function ports.
+    """
+    groups: dict[str, list[LineupEvent]] = {}
+    for ev in evs:
+        groups.setdefault(_bucket_key(ev), []).append(ev)
+
+    buckets = []
+    for group in groups.values():
+        folded = replace(
+            group[0],
+            team_stats=reduce(sum_event_stats, (e.team_stats for e in group)),
+            opponent_stats=reduce(sum_event_stats, (e.opponent_stats for e in group)),
+        )
+        buckets.append(
+            lineup_stats_bucket(folded, avg_eff=avg_eff, opponent_baselines=opponent_baselines, doc_count=len(group))
+        )
+    return buckets

--- a/sportsdataverse/mbb/mbb_ncaa_lineup_aggregation.py
+++ b/sportsdataverse/mbb/mbb_ncaa_lineup_aggregation.py
@@ -12,10 +12,9 @@ from dataclasses import replace
 from functools import reduce
 from typing import Any, Optional
 
+from .mbb_lineup_stats import LineupStatSet
 from .mbb_ncaa_lineup_enrich import sum_event_stats
 from .mbb_ncaa_models import LineupEvent, LineupEventStats, ShotClockStats
-
-LineupStatSet = dict[str, Any]
 
 __all__ = ["LineupStatSet", "lineup_stats_bucket", "lineup_stats_buckets"]
 
@@ -34,7 +33,10 @@ def _bucket_key(ev: LineupEvent) -> str:
 
 
 def _players_array(ev: LineupEvent) -> dict:
-    return {"hits": {"hits": [{"_source": {"players": [{"code": p.code, "id": p.id} for p in ev.players]}}]}}
+    # ponytail: unwrap PlayerId -> its raw `.name` string -- consumers (mbb_lineup_stats
+    # ._get_player_set, mbb_rapm players_baseline lookups) key on a plain string, and a
+    # PlayerId object would never equal that key (plus isn't JSON-serializable).
+    return {"hits": {"hits": [{"_source": {"players": [{"code": p.code, "id": p.id.name} for p in ev.players]}}]}}
 
 
 # (name, attribute-path-tuple)  — ponytail: commonShotAggs/commonMiscAggs, .ts:31-78
@@ -121,7 +123,15 @@ def _rate(
     num = totals.get(f"total_{dst}_{top}", 0.0)
     den = totals.get(f"total_{dst}_{bottom}", 0.0)
     # ponytail: guard den==0 too (num>0 alone can still divide by zero when the
-    # denominator field is absent/zero, e.g. a partial totals dict in tests).
+    # denominator field is absent/zero, e.g. a partial totals dict in tests). For the
+    # shot%/shot-rate/assist-rate families `top` is always a subset of `bottom` (e.g.
+    # made <= attempts), so den==0 implies num==0 there and this guard is output-identical
+    # to the TS `(num>0)?...:0` ternary. That subset property does NOT hold for `ftr`
+    # (fta/fga -- a stint can log FTs with zero FGA), `ppp` (pts/poss), and `to` (to/poss),
+    # whose denominators are independently sourced: on those, a degenerate den==0/num>0
+    # input makes TS emit `Infinity` while this guard deliberately emits 0.0 instead. That
+    # is an intentional safety divergence, not a bug -- Infinity isn't JSON-serializable and
+    # would destabilize downstream models, so 0.0 is the correct safe value here.
     out[f"{dst}_{name}"] = {"value": factor * num / den if num > 0 and den > 0 else 0.0}
 
 

--- a/sportsdataverse/mbb/mbb_ncaa_lineup_aggregation.py
+++ b/sportsdataverse/mbb/mbb_ncaa_lineup_aggregation.py
@@ -1,0 +1,36 @@
+"""Stage-2 rate-minting: raw-count LineupEventStats -> 254-field LineupStatSet bucket.
+
+Faithful port of hoop-explorer's ``commonLineupAggregations.ts`` (the Elasticsearch
+aggregation that mints per-lineup rate fields). Stage 1 (classification) is
+``mbb_ncaa_lineup_enrich``; stage 3 (on/off re-weighting) is ``mbb_lineup_stats``.
+See dev/bigballr_port/lineup_aggregation_design.md.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from .mbb_ncaa_models import LineupEvent, ShotClockStats
+
+LineupStatSet = dict[str, Any]
+
+# ponytail: __all__ omitted -- lineup_stats_bucket/lineup_stats_buckets (the
+# public entry points) land in a later task; this task ships only the
+# underscore-prefixed accessors + the LineupStatSet alias.
+
+
+def _leaf(stat: Optional[ShotClockStats], suffix: str) -> float:
+    # ponytail: ES leaf selector, commonLineupAggregations.ts:171-180 suffix map.
+    if stat is None:
+        return 0.0
+    attr = suffix.lstrip(".")  # ".total" -> "total"
+    val = getattr(stat, attr, None)
+    return float(val) if val is not None else 0.0
+
+
+def _bucket_key(ev: LineupEvent) -> str:
+    return "_".join(sorted(p.code for p in ev.players))
+
+
+def _players_array(ev: LineupEvent) -> dict:
+    return {"hits": {"hits": [{"_source": {"players": [{"code": p.code, "id": p.id} for p in ev.players]}}]}}

--- a/sportsdataverse/parsed/mbb.py
+++ b/sportsdataverse/parsed/mbb.py
@@ -354,6 +354,8 @@ from sportsdataverse.mbb import kmeans_fit as kmeans_fit  # noqa: F401
 from sportsdataverse.mbb import lineup_as_raw_clumps as lineup_as_raw_clumps  # noqa: F401
 from sportsdataverse.mbb import lineup_balancer as lineup_balancer  # noqa: F401
 from sportsdataverse.mbb import lineup_fixer as lineup_fixer  # noqa: F401
+from sportsdataverse.mbb import lineup_stats_bucket as lineup_stats_bucket  # noqa: F401
+from sportsdataverse.mbb import lineup_stats_buckets as lineup_stats_buckets  # noqa: F401
 from sportsdataverse.mbb import lineup_to_team_report as lineup_to_team_report  # noqa: F401
 from sportsdataverse.mbb import load_artifact as load_artifact  # noqa: F401
 from sportsdataverse.mbb import load_mbb_game_rosters as load_mbb_game_rosters  # noqa: F401
@@ -856,6 +858,8 @@ __all__ = [
     "lineup_as_raw_clumps",
     "lineup_balancer",
     "lineup_fixer",
+    "lineup_stats_bucket",
+    "lineup_stats_buckets",
     "lineup_to_team_report",
     "load_artifact",
     "load_mbb_game_rosters",

--- a/tests/mbb/test_mbb_ncaa_lineup_aggregation.py
+++ b/tests/mbb/test_mbb_ncaa_lineup_aggregation.py
@@ -214,3 +214,41 @@ def test_scramble_and_trans_rates_emitted():
     assert fields["off_scramble_ppp"]["value"] == 100.0 * 6.0 / 10.0
     assert fields["off_trans_3p"]["value"] == 1.0 / 3.0
     assert "off_scramble_orb" not in fields  # orb is prefix "" only
+
+
+def test_play_type_pts_poss_formula():
+    # TS :342-380 -- pts = 3*made3p + 2*made2p + ftm; poss = fgm + (1-rebound_pct)*fgMiss
+    # + 0.475*fta + to, rebound_pct from the BASE (prefix "") cross-side orb/drb.
+    off_totals = {
+        "": {"total_off_orb": 4.0},
+        "scramble_": {
+            "total_off_scramble_3p_made": 2.0,
+            "total_off_scramble_2p_made": 1.0,
+            "total_off_scramble_ftm": 3.0,
+            "total_off_scramble_fga": 10.0,
+            "total_off_scramble_fgm": 4.0,
+            "total_off_scramble_fta": 4.0,
+            "total_off_scramble_to": 2.0,
+        },
+        "trans_": {},
+    }
+    def_totals = {"": {"total_def_drb": 6.0}, "scramble_": {}, "trans_": {}}
+    out = agg._play_type_pts_poss(off_totals, def_totals)
+    assert out["total_off_scramble_pts"] == 3.0 * 2.0 + 2.0 * 1.0 + 3.0  # 11.0
+    rebound_pct = 4.0 / (4.0 + 6.0)
+    fg_missed = 10.0 - 4.0
+    expected_poss = 4.0 + (1.0 - rebound_pct) * fg_missed + 0.475 * 4.0 + 2.0
+    assert out["total_off_scramble_poss"] == expected_poss
+    assert out["total_off_trans_pts"] == 0.0
+    assert out["total_def_scramble_pts"] == 0.0  # def-side totals empty here
+
+
+def test_adj_ppp_fallback_equals_raw_ppp_when_no_baselines():
+    f = agg._adj_fields(pts=30.0, poss=25.0, dst="off", opponent_baselines=None, avg_eff=100.0)
+    assert f["off_adj_ppp"]["value"] == 100.0 * 30.0 / 25.0  # faithful fallback
+    assert f["off_adj_opp"]["value"] == 100.0  # avg_eff
+
+
+def test_adj_ppp_zero_poss_guarded():
+    f = agg._adj_fields(pts=0.0, poss=0.0, dst="off", opponent_baselines=None, avg_eff=100.0)
+    assert f["off_adj_ppp"]["value"] == 0.0

--- a/tests/mbb/test_mbb_ncaa_lineup_aggregation.py
+++ b/tests/mbb/test_mbb_ncaa_lineup_aggregation.py
@@ -288,10 +288,10 @@ def _full_stats(pts: int, poss: int) -> LineupEventStats:
     )
 
 
-def _enriched_lineup_event() -> LineupEvent:
+def _enriched_lineup_event(off_pts: int = 20, off_poss: int = 15) -> LineupEvent:
     players = [PlayerCodeId(code=c, id=c) for c in ["JaSmith", "AaWiggins", "ErAyala", "AnCowan", "DaMorsell"]]
     ev = _minimal_lineup_event(players)
-    ev.team_stats = _full_stats(pts=20, poss=15)
+    ev.team_stats = _full_stats(pts=off_pts, poss=off_poss)
     ev.opponent_stats = _full_stats(pts=18, poss=16)
     return ev
 
@@ -321,3 +321,13 @@ def test_bucket_matches_254_fixture_field_set():
     produced = set(agg.lineup_stats_bucket(ev)) - {"doc_count", "key", "players_array"}
     expected = _fixture_field_names()
     assert produced == expected, f"missing={expected - produced}  extra={produced - expected}"
+
+
+def test_two_events_same_lineup_fold_into_one_bucket():
+    e1 = _enriched_lineup_event(off_pts=10, off_poss=8)
+    e2 = _enriched_lineup_event(off_pts=6, off_poss=5)  # same players
+    buckets = agg.lineup_stats_buckets([e1, e2])
+    assert len(buckets) == 1
+    assert buckets[0]["doc_count"] == 2
+    assert buckets[0]["total_off_pts"]["value"] == 16.0
+    assert buckets[0]["total_off_poss"]["value"] == 13.0

--- a/tests/mbb/test_mbb_ncaa_lineup_aggregation.py
+++ b/tests/mbb/test_mbb_ncaa_lineup_aggregation.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from sportsdataverse.mbb.mbb_ncaa_models import (
+    AssistInfo,
     FieldGoalStats,
     LineupEvent,
     LineupEventStats,
@@ -15,6 +16,66 @@ from sportsdataverse.mbb.mbb_ncaa_models import (
     Year,
 )
 from sportsdataverse.mbb import mbb_ncaa_lineup_aggregation as agg
+
+# T3 base-prefix (prefix="") off_* rate names -- commonAverageAggs.ts:291-397.
+BASE_OFF_RATE_NAMES = {
+    "off_2p",
+    "off_2p_ast",
+    "off_3p",
+    "off_3p_ast",
+    "off_2prim",
+    "off_2prim_ast",
+    "off_2pmid",
+    "off_2pmid_ast",
+    "off_ft",
+    "off_ftr",
+    "off_2primr",
+    "off_2pmidr",
+    "off_3pr",
+    "off_assist",
+    "off_ppp",
+    "off_to",
+    "off_efg",
+    "off_orb",
+    "off_ast_rim",
+    "off_ast_mid",
+    "off_ast_3p",
+}
+
+
+def _full_synthetic_totals(dst: str, prefix: str) -> dict[str, float]:
+    """Every ``total_{dst}_{prefix}*`` stem set to ``1.0``.
+
+    Derived by running :func:`agg._sum_fields` over a fully populated
+    synthetic :class:`LineupEventStats` (every leaf ``.total`` == 1) rather
+    than hand-enumerating stems, so this helper can't drift from the
+    module's actual ``_sum_fields`` output shape.
+    """
+    one = ShotClockStats(total=1)
+    fg_full = FieldGoalStats(
+        attempts=ShotClockStats(total=1), made=ShotClockStats(total=1), ast=ShotClockStats(total=1)
+    )
+    s = LineupEventStats(
+        fg=fg_full,
+        fg_rim=fg_full,
+        fg_mid=fg_full,
+        fg_2p=fg_full,
+        fg_3p=fg_full,
+        ft=fg_full,
+        orb=one,
+        drb=one,
+        to=ShotClockStats(total=1),
+        stl=one,
+        blk=one,
+        assist=one,
+        ast_rim=AssistInfo(counts=one),
+        ast_mid=AssistInfo(counts=one),
+        ast_3p=AssistInfo(counts=one),
+        foul=one,
+        pts=1,
+        num_possessions=1,
+    )
+    return agg._sum_fields(s, dst=dst, prefix=prefix, suffix=".total")
 
 
 def _minimal_lineup_event(players: list[PlayerCodeId]) -> LineupEvent:
@@ -124,3 +185,10 @@ def test_orb_rate_uses_cross_side_drb():
     oppo = {"total_def_drb": 14.0}
     fields = agg._rate_fields(totals, dst="off", prefix="", oppo_totals=oppo)
     assert fields["off_orb"]["value"] == 6.0 / (6.0 + 14.0)
+
+
+def test_base_prefix_emits_all_rate_names():
+    totals = _full_synthetic_totals("off", "")
+    fields = agg._rate_fields(totals, dst="off", prefix="", oppo_totals=_full_synthetic_totals("def", ""))
+    missing = BASE_OFF_RATE_NAMES - set(fields)
+    assert not missing, f"missing rate fields: {missing}"

--- a/tests/mbb/test_mbb_ncaa_lineup_aggregation.py
+++ b/tests/mbb/test_mbb_ncaa_lineup_aggregation.py
@@ -92,3 +92,35 @@ def test_sum_fields_scramble_prefix_reads_orb():
     s = _stats_with_rim(att_total=8, made_total=5, att_orb=3)
     out = agg._sum_fields(s, dst="off", prefix="scramble_", suffix=".orb")
     assert out["total_off_scramble_2prim_attempts"] == 3.0  # .orb leaf
+
+
+def test_rate_guarded_formula_and_ppp_factor():
+    totals = {
+        "total_off_2prim_made": 5.0,
+        "total_off_2prim_attempts": 8.0,
+        "total_off_pts": 12.0,
+        "total_off_poss": 20.0,
+        "total_off_2prim_attempts_zero": 0.0,
+    }
+    fields = agg._rate_fields(totals, dst="off", prefix="", oppo_totals={})
+    assert fields["off_2prim"]["value"] == 5.0 / 8.0  # cross-check ES off_2prim
+    assert fields["off_ppp"]["value"] == 100.0 * 12.0 / 20.0
+
+
+def test_rate_zero_guard_returns_zero_not_nan():
+    totals = {"total_off_3p_made": 0.0, "total_off_3p_attempts": 0.0}
+    fields = agg._rate_fields(totals, dst="off", prefix="", oppo_totals={})
+    assert fields["off_3p"]["value"] == 0.0  # (num>0)?...:0 guard
+
+
+def test_efg_weights_threes_by_1_5():
+    totals = {"total_off_fga": 10.0, "total_off_2p_made": 3.0, "total_off_3p_made": 2.0}
+    fields = agg._rate_fields(totals, dst="off", prefix="", oppo_totals={})
+    assert fields["off_efg"]["value"] == (1.0 * 3.0 + 1.5 * 2.0) / 10.0
+
+
+def test_orb_rate_uses_cross_side_drb():
+    totals = {"total_off_orb": 6.0}
+    oppo = {"total_def_drb": 14.0}
+    fields = agg._rate_fields(totals, dst="off", prefix="", oppo_totals=oppo)
+    assert fields["off_orb"]["value"] == 6.0 / (6.0 + 14.0)

--- a/tests/mbb/test_mbb_ncaa_lineup_aggregation.py
+++ b/tests/mbb/test_mbb_ncaa_lineup_aggregation.py
@@ -1,3 +1,5 @@
+import json
+import pathlib
 from datetime import datetime
 
 from sportsdataverse.mbb.mbb_ncaa_models import (
@@ -16,6 +18,8 @@ from sportsdataverse.mbb.mbb_ncaa_models import (
     Year,
 )
 from sportsdataverse.mbb import mbb_ncaa_lineup_aggregation as agg
+
+FIX = pathlib.Path(__file__).parent.parent / "fixtures" / "hoop_explorer" / "lineup_utils_inputs.json"
 
 # T3 base-prefix (prefix="") off_* rate names -- commonAverageAggs.ts:291-397.
 BASE_OFF_RATE_NAMES = {
@@ -304,3 +308,16 @@ def test_bucket_has_structural_keys_and_wrapped_fields():
     # Step 3's ordering requirement: play-type pts/poss must be folded into the
     # per-prefix totals BEFORE minting rates, else off_scramble_ppp reads 0.
     assert b["off_scramble_ppp"]["value"] != 0.0
+
+
+def _fixture_field_names() -> set[str]:
+    d = json.loads(FIX.read_text(encoding="utf-8"))
+    b = d["sampleLineupStatsResponse"]["responses"][0]["aggregations"]["lineups"]["buckets"][0]
+    return set(b) - {"doc_count", "key", "players_array"}  # 254 agg fields
+
+
+def test_bucket_matches_254_fixture_field_set():
+    ev = _enriched_lineup_event()
+    produced = set(agg.lineup_stats_bucket(ev)) - {"doc_count", "key", "players_array"}
+    expected = _fixture_field_names()
+    assert produced == expected, f"missing={expected - produced}  extra={produced - expected}"

--- a/tests/mbb/test_mbb_ncaa_lineup_aggregation.py
+++ b/tests/mbb/test_mbb_ncaa_lineup_aggregation.py
@@ -1,0 +1,65 @@
+from datetime import datetime
+
+from sportsdataverse.mbb.mbb_ncaa_models import (
+    LineupEvent,
+    LineupEventStats,
+    LineupId,
+    LocationType,
+    PlayerCodeId,
+    Score,
+    ScoreInfo,
+    ShotClockStats,
+    TeamId,
+    TeamSeasonId,
+    Year,
+)
+from sportsdataverse.mbb import mbb_ncaa_lineup_aggregation as agg
+
+
+def _minimal_lineup_event(players: list[PlayerCodeId]) -> LineupEvent:
+    team = TeamSeasonId(team=TeamId(name="Duke"), year=Year(value=2024))
+    opponent = TeamSeasonId(team=TeamId(name="UNC"), year=Year(value=2024))
+    return LineupEvent(
+        date=datetime(2024, 1, 1),
+        location_type=LocationType.HOME,
+        start_min=0.0,
+        end_min=1.0,
+        duration_mins=1.0,
+        score_info=ScoreInfo(
+            start=Score(scored=0, allowed=0),
+            end=Score(scored=0, allowed=0),
+            start_diff=0,
+            end_diff=0,
+        ),
+        team=team,
+        opponent=opponent,
+        lineup_id=LineupId.unknown,
+        players=players,
+        players_in=[],
+        players_out=[],
+        raw_game_events=[],
+        team_stats=LineupEventStats.empty(),
+        opponent_stats=LineupEventStats.empty(),
+    )
+
+
+def test_leaf_selects_suffix_and_coalesces_none():
+    s = ShotClockStats(total=10, orb=3, early=2)
+    assert agg._leaf(s, ".total") == 10.0
+    assert agg._leaf(s, ".orb") == 3.0
+    assert agg._leaf(s, ".early") == 2.0
+    assert agg._leaf(None, ".total") == 0.0  # Optional stat → 0
+    assert agg._leaf(ShotClockStats(total=5), ".orb") == 0.0  # None leaf → 0
+
+
+def test_bucket_key_is_sorted_codes_joined():
+    players = [PlayerCodeId(code=c, id=c) for c in ["JaSmith", "AaWiggins", "ErAyala", "AnCowan", "DaMorsell"]]
+    ev = _minimal_lineup_event(players)
+    assert agg._bucket_key(ev) == "AaWiggins_AnCowan_DaMorsell_ErAyala_JaSmith"
+
+
+def test_players_array_is_top_hits_shaped():
+    players = [PlayerCodeId(code="AaWiggins", id="Wiggins, Aaron")]
+    ev = _minimal_lineup_event(players)
+    pa = agg._players_array(ev)
+    assert pa["hits"]["hits"][0]["_source"]["players"] == [{"code": "AaWiggins", "id": "Wiggins, Aaron"}]

--- a/tests/mbb/test_mbb_ncaa_lineup_aggregation.py
+++ b/tests/mbb/test_mbb_ncaa_lineup_aggregation.py
@@ -192,3 +192,25 @@ def test_base_prefix_emits_all_rate_names():
     fields = agg._rate_fields(totals, dst="off", prefix="", oppo_totals=_full_synthetic_totals("def", ""))
     missing = BASE_OFF_RATE_NAMES - set(fields)
     assert not missing, f"missing rate fields: {missing}"
+
+
+def test_scramble_and_trans_rates_emitted():
+    tp = {
+        "": _full_synthetic_totals("off", ""),
+        "scramble_": {
+            "total_off_scramble_2prim_made": 2.0,
+            "total_off_scramble_2prim_attempts": 4.0,
+            "total_off_scramble_pts": 6.0,
+            "total_off_scramble_poss": 10.0,
+        },
+        "trans_": {"total_off_trans_3p_made": 1.0, "total_off_trans_3p_attempts": 3.0},
+    }
+    fields = agg._all_rate_fields(
+        tp,
+        dst="off",
+        oppo_totals_by_prefix={"": _full_synthetic_totals("def", ""), "scramble_": {}, "trans_": {}},
+    )
+    assert fields["off_scramble_2prim"]["value"] == 2.0 / 4.0
+    assert fields["off_scramble_ppp"]["value"] == 100.0 * 6.0 / 10.0
+    assert fields["off_trans_3p"]["value"] == 1.0 / 3.0
+    assert "off_scramble_orb" not in fields  # orb is prefix "" only

--- a/tests/mbb/test_mbb_ncaa_lineup_aggregation.py
+++ b/tests/mbb/test_mbb_ncaa_lineup_aggregation.py
@@ -10,6 +10,7 @@ from sportsdataverse.mbb.mbb_ncaa_models import (
     LineupId,
     LocationType,
     PlayerCodeId,
+    PlayerId,
     Score,
     ScoreInfo,
     ShotClockStats,
@@ -119,16 +120,23 @@ def test_leaf_selects_suffix_and_coalesces_none():
 
 
 def test_bucket_key_is_sorted_codes_joined():
-    players = [PlayerCodeId(code=c, id=c) for c in ["JaSmith", "AaWiggins", "ErAyala", "AnCowan", "DaMorsell"]]
+    players = [
+        PlayerCodeId(code=c, id=PlayerId(name=c)) for c in ["JaSmith", "AaWiggins", "ErAyala", "AnCowan", "DaMorsell"]
+    ]
     ev = _minimal_lineup_event(players)
     assert agg._bucket_key(ev) == "AaWiggins_AnCowan_DaMorsell_ErAyala_JaSmith"
 
 
 def test_players_array_is_top_hits_shaped():
-    players = [PlayerCodeId(code="AaWiggins", id="Wiggins, Aaron")]
+    players = [PlayerCodeId(code="AaWiggins", id=PlayerId(name="Wiggins, Aaron"))]
     ev = _minimal_lineup_event(players)
     pa = agg._players_array(ev)
-    assert pa["hits"]["hits"][0]["_source"]["players"] == [{"code": "AaWiggins", "id": "Wiggins, Aaron"}]
+    # `id` must be unwrapped to the raw string (not a PlayerId object) -- consumers
+    # (mbb_lineup_stats._get_player_set, mbb_rapm players_baseline lookups) key on
+    # a plain string, and a PlayerId object would never equal that key.
+    out_player = pa["hits"]["hits"][0]["_source"]["players"][0]
+    assert out_player == {"code": "AaWiggins", "id": "Wiggins, Aaron"}
+    assert isinstance(out_player["id"], str)
 
 
 def _stats_with_rim(att_total, made_total, att_orb=0):
@@ -289,7 +297,9 @@ def _full_stats(pts: int, poss: int) -> LineupEventStats:
 
 
 def _enriched_lineup_event(off_pts: int = 20, off_poss: int = 15) -> LineupEvent:
-    players = [PlayerCodeId(code=c, id=c) for c in ["JaSmith", "AaWiggins", "ErAyala", "AnCowan", "DaMorsell"]]
+    players = [
+        PlayerCodeId(code=c, id=PlayerId(name=c)) for c in ["JaSmith", "AaWiggins", "ErAyala", "AnCowan", "DaMorsell"]
+    ]
     ev = _minimal_lineup_event(players)
     ev.team_stats = _full_stats(pts=off_pts, poss=off_poss)
     ev.opponent_stats = _full_stats(pts=18, poss=16)
@@ -305,6 +315,12 @@ def test_bucket_has_structural_keys_and_wrapped_fields():
     assert isinstance(b["off_ppp"], dict) and "value" in b["off_ppp"]
     assert isinstance(b["def_ppp"], dict) and "value" in b["def_ppp"]
     assert isinstance(b["total_off_fga"], dict)
+    # Regression for the PlayerId-leak bug: player "id" must be a plain string (not a
+    # PlayerId dataclass instance), both for JSON-serializability and so downstream
+    # dict-keyed lookups (mbb_lineup_stats._get_player_set, mbb_rapm players_baseline)
+    # actually hit.
+    assert isinstance(b["players_array"]["hits"]["hits"][0]["_source"]["players"][0]["id"], str)
+    json.dumps(b)
     # Step 3's ordering requirement: play-type pts/poss must be folded into the
     # per-prefix totals BEFORE minting rates, else off_scramble_ppp reads 0.
     assert b["off_scramble_ppp"]["value"] != 0.0

--- a/tests/mbb/test_mbb_ncaa_lineup_aggregation.py
+++ b/tests/mbb/test_mbb_ncaa_lineup_aggregation.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from sportsdataverse.mbb.mbb_ncaa_models import (
+    FieldGoalStats,
     LineupEvent,
     LineupEventStats,
     LineupId,
@@ -63,3 +64,31 @@ def test_players_array_is_top_hits_shaped():
     ev = _minimal_lineup_event(players)
     pa = agg._players_array(ev)
     assert pa["hits"]["hits"][0]["_source"]["players"] == [{"code": "AaWiggins", "id": "Wiggins, Aaron"}]
+
+
+def _stats_with_rim(att_total, made_total, att_orb=0):
+    s = LineupEventStats()
+    s.fg_rim = FieldGoalStats(
+        attempts=ShotClockStats(total=att_total, orb=att_orb),
+        made=ShotClockStats(total=made_total),
+    )
+    s.fg = FieldGoalStats(attempts=ShotClockStats(total=att_total))
+    s.pts = 12
+    s.num_possessions = 20
+    return s
+
+
+def test_sum_fields_base_prefix_reads_total():
+    s = _stats_with_rim(att_total=8, made_total=5)
+    out = agg._sum_fields(s, dst="off", prefix="", suffix=".total")
+    assert out["total_off_2prim_attempts"] == 8.0
+    assert out["total_off_2prim_made"] == 5.0
+    assert out["total_off_fga"] == 8.0
+    assert out["total_off_pts"] == 12.0  # scalar, prefix "" only
+    assert out["total_off_poss"] == 20.0
+
+
+def test_sum_fields_scramble_prefix_reads_orb():
+    s = _stats_with_rim(att_total=8, made_total=5, att_orb=3)
+    out = agg._sum_fields(s, dst="off", prefix="scramble_", suffix=".orb")
+    assert out["total_off_scramble_2prim_attempts"] == 3.0  # .orb leaf

--- a/tests/mbb/test_mbb_ncaa_lineup_aggregation.py
+++ b/tests/mbb/test_mbb_ncaa_lineup_aggregation.py
@@ -252,3 +252,55 @@ def test_adj_ppp_fallback_equals_raw_ppp_when_no_baselines():
 def test_adj_ppp_zero_poss_guarded():
     f = agg._adj_fields(pts=0.0, poss=0.0, dst="off", opponent_baselines=None, avg_eff=100.0)
     assert f["off_adj_ppp"]["value"] == 0.0
+
+
+def _full_stats(pts: int, poss: int) -> LineupEventStats:
+    # ponytail: every ShotClockStats.total/orb/early set equal so all 3 prefixes
+    # (""/"scramble_"/"trans_") read nonzero data -- exercises the play-type
+    # pts/poss merge, not just the base "" family.
+    def sc(v: int) -> ShotClockStats:
+        return ShotClockStats(total=v, orb=v, early=v)
+
+    fg_full = FieldGoalStats(attempts=sc(10), made=sc(5), ast=sc(3))
+    return LineupEventStats(
+        fg=fg_full,
+        fg_rim=fg_full,
+        fg_mid=fg_full,
+        fg_2p=fg_full,
+        fg_3p=fg_full,
+        ft=fg_full,
+        orb=sc(4),
+        drb=sc(6),
+        to=sc(2),
+        stl=sc(1),
+        blk=sc(1),
+        assist=sc(3),
+        ast_rim=AssistInfo(counts=sc(1)),
+        ast_mid=AssistInfo(counts=sc(1)),
+        ast_3p=AssistInfo(counts=sc(1)),
+        foul=sc(1),
+        pts=pts,
+        num_possessions=poss,
+    )
+
+
+def _enriched_lineup_event() -> LineupEvent:
+    players = [PlayerCodeId(code=c, id=c) for c in ["JaSmith", "AaWiggins", "ErAyala", "AnCowan", "DaMorsell"]]
+    ev = _minimal_lineup_event(players)
+    ev.team_stats = _full_stats(pts=20, poss=15)
+    ev.opponent_stats = _full_stats(pts=18, poss=16)
+    return ev
+
+
+def test_bucket_has_structural_keys_and_wrapped_fields():
+    ev = _enriched_lineup_event()
+    b = agg.lineup_stats_bucket(ev, doc_count=7)
+    assert b["key"] == agg._bucket_key(ev)
+    assert b["players_array"]["hits"]["hits"][0]["_source"]["players"]
+    assert b["doc_count"] == 7
+    assert isinstance(b["off_ppp"], dict) and "value" in b["off_ppp"]
+    assert isinstance(b["def_ppp"], dict) and "value" in b["def_ppp"]
+    assert isinstance(b["total_off_fga"], dict)
+    # Step 3's ordering requirement: play-type pts/poss must be folded into the
+    # per-prefix totals BEFORE minting rates, else off_scramble_ppp reads 0.
+    assert b["off_scramble_ppp"]["value"] != 0.0

--- a/tests/mbb/test_mbb_ncaa_lineup_aggregation_e2e.py
+++ b/tests/mbb/test_mbb_ncaa_lineup_aggregation_e2e.py
@@ -1,0 +1,85 @@
+"""End-to-end payoff proof (Task 10): a real committed NCAA game HTML page
+driven through the full pipeline -- parse -> lineup stints -> enrich ->
+:func:`~sportsdataverse.mbb.mbb_ncaa_lineup_aggregation.lineup_stats_buckets`
+-> :func:`~sportsdataverse.mbb.mbb_lineup_stats.calculate_aggregated_lineup_stats`
+-> :func:`~sportsdataverse.mbb.mbb_rapm.build_player_context`.
+
+Game: contest 5722355 (South Carolina 92-60 Coppin St., 2024-11-14),
+``tests/fixtures/ncaa/bigballr/html/pbp_5722355.html`` +
+``individual_stats_5722355.html``. Chosen over ``pbp_1613299`` /
+``pbp_6479639`` per the task brief (those carry a technical/flagrant); this
+is a "clean" blowout game. Although captured for the WBB surface, the
+underlying parser is a shared core -- ``sportsdataverse.wbb.wbb_ncaa_pbp_parser``
+is a verified identity re-export of ``sportsdataverse.mbb.mbb_ncaa_pbp_parser``
+(see ``tests/wbb/test_wbb_ncaa_pbp_parser.py``), so this fixture exercises
+the exact same MBB code under test.
+
+The parse/enrich call sequence (``get_box_lineup`` then ``create_lineup_data``)
+is copied verbatim from
+``tests/mbb/test_mbb_ncaa_v1_live.py::test_create_lineup_data_v1_end_to_end``
+-- ``create_lineup_data`` internally chains ``enrich_lineup`` as step 4 of its
+5a-5d pipeline (see its docstring), so the returned lineup events are already
+enriched.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sportsdataverse.mbb import mbb_ncaa_lineup_aggregation as agg
+from sportsdataverse.mbb.mbb_lineup_stats import calculate_aggregated_lineup_stats, lineup_to_team_report
+from sportsdataverse.mbb.mbb_ncaa_boxscore_parser import get_box_lineup
+from sportsdataverse.mbb.mbb_ncaa_data_quality import ParseError
+from sportsdataverse.mbb.mbb_ncaa_models import LineupEvent, TeamId
+from sportsdataverse.mbb.mbb_ncaa_pbp_parser import create_lineup_data
+from sportsdataverse.mbb.mbb_rapm import DEFAULT_RAPM_CONFIG, build_player_context
+
+_FIX = Path(__file__).resolve().parents[1] / "fixtures" / "ncaa" / "bigballr" / "html"
+_PBP_HTML = (_FIX / "pbp_5722355.html").read_text(encoding="utf-8")
+_BOX_HTML = (_FIX / "individual_stats_5722355.html").read_text(encoding="utf-8")
+
+_TEAM = "South Carolina"
+
+
+def _load_and_enrich_one_game() -> list[LineupEvent]:
+    """Parse -> lineup-stint -> enrich, via the exact call sequence copied
+    from ``test_create_lineup_data_v1_end_to_end`` (``format_version=1``, the
+    2018+ layout -- this is a 2024-11-14 capture)."""
+    box_lineup = get_box_lineup("individual_stats_5722355.html", _BOX_HTML, TeamId(_TEAM), format_version=1)
+    assert not isinstance(box_lineup, list), box_lineup  # not list[ParseError]
+
+    result = create_lineup_data("pbp_5722355.html", _PBP_HTML, box_lineup, format_version=1)
+    assert not isinstance(result, list) or not any(isinstance(e, ParseError) for e in result), result
+    lineup_events, _bad_lineup_events = result
+    return lineup_events
+
+
+def test_real_game_buckets_feed_aggregation_and_rapm() -> None:
+    events = _load_and_enrich_one_game()
+    assert len(events) > 0
+
+    buckets = agg.lineup_stats_buckets(events)
+    assert len(buckets) > 0
+
+    # CORE: stage-2 (aggregation-module) buckets feed stage-3
+    # (mbb_lineup_stats) without error, on real data.
+    agg_team = calculate_aggregated_lineup_stats(buckets)
+    assert agg_team["off_poss"]["value"] > 0
+
+    # RAPM smoke: build_player_context must RUN on the real buckets. No real
+    # D1 per-player baselines exist for this fixture's roster (same
+    # external-data gap class as adj_ppp), so players_baseline/stats_averages
+    # are passed empty -- build_priors' fallback-to-default-prior path
+    # (get_val(...) or 0.0) makes this a legitimate run, not a fabrication.
+    on_off_report = lineup_to_team_report({"lineups": buckets, "error_code": None})
+    ctx = build_player_context(
+        on_off_report.get("players") or [],
+        buckets,
+        {},
+        {},
+        100.0,
+        "value",
+        DEFAULT_RAPM_CONFIG,
+    )
+    assert ctx is not None
+    assert ctx["team_info"]["off_poss"]["value"] > 0

--- a/tests/wbb/test_wbb_ncaa_lineup_aggregation.py
+++ b/tests/wbb/test_wbb_ncaa_lineup_aggregation.py
@@ -1,0 +1,53 @@
+"""WBB parity smoke (Task 11): the real-HTML pipeline runs through the WOMENS
+path (``sportsdataverse.wbb`` parse/enrich modules) into stage-2 aggregation.
+
+Game: contest 5722355 (South Carolina 92-60 Coppin St., 2024-11-14) --
+``tests/fixtures/ncaa/bigballr/html/pbp_5722355.html`` +
+``individual_stats_5722355.html``. This is the SAME fixture the mbb e2e test
+(``tests/mbb/test_mbb_ncaa_lineup_aggregation_e2e.py``) uses: per that test's
+docstring the page was captured for the WBB surface in the first place, and
+``sportsdataverse.wbb.wbb_ncaa_pbp_parser`` / ``wbb_ncaa_boxscore_parser`` /
+``wbb_ncaa_models`` / ``wbb_ncaa_data_quality`` are verified identity
+re-exports of their mbb counterparts (``tests/wbb/test_wbb_ncaa_pbp_parser.py``
+et al.) -- there is no separate womens-flagged fixture set to reach for. This
+test therefore proves the womens import path (not a distinct womens dataset)
+drives enrich -> buckets -> :func:`calculate_aggregated_lineup_stats`
+end-to-end.
+
+Stage-2 aggregation (``lineup_stats_buckets``) has no wbb-side re-export
+module -- it's called directly from ``sportsdataverse.mbb`` per the task
+brief, same as the mbb e2e test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sportsdataverse.mbb import mbb_ncaa_lineup_aggregation as agg
+from sportsdataverse.mbb.mbb_lineup_stats import calculate_aggregated_lineup_stats
+from sportsdataverse.wbb.wbb_ncaa_boxscore_parser import get_box_lineup
+from sportsdataverse.wbb.wbb_ncaa_data_quality import ParseError
+from sportsdataverse.wbb.wbb_ncaa_models import TeamId
+from sportsdataverse.wbb.wbb_ncaa_pbp_parser import create_lineup_data
+
+_FIX = Path(__file__).resolve().parents[1] / "fixtures" / "ncaa" / "bigballr" / "html"
+_PBP_HTML = (_FIX / "pbp_5722355.html").read_text(encoding="utf-8")
+_BOX_HTML = (_FIX / "individual_stats_5722355.html").read_text(encoding="utf-8")
+
+_TEAM = "South Carolina"
+
+
+def test_wbb_real_game_buckets_feed_aggregation() -> None:
+    box_lineup = get_box_lineup("individual_stats_5722355.html", _BOX_HTML, TeamId(_TEAM), format_version=1)
+    assert not isinstance(box_lineup, list), box_lineup  # not list[ParseError]
+
+    result = create_lineup_data("pbp_5722355.html", _PBP_HTML, box_lineup, format_version=1)
+    assert not isinstance(result, list) or not any(isinstance(e, ParseError) for e in result), result
+    events, _bad_events = result
+    assert len(events) > 0
+
+    buckets = agg.lineup_stats_buckets(events)
+    assert len(buckets) > 0
+
+    agg_team = calculate_aggregated_lineup_stats(buckets)
+    assert agg_team["off_poss"]["value"] > 0


### PR DESCRIPTION
## Summary

Ports hoop-explorer's `commonLineupAggregations.ts` (the Elasticsearch lineup-stat aggregation) to Python as `sportsdataverse/mbb/mbb_ncaa_lineup_aggregation.py` — the missing **stage-2** layer that mints the 254-field `LineupStatSet` bucket from the already-ported raw-count tree.

This connects the finished college model tier to real NCAA data. The ported models (`mbb_rapm`, `mbb_lineup_stats`, `mbb_luck`, `mbb_ratings`; wbb are by-reference re-exports) consume an ES-aggregation bucket — `dict` with 254 `{"value": float}` fields — that until now came **only** from vendored jest fixtures. Nothing constructed one from real data. This PR closes that gap: real HTML game → parse → `enrich` → **`lineup_stats_buckets`** → the models run.

## What this is (and isn't)

The three-stage hoop-explorer pipeline is: (1) cbb-explorer Scala classifies events (scramble/transition/rim/mid/assisted), (2) the ES query mints rate fields, (3) `LineupUtils.ts` re-weights into on/off splits. **Stages 1 and 3 were already ported** (`mbb_ncaa_lineup_enrich`, `mbb_lineup_stats`); only stage 2 was missing. So this is a bounded, field-for-field arithmetic port — not new modeling.

## Public API

```python
from sportsdataverse.mbb import lineup_stats_bucket, lineup_stats_buckets
buckets = lineup_stats_buckets(enriched_lineup_events)   # list[LineupStatSet] the models consume
```

- `lineup_stats_bucket(ev, *, avg_eff=100.0, opponent_baselines=None, doc_count=1)` — one summed `LineupEvent` → one 254-field bucket.
- `lineup_stats_buckets(evs, ...)` — groups events by lineup, folds via `sum_event_stats`, emits the list.

Internals mirror the TS factories field-for-field (`ponytail:` comments cite the TS line): `total_*` raw sums, the guarded `(num>0)?factor*num/den:0` rate formula over the `["", "scramble_", "trans_"] × ["off","def"]` loop, eFG (1.5-weighted threes), cross-side orb rate, the play-type pts/poss recompute, and assist distribution.

## Documented divergences (honest stubs, not faithful reproductions)

Two field families need external opponent D1 baselines that don't exist in a single game. Both emit a **documented fallback** (guarded by `NotImplementedError` on the real-baseline branch, which no caller exercises), and both are the next external-data phase:

- **`adj_ppp` / `adj_opp`** — no baseline → raw ppp / `avg_eff`. Chosen so RAPM receives real per-lineup signal (a constant 100 would give it none). Diverges from the source's degenerate null→100 path; that's deliberate and user-approved, not a faithful reproduction.
- **`def_3p_opp`** — no `vs_3p` baseline → raw `def_3p` rate (DEF-only).
- **Rate `den>0` guard** — for `ftr`/`ppp`/`to` (numerator not a subset of denominator) this emits `0.0` where the TS painless yields `Infinity` on the rare `fga==0`/`poss==0` stint; a safety divergence that keeps the bucket JSON-serializable and the models stable.

## Validation (three tiers, honest oracle partition)

1. **Per-field formula parity** against the TS `commonAverageAggs` table (the authoritative oracle; the ES DSL sample farms most rates out to external `$$script_field()` templates).
2. **254-field shape parity** vs `tests/fixtures/hoop_explorer/lineup_utils_inputs.json` — **name-set only**; the 4 `adj_*` values are pinned to the fallback formula, never bug-matched to the baseline-minted fixture value.
3. **End-to-end** — real committed HTML game (`pbp_5722355`) → parse → enrich → buckets → `calculate_aggregated_lineup_stats` + RAPM `build_player_context`, all run on real data.

`tests/mbb` suite: **861 passed, 4 skipped**, mypy + ruff clean, reference docs regenerated (no `uv.lock` bump).

## Review

Whole-branch review + `sdv-toolkit:port-parity-reviewer`. The parity reviewer caught one MUST-FIX the general review missed: `players_array.id` leaked a `PlayerId` dataclass where consumers expect a plain string (would silently miss every real baseline lookup + break JSON) — **masked** by tests using bare-string ids and empty baselines. Fixed (`p.id.name`), the unit tests switched to the real `PlayerId` wrapper, and a `json.dumps` + `isinstance(..., str)` regression added.

## Notes

- MBB module; wbb runs free via the existing re-exports (smoke test included).
- Does not touch the parallel bigballR `ncaa_mbb_lineups` frame (different lineage — this reads `mbb_ncaa_lineup_enrich`).
- Opponent-baseline table for the adj/`def_3p_opp` fields is a follow-up phase (gated on season data).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lineup statistics aggregation for NCAA basketball, including totals, rates, possessions, player details, and lineup-level buckets.
  * Exposed the new aggregation functions through the primary and legacy basketball namespaces.
  * Added public API reference documentation for the new functions.

* **Documentation**
  * Updated the MBB reference to reflect 302 additional functions.

* **Tests**
  * Added comprehensive unit and real-game coverage for men’s and women’s lineup aggregation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->