### PR TITLE
feat(cfb): add the load_cfb_ratings dataset loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Unreleased](#unreleased)
+  - [CFB — `load_cfb_ratings` dataset loader](#cfb--load_cfb_ratings-dataset-loader)
   - [NBA / WNBA — CTG play context (T3.6): possession/shot/lineup/player tables + start-type oracle](#nba--wnba--ctg-play-context-t36-possessionshotlineupplayer-tables--start-type-oracle)
   - [Fixes](#fixes)
   - [Dependencies](#dependencies)
@@ -175,6 +176,20 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Unreleased
+
+### CFB — `load_cfb_ratings` dataset loader
+
+- **`load_cfb_ratings(seasons)`** — loads the published `cfb_ratings` release
+  (one row per team per season, 2004–): opponent-adjusted offensive / defensive /
+  special-teams EPA, FEI, `games`, `off_pace`, dense `off_rank` / `def_rank` /
+  `net_rank`, and `net_z`. The tag is produced by `cfbfastR-cfb-data`'s
+  `cfb_model_publish ratings` builder running sdv-py's own
+  :func:`sportsdataverse.cfb.cfb_ratings` over the released `espn_cfb_pbp`
+  play-by-play, so the loader's returns-schema is the compute function's output
+  schema — a contract test pins the two together (both column order and dtype)
+  so a producer change can't silently leave the published returns-table lying.
+  Like every release loader it is 404-safe: seasons with no published asset are
+  skipped with a warning rather than raising.
 
 ### NBA / WNBA — CTG play context (T3.6): possession/shot/lineup/player tables + start-type oracle
 

--- a/docs/docs/cfb/index.md
+++ b/docs/docs/cfb/index.md
@@ -12,8 +12,8 @@ sidebar_label: CFB
 | [On3 Recruit Database (api.on3.com)](reference/on3) | 78 | `https://api.on3.com/public/rdb/v1` |
 | [247Sports Recruit Database (ipa.247sports.com)](reference/sports247) | 12 | `https://ipa.247sports.com` |
 | [247Sports Site Pages (247sports.com)](reference/sports247_site_pages) | 35 | `https://247sports.com` |
-| [Dataset loaders](reference/loaders) | 24 | sportsdataverse raw data / sportsdataverse-data releases |
-| [Additional functions](reference/additional) | 73 | hand-written wrappers, loaders & helpers |
+| [Dataset loaders](reference/loaders) | 25 | sportsdataverse raw data / sportsdataverse-data releases |
+| [Additional functions](reference/additional) | 72 | hand-written wrappers, loaders & helpers |
 
 ## Examples
 

--- a/docs/docs/cfb/reference/additional.md
+++ b/docs/docs/cfb/reference/additional.md
@@ -1351,69 +1351,6 @@ ratings = cfb_ratings(2023)
 preds = cfb_predict_games(schedule_2023, ratings)
 ```
 
-### `cfb_ratings(seasons: 'int | list[int]', *, as_of_date: 'datetime.date | None' = None, config: 'RatingsConfig | None' = None, return_as_pandas: 'bool' = False) -> 'pl.DataFrame | pd.DataFrame'` {#cfb_ratings}
-
-One row per team: the full CFB ratings spine (off/def/ST EPA + FEI).
-
-Public orchestrator over `efficiency_ratings`,
-`special_teams_ratings`, and `fei_ratings`. Loads play-by-play
-+ schedule via `sportsdataverse.cfb.cfb_loaders.load_cfb_pbp` /
-`sportsdataverse.cfb.cfb_loaders.load_cfb_schedule`, joins the
-schedule's per-game date onto the plays, optionally applies the
-as-of-date leakage boundary
-(`sportsdataverse.cfb.cfb_prediction_constants.as_of_ratings_split`),
-then fits all three component ratings on the (optionally filtered) plays
-and reshapes them into one wide per-team table with dense ranks and a
-net-rating z-score.
-
-**Parameters**
-
-| Parameter | Type | Default | Description |
-|---|---|---|---|
-| `seasons` | `int \| list[int]` |  | A single season (e.g. `2023`) or a list of seasons to pool into one combined fit. |
-| `as_of_date` | `date \| None` | `None` | When given, the leakage boundary -- only plays from games with `date < as_of_date` are used to fit the ratings (mirrors what was knowable heading into that date). `None` (default) uses the full season(s), unfiltered. |
-| `config` | `RatingsConfig \| None` | `None` | Ratings tuning knobs forwarded to all three component functions. Defaults to `RatingsConfig` when omitted. |
-| `return_as_pandas` | `bool` | `False` | If True, returns a pandas DataFrame; otherwise polars. |
-
-**Returns**
-
-A DataFrame with one row per `team_id`, columns in this order: `season` (Int64 -- the single passed season for the common single-season call; `null` for a pooled multi-season call, since no single season applies to every row), `team_id` (Utf8), `adj_off_epa`, `adj_def_epa` (Float64, from `efficiency_ratings`), `adj_st_epa` (Float64, from `special_teams_ratings`), `adj_net` (Float64 -- offense minus defense only; special teams is a separate column, not folded in), `fei_off`, `fei_def`, `fei_net` (Float64, from `fei_ratings`), `games` (Int64), `off_pace` (Float64 -- scrimmage plays per game, the tempo input the totals model uses), `off_rank` (Int64, dense rank on `adj_off_epa` descending), `def_rank` (Int64, dense rank on `adj_def_epa` **ascending** -- fewer EPA allowed ranks better), `net_rank` (Int64, dense rank on `adj_net` descending), `net_z` (Float64, z-score of `adj_net`). Zero-row (correctly-typed) when the requested season(s) have no published pbp/schedule asset, or when `as_of_date` filters out every play.
-
-| col_name | type | description |
-|---|---|---|
-| `season` | integer | Season the ratings cover (null for a pooled multi-season fit). |
-| `team_id` | character | Team ESPN id (character join key). |
-| `adj_off_epa` | double | Opponent-adjusted offensive EPA per play (higher is better); ridge fit. |
-| `adj_def_epa` | double | Opponent-adjusted defensive EPA allowed per play (lower is better); ridge fit. |
-| `adj_st_epa` | double | Special-teams rating - z-composite of per-unit field-goal/punt/kick-return EPA. |
-| `adj_net` | double | Opponent-adjusted net efficiency (adj_off_epa minus adj_def_epa; special teams not folded in). |
-| `fei_off` | double | Opponent-adjusted offensive drive efficiency (Fremeau-FEI style). |
-| `fei_def` | double | Opponent-adjusted defensive drive efficiency (Fremeau-FEI style). |
-| `fei_net` | double | Opponent-adjusted net drive efficiency (fei_off minus fei_def). |
-| `games` | integer | Number of games the team played in the fitted window. |
-| `off_pace` | double | Offensive scrimmage plays per game (the tempo input to the totals model). |
-| `off_rank` | integer | Dense rank on adj_off_epa descending (best offense = 1). |
-| `def_rank` | integer | Dense rank on adj_def_epa ascending (fewer EPA allowed ranks better). |
-| `net_rank` | integer | Dense rank on adj_net descending (best net rating = 1). |
-| `net_z` | double | Z-score of adj_net across the FBS teams. |
-
-**Example**
-
-```python
-from sportsdataverse.cfb.cfb_ratings import cfb_ratings
-ratings = cfb_ratings(2023)
-ratings.sort("net_rank").head()
-
-# As-of-date leakage boundary
-
-import datetime as dt
-week3 = cfb_ratings(2023, as_of_date=dt.date(2023, 9, 18))
-
-# Pandas round-trip
-
-ratings_pd = cfb_ratings(2023, return_as_pandas=True)
-```
-
 ### `cfb_recruiting_projection(target_season: 'int', *, division: 'str' = 'fbs', history_seasons: 'list[int] | None' = None, alpha: 'float' = 1.0, return_as_pandas: 'bool' = False) -> 'pl.DataFrame | pd.DataFrame'` {#cfb_recruiting_projection}
 
 Project team wins / scoring margin for a season from preseason roster features.

--- a/docs/docs/cfb/reference/loaders.md
+++ b/docs/docs/cfb/reference/loaders.md
@@ -15,6 +15,7 @@ flowchart LR
 | Dataset | Release tag | Pipeline |
 |---|---|---|
 | `load_cfb_pbp` | [espn_cfb_pbp](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_cfb_pbp) | — |
+| `load_cfb_ratings` | [cfb_ratings](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_ratings) | — |
 | `load_cfb_rosters` | [cfbfastR-data](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfbfastR-data) | — |
 | `load_cfb_schedule` | [cfbfastR-data](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfbfastR-data) | — |
 | `load_cfb_team_info` | [cfbfastR-data](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfbfastR-data) | — |
@@ -411,6 +412,33 @@ Release: [espn_cfb_pbp](https://github.com/sportsdataverse/sportsdataverse-data/
 
 ```python
 load_cfb_pbp(seasons=2024)
+```
+
+## `load_cfb_ratings`
+
+Release: [cfb_ratings](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_ratings) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/cfb_ratings/cfb_ratings_{season}.parquet`
+### Returns
+
+| col_name | type |
+|---|---|
+| `season` | Int64 |
+| `team_id` | String |
+| `adj_off_epa` | Float64 |
+| `adj_def_epa` | Float64 |
+| `adj_st_epa` | Float64 |
+| `adj_net` | Float64 |
+| `fei_off` | Float64 |
+| `fei_def` | Float64 |
+| `fei_net` | Float64 |
+| `games` | Int64 |
+| `off_pace` | Float64 |
+| `off_rank` | Int64 |
+| `def_rank` | Int64 |
+| `net_rank` | Int64 |
+| `net_z` | Float64 |
+
+```python
+load_cfb_ratings(seasons=2024)
 ```
 
 ## `load_cfb_rosters`

--- a/docs/src/pages/CHANGELOG.md
+++ b/docs/src/pages/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Unreleased](#unreleased)
+  - [CFB — `load_cfb_ratings` dataset loader](#cfb--load_cfb_ratings-dataset-loader)
   - [NBA / WNBA — CTG play context (T3.6): possession/shot/lineup/player tables + start-type oracle](#nba--wnba--ctg-play-context-t36-possessionshotlineupplayer-tables--start-type-oracle)
   - [Fixes](#fixes)
   - [Dependencies](#dependencies)
@@ -175,6 +176,20 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Unreleased
+
+### CFB — `load_cfb_ratings` dataset loader
+
+- **`load_cfb_ratings(seasons)`** — loads the published `cfb_ratings` release
+  (one row per team per season, 2004–): opponent-adjusted offensive / defensive /
+  special-teams EPA, FEI, `games`, `off_pace`, dense `off_rank` / `def_rank` /
+  `net_rank`, and `net_z`. The tag is produced by `cfbfastR-cfb-data`'s
+  `cfb_model_publish ratings` builder running sdv-py's own
+  :func:`sportsdataverse.cfb.cfb_ratings` over the released `espn_cfb_pbp`
+  play-by-play, so the loader's returns-schema is the compute function's output
+  schema — a contract test pins the two together (both column order and dtype)
+  so a producer change can't silently leave the published returns-table lying.
+  Like every release loader it is 404-safe: seasons with no published asset are
+  skipped with a warning rather than raising.
 
 ### NBA / WNBA — CTG play context (T3.6): possession/shot/lineup/player tables + start-type oracle
 

--- a/sportsdataverse/cfb/cfb_loaders.py
+++ b/sportsdataverse/cfb/cfb_loaders.py
@@ -15,6 +15,7 @@ from sportsdataverse._codegen_runtime import (
 
 __all__ = [
     "load_cfb_pbp",
+    "load_cfb_ratings",
     "load_cfb_rosters",
     "load_cfb_schedule",
     "load_cfb_team_info",
@@ -437,6 +438,61 @@ def load_cfb_pbp(seasons, return_as_pandas: bool = False):
         frames.append(df)
     if missing:
         cli_warn("load_cfb_pbp: no data for season(s) {missing} (skipped)".format(missing=missing))
+    # diagonal: per-season release schemas can drift (columns added/dropped
+    # over the years) -- union columns, null-fill gaps.
+    out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
+
+
+def load_cfb_ratings(seasons, return_as_pandas: bool = False):
+    """Load cfb_ratings (sportsdataverse-data release).
+
+    Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_ratings
+
+    Args:
+        seasons: an int or iterable of seasons (>= 2004).
+        return_as_pandas: return a pandas DataFrame instead of polars.
+
+    Returns:
+        A polars (or pandas) DataFrame; seasons with no published asset are
+        skipped with a warning rather than raising (404-safe).
+
+        |col_name    |type    |
+        |:-----------|:-------|
+        |season      |Int64   |
+        |team_id     |String  |
+        |adj_off_epa |Float64 |
+        |adj_def_epa |Float64 |
+        |adj_st_epa  |Float64 |
+        |adj_net     |Float64 |
+        |fei_off     |Float64 |
+        |fei_def     |Float64 |
+        |fei_net     |Float64 |
+        |games       |Int64   |
+        |off_pace    |Float64 |
+        |off_rank    |Int64   |
+        |def_rank    |Int64   |
+        |net_rank    |Int64   |
+        |net_z       |Float64 |
+
+    Example:
+        Quick start::
+
+            load_cfb_ratings(seasons=2024)
+    """
+    frames, missing = [], []
+    for season in _as_season_list(seasons):
+        if int(season) < 2004:
+            raise SeasonNotFoundError("season cannot be less than 2004")
+        df = _read_release_parquet(
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/cfb_ratings/cfb_ratings_{season}.parquet"
+        )
+        if df is None:
+            missing.append(season)
+            continue
+        frames.append(df)
+    if missing:
+        cli_warn("load_cfb_ratings: no data for season(s) {missing} (skipped)".format(missing=missing))
     # diagonal: per-season release schemas can drift (columns added/dropped
     # over the years) -- union columns, null-fill gaps.
     out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()

--- a/sportsdataverse/parsed/cfb.py
+++ b/sportsdataverse/parsed/cfb.py
@@ -397,6 +397,7 @@ from sportsdataverse.cfb import load_cfb_pbp as load_cfb_pbp  # noqa: F401
 from sportsdataverse.cfb import load_cfb_play_participants as load_cfb_play_participants  # noqa: F401
 from sportsdataverse.cfb import load_cfb_player_box as load_cfb_player_box  # noqa: F401
 from sportsdataverse.cfb import load_cfb_power_index as load_cfb_power_index  # noqa: F401
+from sportsdataverse.cfb import load_cfb_ratings as load_cfb_ratings  # noqa: F401
 from sportsdataverse.cfb import load_cfb_rosters as load_cfb_rosters  # noqa: F401
 from sportsdataverse.cfb import load_cfb_rosters_crosswalk as load_cfb_rosters_crosswalk  # noqa: F401
 from sportsdataverse.cfb import load_cfb_schedule as load_cfb_schedule  # noqa: F401
@@ -619,6 +620,7 @@ __all__ = [
     "load_cfb_play_participants",
     "load_cfb_player_box",
     "load_cfb_power_index",
+    "load_cfb_ratings",
     "load_cfb_rosters",
     "load_cfb_rosters_crosswalk",
     "load_cfb_schedule",

--- a/tests/cfb/test_cfb_loaders_ratings.py
+++ b/tests/cfb/test_cfb_loaders_ratings.py
@@ -1,0 +1,74 @@
+"""Contract tests for the ``load_cfb_ratings`` dataset loader.
+
+The codegen suite already covers URL shape and that loader modules render valid
+Python. What it does NOT cover is the loader's declared returns-schema agreeing
+with what the producer actually emits -- so a change to ``cfb_ratings()``'s
+output would silently leave the loader's published returns-table lying. That
+agreement is what these tests pin.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import polars as pl
+import yaml
+
+# Per the NOTE in cfb_ratings.py, `sportsdataverse.cfb` re-exports the
+# `cfb_ratings` *function*, shadowing the submodule -- reach the module's
+# constants through a fully-qualified sys.modules lookup.
+import sportsdataverse.cfb.cfb_ratings  # noqa: F401
+
+_ratings_mod = sys.modules["sportsdataverse.cfb.cfb_ratings"]
+
+_ROOT = Path(__file__).resolve().parents[2]
+_SCHEMAS = _ROOT / "tools" / "codegen" / "schemas" / "loader_schemas.yaml"
+_RELEASES = _ROOT / "tools" / "codegen" / "endpoints" / "releases.yaml"
+
+_POLARS_BY_NAME = {"Int64": pl.Int64, "Float64": pl.Float64, "String": pl.Utf8, "Utf8": pl.Utf8}
+
+
+def _declared_schema() -> list[dict]:
+    return yaml.safe_load(_SCHEMAS.read_text(encoding="utf-8"))["load_cfb_ratings"]
+
+
+def _loader_entry() -> dict:
+    loaders = yaml.safe_load(_RELEASES.read_text(encoding="utf-8"))["loaders"]
+    return next(ld for ld in loaders if ld["fn"] == "load_cfb_ratings")
+
+
+def test_declared_schema_matches_the_producer_output_schema() -> None:
+    """The loader's returns-table must match `cfb_ratings()`'s real output.
+
+    Both column ORDER and dtype: the published parquet is written straight from
+    that frame, so any divergence here is a docs lie, not a formatting nit.
+    """
+    produced = _ratings_mod._RATINGS_OUTPUT_SCHEMA
+    declared = _declared_schema()
+
+    assert [c["name"] for c in declared] == list(produced.keys())
+    for col in declared:
+        assert _POLARS_BY_NAME[col["type"]] == produced[col["name"]], col["name"]
+
+
+def test_loader_entry_points_at_the_published_tag_and_floor() -> None:
+    entry = _loader_entry()
+
+    assert entry["tag"] == "cfb_ratings"
+    assert entry["base"] == "sdv_releases"
+    # matches what cfb_model_publish's builder writes: cfb_ratings_{season}.parquet
+    assert entry["url"] == "cfb_ratings/cfb_ratings_{season}.parquet"
+    # the espn_cfb_pbp asset the ratings are computed from starts at 2004
+    assert entry["min_season"] == 2004 == _loader_entry_min_season_of("load_cfb_pbp")
+
+
+def _loader_entry_min_season_of(fn: str) -> int:
+    loaders = yaml.safe_load(_RELEASES.read_text(encoding="utf-8"))["loaders"]
+    return next(ld for ld in loaders if ld["fn"] == fn)["min_season"]
+
+
+def test_loader_is_exported() -> None:
+    from sportsdataverse.cfb import load_cfb_ratings
+
+    assert callable(load_cfb_ratings)

--- a/tools/codegen/endpoints/releases.yaml
+++ b/tools/codegen/endpoints/releases.yaml
@@ -11,6 +11,14 @@ loaders:
   min_season: 2004
   example_args:
     seasons: 2024
+- fn: load_cfb_ratings
+  league: cfb
+  base: sdv_releases
+  url: cfb_ratings/cfb_ratings_{season}.parquet
+  tag: cfb_ratings
+  min_season: 2004
+  example_args:
+    seasons: 2024
 - fn: load_cfb_rosters
   league: cfb
   base: raw_data

--- a/tools/codegen/schemas/loader_schemas.yaml
+++ b/tools/codegen/schemas/loader_schemas.yaml
@@ -1758,6 +1758,37 @@ load_cfb_power_index:
   type: Int64
 - name: week
   type: Int64
+load_cfb_ratings:
+- name: season
+  type: Int64
+- name: team_id
+  type: String
+- name: adj_off_epa
+  type: Float64
+- name: adj_def_epa
+  type: Float64
+- name: adj_st_epa
+  type: Float64
+- name: adj_net
+  type: Float64
+- name: fei_off
+  type: Float64
+- name: fei_def
+  type: Float64
+- name: fei_net
+  type: Float64
+- name: games
+  type: Int64
+- name: off_pace
+  type: Float64
+- name: off_rank
+  type: Int64
+- name: def_rank
+  type: Int64
+- name: net_rank
+  type: Int64
+- name: net_z
+  type: Float64
 load_cfb_rosters:
 - name: athlete_id
   type: String


### PR DESCRIPTION
## Summary

Half B of the CFB ratings publish program — the **read** side of the `cfb_ratings` tag that [`cfbfastR-cfb-data#21`](https://github.com/sportsdataverse/cfbfastR-cfb-data/pull/21)'s `cfb_model_publish ratings` builder publishes. Follows #262, which made `cfb_ratings()` work against the released `espn_cfb_pbp` asset in the first place.

- **`releases.yaml`** — `load_cfb_ratings` (base `sdv_releases`, url `cfb_ratings/cfb_ratings_{season}.parquet`, `min_season: 2004` — the `espn_cfb_pbp` floor the ratings are computed from).
- **`loader_schemas.yaml`** — the 15-column returns-schema, **introspected from a real parquet emitted by the builder** rather than derived by hand.
- Regenerated `cfb_loaders.py` + `parsed/cfb.py` + docs.

## One loader, not three

The plan sketched three. It's one:

- **`cfb_adv_efficiency` — dropped as redundant.** The union of `efficiency_ratings` + `special_teams_ratings` + `fei_ratings` is **10 columns**, every one of which is already in `cfb_ratings`' **15** at an identical dtype (the orchestrator's final `.select()` drops none of them). It would have published a strict subset of tag #1.
- **`cfb_recruiting_proj`** waits on its own builder.

## The contract test

The existing codegen suite covers URL shape and that loader modules render valid Python. Nothing asserted that **a loader's declared returns-schema still matches what the producer actually emits** — and the published parquet is written straight from `cfb_ratings()`'s frame, so any divergence is a docs lie rather than a formatting nit.

`test_declared_schema_matches_the_producer_output_schema` pins the two together on column order **and** dtype. Verified it catches both failure modes it exists for: an added producer column, and a `team_id` `Utf8 -> Int64` flip (the ID-dtype footgun in CLAUDE.md).

## Gates

Full `tests/cfb/` + `tests/codegen/`: **611 passed**, 53 skipped, 2 xfailed. `codegen --check` clean. `ruff check` + `format --check` clean. `mypy` clean. `uv.lock` untouched.

## Note for the next person regenerating

`generate.py` renders `parsed/<league>.py` by introspecting the **imported** package, so the run that first writes a new loader into `cfb_loaders.py` still renders `parsed/cfb.py` *without* it — and `--check` then reports `parsed/cfb.py` stale even though `git status` shows it unmodified. A **second `generate.py` pass** converges it. (Confirmed the drift is caused by this change, not pre-existing: `--check` on pristine `origin/main` is clean.)

`load_cfb_ratings` is 404-safe like every release loader, so until the backfill publishes the tag it returns empty-with-a-warning rather than raising.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `load_cfb_ratings` college football dataset loader.
  - Supports loading ratings by season as Polars or pandas data.
  - Handles unavailable season releases safely with warnings.
  - Added public exports and reference documentation, including output fields and usage examples.

- **Documentation**
  - Updated the CFB documentation index and unreleased changelog.
  - Replaced the previous ratings function reference with the new loader documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->