### PR TITLE
test(cfb): make the Fox roster live tests resilient to the off-season

### DIFF
--- a/tests/cfb/test_cfb_fox.py
+++ b/tests/cfb/test_cfb_fox.py
@@ -2,10 +2,15 @@
 
 Gated behind ``SDV_PY_LIVE_TESTS=1`` (Fox is a third-party live API). Stable
 ids: game 41616 (completed 2025 FSU-Kent St.), team 11 (Miami FL).
+
+The team ID is stable but a team's *roster* is not: Fox serves the roster for
+the current season, which sits empty between the bowls and fall camp. Prefer the
+completed GAME for assertions that just need populated data.
 """
 
 import pandas as pd
 import polars as pl
+import pytest
 
 from sportsdataverse.cfb.cfb_fox_ext import (
     fox_cfb_boxscore,
@@ -25,6 +30,30 @@ GAME = "41616"
 TEAM = "11"
 
 
+def _fox_roster_athlete_rows(team_id: str) -> int:
+    """How many athlete rows Fox is actually serving for ``team_id``.
+
+    Fox publishes the roster for the CURRENT season only. Between the bowls and
+    fall camp the table is unpopulated: the payload is titled e.g. "2026 Miami
+    (FL) Hurricanes Roster" but ships a single summary group whose lone row reads
+    ``PLAYER COUNT: 0`` and carries no ``entityLink`` (verified July 2026 across
+    teams 11 / 2 / 8 / 52 -- it is league-wide, not a bad team id).
+
+    Asserting a row count against that is testing Fox's calendar, not our parser,
+    so the roster tests below skip when this is 0. Counting from the RAW payload
+    (not the parsed frame) is what keeps the tests honest: if Fox IS serving
+    players and our parser drops them, this returns > 0 and the assertions still
+    fire.
+    """
+    raw = fox_cfb_team_roster(team_id, return_parsed=False)
+    return sum(
+        1
+        for g in (raw.get("groups") or [])
+        for r in (g.get("rows") or [])
+        if "athletes/" in ((r.get("entityLink") or {}).get("contentUri") or "")
+    )
+
+
 def test_fox_cfb_pbp():
     df = fox_cfb_pbp(GAME, return_as_pandas=False)
     assert isinstance(df, pl.DataFrame)
@@ -42,6 +71,8 @@ def test_fox_cfb_boxscore():
 def test_fox_cfb_team_roster():
     df = fox_cfb_team_roster(TEAM, return_as_pandas=False)
     assert isinstance(df, pl.DataFrame)
+    if _fox_roster_athlete_rows(TEAM) == 0:
+        pytest.skip("Fox has not populated the current-season roster for this team (off-season)")
     assert len(df) > 0
     assert {"team_id", "player", "pos", "athlete_id"}.issubset(df.columns)
 
@@ -83,7 +114,10 @@ def test_fox_cfb_odds():
 
 
 def test_fox_cfb_return_as_pandas():
-    df = fox_cfb_team_roster(TEAM, return_as_pandas=True)
+    # Uses the completed-2025 game, not the roster: this asserts the
+    # return_as_pandas flag, and GAME's data is settled where the roster is
+    # season-dependent (see _fox_roster_athlete_rows).
+    df = fox_cfb_pbp(GAME, return_as_pandas=True)
     assert isinstance(df, pd.DataFrame)
     assert len(df) > 0
 


### PR DESCRIPTION
## Summary

`tests/cfb/test_cfb_fox.py` has **2 failing tests on main**, and they fail on every PR (`tests.yml` sets `SDV_PY_LIVE_TESTS=1`):

```
FAILED tests/cfb/test_cfb_fox.py::test_fox_cfb_team_roster - assert 0 > 0
FAILED tests/cfb/test_cfb_fox.py::test_fox_cfb_return_as_pandas - assert 0 > 0
2 failed, 4764 passed
```

## Not a parser bug — Fox's roster is seasonally empty

Fox serves the roster for the **current** season. In July the 2026 rosters are unpopulated: the payload is titled `2026 Miami (FL) Hurricanes Roster` but ships a single *summary* group whose lone row reads `PLAYER COUNT: 0`, with no `entityLink`:

```
group keys: ['headers', 'rows', 'template']
headers:    PLAYER COUNT | (hidden) | AVG AGE | ...
row:        {"columns": [{"text": "0"}, {}, {"text": "-"}, ...]}   # no entityLink
```

Verified **league-wide**, so it isn't a stale team id:

```
team  11: athlete_rows=0  | 2026 Miami (FL) Hurricanes Roster
team   2: athlete_rows=0  | 2026 Duke Blue Devils Roster
team   8: athlete_rows=0  | 2026 Virginia Cavaliers Roster
team  52: athlete_rows=0  | 2026 Memphis Tigers Roster
```

The parser is correct to emit zero rows. The tests were asserting on Fox's calendar.

## The fix

- **`test_fox_cfb_team_roster`** skips when Fox serves no athlete rows. The count comes from the **raw payload, not the parsed frame** — that's what stops the skip from masking a parser regression: if Fox *has* players and we drop them, the count is > 0, the skip doesn't fire, and the `len`/column assertions still run. Verified both directions (live payload → 0, synthetic payload with 2 athletes + 1 non-athlete → 2).
- **`test_fox_cfb_return_as_pandas`** now exercises the completed-2025 `GAME` rather than the roster. Its job is the `return_as_pandas` flag, which needs populated data but not *season-dependent* data — the roster was simply an unlucky endpoint choice.
- The module docstring called team 11 a "stable id". True of the id, not of its roster — noted inline so the trap isn't re-laid.

## Result

`tests/cfb/test_cfb_fox.py`: **2 failed / 8 passed → 9 passed / 1 skipped** (skip carries an explicit reason). `ruff check` + `format --check` clean.

Per CLAUDE.md's test-gating guidance — *"the live suite DOES run on CI; keep gated tests resilient to upstream flakiness"* — this is that, for a seasonal upstream rather than a flaky one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved college football roster test handling when current roster data is temporarily unavailable.
  * Updated pandas output coverage to validate play-by-play results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->