### PR TITLE
fix(mbb): NCAA browser transport uses patchright to clear bm-verify

### DIFF
--- a/docs/docs/mbb/reference/additional.md
+++ b/docs/docs/mbb/reference/additional.md
@@ -7959,7 +7959,7 @@ from sportsdataverse.mbb.mbb_player_value_constants import player_per100_feature
 feats = player_per100_features(season_stats)
 ```
 
-### `playwright_transport(*, headless_new: 'bool' = True, challenge_wait_ms: 'int' = 8000, nav_timeout_ms: 'int' = 30000, user_agent: 'Optional[str]' = None, solve_attempts: 'int' = 2) -> "'_PlaywrightTransport'"` {#playwright_transport}
+### `playwright_transport(*, headless_new: 'bool' = True, challenge_wait_ms: 'int' = 8000, nav_timeout_ms: 'int' = 45000, user_agent: 'Optional[str]' = None, solve_attempts: 'int' = 3) -> "'_PlaywrightTransport'"` {#playwright_transport}
 
 Build the **suggested** stats.ncaa.org game-detail scraping transport.
 
@@ -7975,9 +7975,9 @@ Playwright is a **lazy optional import** (not a hard dependency); a clear
 |---|---|---|---|
 | `headless_new` | `bool` | `True` | Use `--headless=new` (real-GPU render, no window) -- the default and the proven-working mode. `False` runs old headless (`headless_shell`), which Akamai flags -- avoid. |
 | `challenge_wait_ms` | `int` | `8000` | Milliseconds to let the bm-verify sensor run after the first navigation. |
-| `nav_timeout_ms` | `int` | `30000` | Per-navigation timeout. |
+| `nav_timeout_ms` | `int` | `45000` | Per-navigation timeout. |
 | `user_agent` | `Optional[str]` | `None` | Override the Chrome UA string. |
-| `solve_attempts` | `int` | `2` |  |
+| `solve_attempts` | `int` | `3` |  |
 
 **Returns**
 

--- a/docs/docs/wbb/reference/additional.md
+++ b/docs/docs/wbb/reference/additional.md
@@ -7005,7 +7005,7 @@ from sportsdataverse.mbb.mbb_player_value_constants import player_per100_feature
 feats = player_per100_features(season_stats)
 ```
 
-### `playwright_transport(*, headless_new: 'bool' = True, challenge_wait_ms: 'int' = 8000, nav_timeout_ms: 'int' = 30000, user_agent: 'Optional[str]' = None, solve_attempts: 'int' = 2) -> "'_PlaywrightTransport'"` {#playwright_transport}
+### `playwright_transport(*, headless_new: 'bool' = True, challenge_wait_ms: 'int' = 8000, nav_timeout_ms: 'int' = 45000, user_agent: 'Optional[str]' = None, solve_attempts: 'int' = 3) -> "'_PlaywrightTransport'"` {#playwright_transport}
 
 Build the **suggested** stats.ncaa.org game-detail scraping transport.
 
@@ -7021,9 +7021,9 @@ Playwright is a **lazy optional import** (not a hard dependency); a clear
 |---|---|---|---|
 | `headless_new` | `bool` | `True` | Use `--headless=new` (real-GPU render, no window) -- the default and the proven-working mode. `False` runs old headless (`headless_shell`), which Akamai flags -- avoid. |
 | `challenge_wait_ms` | `int` | `8000` | Milliseconds to let the bm-verify sensor run after the first navigation. |
-| `nav_timeout_ms` | `int` | `30000` | Per-navigation timeout. |
+| `nav_timeout_ms` | `int` | `45000` | Per-navigation timeout. |
 | `user_agent` | `Optional[str]` | `None` | Override the Chrome UA string. |
-| `solve_attempts` | `int` | `2` |  |
+| `solve_attempts` | `int` | `3` |  |
 
 **Returns**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,9 @@ all = [
     "scikit-learn>=1.0.0",
     "xgboost>=2.0.0",
     "playwright>=1.40",
+    # NCAA (stats.ncaa.org) browser transport -- anti-detect fork of Playwright
+    # that clears Akamai bm-verify; vanilla Playwright is flagged. See mbb_ncaa_fetch.
+    "patchright>=1.50",
 ]
 
 

--- a/sportsdataverse/mbb/mbb_ncaa_fetch.py
+++ b/sportsdataverse/mbb/mbb_ncaa_fetch.py
@@ -553,6 +553,9 @@ class _PlaywrightTransport:
         self._pw: Any = None
         self._browser: Any = None
         self._page: Any = None
+        # Browser profile dir, tied to this transport's lifetime -- removed in
+        # close() so a per-launch temp dir does not leak across proxy rotations.
+        self._temp_dir: Any = None
         self._challenge_solved = False
         # The proxy this browser was LAUNCHED with. Playwright binds the proxy at
         # launch, so honoring a rotation means relaunching -- see _ensure_page.
@@ -591,8 +594,12 @@ class _PlaywrightTransport:
         # (not the SwiftShader tell). The user_agent override is load-bearing (see
         # __init__). Proven live 2026-07-16: this exact shape clears bm-verify where
         # vanilla Playwright and a leaky-UA browser both failed.
+        # Retain the profile dir on the instance so close() can remove it; a bare
+        # mkdtemp leaked one dir per launch, and the browser relaunches on every
+        # proxy rotation. TemporaryDirectory also GC-finalizes as a backstop.
+        self._temp_dir = tempfile.TemporaryDirectory(prefix="ncaa_pw_")
         launch_kwargs: "dict[str, object]" = {
-            "user_data_dir": tempfile.mkdtemp(prefix="ncaa_pw_"),
+            "user_data_dir": self._temp_dir.name,
             "user_agent": self.user_agent,
             "no_viewport": True,
         }
@@ -661,13 +668,19 @@ class _PlaywrightTransport:
         )
 
     def close(self) -> None:
-        """Stop the browser + Playwright. Idempotent."""
+        """Stop the browser + Playwright and remove the profile dir. Idempotent."""
         for obj, meth in ((self._browser, "close"), (self._pw, "stop")):
             try:
                 if obj is not None:
                     getattr(obj, meth)()
             except Exception:  # noqa: BLE001 - best-effort teardown
                 pass
+        if self._temp_dir is not None:
+            try:
+                self._temp_dir.cleanup()  # remove the browser profile dir
+            except Exception:  # noqa: BLE001 - best-effort; a lingering file lock may defer it
+                pass
+            self._temp_dir = None
         self._browser = self._pw = self._page = None
         self._challenge_solved = False
         self._current_proxy = None

--- a/sportsdataverse/mbb/mbb_ncaa_fetch.py
+++ b/sportsdataverse/mbb/mbb_ncaa_fetch.py
@@ -66,18 +66,21 @@ game-detail pages, so there are two transports:
   clears the challenge, then serves the raw server HTML the Phase 5a-5e parsers
   consume. It runs fully headless (no window) on any host with a real GPU.
 
-**Why new-headless is the load-bearing detail.** Playwright's *default*
-``headless=True`` uses the old ``headless_shell`` binary, whose SwiftShader
-software-GPU WebGL renderer (``"Google SwiftShader"``) is a textbook Akamai
-headless tell -> edge-denied. ``--headless=new`` renders through the real
-GPU/ANGLE path, so that tell disappears and bm-verify passes. It is **not** the
-automation fingerprint -- vanilla Playwright (``navigator.webdriver`` + CDP
-leak intact) passes both headful and new-headless -- so anti-detect forks
-(patchright/nodriver) are unnecessary. Ceiling: a GPU-less headless CI box
-falls back to SwiftShader and is re-detected; run on a GPU instance / ``xvfb``
-+ real GPU, or a managed browser, there.
+**Three load-bearing details, all required together (re-established live 2026-07-16
+after Akamai tightened -- the earlier "anti-detect is unnecessary" note was
+FALSIFIED).** (1) **new-headless** (``--headless=new``) renders through the real
+GPU/ANGLE path; the default ``headless=True``/old ``headless_shell`` uses the
+SwiftShader software-GPU renderer (``"Google SwiftShader"``), a textbook Akamai
+tell. (2) **patchright, not vanilla Playwright** -- vanilla Playwright leaks
+``navigator.webdriver=true`` + the ``Runtime.enable`` CDP tell and gets
+*challenged*; patchright patches both. (3) **a real Chrome ``user_agent``** --
+new-headless otherwise reports ``HeadlessChrome`` in ``navigator.userAgent``, the
+single tell that broke every prior attempt. With all three + a **residential** IP
+(datacenter gets an instant edge 403 regardless of browser), bm-verify clears
+(proven: 10-game canary, real 100 KB+ pages, ~11 s/page warm). Ceiling: a GPU-less
+headless CI box falls back to SwiftShader and is re-detected; run on a real-GPU host.
 
-**Playwright stays an OPTIONAL import** (lazy, like ``curl_cffi``): importing
+**patchright stays an OPTIONAL import** (lazy, like ``curl_cffi``): importing
 this module never requires it; only :func:`playwright_transport` does, with a
 clear ``ImportError`` + install hint on first use. Game-id **discovery**
 (scoreboards / ``teams/{id}/game_by_game`` are JS-rendered, no server-side ids)
@@ -492,25 +495,25 @@ _RAW_FETCH_JS = (
 
 
 class _PlaywrightTransport:
-    """Stateful `FetchTransport` that drives a real Chromium (Playwright) to
-    clear the Akamai ``bm-verify`` challenge, then returns raw server HTML.
+    """Stateful `FetchTransport` that drives an anti-detect Chromium (patchright)
+    to clear the Akamai ``bm-verify`` challenge, then returns raw server HTML.
 
     **This is the suggested method for scraping stats.ncaa.org game-detail
     pages** (play-by-play / individual-stats / box-score), which sit behind an
     Akamai BotManager JS proof-of-work that ``curl_cffi`` cannot clear. Built
     via :func:`playwright_transport` and wired through
     :attr:`NcaaFetchConfig.transport` (or the :meth:`NcaaFetcher.with_browser`
-    convenience). Proven live 2026-07-07 -- see ``dev/phase5f-live-proof.md``.
+    convenience). Re-proven live 2026-07-16 (10-game canary PASS).
 
-    **Why new-headless (the load-bearing detail):** Chrome's *new* headless
-    (``--headless=new``) renders through the real GPU/ANGLE path, so its WebGL
-    renderer string is a normal GPU -- not the ``"Google SwiftShader"`` of
-    Playwright's default old-``headless_shell``, which Akamai flags. So this
-    runs fully headless (no visible window) on any host with a real GPU. It is
-    NOT the automation fingerprint: vanilla Playwright (``navigator.webdriver``
-    + CDP leak intact) passes, so no anti-detect fork is needed. Caveat: a
-    GPU-less headless CI box falls back to SwiftShader and is re-detected --
-    there, run on a GPU instance / ``xvfb`` + real GPU, or a managed browser.
+    **Three tells must ALL be neutralized** (see the module docstring): (1)
+    **new-headless** (``--headless=new``) → real GPU/ANGLE, not the
+    ``"Google SwiftShader"`` of old ``headless_shell``; (2) **patchright** patches
+    ``navigator.webdriver`` + the ``Runtime.enable`` CDP leak that get *vanilla*
+    Playwright challenged; (3) a **real Chrome ``user_agent``** (new-headless
+    leaks ``HeadlessChrome`` otherwise). Plus a **residential** proxy -- a
+    datacenter IP gets an instant edge 403 no matter how clean the browser is.
+    Caveat: a GPU-less headless CI box falls back to SwiftShader and is
+    re-detected -- run on a real-GPU host.
 
     Reuses ONE browser across the whole session: the first fetch navigates to
     mint the ``_abck`` cookie, every fetch (including the first) reads raw
@@ -523,9 +526,9 @@ class _PlaywrightTransport:
         *,
         headless_new: bool = True,
         challenge_wait_ms: int = 8000,
-        nav_timeout_ms: int = 30000,
+        nav_timeout_ms: int = 45000,
         user_agent: Optional[str] = None,
-        solve_attempts: int = 2,
+        solve_attempts: int = 3,
     ) -> None:
         self.headless_new = headless_new
         self.challenge_wait_ms = challenge_wait_ms
@@ -537,9 +540,13 @@ class _PlaywrightTransport:
         # is not passing the sensor, rotating to a fresh proxy (fresh browser,
         # fresh sensor run) recovers far faster than re-waiting on the same one.
         self.solve_attempts = max(1, solve_attempts)
+        # A REAL Chrome UA is load-bearing: new-headless otherwise reports
+        # "HeadlessChrome" in navigator.userAgent, and that single tell is what made
+        # every pre-2026-07-16 solve attempt fail. Overriding it (any real Chrome UA)
+        # is half the fix; anti-detect patchright (webdriver=false) is the other half.
         self.user_agent = user_agent or (
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
-            "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+            "(KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36"
         )
         # Any (not object): these hold optional-import Playwright handles; the
         # module never imports playwright at type-check time.
@@ -564,33 +571,46 @@ class _PlaywrightTransport:
             logger.info("browser proxy rotated -> %s (relaunching)", _redact_proxy_url(proxy))
             self.close()
         try:
-            from playwright.sync_api import sync_playwright
-        except ImportError as exc:  # pragma: no cover - exercised only without playwright
+            from patchright.sync_api import sync_playwright
+        except ImportError as exc:  # pragma: no cover - exercised only without patchright
             raise ImportError(
-                "The NCAA browser transport requires Playwright (game-detail pages "
-                "sit behind an Akamai bm-verify JS challenge). Install with: "
-                "pip install playwright && playwright install chromium. "
-                "Playwright is intentionally NOT a hard sportsdataverse dependency."
+                "The NCAA browser transport requires patchright -- an anti-detect "
+                "Playwright fork. Game-detail pages sit behind Akamai bm-verify, and "
+                "vanilla Playwright's navigator.webdriver=true is flagged (only "
+                "patchright, which patches that + the Runtime.enable CDP leak, clears "
+                "it). Install with: pip install patchright && patchright install "
+                "chromium. patchright is intentionally NOT a hard sportsdataverse "
+                "dependency."
             ) from exc
         import atexit
+        import tempfile
 
         self._pw = sync_playwright().start()
-        launch_kwargs: "dict[str, object]" = (
+        # launch_persistent_context (not launch + new_context) is the more stealthy
+        # path patchright recommends. new-headless renders through the real GPU/ANGLE
+        # (not the SwiftShader tell). The user_agent override is load-bearing (see
+        # __init__). Proven live 2026-07-16: this exact shape clears bm-verify where
+        # vanilla Playwright and a leaky-UA browser both failed.
+        launch_kwargs: "dict[str, object]" = {
+            "user_data_dir": tempfile.mkdtemp(prefix="ncaa_pw_"),
+            "user_agent": self.user_agent,
+            "no_viewport": True,
+        }
+        launch_kwargs.update(
             {"headless": False, "args": ["--headless=new"]} if self.headless_new else {"headless": True}
         )
         proxy = proxies.get("http") or proxies.get("https")
-        if proxy:  # honor a configured (residential) proxy; datacenter IPs defeat bm-verify
+        if proxy:  # honor a configured RESIDENTIAL proxy; datacenter IPs get an edge 403
             parts = urlsplit(proxy)
             launch_kwargs["proxy"] = {
                 "server": f"{parts.scheme}://{parts.hostname}:{parts.port}",
                 **({"username": parts.username} if parts.username else {}),
                 **({"password": parts.password} if parts.password else {}),
             }
-        self._browser = self._pw.chromium.launch(**launch_kwargs)
-        ctx = self._browser.new_context(
-            user_agent=self.user_agent, locale="en-US", viewport={"width": 1366, "height": 900}
-        )
-        self._page = ctx.new_page()
+        # launch_persistent_context returns a BrowserContext (closeable) -- kept in
+        # self._browser so close() works unchanged.
+        self._browser = self._pw.chromium.launch_persistent_context(**launch_kwargs)
+        self._page = self._browser.pages[0] if self._browser.pages else self._browser.new_page()
         self._current_proxy = proxy
         atexit.register(self.close)
 
@@ -663,9 +683,9 @@ def playwright_transport(
     *,
     headless_new: bool = True,
     challenge_wait_ms: int = 8000,
-    nav_timeout_ms: int = 30000,
+    nav_timeout_ms: int = 45000,
     user_agent: Optional[str] = None,
-    solve_attempts: int = 2,
+    solve_attempts: int = 3,
 ) -> "_PlaywrightTransport":
     """Build the **suggested** stats.ncaa.org game-detail scraping transport.
 

--- a/tests/mbb/test_mbb_ncaa_fetch.py
+++ b/tests/mbb/test_mbb_ncaa_fetch.py
@@ -653,11 +653,11 @@ def test_playwright_transport_shape() -> None:
 
 
 def test_playwright_transport_missing_dep_raises() -> None:
-    """Playwright is not a hard dep; first use without it raises a clear hint."""
-    if importlib.util.find_spec("playwright") is not None:
-        pytest.skip("playwright installed -- ImportError path not exercised")
+    """patchright is not a hard dep; first use without it raises a clear hint."""
+    if importlib.util.find_spec("patchright") is not None:
+        pytest.skip("patchright installed -- ImportError path not exercised")
     t = playwright_transport()
-    with pytest.raises(ImportError, match="[Pp]laywright"):
+    with pytest.raises(ImportError, match="[Pp]atchright"):
         t("https://stats.ncaa.org/contests/1/play_by_play", {}, {})
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -4542,6 +4542,66 @@ wheels = [
 ]
 
 [[package]]
+name = "patchright"
+version = "1.60.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version > '3.9' and python_full_version < '3.10'",
+    "python_full_version <= '3.9'",
+]
+dependencies = [
+    { name = "greenlet", version = "3.2.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyee", marker = "python_full_version < '3.10'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/26/c1e858fd1acc63e410b3d33243955f36d2a0814487b97a7aa604ad2baffd/patchright-1.60.1-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:e9492100d4e2a85ff92fc3a668dd16dee03f21df6e559c7b9f7c71e86ff48c6b", size = 43458936, upload-time = "2026-06-03T12:11:50.892Z" },
+    { url = "https://files.pythonhosted.org/packages/55/dd/2dd8e4e02489ec8fd57ad93dec9ef444b6f42adcc4fe95df30237c92841d/patchright-1.60.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:20bd806df2469b451ccd2ea10f5f944ceb0e0d83c716f5752b0c956c1ee59476", size = 42245629, upload-time = "2026-06-03T12:11:56.098Z" },
+    { url = "https://files.pythonhosted.org/packages/54/cc/0fa0bedec61045fd9068682e3695557b622c483f829d341093879ec8dbd9/patchright-1.60.1-py3-none-macosx_11_0_universal2.whl", hash = "sha256:9fd15a64c0ca80740dc2a3f41cda336a06a2ed6068d0ab893172654290b06e6b", size = 43458935, upload-time = "2026-06-03T12:12:01.077Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/c2/4b8f69de0a20d90792980c43c0e60b10b801e08cf0224ccc8a8266e1fffb/patchright-1.60.1-py3-none-manylinux1_x86_64.whl", hash = "sha256:547e7bfb813102309789cc42933780e5fdf7c4727de59fb2791e64bd1298a7f3", size = 47451519, upload-time = "2026-06-03T12:12:06.645Z" },
+    { url = "https://files.pythonhosted.org/packages/db/fc/9fd6a70818cf0bc3b62574af483d762963cb65ca0a369826a0536faffe41/patchright-1.60.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:023945a2fd30219a284721ca36385bd44075ae7b53071dc1da38036b6dbe88ec", size = 47139153, upload-time = "2026-06-03T12:12:12.047Z" },
+    { url = "https://files.pythonhosted.org/packages/08/bc/81fb621e5ab4131e6f324c9ba6cb2a9f3b146c92f12484bec95efe8c8347/patchright-1.60.1-py3-none-win32.whl", hash = "sha256:05b98a6afdbe7e6645fe223009c47cc8e7859df55fd8ce9d8a9925b3389b0ee1", size = 37886460, upload-time = "2026-06-03T12:12:16.598Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8e/fff80350ed2c2c1f62145d667070799c60ca9e9b28d54e4f751f0b4f8da6/patchright-1.60.1-py3-none-win_amd64.whl", hash = "sha256:51b306ed55cd58f1bca24641458f5c9f7e86a1f1727dcffdead669cfe4c0a485", size = 37886465, upload-time = "2026-06-03T12:12:21.448Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b8/b6d1bfe98a420c1ccfb2f23a7bb2b4cdb40170907bae638e7ae92abd287c/patchright-1.60.1-py3-none-win_arm64.whl", hash = "sha256:f795728c1e27fc226dbe203c1aec713a537f01be963474fe0f3691f5e6457f9f", size = 34022283, upload-time = "2026-06-03T12:12:26.732Z" },
+]
+
+[[package]]
+name = "patchright"
+version = "1.61.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
+    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.10.*'",
+]
+dependencies = [
+    { name = "greenlet", version = "3.5.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyee", marker = "python_full_version >= '3.10'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/42/a76e2ea17dd4feccbf5ef6df017fb2e67f4b72a6f559f59d9aad1197f83a/patchright-1.61.2-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:43ae10cd2a3e46b222179a120ab39ba88f801f3a42aa41cab45fac9928f2103d", size = 43727572, upload-time = "2026-07-05T21:17:52.382Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e7/1ff89853c9aeaf26cd20559f401375ec71a40e4041cf7ace03d41a741f06/patchright-1.61.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a3da24d7890631255c7bef467b94ffe7f7bfa36f96fc72c10d5787d3cb396873", size = 42512921, upload-time = "2026-07-05T21:17:55.657Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d0/d730536a7fc43c3aaf2781518595ca71ffa1fc2f24e580c0d0cf04e00eca/patchright-1.61.2-py3-none-macosx_11_0_universal2.whl", hash = "sha256:edef852aa7d28791fa2d3f7ce135edfea2ce07a2bc5e0a74fb2dfe269af62223", size = 43727573, upload-time = "2026-07-05T21:17:59.121Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b5/c76dcda275cb0d9651321e343f3268609ae24cef196bff56751754ffba16/patchright-1.61.2-py3-none-manylinux1_x86_64.whl", hash = "sha256:545bdf2c0bb5f9ad78ab315e91c8c2990cc6a702e7f18650b71fe1071049b5c1", size = 47729338, upload-time = "2026-07-05T21:18:02.608Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ef/5de6feaedf47a6ba8efb9e8c4f8a42bad29cc59c35bbd088b1729a36b271/patchright-1.61.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1824da30cf6560749bc1bb4a7f002fec325d5b709090dd7c8c1b643899331cee", size = 47426969, upload-time = "2026-07-05T21:18:06.88Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/6e/ce2c5d03a4c785ac8f3e0180bbf83ef85149cf41fdfa41c09bd8cbcfd945/patchright-1.61.2-py3-none-win32.whl", hash = "sha256:a5aaf4cec2bd38714f2447f84bcdfe7dcb592a16e9616bf6d2d872066d1c78af", size = 38155048, upload-time = "2026-07-05T21:18:09.938Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c8/fceb57b9d32ed078f53fc6a757c6e4b54cb117f59412938252a3359105e5/patchright-1.61.2-py3-none-win_amd64.whl", hash = "sha256:506bca9b72e609fd8fee35e2a3ad26e5d92e25337002f5c2cdad53d5cacb0b67", size = 38155052, upload-time = "2026-07-05T21:18:13.051Z" },
+    { url = "https://files.pythonhosted.org/packages/33/96/67a791c6b7cd76424b44d356beaf414ab97c3aef2d42fad4641e7905b41d/patchright-1.61.2-py3-none-win_arm64.whl", hash = "sha256:3dee1e2daada9f98653763831f688d39c924e0cf0eeb988e8047b703766cee73", size = 34268624, upload-time = "2026-07-05T21:18:15.966Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -7218,6 +7278,8 @@ all = [
     { name = "matplotlib", version = "3.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "mypy", version = "1.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "mypy", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "patchright", version = "1.60.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "patchright", version = "1.61.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "playwright", version = "1.60.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "playwright", version = "1.61.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -7366,6 +7428,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'tests'", specifier = ">=1.0.0" },
     { name = "numpy", specifier = ">=1.23.0" },
     { name = "pandas", specifier = ">=2.0.0" },
+    { name = "patchright", marker = "extra == 'all'", specifier = ">=1.50" },
     { name = "playwright", marker = "extra == 'all'", specifier = ">=1.40" },
     { name = "playwright", marker = "extra == 'pff'", specifier = ">=1.40" },
     { name = "polars", specifier = ">=1.0,<2.0" },


### PR DESCRIPTION
## Summary

stats.ncaa.org's Akamai `bm-verify` tightened since the original solve: **vanilla
Playwright (even new-headless + a real UA) now gets *challenged*** because
`navigator.webdriver=true` + the `Runtime.enable` CDP leak are flagged. This
switches the NCAA game-detail browser transport (`mbb_ncaa_fetch._PlaywrightTransport`,
inherited by WBB by reference) to **patchright** — an anti-detect Playwright fork
that patches both tells.

**Three tells must ALL be neutralized together, plus a residential IP:**
1. `--headless=new` → real GPU/ANGLE (not the SwiftShader tell)
2. **patchright** → `navigator.webdriver=false` + no `Runtime.enable` leak
3. real Chrome `user_agent` → new-headless otherwise leaks `HeadlessChrome`
4. **residential** proxy → a datacenter IP gets an instant edge 403 regardless

## Changes

- `_PlaywrightTransport._ensure_page`: patchright import + `launch_persistent_context`
  (+ `no_viewport`); ImportError hint updated to patchright.
- Defaults: `nav_timeout_ms` 30s→45s (residential + multi-round-trip solve),
  `solve_attempts` 2→3 (cold-start hedge); real-Chrome UA override retained.
- Corrected the module + class docstrings (the old "anti-detect is unnecessary /
  vanilla Playwright passes" note was **falsified**).
- `patchright>=1.50` added to the `all` extras (lazy optional import, like
  playwright) + `uv.lock` regenerated.
- `test_playwright_transport_missing_dep_raises` repointed to patchright.

## Verification

- **40 offline tests pass**, ruff + mypy clean. The `__call__` / solve-loop /
  proxy-rotation logic is unchanged (still pinned by tests).
- **Config-identical to a transport that passed a live 10-game canary** in
  `ncaa-mbb-hoops-raw` (19/20 pages clean, ~11s/page warm on one sticky US
  residential IP).

## ⚠️ Live re-validation pending

A fresh live smoke through the real `NcaaFetcher.with_browser` API is **pending a
residential-IP cooldown** — a full session of testing flagged the proxy pool for
this target (the previously-passing standalone also 403s right now, confirming
it's IP reputation, not the code). Re-smoke + confirm before/at merge.

## Follow-ups (not in scope)

- Characterize residential IP lifetime at scale + wire proxy rotation (this PR's
  testing showed the pool degrades under heavy load).
- Coordinate with the sport-neutral `sportsdataverse/ncaa/` module work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved NCAA game-detail fetching reliability under updated website security protections.
  - Increased default navigation timeout and retry attempts for browser-based retrieval.
- **Documentation**
  - Updated `playwright_transport` docs to reflect the new default timeout/retry settings and clarified the required hardened browser setup.
- **Tests**
  - Adjusted dependency-missing test coverage to validate behavior when the required browser transport package is not installed.
- **Chores**
  - Added the required transport dependency to the main optional dependency set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->