### PR TITLE
fix(mbb): make NCAA proxy rotation real — the browser was pinned to one IP

### DIFF
--- a/sportsdataverse/mbb/mbb_ncaa_fetch.py
+++ b/sportsdataverse/mbb/mbb_ncaa_fetch.py
@@ -166,6 +166,13 @@ class NcaaFetchConfig:
     # Seconds to sleep between proxy-rotation attempts (retry path only);
     # paces a ban wave instead of bursting the pool.
     rotation_backoff: float = 1.0
+    # PROACTIVE rotation: advance to the next proxy after this many successful
+    # fetches (0 = never rotate until something fails). stats.ncaa.org bans per
+    # IP and those bans are PERMANENT -- IPs are a consumable budget, so the
+    # goal is to never burn one. A single IP was observed serving ~4200 requests
+    # before degrading; spreading a season (~11.7k requests) over a 50-proxy
+    # pool at 200/proxy keeps every IP an order of magnitude under that.
+    rotate_every: int = 200
     # Injection point for tests / alternate transports. ``None`` -> the real
     # curl_cffi-backed transport built lazily by NcaaFetcher.
     transport: Optional[FetchTransport] = None
@@ -185,6 +192,7 @@ class NcaaFetchConfig:
             f"timeout={self.timeout}, impersonate={self.impersonate!r}, "
             f"max_retries={self.max_retries}, "
             f"rotation_backoff={self.rotation_backoff}, "
+            f"rotate_every={self.rotate_every}, "
             f"transport={'<custom>' if self.transport else None})"
         )
 
@@ -232,6 +240,11 @@ def _from_env() -> NcaaFetchConfig:
         # the retry path and raise OverflowError/ValueError.
         if parsed is not None and math.isfinite(parsed):
             cfg.rotation_backoff = parsed
+    if (v := os.environ.get("SDV_PY_NCAA_ROTATE_EVERY")) is not None:
+        try:
+            cfg.rotate_every = int(v)
+        except ValueError:
+            pass
     return cfg
 
 
@@ -645,6 +658,12 @@ class NcaaFetcher:
         else:
             self._pool = []
         self._proxy_idx = 0
+        # Successful fetches on the CURRENT proxy (drives config.rotate_every).
+        self._since_rotate = 0
+        # Proxies that returned a ban this session. stats.ncaa.org's per-IP bans
+        # are permanent, so a burned proxy must never be handed out again --
+        # otherwise rotation cycles straight back into a known-dead IP.
+        self._dead: "set[str]" = set()
         self._session: object = None  # lazy curl_cffi.Session (real transport only)
 
     @classmethod
@@ -709,19 +728,58 @@ class NcaaFetcher:
         for i in range(attempts):
             if i and self.config.rotation_backoff > 0:
                 time.sleep(self.config.rotation_backoff)
-            proxy = pool[self._proxy_idx % len(pool)]
+            proxy = self._pick_proxy(pool)
+            if proxy is None:
+                raise RuntimeError(
+                    f"NCAA fetch failed: every proxy in the pool is banned "
+                    f"({len(self._dead)}/{len(pool)}): {url}: {last_err}"
+                )
             proxies = {"http": proxy, "https": proxy} if proxy else {}
             try:
                 status, text = transport(url, proxies, headers)
             except Exception as exc:  # noqa: BLE001 - rotate on any transport failure
                 last_err = str(exc)
-                self._proxy_idx += 1
+                self._rotate("transport error")
                 continue
             if status == 200 and _ban_check(text) == "clean":
+                self._since_rotate += 1
+                if self.config.rotate_every and self._since_rotate >= self.config.rotate_every:
+                    # Proactive: retire this IP while it is still HEALTHY. Waiting
+                    # for a ban means the ban already happened -- and it's permanent.
+                    self._rotate(f"{self._since_rotate} fetches on this proxy")
                 return text
-            last_err = f"status={status} {_ban_check(text)}"
-            self._proxy_idx += 1
+            marker = _ban_check(text)
+            last_err = f"status={status} {marker}"
+            if proxy and (status == 403 or marker != "clean"):
+                # Burned: never hand this IP out again this session.
+                self._dead.add(proxy)
+                logger.warning(
+                    "proxy %s looks banned (%s) -- retiring it for this session (%d/%d dead)",
+                    _redact_proxy_url(proxy),
+                    last_err,
+                    len(self._dead),
+                    len(pool),
+                )
+            self._rotate("ban/failed response")
         raise RuntimeError(f"NCAA fetch failed after rotating proxies: {url}: {last_err}")
+
+    def _rotate(self, why: str) -> None:
+        """Advance to the next proxy and reset the per-proxy fetch counter."""
+        self._proxy_idx += 1
+        self._since_rotate = 0
+        logger.debug("rotating proxy: %s", why)
+
+    def _pick_proxy(self, pool: "list[str]") -> Optional[str]:
+        """Next non-dead proxy, or ``None`` when every proxy is burned.
+
+        The ``[""]`` sentinel (custom transport, no pool) is never marked dead.
+        """
+        for _ in range(len(pool)):
+            proxy = pool[self._proxy_idx % len(pool)]
+            if proxy not in self._dead:
+                return proxy
+            self._proxy_idx += 1
+        return None
 
     def fetch_html(self, path: str, *, force: bool = False) -> str:
         """Fetch *path* (bare path or full stats.ncaa.org URL), cache-first.

--- a/sportsdataverse/mbb/mbb_ncaa_fetch.py
+++ b/sportsdataverse/mbb/mbb_ncaa_fetch.py
@@ -90,6 +90,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import re
 import time
@@ -224,9 +225,13 @@ def _from_env() -> NcaaFetchConfig:
         cfg.impersonate = v
     if (v := os.environ.get("SDV_PY_NCAA_ROTATION_BACKOFF")) is not None:
         try:
-            cfg.rotation_backoff = float(v)
+            parsed = float(v)
         except ValueError:
-            pass
+            parsed = None
+        # Reject non-finite values (inf/nan): they would reach time.sleep() on
+        # the retry path and raise OverflowError/ValueError.
+        if parsed is not None and math.isfinite(parsed):
+            cfg.rotation_backoff = parsed
     return cfg
 
 

--- a/sportsdataverse/mbb/mbb_ncaa_fetch.py
+++ b/sportsdataverse/mbb/mbb_ncaa_fetch.py
@@ -89,6 +89,7 @@ fixture oracle (Phases 5a-5e) is the validated parse path. See
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 import time
@@ -96,6 +97,8 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Callable, Optional
 from urllib.parse import urlsplit
+
+logger = logging.getLogger(__name__)
 
 NCAA_HOST = "stats.ncaa.org"
 NCAA_HOST_URL = f"https://{NCAA_HOST}"
@@ -468,10 +471,22 @@ class _PlaywrightTransport:
         self._browser: Any = None
         self._page: Any = None
         self._challenge_solved = False
+        # The proxy this browser was LAUNCHED with. Playwright binds the proxy at
+        # launch, so honoring a rotation means relaunching -- see _ensure_page.
+        self._current_proxy: Optional[str] = None
 
     def _ensure_page(self, proxies: "dict[str, str]") -> None:
+        proxy = proxies.get("http") or proxies.get("https") or None
         if self._page is not None:
-            return
+            if proxy == self._current_proxy:
+                return
+            # The caller rotated the proxy. A live browser is pinned to its
+            # LAUNCH proxy, so reusing it would silently keep egressing from the
+            # old IP -- which is how one IP absorbed a whole backfill and got
+            # permanently banned while _proxy_idx "rotated" to no effect.
+            # Relaunch on the new IP (costs a fresh bm-verify solve).
+            logger.info("browser proxy rotated -> %s (relaunching)", _redact_proxy_url(proxy))
+            self.close()
         try:
             from playwright.sync_api import sync_playwright
         except ImportError as exc:  # pragma: no cover - exercised only without playwright
@@ -500,6 +515,7 @@ class _PlaywrightTransport:
             user_agent=self.user_agent, locale="en-US", viewport={"width": 1366, "height": 900}
         )
         self._page = ctx.new_page()
+        self._current_proxy = proxy
         atexit.register(self.close)
 
     def __call__(self, url: str, proxies: "dict[str, str]", headers: "dict[str, str]") -> "tuple[int, str]":
@@ -525,6 +541,7 @@ class _PlaywrightTransport:
                 pass
         self._browser = self._pw = self._page = None
         self._challenge_solved = False
+        self._current_proxy = None
 
     def __enter__(self) -> "_PlaywrightTransport":
         return self

--- a/tests/mbb/test_mbb_ncaa_fetch.py
+++ b/tests/mbb/test_mbb_ncaa_fetch.py
@@ -172,6 +172,11 @@ def test_rotation_backoff_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("SDV_PY_NCAA_ROTATION_BACKOFF", "abc")
     assert _from_env().rotation_backoff == 1.0
 
+    # Non-finite values would reach time.sleep() and raise -- keep the default.
+    for bad in ("inf", "-inf", "nan"):
+        monkeypatch.setenv("SDV_PY_NCAA_ROTATION_BACKOFF", bad)
+        assert _from_env().rotation_backoff == 1.0
+
 
 # --- redaction ---------------------------------------------------------------
 

--- a/tests/mbb/test_mbb_ncaa_fetch.py
+++ b/tests/mbb/test_mbb_ncaa_fetch.py
@@ -49,6 +49,125 @@ def _cfg(
     return NcaaFetchConfig(cache_dir=tmp_path, proxy_url=proxy_url, transport=transport)
 
 
+_POOL = ["http://u:p@10.0.0.1:1", "http://u:p@10.0.0.2:1", "http://u:p@10.0.0.3:1"]
+_CLEAN = "<html><body><table>" + "<tr><td>x</td></tr>" * 40 + "</table></body></html>"
+_BAN = "<html><body>Access Denied</body></html>"
+
+
+def _proxies_used(transport: FakeTransport) -> "list[str]":
+    return [c[1].get("http") for c in transport.calls]
+
+
+# --- proxy rotation: IPs are a consumable budget (bans are permanent) ------
+
+
+def test_rotate_every_retires_a_proxy_while_it_is_still_healthy(tmp_path: Path) -> None:
+    """PROACTIVE rotation -- the whole point. Waiting for a ban is too late:
+    stats.ncaa.org's per-IP bans never lift, so a healthy IP must be retired on
+    a fetch budget, not on failure. One IP absorbing a backfill is what burned
+    31.14.9.13 permanently."""
+    transport = FakeTransport([(200, _CLEAN)] * 6)
+    cfg = NcaaFetchConfig(cache_dir=tmp_path, transport=transport, rotate_every=2, rotation_backoff=0.0)
+    fetcher = NcaaFetcher(cfg, proxy_pool=_POOL)
+
+    for i in range(6):
+        fetcher.fetch_html(f"contests/{i}/play_by_play")
+
+    # 2 fetches per proxy, cycling the pool -- never 6 on one IP.
+    assert _proxies_used(transport) == [_POOL[0], _POOL[0], _POOL[1], _POOL[1], _POOL[2], _POOL[2]]
+
+
+def test_rotate_every_zero_disables_proactive_rotation(tmp_path: Path) -> None:
+    transport = FakeTransport([(200, _CLEAN)] * 3)
+    cfg = NcaaFetchConfig(cache_dir=tmp_path, transport=transport, rotate_every=0, rotation_backoff=0.0)
+    fetcher = NcaaFetcher(cfg, proxy_pool=_POOL)
+
+    for i in range(3):
+        fetcher.fetch_html(f"contests/{i}/play_by_play")
+
+    assert _proxies_used(transport) == [_POOL[0]] * 3  # legacy behavior, opt-out
+
+
+def test_banned_proxy_is_retired_and_never_reused(tmp_path: Path) -> None:
+    """A burned IP must never be handed out again -- rotation that cycles back
+    into a known-dead proxy just re-earns the 403."""
+    # p0 bans; the retry lands clean on p1. Then 2 more fetches must avoid p0.
+    transport = FakeTransport([(403, _BAN), (200, _CLEAN), (200, _CLEAN), (200, _CLEAN)])
+    cfg = NcaaFetchConfig(cache_dir=tmp_path, transport=transport, rotate_every=0, rotation_backoff=0.0)
+    fetcher = NcaaFetcher(cfg, proxy_pool=_POOL)
+
+    for i in range(3):
+        fetcher.fetch_html(f"contests/{i}/play_by_play")
+
+    used = _proxies_used(transport)
+    assert used[0] == _POOL[0]  # tried once
+    assert _POOL[0] not in used[1:]  # then retired for good
+    assert _POOL[0] in fetcher._dead
+
+
+def test_all_proxies_banned_raises_a_clear_error(tmp_path: Path) -> None:
+    transport = FakeTransport([(403, _BAN)] * 8)
+    cfg = NcaaFetchConfig(cache_dir=tmp_path, transport=transport, rotation_backoff=0.0)
+    fetcher = NcaaFetcher(cfg, proxy_pool=_POOL)
+
+    with pytest.raises(RuntimeError, match="every proxy in the pool is banned"):
+        fetcher.fetch_html("contests/1/play_by_play")
+
+
+def test_rotate_every_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    from sportsdataverse.mbb.mbb_ncaa_fetch import _from_env
+
+    monkeypatch.setenv("SDV_PY_NCAA_ROTATE_EVERY", "25")
+    assert _from_env().rotate_every == 25
+    monkeypatch.setenv("SDV_PY_NCAA_ROTATE_EVERY", "abc")
+    assert _from_env().rotate_every == 200  # invalid -> default
+
+
+# --- the browser transport must honor a rotation (it is pinned at launch) ---
+
+
+class _StopBeforeLaunch(Exception):
+    pass
+
+
+def test_browser_transport_relaunches_when_the_proxy_rotates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Playwright binds the proxy at LAUNCH. _ensure_page used to early-return
+    whenever a page existed, so the browser kept egressing from its first IP
+    forever while the fetcher 'rotated' -- the bug that burned one IP and
+    stalled the backfill at 38%."""
+    t = playwright_transport()
+    t._page = object()  # pretend a live browser on proxy A
+    t._current_proxy = _POOL[0]
+
+    def _boom() -> None:
+        raise _StopBeforeLaunch  # stand in for the (real) relaunch
+
+    monkeypatch.setattr(t, "close", _boom)
+
+    # Same proxy -> reuse, no relaunch.
+    t._ensure_page({"http": _POOL[0], "https": _POOL[0]})
+
+    # Different proxy -> MUST close/relaunch rather than silently reuse proxy A.
+    with pytest.raises(_StopBeforeLaunch):
+        t._ensure_page({"http": _POOL[1], "https": _POOL[1]})
+
+
+# --- the wbb shim must inherit all of the above, by reference ---------------
+
+
+def test_wbb_fetch_shim_is_the_same_implementation() -> None:
+    """wbb_ncaa_fetch re-exports the mbb core BY REFERENCE, so every fix here
+    reaches WBB with no duplication. Pin it: a copy-paste fork would silently
+    strand WBB on the old, IP-burning behavior."""
+    from sportsdataverse.mbb import mbb_ncaa_fetch as m
+    from sportsdataverse.wbb import wbb_ncaa_fetch as w
+
+    assert w.NcaaFetcher is m.NcaaFetcher
+    assert w.playwright_transport is m.playwright_transport
+    assert w.NcaaFetchConfig is m.NcaaFetchConfig
+    assert w.get_config() is m.get_config()  # one process-wide config singleton
+
+
 # --- binding directive 1: no direct-fetch mode -----------------------------
 
 


### PR DESCRIPTION
The first live NCAA MBB backfill stalled at **2402/6300 (38%)** with a permanent ban. Root cause is not rate — it's that **proxy rotation never rotated**.

`_PlaywrightTransport._ensure_page` early-returned whenever a page existed. Playwright binds the proxy **at launch**, so the browser kept egressing from its *first* proxy forever while `_get_with_rotation` dutifully advanced `_proxy_idx` to no effect. One IP (`31.14.9.13`) absorbed the entire run: ~1412 clean bundles → degraded into a 1485 "challenge not cleared" storm → permanent 403.

**stats.ncaa.org bans per IP, and those bans are permanent** — 26/50 of that pool still 403 after 62 hours. IPs are a consumable budget; the goal is to never burn one.

## Changes

1. **`_PlaywrightTransport` honors rotation** — relaunch when the requested proxy differs from the launched one (costs a fresh bm-verify solve; negligible amortized). Also tracks/clears `_current_proxy` on `close()`.
2. **Proactive rotation** — `NcaaFetchConfig.rotate_every` (default **200**, env `SDV_PY_NCAA_ROTATE_EVERY`, `0` = off) retires a proxy **while it is still healthy**. Rotation previously only fired on failure, i.e. after the IP was already dead. A season (~11.7k requests) across a 50-proxy pool → ~234 req/IP, ~18× under the observed ~4200-request burn point.
3. **Retire banned IPs** — a proxy that returns a ban is never handed out again this session (rotation used to cycle straight back into a known-dead IP). All-banned now raises a distinct, clear error.
4. **Recovers an orphaned fix** — the `math.isfinite` guard for `SDV_PY_NCAA_ROTATION_BACKOFF` (`inf`/`nan` reach `time.sleep` → `OverflowError`). It was committed to #259's branch ~4 min *after* that PR merged, so it never reached main (`main` still returns `inf` today). Cherry-picked here.

## Live validation (proxies only)

- **Egress IP follows the rotation**: requested `23.239.174.2` → egress `23.239.174.2`; requested `23.239.174.24` → egress `23.239.174.24`. On `main` this returns the **same IP twice** — the bug.
- **Real capture**: 2 contests via browser+proxy with rotation firing mid-capture → `{'captured': 2, 'skipped': 0, 'failed': 0}`, payloads 135–319 KB/page, bm-verify clearing on the new IP.
- Offline suite: 31 passed / 1 skipped; ruff + mypy clean.

## WBB

No duplication: `wbb_ncaa_fetch` re-exports the mbb core **by reference** (`wbb.NcaaFetcher is mbb.NcaaFetcher`), so WBB inherits all of this. Added a test pinning that identity — a copy-paste fork would silently strand WBB on the IP-burning behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable proxy rotation after a set number of successful requests.
  - Proxies flagged as banned or suspicious are no longer reused during the session.
  - Browser-based fetching now relaunches automatically when the active proxy changes.
  - Added environment configuration for proxy rotation intervals.

- **Bug Fixes**
  - Improved handling of invalid rotation-backoff values.
  - Enhanced fetch reliability across curl and browser transports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->