### PR TITLE
fix(mbb): keep the Playwright driver alive across proxy rotations (EPIPE fix)

### DIFF
--- a/docs/docs/mbb/reference/additional.md
+++ b/docs/docs/mbb/reference/additional.md
@@ -7959,7 +7959,7 @@ from sportsdataverse.mbb.mbb_player_value_constants import player_per100_feature
 feats = player_per100_features(season_stats)
 ```
 
-### `playwright_transport(*, headless_new: 'bool' = True, challenge_wait_ms: 'int' = 8000, nav_timeout_ms: 'int' = 45000, user_agent: 'Optional[str]' = None, solve_attempts: 'int' = 3) -> "'_PlaywrightTransport'"` {#playwright_transport}
+### `playwright_transport(*, headless_new: 'bool' = True, challenge_wait_ms: 'int' = 8000, nav_timeout_ms: 'int' = 45000, user_agent: 'Optional[str]' = None, solve_attempts: 'int' = 3, relaunch_backoff: 'float' = 2.0) -> "'_PlaywrightTransport'"` {#playwright_transport}
 
 Build the **suggested** stats.ncaa.org game-detail scraping transport.
 
@@ -7978,6 +7978,7 @@ Playwright is a **lazy optional import** (not a hard dependency); a clear
 | `nav_timeout_ms` | `int` | `45000` | Per-navigation timeout. |
 | `user_agent` | `Optional[str]` | `None` | Override the Chrome UA string. |
 | `solve_attempts` | `int` | `3` |  |
+| `relaunch_backoff` | `float` | `2.0` |  |
 
 **Returns**
 

--- a/docs/docs/wbb/reference/additional.md
+++ b/docs/docs/wbb/reference/additional.md
@@ -7005,7 +7005,7 @@ from sportsdataverse.mbb.mbb_player_value_constants import player_per100_feature
 feats = player_per100_features(season_stats)
 ```
 
-### `playwright_transport(*, headless_new: 'bool' = True, challenge_wait_ms: 'int' = 8000, nav_timeout_ms: 'int' = 45000, user_agent: 'Optional[str]' = None, solve_attempts: 'int' = 3) -> "'_PlaywrightTransport'"` {#playwright_transport}
+### `playwright_transport(*, headless_new: 'bool' = True, challenge_wait_ms: 'int' = 8000, nav_timeout_ms: 'int' = 45000, user_agent: 'Optional[str]' = None, solve_attempts: 'int' = 3, relaunch_backoff: 'float' = 2.0) -> "'_PlaywrightTransport'"` {#playwright_transport}
 
 Build the **suggested** stats.ncaa.org game-detail scraping transport.
 
@@ -7024,6 +7024,7 @@ Playwright is a **lazy optional import** (not a hard dependency); a clear
 | `nav_timeout_ms` | `int` | `45000` | Per-navigation timeout. |
 | `user_agent` | `Optional[str]` | `None` | Override the Chrome UA string. |
 | `solve_attempts` | `int` | `3` |  |
+| `relaunch_backoff` | `float` | `2.0` |  |
 
 **Returns**
 

--- a/sportsdataverse/mbb/mbb_ncaa_fetch.py
+++ b/sportsdataverse/mbb/mbb_ncaa_fetch.py
@@ -529,10 +529,16 @@ class _PlaywrightTransport:
         nav_timeout_ms: int = 45000,
         user_agent: Optional[str] = None,
         solve_attempts: int = 3,
+        relaunch_backoff: float = 2.0,
     ) -> None:
         self.headless_new = headless_new
         self.challenge_wait_ms = challenge_wait_ms
         self.nav_timeout_ms = nav_timeout_ms
+        # Seconds to let a rotated-off context fully tear down before relaunching a
+        # new one. A proxy rotation relaunches only the browser CONTEXT (not the
+        # Playwright driver); rapid back-to-back relaunches with no settle crashed
+        # patchright's driver (EPIPE) during a whole-season backfill. See _ensure_page.
+        self.relaunch_backoff = max(0.0, relaunch_backoff)
         # How many times to (re-)run the bm-verify sensor before giving up and
         # letting the fetch layer rotate. The solve is PROVEN by the in-page
         # fetch, never assumed -- see __call__. Kept LOW on purpose: each
@@ -566,29 +572,34 @@ class _PlaywrightTransport:
         if self._page is not None:
             if proxy == self._current_proxy:
                 return
-            # The caller rotated the proxy. A live browser is pinned to its
-            # LAUNCH proxy, so reusing it would silently keep egressing from the
-            # old IP -- which is how one IP absorbed a whole backfill and got
-            # permanently banned while _proxy_idx "rotated" to no effect.
-            # Relaunch on the new IP (costs a fresh bm-verify solve).
-            logger.info("browser proxy rotated -> %s (relaunching)", _redact_proxy_url(proxy))
-            self.close()
-        try:
-            from patchright.sync_api import sync_playwright
-        except ImportError as exc:  # pragma: no cover - exercised only without patchright
-            raise ImportError(
-                "The NCAA browser transport requires patchright -- an anti-detect "
-                "Playwright fork. Game-detail pages sit behind Akamai bm-verify, and "
-                "vanilla Playwright's navigator.webdriver=true is flagged (only "
-                "patchright, which patches that + the Runtime.enable CDP leak, clears "
-                "it). Install with: pip install patchright && patchright install "
-                "chromium. patchright is intentionally NOT a hard sportsdataverse "
-                "dependency."
-            ) from exc
-        import atexit
+            # The caller rotated the proxy. A live context is pinned to its LAUNCH
+            # proxy, so reusing it would keep egressing from the old IP. Close only
+            # the CONTEXT (keeping the Playwright driver alive), let it settle, then
+            # relaunch on the new IP -- stop/starting the whole driver per rotation
+            # crashed patchright (EPIPE) under a backfill's many rotations.
+            logger.info("browser proxy rotated -> %s (relaunching context)", _redact_proxy_url(proxy))
+            self._close_context()
+            if self.relaunch_backoff:
+                time.sleep(self.relaunch_backoff)
+        if self._pw is None:  # start the Playwright DRIVER once; reuse across rotations
+            try:
+                from patchright.sync_api import sync_playwright
+            except ImportError as exc:  # pragma: no cover - exercised only without patchright
+                raise ImportError(
+                    "The NCAA browser transport requires patchright -- an anti-detect "
+                    "Playwright fork. Game-detail pages sit behind Akamai bm-verify, and "
+                    "vanilla Playwright's navigator.webdriver=true is flagged (only "
+                    "patchright, which patches that + the Runtime.enable CDP leak, clears "
+                    "it). Install with: pip install patchright && patchright install "
+                    "chromium. patchright is intentionally NOT a hard sportsdataverse "
+                    "dependency."
+                ) from exc
+            import atexit
+
+            self._pw = sync_playwright().start()
+            atexit.register(self.close)
         import tempfile
 
-        self._pw = sync_playwright().start()
         # launch_persistent_context (not launch + new_context) is the more stealthy
         # path patchright recommends. new-headless renders through the real GPU/ANGLE
         # (not the SwiftShader tell). The user_agent override is load-bearing (see
@@ -619,7 +630,26 @@ class _PlaywrightTransport:
         self._browser = self._pw.chromium.launch_persistent_context(**launch_kwargs)
         self._page = self._browser.pages[0] if self._browser.pages else self._browser.new_page()
         self._current_proxy = proxy
-        atexit.register(self.close)
+
+    def _close_context(self) -> None:
+        """Close ONLY the browser context + its profile dir, keeping the Playwright
+        DRIVER (``self._pw``) alive so a proxy rotation relaunches just the context.
+        Repeatedly stop/starting the driver process is what crashed patchright
+        (EPIPE) mid-backfill."""
+        try:
+            if self._browser is not None:
+                self._browser.close()
+        except Exception:  # noqa: BLE001 - best-effort teardown
+            pass
+        if self._temp_dir is not None:
+            try:
+                self._temp_dir.cleanup()
+            except Exception:  # noqa: BLE001 - best-effort; a lingering file lock may defer it
+                pass
+            self._temp_dir = None
+        self._browser = self._page = None
+        self._challenge_solved = False
+        self._current_proxy = None
 
     def _solve_challenge(self, url: str) -> None:
         """Run a real navigation so the bm-verify sensor executes and mints ``_abck``.
@@ -668,22 +698,15 @@ class _PlaywrightTransport:
         )
 
     def close(self) -> None:
-        """Stop the browser + Playwright and remove the profile dir. Idempotent."""
-        for obj, meth in ((self._browser, "close"), (self._pw, "stop")):
-            try:
-                if obj is not None:
-                    getattr(obj, meth)()
-            except Exception:  # noqa: BLE001 - best-effort teardown
-                pass
-        if self._temp_dir is not None:
-            try:
-                self._temp_dir.cleanup()  # remove the browser profile dir
-            except Exception:  # noqa: BLE001 - best-effort; a lingering file lock may defer it
-                pass
-            self._temp_dir = None
-        self._browser = self._pw = self._page = None
-        self._challenge_solved = False
-        self._current_proxy = None
+        """Full teardown: close the context, stop the Playwright driver, remove the
+        profile dir. Idempotent."""
+        self._close_context()  # context + temp dir + solved/proxy state
+        try:
+            if self._pw is not None:
+                self._pw.stop()
+        except Exception:  # noqa: BLE001 - best-effort teardown
+            pass
+        self._pw = None
 
     def __enter__(self) -> "_PlaywrightTransport":
         return self
@@ -699,6 +722,7 @@ def playwright_transport(
     nav_timeout_ms: int = 45000,
     user_agent: Optional[str] = None,
     solve_attempts: int = 3,
+    relaunch_backoff: float = 2.0,
 ) -> "_PlaywrightTransport":
     """Build the **suggested** stats.ncaa.org game-detail scraping transport.
 
@@ -737,6 +761,7 @@ def playwright_transport(
         nav_timeout_ms=nav_timeout_ms,
         user_agent=user_agent,
         solve_attempts=solve_attempts,
+        relaunch_backoff=relaunch_backoff,
     )
 
 

--- a/tests/mbb/test_mbb_ncaa_fetch.py
+++ b/tests/mbb/test_mbb_ncaa_fetch.py
@@ -313,26 +313,48 @@ class _StopBeforeLaunch(Exception):
     pass
 
 
-def test_browser_transport_relaunches_when_the_proxy_rotates(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Playwright binds the proxy at LAUNCH. _ensure_page used to early-return
-    whenever a page existed, so the browser kept egressing from its first IP
-    forever while the fetcher 'rotated' -- the bug that burned one IP and
-    stalled the backfill at 38%."""
+def test_browser_transport_relaunches_context_when_the_proxy_rotates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Playwright binds the proxy at LAUNCH. A rotation must relaunch the CONTEXT
+    (not silently reuse proxy A -- the bug that burned one IP and stalled the
+    backfill at 38%). It closes only the context, NOT the driver: stop/starting the
+    driver per rotation crashed patchright (EPIPE)."""
     t = playwright_transport()
-    t._page = object()  # pretend a live browser on proxy A
+    t._page = object()  # pretend a live context on proxy A
     t._current_proxy = _POOL[0]
 
     def _boom() -> None:
-        raise _StopBeforeLaunch  # stand in for the (real) relaunch
+        raise _StopBeforeLaunch  # stand in for the (real) context relaunch
 
-    monkeypatch.setattr(t, "close", _boom)
+    monkeypatch.setattr(t, "_close_context", _boom)
 
     # Same proxy -> reuse, no relaunch.
     t._ensure_page({"http": _POOL[0], "https": _POOL[0]})
 
-    # Different proxy -> MUST close/relaunch rather than silently reuse proxy A.
+    # Different proxy -> MUST close the CONTEXT + relaunch, not reuse proxy A.
     with pytest.raises(_StopBeforeLaunch):
         t._ensure_page({"http": _POOL[1], "https": _POOL[1]})
+
+
+def test_rotation_uses_close_context_never_full_close(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The EPIPE fix: a rotation relaunches only the CONTEXT (``_close_context``);
+    it must NEVER call ``close()`` (which stops the Playwright driver). Stop/starting
+    the driver per rotation is what crashed patchright during a backfill."""
+    t = playwright_transport(relaunch_backoff=0.0)
+    t._page = object()
+    t._current_proxy = _POOL[0]
+    calls: "list[str]" = []
+    monkeypatch.setattr(t, "close", lambda: calls.append("close"))
+
+    def _ctx() -> None:
+        calls.append("_close_context")
+        raise _StopBeforeLaunch  # stop before the real (browser-launching) relaunch
+
+    monkeypatch.setattr(t, "_close_context", _ctx)
+    with pytest.raises(_StopBeforeLaunch):
+        t._ensure_page({"http": _POOL[1], "https": _POOL[1]})
+    assert calls == ["_close_context"]  # context closed; full close()/driver-stop NOT called
 
 
 # --- the wbb shim must inherit all of the above, by reference ---------------


### PR DESCRIPTION
## Summary

The NCAA browser transport (`mbb_ncaa_fetch._PlaywrightTransport`, inherited by
WBB) relaunched the **whole Playwright driver** on every proxy rotation: `close()`
stops the driver, then `_ensure_page` starts a fresh one. Rapid back-to-back
driver stop/starts during a backfill's rotations crashed **patchright** with
`EPIPE` ("broken pipe" in the driver's `sendCreate`), tearing down capture at
scale (this was the standing "IP rotation at scale" blocker for NCAA backfills).

## Fix

Split **context** teardown from **driver** teardown:

- Keep ONE long-lived Playwright driver (`self._pw`), started once.
- A proxy rotation now calls a new `_close_context()` — closes only the browser
  **context** (which is what binds the proxy) + its profile dir — then relaunches
  a context on the *same* driver, after a `relaunch_backoff` settle delay (default
  2s, configurable via `playwright_transport(relaunch_backoff=…)`).
- Full `close()` still closes the context **and** stops the driver (teardown/atexit).

## Verification

- **Live**: with `rotate_every` forcing a rotation between fetches, 3/3 fetches
  landed real content across a context relaunch (cold-solve on the new IP) — **no
  EPIPE**. (A pathological `rotate_every=1` run also survived every relaunch — it
  only ran long because every fetch forced a fresh cold solve, a speed artifact,
  not a crash.)
- **Offline**: 41 tests pass, incl. a new test pinning "rotation calls
  `_close_context`, never full `close()`" (so the driver is not stop/started per
  rotation). ruff + mypy clean.
- mbb/wbb reference docs regenerated for the new `relaunch_backoff` arg. WBB
  inherits by reference.

## Follow-up (not in scope)

`rotate_every` default (200, a datacenter-era value) may want lowering for
*residential* pools (semi-consumable IPs), traded off against cold-solve cost per
rotation — a per-deployment tuning, left to the runner's config.