### PR TITLE
feat(cfb): add the load_cfb_recruiting_proj dataset loader

### DIFF
--- a/docs/docs/cfb/index.md
+++ b/docs/docs/cfb/index.md
@@ -12,7 +12,7 @@ sidebar_label: CFB
 | [On3 Recruit Database (api.on3.com)](reference/on3) | 78 | `https://api.on3.com/public/rdb/v1` |
 | [247Sports Recruit Database (ipa.247sports.com)](reference/sports247) | 12 | `https://ipa.247sports.com` |
 | [247Sports Site Pages (247sports.com)](reference/sports247_site_pages) | 35 | `https://247sports.com` |
-| [Dataset loaders](reference/loaders) | 31 | sportsdataverse raw data / sportsdataverse-data releases |
+| [Dataset loaders](reference/loaders) | 32 | sportsdataverse raw data / sportsdataverse-data releases |
 | [Additional functions](reference/additional) | 72 | hand-written wrappers, loaders & helpers |
 
 ## Examples

--- a/docs/docs/cfb/reference/loaders.md
+++ b/docs/docs/cfb/reference/loaders.md
@@ -16,6 +16,7 @@ flowchart LR
 |---|---|---|
 | `load_cfb_pbp` | [espn_cfb_pbp](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_cfb_pbp) | — |
 | `load_cfb_ratings` | [cfb_ratings](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_ratings) | — |
+| `load_cfb_recruiting_proj` | [cfb_recruiting_proj](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_recruiting_proj) | — |
 | `load_cfb_rosters` | [cfbfastR-data](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfbfastR-data) | — |
 | `load_cfb_schedule` | [cfbfastR-data](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfbfastR-data) | — |
 | `load_cfb_team_info` | [cfbfastR-data](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfbfastR-data) | — |
@@ -445,6 +446,23 @@ Release: [cfb_ratings](https://github.com/sportsdataverse/sportsdataverse-data/r
 
 ```python
 load_cfb_ratings(seasons=2024)
+```
+
+## `load_cfb_recruiting_proj`
+
+Release: [cfb_recruiting_proj](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_recruiting_proj) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/cfb_recruiting_proj/cfb_recruiting_proj_{season}.parquet`
+### Returns
+
+| col_name | type |
+|---|---|
+| `season` | Int64 |
+| `team_id` | String |
+| `pred_wins` | Float64 |
+| `pred_margin` | Float64 |
+| `pred_net_epa` | Float64 |
+
+```python
+load_cfb_recruiting_proj(seasons=2024)
 ```
 
 ## `load_cfb_rosters`

--- a/sportsdataverse/cfb/cfb_loaders.py
+++ b/sportsdataverse/cfb/cfb_loaders.py
@@ -16,6 +16,7 @@ from sportsdataverse._codegen_runtime import (
 __all__ = [
     "load_cfb_pbp",
     "load_cfb_ratings",
+    "load_cfb_recruiting_proj",
     "load_cfb_rosters",
     "load_cfb_schedule",
     "load_cfb_team_info",
@@ -499,6 +500,51 @@ def load_cfb_ratings(seasons, return_as_pandas: bool = False):
         frames.append(df)
     if missing:
         cli_warn("load_cfb_ratings: no data for season(s) {missing} (skipped)".format(missing=missing))
+    # diagonal: per-season release schemas can drift (columns added/dropped
+    # over the years) -- union columns, null-fill gaps.
+    out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
+
+
+def load_cfb_recruiting_proj(seasons, return_as_pandas: bool = False):
+    """Load cfb_recruiting_proj (sportsdataverse-data release).
+
+    Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_recruiting_proj
+
+    Args:
+        seasons: an int or iterable of seasons (>= 2016).
+        return_as_pandas: return a pandas DataFrame instead of polars.
+
+    Returns:
+        A polars (or pandas) DataFrame; seasons with no published asset are
+        skipped with a warning rather than raising (404-safe).
+
+        |col_name     |type    |
+        |:------------|:-------|
+        |season       |Int64   |
+        |team_id      |String  |
+        |pred_wins    |Float64 |
+        |pred_margin  |Float64 |
+        |pred_net_epa |Float64 |
+
+    Example:
+        Quick start::
+
+            load_cfb_recruiting_proj(seasons=2024)
+    """
+    frames, missing = [], []
+    for season in _as_season_list(seasons):
+        if int(season) < 2016:
+            raise SeasonNotFoundError("season cannot be less than 2016")
+        df = _read_release_parquet(
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/cfb_recruiting_proj/cfb_recruiting_proj_{season}.parquet"
+        )
+        if df is None:
+            missing.append(season)
+            continue
+        frames.append(df)
+    if missing:
+        cli_warn("load_cfb_recruiting_proj: no data for season(s) {missing} (skipped)".format(missing=missing))
     # diagonal: per-season release schemas can drift (columns added/dropped
     # over the years) -- union columns, null-fill gaps.
     out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()

--- a/sportsdataverse/parsed/cfb.py
+++ b/sportsdataverse/parsed/cfb.py
@@ -402,6 +402,7 @@ from sportsdataverse.cfb import load_cfb_player_box as load_cfb_player_box  # no
 from sportsdataverse.cfb import load_cfb_power_index as load_cfb_power_index  # noqa: F401
 from sportsdataverse.cfb import load_cfb_ratings as load_cfb_ratings  # noqa: F401
 from sportsdataverse.cfb import load_cfb_receiving as load_cfb_receiving  # noqa: F401
+from sportsdataverse.cfb import load_cfb_recruiting_proj as load_cfb_recruiting_proj  # noqa: F401
 from sportsdataverse.cfb import load_cfb_rosters as load_cfb_rosters  # noqa: F401
 from sportsdataverse.cfb import load_cfb_rosters_crosswalk as load_cfb_rosters_crosswalk  # noqa: F401
 from sportsdataverse.cfb import load_cfb_rushing as load_cfb_rushing  # noqa: F401
@@ -631,6 +632,7 @@ __all__ = [
     "load_cfb_power_index",
     "load_cfb_ratings",
     "load_cfb_receiving",
+    "load_cfb_recruiting_proj",
     "load_cfb_rosters",
     "load_cfb_rosters_crosswalk",
     "load_cfb_rushing",

--- a/tests/cfb/test_cfb_loaders_recruiting.py
+++ b/tests/cfb/test_cfb_loaders_recruiting.py
@@ -1,0 +1,69 @@
+"""Contract tests for the ``load_cfb_recruiting_proj`` dataset loader.
+
+Mirrors ``test_cfb_loaders_ratings.py``: the codegen suite covers URL shape and
+loader rendering; these pin the loader's declared returns-schema to what the
+producer (``cfb_recruiting_projection``) actually emits, so a producer schema
+change cannot silently leave the published returns-table lying.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import polars as pl
+import yaml
+
+# `sportsdataverse.cfb` re-exports the `cfb_recruiting_projection` *function*,
+# shadowing the submodule -- reach the module's constants through a
+# fully-qualified sys.modules lookup.
+import sportsdataverse.cfb.cfb_recruiting_projection  # noqa: F401
+
+_proj_mod = sys.modules["sportsdataverse.cfb.cfb_recruiting_projection"]
+
+_ROOT = Path(__file__).resolve().parents[2]
+_SCHEMAS = _ROOT / "tools" / "codegen" / "schemas" / "loader_schemas.yaml"
+_RELEASES = _ROOT / "tools" / "codegen" / "endpoints" / "releases.yaml"
+
+_POLARS_BY_NAME = {"Int64": pl.Int64, "Float64": pl.Float64, "String": pl.Utf8, "Utf8": pl.Utf8}
+
+
+def _declared_schema() -> list[dict]:
+    return yaml.safe_load(_SCHEMAS.read_text(encoding="utf-8"))["load_cfb_recruiting_proj"]
+
+
+def _loader_entry() -> dict:
+    loaders = yaml.safe_load(_RELEASES.read_text(encoding="utf-8"))["loaders"]
+    return next(ld for ld in loaders if ld["fn"] == "load_cfb_recruiting_proj")
+
+
+def test_declared_schema_matches_the_producer_output_schema() -> None:
+    """The loader's returns-table must match the projection's real output.
+
+    Both column ORDER and dtype: the published parquet is written straight from
+    that frame, so any divergence here is a docs lie, not a formatting nit.
+    """
+    produced = _proj_mod._PROJECTION_SCHEMA
+    declared = _declared_schema()
+
+    assert [c["name"] for c in declared] == list(produced.keys())
+    for col in declared:
+        assert _POLARS_BY_NAME[col["type"]] == produced[col["name"]], col["name"]
+
+
+def test_loader_entry_points_at_the_published_tag_and_floor() -> None:
+    entry = _loader_entry()
+
+    assert entry["tag"] == "cfb_recruiting_proj"
+    assert entry["base"] == "sdv_releases"
+    # matches what cfb_model_publish's builder writes: cfb_recruiting_proj_{season}.parquet
+    assert entry["url"] == "cfb_recruiting_proj/cfb_recruiting_proj_{season}.parquet"
+    # cfbfastR-data player_stats starts 2014; returning production lags one
+    # season and the as-of ridge needs one trainable prior season -> 2016.
+    assert entry["min_season"] == 2016
+
+
+def test_loader_is_exported() -> None:
+    from sportsdataverse.cfb import load_cfb_recruiting_proj
+
+    assert callable(load_cfb_recruiting_proj)

--- a/tools/codegen/endpoints/releases.yaml
+++ b/tools/codegen/endpoints/releases.yaml
@@ -19,6 +19,14 @@ loaders:
   min_season: 2004
   example_args:
     seasons: 2024
+- fn: load_cfb_recruiting_proj
+  league: cfb
+  base: sdv_releases
+  url: cfb_recruiting_proj/cfb_recruiting_proj_{season}.parquet
+  tag: cfb_recruiting_proj
+  min_season: 2016
+  example_args:
+    seasons: 2024
 - fn: load_cfb_rosters
   league: cfb
   base: raw_data

--- a/tools/codegen/schemas/loader_schemas.yaml
+++ b/tools/codegen/schemas/loader_schemas.yaml
@@ -2083,6 +2083,17 @@ load_cfb_receiving:
   type: Float64
 - name: fbs_class
   type: String
+load_cfb_recruiting_proj:
+- name: season
+  type: Int64
+- name: team_id
+  type: String
+- name: pred_wins
+  type: Float64
+- name: pred_margin
+  type: Float64
+- name: pred_net_epa
+  type: Float64
 load_cfb_rosters:
 - name: athlete_id
   type: String


### PR DESCRIPTION
## What

Consumer half of **CFB Phase 2's second and last tag** (producer: cfbfastR-cfb-data#24). Mirrors #263's `load_cfb_ratings`:

- `releases.yaml`: `load_cfb_recruiting_proj` (base `sdv_releases`, tag `cfb_recruiting_proj`, url `cfb_recruiting_proj/cfb_recruiting_proj_{season}.parquet`, **floor 2016** — cfbfastR-data `player_stats` starts 2014, returning production lags one season, and the as-of ridge needs ≥1 trainable prior season).
- Declared returns-schema pinned to the producer's `_PROJECTION_SCHEMA` by a contract test (column order + dtypes), so a producer schema change cannot silently leave the published returns-table lying.
- Regenerated `cfb_loaders.py` + `parsed/cfb.py` + reference docs; `generate.py --check` clean.

## Tests

6 passed (`test_cfb_loaders_recruiting.py` + the ratings contract suite). Live smoke of the producer fn: `cfb_recruiting_projection(2024)` returns real projections end-to-end (no CFBD key needed — inputs are the 247 RDB feed + public cfbfastR-data parquet).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the CFB recruiting projections dataset loader.
  * Supports season-based loading from 2016 onward and optional pandas output.
  * Exposes projection fields including team, predicted wins, margin, and net EPA.
* **Documentation**
  * Added loader usage details, release information, schema documentation, and an example for the 2024 season.
  * Updated the documented CFB dataset loader count from 31 to 32.
* **Tests**
  * Added validation for the loader’s schema, release configuration, supported seasons, and public availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->