### PR TITLE
feat(espn): add cross-league player_core producer (athlete identity + bio)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -623,4 +623,8 @@ files = [
     "sportsdataverse/mbb/mbb_team_box.py",
     "sportsdataverse/mbb/mbb_game_officials.py",
     "sportsdataverse/mbb/mbb_season_producers.py",
+    "sportsdataverse/nba/nba_player_core.py",
+    "sportsdataverse/mbb/mbb_player_core.py",
+    "sportsdataverse/wnba/wnba_player_core.py",
+    "sportsdataverse/wbb/wbb_player_core.py",
 ]

--- a/sportsdataverse/mbb/__init__.py
+++ b/sportsdataverse/mbb/__init__.py
@@ -4,6 +4,7 @@ from sportsdataverse.mbb.mbb_espn_ext import *
 from sportsdataverse.mbb.mbb_bracketology import *
 from sportsdataverse.mbb.mbb_fox_ext import *
 from sportsdataverse.mbb.mbb_game_officials import *
+from sportsdataverse.mbb.mbb_player_core import *
 from sportsdataverse.mbb.mbb_game_predict import *
 from sportsdataverse.mbb.mbb_game_rosters import *
 from sportsdataverse.mbb.mbb_play_by_play import *

--- a/sportsdataverse/mbb/mbb_player_core.py
+++ b/sportsdataverse/mbb/mbb_player_core.py
@@ -1,0 +1,55 @@
+"""ESPN MBB athlete core records -- identity + bio season-builder release producer.
+
+The core-v2 ``/athletes/{id}`` resource is league-neutral: nba/wnba/mbb/wbb all
+ship the same payload shape (30 keys common to all four; the deltas -- pro-only
+``contract``/``seasons``, college-only ``proAthlete``/``flag`` -- are optional
+fields this producer already gates on). So this re-exports the NBA
+implementation rather than forking a second copy, exactly as
+``mbb_game_officials`` re-exports ``helper_nba_officials``.
+
+See :mod:`sportsdataverse.nba.nba_player_core` for the two traps this encodes:
+``current_team_id`` is the athlete's CURRENT team (not their season team), and
+bio is a Type-1 overwriting snapshot (not era-correct).
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+from sportsdataverse.nba.nba_player_core import helper_nba_player_core
+
+__all__ = ["helper_mbb_player_core"]
+
+
+def helper_mbb_player_core(payload: dict, *, athlete_id: int | str) -> pl.DataFrame:
+    """Project one ESPN core-v2 athlete record into the released player_core row.
+
+    Delegates to :func:`sportsdataverse.nba.helper_nba_player_core` -- the
+    core-v2 athlete resource is identical across leagues.
+
+    Args:
+        payload: One athlete's ``mbb/player_core/json/{athlete_id}.json`` as a
+            dict (ESPN core-v2 ``/athletes/{id}``).
+        athlete_id: ESPN athlete id. **Required and not inferred** -- callers
+            pass the id from the file path. The released dtype is Int64.
+
+    Returns:
+        pl.DataFrame: Exactly one row carrying the full documented column set
+        (absent fields null); empty frame for an empty payload.
+        ``current_team_id`` is the CURRENT team, not the season team.
+
+    Example:
+        Quick start::
+
+            import json
+            from sportsdataverse.mbb import helper_mbb_player_core
+            payload = json.load(open("4433176.json", encoding="utf-8"))
+            df = helper_mbb_player_core(payload, athlete_id=4433176)
+            print(df.select("full_name", "display_height").row(0))
+
+    See Also:
+        * `hoopR`_ -- R sister package for these releases.
+
+    .. _hoopR: https://hoopR.sportsdataverse.org
+    """
+    return helper_nba_player_core(payload, athlete_id=athlete_id)

--- a/sportsdataverse/nba/__init__.py
+++ b/sportsdataverse/nba/__init__.py
@@ -4,6 +4,7 @@ from sportsdataverse.nba.nba_draft import *
 from sportsdataverse.nba.nba_espn_ext import *
 from sportsdataverse.nba.nba_fox_ext import *
 from sportsdataverse.nba.nba_game_officials import *
+from sportsdataverse.nba.nba_player_core import *
 from sportsdataverse.nba.nba_game_rosters import *
 from sportsdataverse.nba.nba_loaders import *
 from sportsdataverse.nba.nba_pbp import *

--- a/sportsdataverse/nba/nba_player_core.py
+++ b/sportsdataverse/nba/nba_player_core.py
@@ -1,0 +1,221 @@
+"""ESPN athlete core records -- identity + bio season-builder release producer.
+
+Why this producer exists: the ``player_season_stats`` payload carries NO athlete
+identity whatsoever -- no name, no bio, and not even the athlete id (its only
+carrier is the *filename*). Its ``"height"`` keys are team-logo pixel heights and
+its ``"fullName"`` keys are arena names. Identity is therefore joined in from
+``player_box`` (see :func:`build_nba_player_identity_lookup`), and bio had no
+source at all until the ``{lg}/player_core/json/{athlete_id}.json`` raw dataset.
+
+This is the producer for that dataset. The raw source is ESPN's core-v2
+``/athletes/{id}`` resource, which resolves for ~100% of athletes in every era
+sampled -- unlike the season-stats endpoint, which 404s constantly.
+
+Cross-league: the core-v2 athlete resource is the SAME payload shape for
+nba/wnba/mbb/wbb (30 keys common to all four; the deltas are pro-only
+``contract``/``seasons`` and college-only ``proAthlete``/``flag``, all optional
+here). So this implements once and the sibling league modules re-export it --
+the same pattern as :func:`sportsdataverse.nba.helper_nba_officials`.
+
+Two traps this producer encodes, both permanent properties of the source:
+
+* **``team_id`` is the athlete's CURRENT team, not their team in any past
+  season.** The payload's ``team.$ref`` is literally
+  ``/seasons/{current_season}/teams/{id}``. Season team belongs to
+  ``player_season_stats.statistics[].teamId`` or to ``player_box`` -- never to
+  this frame. The column is named ``current_team_id`` so a join can't quietly
+  pretend otherwise.
+* **Bio is a Type-1 (overwriting) snapshot.** ESPN serves today's height /
+  weight / jersey, not the value during season Y. Era-correct bio is not
+  obtainable from this or any other ESPN endpoint. A season-partitioned
+  ``player_core_{season}.parquet`` therefore means "the athletes who appeared in
+  season Y, with their CURRENT bio" -- the season dimension is participation,
+  not the bio's vintage.
+
+``college`` and ``team`` arrive as ``{"$ref": url}`` only. Hydrating them would
+triple the request count across the whole athlete universe, so the ids are
+parsed straight out of the ref URL instead -- no extra HTTP.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import polars as pl
+
+from sportsdataverse.wbb.wbb_game_rosters import _rel_chr, _rel_int
+
+__all__ = ["helper_nba_player_core"]
+
+# Ids are embedded in the core-v2 $ref URL -- parse, never fetch:
+#   http://sports.core.api.espn.com/v2/colleges/153?lang=en&region=us
+#   http://sports.core.api.espn.com/v2/sports/basketball/leagues/mbb/seasons/2025/teams/153?...
+_REF_ID_RE = re.compile(r"/(?:colleges|teams)/(\d+)")
+
+_CORE_COLS: tuple[str, ...] = (
+    "athlete_id",
+    "guid",
+    "uid",
+    "slug",
+    "type",
+    "first_name",
+    "last_name",
+    "full_name",
+    "display_name",
+    "short_name",
+    "height",
+    "display_height",
+    "weight",
+    "display_weight",
+    "age",
+    "date_of_birth",
+    "birth_city",
+    "birth_state",
+    "birth_country",
+    "jersey",
+    "position_id",
+    "position_name",
+    "position_abbreviation",
+    "position_display_name",
+    "college_id",
+    "current_team_id",
+    "headshot_href",
+    "experience_years",
+    "status_id",
+    "status_name",
+    "status_type",
+    "draft_year",
+    "draft_round",
+    "draft_selection",
+    "active",
+)
+
+_INT_COLS: tuple[str, ...] = (
+    "age",
+    "position_id",
+    "college_id",
+    "current_team_id",
+    "experience_years",
+    "status_id",
+    "draft_year",
+    "draft_round",
+    "draft_selection",
+)
+_FLOAT_COLS: tuple[str, ...] = ("height", "weight")
+
+
+def _ref_id(node: object) -> int | None:
+    """Pull the trailing numeric id out of a core-v2 ``$ref`` URL.
+
+    Returns None when the node is absent or carries no ``/colleges/{id}`` /
+    ``/teams/{id}`` segment. Never fetches the ref.
+    """
+    if not isinstance(node, dict):
+        return None
+    ref = node.get("$ref")
+    if not isinstance(ref, str):
+        return None
+    m = _REF_ID_RE.search(ref)
+    return int(m.group(1)) if m else None
+
+
+def helper_nba_player_core(payload: dict, *, athlete_id: int | str) -> pl.DataFrame:
+    """Project one ESPN core-v2 athlete record into the released player_core row.
+
+    Args:
+        payload: One athlete's ``{lg}/player_core/json/{athlete_id}.json`` as a
+            dict (ESPN core-v2 ``/athletes/{id}``).
+        athlete_id: ESPN athlete id. **Required and not inferred** -- callers
+            pass the id from the file path. The released dtype is Int64.
+
+    Returns:
+        pl.DataFrame: Exactly one row, always carrying the full documented
+        column set (absent fields are null) so callers see a stable schema.
+        An empty (zero-column) frame when the payload is empty or not a dict.
+
+        ``current_team_id`` is the athlete's CURRENT team, NOT their team in
+        any past season -- see the module docstring. Height/weight/jersey are
+        a current snapshot, not era-correct.
+
+    Example:
+        Quick start::
+
+            import json
+            from sportsdataverse.nba import helper_nba_player_core
+            payload = json.load(open("1966.json", encoding="utf-8"))
+            df = helper_nba_player_core(payload, athlete_id=1966)
+            print(df.select("full_name", "display_height", "weight").row(0))
+
+        Season dimension comes from player_box, not from this payload::
+
+            from sportsdataverse.nba import build_nba_player_identity_lookup
+            ids = sorted(int(k) for k in build_nba_player_identity_lookup(player_box))
+
+    See Also:
+        * `hoopR`_ -- R sister package for the men's basketball releases.
+        * `wehoop`_ -- R sister package for the women's basketball releases.
+
+    .. _hoopR: https://hoopR.sportsdataverse.org
+    .. _wehoop: https://wehoop.sportsdataverse.org
+    """
+    if not isinstance(payload, dict) or not payload:
+        return pl.DataFrame()
+
+    position = payload.get("position") or {}
+    status = payload.get("status") or {}
+    birth = payload.get("birthPlace") or {}
+    headshot = payload.get("headshot") or {}
+    experience = payload.get("experience") or {}
+    draft = payload.get("draft") or {}
+
+    row: dict[str, Any] = {
+        "athlete_id": _rel_int(athlete_id),
+        "guid": _rel_chr(payload.get("guid")),
+        "uid": _rel_chr(payload.get("uid")),
+        "slug": _rel_chr(payload.get("slug")),
+        "type": _rel_chr(payload.get("type")),
+        "first_name": _rel_chr(payload.get("firstName")),
+        "last_name": _rel_chr(payload.get("lastName")),
+        "full_name": _rel_chr(payload.get("fullName")),
+        "display_name": _rel_chr(payload.get("displayName")) or _rel_chr(payload.get("fullName")),
+        "short_name": _rel_chr(payload.get("shortName")),
+        "height": payload.get("height"),
+        "display_height": _rel_chr(payload.get("displayHeight")),
+        "weight": payload.get("weight"),
+        "display_weight": _rel_chr(payload.get("displayWeight")),
+        "age": _rel_int(payload.get("age")),
+        "date_of_birth": _rel_chr(payload.get("dateOfBirth")),
+        "birth_city": _rel_chr(birth.get("city")),
+        "birth_state": _rel_chr(birth.get("state")),
+        # College payloads carry a top-level birthCountry; pro payloads nest it.
+        "birth_country": _rel_chr(birth.get("country")) or _rel_chr(payload.get("birthCountry")),
+        "jersey": _rel_chr(payload.get("jersey")),
+        "position_id": _rel_int(position.get("id")),
+        "position_name": _rel_chr(position.get("name")),
+        "position_abbreviation": _rel_chr(position.get("abbreviation")),
+        "position_display_name": _rel_chr(position.get("displayName")),
+        "college_id": _ref_id(payload.get("college")),
+        "current_team_id": _ref_id(payload.get("team")),
+        "headshot_href": _rel_chr(headshot.get("href")),
+        "experience_years": _rel_int(experience.get("years")),
+        "status_id": _rel_int(status.get("id")),
+        "status_name": _rel_chr(status.get("name")),
+        "status_type": _rel_chr(status.get("type")),
+        "draft_year": _rel_int(draft.get("year")),
+        "draft_round": _rel_int(draft.get("round")),
+        "draft_selection": _rel_int(draft.get("selection")),
+        "active": payload.get("active"),
+    }
+
+    df = pl.DataFrame({c: [row.get(c)] for c in _CORE_COLS}, strict=False)
+    str_cols = [c for c in _CORE_COLS if c not in _INT_COLS + _FLOAT_COLS + ("athlete_id", "active")]
+    return df.with_columns(
+        # athlete_id is the join key into player_box / player_season_stats --
+        # Int64 here and everywhere, never a float-origin string ("123.0").
+        [pl.col("athlete_id").cast(pl.Int64, strict=False)]
+        + [pl.col(c).cast(pl.Int32, strict=False) for c in _INT_COLS]
+        + [pl.col(c).cast(pl.Float64, strict=False) for c in _FLOAT_COLS]
+        + [pl.col("active").cast(pl.Boolean, strict=False)]
+        + [pl.col(c).cast(pl.Utf8) for c in str_cols]
+    )

--- a/sportsdataverse/parsed/mbb.py
+++ b/sportsdataverse/parsed/mbb.py
@@ -340,6 +340,7 @@ from sportsdataverse.mbb import helper_mbb_pbp_features as helper_mbb_pbp_featur
 from sportsdataverse.mbb import helper_mbb_pickcenter as helper_mbb_pickcenter  # noqa: F401
 from sportsdataverse.mbb import helper_mbb_play_by_play as helper_mbb_play_by_play  # noqa: F401
 from sportsdataverse.mbb import helper_mbb_player_box as helper_mbb_player_box  # noqa: F401
+from sportsdataverse.mbb import helper_mbb_player_core as helper_mbb_player_core  # noqa: F401
 from sportsdataverse.mbb import helper_mbb_player_season_stats as helper_mbb_player_season_stats  # noqa: F401
 from sportsdataverse.mbb import helper_mbb_roster_items as helper_mbb_roster_items  # noqa: F401
 from sportsdataverse.mbb import helper_mbb_rosters as helper_mbb_rosters  # noqa: F401
@@ -856,6 +857,7 @@ __all__ = [
     "helper_mbb_pickcenter",
     "helper_mbb_play_by_play",
     "helper_mbb_player_box",
+    "helper_mbb_player_core",
     "helper_mbb_player_season_stats",
     "helper_mbb_roster_items",
     "helper_mbb_rosters",

--- a/sportsdataverse/parsed/nba.py
+++ b/sportsdataverse/parsed/nba.py
@@ -197,6 +197,7 @@ from sportsdataverse.nba import helper_nba_pbp_features as helper_nba_pbp_featur
 from sportsdataverse.nba import helper_nba_pickcenter as helper_nba_pickcenter  # noqa: F401
 from sportsdataverse.nba import helper_nba_play_by_play as helper_nba_play_by_play  # noqa: F401
 from sportsdataverse.nba import helper_nba_player_box as helper_nba_player_box  # noqa: F401
+from sportsdataverse.nba import helper_nba_player_core as helper_nba_player_core  # noqa: F401
 from sportsdataverse.nba import helper_nba_player_season_stats as helper_nba_player_season_stats  # noqa: F401
 from sportsdataverse.nba import helper_nba_roster_items as helper_nba_roster_items  # noqa: F401
 from sportsdataverse.nba import helper_nba_rosters as helper_nba_rosters  # noqa: F401
@@ -475,6 +476,7 @@ __all__ = [
     "helper_nba_pickcenter",
     "helper_nba_play_by_play",
     "helper_nba_player_box",
+    "helper_nba_player_core",
     "helper_nba_player_season_stats",
     "helper_nba_roster_items",
     "helper_nba_rosters",

--- a/sportsdataverse/parsed/wbb.py
+++ b/sportsdataverse/parsed/wbb.py
@@ -332,6 +332,7 @@ from sportsdataverse.wbb import helper_wbb_pbp_features as helper_wbb_pbp_featur
 from sportsdataverse.wbb import helper_wbb_pickcenter as helper_wbb_pickcenter  # noqa: F401
 from sportsdataverse.wbb import helper_wbb_play_by_play as helper_wbb_play_by_play  # noqa: F401
 from sportsdataverse.wbb import helper_wbb_player_box as helper_wbb_player_box  # noqa: F401
+from sportsdataverse.wbb import helper_wbb_player_core as helper_wbb_player_core  # noqa: F401
 from sportsdataverse.wbb import helper_wbb_player_season_stats as helper_wbb_player_season_stats  # noqa: F401
 from sportsdataverse.wbb import helper_wbb_roster_items as helper_wbb_roster_items  # noqa: F401
 from sportsdataverse.wbb import helper_wbb_rosters as helper_wbb_rosters  # noqa: F401
@@ -816,6 +817,7 @@ __all__ = [
     "helper_wbb_pickcenter",
     "helper_wbb_play_by_play",
     "helper_wbb_player_box",
+    "helper_wbb_player_core",
     "helper_wbb_player_season_stats",
     "helper_wbb_roster_items",
     "helper_wbb_rosters",

--- a/sportsdataverse/parsed/wnba.py
+++ b/sportsdataverse/parsed/wnba.py
@@ -153,6 +153,7 @@ from sportsdataverse.wnba import helper_wnba_pbp_features as helper_wnba_pbp_fea
 from sportsdataverse.wnba import helper_wnba_pickcenter as helper_wnba_pickcenter  # noqa: F401
 from sportsdataverse.wnba import helper_wnba_play_by_play as helper_wnba_play_by_play  # noqa: F401
 from sportsdataverse.wnba import helper_wnba_player_box as helper_wnba_player_box  # noqa: F401
+from sportsdataverse.wnba import helper_wnba_player_core as helper_wnba_player_core  # noqa: F401
 from sportsdataverse.wnba import helper_wnba_player_season_stats as helper_wnba_player_season_stats  # noqa: F401
 from sportsdataverse.wnba import helper_wnba_roster_items as helper_wnba_roster_items  # noqa: F401
 from sportsdataverse.wnba import helper_wnba_rosters as helper_wnba_rosters  # noqa: F401
@@ -358,6 +359,7 @@ __all__ = [
     "helper_wnba_pickcenter",
     "helper_wnba_play_by_play",
     "helper_wnba_player_box",
+    "helper_wnba_player_core",
     "helper_wnba_player_season_stats",
     "helper_wnba_roster_items",
     "helper_wnba_rosters",

--- a/sportsdataverse/wbb/__init__.py
+++ b/sportsdataverse/wbb/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from sportsdataverse.wbb.wbb_bracketology import *
 from sportsdataverse.wbb.wbb_espn_ext import *
 from sportsdataverse.wbb.wbb_game_officials import *
+from sportsdataverse.wbb.wbb_player_core import *
 from sportsdataverse.wbb.wbb_game_predict import *
 from sportsdataverse.wbb.wbb_game_rosters import *
 from sportsdataverse.wbb.wbb_lineup_stats import *

--- a/sportsdataverse/wbb/wbb_player_core.py
+++ b/sportsdataverse/wbb/wbb_player_core.py
@@ -1,0 +1,55 @@
+"""ESPN WBB athlete core records -- identity + bio season-builder release producer.
+
+The core-v2 ``/athletes/{id}`` resource is league-neutral: nba/wnba/mbb/wbb all
+ship the same payload shape (30 keys common to all four; the deltas -- pro-only
+``contract``/``seasons``, college-only ``proAthlete``/``flag`` -- are optional
+fields this producer already gates on). So this re-exports the NBA
+implementation rather than forking a second copy, exactly as
+``wbb_game_officials`` re-exports ``helper_nba_officials``.
+
+See :mod:`sportsdataverse.nba.nba_player_core` for the two traps this encodes:
+``current_team_id`` is the athlete's CURRENT team (not their season team), and
+bio is a Type-1 overwriting snapshot (not era-correct).
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+from sportsdataverse.nba.nba_player_core import helper_nba_player_core
+
+__all__ = ["helper_wbb_player_core"]
+
+
+def helper_wbb_player_core(payload: dict, *, athlete_id: int | str) -> pl.DataFrame:
+    """Project one ESPN core-v2 athlete record into the released player_core row.
+
+    Delegates to :func:`sportsdataverse.nba.helper_nba_player_core` -- the
+    core-v2 athlete resource is identical across leagues.
+
+    Args:
+        payload: One athlete's ``wbb/player_core/json/{athlete_id}.json`` as a
+            dict (ESPN core-v2 ``/athletes/{id}``).
+        athlete_id: ESPN athlete id. **Required and not inferred** -- callers
+            pass the id from the file path. The released dtype is Int64.
+
+    Returns:
+        pl.DataFrame: Exactly one row carrying the full documented column set
+        (absent fields null); empty frame for an empty payload.
+        ``current_team_id`` is the CURRENT team, not the season team.
+
+    Example:
+        Quick start::
+
+            import json
+            from sportsdataverse.wbb import helper_wbb_player_core
+            payload = json.load(open("10000.json", encoding="utf-8"))
+            df = helper_wbb_player_core(payload, athlete_id=10000)
+            print(df.select("full_name", "display_height").row(0))
+
+    See Also:
+        * `wehoop`_ -- R sister package for these releases.
+
+    .. _wehoop: https://wehoop.sportsdataverse.org
+    """
+    return helper_nba_player_core(payload, athlete_id=athlete_id)

--- a/sportsdataverse/wnba/__init__.py
+++ b/sportsdataverse/wnba/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from sportsdataverse.wnba.wnba_draft import *
 from sportsdataverse.wnba.wnba_espn_ext import *
 from sportsdataverse.wnba.wnba_game_officials import *
+from sportsdataverse.wnba.wnba_player_core import *
 from sportsdataverse.wnba.wnba_game_rosters import *
 from sportsdataverse.wnba.wnba_loaders import *
 from sportsdataverse.wnba.wnba_loaders_extra import *

--- a/sportsdataverse/wnba/wnba_player_core.py
+++ b/sportsdataverse/wnba/wnba_player_core.py
@@ -1,0 +1,55 @@
+"""ESPN WNBA athlete core records -- identity + bio season-builder release producer.
+
+The core-v2 ``/athletes/{id}`` resource is league-neutral: nba/wnba/mbb/wbb all
+ship the same payload shape (30 keys common to all four; the deltas -- pro-only
+``contract``/``seasons``, college-only ``proAthlete``/``flag`` -- are optional
+fields this producer already gates on). So this re-exports the NBA
+implementation rather than forking a second copy, exactly as
+``wnba_game_officials`` re-exports ``helper_nba_officials``.
+
+See :mod:`sportsdataverse.nba.nba_player_core` for the two traps this encodes:
+``current_team_id`` is the athlete's CURRENT team (not their season team), and
+bio is a Type-1 overwriting snapshot (not era-correct).
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+from sportsdataverse.nba.nba_player_core import helper_nba_player_core
+
+__all__ = ["helper_wnba_player_core"]
+
+
+def helper_wnba_player_core(payload: dict, *, athlete_id: int | str) -> pl.DataFrame:
+    """Project one ESPN core-v2 athlete record into the released player_core row.
+
+    Delegates to :func:`sportsdataverse.nba.helper_nba_player_core` -- the
+    core-v2 athlete resource is identical across leagues.
+
+    Args:
+        payload: One athlete's ``wnba/player_core/json/{athlete_id}.json`` as a
+            dict (ESPN core-v2 ``/athletes/{id}``).
+        athlete_id: ESPN athlete id. **Required and not inferred** -- callers
+            pass the id from the file path. The released dtype is Int64.
+
+    Returns:
+        pl.DataFrame: Exactly one row carrying the full documented column set
+        (absent fields null); empty frame for an empty payload.
+        ``current_team_id`` is the CURRENT team, not the season team.
+
+    Example:
+        Quick start::
+
+            import json
+            from sportsdataverse.wnba import helper_wnba_player_core
+            payload = json.load(open("1002.json", encoding="utf-8"))
+            df = helper_wnba_player_core(payload, athlete_id=1002)
+            print(df.select("full_name", "display_height").row(0))
+
+    See Also:
+        * `wehoop`_ -- R sister package for these releases.
+
+    .. _wehoop: https://wehoop.sportsdataverse.org
+    """
+    return helper_nba_player_core(payload, athlete_id=athlete_id)

--- a/tests/fixtures/player_core/README.md
+++ b/tests/fixtures/player_core/README.md
@@ -1,0 +1,23 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [player_core fixtures](#player_core-fixtures)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# player_core fixtures
+
+Real ESPN core-v2 `/athletes/{id}` captures backing `tests/test_player_core.py`.
+Captured 2026-07-16 from the committed `{lg}/player_core/json/` raw trees
+(themselves scraped from `sports.core.api.espn.com/v2/sports/basketball/leagues/{lg}/athletes/{id}`).
+
+| file | league | athlete | why this one |
+|---|---|---|---|
+| `cap_player_core_nba_1966.json` | nba | LeBron James | richest record: draft + headshot + experience; **no `college`** (prep-to-pro) — the legitimately-null case |
+| `cap_player_core_mbb_4433176.json` | mbb | RJ Davis | `college_id == current_team_id` (in college ball the team *is* the college) |
+| `cap_player_core_wnba_1002.json` | wnba | Jessica Breland | draft + college populated; pro-league shape |
+| `cap_player_core_wbb_9617.json` | wbb | id 9617 | sparsest WBB record on disk — pins schema stability when most fields are absent |
+
+Coverage is **era-dependent by nature** (headshots only exist for modern players;
+`college`/`dateOfBirth` decline the other way), so these deliberately span the extremes.

--- a/tests/fixtures/player_core/cap_player_core_mbb_4433176.json
+++ b/tests/fixtures/player_core/cap_player_core_mbb_4433176.json
@@ -1,0 +1,242 @@
+{
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/mens-college-basketball/athletes/4433176?lang=en&region=us",
+"id": "4433176",
+"uid": "s:40~l:41~a:4433176",
+"guid": "92032d38-4571-3279-81bd-be76ed0578a5",
+"type": "basketball",
+"alternateIds": {
+"sdr": "4433176"
+},
+"firstName": "RJ",
+"lastName": "Davis",
+"fullName": "RJ Davis",
+"displayName": "RJ Davis",
+"shortName": "R. Davis",
+"weight": 175.0,
+"displayWeight": "175 lbs",
+"height": 72.0,
+"displayHeight": "6' 0\"",
+"age": 24,
+"dateOfBirth": "2001-10-21T07:00Z",
+"links": [
+{
+"language": "en-US",
+"rel": [
+"playercard",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/mens-college-basketball/player/_/id/4433176/rj-davis",
+"text": "Player Card",
+"shortText": "Player Card",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"stats",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/mens-college-basketball/player/stats/_/id/4433176/rj-davis",
+"text": "Stats",
+"shortText": "Stats",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"stats",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:41~a:4433176&section=stats",
+"text": "Stats",
+"shortText": "Stats",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"splits",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/mens-college-basketball/player/splits/_/id/4433176/rj-davis",
+"text": "Splits",
+"shortText": "Splits",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"gamelog",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/mens-college-basketball/player/gamelog/_/id/4433176/rj-davis",
+"text": "Game Log",
+"shortText": "Game Log",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"gamelog",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:41~a:4433176&section=gamelog",
+"text": "Game Log",
+"shortText": "Game Log",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"news",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/mens-college-basketball/player/news/_/id/4433176/rj-davis",
+"text": "News",
+"shortText": "News",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"news",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:41~a:4433176&section=news",
+"text": "News",
+"shortText": "News",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"bio",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/mens-college-basketball/player/bio/_/id/4433176/rj-davis",
+"text": "Bio",
+"shortText": "Bio",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"bio",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:41~a:4433176&section=bio",
+"text": "Bio",
+"shortText": "Bio",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"overview",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/mens-college-basketball/player/_/id/4433176/rj-davis",
+"text": "Overview",
+"shortText": "Overview",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"overview",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:41~a:4433176",
+"text": "Overview",
+"shortText": "Overview",
+"isExternal": false,
+"isPremium": false
+}
+],
+"birthPlace": {
+"city": "White Plains",
+"state": "NY",
+"country": "USA"
+},
+"birthCountry": {
+"alternateId": "1",
+"abbreviation": "USA"
+},
+"college": {
+"$ref": "http://sports.core.api.espn.com/v2/colleges/153?lang=en&region=us"
+},
+"slug": "rj-davis",
+"headshot": {
+"href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4433176.png",
+"alt": "RJ Davis"
+},
+"jersey": "4",
+"flag": {
+"href": "https://a.espncdn.com/i/teamlogos/countries/500/usa.png",
+"alt": "USA",
+"rel": [
+"country-flag"
+]
+},
+"position": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/mens-college-basketball/positions/3?lang=en&region=us",
+"id": "3",
+"name": "Guard",
+"displayName": "Guard",
+"abbreviation": "G",
+"leaf": false
+},
+"linked": true,
+"team": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/mens-college-basketball/seasons/2025/teams/153?lang=en&region=us"
+},
+"statistics": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/mens-college-basketball/athletes/4433176/statistics?lang=en&region=us"
+},
+"experience": {
+"years": 4,
+"displayValue": "Senior",
+"abbreviation": "SR"
+},
+"proAthlete": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/nba/athletes/4433176?lang=en&region=us"
+},
+"active": false,
+"status": {
+"id": "2",
+"name": "Inactive",
+"type": "inactive",
+"abbreviation": "Inactive"
+},
+"statisticslog": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/mens-college-basketball/athletes/4433176/statisticslog?lang=en&region=us"
+}
+}

--- a/tests/fixtures/player_core/cap_player_core_nba_1966.json
+++ b/tests/fixtures/player_core/cap_player_core_nba_1966.json
@@ -1,0 +1,287 @@
+{
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/nba/athletes/1966?lang=en&region=us",
+"id": "1966",
+"uid": "s:40~l:46~a:1966",
+"guid": "1f6592b3-ff53-d321-8dc5-6038d48c1786",
+"type": "basketball",
+"alternateIds": {
+"sdr": "2126588"
+},
+"firstName": "LeBron",
+"lastName": "James",
+"fullName": "LeBron James",
+"displayName": "LeBron James",
+"shortName": "L. James",
+"weight": 250.0,
+"displayWeight": "250 lbs",
+"height": 81.0,
+"displayHeight": "6' 9\"",
+"age": 41,
+"dateOfBirth": "1984-12-30T08:00Z",
+"debutYear": 2003,
+"links": [
+{
+"language": "en-US",
+"rel": [
+"playercard",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/nba/player/_/id/1966/lebron-james",
+"text": "Player Card",
+"shortText": "Player Card",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"stats",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/nba/player/stats/_/id/1966/lebron-james",
+"text": "Stats",
+"shortText": "Stats",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"stats",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:46~a:1966&section=stats",
+"text": "Stats",
+"shortText": "Stats",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"splits",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/nba/player/splits/_/id/1966/lebron-james",
+"text": "Splits",
+"shortText": "Splits",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"gamelog",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/nba/player/gamelog/_/id/1966/lebron-james",
+"text": "Game Log",
+"shortText": "Game Log",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"gamelog",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:46~a:1966&section=gamelog",
+"text": "Game Log",
+"shortText": "Game Log",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"news",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/nba/player/news/_/id/1966/lebron-james",
+"text": "News",
+"shortText": "News",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"news",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:46~a:1966&section=news",
+"text": "News",
+"shortText": "News",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"bio",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/nba/player/bio/_/id/1966/lebron-james",
+"text": "Bio",
+"shortText": "Bio",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"bio",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:46~a:1966&section=bio",
+"text": "Bio",
+"shortText": "Bio",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"overview",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/nba/player/_/id/1966/lebron-james",
+"text": "Overview",
+"shortText": "Overview",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"overview",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:46~a:1966",
+"text": "Overview",
+"shortText": "Overview",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"advancedstats",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/nba/player/advancedstats/_/id/1966/lebron-james",
+"text": "Advanced Stats",
+"shortText": "Advanced Stats",
+"isExternal": false,
+"isPremium": false
+}
+],
+"birthPlace": {
+"city": "Akron",
+"state": "OH",
+"country": "USA"
+},
+"slug": "lebron-james",
+"headshot": {
+"href": "https://a.espncdn.com/i/headshots/nba/players/full/1966.png",
+"alt": "LeBron James"
+},
+"jersey": "23",
+"position": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/nba/positions/7?lang=en&region=us",
+"id": "7",
+"name": "Forward",
+"displayName": "Forward",
+"abbreviation": "F",
+"leaf": false
+},
+"linked": true,
+"team": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/nba/seasons/2026/teams/13?lang=en&region=us"
+},
+"statistics": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/nba/athletes/1966/statistics?lang=en&region=us"
+},
+"contracts": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/nba/athletes/1966/contracts?lang=en&region=us"
+},
+"experience": {
+"years": 23
+},
+"active": false,
+"contract": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/nba/athletes/1966/contracts/2026?lang=en&region=us",
+"birdStatus": 0,
+"baseYearCompensation": {
+"active": false
+},
+"poisonPillProvision": {
+"active": false
+},
+"incomingTradeValue": 52627153,
+"outgoingTradeValue": 52627153,
+"minimumSalaryException": false,
+"optionType": 0,
+"salary": 52627153,
+"salaryRemaining": 0,
+"yearsRemaining": 1,
+"season": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/nba/seasons/2026?lang=en&region=us"
+},
+"team": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/nba/seasons/2026/teams/13?lang=en&region=us"
+},
+"tradeKicker": {
+"active": false,
+"percentage": 0.0,
+"value": 0,
+"tradeValue": 0
+},
+"tradeRestriction": true,
+"unsignedForeignPick": false,
+"active": true
+},
+"draft": {
+"displayText": "Year: 2003 Round: 1 Pick: 1",
+"round": 1,
+"year": 2003,
+"selection": 1,
+"team": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/nba/seasons/2003/teams/5?lang=en&region=us"
+},
+"pick": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/nba/seasons/2003/draft/rounds/1/picks/1?lang=en&region=us"
+}
+},
+"status": {
+"id": "9",
+"name": "Free Agent",
+"type": "free-agent",
+"abbreviation": "FA"
+},
+"statisticslog": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/nba/athletes/1966/statisticslog?lang=en&region=us"
+},
+"seasons": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/nba/athletes/1966/seasons?lang=en&region=us"
+}
+}

--- a/tests/fixtures/player_core/cap_player_core_wbb_9617.json
+++ b/tests/fixtures/player_core/cap_player_core_wbb_9617.json
@@ -1,0 +1,33 @@
+{
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/womens-college-basketball/athletes/9617?lang=en&region=us",
+"id": "9617",
+"uid": "s:40~l:54~a:9617",
+"guid": "eecb6134-c9de-b11c-913d-be2c913d7c81",
+"type": "basketball",
+"alternateIds": {
+"sdr": "2246611"
+},
+"firstName": "Lisa",
+"lastName": "Bue",
+"fullName": "Lisa Bue",
+"displayName": "Lisa Bue",
+"shortName": "L. Bue",
+"birthPlace": {},
+"slug": "lisa-bue",
+"position": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/womens-college-basketball/positions/0?lang=en&region=us",
+"id": "0",
+"name": "Not Available",
+"displayName": "Not Available",
+"abbreviation": "NA",
+"leaf": false
+},
+"linked": true,
+"active": false,
+"status": {
+"id": "2",
+"name": "Inactive",
+"type": "inactive",
+"abbreviation": "Inactive"
+}
+}

--- a/tests/fixtures/player_core/cap_player_core_wnba_1002.json
+++ b/tests/fixtures/player_core/cap_player_core_wnba_1002.json
@@ -1,0 +1,231 @@
+{
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/athletes/1002?lang=en&region=us",
+"id": "1002",
+"uid": "s:40~l:59~a:1002",
+"guid": "f088d34a-8add-0d4e-b4b9-813a1a41af37",
+"type": "basketball",
+"alternateIds": {
+"sdr": "2238321"
+},
+"firstName": "Jessica",
+"lastName": "Breland",
+"fullName": "Jessica Breland",
+"displayName": "Jessica Breland",
+"shortName": "J. Breland",
+"weight": 166.0,
+"displayWeight": "166 lbs",
+"height": 74.0,
+"displayHeight": "6' 2\"",
+"age": 38,
+"dateOfBirth": "1988-02-23T08:00Z",
+"links": [
+{
+"language": "en-US",
+"rel": [
+"playercard",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/_/id/1002/jessica-breland",
+"text": "Player Card",
+"shortText": "Player Card",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"stats",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/stats/_/id/1002/jessica-breland",
+"text": "Stats",
+"shortText": "Stats",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"stats",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:59~a:1002&section=stats",
+"text": "Stats",
+"shortText": "Stats",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"gamelog",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/gamelog/_/id/1002/jessica-breland",
+"text": "Game Log",
+"shortText": "Game Log",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"gamelog",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:59~a:1002&section=gamelog",
+"text": "Game Log",
+"shortText": "Game Log",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"news",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/news/_/id/1002/jessica-breland",
+"text": "News",
+"shortText": "News",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"news",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:59~a:1002&section=news",
+"text": "News",
+"shortText": "News",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"bio",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/bio/_/id/1002/jessica-breland",
+"text": "Bio",
+"shortText": "Bio",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"bio",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:59~a:1002&section=bio",
+"text": "Bio",
+"shortText": "Bio",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"overview",
+"desktop",
+"athlete"
+],
+"href": "https://www.espn.com/wnba/player/_/id/1002/jessica-breland",
+"text": "Overview",
+"shortText": "Overview",
+"isExternal": false,
+"isPremium": false
+},
+{
+"language": "en-US",
+"rel": [
+"overview",
+"sportscenter",
+"app",
+"athlete"
+],
+"href": "sportscenter://x-callback-url/showClubhouse?uid=s:40~l:59~a:1002",
+"text": "Overview",
+"shortText": "Overview",
+"isExternal": false,
+"isPremium": false
+}
+],
+"birthPlace": {
+"city": "New York",
+"state": "NY",
+"country": "USA"
+},
+"college": {
+"$ref": "http://sports.core.api.espn.com/v2/colleges/153?lang=en&region=us"
+},
+"slug": "jessica-breland",
+"headshot": {
+"href": "https://a.espncdn.com/i/headshots/wnba/players/full/1002.png",
+"alt": "Jessica Breland"
+},
+"jersey": "51",
+"position": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/positions/7?lang=en&region=us",
+"id": "7",
+"name": "Forward",
+"displayName": "Forward",
+"abbreviation": "F",
+"leaf": false
+},
+"linked": true,
+"team": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/seasons/2019/teams/5?lang=en&region=us"
+},
+"statistics": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/athletes/1002/statistics?lang=en&region=us"
+},
+"contracts": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/athletes/1002/contracts?lang=en&region=us"
+},
+"experience": {
+"years": 8
+},
+"collegeAthlete": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/womens-college-basketball/athletes/5954?lang=en&region=us"
+},
+"active": false,
+"draft": {
+"displayText": "Year: 2011 Round: 2 Pick: 13",
+"round": 2,
+"year": 2011,
+"selection": 13,
+"team": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/seasons/2011/teams/8?lang=en&region=us"
+}
+},
+"status": {
+"id": "2",
+"name": "Inactive",
+"type": "inactive",
+"abbreviation": "Inactive"
+},
+"statisticslog": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/athletes/1002/statisticslog?lang=en&region=us"
+},
+"seasons": {
+"$ref": "http://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/athletes/1002/seasons?lang=en&region=us"
+}
+}

--- a/tests/test_player_core.py
+++ b/tests/test_player_core.py
@@ -1,0 +1,116 @@
+"""Offline tests for the cross-league player_core producer.
+
+Fixtures are REAL core-v2 captures (see ``tests/fixtures/player_core/README.md``)
+— the repo rule is that parsers are pinned against real payloads, never
+hand-written ones. They deliberately span the coverage extremes, because
+player_core field coverage is era-dependent by nature.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from sportsdataverse.mbb import helper_mbb_player_core
+from sportsdataverse.nba import helper_nba_player_core
+from sportsdataverse.nba.nba_player_core import _CORE_COLS, _ref_id
+from sportsdataverse.wbb import helper_wbb_player_core
+from sportsdataverse.wnba import helper_wnba_player_core
+
+FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "player_core"
+
+
+def _load(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_nba_rich_record_projects_expected_values() -> None:
+    df = helper_nba_player_core(_load("cap_player_core_nba_1966.json"), athlete_id=1966)
+    assert df.height == 1
+    row = df.row(0, named=True)
+    assert row["athlete_id"] == 1966
+    assert row["full_name"] == "LeBron James"
+    assert row["height"] == 81.0 and row["display_height"] == "6' 9\""
+    assert row["weight"] == 250.0
+    assert row["jersey"] == "23"
+    assert row["draft_year"] == 2003 and row["draft_round"] == 1 and row["draft_selection"] == 1
+    assert row["headshot_href"].endswith("/1966.png")
+    # Prep-to-pro: college is legitimately absent, NOT a parse failure.
+    assert row["college_id"] is None
+
+
+def test_athlete_id_is_int64_and_comes_from_the_caller() -> None:
+    """athlete_id is the join key into player_box / player_season_stats.
+
+    It is NOT in the payload body — the raw file's *name* is its only carrier —
+    so the caller must supply it, and it must land as Int64 (never a
+    float-origin "123.0" string).
+    """
+    payload = _load("cap_player_core_nba_1966.json")
+    df = helper_nba_player_core(payload, athlete_id="1966")  # string in ...
+    assert df.schema["athlete_id"] == pl.Int64  # ... Int64 out
+    assert df.row(0, named=True)["athlete_id"] == 1966
+
+
+def test_college_and_team_ids_are_parsed_from_refs_not_fetched() -> None:
+    """team/college arrive as {"$ref": url} only. Hydrating them would triple
+    the request count over the whole athlete universe, so the ids are parsed
+    out of the URL. In college ball the team IS the college, hence the equality.
+    """
+    df = helper_mbb_player_core(_load("cap_player_core_mbb_4433176.json"), athlete_id=4433176)
+    row = df.row(0, named=True)
+    assert row["college_id"] == 153
+    assert row["current_team_id"] == 153
+
+
+@pytest.mark.parametrize(
+    ("ref", "expected"),
+    [
+        ({"$ref": "http://sports.core.api.espn.com/v2/colleges/153?lang=en"}, 153),
+        ({"$ref": "http://x/v2/sports/basketball/leagues/nba/seasons/2026/teams/13?lang=en"}, 13),
+        ({"$ref": "http://x/v2/athletes/1966"}, None),  # neither colleges/ nor teams/
+        ({}, None),
+        (None, None),
+        ("not-a-dict", None),
+    ],
+)
+def test_ref_id_extraction(ref: object, expected: int | None) -> None:
+    assert _ref_id(ref) == expected
+
+
+def test_empty_payload_returns_empty_frame_without_raising() -> None:
+    assert helper_nba_player_core({}, athlete_id=1).shape == (0, 0)
+    assert helper_nba_player_core(None, athlete_id=1).shape == (0, 0)  # type: ignore[arg-type]
+
+
+def test_sparse_record_still_carries_the_full_schema() -> None:
+    """A 2000s-era athlete is missing most bio, but callers must still see a
+    stable column set — coverage is era-dependent, the schema is not.
+    """
+    sparse = helper_wbb_player_core(_load("cap_player_core_wbb_9617.json"), athlete_id=9617)
+    rich = helper_nba_player_core(_load("cap_player_core_nba_1966.json"), athlete_id=1966)
+    assert sparse.columns == rich.columns == list(_CORE_COLS)
+    assert sparse.schema == rich.schema
+    assert sparse.height == 1
+    # It really is sparse — otherwise this test proves nothing.
+    assert sum(v is None for v in sparse.row(0)) > 0
+
+
+def test_all_four_leagues_share_one_schema() -> None:
+    """The core-v2 athlete resource is league-neutral; the siblings delegate to
+    the NBA implementation. If a league ever forks, this fails first.
+    """
+    frames = [
+        helper_nba_player_core(_load("cap_player_core_nba_1966.json"), athlete_id=1966),
+        helper_mbb_player_core(_load("cap_player_core_mbb_4433176.json"), athlete_id=4433176),
+        helper_wnba_player_core(_load("cap_player_core_wnba_1002.json"), athlete_id=1002),
+        helper_wbb_player_core(_load("cap_player_core_wbb_9617.json"), athlete_id=9617),
+    ]
+    first = frames[0].schema
+    for f in frames[1:]:
+        assert f.schema == first
+    # ... and they concat, which is what the season builder actually does.
+    assert pl.concat(frames, how="vertical").height == 4


### PR DESCRIPTION
`player_season_stats` carries **no athlete identity whatsoever** — no name, no bio, and **not even the athlete id** (its only carrier is the *filename*). Its `"height"` keys are team-logo pixel heights; its `"fullName"` keys are arena names. Identity has to be joined in from player_box via `build_nba_player_identity_lookup`, and **bio had no source at all** until the `{lg}/player_core/json/{athlete_id}.json` raw dataset landed (147,280 records now committed across the four raw repos).

This is the producer for it. `helper_nba_player_core` projects one ESPN core-v2 `/athletes/{id}` record into a **35-column row**: names, `height` (numeric) + `display_height`, `weight`, `jersey`, `position`, `headshot`, `birthPlace`, `dateOfBirth`, `experience`, `draft`, `status`, `active`. That resource resolves for **~100% of athletes in every era sampled** — unlike the season-stats endpoint, which 404s constantly.

**Cross-league by construction.** The core-v2 athlete resource is the same payload for nba/wnba/mbb/wbb (30 keys common to all four; the deltas — pro-only `contract`/`seasons`, college-only `proAthlete`/`flag` — are optional). So mbb/wnba/wbb **re-export** the NBA implementation rather than forking, exactly as `{lg}_game_officials` re-exports `helper_nba_officials`.

## Three deliberate decisions
- **`athlete_id` is a required kwarg, never inferred** — it isn't in the payload body. Released **Int64** (the join key into player_box / player_season_stats); never a float-origin `"123.0"`.
- **`team`/`college` are `$ref`-only and deliberately NOT hydrated** — that would **triple** the request count across the whole athlete universe. The ids are parsed out of the ref URL for free. The column is `current_team_id` because it's the athlete's team **today** (the ref is literally `/seasons/{current}/teams/{id}`), **not** their team in any past season.
- **The helper takes no `season`.** A core record isn't season data — bio is a **Type-1 overwriting snapshot** and era-correct bio is unobtainable from any ESPN endpoint. Season partitioning belongs to the data-build's builder.

## Verified
- **12 offline tests**, pinned against **real captures** spanning the coverage extremes: LeBron (draft + headshot, **no college** — prep-to-pro, the legitimately-null case), RJ Davis (`college_id == current_team_id` — in college ball the team *is* the college), and the sparsest WBB record (schema stability).
- Empty payload → empty frame, never raises. A sparse 2000s athlete still carries the full 35-column schema — coverage is era-dependent, the schema is not.
- Full suite: **260 passed, 11 skipped** (includes the codegen drift gate + the 121/121 parser-coverage invariant).
- Codegen regenerated (the `parsed/` modules go stale otherwise), mypy ratchet extended, ruff clean.

Downstream: the `{lg}_data_build` `player_core` dataset consumes this. Release tag + R loader are a separate, deliberate decision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent player-core data extraction across NBA, WNBA, men’s basketball, and women’s basketball.
  * Exposed league-specific player-core helpers through the standard and legacy public APIs.
  * Standardized player identifiers, team and college references, field types, and shared output schemas.

* **Tests**
  * Added offline coverage for complete, sparse, invalid, and cross-league player records.

* **Documentation**
  * Documented player-core fixture coverage and representative data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->