### PR TITLE
fix(cfb): make cfb_ratings() work against the released espn_cfb_pbp asset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,23 @@
 
 ### Fixes
 
+- fix(cfb): `cfb_ratings()` now works against the **released `espn_cfb_pbp`
+  asset** it documents itself as loading. The function advertises that it pulls
+  play-by-play via `load_cfb_pbp`, but that path had never been exercised — the
+  module was built and gated entirely against a 14-column fixture carrying
+  cfbfastR-canonical names, while the published asset is ESPN-shaped. Every real
+  call (`cfb_ratings(2023)`) raised `KeyError` on `pos_team_id` /
+  `def_pos_team_id` / `home` / `neutral_site`, then on `play_type` / `drive_id`.
+  The orchestrator now normalizes the released field names (`start.pos_team.id`,
+  `start.def_pos_team.id`, `homeTeamId`, `type.text`, `drive.id`, plus
+  `neutral_site` off the schedule join), aliasing **only** when the canonical
+  name is absent so callers passing an already-canonical frame are unchanged.
+  The HFA term is now guarded on `pos_team`/`home` dtype agreement — it derives
+  from `pos_team == home`, which across mismatched namespaces silently marked
+  every play a road play rather than failing. Verified on the real 2023 asset
+  (153,625 plays → 227 teams); the oracle gates hold on released data (`adj_net`
+  vs FPI 0.926, vs SP+ 0.936; `adj_off` vs SP+ off 0.846; `adj_def` vs SP+ def
+  0.793).
 - fix(codegen): all codegen/capture writers now emit LF explicitly
   (`newline="\n"`), matching `generate.py`'s convention. On Windows the
   text-mode default translated `\n` to CRLF, so every codegen-test run (which

--- a/docs/src/pages/CHANGELOG.md
+++ b/docs/src/pages/CHANGELOG.md
@@ -204,6 +204,23 @@
 
 ### Fixes
 
+- fix(cfb): `cfb_ratings()` now works against the **released `espn_cfb_pbp`
+  asset** it documents itself as loading. The function advertises that it pulls
+  play-by-play via `load_cfb_pbp`, but that path had never been exercised — the
+  module was built and gated entirely against a 14-column fixture carrying
+  cfbfastR-canonical names, while the published asset is ESPN-shaped. Every real
+  call (`cfb_ratings(2023)`) raised `KeyError` on `pos_team_id` /
+  `def_pos_team_id` / `home` / `neutral_site`, then on `play_type` / `drive_id`.
+  The orchestrator now normalizes the released field names (`start.pos_team.id`,
+  `start.def_pos_team.id`, `homeTeamId`, `type.text`, `drive.id`, plus
+  `neutral_site` off the schedule join), aliasing **only** when the canonical
+  name is absent so callers passing an already-canonical frame are unchanged.
+  The HFA term is now guarded on `pos_team`/`home` dtype agreement — it derives
+  from `pos_team == home`, which across mismatched namespaces silently marked
+  every play a road play rather than failing. Verified on the real 2023 asset
+  (153,625 plays → 227 teams); the oracle gates hold on released data (`adj_net`
+  vs FPI 0.926, vs SP+ 0.936; `adj_off` vs SP+ off 0.846; `adj_def` vs SP+ def
+  0.793).
 - fix(codegen): all codegen/capture writers now emit LF explicitly
   (`newline="\n"`), matching `generate.py`'s convention. On Windows the
   text-mode default translated `\n` to CRLF, so every codegen-test run (which

--- a/sportsdataverse/cfb/cfb_ratings.py
+++ b/sportsdataverse/cfb/cfb_ratings.py
@@ -81,6 +81,22 @@ _RATINGS_OUTPUT_SCHEMA: dict[str, pl.PolarsDataType] = {
     "net_z": pl.Float64,
 }
 
+# `load_cfb_pbp` serves the published `espn_cfb_pbp` asset, which ships ESPN's
+# dotted field names rather than the cfbfastR-canonical ones `_prepare`
+# requires. `home` maps to `homeTeamId` because the released `pos_team` is
+# itself a team *id* (Int64), not a name -- `_prepare`'s HFA test compares the
+# two directly, so they must share a namespace.
+_RELEASED_PBP_ALIASES: dict[str, str] = {
+    "pos_team_id": "start.pos_team.id",
+    "def_pos_team_id": "start.def_pos_team.id",
+    "home": "homeTeamId",
+    # `type.text` is the reclassified play type (`orig_play_type` freezes the
+    # pre-reclassification original); it is also what `cfb_pbp` itself reads
+    # first, ahead of `play_type`.
+    "play_type": "type.text",
+    "drive_id": "drive.id",
+}
+
 # Case-insensitive keyword match over the cfbfastR `play_type` vocabulary for
 # kickoffs/punts/field goals (returns, blocks, touchbacks, etc. all contain one
 # of these words) -- deliberately loose since `play_type` free text varies.
@@ -93,6 +109,22 @@ _ST_UNIT_PATTERNS: tuple[tuple[str, str], ...] = (
     ("punt", "(?i)punt"),
     ("kick_return", "(?i)kickoff"),  # pos_team on a kickoff is the receiving/return team
 )
+
+
+def _alias_released_pbp(plays: pl.DataFrame) -> pl.DataFrame:
+    """Map the released `espn_cfb_pbp` field names onto the canonical ones.
+
+    Aliases only when the canonical name is absent, so a caller passing an
+    already-canonical frame (e.g. `CFBPlayProcess` output) is untouched.
+    """
+    aliases = {
+        canon: src
+        for canon, src in _RELEASED_PBP_ALIASES.items()
+        if canon not in plays.columns and src in plays.columns
+    }
+    if not aliases:
+        return plays
+    return plays.with_columns([pl.col(src).alias(canon) for canon, src in aliases.items()])
 
 
 def efficiency_ratings(plays: pl.DataFrame, *, config: RatingsConfig | None = None) -> pl.DataFrame:
@@ -469,13 +501,28 @@ def cfb_ratings(
     schedule = schedule.with_columns(pl.col("game_id").cast(pl.Utf8))
     assert plays.schema["game_id"] == schedule.schema["game_id"]
 
+    plays = _alias_released_pbp(plays)
+    if "home" in plays.columns and plays.schema["pos_team"] != plays.schema["home"]:
+        # `_prepare` derives HFA from `pos_team == home`; mismatched namespaces
+        # (a name on one side, an id on the other) never compare equal and would
+        # silently mark every play a road play rather than fail.
+        raise KeyError(
+            f"cfb_ratings: `pos_team` ({plays.schema['pos_team']}) and `home` "
+            f"({plays.schema['home']}) must share a namespace for the HFA term."
+        )
+
     if "date" in schedule.columns:
         date_expr = pl.col("date").cast(pl.Date)
     else:
         # Real `load_cfb_schedule` ships `start_date` (an ISO datetime
         # string), not a bare `date` column -- take the calendar-day prefix.
         date_expr = pl.col("start_date").cast(pl.Utf8).str.slice(0, 10).str.to_date()
-    schedule_dates = schedule.select("game_id", date_expr.alias("date"))
+    sched_cols: list[pl.Expr] = [pl.col("game_id"), date_expr.alias("date")]
+    if "neutral_site" not in plays.columns and "neutral_site" in schedule.columns:
+        # `neutral_site` is a game attribute -- the released pbp omits it, so it
+        # rides the schedule join that already runs for `date`.
+        sched_cols.append(pl.col("neutral_site"))
+    schedule_dates = schedule.select(sched_cols)
 
     dated_plays = plays.join(schedule_dates, on="game_id", how="left")
     if as_of_date is not None:

--- a/tests/cfb/test_cfb_ratings.py
+++ b/tests/cfb/test_cfb_ratings.py
@@ -14,6 +14,7 @@ import sys
 import pandas as pd
 import polars as pl
 import pytest
+from polars.testing import assert_frame_equal
 
 # See the NOTE in cfb_ratings.py: `sportsdataverse/cfb/__init__.py` re-exports
 # the `cfb_ratings` *function*, shadowing the submodule of the same name in
@@ -549,3 +550,68 @@ def test_cfb_ratings_empty_seasons_returns_documented_schema(monkeypatch: pytest
     out = cfb_ratings(_SEASON)
     assert out.height == 0
     assert out.schema == _RATINGS_SCHEMA
+
+
+def _released_shaped_plays() -> pl.DataFrame:
+    """`_mini_season_plays` re-expressed in the released `espn_cfb_pbp` names.
+
+    That asset -- what `load_cfb_pbp` actually serves -- ships ESPN's dotted
+    field names and omits `neutral_site` (a game attribute, carried on the
+    schedule). Renaming the canonical fixture is deliberate: it keeps the two
+    frames the same DATA, so the ratings must come out identical.
+    """
+    return (
+        _mini_season_plays()
+        .drop("neutral_site")
+        .rename(
+            {
+                "pos_team_id": "start.pos_team.id",
+                "def_pos_team_id": "start.def_pos_team.id",
+                "home": "homeTeamId",
+                "play_type": "type.text",
+                "drive_id": "drive.id",
+            }
+        )
+    )
+
+
+def test_cfb_ratings_accepts_released_pbp_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The released ESPN-shaped frame must rate identically to the canonical one.
+
+    Regression for the released feed raising `KeyError` on
+    ['pos_team_id', 'def_pos_team_id', 'home', 'neutral_site'] (then
+    `play_type` / `drive_id`) -- `cfb_ratings` advertises that it loads via
+    `load_cfb_pbp`, but was only ever exercised against canonical fixtures.
+    """
+    _patch_loaders(monkeypatch)
+    canonical = cfb_ratings(_SEASON)
+
+    monkeypatch.setattr(
+        _cfb_ratings_mod, "load_cfb_pbp", lambda seasons, return_as_pandas=False: _released_shaped_plays()
+    )
+    monkeypatch.setattr(
+        _cfb_ratings_mod,
+        "load_cfb_schedule",
+        lambda seasons, return_as_pandas=False: _mini_season_schedule().with_columns(neutral_site=pl.lit(False)),
+    )
+    released = cfb_ratings(_SEASON)
+
+    assert released.schema == _RATINGS_SCHEMA
+    # Sort both: the ridge fit runs through a `group_by`, whose row order
+    # polars does not guarantee -- comparing unsorted is flaky, not strict.
+    assert_frame_equal(released.sort("team_id"), canonical.sort("team_id"))
+
+
+def test_cfb_ratings_rejects_mismatched_hfa_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`pos_team` and `home` in different namespaces must raise, not silently
+    mark every play a road game (HFA is derived from `pos_team == home`)."""
+    plays = _released_shaped_plays().with_columns(pl.col("homeTeamId").cast(pl.Categorical))
+    monkeypatch.setattr(_cfb_ratings_mod, "load_cfb_pbp", lambda seasons, return_as_pandas=False: plays)
+    monkeypatch.setattr(
+        _cfb_ratings_mod,
+        "load_cfb_schedule",
+        lambda seasons, return_as_pandas=False: _mini_season_schedule().with_columns(neutral_site=pl.lit(False)),
+    )
+
+    with pytest.raises(KeyError, match="must share a namespace"):
+        cfb_ratings(_SEASON)


### PR DESCRIPTION
## Summary

`cfb_ratings()` documents itself as loading play-by-play via `load_cfb_pbp`, but that path had **never been executed**. The module was built and gated entirely against `tests/fixtures/cfb_prediction/pbp_2023_sample.parquet` — a 14-column slice carrying cfbfastR-canonical names — while the published `espn_cfb_pbp` asset that `load_cfb_pbp` actually serves is ESPN-shaped.

Every real call raised:

```
>>> cfb_ratings(2023)
KeyError: cfb_adjusted_epa: plays is missing required columns
          ['pos_team_id', 'def_pos_team_id', 'home', 'neutral_site']
```

...and then, once each of those cleared, again on `play_type` and `drive_id`. The asset itself is fine (HTTP 200, 153,625 x 460) — the divergence is schema, not availability.

| `_REQUIRED_COLUMNS` | fixture (what the code assumed) | released `espn_cfb_pbp` (reality) |
|---|---|---|
| `pos_team` | `String` — a **name** (`'Buffalo'`) | `Int64` — an **id** (`2`, `5`, `6`) |
| `home` | `String` name | absent → `homeTeamId` (`Int64`) |
| `pos_team_id` | `String` (`'201'`) | absent → `start.pos_team.id` |
| `def_pos_team_id` | `String` (`'2633'`) | absent → `start.def_pos_team.id` |
| `neutral_site` | `Boolean` | absent from pbp — a **schedule** attribute |
| `play_type` | `String` | absent → `type.text` |
| `drive_id` | `Float64` | absent → `drive.id` |

## Approach

Normalize in the **orchestrator**, where every caller routes through, rather than in any one consumer — a caller-side adapter would leave `cfb_ratings()` broken for everyone else.

- Aliases apply **only when the canonical name is absent**, so callers passing an already-canonical frame (e.g. `CFBPlayProcess` output) are unaffected.
- `home` maps to `homeTeamId` because the released `pos_team` is itself an id — `_prepare`'s HFA test compares the two directly, so they must share a namespace.
- `play_type` maps to `type.text` (the reclassified type; `orig_play_type` freezes the pre-reclassification original). `cfb_pbp` itself reads `type.text` first, ahead of `play_type`.
- `neutral_site` rides the schedule join that already runs for `date` — no extra I/O.
- **New guard:** `pos_team`/`home` dtype agreement. `_prepare` derives HFA from `pos_team == home`; across mismatched namespaces that never compares equal and would silently mark every play a road play rather than fail. That silent-wrongness is the class of bug that caused this one.

## Verification

Against the **real** 2023 asset — 153,625 plays → 227 teams, 0 nulls, and `team_id` 130 (Michigan, the actual 2023 champion) at `net_rank` 1.

Oracle gates re-run on **released** data (previously only ever measured on the fixture). All pass, tracking the fixture within ~0.02 — two of them better:

| gate | floor | fixture | **released** |
|---|---|---|---|
| `adj_net` vs FPI | 0.90 | 0.9281 | **0.9259** |
| `adj_net` vs SP+ overall | 0.90 | 0.9232 | **0.9355** |
| `adj_off_epa` vs SP+ off | 0.84 | 0.8490 | **0.8464** |
| `adj_def_epa` vs SP+ def | 0.72 | 0.7712 | **0.7929** |
| `fei_net` vs FEI | — | 0.9669 | **0.9644** |

That the correlations track rather than crater is the evidence the aliasing is semantically right, not merely type-correct.

**Gates:** full `pytest` green · `codegen --check` clean (`all generated files current`) · `ruff check` + `format --check` clean suite-wide · `mypy` clean (module is on the ratchet) · `uv.lock` untouched.

## Tests

- `test_cfb_ratings_accepts_released_pbp_schema` — the same mini-league expressed in released field names must rate **identically** to the canonical one. Proven to fail when the alias map is blanked (raises the exact `KeyError` above), so it's a real regression check rather than a passing no-op.
- `test_cfb_ratings_rejects_mismatched_hfa_namespace` — the HFA guard raises instead of silently degrading.

Both sort before comparing: the ridge fit runs through a `group_by`, whose row order polars does not guarantee.

## Notes for reviewers

- The `wins-MAE 2.19` anchor is **not** verified against released data here. It lives in `test_cfb_projection_backtest.py` (gate `<= 2.35`) and is a *projection* gate, not a ratings one; it passes on fixtures. Verifying it on released-derived ratings is projection-spine work.
- The stale "`load_cfb_pbp` 404" note in `.superpowers/sdd/cfb-ratings-prediction/progress.md` is no longer accurate — the asset resolves.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `cfb_ratings()` compatibility with released ESPN college football play-by-play data.
  * Added handling for released field names while preserving support for canonical inputs.
  * Improved home-field advantage validation to prevent incorrect classifications when team identifiers use incompatible formats.
  * Ensured schedule-based neutral-site information is retained when needed.

* **Documentation**
  * Added changelog entries describing the fix and verification against the released 2023 asset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->