### PR TITLE
feat(pwhl): add pwhl_shot_xg (shot-level coord xG) + load_pwhl_xg_pbp loader

### DIFF
--- a/docs/docs/pwhl/index.md
+++ b/docs/docs/pwhl/index.md
@@ -6,7 +6,7 @@ sidebar_label: PWHL
 
 | Reference | Functions | Base URL |
 |---|---:|---|
-| [Dataset loaders](reference/loaders) | 20 | sportsdataverse-data releases |
+| [Dataset loaders](reference/loaders) | 21 | sportsdataverse-data releases |
 | [Additional functions](reference/additional) | 43 | hand-written wrappers, loaders & helpers |
 
 ## Examples

--- a/docs/docs/pwhl/reference/loaders.md
+++ b/docs/docs/pwhl/reference/loaders.md
@@ -24,6 +24,7 @@ flowchart LR
 | `load_pwhl_goalie_boxscores` | [pwhl_goalie_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/pwhl_goalie_boxscores) | — |
 | `load_pwhl_officials` | [pwhl_officials](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/pwhl_officials) | — |
 | `load_pwhl_pbp` | [pwhl_pbp](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/pwhl_pbp) | — |
+| `load_pwhl_xg_pbp` | [pwhl_xg_pbp](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/pwhl_xg_pbp) | — |
 | `load_pwhl_penalty_summary` | [pwhl_penalty_summary](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/pwhl_penalty_summary) | — |
 | `load_pwhl_player_boxscores` | [pwhl_player_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/pwhl_player_boxscores) | — |
 | `load_pwhl_rosters` | [pwhl_rosters](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/pwhl_rosters) | — |
@@ -530,6 +531,39 @@ Release: [pwhl_pbp](https://github.com/sportsdataverse/sportsdataverse-data/rele
 
 ```python
 load_pwhl_pbp(seasons=2024)
+```
+
+## `load_pwhl_xg_pbp`
+
+Release: [pwhl_xg_pbp](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/pwhl_xg_pbp) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/pwhl_xg_pbp/pwhl_xg_pbp_{season}.parquet`
+### Returns
+
+| col_name | type |
+|---|---|
+| `game_id` | Int32 |
+| `game_season` | Int32 |
+| `game_date` | String |
+| `team_id` | Int32 |
+| `player_id` | Int32 |
+| `goalie_id` | Int32 |
+| `period_of_game` | String |
+| `sec_from_start` | Int32 |
+| `clock` | String |
+| `x_coord` | Float64 |
+| `y_coord` | Float64 |
+| `shot_distance` | Float64 |
+| `shot_angle` | Float64 |
+| `event_type` | String |
+| `shot_quality` | String |
+| `power_play` | Int32 |
+| `short_handed` | String |
+| `empty_net` | String |
+| `penalty_shot` | String |
+| `goal` | Boolean |
+| `xg` | Float64 |
+
+```python
+load_pwhl_xg_pbp(seasons=2025)
 ```
 
 ## `load_pwhl_penalty_summary`

--- a/sportsdataverse/pwhl/pwhl_loaders.py
+++ b/sportsdataverse/pwhl/pwhl_loaders.py
@@ -24,6 +24,7 @@ __all__ = [
     "load_pwhl_goalie_boxscores",
     "load_pwhl_officials",
     "load_pwhl_pbp",
+    "load_pwhl_xg_pbp",
     "load_pwhl_penalty_summary",
     "load_pwhl_player_boxscores",
     "load_pwhl_rosters",
@@ -808,6 +809,67 @@ def load_pwhl_pbp(seasons, return_as_pandas: bool = False):
         frames.append(df)
     if missing:
         cli_warn("load_pwhl_pbp: no data for season(s) {missing} (skipped)".format(missing=missing))
+    # diagonal: per-season release schemas can drift (columns added/dropped
+    # over the years) -- union columns, null-fill gaps.
+    out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
+
+
+def load_pwhl_xg_pbp(seasons, return_as_pandas: bool = False):
+    """Load pwhl_xg_pbp (sportsdataverse-data release).
+
+    Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/pwhl_xg_pbp
+
+    Args:
+        seasons: an int or iterable of seasons (>= 2024).
+        return_as_pandas: return a pandas DataFrame instead of polars.
+
+    Returns:
+        A polars (or pandas) DataFrame; seasons with no published asset are
+        skipped with a warning rather than raising (404-safe).
+
+        |col_name       |type    |
+        |:--------------|:-------|
+        |game_id        |Int32   |
+        |game_season    |Int32   |
+        |game_date      |String  |
+        |team_id        |Int32   |
+        |player_id      |Int32   |
+        |goalie_id      |Int32   |
+        |period_of_game |String  |
+        |sec_from_start |Int32   |
+        |clock          |String  |
+        |x_coord        |Float64 |
+        |y_coord        |Float64 |
+        |shot_distance  |Float64 |
+        |shot_angle     |Float64 |
+        |event_type     |String  |
+        |shot_quality   |String  |
+        |power_play     |Int32   |
+        |short_handed   |String  |
+        |empty_net      |String  |
+        |penalty_shot   |String  |
+        |goal           |Boolean |
+        |xg             |Float64 |
+
+    Example:
+        Quick start::
+
+            load_pwhl_xg_pbp(seasons=2025)
+    """
+    frames, missing = [], []
+    for season in _as_season_list(seasons):
+        if int(season) < 2024:
+            raise SeasonNotFoundError("season cannot be less than 2024")
+        df = _read_release_parquet(
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/pwhl_xg_pbp/pwhl_xg_pbp_{season}.parquet"
+        )
+        if df is None:
+            missing.append(season)
+            continue
+        frames.append(df)
+    if missing:
+        cli_warn("load_pwhl_xg_pbp: no data for season(s) {missing} (skipped)".format(missing=missing))
     # diagonal: per-season release schemas can drift (columns added/dropped
     # over the years) -- union columns, null-fill gaps.
     out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()

--- a/sportsdataverse/pwhl/pwhl_xg_proxy.py
+++ b/sportsdataverse/pwhl/pwhl_xg_proxy.py
@@ -1099,3 +1099,103 @@ def pwhl_ratings_from_proxy(
 def _empty_ratings(return_as_pandas: bool) -> Union[pl.DataFrame, pd.DataFrame]:
     out = pl.DataFrame(schema=_RATINGS_SCHEMA)
     return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
+
+
+#: Published `pwhl_xg_pbp` dataset schema: one row per on-net shot, curated
+#: identity/geometry/context columns + the model xG. Dtypes are locked here
+#: (explicit casts at the boundary) so both input shapes -- `load_pwhl_pbp`
+#: output and the pwhl-data committed parquet, whose id dtypes differ --
+#: land on one published schema.
+_SHOT_XG_SCHEMA: dict[str, pl.DataType] = {
+    "game_id": pl.Int32,
+    "game_season": pl.Int32,
+    "game_date": pl.Utf8,
+    "team_id": pl.Int32,
+    "player_id": pl.Int32,
+    "goalie_id": pl.Int32,
+    "period_of_game": pl.Utf8,
+    "sec_from_start": pl.Int32,
+    "clock": pl.Utf8,
+    "x_coord": pl.Float64,
+    "y_coord": pl.Float64,
+    "shot_distance": pl.Float64,
+    "shot_angle": pl.Float64,
+    "event_type": pl.Utf8,
+    "shot_quality": pl.Utf8,
+    "power_play": pl.Int32,
+    "short_handed": pl.Utf8,
+    "empty_net": pl.Utf8,
+    "penalty_shot": pl.Utf8,
+    "goal": pl.Boolean,
+    "xg": pl.Float64,
+}
+
+
+def pwhl_shot_xg(
+    pbp: pl.DataFrame,
+    *,
+    model: PwhlCoordXGModel | None = None,
+    calibrate_strength: bool = True,
+    return_as_pandas: bool = False,
+) -> Union[pl.DataFrame, pd.DataFrame]:
+    """Score every on-net PWHL shot with coordinate xG (the `pwhl_xg_pbp` shape).
+
+    The shot-level counterpart to :func:`pwhl_team_game_xg_rates`: runs the
+    same pre-shot context derivation (:func:`_add_preshot_context`) over the
+    FULL pbp so rebound/movement features exist, filters to
+    ``event == "shot"`` rows (the complete on-net shot log; ``goal`` is the
+    outcome flag), scores them with :meth:`PwhlCoordXGModel.predict`, and
+    returns the curated :data:`_SHOT_XG_SCHEMA` frame -- identity, geometry
+    (``shot_distance``/``shot_angle`` derived via the shared HockeyTech
+    analytics core inside the model), strength context, outcome, and ``xg``.
+    This is the frame the `pwhl_xg_pbp` dataset release publishes per season.
+
+    Args:
+        pbp: A frame shaped like ``load_pwhl_pbp`` output (needs ``event``,
+            ``goal``, ``x_coord``, ``y_coord``; extra columns are fine and
+            improve the feature set). Pass the FULL pbp, not a shots-only
+            frame, so the pre-shot movement features can be derived.
+        model: A fitted :class:`PwhlCoordXGModel` to score with. Default
+            ``None`` fits one from ``pbp`` via :func:`fit_pwhl_coord_xg` --
+            pass a model fit on pooled seasons when scoring one season at a
+            time so every season is scored by the same model.
+        calibrate_strength: Forwarded to :func:`fit_pwhl_coord_xg` when
+            ``model`` is ``None``.
+        return_as_pandas: If True, return a pandas DataFrame; otherwise polars.
+
+    Returns:
+        One row per on-net shot with the :data:`_SHOT_XG_SCHEMA` columns, in
+        pbp order. Zero-row (typed) when ``pbp`` is empty or has no shot rows.
+
+    Example:
+        Quick start::
+
+            from sportsdataverse.pwhl.pwhl_loaders import load_pwhl_pbp
+            from sportsdataverse.pwhl.pwhl_xg_proxy import pwhl_shot_xg
+
+            shots = pwhl_shot_xg(load_pwhl_pbp(2025))
+            shots.select("shot_distance", "xg", "goal").describe()
+
+    See Also:
+        * :func:`fit_pwhl_coord_xg` -- the model this scores with.
+        * :func:`pwhl_team_game_xg_rates` -- the per-(game, team) aggregate.
+    """
+    if pbp.height == 0:
+        out = pl.DataFrame(schema=_SHOT_XG_SCHEMA)
+        return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
+
+    if model is None:
+        model = fit_pwhl_coord_xg(pbp, calibrate_strength=calibrate_strength)
+
+    enriched = _add_preshot_context(pbp)
+    shots = enriched.filter(pl.col("event") == "shot")
+    if shots.height == 0:
+        out = pl.DataFrame(schema=_SHOT_XG_SCHEMA)
+        return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
+
+    xg = model.predict(shots)
+    # predict() derives shot_distance/shot_angle internally when absent; the
+    # published frame must carry them too, so derive on the output path as well.
+    shots = _shot_geometry(shots)
+    out = shots.with_columns(xg).select([pl.col(c).cast(t) for c, t in _SHOT_XG_SCHEMA.items()])
+    return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out

--- a/tests/pwhl/test_pwhl_shot_xg.py
+++ b/tests/pwhl/test_pwhl_shot_xg.py
@@ -1,0 +1,118 @@
+"""Offline tests for ``pwhl_shot_xg`` + the ``load_pwhl_xg_pbp`` loader contract.
+
+Under ``_MIN_COORD_SHOTS`` qualifying shots the fitter deterministically falls
+back to a constant-rate model at the observed goal rate, so a small synthetic
+pbp exercises the full score path (context -> filter -> predict -> curated
+select) with no network and no sklearn fit.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import polars as pl
+import yaml
+
+import sportsdataverse.pwhl.pwhl_xg_proxy  # noqa: F401
+
+_mod = sys.modules["sportsdataverse.pwhl.pwhl_xg_proxy"]
+
+_ROOT = Path(__file__).resolve().parents[2]
+_SCHEMAS = _ROOT / "tools" / "codegen" / "schemas" / "loader_schemas.yaml"
+_RELEASES = _ROOT / "tools" / "codegen" / "endpoints" / "releases.yaml"
+
+_POLARS_BY_NAME = {
+    "Int32": pl.Int32,
+    "Int64": pl.Int64,
+    "Float64": pl.Float64,
+    "String": pl.Utf8,
+    "Utf8": pl.Utf8,
+    "Boolean": pl.Boolean,
+}
+
+
+def _tiny_pbp() -> pl.DataFrame:
+    """8 events, 4 on-net shots (1 goal) with rink-feet coordinates."""
+    n = 8
+    events = ["faceoff", "shot", "shot", "penalty", "shot", "goal", "shot", "faceoff"]
+    return pl.DataFrame(
+        {
+            "game_id": pl.Series([101] * n, dtype=pl.Int32),
+            "game_season": pl.Series([2025] * n, dtype=pl.Int32),
+            "game_date": ["2025-01-05"] * n,
+            "event": events,
+            "team_id": pl.Series([1, 1, 2, 1, 2, 2, 1, 2], dtype=pl.Int32),
+            "player_id": pl.Series(range(10, 10 + n), dtype=pl.Int32),
+            "goalie_id": pl.Series([30] * n, dtype=pl.Int32),
+            "period_of_game": ["1"] * n,
+            "sec_from_start": pl.Series(range(0, n * 60, 60), dtype=pl.Int32),
+            "clock": ["12:00"] * n,
+            "x_coord": [None, 70.0, -60.0, None, 80.0, 85.0, 55.0, None],
+            "y_coord": [None, 10.0, -5.0, None, 0.0, 2.0, -20.0, None],
+            "event_type": [None, "wrist", "snap", None, "slap", "wrist", "backhand", None],
+            "shot_quality": [
+                None,
+                "Quality on net",
+                "Non quality on net",
+                None,
+                "Quality on net",
+                "Quality goal",
+                "Non quality on net",
+                None,
+            ],
+            "power_play": pl.Series([None, None, 1, None, None, None, None, None], dtype=pl.Int32),
+            "short_handed": [None] * n,
+            "empty_net": [None] * n,
+            "penalty_shot": [None] * n,
+            "goal": [None, False, False, None, False, True, True, None],
+        }
+    )
+
+
+def test_shot_xg_scores_shot_rows_with_the_published_schema():
+    out = _mod.pwhl_shot_xg(_tiny_pbp())
+
+    # 4 `event == "shot"` rows (the trailing goal row is not an on-net shot event)
+    assert out.height == 4
+    assert dict(out.schema) == dict(_mod._SHOT_XG_SCHEMA)
+    # under _MIN_COORD_SHOTS the model is the constant observed-goal-rate
+    # fallback: every xg equals the shot-row goal rate (1 goal / 4 shots)
+    assert set(out["xg"].to_list()) == {0.25}
+    assert out["shot_distance"].null_count() == 0
+
+
+def test_shot_xg_empty_and_shotless_inputs_return_typed_empty():
+    empty = _mod.pwhl_shot_xg(pl.DataFrame(schema={"event": pl.Utf8, "goal": pl.Boolean}))
+    assert empty.height == 0
+    assert dict(empty.schema) == dict(_mod._SHOT_XG_SCHEMA)
+
+    shotless = _mod.pwhl_shot_xg(_tiny_pbp().filter(pl.col("event") == "faceoff"))
+    assert shotless.height == 0
+    assert dict(shotless.schema) == dict(_mod._SHOT_XG_SCHEMA)
+
+
+def test_declared_loader_schema_matches_the_producer_output_schema():
+    declared = yaml.safe_load(_SCHEMAS.read_text(encoding="utf-8"))["load_pwhl_xg_pbp"]
+    produced = _mod._SHOT_XG_SCHEMA
+
+    assert [c["name"] for c in declared] == list(produced.keys())
+    for col in declared:
+        assert _POLARS_BY_NAME[col["type"]] == produced[col["name"]], col["name"]
+
+
+def test_loader_entry_points_at_the_published_tag_and_floor():
+    loaders = yaml.safe_load(_RELEASES.read_text(encoding="utf-8"))["loaders"]
+    entry = next(ld for ld in loaders if ld["fn"] == "load_pwhl_xg_pbp")
+
+    assert entry["tag"] == "pwhl_xg_pbp"
+    assert entry["base"] == "sdv_releases"
+    assert entry["url"] == "pwhl_xg_pbp/pwhl_xg_pbp_{season}.parquet"
+    # PWHL's inaugural season
+    assert entry["min_season"] == 2024
+
+
+def test_loader_is_exported():
+    from sportsdataverse.pwhl import load_pwhl_xg_pbp
+
+    assert callable(load_pwhl_xg_pbp)

--- a/tools/codegen/endpoints/releases.yaml
+++ b/tools/codegen/endpoints/releases.yaml
@@ -905,6 +905,14 @@ loaders:
   min_season: 2024
   example_args:
     seasons: 2024
+- fn: load_pwhl_xg_pbp
+  league: pwhl
+  base: sdv_releases
+  url: pwhl_xg_pbp/pwhl_xg_pbp_{season}.parquet
+  tag: pwhl_xg_pbp
+  min_season: 2024
+  example_args:
+    seasons: 2025
 - fn: load_pwhl_penalty_summary
   league: pwhl
   base: sdv_releases

--- a/tools/codegen/schemas/loader_schemas.yaml
+++ b/tools/codegen/schemas/loader_schemas.yaml
@@ -6979,6 +6979,49 @@ load_pwhl_pbp:
   type: String
 - name: sec_from_start
   type: Int32
+load_pwhl_xg_pbp:
+- name: game_id
+  type: Int32
+- name: game_season
+  type: Int32
+- name: game_date
+  type: String
+- name: team_id
+  type: Int32
+- name: player_id
+  type: Int32
+- name: goalie_id
+  type: Int32
+- name: period_of_game
+  type: String
+- name: sec_from_start
+  type: Int32
+- name: clock
+  type: String
+- name: x_coord
+  type: Float64
+- name: y_coord
+  type: Float64
+- name: shot_distance
+  type: Float64
+- name: shot_angle
+  type: Float64
+- name: event_type
+  type: String
+- name: shot_quality
+  type: String
+- name: power_play
+  type: Int32
+- name: short_handed
+  type: String
+- name: empty_net
+  type: String
+- name: penalty_shot
+  type: String
+- name: goal
+  type: Boolean
+- name: xg
+  type: Float64
 load_pwhl_penalty_summary:
 - name: game_id
   type: Int32


### PR DESCRIPTION
## What

**Publication-plan Phase 5a, sdv-py half** (producer: fastRhockey-pwhl-data#2).

- **`pwhl_shot_xg()`** — public shot-level counterpart to `pwhl_team_game_xg_rates`: same pre-shot context derivation over the FULL pbp, `event == 'shot'` filter, `PwhlCoordXGModel` scoring, returned as a curated 21-column `_SHOT_XG_SCHEMA` frame (identity, rink-feet geometry, strength context, outcome, `xg`). Dtypes cast at the boundary so `load_pwhl_pbp` output and the pwhl-data committed parquet (different id dtypes) land on one published schema. Takes `model=` so a producer can fit once on pooled seasons and score every season with the same model.
- **`load_pwhl_xg_pbp`** — releases.yaml entry (tag `pwhl_xg_pbp`, floor 2024) + declared returns-schema pinned to `_SHOT_XG_SCHEMA` by a contract test. Regenerated loader + docs; `--check` clean.

## Verification

- 5 offline tests ride the deterministic `<_MIN_COORD_SHOTS` fallback path (no network, no sklearn fit).
- Real-data smoke: fit pooled 2024–2026, scored 2025 → **5,671 shots, xG sum 464.8 vs 499 goals**, exact schema.