### PR TITLE
fix(mbb): order player_box active-column last to match the MBB release oracle

### DIFF
--- a/sportsdataverse/mbb/mbb_player_box.py
+++ b/sportsdataverse/mbb/mbb_player_box.py
@@ -14,9 +14,11 @@ already match WBB, NOT WNBA/NBA:
   is.data.frame(valid_stats[["athletes"]][[2]])``) -- byte-for-byte the WBB
   gate, not WNBA/NBA's laxer one -- so ``require_both_teams=True``.
 
-WBB's ``_FINAL_ORDER`` tuple is imported verbatim (no plus_minus insert). The
-R-released ``espn_mens_college_basketball_player_boxscores`` parquet is the
-parity oracle.
+MBB's column order is WBB's shared ``_FINAL_ORDER`` with one column moved:
+``active`` is LAST in the R-released ``espn_mens_college_basketball_player_boxscores``
+parquet (idx 54/55), where WBB keeps it mid-list -- the single confirmed
+MBB/WBB order divergence, captured in ``_MBB_FINAL_ORDER`` below (still no
+plus_minus insert). That parquet is the parity oracle.
 """
 
 from __future__ import annotations
@@ -27,6 +29,14 @@ from sportsdataverse.wbb.wbb_player_box import _FINAL_ORDER as _FINAL_ORDER
 from sportsdataverse.wbb.wbb_player_box import _basketball_player_box
 
 __all__ = ["helper_mbb_player_box"]
+
+# The real MBB release orders ``active`` LAST (confirmed against the 2025
+# ``espn_mens_college_basketball_player_boxscores`` parquet, idx 54 of 55),
+# whereas WBB keeps it mid-list after ``did_not_play``/``reason``. Same column
+# set as WBB's shared ``_FINAL_ORDER`` -- only ``active``'s position differs --
+# so derive the MBB order from it rather than changing the shared template
+# (which is correct for WBB). Pinned by tests/mbb/test_mbb_player_box_order.py.
+_MBB_FINAL_ORDER: tuple[str, ...] = tuple(c for c in _FINAL_ORDER if c != "active") + ("active",)
 
 
 def helper_mbb_player_box(final: dict) -> pl.DataFrame:
@@ -69,4 +79,4 @@ def helper_mbb_player_box(final: dict) -> pl.DataFrame:
     # MBB's R gate carries WBB's valid_athletes (both-teams) probe, so a game
     # whose second team ships no athletes is skipped entirely, not partially
     # published.
-    return _basketball_player_box(final, final_order=_FINAL_ORDER, require_both_teams=True)
+    return _basketball_player_box(final, final_order=_MBB_FINAL_ORDER, require_both_teams=True)

--- a/tests/mbb/test_mbb_player_box_order.py
+++ b/tests/mbb/test_mbb_player_box_order.py
@@ -1,0 +1,47 @@
+"""Pin the WBB/MBB ``active``-column divergence in the player-box select order.
+
+Both the men's and women's ESPN player-box producers share one canonical
+column-order template (``wbb_player_box._FINAL_ORDER``), but the two real
+release parquets order ONE column differently:
+
+* **WBB** (``espn_womens_college_basketball_player_boxscores``): ``active``
+  sits mid-list, immediately after ``did_not_play``/``reason``.
+* **MBB** (``espn_mens_college_basketball_player_boxscores``): ``active`` is
+  the LAST column.
+
+Both positions were confirmed against the real R-released 2025 parquets
+(``wehoop-wbb-data/wbb/player_box/parquet/player_box_2025.parquet`` at
+``active`` index 30, and ``hoopR-mbb-data/mbb/player_box/parquet/
+player_box_2025.parquet`` at ``active`` index 54 -- the last of 55 columns;
+``reason`` is a conditionally-emitted column absent from both 2025 releases,
+so the shared template's mid-list ``active`` lands at index 30 once ``reason``
+is filtered out, matching the WBB oracle exactly).
+
+This is an offline structural pin. The full-frame value/order parity against
+the real MBB oracle lives in
+``hoopR-mbb-data/python/tests/mbb_data_build/test_parity_player_box.py``
+(``assert_parquet_parity(..., require_order=True)``); there is no equivalent
+committed WBB-side build package, so the WBB order is guarded here at the
+template level.
+"""
+
+from sportsdataverse.mbb.mbb_player_box import _MBB_FINAL_ORDER
+from sportsdataverse.wbb.wbb_player_box import _FINAL_ORDER
+
+
+def test_wbb_keeps_active_mid_list_after_did_not_play():
+    # WBB oracle: active is NOT last; it follows did_not_play/reason.
+    assert _FINAL_ORDER[-1] != "active"
+    i = _FINAL_ORDER.index("active")
+    assert _FINAL_ORDER[i - 2 : i] == ("did_not_play", "reason")
+
+
+def test_mbb_moves_active_to_the_end():
+    # MBB oracle: active is the final column.
+    assert _MBB_FINAL_ORDER[-1] == "active"
+
+
+def test_mbb_order_is_wbb_order_with_active_last():
+    # Same column set, differing only in active's position.
+    assert set(_MBB_FINAL_ORDER) == set(_FINAL_ORDER)
+    assert _MBB_FINAL_ORDER == tuple(c for c in _FINAL_ORDER if c != "active") + ("active",)


### PR DESCRIPTION
The ESPN MBB player-box `active` column position is a **confirmed** WBB/MBB divergence (verified against both real 2025 release parquets):

- **WBB** keeps `active` mid-list (after `did_not_play`/`reason`, idx 30).
- **MBB** puts `active` LAST (idx 54 of 55).

## Change
- Add `mbb_player_box._MBB_FINAL_ORDER` = the shared WBB `_FINAL_ORDER` with `active` moved to the end, and wire `helper_mbb_player_box` to use it. WBB's shared `_FINAL_ORDER` is left unchanged (it is correct for WBB — only MBB needed the override).
- Add `tests/mbb/test_mbb_player_box_order.py` pinning the divergence (WBB active mid-list; MBB active last; same column set).

## Why now / coupling
`hoopR-mbb-data`'s reshaper already removed its compensating `active`-reorder hack, deferring the divergence to `sdv-py._MBB_FINAL_ORDER`. That override was never merged, so the installed (pre-fix) helper currently emits MBB `active` mid-list and the order-checked parity test in the `-data` build would fail. This lands the missing sdv-py half; once merged, re-sync the `mbb_data_build` git-main pin (uv.lock bump) so the two ship together.

## Verification
- `tests/mbb/test_mbb_player_box_order.py` — 3 passed.
- ruff + mypy clean on the changed producer; codegen regenerated with no drift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected men’s basketball player box score column ordering to match the parquet release format.
  * Ensured the `active` column appears at the end of men’s basketball data.

* **Tests**
  * Added coverage to verify consistent column sets and expected ordering across men’s and women’s basketball player box scores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->