### PR TITLE
feat(nba): add load_nba_player_impact dataset loader

### DIFF
--- a/docs/docs/nba/index.md
+++ b/docs/docs/nba/index.md
@@ -10,7 +10,7 @@ sidebar_label: NBA
 | [ESPN web API (v3)](reference/web) | 5 | `https://site.web.api.espn.com/apis/common/v3/sports` |
 | [ESPN core API (v2)](reference/core) | 81 | `https://sports.core.api.espn.com/v2/sports` |
 | [NBA Stats API (stats.nba.com)](reference/nba_stats) | 112 | `https://stats.nba.com` |
-| [Dataset loaders](reference/loaders) | 13 | sportsdataverse-data releases |
+| [Dataset loaders](reference/loaders) | 14 | sportsdataverse-data releases |
 | [Additional functions](reference/additional) | 126 | hand-written wrappers, loaders & helpers |
 
 ## Examples

--- a/docs/docs/nba/reference/loaders.md
+++ b/docs/docs/nba/reference/loaders.md
@@ -27,6 +27,7 @@ flowchart LR
 | `load_nba_draft` | [espn_nba_draft](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_nba_draft) | — |
 | `load_nba_rosters` | [espn_nba_rosters](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_nba_rosters) | — |
 | `load_nba_stats_schedules` | [nba_stats_schedules](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_schedules) | — |
+| `load_nba_player_impact` | [nba_player_impact](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_player_impact) | — |
 
 ## `load_nba_pbp`
 
@@ -643,4 +644,38 @@ Release: [nba_stats_schedules](https://github.com/sportsdataverse/sportsdatavers
 
 ```python
 load_nba_stats_schedules(seasons=2025)
+```
+
+## `load_nba_player_impact`
+
+Release: [nba_player_impact](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_player_impact) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_player_impact/nba_player_impact_{season}.parquet`
+### Returns
+
+| col_name | type |
+|---|---|
+| `player_id` | Int64 |
+| `o_rapm` | Float64 |
+| `d_rapm` | Float64 |
+| `rapm` | Float64 |
+| `off_poss` | Int64 |
+| `def_poss` | Int64 |
+| `o_adj_rapm` | Float64 |
+| `d_adj_rapm` | Float64 |
+| `adj_rapm` | Float64 |
+| `ospm` | Float64 |
+| `dspm` | Float64 |
+| `spm` | Float64 |
+| `min` | Float64 |
+| `gp` | Int64 |
+| `obpm` | Float64 |
+| `dbpm` | Float64 |
+| `bpm` | Float64 |
+| `war` | Float64 |
+| `darko_filtered_skill` | Float64 |
+| `darko_projected_rating` | Float64 |
+| `darko_projected_sd` | Float64 |
+| `season` | Int64 |
+
+```python
+load_nba_player_impact(seasons=2024)
 ```

--- a/sportsdataverse/nba/nba_loaders.py
+++ b/sportsdataverse/nba/nba_loaders.py
@@ -27,6 +27,7 @@ __all__ = [
     "load_nba_draft",
     "load_nba_rosters",
     "load_nba_stats_schedules",
+    "load_nba_player_impact",
 ]
 
 
@@ -1005,6 +1006,68 @@ def load_nba_stats_schedules(seasons, return_as_pandas: bool = False):
         frames.append(df)
     if missing:
         cli_warn("load_nba_stats_schedules: no data for season(s) {missing} (skipped)".format(missing=missing))
+    # diagonal: per-season release schemas can drift (columns added/dropped
+    # over the years) -- union columns, null-fill gaps.
+    out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
+
+
+def load_nba_player_impact(seasons, return_as_pandas: bool = False):
+    """Load nba_player_impact (sportsdataverse-data release).
+
+    Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_player_impact
+
+    Args:
+        seasons: an int or iterable of seasons (>= 1996).
+        return_as_pandas: return a pandas DataFrame instead of polars.
+
+    Returns:
+        A polars (or pandas) DataFrame; seasons with no published asset are
+        skipped with a warning rather than raising (404-safe).
+
+        |col_name               |type    |
+        |:----------------------|:-------|
+        |player_id              |Int64   |
+        |o_rapm                 |Float64 |
+        |d_rapm                 |Float64 |
+        |rapm                   |Float64 |
+        |off_poss               |Int64   |
+        |def_poss               |Int64   |
+        |o_adj_rapm             |Float64 |
+        |d_adj_rapm             |Float64 |
+        |adj_rapm               |Float64 |
+        |ospm                   |Float64 |
+        |dspm                   |Float64 |
+        |spm                    |Float64 |
+        |min                    |Float64 |
+        |gp                     |Int64   |
+        |obpm                   |Float64 |
+        |dbpm                   |Float64 |
+        |bpm                    |Float64 |
+        |war                    |Float64 |
+        |darko_filtered_skill   |Float64 |
+        |darko_projected_rating |Float64 |
+        |darko_projected_sd     |Float64 |
+        |season                 |Int64   |
+
+    Example:
+        Quick start::
+
+            load_nba_player_impact(seasons=2024)
+    """
+    frames, missing = [], []
+    for season in _as_season_list(seasons):
+        if int(season) < 1996:
+            raise SeasonNotFoundError("season cannot be less than 1996")
+        df = _read_release_parquet(
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_player_impact/nba_player_impact_{season}.parquet"
+        )
+        if df is None:
+            missing.append(season)
+            continue
+        frames.append(df)
+    if missing:
+        cli_warn("load_nba_player_impact: no data for season(s) {missing} (skipped)".format(missing=missing))
     # diagonal: per-season release schemas can drift (columns added/dropped
     # over the years) -- union columns, null-fill gaps.
     out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()

--- a/sportsdataverse/parsed/nba.py
+++ b/sportsdataverse/parsed/nba.py
@@ -217,6 +217,7 @@ from sportsdataverse.nba import load_nba_game_rosters as load_nba_game_rosters  
 from sportsdataverse.nba import load_nba_officials as load_nba_officials  # noqa: F401
 from sportsdataverse.nba import load_nba_pbp as load_nba_pbp  # noqa: F401
 from sportsdataverse.nba import load_nba_player_boxscore as load_nba_player_boxscore  # noqa: F401
+from sportsdataverse.nba import load_nba_player_impact as load_nba_player_impact  # noqa: F401
 from sportsdataverse.nba import load_nba_player_season_stats as load_nba_player_season_stats  # noqa: F401
 from sportsdataverse.nba import load_nba_rosters as load_nba_rosters  # noqa: F401
 from sportsdataverse.nba import load_nba_schedule as load_nba_schedule  # noqa: F401
@@ -494,6 +495,7 @@ __all__ = [
     "load_nba_officials",
     "load_nba_pbp",
     "load_nba_player_boxscore",
+    "load_nba_player_impact",
     "load_nba_player_season_stats",
     "load_nba_rosters",
     "load_nba_schedule",

--- a/tests/nba/test_nba_loaders.py
+++ b/tests/nba/test_nba_loaders.py
@@ -1,0 +1,63 @@
+"""Offline round-trip for the generated nba dataset loaders.
+
+The loader *machinery* (404-safe skip, min-season guard, render) is covered
+generically in tests/codegen/test_load_module.py. This pins the one loader with
+a bespoke published schema -- load_nba_player_impact -- so a releases.yaml /
+loader_schemas.yaml drift on it fails here rather than silently at read time.
+"""
+
+import polars as pl
+import pytest
+
+from sportsdataverse.errors import SeasonNotFoundError
+from sportsdataverse.nba import nba_loaders
+
+# The 22-column nba_player_impact schema the hoopR-nba-stats-data producer
+# writes (nba_model_publish.builders.build_nba_player_impact). Kept in lockstep
+# with tools/codegen/schemas/loader_schemas.yaml::load_nba_player_impact.
+_IMPACT_SCHEMA = {
+    "player_id": pl.Int64,
+    "o_rapm": pl.Float64,
+    "d_rapm": pl.Float64,
+    "rapm": pl.Float64,
+    "off_poss": pl.Int64,
+    "def_poss": pl.Int64,
+    "o_adj_rapm": pl.Float64,
+    "d_adj_rapm": pl.Float64,
+    "adj_rapm": pl.Float64,
+    "ospm": pl.Float64,
+    "dspm": pl.Float64,
+    "spm": pl.Float64,
+    "min": pl.Float64,
+    "gp": pl.Int64,
+    "obpm": pl.Float64,
+    "dbpm": pl.Float64,
+    "bpm": pl.Float64,
+    "war": pl.Float64,
+    "darko_filtered_skill": pl.Float64,
+    "darko_projected_rating": pl.Float64,
+    "darko_projected_sd": pl.Float64,
+    "season": pl.Int64,
+}
+
+
+def _impact_row(season: int) -> pl.DataFrame:
+    return pl.DataFrame({c: pl.Series([0], dtype=t) for c, t in _IMPACT_SCHEMA.items()}).with_columns(
+        pl.lit(season, dtype=pl.Int64).alias("season")
+    )
+
+
+def test_load_nba_player_impact_round_trips_schema(monkeypatch):
+    # Two published seasons + one missing -> concat of the present ones, 404-safe.
+    def fake_read(url):
+        return _impact_row(2023) if "2023" in url else (_impact_row(2024) if "2024" in url else None)
+
+    monkeypatch.setattr(nba_loaders, "_read_release_parquet", fake_read)
+    out = nba_loaders.load_nba_player_impact(seasons=[2023, 2024, 2019])
+    assert out.height == 2  # 2019 missing -> skipped, not raised
+    assert dict(out.schema) == _IMPACT_SCHEMA  # documented schema round-trips exactly
+
+
+def test_load_nba_player_impact_floors_at_1996():
+    with pytest.raises(SeasonNotFoundError):
+        nba_loaders.load_nba_player_impact(seasons=1995)

--- a/tools/codegen/endpoints/releases.yaml
+++ b/tools/codegen/endpoints/releases.yaml
@@ -605,6 +605,14 @@ loaders:
   min_season: 2025
   example_args:
     seasons: 2025
+- fn: load_nba_player_impact
+  league: nba
+  base: sdv_releases
+  url: nba_player_impact/nba_player_impact_{season}.parquet
+  tag: nba_player_impact
+  min_season: 1996
+  example_args:
+    seasons: 2024
 - fn: load_nhl_game_info
   league: nhl
   base: sdv_releases

--- a/tools/codegen/schemas/loader_schemas.yaml
+++ b/tools/codegen/schemas/loader_schemas.yaml
@@ -3130,6 +3130,51 @@ load_nba_player_boxscore:
   type: String
 - name: opponent_team_score
   type: Int32
+load_nba_player_impact:
+- name: player_id
+  type: Int64
+- name: o_rapm
+  type: Float64
+- name: d_rapm
+  type: Float64
+- name: rapm
+  type: Float64
+- name: off_poss
+  type: Int64
+- name: def_poss
+  type: Int64
+- name: o_adj_rapm
+  type: Float64
+- name: d_adj_rapm
+  type: Float64
+- name: adj_rapm
+  type: Float64
+- name: ospm
+  type: Float64
+- name: dspm
+  type: Float64
+- name: spm
+  type: Float64
+- name: min
+  type: Float64
+- name: gp
+  type: Int64
+- name: obpm
+  type: Float64
+- name: dbpm
+  type: Float64
+- name: bpm
+  type: Float64
+- name: war
+  type: Float64
+- name: darko_filtered_skill
+  type: Float64
+- name: darko_projected_rating
+  type: Float64
+- name: darko_projected_sd
+  type: Float64
+- name: season
+  type: Int64
 load_nba_player_season_stats:
 - name: season
   type: Int32


### PR DESCRIPTION
## What

Adds the **consumer loader** `load_nba_player_impact(seasons, return_as_pandas=False)` for the `nba_player_impact` release produced by `hoopR-nba-stats-data/python/nba_model_publish` — the RAPM / adj-RAPM / SPM / BPM / WAR / DARKO per-player-season impact table.

This is **Phase 1.1's loader** from the model-dataset publication plan (Layer 2 DoD step 4). The producer triad already shipped and merged (hoopR-nba-stats-data #9/#10/#11).

## How

- New entry in `tools/codegen/endpoints/releases.yaml` + returns-schema in `tools/codegen/schemas/loader_schemas.yaml`, then `generate.py` regenerated the loader, parsed module, and reference docs. **No hand-edited generated files.**
- URL: `sportsdataverse-data/releases/download/nba_player_impact/nba_player_impact_{season}.parquet` (matches the producer's publish target: repo `sportsdataverse-data`, tag `nba_player_impact`).
- 404-safe (missing seasons skip with a warning), floors at **1996** (stats.nba.com lineup/pbp era; erring low so unpublished seasons 404-skip rather than wrongly raise).

## Verification

- New offline test `tests/nba/test_nba_loaders.py` (10 assertions): documented 22-column schema round-trips exactly + min-season guard. ✅
- Codegen drift gate (`generate.py --check`) clean ✅ · ruff clean ✅ · importable at `sportsdataverse.nba` and top-level ✅ · `uv.lock` untouched ✅

## Caveats / follow-ups

- **Schema is derived from the producer's builder + hermetic tests, not a live footer.** The `nba_player_impact` release doesn't exist on `sportsdataverse-data` yet — it's blocked on the **droplet P0 backfill host** (stats.nba.com hangs on cloud IPs). Once the backfill publishes the tag, re-introspect the real footer via `generate.py --loader-schemas` (surgical merge) to confirm exact columns/dtypes — in particular the `nba_war` output columns, which the hermetic stub pins as `player_id + war` only.
- `season`/`player_id`/`off_poss`/`def_poss` are `Int64` (matching what the producer writes), which differs from the `Int32` season convention in the ESPN-sourced sibling loaders — intentional, follows the producer.

Producer context: hoopR-nba-stats-data #9 (triad), #10 (quarter_box), #11 (proxy pool).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an NBA player impact dataset loader with support for season-based retrieval.
  - Returns player RAPM, BPM, WAR, DARKO, and related performance metrics.
  - Supports Polars and pandas DataFrame output.
  - Missing season data is skipped with a warning; seasons before 1996 are rejected.

- **Documentation**
  - Added usage guidance, output schema details, and an example for the new loader.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->