### PR TITLE
fix(mbb): prove the bm-verify solve instead of assuming it

### DIFF
--- a/sportsdataverse/mbb/mbb_ncaa_fetch.py
+++ b/sportsdataverse/mbb/mbb_ncaa_fetch.py
@@ -121,6 +121,20 @@ _BAN_MARKERS = (
     "rate limit",
 )
 
+# An unsolved bm-verify has TWO observed shapes, because Akamai answers a
+# navigation differently from an in-page fetch:
+#   * navigation  -> the full ~2.3 KB interstitial carrying the sensor markers
+#                    (this is what curl_cffi sees, with no cookie at all).
+#   * in-page XHR -> a THIN stub when ``_abck`` is missing/invalid. Observed
+#                    live as a 15-byte body: just ``NCAA Statistics``.
+# The stub carries no markers and no ban text, so marker-matching alone misses
+# it -- which is how unsolved challenges were mistaken for successful fetches.
+# Any stats.ncaa.org page worth having is >= 10 KB (game pages run 100 KB+), so
+# a sub-1 KB body is never content.
+_CHALLENGE_MARKERS = ("bm-verify", "_abck")
+_CHALLENGE_MAX_BYTES = 20000
+_MIN_CONTENT_BYTES = 1000
+
 PoolTransport = Callable[[str, "dict[str, str]"], "tuple[int, str]"]
 FetchTransport = Callable[[str, "dict[str, str]", "dict[str, str]"], "tuple[int, str]"]
 
@@ -375,6 +389,42 @@ def _ban_check(text: str) -> str:
     return "clean"
 
 
+def _is_challenge(text: str) -> bool:
+    """Is *text* an UNSOLVED ``bm-verify`` response -- neither content nor a ban?
+
+    The third response class, and the one that used to slip through: an unsolved
+    challenge is HTTP 200 and carries no ban marker, so :func:`_ban_check` calls
+    it ``"clean"`` and the fetch layer returned it as a successful fetch. Callers
+    then rejected it as too-small/table-less while the fetcher, believing it had
+    succeeded, never re-solved and never rotated -- so a single failed solve
+    turned into an unbounded run of useless requests.
+
+    Both observed shapes are caught:
+
+    * the ~2.3 KB navigation interstitial (matched by sensor marker + size), and
+    * the THIN in-page-fetch stub returned when ``_abck`` is invalid -- observed
+      live as 15 bytes of ``NCAA Statistics``, which carries no marker at all and
+      is only detectable by size.
+    """
+    if not text or len(text) > _CHALLENGE_MAX_BYTES:
+        return False
+    low = text.lower()
+    return any(marker in low for marker in _CHALLENGE_MARKERS)
+
+
+def _browser_response_unsolved(text: str) -> bool:
+    """Did an in-page browser fetch come back UNSOLVED?
+
+    Only the browser transport may use this. It knows two things the generic
+    fetch layer does not: the response came from an in-page ``fetch()`` against
+    stats.ncaa.org, and every page worth having there is >= 10 KB. That licenses
+    the size test which catches the marker-less thin stub (15 bytes observed).
+    :func:`_is_challenge` deliberately does NOT apply a size floor -- it judges
+    responses from every transport, where a small body may be legitimate.
+    """
+    return _is_challenge(text) or not text or len(text) < _MIN_CONTENT_BYTES
+
+
 def _normalize_path(path_or_url: str) -> str:
     """Strip a ``https://stats.ncaa.org/...`` URL down to its bare path+query.
 
@@ -475,10 +525,18 @@ class _PlaywrightTransport:
         challenge_wait_ms: int = 8000,
         nav_timeout_ms: int = 30000,
         user_agent: Optional[str] = None,
+        solve_attempts: int = 2,
     ) -> None:
         self.headless_new = headless_new
         self.challenge_wait_ms = challenge_wait_ms
         self.nav_timeout_ms = nav_timeout_ms
+        # How many times to (re-)run the bm-verify sensor before giving up and
+        # letting the fetch layer rotate. The solve is PROVEN by the in-page
+        # fetch, never assumed -- see __call__. Kept LOW on purpose: each
+        # attempt costs a navigation + challenge_wait_ms, and when an IP simply
+        # is not passing the sensor, rotating to a fresh proxy (fresh browser,
+        # fresh sensor run) recovers far faster than re-waiting on the same one.
+        self.solve_attempts = max(1, solve_attempts)
         self.user_agent = user_agent or (
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
             "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
@@ -536,18 +594,51 @@ class _PlaywrightTransport:
         self._current_proxy = proxy
         atexit.register(self.close)
 
+    def _solve_challenge(self, url: str) -> None:
+        """Run a real navigation so the bm-verify sensor executes and mints ``_abck``.
+
+        Gives the sensor up to :attr:`solve_attempts` cycles to clear the
+        interstitial. Note this only observes the NAVIGATION; whether the token
+        is actually usable is proven by the in-page fetch in :meth:`__call__`.
+        """
+        page = self._page
+        page.goto(url, wait_until="domcontentloaded", timeout=self.nav_timeout_ms)
+        for _ in range(self.solve_attempts):
+            page.wait_for_timeout(self.challenge_wait_ms)
+            if "bm-verify" not in page.content():
+                break  # interstitial cleared
+
     def __call__(self, url: str, proxies: "dict[str, str]", headers: "dict[str, str]") -> "tuple[int, str]":
         self._ensure_page(proxies)
-        page = self._page
-        if not self._challenge_solved:
-            # A real navigation runs the bm-verify sensor and mints _abck.
-            page.goto(url, wait_until="domcontentloaded", timeout=self.nav_timeout_ms)
-            page.wait_for_timeout(self.challenge_wait_ms)
-            if "bm-verify" in page.content():
-                page.wait_for_timeout(self.challenge_wait_ms)  # one more sensor cycle
-            self._challenge_solved = True
-        result = page.evaluate(_RAW_FETCH_JS, url)
-        return int(result["status"]), str(result["text"])
+        status, text = 0, ""
+        for attempt in range(1, self.solve_attempts + 1):
+            if not self._challenge_solved:
+                self._solve_challenge(url)
+                self._challenge_solved = True
+            result = self._page.evaluate(_RAW_FETCH_JS, url)
+            status, text = int(result["status"]), str(result["text"])
+            if not _browser_response_unsolved(text):
+                return status, text
+            # The solve did NOT take -- either it never passed, or Akamai
+            # re-challenged once _abck aged out. The old code set
+            # _challenge_solved=True after a BLIND wait and never checked, so a
+            # failed solve latched "solved" and every later fetch returned an
+            # unsolved response forever (1485 of them in one live run). The
+            # fetch itself is the only honest proof; force a real re-solve.
+            logger.info(
+                "bm-verify not passed (%d-byte response) -- re-solving, attempt %d/%d",
+                len(text),
+                attempt,
+                self.solve_attempts,
+            )
+            self._challenge_solved = False
+        # Still unsolved after every attempt. Raise so the fetch layer's
+        # rotate-on-transport-error path moves us to a fresh proxy -- which
+        # relaunches the browser and runs a genuinely fresh sensor. Returning
+        # the stub instead is what let the fetcher mistake it for a success.
+        raise RuntimeError(
+            f"bm-verify not passed after {self.solve_attempts} attempts ({len(text)}-byte response): {url}"
+        )
 
     def close(self) -> None:
         """Stop the browser + Playwright. Idempotent."""
@@ -574,6 +665,7 @@ def playwright_transport(
     challenge_wait_ms: int = 8000,
     nav_timeout_ms: int = 30000,
     user_agent: Optional[str] = None,
+    solve_attempts: int = 2,
 ) -> "_PlaywrightTransport":
     """Build the **suggested** stats.ncaa.org game-detail scraping transport.
 
@@ -611,6 +703,7 @@ def playwright_transport(
         challenge_wait_ms=challenge_wait_ms,
         nav_timeout_ms=nav_timeout_ms,
         user_agent=user_agent,
+        solve_attempts=solve_attempts,
     )
 
 
@@ -740,6 +833,17 @@ class NcaaFetcher:
             except Exception as exc:  # noqa: BLE001 - rotate on any transport failure
                 last_err = str(exc)
                 self._rotate("transport error")
+                continue
+            if status == 200 and _is_challenge(text):
+                # Third response class: a 200 with no ban marker that is still an
+                # unsolved bm-verify shell. The browser transport already tried a
+                # re-solve, so this IP is not currently clearing the sensor. NOT a
+                # ban -- the IP may be perfectly healthy -- so rotate to a fresh
+                # proxy (which relaunches the browser = a fresh solve) but do NOT
+                # retire it. Returning this shell is what made the fetcher believe
+                # it had succeeded and hammer one IP into a permanent ban.
+                last_err = "bm-verify challenge not cleared"
+                self._rotate("challenge not cleared")
                 continue
             if status == 200 and _ban_check(text) == "clean":
                 self._since_rotate += 1

--- a/tests/mbb/test_mbb_ncaa_fetch.py
+++ b/tests/mbb/test_mbb_ncaa_fetch.py
@@ -50,7 +50,11 @@ def _cfg(
 
 
 _POOL = ["http://u:p@10.0.0.1:1", "http://u:p@10.0.0.2:1", "http://u:p@10.0.0.3:1"]
-_CLEAN = "<html><body><table>" + "<tr><td>x</td></tr>" * 40 + "</table></body></html>"
+# Stand-in for a real game page. Must exceed _MIN_CONTENT_BYTES (1KB) -- real
+# stats.ncaa.org pages run 100KB+, and the browser transport uses size to spot
+# the marker-less thin stub, so a 700-byte "clean" fixture would be unrealistic
+# AND would read as unsolved.
+_CLEAN = "<html><body><table>" + "<tr><td>xxxxxxxxxx</td></tr>" * 100 + "</table></body></html>"
 _BAN = "<html><body>Access Denied</body></html>"
 
 
@@ -121,6 +125,185 @@ def test_rotate_every_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
     assert _from_env().rotate_every == 25
     monkeypatch.setenv("SDV_PY_NCAA_ROTATE_EVERY", "abc")
     assert _from_env().rotate_every == 200  # invalid -> default
+
+
+# --- the bm-verify challenge shell is a THIRD response class ---------------
+
+# Shape 1 -- the NAVIGATION interstitial (what curl_cffi sees, ~2.3KB + markers).
+_CHALLENGE = (
+    '<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0">'
+    '<script>window._abck="x";bm-verify</script></head><body></body></html>'
+)
+# Shape 2 -- the THIN in-page-fetch stub Akamai returns when _abck is invalid.
+# Captured live from stats.ncaa.org: exactly this, 15 bytes, no markers at all.
+_STUB = "NCAA Statistics"
+
+
+def test_unsolved_challenge_is_not_a_ban_and_not_content() -> None:
+    """The classification hole behind the outage: an unsolved challenge is 200
+    with NO ban marker, so _ban_check calls it 'clean' and the fetch layer
+    returned it as a successful fetch."""
+    from sportsdataverse.mbb.mbb_ncaa_fetch import _ban_check, _is_challenge
+
+    assert _ban_check(_CHALLENGE) == "clean"  # ban-check genuinely cannot see it
+    assert _is_challenge(_CHALLENGE) is True  # ...which is why this exists
+    assert _is_challenge(_CLEAN) is False  # real content is not a challenge
+    assert _is_challenge(_BAN) is False  # a ban is not a challenge
+    # Size guard: a huge page mentioning _abck is content, not a shell.
+    assert _is_challenge("<html>" + "x" * 30000 + "_abck</html>") is False
+
+
+def test_thin_xhr_stub_is_detected_as_unsolved() -> None:
+    """The shape that actually broke us. Akamai answers an in-page fetch that
+    carries an invalid _abck with a 15-byte body -- no 'bm-verify', no '_abck',
+    no ban text. Nothing marker-based can see it, so the BROWSER check catches
+    it by size (no real stats.ncaa.org page is under 1KB).
+
+    The size rule lives ONLY in the browser check: _is_challenge judges
+    responses from every transport, where a small body may be legitimate --
+    putting a size floor there broke 18 unrelated tests."""
+    from sportsdataverse.mbb.mbb_ncaa_fetch import (
+        _ban_check,
+        _browser_response_unsolved,
+        _is_challenge,
+    )
+
+    assert len(_STUB) == 15
+    assert _ban_check(_STUB) == "clean"  # invisible to ban-check
+    assert "bm-verify" not in _STUB.lower() and "_abck" not in _STUB.lower()
+    assert _is_challenge(_STUB) is False  # marker-based: genuinely cannot see it
+    assert _browser_response_unsolved(_STUB) is True  # size-based: caught here
+    assert _browser_response_unsolved("") is True
+    # Both shapes converge for the browser; real content passes both.
+    assert _browser_response_unsolved(_CHALLENGE) is True
+    assert _browser_response_unsolved(_CLEAN) is False
+
+
+def test_challenge_rotates_the_proxy_and_never_returns_the_shell(tmp_path: Path) -> None:
+    """A challenge must rotate to a fresh IP (fresh browser = fresh solve) and
+    must NOT be handed back to the caller as if it were a page."""
+    transport = FakeTransport([(200, _CHALLENGE), (200, _CLEAN)])
+    cfg = NcaaFetchConfig(cache_dir=tmp_path, transport=transport, rotation_backoff=0.0)
+    fetcher = NcaaFetcher(cfg, proxy_pool=_POOL)
+
+    got = fetcher.fetch_html("contests/1/play_by_play")
+
+    assert got == _CLEAN  # never the shell
+    assert _proxies_used(transport) == [_POOL[0], _POOL[1]]  # rotated on the challenge
+
+
+def test_challenge_does_not_retire_the_proxy(tmp_path: Path) -> None:
+    """A challenge is NOT a ban -- the IP may be fine. Retiring on a challenge
+    would throw away healthy IPs (they are a scarce, subnet-shared resource)."""
+    transport = FakeTransport([(200, _CHALLENGE), (200, _CLEAN)])
+    cfg = NcaaFetchConfig(cache_dir=tmp_path, transport=transport, rotation_backoff=0.0)
+    fetcher = NcaaFetcher(cfg, proxy_pool=_POOL)
+
+    fetcher.fetch_html("contests/1/play_by_play")
+
+    assert fetcher._dead == set()  # vs a 403, which DOES retire the proxy
+
+
+def test_challenge_does_not_count_toward_rotate_every(tmp_path: Path) -> None:
+    """Only real fetches age a proxy's budget; shells must not."""
+    transport = FakeTransport([(200, _CHALLENGE), (200, _CLEAN), (200, _CLEAN)])
+    cfg = NcaaFetchConfig(cache_dir=tmp_path, transport=transport, rotate_every=2, rotation_backoff=0.0)
+    fetcher = NcaaFetcher(cfg, proxy_pool=_POOL)
+
+    fetcher.fetch_html("contests/1/play_by_play")  # challenge -> rotate to p1, then clean on p1
+    assert fetcher._since_rotate == 1  # the shell did NOT increment the budget
+    fetcher.fetch_html("contests/2/play_by_play")
+    assert fetcher._since_rotate == 0  # 2 real fetches on p1 -> rotated
+
+
+# --- the solve must be PROVEN by the fetch, never assumed ------------------
+
+
+class _FakePage:
+    """Stands in for a Playwright page: scripted fetch bodies, records solves."""
+
+    def __init__(self, bodies: "list[str]") -> None:
+        self.bodies = list(bodies)
+        self.gotos = 0
+
+    def goto(self, url: str, **kw: object) -> None:
+        self.gotos += 1
+
+    def wait_for_timeout(self, ms: int) -> None:
+        pass
+
+    def content(self) -> str:
+        return "<html>ok</html>"  # interstitial looks cleared
+
+    def evaluate(self, js: str, url: str) -> dict:
+        return {"status": 200, "text": self.bodies.pop(0)}
+
+
+def _transport_with(page: _FakePage) -> object:
+    t = playwright_transport(challenge_wait_ms=0, solve_attempts=2)
+    t._page = page
+    t._current_proxy = _POOL[0]
+    t._challenge_solved = False
+    return t
+
+
+def test_failed_solve_is_retried_not_latched() -> None:
+    """The latch bug: _challenge_solved was set True after a BLIND wait, so a
+    solve that never actually passed was treated as success -- and every later
+    fetch returned an unsolved response forever (1485 in one live run).
+    The fetch itself must be the proof."""
+    page = _FakePage([_STUB, _CLEAN])  # two failed solves, then it takes
+    t = _transport_with(page)
+
+    status, text = t("https://stats.ncaa.org/contests/1/play_by_play", {"http": _POOL[0]}, {})
+
+    assert text == _CLEAN  # never returned a stub as if it were a page
+    assert page.gotos == 2  # re-solved on the unsolved response
+
+
+def test_solve_gives_up_after_solve_attempts_so_the_fetcher_can_rotate() -> None:
+    """Bounded: after solve_attempts the transport RAISES, which the fetch
+    layer's rotate-on-transport-error path turns into a fresh proxy (= fresh
+    browser + a genuinely fresh sensor run). It must never hand the stub back
+    as if it were a page -- that is what made the fetcher think it succeeded."""
+    page = _FakePage([_STUB, _STUB])
+    t = _transport_with(page)
+
+    with pytest.raises(RuntimeError, match="bm-verify not passed after 2 attempts"):
+        t("https://stats.ncaa.org/contests/1/play_by_play", {"http": _POOL[0]}, {})
+
+    assert page.gotos == 2  # exactly solve_attempts sensor runs, then stop
+
+
+def test_unsolvable_proxy_is_rotated_away_from_not_returned(tmp_path: Path) -> None:
+    """End-to-end at the fetch layer: a transport that cannot solve raises, the
+    fetcher rotates to the next proxy, and the caller gets real content."""
+    calls: "list[str]" = []
+
+    def transport(url: str, proxies: dict, headers: dict) -> "tuple[int, str]":
+        px = proxies.get("http")
+        calls.append(px)
+        if px == _POOL[0]:
+            raise RuntimeError("bm-verify not passed after 3 attempts (15-byte response)")
+        return (200, _CLEAN)
+
+    cfg = NcaaFetchConfig(cache_dir=tmp_path, transport=transport, rotation_backoff=0.0)
+    fetcher = NcaaFetcher(cfg, proxy_pool=_POOL)
+
+    assert fetcher.fetch_html("contests/1/play_by_play") == _CLEAN
+    assert calls == [_POOL[0], _POOL[1]]  # rotated off the unsolvable proxy
+    assert fetcher._dead == set()  # unsolved != banned -- the IP is not retired
+
+
+def test_solved_session_does_not_re_solve_on_every_fetch() -> None:
+    """Once genuinely solved, the token is reused -- no needless navigation."""
+    page = _FakePage([_CLEAN, _CLEAN])
+    t = _transport_with(page)
+
+    t("https://stats.ncaa.org/contests/1/play_by_play", {"http": _POOL[0]}, {})
+    t("https://stats.ncaa.org/contests/2/play_by_play", {"http": _POOL[0]}, {})
+
+    assert page.gotos == 1  # solved once, reused
 
 
 # --- the browser transport must honor a rotation (it is pinned at launch) ---


### PR DESCRIPTION
`_solve_challenge` waited, optionally waited once more, then set `_challenge_solved = True` — **without ever checking whether the sensor actually passed**. So a failed solve latched "solved" for the life of the session, and every in-page fetch from that point returned an unsolved response *forever* (1485 of them in one live run). The fetch layer saw HTTP 200 with no ban marker, called it a success, and kept hammering — which is what earned the IP a ban.

## The response class nobody was looking for

Akamai answers a **navigation** and an **in-page fetch** differently:

| Path | Unsolved response |
|---|---|
| navigation (curl_cffi, no cookie) | the ~2.3 KB interstitial, carries `bm-verify` / `_abck` |
| in-page `fetch()` with invalid `_abck` | a **15-byte** body: `NCAA Statistics` — no markers, no ban text |

The thin stub is invisible to `_ban_check` *and* to marker matching. Captured live and pinned as a test fixture.

## Changes

1. **The fetch is the proof.** If a response comes back unsolved, force a real re-solve and retry (`solve_attempts`, default **2**). Deliberately low: when an IP isn't passing the sensor, rotating to a fresh proxy recovers faster than re-waiting on the same one.
2. **Give up by raising**, so the fetch layer's existing rotate-on-transport-error path moves to a fresh proxy (fresh browser = fresh sensor run). An unsolved body is never handed back as if it were a page.
3. **Detect both shapes.** `_browser_response_unsolved` adds a size floor (no real stats.ncaa.org page is <1 KB). That floor lives **only** in the browser check — `_is_challenge` judges every transport's responses, where a small body may be legitimate. (I first put the floor in `_is_challenge` and it broke 18 unrelated tests; the suite caught it.)
4. An unsolved response is **not** a ban — the proxy is rotated away from but never retired.

## Testing

- **40 passed** in the fetch suite; **883 passed** across `tests/mbb` (no regressions); ruff + mypy clean.
- New tests pin: the 15-byte stub signature, failed-solve-is-retried-not-latched, bounded give-up → rotate, a genuinely-solved session doesn't re-solve per fetch, and end-to-end rotate-off-an-unsolvable-proxy.

## Honest limitation

**Not validated by a green live run.** The proxy pool is currently not passing the sensor at all (a 12-contest live attempt captured 0), so the retry/rotate path is proven by tests plus the recorded live signature, not by live capture. This ships the correct classification and control flow; whether these particular IPs can solve is a separate question.

## WBB
Inherited by reference — `wbb_ncaa_fetch` re-exports the mbb core (`wbb.NcaaFetcher is mbb.NcaaFetcher`, pinned by test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NCAA data retrieval when anti-bot verification challenges occur.
  * Prevented incomplete challenge pages from being returned or cached as valid results.
  * Added automatic retry and recovery handling for verification failures.
  * Improved connection rotation without incorrectly marking usable connections as unavailable.
* **Reliability**
  * Fetches now verify that protected pages are fully loaded before returning results, reducing failed or incomplete requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->