### PR TITLE
docs(codegen): regenerate mbb/wbb reference for playwright_transport.solve_attempts

### DIFF
--- a/docs/docs/mbb/reference/additional.md
+++ b/docs/docs/mbb/reference/additional.md
@@ -7959,7 +7959,7 @@ from sportsdataverse.mbb.mbb_player_value_constants import player_per100_feature
 feats = player_per100_features(season_stats)
 ```
 
-### `playwright_transport(*, headless_new: 'bool' = True, challenge_wait_ms: 'int' = 8000, nav_timeout_ms: 'int' = 30000, user_agent: 'Optional[str]' = None) -> "'_PlaywrightTransport'"` {#playwright_transport}
+### `playwright_transport(*, headless_new: 'bool' = True, challenge_wait_ms: 'int' = 8000, nav_timeout_ms: 'int' = 30000, user_agent: 'Optional[str]' = None, solve_attempts: 'int' = 2) -> "'_PlaywrightTransport'"` {#playwright_transport}
 
 Build the **suggested** stats.ncaa.org game-detail scraping transport.
 
@@ -7977,6 +7977,7 @@ Playwright is a **lazy optional import** (not a hard dependency); a clear
 | `challenge_wait_ms` | `int` | `8000` | Milliseconds to let the bm-verify sensor run after the first navigation. |
 | `nav_timeout_ms` | `int` | `30000` | Per-navigation timeout. |
 | `user_agent` | `Optional[str]` | `None` | Override the Chrome UA string. |
+| `solve_attempts` | `int` | `2` |  |
 
 **Returns**
 

--- a/docs/docs/wbb/reference/additional.md
+++ b/docs/docs/wbb/reference/additional.md
@@ -7005,7 +7005,7 @@ from sportsdataverse.mbb.mbb_player_value_constants import player_per100_feature
 feats = player_per100_features(season_stats)
 ```
 
-### `playwright_transport(*, headless_new: 'bool' = True, challenge_wait_ms: 'int' = 8000, nav_timeout_ms: 'int' = 30000, user_agent: 'Optional[str]' = None) -> "'_PlaywrightTransport'"` {#playwright_transport}
+### `playwright_transport(*, headless_new: 'bool' = True, challenge_wait_ms: 'int' = 8000, nav_timeout_ms: 'int' = 30000, user_agent: 'Optional[str]' = None, solve_attempts: 'int' = 2) -> "'_PlaywrightTransport'"` {#playwright_transport}
 
 Build the **suggested** stats.ncaa.org game-detail scraping transport.
 
@@ -7023,6 +7023,7 @@ Playwright is a **lazy optional import** (not a hard dependency); a clear
 | `challenge_wait_ms` | `int` | `8000` | Milliseconds to let the bm-verify sensor run after the first navigation. |
 | `nav_timeout_ms` | `int` | `30000` | Per-navigation timeout. |
 | `user_agent` | `Optional[str]` | `None` | Override the Chrome UA string. |
+| `solve_attempts` | `int` | `2` |  |
 
 **Returns**
 


### PR DESCRIPTION
Unblocks **main's codegen drift gate**, which is still red after #265.

## Different symbol, same root cause

#266 added `solve_attempts` to `playwright_transport` (the bm-verify retry knob) without regenerating the reference subtree its docstrings feed:

```
-### `playwright_transport(*, headless_new: 'bool' = True, ..., user_agent: 'Optional[str]' = None) -> ...`
+### `playwright_transport(*, headless_new: 'bool' = True, ..., user_agent: 'Optional[str]' = None, solve_attempts: 'int' = 2) -> ...`
+| `solve_attempts` | `int` | `2` |  |
```

## Why #265 didn't cover it

#265 was **not wrong** — it regenerated against `ce8e51eb`, which was correct at the time. #266 landed at 20:34, *between* that regen and #265's 21:00 merge, and invalidated it. A regen is only valid for the source tree it ran against; per-task green does not compose across PRs.

This one was regenerated at **current main (`6ddf6d6b`, includes #266)** and `--check` reports `all generated files current`. Two files, four lines, docs-only:

```
 docs/docs/mbb/reference/additional.md | 3 ++-
 docs/docs/wbb/reference/additional.md | 3 ++-
```

## The pattern worth fixing

Two mbb PRs in a row (#264, #266) have now changed docstring-bearing source without regenerating, and each re-reds a **required** check that subsequent PRs then merge past — which is how #264's drift reached main in the first place. Every branch cut from main inherits the red gate meanwhile.

Chasing this with regen PRs is a treadmill: any mbb merge landing between a regen and its merge re-breaks it (exactly what happened to #265). The durable fixes are either **regenerate at merge time** (rebase-and-regen immediately before merging) or **make the drift gate actually block the merge** so a PR touching docstring-bearing source can't land without its regen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the new `solve_attempts` option for Playwright transport configuration.
  * Updated API signatures and parameter references with the default value of 2.
  * Applied the documentation update consistently across both supported reference guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->