### PR TITLE
fix(mbb): pace NcaaFetcher proxy rotation with an inter-rotation backoff

### DIFF
--- a/docs/docs/mbb/reference/additional.md
+++ b/docs/docs/mbb/reference/additional.md
@@ -971,7 +971,7 @@ The set of players on the floor, as an opaque id string
 
 Game location (`Game.LocationType`, `Game.scala:36-38`).
 
-### `NcaaFetchConfig(cache_dir: 'Optional[Path]' = None, proxy_url: 'Optional[str]' = None, proxybonanza_key: 'Optional[str]' = None, proxybonanza_pkg: 'Optional[str]' = None, timeout: 'int' = 45, impersonate: 'str' = 'chrome', max_retries: 'int' = 2, transport: 'Optional[FetchTransport]' = None) -> None` {#NcaaFetchConfig}
+### `NcaaFetchConfig(cache_dir: 'Optional[Path]' = None, proxy_url: 'Optional[str]' = None, proxybonanza_key: 'Optional[str]' = None, proxybonanza_pkg: 'Optional[str]' = None, timeout: 'int' = 45, impersonate: 'str' = 'chrome', max_retries: 'int' = 2, rotation_backoff: 'float' = 1.0, transport: 'Optional[FetchTransport]' = None) -> None` {#NcaaFetchConfig}
 
 Runtime configuration for the stats.ncaa.org fetch layer.
 
@@ -990,6 +990,7 @@ via `proxybonanza_key` + `proxybonanza_pkg` (resolved lazily by
 | `timeout` | `int` | `45` |  |
 | `impersonate` | `str` | `'chrome'` |  |
 | `max_retries` | `int` | `2` |  |
+| `rotation_backoff` | `float` | `1.0` |  |
 | `transport` | `Optional[FetchTransport]` | `None` |  |
 
 **Example**

--- a/docs/docs/wbb/reference/additional.md
+++ b/docs/docs/wbb/reference/additional.md
@@ -1064,7 +1064,7 @@ The set of players on the floor, as an opaque id string
 
 Game location (`Game.LocationType`, `Game.scala:36-38`).
 
-### `NcaaFetchConfig(cache_dir: 'Optional[Path]' = None, proxy_url: 'Optional[str]' = None, proxybonanza_key: 'Optional[str]' = None, proxybonanza_pkg: 'Optional[str]' = None, timeout: 'int' = 45, impersonate: 'str' = 'chrome', max_retries: 'int' = 2, transport: 'Optional[FetchTransport]' = None) -> None` {#NcaaFetchConfig}
+### `NcaaFetchConfig(cache_dir: 'Optional[Path]' = None, proxy_url: 'Optional[str]' = None, proxybonanza_key: 'Optional[str]' = None, proxybonanza_pkg: 'Optional[str]' = None, timeout: 'int' = 45, impersonate: 'str' = 'chrome', max_retries: 'int' = 2, rotation_backoff: 'float' = 1.0, transport: 'Optional[FetchTransport]' = None) -> None` {#NcaaFetchConfig}
 
 Runtime configuration for the stats.ncaa.org fetch layer.
 
@@ -1083,6 +1083,7 @@ via `proxybonanza_key` + `proxybonanza_pkg` (resolved lazily by
 | `timeout` | `int` | `45` |  |
 | `impersonate` | `str` | `'chrome'` |  |
 | `max_retries` | `int` | `2` |  |
+| `rotation_backoff` | `float` | `1.0` |  |
 | `transport` | `Optional[FetchTransport]` | `None` |  |
 
 **Example**

--- a/sportsdataverse/mbb/mbb_ncaa_fetch.py
+++ b/sportsdataverse/mbb/mbb_ncaa_fetch.py
@@ -91,6 +91,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import time
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Callable, Optional
@@ -158,6 +159,9 @@ class NcaaFetchConfig:
     timeout: int = 45
     impersonate: str = "chrome"
     max_retries: int = 2
+    # Seconds to sleep between proxy-rotation attempts (retry path only);
+    # paces a ban wave instead of bursting the pool.
+    rotation_backoff: float = 1.0
     # Injection point for tests / alternate transports. ``None`` -> the real
     # curl_cffi-backed transport built lazily by NcaaFetcher.
     transport: Optional[FetchTransport] = None
@@ -176,6 +180,7 @@ class NcaaFetchConfig:
             f"proxybonanza_pkg={self.proxybonanza_pkg!r}, "
             f"timeout={self.timeout}, impersonate={self.impersonate!r}, "
             f"max_retries={self.max_retries}, "
+            f"rotation_backoff={self.rotation_backoff}, "
             f"transport={'<custom>' if self.transport else None})"
         )
 
@@ -214,6 +219,11 @@ def _from_env() -> NcaaFetchConfig:
             pass
     if (v := os.environ.get("SDV_PY_NCAA_IMPERSONATE")) is not None:
         cfg.impersonate = v
+    if (v := os.environ.get("SDV_PY_NCAA_ROTATION_BACKOFF")) is not None:
+        try:
+            cfg.rotation_backoff = float(v)
+        except ValueError:
+            pass
     return cfg
 
 
@@ -674,7 +684,9 @@ class NcaaFetcher:
         pool = self._pool or [""]
         attempts = len(pool) + self.config.max_retries
         last_err = "no proxies in pool"
-        for _ in range(attempts):
+        for i in range(attempts):
+            if i and self.config.rotation_backoff > 0:
+                time.sleep(self.config.rotation_backoff)
             proxy = pool[self._proxy_idx % len(pool)]
             proxies = {"http": proxy, "https": proxy} if proxy else {}
             try:

--- a/tests/mbb/test_mbb_ncaa_fetch.py
+++ b/tests/mbb/test_mbb_ncaa_fetch.py
@@ -107,7 +107,7 @@ def test_other_host_url_rejected(tmp_path: Path) -> None:
 
 def test_ban_marker_response_rotates_proxy(tmp_path: Path) -> None:
     transport = FakeTransport([(200, "Access Denied - captcha"), (200, "<html>ok</html>")])
-    cfg = NcaaFetchConfig(cache_dir=tmp_path, transport=transport)
+    cfg = NcaaFetchConfig(cache_dir=tmp_path, transport=transport, rotation_backoff=0.0)
     fetcher = NcaaFetcher(cfg, proxy_pool=["http://u:p@1.1.1.1:1", "http://u:p@2.2.2.2:2"])
 
     text = fetcher.fetch_html("contests/1/play_by_play")
@@ -122,10 +122,55 @@ def test_ban_marker_response_rotates_proxy(tmp_path: Path) -> None:
 
 def test_all_proxies_exhausted_raises(tmp_path: Path) -> None:
     transport = FakeTransport([(403, "forbidden"), (403, "forbidden"), (403, "forbidden")])
-    cfg = NcaaFetchConfig(cache_dir=tmp_path, transport=transport, max_retries=0)
+    cfg = NcaaFetchConfig(cache_dir=tmp_path, transport=transport, max_retries=0, rotation_backoff=0.0)
     fetcher = NcaaFetcher(cfg, proxy_pool=["http://u:p@1.1.1.1:1"])
     with pytest.raises(RuntimeError, match="rotating proxies"):
         fetcher.fetch_html("contests/1/play_by_play")
+
+
+# --- rotation backoff ---------------------------------------------------------
+
+
+def test_rotation_backoff_sleeps_between_retries_not_before_first(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Backoff paces the retry path only -- no sleep before the first attempt."""
+    transport = FakeTransport(
+        [(200, "Access Denied - captcha"), (200, "Access Denied - captcha"), (200, "<html>ok</html>")]
+    )
+    cfg = NcaaFetchConfig(cache_dir=tmp_path, transport=transport, rotation_backoff=0.5)
+    fetcher = NcaaFetcher(cfg, proxy_pool=["http://u:p@1.1.1.1:1", "http://u:p@2.2.2.2:2", "http://u:p@3.3.3.3:3"])
+
+    sleeps: "list[float]" = []
+    monkeypatch.setattr("sportsdataverse.mbb.mbb_ncaa_fetch.time.sleep", sleeps.append)
+
+    text = fetcher.fetch_html("contests/1/play_by_play")
+
+    assert text == "<html>ok</html>"
+    assert sleeps == [0.5, 0.5]
+
+
+def test_rotation_backoff_no_sleep_on_clean_first_hit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    transport = FakeTransport([(200, "<html>ok</html>")])
+    cfg = NcaaFetchConfig(cache_dir=tmp_path, transport=transport, rotation_backoff=1.0)
+    fetcher = NcaaFetcher(cfg, proxy_pool=["http://u:p@1.1.1.1:1"])
+
+    sleeps: "list[float]" = []
+    monkeypatch.setattr("sportsdataverse.mbb.mbb_ncaa_fetch.time.sleep", sleeps.append)
+
+    fetcher.fetch_html("contests/1/play_by_play")
+
+    assert sleeps == []
+
+
+def test_rotation_backoff_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    from sportsdataverse.mbb.mbb_ncaa_fetch import _from_env
+
+    monkeypatch.setenv("SDV_PY_NCAA_ROTATION_BACKOFF", "2.5")
+    assert _from_env().rotation_backoff == 2.5
+
+    monkeypatch.setenv("SDV_PY_NCAA_ROTATION_BACKOFF", "abc")
+    assert _from_env().rotation_backoff == 1.0
 
 
 # --- redaction ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

`NcaaFetcher._get_with_rotation` rotated to the next proxy on any non-clean
response or transport exception with zero delay. During a ban wave this
fires `len(pool) + max_retries` requests back-to-back, worsening the ban and
burning the whole ~50-proxy pool instantly before hard-stopping.

## Fix

- New `NcaaFetchConfig.rotation_backoff: float = 1.0` (seconds), overridable
  via `SDV_PY_NCAA_ROTATION_BACKOFF`.
- `_get_with_rotation` sleeps `rotation_backoff` seconds before every
  proxy-rotation attempt except the first, so a clean first hit stays
  instant (no added latency on the happy path) and only the retry path is
  paced.

## Tests

- Existing `test_ban_marker_response_rotates_proxy` /
  `test_all_proxies_exhausted_raises` updated to pass `rotation_backoff=0.0`
  so they stay instant.
- New: backoff sleeps exactly twice (once per retry) on a
  ban-ban-clean sequence, verified via a monkeypatched `time.sleep`
  recorder.
- New: no sleep at all on a clean first hit.
- New: `SDV_PY_NCAA_ROTATION_BACKOFF` env override (valid + invalid value).

`uv run pytest tests/mbb/test_mbb_ncaa_fetch.py -q` — 25 passed in ~2s (fast,
no real sleeps). `ruff check` and `mypy` clean.

## Known follow-up

`uv run python tools/codegen/generate.py --check` flags stale
`docs/docs/{mbb,wbb}/reference/additional.md` — both embed
`NcaaFetchConfig`'s generated constructor signature, which now includes
`rotation_backoff`. Docs were intentionally left unregenerated in this PR
pending review; run `uv run python tools/codegen/generate.py` and commit
the diff before merge.

## Test plan

- [ ] `uv run pytest tests/mbb/test_mbb_ncaa_fetch.py -q`
- [ ] `uv run ruff check sportsdataverse/mbb/mbb_ncaa_fetch.py tests/mbb/test_mbb_ncaa_fetch.py`
- [ ] `uv run mypy sportsdataverse/mbb/mbb_ncaa_fetch.py`
- [ ] Regenerate docs (`uv run python tools/codegen/generate.py`) and commit before merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `rotation_backoff` to control pacing between proxy-rotation retry attempts.
  * Added environment-variable support to configure `rotation_backoff` (with safe fallback to the default).
* **Bug Fixes**
  * Added retry delays only when needed, avoiding unnecessary pauses after a successful first request.
* **Tests**
  * Expanded proxy-rotation coverage, including assertions for sleep behavior and environment-based overrides.
* **Documentation**
  * Documented the new `rotation_backoff` parameter in the NCAA/WBB `NcaaFetchConfig` references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->