### PR TITLE
docs(codegen): regenerate mbb/wbb reference for NcaaFetchConfig.rotate_every

### DIFF
--- a/docs/docs/mbb/reference/additional.md
+++ b/docs/docs/mbb/reference/additional.md
@@ -971,7 +971,7 @@ The set of players on the floor, as an opaque id string
 
 Game location (`Game.LocationType`, `Game.scala:36-38`).
 
-### `NcaaFetchConfig(cache_dir: 'Optional[Path]' = None, proxy_url: 'Optional[str]' = None, proxybonanza_key: 'Optional[str]' = None, proxybonanza_pkg: 'Optional[str]' = None, timeout: 'int' = 45, impersonate: 'str' = 'chrome', max_retries: 'int' = 2, rotation_backoff: 'float' = 1.0, transport: 'Optional[FetchTransport]' = None) -> None` {#NcaaFetchConfig}
+### `NcaaFetchConfig(cache_dir: 'Optional[Path]' = None, proxy_url: 'Optional[str]' = None, proxybonanza_key: 'Optional[str]' = None, proxybonanza_pkg: 'Optional[str]' = None, timeout: 'int' = 45, impersonate: 'str' = 'chrome', max_retries: 'int' = 2, rotation_backoff: 'float' = 1.0, rotate_every: 'int' = 200, transport: 'Optional[FetchTransport]' = None) -> None` {#NcaaFetchConfig}
 
 Runtime configuration for the stats.ncaa.org fetch layer.
 
@@ -991,6 +991,7 @@ via `proxybonanza_key` + `proxybonanza_pkg` (resolved lazily by
 | `impersonate` | `str` | `'chrome'` |  |
 | `max_retries` | `int` | `2` |  |
 | `rotation_backoff` | `float` | `1.0` |  |
+| `rotate_every` | `int` | `200` |  |
 | `transport` | `Optional[FetchTransport]` | `None` |  |
 
 **Example**

--- a/docs/docs/wbb/reference/additional.md
+++ b/docs/docs/wbb/reference/additional.md
@@ -1064,7 +1064,7 @@ The set of players on the floor, as an opaque id string
 
 Game location (`Game.LocationType`, `Game.scala:36-38`).
 
-### `NcaaFetchConfig(cache_dir: 'Optional[Path]' = None, proxy_url: 'Optional[str]' = None, proxybonanza_key: 'Optional[str]' = None, proxybonanza_pkg: 'Optional[str]' = None, timeout: 'int' = 45, impersonate: 'str' = 'chrome', max_retries: 'int' = 2, rotation_backoff: 'float' = 1.0, transport: 'Optional[FetchTransport]' = None) -> None` {#NcaaFetchConfig}
+### `NcaaFetchConfig(cache_dir: 'Optional[Path]' = None, proxy_url: 'Optional[str]' = None, proxybonanza_key: 'Optional[str]' = None, proxybonanza_pkg: 'Optional[str]' = None, timeout: 'int' = 45, impersonate: 'str' = 'chrome', max_retries: 'int' = 2, rotation_backoff: 'float' = 1.0, rotate_every: 'int' = 200, transport: 'Optional[FetchTransport]' = None) -> None` {#NcaaFetchConfig}
 
 Runtime configuration for the stats.ncaa.org fetch layer.
 
@@ -1084,6 +1084,7 @@ via `proxybonanza_key` + `proxybonanza_pkg` (resolved lazily by
 | `impersonate` | `str` | `'chrome'` |  |
 | `max_retries` | `int` | `2` |  |
 | `rotation_backoff` | `float` | `1.0` |  |
+| `rotate_every` | `int` | `200` |  |
 | `transport` | `Optional[FetchTransport]` | `None` |  |
 
 **Example**


### PR DESCRIPTION
Unblocks **main's red codegen drift gate**.

#264 added `rotate_every` to `NcaaFetchConfig` (and reworked the rotation docstrings) without regenerating the reference subtree those docstrings feed. `generate.py --check` has been failing on main since it merged (`10b2d99f`, 19:25):

```
codegen --check: stale doc files: mbb/reference/additional.md, wbb/reference/additional.md
```

Reproduced on current main, regenerated, `--check` now reports `all generated files current`. The regen touches **exactly those two files and nothing else**:

```
 docs/docs/mbb/reference/additional.md | 3 ++-
 docs/docs/wbb/reference/additional.md | 3 ++-
 2 files changed, 4 insertions(+), 2 deletions(-)
```

The change is the generated signature catching up with the shipped dataclass — `NcaaFetchConfig(..., rotation_backoff: float = 1.0, rotate_every: int = 200, ...)`. wbb is included because it shares the `NcaaFetcher` surface. Docs-only; no behavior change.

Worth noting: **every PR branched off main inherits this red gate until this lands.** It is not caused by #263 (which touches neither file) — that PR's own codegen passed on its branch and only went red on main by sitting on top of `10b2d99f`.
