### PR TITLE
feat(cfb): graduate stats.ncaa.org college-football pbp parser (cfb_ncaa_pbp)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -310,6 +310,7 @@ files = [
     "sportsdataverse/cfb/cfb_advanced_constants.py",
     "sportsdataverse/cfb/cfb_advanced_stats.py",
     "sportsdataverse/cfb/cfb_field_position.py",
+    "sportsdataverse/cfb/cfb_ncaa_pbp.py",
     "sportsdataverse/cfb/cfb_opponent_adjust.py",
     "sportsdataverse/cfb/cfb_crosswalk.py",
     "sportsdataverse/cfb/cfb_fox_ext.py",

--- a/sportsdataverse/cfb/__init__.py
+++ b/sportsdataverse/cfb/__init__.py
@@ -6,6 +6,7 @@ from sportsdataverse.cfb.cfb_game_rosters import *
 from sportsdataverse.cfb.cfb_loaders import *
 from sportsdataverse.cfb.cfb_loaders_extra import *
 from sportsdataverse.cfb.cfb_pbp import *
+from sportsdataverse.cfb.cfb_ncaa_pbp import *
 from sportsdataverse.cfb.cfb_adjusted_epa import *
 from sportsdataverse.cfb.cfb_advanced_stats import *
 from sportsdataverse.cfb.cfb_field_position import *

--- a/sportsdataverse/cfb/cfb_ncaa_pbp.py
+++ b/sportsdataverse/cfb/cfb_ncaa_pbp.py
@@ -1,0 +1,450 @@
+"""Parse stats.ncaa.org college-football (NCAA sport code ``MFB``) play-by-play
+HTML into a tidy polars frame.
+
+Structured, cfbfastR-style: one row per play with drive context + down/distance/
+yard_line + play_type + players (rusher/passer/receiver/kicker/punter/returner/
+tacklers) + directions + yards + kick/FG details + scoring/turnover/penalty/first-
+down/out-of-bounds flags, keeping the raw ``play_text`` for anything not yet lifted.
+
+**Provenance.** Original sdv-py code (no upstream port). The HTML source is the
+Akamai-``bm-verify``-gated ``/contests/{id}/play_by_play`` game page, fetched via
+the shared browser transport in :mod:`sportsdataverse.mbb.mbb_ncaa_fetch`
+(patchright + ``--headless=new`` + residential IP). This module is the *parser*
+half of that pipeline; capture/discovery is a producer concern.
+
+Markup (fixture-verified, contest 5362535): ``div.drives`` holds, per drive, an
+``h5.(non_)scoring_play`` title, a header-body ``div`` (team + score), then a
+``div`` whose bordered child ``div``s are the plays -- each ``<span>`` bold
+down/dist/yardline + ``<span>`` play text. ``scoring_play`` class = drive scored.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Union
+
+import polars as pl
+from bs4 import BeautifulSoup
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+__all__ = ["PBP_SCHEMA", "parse_cfb_ncaa_pbp"]
+
+# NCAA official "Last,First", incl. suffixes ("Wilborn Jr.,James", "Jordan III,Tre").
+_NAME = r"[A-Z][\w.'\-]+(?:\s(?:Jr|Sr|II|III|IV)\.?)?,\s?[A-Z][\w.'\-]+"
+
+# h5 drive title: "{team} {result} {clock},{yardline}, {n} plays, {yards} yards, {top} {a} - {h}"
+_DRIVE_RE = re.compile(
+    r"^(?P<team>.+?)\s+(?P<result>[A-Za-z/]+)\s+(?P<start_clock>\d+:\d+),(?P<start_yard_line>[A-Z]{1,4}\d+),\s+"
+    r"(?P<n_plays>\d+)\s+plays?,\s+(?P<yards>-?\d+)\s+yards?,\s+(?P<top>\d+:\d+)\s+"
+    r"(?P<score_away>\d+)\s*-\s*(?P<score_home>\d+)\s*$"
+)
+_DD_RE = re.compile(
+    r"^(?P<down>1st|2nd|3rd|4th)\s+&\s+(?P<distance>\d+|Goal)\s+at\s+(?P<yard_line>[A-Z]{1,4}\d+)",
+    re.I,
+)
+_DOWN = {"1st": 1, "2nd": 2, "3rd": 3, "4th": 4}
+_YL_SPLIT_RE = re.compile(r"^([A-Z]{1,4})(\d+)$")
+
+# --- play_text field regexes ----------------------------------------------
+_CLOCK_RE = re.compile(r"^\((\d{1,2}:\d{2})\)\s*")  # some games prefix each play with "(MM:SS)"
+_FORMATION_RE = re.compile(r"^(No Huddle(?:-Shotgun)?|Shotgun|Wildcat|Pistol)\s+")
+_YARDS_RE = re.compile(r"for (\d+) yards? (gain|loss)", re.I)
+_YARDS_PLAIN_RE = re.compile(r"for (\d+) yards? to the", re.I)  # completed pass / 0-yard run: positive
+_END_YL_RE = re.compile(r"to the ([A-Z]{1,4}\d+)")
+_RUSH_RE = re.compile(
+    rf"(?P<rusher>{_NAME}) rush(?:es)?(?:\s+(?P<dir>left|right|middle|up the middle))?",
+    re.I,
+)
+_PASS_RE = re.compile(
+    rf"(?P<passer>{_NAME}) pass (?P<result>complete|incomplete|intercepted)"
+    rf"(?:\s+(?P<depth>short|deep))?(?:\s+(?P<dir>left|right|middle))?"
+    rf"(?:.*?\bto\s+(?P<receiver>{_NAME}))?",
+    re.I,
+)
+_KICKOFF_RE = re.compile(rf"(?P<kicker>{_NAME}) kickoff \d+ yards(?:.*?(?P<returner>{_NAME}) return)?", re.I)
+_PUNT_RE = re.compile(
+    rf"(?P<punter>{_NAME}) punt \d+ yards(?:.*?(?:fair catch by (?P<fc>{_NAME})|(?P<returner>{_NAME}) return))?",
+    re.I,
+)
+_SACK_RE = re.compile(rf"(?P<passer>{_NAME}) sacked", re.I)
+_FG_RE = re.compile(rf"(?P<kicker>{_NAME}) field goal", re.I)
+_XP_RE = re.compile(rf"(?P<kicker>{_NAME}) kick attempt", re.I)
+_POSSESSION_RE = re.compile(r"^[A-Z]{2,4} ball on [A-Z]{1,4}\d+")  # "AKR ball on AKR20." drive marker
+_TWOPT_RE = re.compile(
+    rf"(?P<player>{_NAME}) (?P<kind>pass|run|rush) attempt (?P<result>Successful|failed)",
+    re.I,
+)
+_KICK_YDS_RE = re.compile(r"kickoff (\d+) yards", re.I)
+_PUNT_YDS_RE = re.compile(r"punt (\d+) yards", re.I)
+_RET_YDS_RE = re.compile(r"return (\d+) yards", re.I)
+_FG_DETAIL_RE = re.compile(r"field goal attempt from (\d+) yards\s+(GOOD|NO GOOD)", re.I)
+_PENALTY_RE = re.compile(
+    rf"PENALTY (?P<team>[A-Z]{{2,4}}) (?P<type>[A-Za-z][A-Za-z /'\-]*?)"
+    rf"(?:\s+\((?P<player>{_NAME})\))?\s+(?P<yards>\d+) yards",
+    re.I,
+)
+
+_DECOMP_KEYS = (
+    "play_type",
+    "clock",
+    "yards_gained",
+    "formation",
+    "passer",
+    "rusher",
+    "receiver",
+    "kicker",
+    "punter",
+    "returner",
+    "run_direction",
+    "pass_complete",
+    "pass_depth",
+    "pass_direction",
+    "tackler_1",
+    "tackler_2",
+    "kick_yards",
+    "return_yards",
+    "punt_yards",
+    "fg_distance",
+    "fg_made",
+    "is_first_down",
+    "is_touchdown",
+    "is_safety",
+    "is_fumble",
+    "is_turnover",
+    "turnover_type",
+    "out_of_bounds",
+    "no_play",
+    "fair_catch",
+    "penalty_flag",
+    "penalty_team",
+    "penalty_type",
+    "penalty_player",
+    "penalty_yards",
+    "end_yard_line",
+)
+
+
+def _spaces(text: str) -> str:
+    return " ".join(text.split())
+
+
+def _yards_gained(text: str) -> "int | None":
+    m = _YARDS_RE.search(text)
+    if m:
+        return int(m.group(1)) * (1 if m.group(2).lower() == "gain" else -1)
+    m = _YARDS_PLAIN_RE.search(text)
+    if m:
+        return int(m.group(1))
+    if re.search(r"for no gain", text, re.I):
+        return 0
+    return None
+
+
+def _tacklers(text: str) -> "tuple[str | None, str | None]":
+    pre = text.split("PENALTY")[0]  # tacklers belong to the play, before any penalty note
+    cand = [g for g in re.findall(r"\(([^)]+)\)", pre) if "," in g and not g.startswith(("H:", "LS:"))]
+    if not cand:
+        return None, None
+    names = [n.strip() for n in re.split(r";\s*", cand[-1]) if n.strip()]
+    return (names[0] if names else None), (names[1] if len(names) > 1 else None)
+
+
+def _decompose_play_text(text: str) -> "dict":
+    out: "dict" = dict.fromkeys(_DECOMP_KEYS)
+    cm = _CLOCK_RE.match(text)
+    if cm:
+        out["clock"] = cm.group(1)
+        text = text[cm.end() :]
+    fm = _FORMATION_RE.match(text)
+    if fm:
+        out["formation"] = fm.group(1)
+        text = text[fm.end() :]
+    tl = text.lower()
+
+    # non-play markers -- classify + return early (no per-play fields apply)
+    if "drive start at" in tl or _POSSESSION_RE.match(text):  # "AKR ball on AKR20."
+        out["play_type"] = "drive_start"
+        return out
+    if re.search(r"(start|end) of (1st|2nd|3rd|4th) quarter|end of game|end of (?:the )?half", tl):
+        out["play_type"] = "period_marker"
+        return out
+    if "timeout" in tl:
+        out["play_type"] = "timeout"
+        return out
+    if "will receive" in tl or "will defend" in tl or "won the toss" in tl:
+        out["play_type"] = "coin_toss"
+        return out
+
+    # universal flags (case-sensitive caps markers)
+    out["is_first_down"] = "1ST DOWN" in text
+    out["is_touchdown"] = "TOUCHDOWN" in text
+    out["is_safety"] = "SAFETY" in text
+    out["is_fumble"] = "FUMBLE" in text.upper()
+    out["out_of_bounds"] = "out of bounds" in tl
+    out["no_play"] = "NO PLAY" in text
+    out["fair_catch"] = "fair catch" in tl
+    if "TURNOVER ON DOWNS" in text:
+        out["is_turnover"], out["turnover_type"] = True, "downs"
+    elif "INTERCEPT" in text.upper():
+        out["is_turnover"], out["turnover_type"] = True, "interception"
+    elif out["is_fumble"] and "recovered by" in tl:
+        out["turnover_type"] = "fumble"
+    out["tackler_1"], out["tackler_2"] = _tacklers(text)
+    out["end_yard_line"] = (_END_YL_RE.findall(text) or [None])[-1]
+    pm = _PENALTY_RE.search(text)
+    if pm:
+        out.update(
+            penalty_flag=True,
+            penalty_team=pm.group("team"),
+            penalty_type=_spaces(pm.group("type")),
+            penalty_player=pm.groupdict().get("player"),
+            penalty_yards=int(pm.group("yards")),
+        )
+    else:
+        out["penalty_flag"] = "PENALTY" in text
+
+    # play type + type-specific fields
+    if "kickoff" in tl:
+        out["play_type"] = "kickoff"
+        m = _KICKOFF_RE.search(text)
+        if m:
+            out["kicker"], out["returner"] = (
+                m.group("kicker"),
+                m.groupdict().get("returner"),
+            )
+        ky = _KICK_YDS_RE.search(text)
+        ry = _RET_YDS_RE.search(text)
+        out["kick_yards"] = int(ky.group(1)) if ky else None
+        out["return_yards"] = int(ry.group(1)) if ry else None
+    elif "punt" in tl:
+        out["play_type"] = "punt"
+        m = _PUNT_RE.search(text)
+        if m:
+            out["punter"] = m.group("punter")
+            out["returner"] = m.groupdict().get("returner") or m.groupdict().get("fc")
+        py = _PUNT_YDS_RE.search(text)
+        ry = _RET_YDS_RE.search(text)
+        out["punt_yards"] = int(py.group(1)) if py else None
+        out["return_yards"] = int(ry.group(1)) if ry else None
+    elif "field goal" in tl:
+        out["play_type"] = "field_goal"
+        m = _FG_RE.search(text)
+        if m:
+            out["kicker"] = m.group("kicker")
+        fg = _FG_DETAIL_RE.search(text)
+        if fg:
+            out["fg_distance"], out["fg_made"] = (
+                int(fg.group(1)),
+                fg.group(2).upper() == "GOOD",
+            )
+    elif "kick attempt" in tl or "extra point" in tl:
+        out["play_type"] = "extra_point"
+        m = _XP_RE.search(text)
+        if m:
+            out["kicker"] = m.group("kicker")
+    elif "pass attempt" in tl or "run attempt" in tl or "rush attempt" in tl:
+        out["play_type"] = "two_point"  # 2-pt conversion ("... attempt Successful/failed")
+        tm = _TWOPT_RE.search(text)
+        if tm:
+            out["passer" if tm.group("kind").lower() == "pass" else "rusher"] = tm.group("player")
+    elif "sacked" in tl:
+        out["play_type"] = "sack"
+        out["yards_gained"] = _yards_gained(text)
+        m = _SACK_RE.search(text)
+        if m:
+            out["passer"] = m.group("passer")
+    elif "pass complete" in tl or "pass incomplete" in tl or "pass intercepted" in tl:
+        out["play_type"] = "pass"
+        m = _PASS_RE.search(text)
+        if m:
+            out["passer"] = m.group("passer")
+            out["receiver"] = m.groupdict().get("receiver")
+            out["pass_depth"] = (m.groupdict().get("depth") or "").lower() or None
+            out["pass_direction"] = (m.groupdict().get("dir") or "").lower() or None
+            complete = m.group("result").lower() == "complete"
+            out["pass_complete"] = complete
+            out["yards_gained"] = _yards_gained(text) if complete else 0
+    elif "kneel" in tl:
+        out["play_type"] = "kneel"
+        out["yards_gained"] = _yards_gained(text)
+    elif "rush" in tl:
+        out["play_type"] = "rush"
+        out["yards_gained"] = _yards_gained(text)
+        m = _RUSH_RE.search(text)
+        if m:
+            out["rusher"] = m.group("rusher")
+            out["run_direction"] = (m.groupdict().get("dir") or "").lower() or None
+    elif out["penalty_flag"]:
+        out["play_type"] = "penalty"
+    else:
+        out["play_type"] = "unknown"
+    return out
+
+
+# base structural columns, then decomposed fields, then raw play_text last.
+PBP_SCHEMA: "dict[str, pl.DataType]" = {
+    "contest_id": pl.Utf8,
+    "drive_number": pl.Int64,
+    "play_number": pl.Int64,
+    "offense": pl.Utf8,
+    "drive_result": pl.Utf8,
+    "drive_scored": pl.Boolean,
+    "down": pl.Int64,
+    "distance": pl.Int64,
+    "yard_line": pl.Utf8,
+    "yard_line_side": pl.Utf8,
+    "yard_line_number": pl.Int64,
+    "play_type": pl.Utf8,
+    "clock": pl.Utf8,
+    "yards_gained": pl.Int64,
+    "formation": pl.Utf8,
+    "passer": pl.Utf8,
+    "rusher": pl.Utf8,
+    "receiver": pl.Utf8,
+    "kicker": pl.Utf8,
+    "punter": pl.Utf8,
+    "returner": pl.Utf8,
+    "run_direction": pl.Utf8,
+    # Derived post-parse (NCAA text does NOT label scrambles): a rush by a player
+    # who also throws passes in the game = a QB run (conflates designed keepers +
+    # true scrambles). Null on non-rush plays.
+    "qb_scramble": pl.Boolean,
+    "pass_complete": pl.Boolean,
+    "pass_depth": pl.Utf8,
+    "pass_direction": pl.Utf8,
+    "tackler_1": pl.Utf8,
+    "tackler_2": pl.Utf8,
+    "kick_yards": pl.Int64,
+    "return_yards": pl.Int64,
+    "punt_yards": pl.Int64,
+    "fg_distance": pl.Int64,
+    "fg_made": pl.Boolean,
+    "is_first_down": pl.Boolean,
+    "is_touchdown": pl.Boolean,
+    "is_safety": pl.Boolean,
+    "is_fumble": pl.Boolean,
+    "is_turnover": pl.Boolean,
+    "turnover_type": pl.Utf8,
+    "out_of_bounds": pl.Boolean,
+    "no_play": pl.Boolean,
+    "fair_catch": pl.Boolean,
+    "penalty_flag": pl.Boolean,
+    "penalty_team": pl.Utf8,
+    "penalty_type": pl.Utf8,
+    "penalty_player": pl.Utf8,
+    "penalty_yards": pl.Int64,
+    "end_yard_line": pl.Utf8,
+    "play_text": pl.Utf8,
+}
+
+
+def parse_cfb_ncaa_pbp(
+    html: str,
+    contest_id: "str | int | None" = None,
+    *,
+    return_as_pandas: bool = False,
+) -> "Union[pl.DataFrame, pd.DataFrame]":
+    """Parse a stats.ncaa.org college-football ``play_by_play`` page into a tidy frame.
+
+    One row per play, cfbfastR-style: drive context (``drive_number``/``offense``/
+    ``drive_result``/``drive_scored``), down/distance/yard-line, a classified
+    ``play_type``, extracted players/directions/yards/kick-FG details, and a set of
+    boolean flags (first-down, touchdown, safety, fumble, turnover, penalty, ...),
+    with the raw ``play_text`` retained for anything not yet lifted into a column.
+
+    ``qb_scramble`` is derived frame-wide: NCAA official text does not label
+    scrambles, so a rush by a player who also passes in the same game is flagged as
+    a QB run.
+
+    Args:
+        html: Raw HTML of the ``/contests/{id}/play_by_play`` page (as returned by
+            :meth:`sportsdataverse.mbb.mbb_ncaa_fetch.NcaaFetcher.fetch_game_pbp`).
+        contest_id: Optional stats.ncaa.org contest id, written to every row's
+            ``contest_id`` column. Coerced to ``str``.
+        return_as_pandas: Return a ``pandas.DataFrame`` instead of ``polars``.
+
+    Returns:
+        A ``polars.DataFrame`` (or ``pandas.DataFrame`` when ``return_as_pandas``)
+        with one row per play. Empty/unparseable input returns a **zero-row frame
+        carrying the documented schema**, so callers can chain without null-checks.
+
+    Example:
+        Quick start::
+
+            from sportsdataverse.cfb import parse_cfb_ncaa_pbp
+            df = parse_cfb_ncaa_pbp(open("contest_5362535.html").read(), contest_id=5362535)
+            print(df.shape)
+
+        Inspect scoring plays::
+
+            df.filter(pl.col("is_touchdown") == True).select("offense", "play_text")
+
+        See Also:
+            * `cfbfastR`_ -- ESPN-sourced college-football pbp (R)
+
+        .. _cfbfastR: https://cfbfastR.sportsdataverse.org
+    """
+    soup = BeautifulSoup(html or "", "html.parser")
+    rows: "list[dict]" = []
+    drive_number = 0
+    cid = str(contest_id) if contest_id is not None else None
+
+    for container in soup.select("div.drives"):
+        drive: "dict" = {}
+        for child in container.find_all(["h5", "div"], recursive=False):
+            classes = child.get("class") or []
+            if not ("scoring_play" in classes or "non_scoring_play" in classes):
+                continue
+            if child.name == "h5":
+                drive_number += 1
+                m = _DRIVE_RE.match(_spaces(child.get_text(" ", strip=True)))
+                drive = {
+                    "drive_number": drive_number,
+                    "offense": m.group("team") if m else None,
+                    "drive_result": m.group("result") if m else None,
+                    "drive_scored": "scoring_play" in classes,
+                }
+            elif child.select_one(".headerRight") is None:
+                # play-list div (the header-body div has .headerRight; skip it)
+                play_number = 0
+                for play in child.find_all("div", recursive=False):
+                    spans = play.find_all("span")
+                    if len(spans) < 2:
+                        continue
+                    ddm = _DD_RE.match(_spaces(spans[0].get_text(" ", strip=True)))
+                    play_number += 1
+                    dist = ddm.group("distance") if ddm else None
+                    yl = ddm.group("yard_line") if ddm else None
+                    yl_m = _YL_SPLIT_RE.match(yl) if yl else None
+                    play_text = _spaces(spans[1].get_text(" ", strip=True))
+                    row = {
+                        "contest_id": cid,
+                        "drive_number": drive.get("drive_number"),
+                        "play_number": play_number,
+                        "offense": drive.get("offense"),
+                        "drive_result": drive.get("drive_result"),
+                        "drive_scored": drive.get("drive_scored"),
+                        "down": _DOWN.get(ddm.group("down").lower()) if ddm else None,
+                        "distance": int(dist) if dist and dist.isdigit() else None,
+                        "yard_line": yl,
+                        "yard_line_side": yl_m.group(1) if yl_m else None,
+                        "yard_line_number": int(yl_m.group(2)) if yl_m else None,
+                        "play_text": play_text,
+                    }
+                    row.update(_decompose_play_text(play_text))
+                    rows.append(row)
+
+    df = pl.DataFrame(rows, schema=PBP_SCHEMA) if rows else pl.DataFrame(schema=PBP_SCHEMA)
+    if df.height:
+        # qb_scramble = a rush by a player who also passes in this game (QB run).
+        # Frame-level derivation because NCAA text does not label scrambles.
+        qbs = df.filter(pl.col("passer").is_not_null()).get_column("passer").unique().to_list()
+        df = df.with_columns(
+            pl.when(pl.col("play_type") == "rush")
+            .then(pl.col("rusher").is_in(qbs))
+            .otherwise(None)
+            .alias("qb_scramble")
+        )
+    return df.to_pandas() if return_as_pandas else df

--- a/sportsdataverse/parsed/cfb.py
+++ b/sportsdataverse/parsed/cfb.py
@@ -418,6 +418,7 @@ from sportsdataverse.cfb import load_recruit_classes as load_recruit_classes  # 
 from sportsdataverse.cfb import make_ratings_compute_results as make_ratings_compute_results  # noqa: F401
 from sportsdataverse.cfb import most_recent_cfb_season as most_recent_cfb_season  # noqa: F401
 from sportsdataverse.cfb import normalize_team_roster_columns as normalize_team_roster_columns  # noqa: F401
+from sportsdataverse.cfb import parse_cfb_ncaa_pbp as parse_cfb_ncaa_pbp  # noqa: F401
 from sportsdataverse.cfb import parse_on3_rankings as parse_on3_rankings  # noqa: F401
 from sportsdataverse.cfb import parse_on3_rdb as parse_on3_rdb  # noqa: F401
 from sportsdataverse.cfb import parse_on3_team_rankings as parse_on3_team_rankings  # noqa: F401
@@ -730,6 +731,7 @@ __all__ = [
     "on3_transfers_best_available",
     "on3_transfers_latest",
     "on3_videos_video_key",
+    "parse_cfb_ncaa_pbp",
     "parse_on3_rankings",
     "parse_on3_rdb",
     "parse_on3_team_rankings",

--- a/tests/cfb/test_cfb_ncaa_pbp.py
+++ b/tests/cfb/test_cfb_ncaa_pbp.py
@@ -1,0 +1,198 @@
+"""Offline structural tests for the stats.ncaa.org college-football pbp parser.
+
+Parses committed real-game fixtures (never synthetic) and asserts the structured
+frame: schema stability, empty-input contract, down/distance/yard-line extraction,
+play-type classification (0 unknowns), player/direction/yardage lifts, flags, and
+the frame-wide ``qb_scramble`` derivation. The full 6-game capture corpus lives in
+the ``ncaa-mfb-hoops-raw`` producer repo; three games are vendored here to prove
+the parser generalizes across games.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+
+from sportsdataverse.cfb.cfb_ncaa_pbp import PBP_SCHEMA, parse_cfb_ncaa_pbp
+
+FIX = Path(__file__).resolve().parents[1] / "fixtures" / "cfb_ncaa"
+GAME = FIX / "cfb_ncaa_pbp_5362535.html"
+
+
+def _df() -> pl.DataFrame:
+    return parse_cfb_ncaa_pbp(GAME.read_text(encoding="utf-8"), contest_id="5362535")
+
+
+def test_returns_documented_schema() -> None:
+    df = _df()
+    assert df.columns == list(PBP_SCHEMA.keys())
+    assert df.height > 0
+
+
+def test_empty_input_is_zero_row_with_schema() -> None:
+    df = parse_cfb_ncaa_pbp("")
+    assert df.height == 0
+    assert df.columns == list(PBP_SCHEMA.keys())
+
+
+def test_down_distance_yardline_extracted() -> None:
+    df = _df()
+    dd = df.filter(pl.col("down").is_not_null())
+    assert dd.height > 0
+    assert dd.get_column("down").is_between(1, 4).all()
+    assert dd.get_column("yard_line").str.contains(r"^[A-Z]{1,4}\d+$").all()
+
+
+def test_scoring_drive_flagged() -> None:
+    df = _df()
+    af = df.filter(pl.col("offense") == "Air Force")
+    assert af.height > 0
+    assert af.get_column("drive_scored").any()
+    assert "TD" in af.get_column("drive_result").to_list()
+
+
+def test_play_text_preserved() -> None:
+    df = _df()
+    hit = df.filter(pl.col("play_text").str.contains("Anthony,Malakai rush left"))
+    assert hit.height >= 1
+    assert hit.get_column("down").to_list()[0] == 1
+
+
+def test_contest_id_stamped() -> None:
+    df = _df()
+    assert (df.get_column("contest_id") == "5362535").all()
+
+
+# --- play_text decomposition ----------------------------------------------
+
+
+def test_every_play_is_classified() -> None:
+    df = _df()
+    assert df.filter(pl.col("play_type").is_null()).height == 0
+    assert df.filter(pl.col("play_type") == "unknown").height == 0
+    kinds = set(df.get_column("play_type").unique().to_list())
+    assert {"rush", "pass", "punt", "kickoff", "field_goal"} <= kinds
+
+
+def test_rush_fields_extracted() -> None:
+    df = _df().filter(pl.col("play_type") == "rush")
+    assert df.get_column("rusher").is_not_null().all()
+    assert df.get_column("yards_gained").is_not_null().all()
+    assert df.filter(pl.col("rusher") == "Corbett,Jermaine").get_column("yards_gained").min() < 0
+
+
+def test_pass_fields_extracted() -> None:
+    df = _df().filter(pl.col("play_type") == "pass")
+    assert df.get_column("passer").is_not_null().all()
+    comp = df.filter(pl.col("pass_complete") == True)  # noqa: E712
+    assert comp.get_column("receiver").is_not_null().all()
+    assert comp.get_column("yards_gained").is_not_null().all()
+    inc = df.filter(pl.col("pass_complete") == False)  # noqa: E712
+    assert (inc.get_column("yards_gained") == 0).all()
+
+
+def test_special_teams_players() -> None:
+    df = _df()
+    assert df.filter(pl.col("play_type") == "punt").get_column("punter").is_not_null().all()
+    assert df.filter(pl.col("play_type") == "kickoff").get_column("kicker").is_not_null().all()
+
+
+def test_markers_flagged_not_plays() -> None:
+    df = _df()
+    markers = {"drive_start", "timeout", "period_marker", "coin_toss"}
+    assert df.filter(pl.col("play_type").is_in(list(markers))).height > 0
+
+
+# --- comprehensive field extraction ---------------------------------------
+
+
+def test_yard_line_split_full_coverage() -> None:
+    df = _df()
+    yl = df.filter(pl.col("yard_line").is_not_null())
+    assert yl.get_column("yard_line_side").is_not_null().all()
+    assert yl.get_column("yard_line_number").is_not_null().all()
+
+
+def test_directions_extracted() -> None:
+    df = _df()
+    assert df.filter(pl.col("play_type") == "rush").get_column("run_direction").is_not_null().all()
+    assert df.filter(pl.col("play_type") == "pass").get_column("pass_direction").is_not_null().all()
+
+
+def test_flags_present_and_true_somewhere() -> None:
+    df = _df()
+    for flag in (
+        "is_first_down",
+        "is_touchdown",
+        "is_turnover",
+        "out_of_bounds",
+        "no_play",
+        "fair_catch",
+        "penalty_flag",
+    ):
+        assert df.filter(pl.col(flag) == True).height > 0, flag  # noqa: E712
+
+
+def test_assisted_tackle_split() -> None:
+    df = _df()
+    row = df.filter((pl.col("tackler_1") == "Santiago,David") & (pl.col("tackler_2") == "Zdroik,Payton"))
+    assert row.height >= 1
+
+
+def test_penalty_fully_parsed() -> None:
+    df = _df().filter(pl.col("penalty_type").is_not_null())
+    assert df.height > 0
+    assert df.get_column("penalty_team").is_not_null().all()
+    assert df.get_column("penalty_yards").is_not_null().all()
+    assert "Wilborn Jr.,James" in df.get_column("penalty_player").drop_nulls().to_list()
+
+
+def test_special_teams_yardage() -> None:
+    df = _df()
+    assert df.filter(pl.col("play_type") == "kickoff").get_column("kick_yards").is_not_null().all()
+    assert df.filter(pl.col("play_type") == "punt").get_column("punt_yards").is_not_null().all()
+    fg = df.filter(pl.col("play_type") == "field_goal")
+    assert fg.get_column("fg_distance").is_not_null().all()
+    assert fg.get_column("fg_made").is_not_null().all()
+
+
+def test_touchdown_runs_flagged() -> None:
+    df = _df()
+    td = df.filter(pl.col("is_touchdown") == True)  # noqa: E712
+    assert td.height >= 1
+    assert td.get_column("end_yard_line").str.contains("00").any()
+
+
+def test_qb_scramble_derived() -> None:
+    df = _df()
+    assert df.filter(pl.col("play_type") != "rush").get_column("qb_scramble").is_null().all()
+    assert df.filter(pl.col("play_type") == "rush").get_column("qb_scramble").is_not_null().all()
+    qbs = set(df.filter(pl.col("passer").is_not_null()).get_column("passer").to_list())
+    flagged = df.filter(pl.col("qb_scramble") == True)  # noqa: E712
+    assert set(flagged.get_column("rusher").to_list()) <= qbs
+
+
+def test_return_as_pandas() -> None:
+    import pandas as pd
+
+    df = parse_cfb_ncaa_pbp(GAME.read_text(encoding="utf-8"), return_as_pandas=True)
+    assert isinstance(df, pd.DataFrame)
+    assert list(df.columns) == list(PBP_SCHEMA.keys())
+
+
+def test_parser_generalizes_across_fixtures() -> None:
+    files = sorted(FIX.glob("cfb_ncaa_pbp_*.html"))
+    assert len(files) >= 3, "need multiple captured games to test generalization"
+    for f in files:
+        d = parse_cfb_ncaa_pbp(f.read_text(encoding="utf-8"))
+        assert d.height > 50, f.name  # a full game
+        assert d.filter(pl.col("play_type") == "unknown").height == 0, f.name
+        # a rush naming an individual carrier must resolve a rusher; team-credited
+        # rushes ("Akron rush ... End Of Play") legitimately don't.
+        bad = d.filter(
+            (pl.col("play_type") == "rush")
+            & pl.col("rusher").is_null()
+            & pl.col("play_text").str.contains(r",[A-Z][\w.'\-]+ rush")
+        )
+        assert bad.height == 0, f.name

--- a/tests/fixtures/cfb_ncaa/README.md
+++ b/tests/fixtures/cfb_ncaa/README.md
@@ -1,0 +1,26 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [cfb_ncaa fixtures](#cfb_ncaa-fixtures)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# cfb_ncaa fixtures
+
+Real `stats.ncaa.org` college-football (NCAA sport code `MFB`) play-by-play
+game pages, captured via the browser transport in
+`sportsdataverse/mbb/mbb_ncaa_fetch.py` (patchright + `--headless=new` + US
+residential IP) from `https://stats.ncaa.org/contests/{id}/play_by_play`.
+
+Consumed by `tests/cfb/test_cfb_ncaa_pbp.py` (offline parser tests).
+
+| file | contest_id | source URL | captured |
+|---|---|---|---|
+| `cfb_ncaa_pbp_5362535.html` | 5362535 | <https://stats.ncaa.org/contests/5362535/play_by_play> | 2026-07-16 |
+| `cfb_ncaa_pbp_5336803.html` | 5336803 | <https://stats.ncaa.org/contests/5336803/play_by_play> | 2026-07-16 |
+| `cfb_ncaa_pbp_5361446.html` | 5361446 | <https://stats.ncaa.org/contests/5361446/play_by_play> | 2026-07-16 |
+
+The full 6-game capture corpus lives in the `ncaa-mfb-hoops-raw` producer repo;
+three games are vendored here to prove the parser generalizes across games
+(0 unknown play types on every game).

--- a/tests/fixtures/cfb_ncaa/cfb_ncaa_pbp_5336803.html
+++ b/tests/fixtures/cfb_ncaa/cfb_ncaa_pbp_5336803.html
@@ -1,0 +1,2604 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<META HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=UTF-8">
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="">
+<meta name="author" content="">
+<meta name="version" content="321d28433e9f7a188596117e6f342ec4a84fb4ed">
+<META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<link rel="shortcut icon" href="/assets/favicon-405088046a5f2bab8eedeacfae7636975c095e9c8decd8c28e3fd0e65c2f51c4.ico" type="image/vnd.microsoft.icon">
+
+<title>NCAA Statistics</title>
+
+<!-- Bootstrap core CSS -->
+
+<!--
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+-->
+<!--
+<link rel="stylesheet" href="https://cdn.datatables.net/2.0.0/css/dataTables.bootstrap4.css" crossorigin="anonymous">
+-->
+<link rel="stylesheet" media="all" href="/assets/application-789c3971842ee3597428ccbebd021716b3231e9cbd0a00a184c3b2d6c8e5f152.css" />
+
+
+<script src="/assets/application-9232576bb3cb000ac0841ff2af81251908ec17312a3c5eb72bf1a32f9754800c.js"></script>
+<!--
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+-->
+<!--
+<script src="https://cdn.datatables.net/2.0.0/js/dataTables.bootstrap4.js" crossorigin="anonymous"></script>
+-->
+
+<meta name="csrf-param" content="authenticity_token" />
+<meta name="csrf-token" content="rjMh8Y2C/Zzk+BuH7YWTFhPzGbshBB8l6NVXWn6B42a8xaDU8idwMAVnvlig/kUGGNfOxc0UEhgPzpLSg/1Xqg==" />
+
+<style>
+.grid {clear: all}
+.grid-item, .name {text-align: center;}
+h1 img {max-height: 33px;}
+
+</style>
+<!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+<!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+      <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+    <![endif]-->
+
+
+<script>(window.BOOMR_mq=window.BOOMR_mq||[]).push(["addVar",{"rua.upush":"false","rua.cpush":"false","rua.upre":"false","rua.cpre":"false","rua.uprl":"false","rua.cprl":"false","rua.cprf":"false","rua.trans":"","rua.cook":"false","rua.ims":"false","rua.ufprl":"false","rua.cfprl":"false","rua.isuxp":"false","rua.texp":"norulematch","rua.ceh":"false","rua.ueh":"false","rua.ieh.st":"0"}]);</script>
+                                <script>!function(e){var n="https://s.go-mpulse.net/boomerang/";if("False"=="True")e.BOOMR_config=e.BOOMR_config||{},e.BOOMR_config.PageParams=e.BOOMR_config.PageParams||{},e.BOOMR_config.PageParams.pci=!0,n="https://s2.go-mpulse.net/boomerang/";if(window.BOOMR_API_key="EVKJV-AGD2E-W66AE-NT84S-K5LTF",function(){function e(){if(!r){var e=document.createElement("script");e.id="boomr-scr-as",e.src=window.BOOMR.url,e.async=!0,o.appendChild(e),r=!0}}function t(e){r=!0;var n,t,a,i,d=document,O=window;if(window.BOOMR.snippetMethod=e?"if":"i",t=function(e,n){var t=d.createElement("script");t.id=n||"boomr-if-as",t.src=window.BOOMR.url,BOOMR_lstart=(new Date).getTime(),e=e||d.body,e.appendChild(t)},!window.addEventListener&&window.attachEvent&&navigator.userAgent.match(/MSIE [67]\./))return window.BOOMR.snippetMethod="s",void t(o,"boomr-async");a=document.createElement("IFRAME"),a.src="about:blank",a.title="",a.role="presentation",a.loading="eager",i=(a.frameElement||a).style,i.width=0,i.height=0,i.border=0,i.display="none",o.appendChild(a);try{O=a.contentWindow,d=O.document.open()}catch(_){n=document.domain,a.src="javascript:var d=document.open();d.domain='"+n+"';void 0;",O=a.contentWindow,d=O.document.open()}if(n)d._boomrl=function(){this.domain=n,t()},d.write("<bo"+"dy onload='document._boomrl();'>");else if(O._boomrl=function(){t()},O.addEventListener)O.addEventListener("load",O._boomrl,!1);else if(O.attachEvent)O.attachEvent("onload",O._boomrl);d.close()}function a(e){window.BOOMR_onload=e&&e.timeStamp||(new Date).getTime()}if(!window.BOOMR||!window.BOOMR.version&&!window.BOOMR.snippetExecuted){window.BOOMR=window.BOOMR||{},window.BOOMR.snippetStart=(new Date).getTime(),window.BOOMR.snippetExecuted=!0,window.BOOMR.snippetVersion=14,window.BOOMR.url=n+"EVKJV-AGD2E-W66AE-NT84S-K5LTF";var i=document.currentScript||document.getElementsByTagName("script")[0],o=i.parentNode,r=!1,d=document.createElement("link");if(d.relList&&"function"==typeof d.relList.supports&&d.relList.supports("preload")&&"as"in d)window.BOOMR.snippetMethod="p",d.href=window.BOOMR.url,d.rel="preload",d.as="script",d.addEventListener("load",e),d.addEventListener("error",function(){t(!0)}),setTimeout(function(){if(!r)t(!0)},3e3),BOOMR_lstart=(new Date).getTime(),o.appendChild(d);else t(!1);if(window.addEventListener)window.addEventListener("load",a,!1);else if(window.attachEvent)window.attachEvent("onload",a)}}(),"".length>0)if(e&&"performance"in e&&e.performance&&"function"==typeof e.performance.setResourceTimingBufferSize)e.performance.setResourceTimingBufferSize();!function(){if(BOOMR=e.BOOMR||{},BOOMR.plugins=BOOMR.plugins||{},!BOOMR.plugins.AK){var n=""=="true"?1:0,t="",a="vq5hssix2kdgi2sztkga-f-8a79ea43b-clientnsv4-s.akamaihd.net",i="false"=="true"?2:1,o={"ak.v":"41","ak.cp":"1168236","ak.ai":parseInt("215853",10),"ak.ol":"0","ak.cr":49,"ak.ipv":4,"ak.proto":"h2","ak.rid":"4e5aad12","ak.r":47358,"ak.a2":n,"ak.m":"a","ak.n":"essl","ak.cport":14824,"ak.gh":"23.208.24.235","ak.quicv":"","ak.tlsv":"tls1.3","ak.0rtt":"","ak.0rtt.ed":"","ak.csrc":"-","ak.acc":"","ak.t":"1784257164","ak.ak":"hOBiQwZUYzCg5VSAfCLimQ==7nkOj75lsUatQZD0jLAvXPkunJ+5IudoNXfl85/nuhVnlZaIw3gAQdmFvoJYnTRO4krhz2ucNOBnXrFDUJYxNabvnOmcshPH6pTa8kxTB5XgOHSspO6Zm0qgrC3GkH37sd3w/dSmgEt+B1cb80mbXIg/irC3taTeFCpxZMHjDCUM8mXuOqeiRbUWmG4YRyDrawxlGi82xsVEA8CLaCYq/c8Rs7SmE4giKNOCy4W/6JkeLEY3llrZQ/Z6Peuz3IyG0pvHl64eDw0B07QGzTHAqiOQ0/B+w7s9E6WgDs3VfNIIPo2ll4ykCNAipgtKr0cGmsC8cuRRgNxQutFqmhWw+IrmBpzH3UBojUrX1yoGsa2A21TDS8z5wIKe1DKdmlfSHETQALnHzlagJZnKu4KjZ/7LM36syoRsFMfNz0Gz0Zs=","ak.pv":"93","ak.dpoabenc":"","ak.tf":i};if(""!==t)o["ak.ruds"]=t;var r={i:!1,av:function(n){var t="http.initiator";if(n&&(!n[t]||"spa_hard"===n[t]))o["ak.feo"]=void 0!==e.aFeoApplied?1:0,BOOMR.addVar(o)},rv:function(){var e=["ak.cport","ak.cr","ak.csrc","ak.gh","ak.ipv","ak.m","ak.n","ak.ol","ak.proto","ak.quicv","ak.tlsv","ak.0rtt","ak.0rtt.ed","ak.r","ak.acc","ak.t","ak.tf"];BOOMR.removeVar(e)}};BOOMR.plugins.AK={akVars:o,akDNSPreFetchDomain:a,init:function(){if(!r.i){var e=BOOMR.subscribe;e("before_beacon",r.av,null,null),e("onbeacon",r.rv,null,null),r.i=!0}return this},is_complete:function(){return!0}}}}()}(window);</script></head>
+
+  <script>
+
+    
+  //initialize tooltip
+  $(document).ready(function() {
+    //$("body").tooltip({ selector: '[data-toggle=tooltip]' });
+    $('[data-toggle="tooltip"]').tooltip();
+  });
+
+  $(document).ready(function() {
+    $( "#org_name" ).autocomplete({
+      source: '/team/search',
+      select: function( event, ui ) {
+        $("#org_id").val(ui.item.vid);
+        $("#id").val(ui.item.vid);
+        $('#sport_btn').click();
+      }
+    });
+  });
+
+  var body = 'body';
+
+  $.ajaxSetup ({
+    // Disable caching of AJAX responses
+    cache: false
+  });
+
+  function changeSport(field){
+    var el = $(field);
+    var tmList = el.parent().next().find('.new-team-year')[0];
+    if (tmList == null){
+      tmList = el.nextAll('.new-team-year')[0];
+    }
+    $.ajax({
+      url: "/game_sport_year_ctls/"+el.val()+"/available_teams",
+      dataType: "script",
+      success: function(data, status){
+        $(tmList).empty();
+        $(tmList).append(("<option value=''>Select team</option>"));
+        $.each(JSON.parse(data), function(k, v){
+          $(tmList).append($("<option></option>")
+              .attr("value", v["id"])
+              .text(v["member_org"]["name_tabular"]));
+        });
+        $(tmList).trigger("chosen:updated");
+      }
+    });
+  }
+
+    function set_process_styles(fld, start_color, end_color){
+       $('#'+fld).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    var downImage = "/assets/down12.gif";
+    var rightImage = "/assets/right12.gif";
+
+    function highlight(div_id){
+      $(div_id).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    function show_hide_rows(attr_val, link_id){
+      $('#'+attr_val).toggle();
+      if ($('#'+attr_val).is(':visible')) {
+        $('#'+link_id).attr('src', downImage);
+      }else{
+        $('#'+link_id).attr('src', rightImage);
+      }
+    }
+
+    function mask(label){
+      $('body').mask(label);
+    }
+    function unmask(){
+      $('body').unmask();
+    }
+
+    var winHeight = "auto";
+    var winWidth = "auto";
+    var maxHeight = 700;
+    var maxWidth = 1400;
+    var minHeight = 100;
+    var minWidth = 200;
+    
+    var modalOptions = {"width": winWidth,
+                        "height": winHeight,
+                        "maxHeight": maxHeight,
+                        "maxWidth": maxWidth,
+                        "minHeight": minHeight,
+                        "minWidth": minWidth};
+
+    function dialog(url, title){
+
+      $("#stats_app_dialog").dialog({modal:true, minWidth:minWidth, minHeight:minHeight, maxWidth:maxWidth, maxHeight:maxHeight, width:winWidth, height:winHeight, title:title, closeOnEscape: false});
+    
+      modalOptions.title = title;
+    
+      $("#stats_app_dialog").dialog("option", modalOptions);
+    
+      $("#stats_app_dialog").html("Loading...");
+      $("#stats_app_dialog").load(url).dialog('open');
+    }
+
+    function addDatePicker(){
+    $('.adddatepicker').each(function(i, obj){
+      $(obj).datepicker({ 
+        showOn: 'both', 
+        buttonImage: '/assets/calendar.gif', 
+        buttonImageOnly: true,
+      });
+    });
+    }
+
+   $(document).ready(function() {
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   });
+
+   function setClassInputFields(){
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   }
+
+   function isValidDateFormat(dateStr){
+     const regex = /^([1-9]|0[1-9]|1[0-2])\/([1-9]|0[1-9]|[12][0-9]|3[01])\/(19|20)\d{2}$/;
+     if (!regex.test(dateStr)) {
+       return false;
+     }else{
+       return true;
+     }
+   }
+
+  </script>
+
+
+<body style="font-size: .75rem;" onload="if (top != self) { top.location=self.location; }" >
+
+      <header>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0">
+        <a class="navbar-brand mr-0 mr-md-2" href="/" aria-label="statistics">
+                          <img alt="NCAA" style="margin-left: 24px; margin-right: 0; margin-top: 6px;" src="/assets/ncaa-fbc4d0406ae731b47babcc3fca53775b5955ef372bf8b8e998ca9a513e468b8f.svg" />
+                          <span class="title" class="dark-blue-font">Statistics</span>
+        </a>
+       </nav>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0" style="background-color: var(--color-dark-blue) !important;">
+  <button class="navbar-toggler bg-white" type="button" data-toggle="collapse" data-target="#navbarTogglerDemo01" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarTogglerDemo01">
+        <ul class="navbar-nav mr-auto mt-2 mt-lg-0 justify-content-center">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle skipMask" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Rankings
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+          <a class="dropdown-item" href="/rankings">National Rankings</a>
+          <a class="dropdown-item" href="/active_career_leaders">Active Career Leaders</a>
+        </div>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/contests/livestream_scoreboards">Scoreboard</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/selection_rankings/nitty_gritties">Selection Rankings</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/head_coaches">Head Coaches</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/search/players">Players</a>
+      </li>
+     </ul>
+
+    <form onsubmit="mask(&#39;Loading&#39;);" id="change_team_form" style="display:inline;" class="form-inline my-2 my-lg-0" action="/team/index" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="9mN1hWtu9Ifi+1WotKMYKWxZUFWWbQEIwE3xkqM0qGutRJtjpQ9Iyqqr3V8AGSAj3W/0P+33iZtfOIqq1M+N0w==" />
+  <div style="display:none;">
+  <input type="submit" name="commit" value="Submit" id="sport_btn" data-disable-with="Submit" />
+  </div>
+    <div id="team_autocomplete" class="ui-widget">
+      <input type="search" name="org_name" id="org_name" style="width:200px; font-size: 12px !important" class="form-control mr-sm-2" placeholder="Team Search" />
+      <input type="hidden" name="org_id" id="org_id" />
+    </div>
+</form>  </div>
+  </nav>
+</nav>
+      </header>
+
+       <div id="stats_app_dialog" style="display:none;">
+        </div>
+
+<div class="card p-1">
+  <div class="card-body application contests p-0">
+    <h3 class="card-title p-0"></h3>
+    <div class="container-fluid p-0">
+      <div class="row align-items-center justify-content-center p-0">
+        <div class="col-sm-12 p-0">
+          <br/>
+
+<br/>
+
+<style>
+.winner{
+  --display: flex;
+  vertical-align: middle;
+}
+.winner:before{
+  content: '\25BA';
+  --display: flex;
+  --align-items: center;
+  vertical-align: middle;
+}
+div.center {
+  margin: auto;
+  width: 50%;
+  --border: 3px solid green;
+  padding: 10px;
+}
+</style>
+
+   <div class="table-responsive">
+   <table align="center">
+     <tr>
+   <td>
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589020"><img class="large_logo_image" alt="Akron" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//5.gif" /></a>
+   </td>
+   <td valign="center" class="grey_text d-none d-sm-table-cell" nowrap>
+     <span style="font-size:18px">
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589020">Akron Zips</a>
+     </span><br/>
+       0-1, Conf 0-0
+   </td>
+   <td valign="center" class="">
+   </td>
+   <td valign="center" style="font-size:36px; color: grey">
+     6
+   </td>
+     <td style="padding: 0px 30px 0px 30px"  class="d-none d-md-table-cell">
+       <table style="border-collapse: collapse">
+         <tr>
+           <td class="grey_border_bottom"></td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">1</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">2</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">3</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">4</td>
+           <td width="20px" align="right" style="font-weight:bold" class="grey_border_bottom">S</td>
+         </tr>
+           <tr>
+             <td>Akron</td>
+               <td class="grey_text" align="right">3</td>
+               <td class="grey_text" align="right">0</td>
+               <td class="grey_text" align="right">3</td>
+               <td class="grey_text" align="right">0</td>
+             <td align="right" style="font-weight:bold">6</td>
+           </tr>
+           <tr>
+             <td>Ohio St.</td>
+               <td class="grey_text" align="right">7</td>
+               <td class="grey_text" align="right">10</td>
+               <td class="grey_text" align="right">21</td>
+               <td class="grey_text" align="right">14</td>
+             <td align="right" style="font-weight:bold">52</td>
+           </tr>
+         <tr>
+           <td class="grey_text" colspan="6">08/31/2024 03:30 PM</td>
+         </tr>
+         <tr>
+           <td nowrap class="grey_text" colspan="6">Ohio Stadium (Columbus, OH)</td>
+         </tr>
+         <tr>
+           <td nowrap class="grey_text" colspan="6">Attendance: 102,011</td>
+         </tr>
+       </table>
+     </td>
+   <td>
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/588963"><img class="large_logo_image" alt="Ohio St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//518.gif" /></a>
+   </td>
+   <td valign="center" class="grey_text d-none d-sm-table-cell" nowrap>
+     <span style="font-size:18px">
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/588963">Ohio St. Buckeyes</a>
+     </span><br/>
+       1-0, Conf 0-0
+   </td>
+   <td valign="center" class="winner">
+   </td>
+   <td valign="center" style="font-size:36px; color: black">
+     52
+   </td>
+     </tr>
+     <tr>
+       <td colspan="10" class="grey_border_bottom grey_border_top">
+         <table cellpadding="10px">
+           <tr>
+             <td style="font-size: 16px;"><a href="/contests/5336803/box_score">Box Score</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5336803/team_stats">Team Stats</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5336803/individual_stats">Individual Stats</a></td>
+             <td style="font-size: 16px;">Play By Play</td>
+             <td style="font-size: 16px;"><a href="/contests/5336803/drives">Drives</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5336803/officials">Officials</a></td>
+           </tr>
+         </table>
+       </td>
+     </tr>
+   </table>
+ </div>
+
+
+<br/>
+
+  <script>
+ $( function() {
+    $( ".drives" ).accordion({
+      collapsible: true,
+      heightStyle: "content",
+      header: "h5",
+      active: false
+    });
+  } );
+
+ function showScoringPlays(){
+   $('.non_scoring_play').hide();
+ }
+ function showAllPlays(){
+   $('.non_scoring_play').show();
+   $('.drives').accordion("refresh");
+   $('.drives').accordion("option", "active", false);
+ }
+</script>
+
+<style>
+ .ui-state-default, .ui-widget-content .ui-state-default, .ui-widget-header .ui-state-default {
+   overflow: auto;
+ }
+ .ui-state-default, .ui-widget-content .ui-state-default, .ui-widget-header .ui-state-default {
+    border: 1px solid #CCCCCC;
+    background: white;
+    background-image: none;
+    font-weight: normal;
+    color: #808080;
+}
+
+ .headerRight {
+  float: right;
+}
+.headerLeft {
+  float: left;
+}
+.under{
+text-decoration : underline;
+}
+</style>
+
+<div style="width: 50%; margin-left: auto; margin-right: auto;">
+  <div class="headerRight"><a class="skipMask" href="javascript:showAllPlays();">All Drives</a> | <a class="skipMask" href="javascript:showScoringPlays();">Scoring Drives</a></div>
+  <div style="border-bottom: 1px dotted #dcdddf;"><h1>1st Quarter</h1></div>
+<div class="drives">
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ohio St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//518.gif" /><span class='d-none d-sm-block'>Ohio St.</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">14:53,OSU32, 3 plays, 4 yards, 00:51</span>
+        </div>
+        <div class="headerRight">0 - 0</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR35</br>
+         </span>
+         <span>
+           Jackson,Dante kickoff 61 yards to the OSU04 Ballard,Jayden return 23 yards to the OSU27 (Jackson,Dante; Roach,Noel) PENALTY AKRON Offside 5 yards from OSU27 to OSU32.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU32</br>
+         </span>
+         <span>
+           Ohio State drive start at 14:53.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU32</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Henderson,TreVeyon rush right for 9 yards gain to the OSU41 (Nunnally,CJ).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 1 at OSU41</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass incomplete short left to Smith,Jeremiah thrown to OSU39.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at OSU41</br>
+         </span>
+         <span>
+           PENALTY OSU False Start (Tshabola,Tegra) 5 yards from OSU41 to OSU36. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at OSU36</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass incomplete short right to Egbuka,Emeka thrown to OSU41 broken up by McCoy,Bryan.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 6 at OSU36</br>
+         </span>
+         <span>
+           McGuire,Joe punt 42 yards to the AKRON22, TURNOVER ON DOWNS.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Akron" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//5.gif" /><span class='d-none d-sm-block'>Akron</span></div></div>
+        <div class="headerLeft">FG <br/><span style="font-size: 8px;">14:02,AKR22, 10 plays, 47 yards, 05:18</span>
+        </div>
+        <div class="headerRight">3 - 0</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR22</br>
+         </span>
+         <span>
+           Akron drive start at 14:02.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR22</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben rush left for 5 yards gain to the AKRON27, End Of Play PENALTY OSU Personal Foul (Igbinosun,Davison) 15 yards from AKRON27 to AKRON42, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR42</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj pass complete short right to Simmons,Jordon caught at AKRON38, for 6 yards to the AKRON48 (Hancock,Jordan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 4 at AKR48</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Simmons,Jordon rush middle for 2 yards gain to the AKRON50 (Hamilton,Ty; Ransom,Lathan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at AKR50</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj pass complete short right to Newell,Jake caught at OSU49, for 12 yards to the OSU38 (Burke,Denzel), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU38</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj rush middle for 3 yards gain to the OSU35 (Williams,Tyleik).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at OSU35</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj rush right for 12 yards gain to the OSU23 (Burke,Denzel), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU23</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Akron rush middle for 14 yards loss to the OSU37, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 24 at OSU37</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj sacked for loss of 4 yards to the OSU41 (Tuimoloau,JT).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 28 at OSU41</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj pass complete short left to Golden,Bobby caught at OSU44, for 10 yards to the OSU31 (Williams,Tyleik; Styles,Sonny).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 18 at OSU31</br>
+         </span>
+         <span>
+           Smith,Garrison field goal attempt from 48 yards GOOD (H: Castle,Joseph, LS: Reardon,Liam), clock 08:44.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ohio St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//518.gif" /><span class='d-none d-sm-block'>Ohio St.</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">08:44,OSU25, 14 plays, 75 yards, 06:00</span>
+        </div>
+        <div class="headerRight">3 - 7</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR35</br>
+         </span>
+         <span>
+           Jackson,Dante kickoff 51 yards to the OSU14 fair catch by Ballard,Jayden at OSU14.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU25</br>
+         </span>
+         <span>
+           Ohio State drive start at 08:44.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass incomplete short right to Tate,Carnell thrown to OSU32.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at OSU25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass incomplete short middle to Judkins,Quinshon thrown to OSU27 broken up by Cooper,Shammond.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 10 at OSU25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short right to Smith,Jeremiah caught at OSU36, for 11 yards to the OSU36 (Golden-Nelson,Devonte), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU36</br>
+         </span>
+         <span>
+           Shotgun Judkins,Quinshon rush left for 1 yard gain to the OSU37 (Dall,Bruno).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 9 at OSU37</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short right to Egbuka,Emeka caught at AKRON44, for 19 yards to the AKRON44 (David,Daymon), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR44</br>
+         </span>
+         <span>
+           Shotgun Judkins,Quinshon rush middle for 1 yard gain to the AKRON43 (Fish,Antavious; Murphy,Kiawan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 9 at AKR43</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will rush right for 8 yards gain to the AKRON35, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at AKR35</br>
+         </span>
+         <span>
+           Timeout Other, clock 05:41.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at AKR35</br>
+         </span>
+         <span>
+           Howard,Will rush middle for 1 yard gain to the AKRON34 (Lewis,Darrian), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR34</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short right to Tate,Carnell caught at AKRON29, for 6 yards to the AKRON28 (Golden-Nelson,Devonte), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 4 at AKR28</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Judkins,Quinshon rush right for 0 yards to the AKRON28 (Nunnally,CJ).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 4 at AKR28</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short right to Smith,Jeremiah caught at AKRON20, for 8 yards to the AKRON20, out of bounds at AKRON20, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR20</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass incomplete deep right to Egbuka,Emeka thrown to AKRON00 broken up by Golden-Nelson,Devonte. The previous play is under automatic review - &quot;Incomplete pass&quot;. PLAY CONFIRMED.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at AKR20</br>
+         </span>
+         <span>
+           Shotgun Judkins,Quinshon rush middle for 4 yards gain to the AKRON16 (Lewis,Darrian; Fish,Antavious).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at AKR16</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short left to Smith,Jeremiah caught at AKRON00, for 16 yards to the AKRON00 TOUCHDOWN, clock 02:44, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR3</br>
+         </span>
+         <span>
+           Fielding,Jayden kick attempt good (H: McGuire,Joe, LS: Ferlmann,John).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Akron" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//5.gif" /><span class='d-none d-sm-block'>Akron</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">02:44,AKR25, 5 plays, 9 yards, 02:36</span>
+        </div>
+        <div class="headerRight">3 - 7</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU35</br>
+         </span>
+         <span>
+           Fielding,Jayden kickoff 65 yards to the AKRON00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           Akron drive start at 02:44.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben pass complete short right to Kellom,Charles caught at AKRON25, for 9 yards to the AKRON34 (Ransom,Lathan), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 1 at AKR34</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben pass complete short right to Bullock,Tahj caught at AKRON34, for 5 yards to the AKRON39 (Hicks,C.J.), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR39</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj pass complete short right to Kellom,Charles caught at AKRON38, for 3 yards to the AKRON42 (Hicks,C.J.; Ransom,Lathan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at AKR42</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben sacked for loss of 8 yards to the AKRON34 (Hicks,C.J.).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 15 at AKR34</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben pass incomplete short right to Kellom,Charles thrown to AKRON35.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 15 at AKR34</br>
+         </span>
+         <span>
+           Book,Avery punt 25 yards to the OSU41, out of bounds at OSU41.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ohio St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//518.gif" /><span class='d-none d-sm-block'>Ohio St.</span></div></div>
+        <div class="headerLeft">DOWNS <br/><span style="font-size: 8px;">00:08,OSU41, 6 plays, 34 yards, 02:09</span>
+        </div>
+        <div class="headerRight">3 - 7</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU41</br>
+         </span>
+         <span>
+           Ohio State drive start at 00:08.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU41</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Henderson,TreVeyon rush right for 13 yards gain to the AKRON46 (Lewis,Darrian), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR46</br>
+         </span>
+         <span>
+           Start of 2nd quarter, clock 15:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR46</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short left to Egbuka,Emeka caught at AKRON41, for 16 yards to the AKRON30 (Lewis,Darrian), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR30</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass incomplete short right thrown to AKRON22.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at AKR30</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Henderson,TreVeyon rush left for 3 yards gain to the AKRON27 (Nunnally,CJ; Kapongo,Nate).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 7 at AKR27</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Henderson,TreVeyon rush left for 2 yards gain to the AKRON25 (McCoy,Bryan; Fish,Antavious).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 5 at AKR25</br>
+         </span>
+         <span>
+           Timeout Other, clock 13:11.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 5 at AKR25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass incomplete short right to Egbuka,Emeka thrown to AKRON23 broken up by Greenwood,Aman, TURNOVER ON DOWNS.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+</div>
+  <div style="border-bottom: 1px dotted #dcdddf;"><h1>2nd Quarter</h1></div>
+<div class="drives">
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Akron" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//5.gif" /><span class='d-none d-sm-block'>Akron</span></div></div>
+        <div class="headerLeft">INT <br/><span style="font-size: 8px;">12:59,AKR25, 2 plays, -2 yards, 00:56</span>
+        </div>
+        <div class="headerRight">3 - 7</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           Akron drive start at 12:59.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Simmons,Jordon rush middle for 2 yards loss to the AKRON23 (Ransom,Lathan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 12 at AKR23</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben pass intercepted by Burke,Denzel at AKRON33, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ohio St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//518.gif" /><span class='d-none d-sm-block'>Ohio St.</span></div></div>
+        <div class="headerLeft">FG <br/><span style="font-size: 8px;">12:03,AKR33, 5 plays, 11 yards, 00:40</span>
+        </div>
+        <div class="headerRight">3 - 10</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR33</br>
+         </span>
+         <span>
+           Ohio State drive start at 12:03.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR33</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Henderson,TreVeyon rush middle for 11 yards gain to the AKRON22 (Fish,Antavious; David,Daymon), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR22</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass incomplete short right to Inniss,Brandon thrown to AKRON25 broken up by Greenwood,Aman.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at AKR22</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass incomplete short left to Kacmarek,Will thrown to AKRON05.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 10 at AKR22</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass incomplete deep left to Smith,Jeremiah thrown to AKRON00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 10 at AKR22</br>
+         </span>
+         <span>
+           Fielding,Jayden field goal attempt from 40 yards GOOD (H: McGuire,Joe, LS: Ferlmann,John), clock 11:23.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Akron" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//5.gif" /><span class='d-none d-sm-block'>Akron</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">11:23,AKR25, 3 plays, -3 yards, 02:23</span>
+        </div>
+        <div class="headerRight">3 - 10</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU35</br>
+         </span>
+         <span>
+           Fielding,Jayden kickoff 65 yards to the AKRON00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           Akron drive start at 11:23.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj rush left for 0 yards to the AKRON25 (Tuimoloau,JT).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at AKR25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Kellom,Charles rush middle for 2 yards gain to the AKRON27 (Williams,Tyleik; Sawyer,Jack).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 8 at AKR27</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben sacked for loss of 5 yards to the AKRON22 (Tuimoloau,JT, Downs,Caleb).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 13 at AKR22</br>
+         </span>
+         <span>
+           Book,Avery punt 60 yards to the OSU18 Inniss,Brandon return 6 yards to the OSU24 (Thomas,Terence; Reardon,Liam).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ohio St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//518.gif" /><span class='d-none d-sm-block'>Ohio St.</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">09:00,OSU24, 9 plays, 76 yards, 04:30</span>
+        </div>
+        <div class="headerRight">3 - 17</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU24</br>
+         </span>
+         <span>
+           Ohio State drive start at 09:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU24</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Judkins,Quinshon rush right for 5 yards gain to the OSU29 (Greenwood,Aman).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 5 at OSU29</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short right to Egbuka,Emeka caught at OSU29, for 12 yards to the OSU41 (Greenwood,Aman), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU41</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Judkins,Quinshon rush left for 12 yards gain to the AKRON47 (Lewis III,Paul), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR47</br>
+         </span>
+         <span>
+           Timeout Other, clock 07:39.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR47</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Judkins,Quinshon rush left for 2 yards gain to the AKRON45 (David,Daymon).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 8 at AKR45</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Henderson,TreVeyon rush left for 5 yards gain to the AKRON40, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 3 at AKR40</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short left to Egbuka,Emeka caught at AKRON40, for 14 yards to the AKRON26 (Nunnally,CJ) PENALTY OSU Illegal Formation 5 yards from AKRON40 to AKRON45. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 8 at AKR45</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short right to Tate,Carnell caught at AKRON29, for 16 yards to the AKRON29 (Lewis III,Paul), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR29</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will rush right for 19 yards gain to the AKRON10 (Fish,Antavious; Golden-Nelson,Devonte), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR10</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Henderson,TreVeyon rush middle for 1 yard gain to the AKRON09 (Spriggs,Melvin).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 9 at AKR9</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short middle to Smith,Jeremiah caught at AKRON00, for 9 yards to the AKRON00 TOUCHDOWN, clock 04:30, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR3</br>
+         </span>
+         <span>
+           Fielding,Jayden kick attempt good (H: McGuire,Joe, LS: Ferlmann,John).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU35</br>
+         </span>
+         <span>
+           AKR ball on AKR20.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Akron" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//5.gif" /><span class='d-none d-sm-block'>Akron</span></div></div>
+        <div class="headerLeft">DOWNS <br/><span style="font-size: 8px;">04:30,AKR20, 12 plays, 45 yards, 03:26</span>
+        </div>
+        <div class="headerRight">3 - 17</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU35</br>
+         </span>
+         <span>
+           Fielding,Jayden kickoff 65 yards to the AKRON00, Touchback PENALTY AKRON Illegal Substitution 5 yards from AKRON25 to AKRON20.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR20</br>
+         </span>
+         <span>
+           Akron drive start at 04:30.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR20</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben pass complete short right to Golden,Bobby caught at AKRON24, for 19 yards to the AKRON39 (Hancock,Jordan), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR39</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben rush middle for 5 yards gain to the AKRON44 (Hamilton,Ty).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 5 at AKR44</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben pass incomplete short left to Golden,Bobby thrown to OSU45.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 5 at AKR44</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben pass complete short right to Simmons,Jordon caught at AKRON40, for 6 yards to the AKRON50 (Hicks,C.J.), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR50</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben pass incomplete deep left to Golden,Bobby thrown to OSU25 QB hurried by Sawyer,Jack.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at AKR50</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben pass complete short left to Simmons,Jordon caught at AKRON45, for 8 yards to the OSU42 (Styles,Sonny; Igbinosun,Davison).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at OSU42</br>
+         </span>
+         <span>
+           Timeout Akron, clock 02:02.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at OSU42</br>
+         </span>
+         <span>
+           No Huddle Bullock,Tahj rush middle for 1 yard gain to the OSU41 (Williams,Tyleik; Sawyer,Jack).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 1 at OSU41</br>
+         </span>
+         <span>
+           Timeout Other, clock 01:56.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 1 at OSU41</br>
+         </span>
+         <span>
+           No Huddle Bullock,Tahj rush right for 2 yards gain to the OSU39 (Styles,Sonny; Burke,Denzel), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU39</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben pass incomplete short right to Polk,Israel thrown to OSU23 broken up by Hancock,Jordan.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at OSU39</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben pass complete short left to Polk,Israel caught at OSU40, for 5 yards to the OSU34 (Reese,Arvell), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 5 at OSU34</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben pass incomplete short left to Newell,Jake thrown to OSU32.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 5 at OSU34</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben sacked for loss of 1 yard to the OSU35 (Williams,Tyleik), TURNOVER ON DOWNS.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ohio St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//518.gif" /><span class='d-none d-sm-block'>Ohio St.</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">01:04,OSU35, 3 plays, -7 yards, 00:34</span>
+        </div>
+        <div class="headerRight">3 - 17</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU35</br>
+         </span>
+         <span>
+           Ohio State drive start at 01:04.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU35</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass incomplete short right to Smith,Jeremiah thrown to AKRON48.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at OSU35</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short right to Smith,Jeremiah caught at OSU38, for 3 yards to the OSU38, out of bounds at OSU38.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 7 at OSU38</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will rush middle for 10 yards loss to the OSU28 fumbled by Howard,Will at OSU30 recovered by OSU Henderson,TreVeyon at OSU28, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 17 at OSU28</br>
+         </span>
+         <span>
+           Timeout Akron, clock 00:37.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 17 at OSU28</br>
+         </span>
+         <span>
+           McGuire,Joe punt 51 yards to the AKRON21 fair catch by Granger,Ahmarian at AKRON21.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Akron" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//5.gif" /><span class='d-none d-sm-block'>Akron</span></div></div>
+        <div class="headerLeft">HALF <br/><span style="font-size: 8px;">00:30,AKR21, 1 plays, 2 yards, 00:30</span>
+        </div>
+        <div class="headerRight">3 - 17</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR21</br>
+         </span>
+         <span>
+           Akron drive start at 00:30.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR21</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben pass complete short right to Rush,Jarvis caught at AKRON20, for 2 yards to the AKRON23 (Hancock,Jordan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 8 at AKR23</br>
+         </span>
+         <span>
+           End of game, clock 00:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU35</br>
+         </span>
+         <span>
+           AKR will receive; OSU will defend South end-zone.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU35</br>
+         </span>
+         <span>
+           Start of 3rd quarter, clock 15:00.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+</div>
+  <div style="border-bottom: 1px dotted #dcdddf;"><h1>3rd Quarter</h1></div>
+<div class="drives">
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Akron" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//5.gif" /><span class='d-none d-sm-block'>Akron</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">15:00,AKR25, 10 plays, 19 yards, 06:15</span>
+        </div>
+        <div class="headerRight">3 - 17</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU35</br>
+         </span>
+         <span>
+           Fielding,Jayden kickoff 65 yards to the AKRON00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           Akron drive start at 15:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben rush middle for 5 yards gain to the AKRON30 (Ransom,Lathan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 5 at AKR30</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben pass complete short right to Bullock,Tahj caught at AKRON29, for 1 yard loss to the AKRON29 (Ransom,Lathan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at AKR29</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben pass complete short right to Newell,Jake caught at AKRON34, for 5 yards to the AKRON34 (Burke,Denzel), out of bounds PENALTY OSU Offside (Tuimoloau,JT) 5 yards from AKRON29 to AKRON34. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at AKR34</br>
+         </span>
+         <span>
+           Timeout Akron, clock 13:20.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at AKR34</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Simmons,Jordon rush middle for 0 yards to the AKRON34 (Hamilton,Ty; Williams,Tyleik).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 1 at AKR34</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Simmons,Jordon rush middle for 2 yards gain to the AKRON36 (Downs,Caleb; Hamilton,Ty), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR36</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben rush left for 1 yard loss to the AKRON35 (Reese,Arvell).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 11 at AKR35</br>
+         </span>
+         <span>
+           Timeout Other, clock 11:46.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 11 at AKR35</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj pass complete short left to Simmons,Jordon caught at AKRON31, for 5 yards to the AKRON40 (Hancock,Jordan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at AKR40</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj rush left for 6 yards gain to the AKRON46 (Ransom,Lathan), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR46</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Simmons,Jordon rush left for 5 yards loss to the AKRON41 (Williams,Tyleik; Melton,Mitchell).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 15 at AKR41</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj pass incomplete short left thrown to AKRON45.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 15 at AKR41</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj pass complete short right to Golden,Bobby caught at AKRON37, for 3 yards to the AKRON44 (Burke,Denzel; Reese,Arvell), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 12 at AKR44</br>
+         </span>
+         <span>
+           Book,Avery punt 52 yards to the OSU04 Inniss,Brandon return 36 yards to the OSU40 (Kellom,Charles).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ohio St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//518.gif" /><span class='d-none d-sm-block'>Ohio St.</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">08:45,OSU40, 3 plays, 60 yards, 00:52</span>
+        </div>
+        <div class="headerRight">3 - 24</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU40</br>
+         </span>
+         <span>
+           Ohio State drive start at 08:45.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU40</br>
+         </span>
+         <span>
+           Shotgun Judkins,Quinshon rush middle for 13 yards gain to the AKRON47 (David,Daymon), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR47</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete deep left to Smith,Jeremiah caught at AKRON02, for 45 yards to the AKRON02 (David,Daymon), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 2 at AKR2</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Judkins,Quinshon rush middle for 2 yards gain to the AKRON00 TOUCHDOWN, clock 07:53.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR3</br>
+         </span>
+         <span>
+           Fielding,Jayden kick attempt good (H: McGuire,Joe, LS: Ferlmann,John).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Akron" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//5.gif" /><span class='d-none d-sm-block'>Akron</span></div></div>
+        <div class="headerLeft">FUMB <br/><span style="font-size: 8px;">07:53,AKR25, 3 plays, 2 yards, 00:18</span>
+        </div>
+        <div class="headerRight">3 - 31</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU35</br>
+         </span>
+         <span>
+           Fielding,Jayden kickoff 65 yards to the AKRON00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           Akron drive start at 07:53.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj pass incomplete short left to Rush,Jarvis thrown to AKRON24.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at AKR25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj pass incomplete short left to Rush,Jarvis thrown to AKRON26.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 10 at AKR25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj rush middle for 2 yards gain to the AKRON27 fumbled by Bullock,Tahj at AKRON25 forced by Curry,Caden recovered by OSU Ransom,Lathan at AKRON27 Ransom,Lathan return 27 yards to the AKRON00 TOUCHDOWN, clock 07:35.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR3</br>
+         </span>
+         <span>
+           Fielding,Jayden kick attempt good (H: McGuire,Joe, LS: Ferlmann,John).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Akron" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//5.gif" /><span class='d-none d-sm-block'>Akron</span></div></div>
+        <div class="headerLeft">FG <br/><span style="font-size: 8px;">07:35,AKR25, 7 plays, 44 yards, 03:38</span>
+        </div>
+        <div class="headerRight">6 - 31</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU35</br>
+         </span>
+         <span>
+           Fielding,Jayden kickoff 65 yards to the AKRON00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           Akron drive start at 07:35.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Simmons,Jordon rush middle for 3 yards gain to the AKRON28 (Hicks,C.J.; Ransom,Lathan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at AKR28</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj rush left for 3 yards gain to the AKRON31 (Styles,Sonny).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 4 at AKR31</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj pass complete short left to Newell,Jake caught at AKRON42, for 29 yards to the OSU40 (Styles,Sonny; Ransom,Lathan), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU40</br>
+         </span>
+         <span>
+           PENALTY AKRON False Start (Burrell,Jerrod) 5 yards from OSU40 to OSU45. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 15 at OSU45</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj rush middle for 8 yards gain to the OSU37, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at OSU37</br>
+         </span>
+         <span>
+           Timeout Other, clock 05:11.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at OSU37</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj rush middle for 5 yards gain to the OSU32 (Malone,Tywone; Styles,Sonny).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at OSU32</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Kellom,Charles rush middle for 1 yard gain to the OSU31 (Jackson Jr.,Kenyatta).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 1 at OSU31</br>
+         </span>
+         <span>
+           Smith,Garrison field goal attempt from 49 yards GOOD (H: Castle,Joseph, LS: Reardon,Liam), clock 03:57.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ohio St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//518.gif" /><span class='d-none d-sm-block'>Ohio St.</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">03:57,OSU25, 8 plays, 75 yards, 03:56</span>
+        </div>
+        <div class="headerRight">6 - 38</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR35</br>
+         </span>
+         <span>
+           Jackson,Dante kickoff 65 yards to the OSU00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU25</br>
+         </span>
+         <span>
+           Ohio State drive start at 03:57.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short right to Henderson,TreVeyon caught at OSU22, for 12 yards to the OSU37 (Golden-Nelson,Devonte; Cooper,Shammond), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU37</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Henderson,TreVeyon rush middle for 21 yards gain to the AKRON42 (David,Daymon), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR42</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short left to Henderson,TreVeyon caught at AKRON46, for 6 yards to the AKRON36 (Cooper,Shammond), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 4 at AKR36</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Judkins,Quinshon rush middle for 2 yards gain to the AKRON34 (McCoy,Bryan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at AKR34</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Judkins,Quinshon rush left for 6 yards gain to the AKRON28 (Lewis III,Paul; McCoy,Bryan), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR28</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Judkins,Quinshon rush left for 0 yards to the AKRON28 (Lewis III,Paul).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at AKR28</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass incomplete deep middle to Egbuka,Emeka thrown to AKRON02 PENALTY AKRON Pass Interference (Hunter,Joey) 15 yards from AKRON28 to AKRON13, 1ST DOWN. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR13</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short left to Rodgers,Bryson caught at AKRON07, for 9 yards to the AKRON04 (Spriggs,Melvin; White,Catrell).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 1 at AKR4</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Peoples,James rush left for 4 yards gain to the AKRON00 TOUCHDOWN, clock 00:01, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR3</br>
+         </span>
+         <span>
+           Fielding,Jayden kick attempt good (H: McGuire,Joe, LS: Ferlmann,John).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           Start of 4th quarter, clock 15:00.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+</div>
+  <div style="border-bottom: 1px dotted #dcdddf;"><h1>4th Quarter</h1></div>
+<div class="drives">
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Akron" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//5.gif" /><span class='d-none d-sm-block'>Akron</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">15:00,AKR25, 3 plays, -8 yards, 02:51</span>
+        </div>
+        <div class="headerRight">6 - 38</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU35</br>
+         </span>
+         <span>
+           Fielding,Jayden kickoff 65 yards to the AKRON00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           Akron drive start at 15:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Simmons,Jordon rush right for 2 yards gain to the AKRON27 (Jackson Jr.,Kenyatta).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 8 at AKR27</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj pass complete short left to Davis,Paul caught at AKRON25, for 2 yards to the AKRON29 (Reese,Arvell).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at AKR29</br>
+         </span>
+         <span>
+           PENALTY AKRON False Start (Blanchard,Joshua) 5 yards from AKRON29 to AKRON24. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 11 at AKR24</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj sacked for loss of 7 yards to the AKRON17 (Jackson Jr.,Kenyatta, Melton,Mitchell).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 18 at AKR17</br>
+         </span>
+         <span>
+           Book,Avery punt 42 yards to the OSU41 Inniss,Brandon return 12 yards to the AKRON47 (Roach,Noel).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ohio St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//518.gif" /><span class='d-none d-sm-block'>Ohio St.</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">12:09,AKR47, 4 plays, 47 yards, 01:53</span>
+        </div>
+        <div class="headerRight">6 - 45</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR47</br>
+         </span>
+         <span>
+           Ohio State drive start at 12:09.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR47</br>
+         </span>
+         <span>
+           Shotgun Howard,Will pass complete short right to Egbuka,Emeka caught at AKRON49, for 4 yards to the AKRON43 (Lavea,Lama; Nunnally,CJ).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 6 at AKR43</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short left to Tate,Carnell caught at AKRON46, for 2 yards to the AKRON41 (DeWalt IV,Malcom).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 4 at AKR41</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Judkins,Quinshon rush middle for 7 yards gain to the AKRON34 (Roach,Noel), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR34</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short right to Tate,Carnell caught at AKRON22, for 34 yards to the AKRON00 TOUCHDOWN, clock 10:16, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR3</br>
+         </span>
+         <span>
+           Fielding,Jayden kick attempt good (H: McGuire,Joe, LS: Ferlmann,John).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Akron" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//5.gif" /><span class='d-none d-sm-block'>Akron</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">10:16,AKR25, 5 plays, 15 yards, 03:03</span>
+        </div>
+        <div class="headerRight">6 - 45</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU35</br>
+         </span>
+         <span>
+           Fielding,Jayden kickoff 65 yards to the AKRON00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           Akron drive start at 10:16.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj rush middle for 5 yards gain to the AKRON30 (Hicks,C.J.; Styles Jr.,Lorenzo).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 5 at AKR30</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Kellom,Charles rush middle for 6 yards gain to the AKRON36 (McClain,Jaylen), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR36</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj pass incomplete short left to Kellom,Charles thrown to AKRON35 broken up by Houston,Eddrick.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at AKR36</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj rush left for 6 yards gain to the AKRON42 (Matthews Jr.,Jermaine), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 4 at AKR42</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj pass complete short right to Kellom,Charles caught at AKRON38, for 2 yards loss to the AKRON40 (Matthews Jr.,Jermaine).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 6 at AKR40</br>
+         </span>
+         <span>
+           Book,Avery punt 56 yards to the OSU04 Inniss,Brandon return 27 yards to the OSU31 (Conroy,Sean) PENALTY OSU Holding (Simpson-Hunt,Calvin) 5 yards from OSU10 to OSU05.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 6 at AKR40</br>
+         </span>
+         <span>
+           OSU ball on OSU5.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ohio St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//518.gif" /><span class='d-none d-sm-block'>Ohio St.</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">07:13,OSU5, 9 plays, 31 yards, 04:03</span>
+        </div>
+        <div class="headerRight">6 - 45</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU5</br>
+         </span>
+         <span>
+           Ohio State drive start at 07:13.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU5</br>
+         </span>
+         <span>
+           Shotgun Peoples,James rush middle for 3 yards gain to the OSU08 (Adler,Bennett).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at OSU8</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Peoples,James rush middle for 6 yards gain to the OSU14 (Cheatom,Kam).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at OSU14</br>
+         </span>
+         <span>
+           PENALTY OSU Illegal Snap (McLaughlin,Seth) 5 yards from OSU14 to OSU09. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at OSU9</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Brown,Devin pass complete short right to Ballard,Jayden caught at OSU15, for 6 yards to the OSU15 (DeWalt IV,Malcom), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU15</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Peoples,James rush middle for 3 yards gain to the OSU18 (Nunnally,CJ; Benenge,Rich).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at OSU18</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Peoples,James rush middle for 5 yards gain to the OSU23 (Benenge,Rich; Hunter,Rodrick).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at OSU23</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Peoples,James rush middle for 9 yards gain to the OSU32 (Benenge,Rich; DeWalt IV,Malcom), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU32</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Brown,Devin pass incomplete deep middle to Ballard,Jayden thrown to AKRON25.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at OSU32</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Williams-Dixon,Sam rush left for 4 yards gain to the OSU36 (Anderson,Justin).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at OSU36</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Brown,Devin pass incomplete short left to Ballard,Jayden thrown to OSU43.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 6 at OSU36</br>
+         </span>
+         <span>
+           McGuire,Joe punt 41 yards to the AKRON23 fair catch by Granger,Ahmarian at AKRON23.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Akron" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//5.gif" /><span class='d-none d-sm-block'>Akron</span></div></div>
+        <div class="headerLeft">INT <br/><span style="font-size: 8px;">03:10,AKR23, 2 plays, 9 yards, 00:45</span>
+        </div>
+        <div class="headerRight">6 - 52</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR23</br>
+         </span>
+         <span>
+           Akron drive start at 03:10.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR23</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Roggow,Brayden pass complete short right to Cravaack,Conner caught at AKRON23, for 9 yards to the AKRON32 (Matthews Jr.,Jermaine).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 1 at AKR32</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Roggow,Brayden pass intercepted by Powers,Gabe at AKRON29 broken up by Houston,Eddrick Powers,Gabe return 29 yards to the AKRON00 TOUCHDOWN, clock 02:25.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR3</br>
+         </span>
+         <span>
+           PENALTY OSU Delay Of Game  5 yards from AKRON03 to AKRON08. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR8</br>
+         </span>
+         <span>
+           Fielding,Jayden kick attempt good (H: McGuire,Joe, LS: Ferlmann,John).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Akron" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//5.gif" /><span class='d-none d-sm-block'>Akron</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">02:25,AKR25, 3 plays, 8 yards, 02:04</span>
+        </div>
+        <div class="headerRight">6 - 52</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU35</br>
+         </span>
+         <span>
+           Fielding,Jayden kickoff 65 yards to the AKRON00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           Akron drive start at 02:25.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Williams,Marquese rush right for 7 yards gain to the AKRON32 (Powers,Gabe), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 3 at AKR32</br>
+         </span>
+         <span>
+           Timeout Other, clock 02:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 3 at AKR32</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Williams,Marquese rush middle for 0 yards to the AKRON32 (Styles Jr.,Lorenzo).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 3 at AKR32</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Williams,Marquese rush middle for 1 yard gain to the AKRON33 (Mickens,Joshua; McDonald,Kayden).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 2 at AKR33</br>
+         </span>
+         <span>
+           Book,Avery punt 54 yards to the OSU13 fair catch by Inniss,Brandon at OSU13.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ohio St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//518.gif" /><span class='d-none d-sm-block'>Ohio St.</span></div></div>
+        <div class="headerLeft">HALF <br/><span style="font-size: 8px;">00:21,OSU13, 1 plays, -2 yards, 00:21</span>
+        </div>
+        <div class="headerRight">6 - 52</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU13</br>
+         </span>
+         <span>
+           Ohio State drive start at 00:21.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU13</br>
+         </span>
+         <span>
+           Kneel down by Brown,Devin at OSU11 for loss of 2 yards.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 12 at OSU11</br>
+         </span>
+         <span>
+           End of game, clock 00:00.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+</div>
+</div>
+
+
+
+       </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<footer>&copy; <script>document.write(new Date().getFullYear())</script> NCAA <a href="http://web1.ncaa.org/web_files/terms_and_conditions.html" title ="Terms and Conditions" target=_blank>Terms and Conditions</a> | <a href="http://web1.ncaa.org/web_files/privacy.html" target=_blank title="Our Privacy Policy">Privacy Policy</a> | <a href="mailto:ncaa_stats@ncaa.org">Contact Us</a> </footer>
+
+  <!-- /.container -->
+  <script type="text/javascript"  src="/sU0joiPwv/zplvN/xFxji/wmgXJnBU/whimQww3k9OS/ZXgTG2MrBg/bA4YBlB/oDERZ?v=94743442-ba56-a24e-40df-7388407117d0" defer></script></body>
+
+  <script charset="utf-8">
+    $(document).ready(function() {
+      $('a.remote[data-toggle="tab"]').on('show.bs.tab', function (e) {
+        var tab_id = '#' + $(this).attr('aria-controls');
+        $(tab_id).html('<br/><br/><p style="text-align: center"><img style="vertical-align:middle; text-align: center" src="/assets/ajax-loader-6913acdbf4be7d6a2908a84bdecd6cad18110f5fc6d5a07cf8c9ce78d9548700.gif" /> Loading... </p><br/><br/>');
+        $.get($(this).data('remote'), function(data){
+          $(tab_id).html(data);
+        });
+      });
+    });
+
+    function skipMask(obj){
+      if (obj.hasClass('chosen-single') || obj.hasClass('skipMask') || obj.hasClass('ui-datepicker-prev') || obj.hasClass('ui-datepicker-next') || obj.hasClass('ui-corner-all') || obj.hasClass('paginate_button') || obj.hasClass('dt-button')){
+        return true;
+      }else{
+        return false;
+      }
+    }
+
+    $(document).ajaxComplete(function(){
+      unmask();
+    });
+/*
+    $("form").on('submit', function(event){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    */
+    $(document).on('click', 'a', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    $(document).on('click', 'input.green', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+
+  </script>
+</html>

--- a/tests/fixtures/cfb_ncaa/cfb_ncaa_pbp_5361446.html
+++ b/tests/fixtures/cfb_ncaa/cfb_ncaa_pbp_5361446.html
@@ -1,0 +1,2967 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<META HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=UTF-8">
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="">
+<meta name="author" content="">
+<meta name="version" content="321d28433e9f7a188596117e6f342ec4a84fb4ed">
+<META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<link rel="shortcut icon" href="/assets/favicon-405088046a5f2bab8eedeacfae7636975c095e9c8decd8c28e3fd0e65c2f51c4.ico" type="image/vnd.microsoft.icon">
+
+<title>NCAA Statistics</title>
+
+<!-- Bootstrap core CSS -->
+
+<!--
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+-->
+<!--
+<link rel="stylesheet" href="https://cdn.datatables.net/2.0.0/css/dataTables.bootstrap4.css" crossorigin="anonymous">
+-->
+<link rel="stylesheet" media="all" href="/assets/application-789c3971842ee3597428ccbebd021716b3231e9cbd0a00a184c3b2d6c8e5f152.css" />
+
+
+<script src="/assets/application-9232576bb3cb000ac0841ff2af81251908ec17312a3c5eb72bf1a32f9754800c.js"></script>
+<!--
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+-->
+<!--
+<script src="https://cdn.datatables.net/2.0.0/js/dataTables.bootstrap4.js" crossorigin="anonymous"></script>
+-->
+
+<meta name="csrf-param" content="authenticity_token" />
+<meta name="csrf-token" content="6Ioa7FH2gFv/yFYXyS587/iqTMjB7aa8x7VRBa9w45v6fJvJLlMN9x5X88iEVar/846bti39q4EgrpSNUgxXVw==" />
+
+<style>
+.grid {clear: all}
+.grid-item, .name {text-align: center;}
+h1 img {max-height: 33px;}
+
+</style>
+<!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+<!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+      <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+    <![endif]-->
+
+
+<script>(window.BOOMR_mq=window.BOOMR_mq||[]).push(["addVar",{"rua.upush":"false","rua.cpush":"false","rua.upre":"false","rua.cpre":"false","rua.uprl":"false","rua.cprl":"false","rua.cprf":"false","rua.trans":"","rua.cook":"false","rua.ims":"false","rua.ufprl":"false","rua.cfprl":"false","rua.isuxp":"false","rua.texp":"norulematch","rua.ceh":"false","rua.ueh":"false","rua.ieh.st":"0"}]);</script>
+                                <script>!function(e){var n="https://s.go-mpulse.net/boomerang/";if("False"=="True")e.BOOMR_config=e.BOOMR_config||{},e.BOOMR_config.PageParams=e.BOOMR_config.PageParams||{},e.BOOMR_config.PageParams.pci=!0,n="https://s2.go-mpulse.net/boomerang/";if(window.BOOMR_API_key="EVKJV-AGD2E-W66AE-NT84S-K5LTF",function(){function e(){if(!r){var e=document.createElement("script");e.id="boomr-scr-as",e.src=window.BOOMR.url,e.async=!0,o.appendChild(e),r=!0}}function t(e){r=!0;var n,t,a,i,d=document,O=window;if(window.BOOMR.snippetMethod=e?"if":"i",t=function(e,n){var t=d.createElement("script");t.id=n||"boomr-if-as",t.src=window.BOOMR.url,BOOMR_lstart=(new Date).getTime(),e=e||d.body,e.appendChild(t)},!window.addEventListener&&window.attachEvent&&navigator.userAgent.match(/MSIE [67]\./))return window.BOOMR.snippetMethod="s",void t(o,"boomr-async");a=document.createElement("IFRAME"),a.src="about:blank",a.title="",a.role="presentation",a.loading="eager",i=(a.frameElement||a).style,i.width=0,i.height=0,i.border=0,i.display="none",o.appendChild(a);try{O=a.contentWindow,d=O.document.open()}catch(_){n=document.domain,a.src="javascript:var d=document.open();d.domain='"+n+"';void 0;",O=a.contentWindow,d=O.document.open()}if(n)d._boomrl=function(){this.domain=n,t()},d.write("<bo"+"dy onload='document._boomrl();'>");else if(O._boomrl=function(){t()},O.addEventListener)O.addEventListener("load",O._boomrl,!1);else if(O.attachEvent)O.attachEvent("onload",O._boomrl);d.close()}function a(e){window.BOOMR_onload=e&&e.timeStamp||(new Date).getTime()}if(!window.BOOMR||!window.BOOMR.version&&!window.BOOMR.snippetExecuted){window.BOOMR=window.BOOMR||{},window.BOOMR.snippetStart=(new Date).getTime(),window.BOOMR.snippetExecuted=!0,window.BOOMR.snippetVersion=14,window.BOOMR.url=n+"EVKJV-AGD2E-W66AE-NT84S-K5LTF";var i=document.currentScript||document.getElementsByTagName("script")[0],o=i.parentNode,r=!1,d=document.createElement("link");if(d.relList&&"function"==typeof d.relList.supports&&d.relList.supports("preload")&&"as"in d)window.BOOMR.snippetMethod="p",d.href=window.BOOMR.url,d.rel="preload",d.as="script",d.addEventListener("load",e),d.addEventListener("error",function(){t(!0)}),setTimeout(function(){if(!r)t(!0)},3e3),BOOMR_lstart=(new Date).getTime(),o.appendChild(d);else t(!1);if(window.addEventListener)window.addEventListener("load",a,!1);else if(window.attachEvent)window.attachEvent("onload",a)}}(),"".length>0)if(e&&"performance"in e&&e.performance&&"function"==typeof e.performance.setResourceTimingBufferSize)e.performance.setResourceTimingBufferSize();!function(){if(BOOMR=e.BOOMR||{},BOOMR.plugins=BOOMR.plugins||{},!BOOMR.plugins.AK){var n=""=="true"?1:0,t="",a="vq5hssix2kdgi2sztkpq-f-8da0f6314-clientnsv4-s.akamaihd.net",i="false"=="true"?2:1,o={"ak.v":"41","ak.cp":"1168236","ak.ai":parseInt("215853",10),"ak.ol":"0","ak.cr":46,"ak.ipv":4,"ak.proto":"h2","ak.rid":"4e5bd57e","ak.r":47358,"ak.a2":n,"ak.m":"a","ak.n":"essl","ak.cport":14824,"ak.gh":"23.208.24.235","ak.quicv":"","ak.tlsv":"tls1.3","ak.0rtt":"","ak.0rtt.ed":"","ak.csrc":"-","ak.acc":"","ak.t":"1784257183","ak.ak":"hOBiQwZUYzCg5VSAfCLimQ==xlXL/yN78dZ5SnTL0g2EwtYBw57L53zPDMEbzE7tTrjzenNpabnJMWCJrvkUPJzMrs1EpodotG5CmvIYOlleHyVsXr/A8bakL82oQ1xrUbSZ02LYl5hHL1GFnRYFcmu5XyySIOMknMUDDQoX7gpiqF0X+xb4T9leEBGTQaeqixb+iz/H1UjXklc4IhkCCxMBMMzImv/e9FYaHY+eJgbmPF1XwOcvn2C6E0LOfY9V7nUDLvDu4yc3g8s2b5wQeJ0LDbmSlKWZcpECSHV5dZIS62nVcFw0MV4ZWKPP/uid2cE/LE686H8AXFvtF3JKoY1Swy7tIMOFfbKr2jHJ+FuIAJ2O2pWUra/Z6yrSfLBHDV1E4KoBWpTPNOflnfWh+xk/uDzIK96dJzzmCCfjqwZYZ/aXdebmcprGt9CXAVdKXWQ=","ak.pv":"93","ak.dpoabenc":"","ak.tf":i};if(""!==t)o["ak.ruds"]=t;var r={i:!1,av:function(n){var t="http.initiator";if(n&&(!n[t]||"spa_hard"===n[t]))o["ak.feo"]=void 0!==e.aFeoApplied?1:0,BOOMR.addVar(o)},rv:function(){var e=["ak.cport","ak.cr","ak.csrc","ak.gh","ak.ipv","ak.m","ak.n","ak.ol","ak.proto","ak.quicv","ak.tlsv","ak.0rtt","ak.0rtt.ed","ak.r","ak.acc","ak.t","ak.tf"];BOOMR.removeVar(e)}};BOOMR.plugins.AK={akVars:o,akDNSPreFetchDomain:a,init:function(){if(!r.i){var e=BOOMR.subscribe;e("before_beacon",r.av,null,null),e("onbeacon",r.rv,null,null),r.i=!0}return this},is_complete:function(){return!0}}}}()}(window);</script></head>
+
+  <script>
+
+    
+  //initialize tooltip
+  $(document).ready(function() {
+    //$("body").tooltip({ selector: '[data-toggle=tooltip]' });
+    $('[data-toggle="tooltip"]').tooltip();
+  });
+
+  $(document).ready(function() {
+    $( "#org_name" ).autocomplete({
+      source: '/team/search',
+      select: function( event, ui ) {
+        $("#org_id").val(ui.item.vid);
+        $("#id").val(ui.item.vid);
+        $('#sport_btn').click();
+      }
+    });
+  });
+
+  var body = 'body';
+
+  $.ajaxSetup ({
+    // Disable caching of AJAX responses
+    cache: false
+  });
+
+  function changeSport(field){
+    var el = $(field);
+    var tmList = el.parent().next().find('.new-team-year')[0];
+    if (tmList == null){
+      tmList = el.nextAll('.new-team-year')[0];
+    }
+    $.ajax({
+      url: "/game_sport_year_ctls/"+el.val()+"/available_teams",
+      dataType: "script",
+      success: function(data, status){
+        $(tmList).empty();
+        $(tmList).append(("<option value=''>Select team</option>"));
+        $.each(JSON.parse(data), function(k, v){
+          $(tmList).append($("<option></option>")
+              .attr("value", v["id"])
+              .text(v["member_org"]["name_tabular"]));
+        });
+        $(tmList).trigger("chosen:updated");
+      }
+    });
+  }
+
+    function set_process_styles(fld, start_color, end_color){
+       $('#'+fld).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    var downImage = "/assets/down12.gif";
+    var rightImage = "/assets/right12.gif";
+
+    function highlight(div_id){
+      $(div_id).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    function show_hide_rows(attr_val, link_id){
+      $('#'+attr_val).toggle();
+      if ($('#'+attr_val).is(':visible')) {
+        $('#'+link_id).attr('src', downImage);
+      }else{
+        $('#'+link_id).attr('src', rightImage);
+      }
+    }
+
+    function mask(label){
+      $('body').mask(label);
+    }
+    function unmask(){
+      $('body').unmask();
+    }
+
+    var winHeight = "auto";
+    var winWidth = "auto";
+    var maxHeight = 700;
+    var maxWidth = 1400;
+    var minHeight = 100;
+    var minWidth = 200;
+    
+    var modalOptions = {"width": winWidth,
+                        "height": winHeight,
+                        "maxHeight": maxHeight,
+                        "maxWidth": maxWidth,
+                        "minHeight": minHeight,
+                        "minWidth": minWidth};
+
+    function dialog(url, title){
+
+      $("#stats_app_dialog").dialog({modal:true, minWidth:minWidth, minHeight:minHeight, maxWidth:maxWidth, maxHeight:maxHeight, width:winWidth, height:winHeight, title:title, closeOnEscape: false});
+    
+      modalOptions.title = title;
+    
+      $("#stats_app_dialog").dialog("option", modalOptions);
+    
+      $("#stats_app_dialog").html("Loading...");
+      $("#stats_app_dialog").load(url).dialog('open');
+    }
+
+    function addDatePicker(){
+    $('.adddatepicker').each(function(i, obj){
+      $(obj).datepicker({ 
+        showOn: 'both', 
+        buttonImage: '/assets/calendar.gif', 
+        buttonImageOnly: true,
+      });
+    });
+    }
+
+   $(document).ready(function() {
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   });
+
+   function setClassInputFields(){
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   }
+
+   function isValidDateFormat(dateStr){
+     const regex = /^([1-9]|0[1-9]|1[0-2])\/([1-9]|0[1-9]|[12][0-9]|3[01])\/(19|20)\d{2}$/;
+     if (!regex.test(dateStr)) {
+       return false;
+     }else{
+       return true;
+     }
+   }
+
+  </script>
+
+
+<body style="font-size: .75rem;" onload="if (top != self) { top.location=self.location; }" >
+
+      <header>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0">
+        <a class="navbar-brand mr-0 mr-md-2" href="/" aria-label="statistics">
+                          <img alt="NCAA" style="margin-left: 24px; margin-right: 0; margin-top: 6px;" src="/assets/ncaa-fbc4d0406ae731b47babcc3fca53775b5955ef372bf8b8e998ca9a513e468b8f.svg" />
+                          <span class="title" class="dark-blue-font">Statistics</span>
+        </a>
+       </nav>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0" style="background-color: var(--color-dark-blue) !important;">
+  <button class="navbar-toggler bg-white" type="button" data-toggle="collapse" data-target="#navbarTogglerDemo01" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarTogglerDemo01">
+        <ul class="navbar-nav mr-auto mt-2 mt-lg-0 justify-content-center">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle skipMask" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Rankings
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+          <a class="dropdown-item" href="/rankings">National Rankings</a>
+          <a class="dropdown-item" href="/active_career_leaders">Active Career Leaders</a>
+        </div>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/contests/livestream_scoreboards">Scoreboard</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/selection_rankings/nitty_gritties">Selection Rankings</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/head_coaches">Head Coaches</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/search/players">Players</a>
+      </li>
+     </ul>
+
+    <form onsubmit="mask(&#39;Loading&#39;);" id="change_team_form" style="display:inline;" class="form-inline my-2 my-lg-0" action="/team/index" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="jN71Q0MG81vNJ7mYFPA9oCoCZ/SgT7RgM3/vY7zXPCvX+RuljWdPFoV3MW+gSgWqmzTDntvVPPOsCpRbyywZkw==" />
+  <div style="display:none;">
+  <input type="submit" name="commit" value="Submit" id="sport_btn" data-disable-with="Submit" />
+  </div>
+    <div id="team_autocomplete" class="ui-widget">
+      <input type="search" name="org_name" id="org_name" style="width:200px; font-size: 12px !important" class="form-control mr-sm-2" placeholder="Team Search" />
+      <input type="hidden" name="org_id" id="org_id" />
+    </div>
+</form>  </div>
+  </nav>
+</nav>
+      </header>
+
+       <div id="stats_app_dialog" style="display:none;">
+        </div>
+
+<div class="card p-1">
+  <div class="card-body application contests p-0">
+    <h3 class="card-title p-0"></h3>
+    <div class="container-fluid p-0">
+      <div class="row align-items-center justify-content-center p-0">
+        <div class="col-sm-12 p-0">
+          <br/>
+
+<br/>
+
+<style>
+.winner{
+  --display: flex;
+  vertical-align: middle;
+}
+.winner:before{
+  content: '\25BA';
+  --display: flex;
+  --align-items: center;
+  vertical-align: middle;
+}
+div.center {
+  margin: auto;
+  width: 50%;
+  --border: 3px solid green;
+  padding: 10px;
+}
+</style>
+
+   <div class="table-responsive">
+   <table align="center">
+     <tr>
+   <td>
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589030"><img class="large_logo_image" alt="Boise St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//66.gif" /></a>
+   </td>
+   <td valign="center" class="grey_text d-none d-sm-table-cell" nowrap>
+     <span style="font-size:18px">
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589030">Boise St. Broncos</a>
+     </span><br/>
+       1-0, Conf 0-0
+   </td>
+   <td valign="center" class="winner">
+   </td>
+   <td valign="center" style="font-size:36px; color: black">
+     56
+   </td>
+     <td style="padding: 0px 30px 0px 30px"  class="d-none d-md-table-cell">
+       <table style="border-collapse: collapse">
+         <tr>
+           <td class="grey_border_bottom"></td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">1</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">2</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">3</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">4</td>
+           <td width="20px" align="right" style="font-weight:bold" class="grey_border_bottom">S</td>
+         </tr>
+           <tr>
+             <td>Boise St.</td>
+               <td class="grey_text" align="right">14</td>
+               <td class="grey_text" align="right">14</td>
+               <td class="grey_text" align="right">8</td>
+               <td class="grey_text" align="right">20</td>
+             <td align="right" style="font-weight:bold">56</td>
+           </tr>
+           <tr>
+             <td>Ga. Southern</td>
+               <td class="grey_text" align="right">0</td>
+               <td class="grey_text" align="right">16</td>
+               <td class="grey_text" align="right">14</td>
+               <td class="grey_text" align="right">15</td>
+             <td align="right" style="font-weight:bold">45</td>
+           </tr>
+         <tr>
+           <td class="grey_text" colspan="6">08/31/2024 04:00 PM</td>
+         </tr>
+         <tr>
+           <td nowrap class="grey_text" colspan="6">Allen E. Paulson Stadium (Statesboro, GA)</td>
+         </tr>
+         <tr>
+           <td nowrap class="grey_text" colspan="6">Attendance: 24,134</td>
+         </tr>
+       </table>
+     </td>
+   <td>
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589053"><img class="large_logo_image" alt="Ga. Southern" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//253.gif" /></a>
+   </td>
+   <td valign="center" class="grey_text d-none d-sm-table-cell" nowrap>
+     <span style="font-size:18px">
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589053">Ga. Southern Eagles</a>
+     </span><br/>
+       0-1, Conf 0-0
+   </td>
+   <td valign="center" class="">
+   </td>
+   <td valign="center" style="font-size:36px; color: grey">
+     45
+   </td>
+     </tr>
+     <tr>
+       <td colspan="10" class="grey_border_bottom grey_border_top">
+         <table cellpadding="10px">
+           <tr>
+             <td style="font-size: 16px;"><a href="/contests/5361446/box_score">Box Score</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5361446/team_stats">Team Stats</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5361446/individual_stats">Individual Stats</a></td>
+             <td style="font-size: 16px;">Play By Play</td>
+             <td style="font-size: 16px;"><a href="/contests/5361446/drives">Drives</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5361446/officials">Officials</a></td>
+           </tr>
+         </table>
+       </td>
+     </tr>
+   </table>
+ </div>
+
+
+<br/>
+
+  <script>
+ $( function() {
+    $( ".drives" ).accordion({
+      collapsible: true,
+      heightStyle: "content",
+      header: "h5",
+      active: false
+    });
+  } );
+
+ function showScoringPlays(){
+   $('.non_scoring_play').hide();
+ }
+ function showAllPlays(){
+   $('.non_scoring_play').show();
+   $('.drives').accordion("refresh");
+   $('.drives').accordion("option", "active", false);
+ }
+</script>
+
+<style>
+ .ui-state-default, .ui-widget-content .ui-state-default, .ui-widget-header .ui-state-default {
+   overflow: auto;
+ }
+ .ui-state-default, .ui-widget-content .ui-state-default, .ui-widget-header .ui-state-default {
+    border: 1px solid #CCCCCC;
+    background: white;
+    background-image: none;
+    font-weight: normal;
+    color: #808080;
+}
+
+ .headerRight {
+  float: right;
+}
+.headerLeft {
+  float: left;
+}
+.under{
+text-decoration : underline;
+}
+</style>
+
+<div style="width: 50%; margin-left: auto; margin-right: auto;">
+  <div class="headerRight"><a class="skipMask" href="javascript:showAllPlays();">All Drives</a> | <a class="skipMask" href="javascript:showScoringPlays();">Scoring Drives</a></div>
+  <div style="border-bottom: 1px dotted #dcdddf;"><h1>1st Quarter</h1></div>
+<div class="drives">
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Boise St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//66.gif" /><span class='d-none d-sm-block'>Boise St.</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">15:00,BOI25, 3 plays, 5 yards, 01:42</span>
+        </div>
+        <div class="headerRight">0 - 0</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS35</br>
+         </span>
+         <span>
+           (15:00) Stewart,Gavin kickoff 65 yards to the BOISE00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI25</br>
+         </span>
+         <span>
+           Boise St. drive start at 15:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI25</br>
+         </span>
+         <span>
+           (14:59) No Huddle-Shotgun Jeanty,Ashton rush left for 2 yards loss to the BOISE23 (Watson-Trent,Marques; Gamble,Chance) PENALTY BOISE Personal Foul (Carreon,Roger) 11 yard from BOISE23 to BOISE12.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 23 at BOI12</br>
+         </span>
+         <span>
+           (14:39) No Huddle-Shotgun Madsen,Maddux pass complete short right to Caples,Latrell caught at BOISE20, for 13 yards to the BOISE25 (Stampley II,Marc).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 10 at BOI25</br>
+         </span>
+         <span>
+           (14:06) No Huddle-Shotgun Madsen,Maddux pass complete short left to Lauter,Matt caught at BOISE27, for 5 yards to the BOISE30 (Gamble,Chance).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 5 at BOI30</br>
+         </span>
+         <span>
+           (13:25) Ferguson-Reynolds,James punt 48 yards to the GASO22, out of bounds at GASO22.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ga. Southern" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//253.gif" /><span class='d-none d-sm-block'>Ga. Southern</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">13:18,GS22, 5 plays, 14 yards, 02:38</span>
+        </div>
+        <div class="headerRight">0 - 0</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS22</br>
+         </span>
+         <span>
+           Georgia Southern drive start at 13:18.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS22</br>
+         </span>
+         <span>
+           (13:17) No Huddle-Shotgun French,JC pass complete short right to White,Jalen caught at GASO15, for 0 yards to the GASO22 (Benefield,Ty).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at GS22</br>
+         </span>
+         <span>
+           (12:53) No Huddle-Shotgun French,JC pass complete short left to Cobb,Dalen caught at GASO25, for 15 yards to the GASO37 fumbled by Cobb,Dalen at GASO29 forced by Simpson,Andrew recovered by GASO Broadway,Bryson at GASO37, End Of Play, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS37</br>
+         </span>
+         <span>
+           Timeout Other, clock 12:43.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS37</br>
+         </span>
+         <span>
+           (12:35) No Huddle-Shotgun White,Jalen rush left for 5 yards loss to the GASO32 (Earby,Jeremiah).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 15 at GS32</br>
+         </span>
+         <span>
+           (11:57) No Huddle-Shotgun White,Jalen rush right for 3 yards gain to the GASO35 (Benefield,Ty; Washington,Zion).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 12 at GS35</br>
+         </span>
+         <span>
+           (11:21) No Huddle-Shotgun French,JC pass complete short middle to Dallas,Josh caught at GASO36, for 1 yard to the GASO36 (Oladipo,Seyi).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 11 at GS36</br>
+         </span>
+         <span>
+           (10:46) Smith,Alex punt 41 yards to the BOISE23 fair catch by Caples,Latrell at BOISE23.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Boise St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//66.gif" /><span class='d-none d-sm-block'>Boise St.</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">10:40,BOI23, 1 plays, 77 yards, 00:12</span>
+        </div>
+        <div class="headerRight">7 - 0</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI23</br>
+         </span>
+         <span>
+           Boise St. drive start at 10:40.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS3</br>
+         </span>
+         <span>
+           Timeout Other, clock 10:40.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI23</br>
+         </span>
+         <span>
+           (10:38) No Huddle Jeanty,Ashton rush left for 77 yards gain to the GASO00 TOUCHDOWN, clock 10:28, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS3</br>
+         </span>
+         <span>
+           Dalmas,Jonah kick attempt good (H: Ferguson-Reynolds,James, LS: Hutton,Mason).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ga. Southern" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//253.gif" /><span class='d-none d-sm-block'>Ga. Southern</span></div></div>
+        <div class="headerLeft">FUMB <br/><span style="font-size: 8px;">10:22,GS29, 5 plays, 21 yards, 01:05</span>
+        </div>
+        <div class="headerRight">7 - 0</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI35</br>
+         </span>
+         <span>
+           (10:28) Dalmas,Jonah kickoff 64 yards to the GASO01 Buchannon,DeAndre return 28 yards to the GASO29 (Ripp,Jake).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS29</br>
+         </span>
+         <span>
+           Georgia Southern drive start at 10:22.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS29</br>
+         </span>
+         <span>
+           (10:21) No Huddle-Shotgun French,JC pass incomplete short left to Sanders Jr.,Marcus thrown to GASO33 broken up by McCoy,A&#39;Marion.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at GS29</br>
+         </span>
+         <span>
+           (10:18) No Huddle-Shotgun French,JC pass incomplete short left to Sanders Jr.,Marcus thrown to GASO35.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 10 at GS29</br>
+         </span>
+         <span>
+           (10:13) No Huddle-Shotgun Arnold,OJ rush left for 14 yards gain to the GASO43 (Washington,Zion), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS43</br>
+         </span>
+         <span>
+           (09:55) No Huddle-Shotgun French,JC pass complete short right to Arnold,OJ caught at GASO37, for 1 yard loss to the GASO42 (Hassanein,Ahmed; Robinson,Rodney).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 11 at GS42</br>
+         </span>
+         <span>
+           (09:24) No Huddle-Shotgun French,JC pass complete short left to Sanders Jr.,Marcus caught at GASO45, for 8 yards to the GASO50 fumbled by Sanders Jr.,Marcus at GASO49 forced by McCoy,A&#39;Marion recovered by BOISE Teubner,Alexander at GASO50, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Boise St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//66.gif" /><span class='d-none d-sm-block'>Boise St.</span></div></div>
+        <div class="headerLeft">DOWNS <br/><span style="font-size: 8px;">09:17,GS50, 6 plays, 16 yards, 03:19</span>
+        </div>
+        <div class="headerRight">7 - 0</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS50</br>
+         </span>
+         <span>
+           Boise St. drive start at 09:17.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS50</br>
+         </span>
+         <span>
+           (09:16) No Huddle-Shotgun Madsen,Maddux pass complete short right to Jeanty,Ashton caught at GASO45, for 6 yards to the GASO44 (Meyers,Justin), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 4 at GS44</br>
+         </span>
+         <span>
+           (08:44) No Huddle-Shotgun Madsen,Maddux pass complete short right to Marshall,Chris caught at GASO38, for 6 yards to the GASO38 (Meyers,Justin), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS38</br>
+         </span>
+         <span>
+           (08:05) No Huddle Jeanty,Ashton rush right for 4 yards gain to the GASO34 (Hill Jr.,Tracy), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 6 at GS34</br>
+         </span>
+         <span>
+           (07:31) No Huddle-Shotgun Jeanty,Ashton rush left for 5 yards gain to the GASO29 (Watson-Trent,Marques; Bullard,Latrell).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at GS29</br>
+         </span>
+         <span>
+           (06:46) No Huddle Madsen,Maddux pass complete short left to Jeanty,Ashton caught at GASO35, for 5 yards loss to the GASO34 (Ferguson,Jacob).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 6 at GS34</br>
+         </span>
+         <span>
+           (06:01) No Huddle-Shotgun Madsen,Maddux pass incomplete short middle to Caples,Latrell thrown to GASO33, TURNOVER ON DOWNS.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ga. Southern" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//253.gif" /><span class='d-none d-sm-block'>Ga. Southern</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">05:58,GS34, 3 plays, -6 yards, 00:51</span>
+        </div>
+        <div class="headerRight">7 - 0</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS34</br>
+         </span>
+         <span>
+           Georgia Southern drive start at 05:58.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS34</br>
+         </span>
+         <span>
+           (05:57) No Huddle-Shotgun French,JC pass incomplete short right to Burgess Jr.,Derwin thrown to GASO40.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at GS34</br>
+         </span>
+         <span>
+           (05:53) No Huddle-Shotgun French,JC sacked for loss of 6 yards to the GASO28 (Fely,Braxton).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 16 at GS28</br>
+         </span>
+         <span>
+           (05:17) No Huddle-Shotgun French,JC pass incomplete short middle to Burgess Jr.,Derwin thrown to GASO42.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 16 at GS28</br>
+         </span>
+         <span>
+           (05:13) Smith,Alex punt 43 yards to the BOISE29 fair catch by Caples,Latrell at BOISE29.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Boise St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//66.gif" /><span class='d-none d-sm-block'>Boise St.</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">05:07,BOI29, 6 plays, 71 yards, 02:17</span>
+        </div>
+        <div class="headerRight">14 - 0</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI29</br>
+         </span>
+         <span>
+           Boise St. drive start at 05:07.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI29</br>
+         </span>
+         <span>
+           (05:06) No Huddle Jeanty,Ashton rush middle for 6 yards loss to the BOISE23 (Rhodes,Davion) PENALTY GASO Offside offsetting BOISE Illegal Formation offsetting. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI29</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Madsen,Maddux pass incomplete short middle to Caples,Latrell thrown to BOISE29.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at BOI29</br>
+         </span>
+         <span>
+           (04:38) No Huddle-Shotgun Gaines,Sire rush left for 18 yards gain to the BOISE47 (Meyers,Justin), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI47</br>
+         </span>
+         <span>
+           (04:11) No Huddle-Shotgun Gaines,Sire rush middle for 11 yards gain to the GASO42 (Meyers,Justin; Davis,Da&#39;Shawn), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS42</br>
+         </span>
+         <span>
+           (03:38) No Huddle Madsen,Maddux pass complete short right to Bates,Cameron caught at GASO40, for 16 yards to the GASO26 (Williams,Cam), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS26</br>
+         </span>
+         <span>
+           (03:08) No Huddle-Shotgun Madsen,Maddux pass incomplete short middle to Bolt,Austin thrown to GASO10 broken up by Meyers,Justin.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at GS26</br>
+         </span>
+         <span>
+           (02:57) No Huddle-Shotgun Jeanty,Ashton rush right for 26 yards gain to the GASO00 TOUCHDOWN, clock 02:50, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS3</br>
+         </span>
+         <span>
+           Dalmas,Jonah kick attempt good (H: Ferguson-Reynolds,James, LS: Hutton,Mason).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ga. Southern" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//253.gif" /><span class='d-none d-sm-block'>Ga. Southern</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">02:43,BOI50, 9 plays, 50 yards, 04:15</span>
+        </div>
+        <div class="headerRight">14 - 6</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI35</br>
+         </span>
+         <span>
+           (02:50) Dalmas,Jonah kickoff 60 yards to the GASO05 Buchannon,DeAndre return 45 yards to the BOISE50 (Dalmas,Jonah), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI50</br>
+         </span>
+         <span>
+           Georgia Southern drive start at 02:43.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI50</br>
+         </span>
+         <span>
+           (02:42) No Huddle-Shotgun White,Jalen rush middle for 1 yard gain to the BOISE49 (Virgin-Morgan,Jayden; Gums,Herbert).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 9 at BOI49</br>
+         </span>
+         <span>
+           (02:08) No Huddle-Shotgun French,JC pass incomplete deep middle to Dallas,Josh thrown to BOISE10.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 9 at BOI49</br>
+         </span>
+         <span>
+           (02:02) No Huddle-Shotgun French,JC pass complete short left to Dallas,Josh caught at GASO49, for 9 yards to the BOISE40 (Oladipo,Seyi; Virgin-Morgan,Jayden), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI40</br>
+         </span>
+         <span>
+           (01:25) No Huddle-Shotgun French,JC pass complete short right to Burgess Jr.,Derwin caught at BOISE33, for 9 yards to the BOISE31 (Banks,Davon).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 1 at BOI31</br>
+         </span>
+         <span>
+           (00:51) No Huddle-Shotgun French,JC sacked for loss of 5 yards to the BOISE36 (Ripp,Jake).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at BOI36</br>
+         </span>
+         <span>
+           (00:08) No Huddle-Shotgun French,JC rush middle for 16 yards gain to the BOISE20 (Robinson,Rodney), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI20</br>
+         </span>
+         <span>
+           Start of 2nd quarter, clock 15:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI20</br>
+         </span>
+         <span>
+           (14:58) No Huddle-Shotgun French,JC pass complete short left to Cobb,Dalen caught at BOISE23, for 4 yards to the BOISE16 (Teubner,Alexander).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 6 at BOI16</br>
+         </span>
+         <span>
+           (14:20) No Huddle-Shotgun French,JC rush left for 10 yards gain to the BOISE06 fumbled by French,JC at BOISE09 forced by Earby,Jeremiah recovered by GASO Cobb,Dalen at BOISE06, out of bounds at BOISE06, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 6 at BOI6</br>
+         </span>
+         <span>
+           (13:35) No Huddle-Shotgun French,JC pass incomplete short left to Cobb,Dalen thrown to BOISE00 PENALTY BOISE Pass Interference (Earby,Jeremiah) 4 yards from BOISE06 to BOISE02, 1ST DOWN. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 2 at BOI2</br>
+         </span>
+         <span>
+           (13:30) No Huddle-Shotgun White,Jalen rush right for 2 yards gain to the BOISE00 TOUCHDOWN, clock 13:28.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI3</br>
+         </span>
+         <span>
+           Daniel,Matthew rush attempt failed.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+</div>
+  <div style="border-bottom: 1px dotted #dcdddf;"><h1>2nd Quarter</h1></div>
+<div class="drives">
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Boise St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//66.gif" /><span class='d-none d-sm-block'>Boise St.</span></div></div>
+        <div class="headerLeft">INT <br/><span style="font-size: 8px;">13:21,BOI23, 3 plays, 1 yards, 00:45</span>
+        </div>
+        <div class="headerRight">14 - 6</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS35</br>
+         </span>
+         <span>
+           (13:28) Stewart,Gavin kickoff 55 yards to the BOISE10 Chan,Kayden return 13 yards to the BOISE23 (Morris,Deontre).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI23</br>
+         </span>
+         <span>
+           Boise St. drive start at 13:21.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI23</br>
+         </span>
+         <span>
+           (13:20) No Huddle Jeanty,Ashton rush left for 1 yard gain to the BOISE24 (Walker,Isaac).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 9 at BOI24</br>
+         </span>
+         <span>
+           (12:45) No Huddle-Shotgun Madsen,Maddux pass incomplete short right to Camper,Cameron thrown to BOISE37 broken up by Hill Jr.,Tracy.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 9 at BOI24</br>
+         </span>
+         <span>
+           (12:40) No Huddle-Shotgun Madsen,Maddux pass intercepted by Davis,Tyrell at BOISE31 Davis,Tyrell return 0 yards to the BOISE31, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ga. Southern" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//253.gif" /><span class='d-none d-sm-block'>Ga. Southern</span></div></div>
+        <div class="headerLeft">FG <br/><span style="font-size: 8px;">12:36,BOI31, 5 plays, 18 yards, 01:36</span>
+        </div>
+        <div class="headerRight">14 - 9</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI31</br>
+         </span>
+         <span>
+           Georgia Southern drive start at 12:36.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI31</br>
+         </span>
+         <span>
+           (12:35) No Huddle-Shotgun French,JC pass complete short left to Fromm,Tyler caught at BOISE39, for 14 yards to the BOISE17 (Teubner,Alexander), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI17</br>
+         </span>
+         <span>
+           (12:17) No Huddle-Shotgun French,JC rush middle for 2 yards gain to the BOISE15, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 8 at BOI15</br>
+         </span>
+         <span>
+           (11:37) No Huddle-Shotgun Burgess Jr.,Derwin rush left for 2 yards gain to the BOISE13 (Washington,Zion), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at BOI13</br>
+         </span>
+         <span>
+           (11:06) No Huddle-Shotgun French,JC pass incomplete short right to Cobb,Dalen thrown to BOISE19.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 6 at BOI13</br>
+         </span>
+         <span>
+           (11:02) Stewart,Gavin field goal attempt from 31 yards GOOD (H: Daniel,Matthew, LS: Wheeler,Jackson), clock 11:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS35</br>
+         </span>
+         <span>
+           BOI ball on BOI10.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Boise St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//66.gif" /><span class='d-none d-sm-block'>Boise St.</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">10:57,BOI10, 5 plays, 90 yards, 01:38</span>
+        </div>
+        <div class="headerRight">21 - 9</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS35</br>
+         </span>
+         <span>
+           (11:00) Stewart,Gavin kickoff 55 yards to the BOISE10 Chan,Kayden return 10 yards to the BOISE20 (Smith,TJ; Dedman,Reid), out of bounds PENALTY BOISE Holding (Miller,Cole) 10 yards from BOISE20 to BOISE10.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI10</br>
+         </span>
+         <span>
+           Boise St. drive start at 10:57.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI10</br>
+         </span>
+         <span>
+           (10:56) No Huddle-Shotgun Madsen,Maddux pass complete deep right to Camper,Cameron caught at BOISE49, for 53 yards to the GASO37 (Smith,TJ), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS37</br>
+         </span>
+         <span>
+           (10:33) No Huddle Madsen,Maddux pass complete deep left to Caples,Latrell caught at GASO01, for 36 yards to the GASO01, End Of Play, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 1 at GS1</br>
+         </span>
+         <span>
+           (09:55) No Huddle Gaines,Sire rush left for 0 yards to the GASO01 (Watson-Trent,Marques; Varner,Kristian).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 1 at GS1</br>
+         </span>
+         <span>
+           (09:25) No Huddle Madsen,Maddux pass incomplete short right to Gums,Herbert thrown to GASO01.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at GS1</br>
+         </span>
+         <span>
+           (09:21) No Huddle Jeanty,Ashton rush middle for 1 yard gain to the GASO00 TOUCHDOWN, clock 09:19.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS3</br>
+         </span>
+         <span>
+           Dalmas,Jonah kick attempt good (H: Ferguson-Reynolds,James, LS: Hutton,Mason).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ga. Southern" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//253.gif" /><span class='d-none d-sm-block'>Ga. Southern</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">09:19,GS25, 4 plays, 6 yards, 01:57</span>
+        </div>
+        <div class="headerRight">21 - 9</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI35</br>
+         </span>
+         <span>
+           (09:19) Schive,Taren kickoff 65 yards to the GASO00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS25</br>
+         </span>
+         <span>
+           Georgia Southern drive start at 09:19.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS25</br>
+         </span>
+         <span>
+           (09:19) No Huddle-Shotgun Mbadinga,David rush right for 2 yards gain to the GASO27 (Robinson,Rodney).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 8 at GS27</br>
+         </span>
+         <span>
+           (08:38) No Huddle-Shotgun French,JC rush right for 36 yards gain (8) to the BOISE37, out of bounds at BOISE37 PENALTY GASO Holding (Johnson,Beau) 10 yards from GASO35 to GASO25.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at GS25</br>
+         </span>
+         <span>
+           (08:17) No Huddle-Shotgun Mbadinga,David rush left for 6 yards gain to the GASO31 (Benefield,Ty; Ripp,Jake).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 4 at GS31</br>
+         </span>
+         <span>
+           (07:37) No Huddle-Shotgun French,JC pass incomplete short left to Dallas,Josh thrown to GASO38 broken up by Washington,Zion.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 4 at GS31</br>
+         </span>
+         <span>
+           (07:32) Smith,Alex punt 40 yards to the BOISE29, TURNOVER ON DOWNS.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Boise St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//66.gif" /><span class='d-none d-sm-block'>Boise St.</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">07:22,BOI29, 10 plays, 71 yards, 04:49</span>
+        </div>
+        <div class="headerRight">28 - 9</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI29</br>
+         </span>
+         <span>
+           Boise St. drive start at 07:22.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI29</br>
+         </span>
+         <span>
+           (07:22) No Huddle Jeanty,Ashton rush left for 8 yards gain to the BOISE37 (Rhodes,Davion).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 2 at BOI37</br>
+         </span>
+         <span>
+           (06:46) No Huddle-Shotgun Jeanty,Ashton rush right for 3 yards gain to the BOISE40 (Fall,Elhadj; Walker,Isaac), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI40</br>
+         </span>
+         <span>
+           (06:05) No Huddle-Shotgun Madsen,Maddux pass complete short right to Marshall,Chris caught at BOISE46, for 7 yards to the BOISE47 (Hill Jr.,Tracy).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 3 at BOI47</br>
+         </span>
+         <span>
+           (05:26) No Huddle-Shotgun Madsen,Maddux pass incomplete short right to Jeanty,Ashton thrown to BOISE45.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 3 at BOI47</br>
+         </span>
+         <span>
+           (05:22) No Huddle-Shotgun Madsen,Maddux pass complete short middle to Camper,Cameron caught at GASO43, for 10 yards to the GASO43 (Morris,Deontre), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS43</br>
+         </span>
+         <span>
+           (04:48) No Huddle Gaines,Sire rush left for 6 yards gain to the GASO37 (Morris,Deontre).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 4 at GS37</br>
+         </span>
+         <span>
+           Timeout Other, clock 04:43.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 4 at GS37</br>
+         </span>
+         <span>
+           (04:14) No Huddle Jeanty,Ashton rush middle for 24 yards gain to the GASO13 (Smith,TJ), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS13</br>
+         </span>
+         <span>
+           (03:36) No Huddle-Shotgun Gaines,Sire rush left for 11 yards gain (3) to the GASO02 (Gamble,Chance), out of bounds PENALTY BOISE Holding (Caples,Latrell) 10 yards from GASO10 to GASO20.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 17 at GS20</br>
+         </span>
+         <span>
+           (03:15) No Huddle Madsen,Maddux pass complete short right to Gaines,Sire caught at GASO20, for 15 yards to the GASO05 (Hill Jr.,Tracy), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 2 at GS5</br>
+         </span>
+         <span>
+           (02:35) No Huddle Jeanty,Ashton rush middle for 5 yards gain to the GASO00 TOUCHDOWN, clock 02:33, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS3</br>
+         </span>
+         <span>
+           Dalmas,Jonah kick attempt good (H: Ferguson-Reynolds,James, LS: Hutton,Mason).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ga. Southern" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//253.gif" /><span class='d-none d-sm-block'>Ga. Southern</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">02:28,GS19, 11 plays, 81 yards, 02:10</span>
+        </div>
+        <div class="headerRight">28 - 16</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI35</br>
+         </span>
+         <span>
+           (02:33) Schive,Taren kickoff 65 yards to the GASO00 Buchannon,DeAndre return 19 yards to the GASO19 (Reed,Markel).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS19</br>
+         </span>
+         <span>
+           Georgia Southern drive start at 02:28.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS19</br>
+         </span>
+         <span>
+           (02:28) No Huddle-Shotgun Cobb,Dalen rush left for 6 yards gain to the GASO25 (Benefield,Ty).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 4 at GS25</br>
+         </span>
+         <span>
+           Timeout Other, clock 02:18.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 4 at GS25</br>
+         </span>
+         <span>
+           (02:00) No Huddle-Shotgun White,Jalen rush middle for 0 yards to the GASO25 (Notarainni,Marco; Fely,Braxton).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 4 at GS25</br>
+         </span>
+         <span>
+           (01:22) No Huddle-Shotgun French,JC pass complete short middle to Fromm,Tyler caught at GASO37, for 12 yards to the GASO37 (Washington,Zion), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS37</br>
+         </span>
+         <span>
+           (01:07) No Huddle-Shotgun French,JC pass complete short left to Bunkley-Shelton,LV caught at GASO35, for 4 yards to the GASO41 (Earby,Jeremiah), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 6 at GS41</br>
+         </span>
+         <span>
+           (01:05) No Huddle-Shotgun French,JC rush left for 4 yards gain to the GASO45 (Teubner,Alexander).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at GS45</br>
+         </span>
+         <span>
+           Timeout Georgia Southern, clock 00:59.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at GS45</br>
+         </span>
+         <span>
+           (00:59) No Huddle-Shotgun French,JC rush left for 3 yards gain to the GASO48, out of bounds at GASO48, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS48</br>
+         </span>
+         <span>
+           (00:55) No Huddle-Shotgun French,JC pass incomplete short left to Mbadinga,David thrown to GASO42.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at GS48</br>
+         </span>
+         <span>
+           (00:49) No Huddle-Shotgun French,JC pass complete short middle to Cobb,Dalen caught at BOISE44, for 18 yards to the BOISE34 (Benefield,Ty), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI34</br>
+         </span>
+         <span>
+           (00:36) No Huddle-Shotgun French,JC pass incomplete short left to Bunkley-Shelton,LV thrown to BOISE15 PENALTY BOISE Pass Interference (Earby,Jeremiah) 15 yards from BOISE34 to BOISE19, 1ST DOWN. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI19</br>
+         </span>
+         <span>
+           Timeout Boise St., clock 00:32.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI19</br>
+         </span>
+         <span>
+           (00:31) No Huddle-Shotgun French,JC pass incomplete short right to Burgess Jr.,Derwin thrown to BOISE00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at BOI19</br>
+         </span>
+         <span>
+           (00:26) No Huddle-Shotgun French,JC rush middle for 1 yard gain to the BOISE18 (Hassanein,Ahmed).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 9 at BOI18</br>
+         </span>
+         <span>
+           Timeout Boise St., clock 00:23.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 9 at BOI18</br>
+         </span>
+         <span>
+           (00:23) No Huddle-Shotgun French,JC pass complete short middle to Cobb,Dalen caught at BOISE00, for 18 yards to the BOISE00 TOUCHDOWN, clock 00:18, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI3</br>
+         </span>
+         <span>
+           Stewart,Gavin kick attempt good (H: Daniel,Matthew, LS: Wheeler,Jackson).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Boise St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//66.gif" /><span class='d-none d-sm-block'>Boise St.</span></div></div>
+        <div class="headerLeft">HALF <br/><span style="font-size: 8px;">00:18,BOI25, 1 plays, -2 yards, 00:18</span>
+        </div>
+        <div class="headerRight">28 - 16</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS35</br>
+         </span>
+         <span>
+           (00:18) Stewart,Gavin kickoff 64 yards to the BOISE01 fair catch by Chan,Kayden at BOISE01.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI25</br>
+         </span>
+         <span>
+           Boise St. drive start at 00:18.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI25</br>
+         </span>
+         <span>
+           Kneel down by Boise St. at BOISE23 for loss of 2 yards.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 12 at BOI23</br>
+         </span>
+         <span>
+           End of game, clock 00:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI35</br>
+         </span>
+         <span>
+           GS will receive; BOI will defend East end-zone.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI35</br>
+         </span>
+         <span>
+           Start of 3rd quarter, clock 15:00.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+</div>
+  <div style="border-bottom: 1px dotted #dcdddf;"><h1>3rd Quarter</h1></div>
+<div class="drives">
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ga. Southern" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//253.gif" /><span class='d-none d-sm-block'>Ga. Southern</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">15:00,GS25, 8 plays, 75 yards, 03:23</span>
+        </div>
+        <div class="headerRight">28 - 23</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI35</br>
+         </span>
+         <span>
+           (15:00) Schive,Taren kickoff 65 yards to the GASO00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS25</br>
+         </span>
+         <span>
+           Georgia Southern drive start at 15:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS25</br>
+         </span>
+         <span>
+           (15:00) No Huddle-Shotgun White,Jalen rush right for 3 yards gain to the GASO28 (Hassanein,Ahmed).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at GS28</br>
+         </span>
+         <span>
+           (14:33) No Huddle-Shotgun French,JC pass incomplete deep left to Bunkley-Shelton,LV thrown to BOISE49 broken up by Banks,Davon.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 7 at GS28</br>
+         </span>
+         <span>
+           (14:28) No Huddle-Shotgun French,JC pass incomplete short left to Burgess Jr.,Derwin thrown to GASO30 PENALTY BOISE Personal Foul (Virgin-Morgan,Jayden) 15 yards from GASO28 to GASO43, 1ST DOWN. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS43</br>
+         </span>
+         <span>
+           (14:23) No Huddle-Shotgun White,Jalen rush middle for 9 yards gain to the BOISE48 (Virgin-Morgan,Jayden).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 1 at BOI48</br>
+         </span>
+         <span>
+           (13:49) No Huddle-Shotgun French,JC rush right for 3 yards loss to the GASO49 (Banks,Davon).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 4 at GS49</br>
+         </span>
+         <span>
+           (13:11) No Huddle-Shotgun French,JC pass complete short right to Burgess Jr.,Derwin caught at BOISE46, for 5 yards to the BOISE46, End Of Play, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI46</br>
+         </span>
+         <span>
+           (12:48) No Huddle-Shotgun French,JC pass complete deep right to Burgess Jr.,Derwin caught at BOISE15, for 31 yards to the BOISE15, End Of Play, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI15</br>
+         </span>
+         <span>
+           (12:23) No Huddle-Shotgun French,JC pass complete short right to White,Jalen caught at BOISE17, for 4 yards to the BOISE11 (Simpson,Andrew).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 6 at BOI11</br>
+         </span>
+         <span>
+           (11:40) No Huddle-Shotgun French,JC rush right for 11 yards gain to the BOISE00 TOUCHDOWN, clock 11:37, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI3</br>
+         </span>
+         <span>
+           Stewart,Gavin kick attempt good (H: Daniel,Matthew, LS: Wheeler,Jackson).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Boise St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//66.gif" /><span class='d-none d-sm-block'>Boise St.</span></div></div>
+        <div class="headerLeft">DOWNS <br/><span style="font-size: 8px;">11:37,BOI25, 4 plays, 8 yards, 01:51</span>
+        </div>
+        <div class="headerRight">28 - 23</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS35</br>
+         </span>
+         <span>
+           (11:37) Stewart,Gavin kickoff 60 yards to the BOISE05 fair catch by Chan,Kayden at BOISE05.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI25</br>
+         </span>
+         <span>
+           Boise St. drive start at 11:37.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI25</br>
+         </span>
+         <span>
+           (11:37) No Huddle Jeanty,Ashton rush middle for 6 yards gain to the BOISE31 (Bullard,Latrell).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 4 at BOI31</br>
+         </span>
+         <span>
+           (11:05) No Huddle Jeanty,Ashton rush middle for 0 yards to the BOISE31 (Bullard,Latrell; Davis,Da&#39;Shawn).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 4 at BOI31</br>
+         </span>
+         <span>
+           (10:20) No Huddle-Shotgun Madsen,Maddux pass complete short right to Jeanty,Ashton caught at BOISE33, for 3 yards to the BOISE34 (Walker,Isaac).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 1 at BOI34</br>
+         </span>
+         <span>
+           (09:49) No Huddle Gaines,Sire rush middle for 1 yard loss to the BOISE33 (Gilmore,Davon; Meyers,Justin), TURNOVER ON DOWNS.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ga. Southern" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//253.gif" /><span class='d-none d-sm-block'>Ga. Southern</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">09:46,BOI33, 8 plays, 33 yards, 02:58</span>
+        </div>
+        <div class="headerRight">28 - 30</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI33</br>
+         </span>
+         <span>
+           Georgia Southern drive start at 09:46.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI33</br>
+         </span>
+         <span>
+           (09:44) No Huddle-Shotgun French,JC pass incomplete short left to Mbadinga,David thrown to BOISE30 QB hurried by Ripp,Jake.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at BOI33</br>
+         </span>
+         <span>
+           (09:40) No Huddle-Shotgun French,JC pass incomplete deep left to Sanders Jr.,Marcus thrown to BOISE04.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 10 at BOI33</br>
+         </span>
+         <span>
+           (09:34) No Huddle-Shotgun French,JC pass complete short left to Kenerson,Sam caught at BOISE17, for 16 yards to the BOISE17, out of bounds at BOISE17, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI17</br>
+         </span>
+         <span>
+           (09:16) No Huddle-Shotgun French,JC sacked for loss of 2 yards to the BOISE19 (Virgin-Morgan,Jayden).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 12 at BOI19</br>
+         </span>
+         <span>
+           (08:43) No Huddle-Shotgun French,JC pass complete short right to Bunkley-Shelton,LV caught at BOISE15, for 4 yards to the BOISE15 (McCoy,A&#39;Marion), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 8 at BOI15</br>
+         </span>
+         <span>
+           (08:10) No Huddle-Shotgun French,JC pass complete short right to Bunkley-Shelton,LV caught at BOISE10, for 14 yards to the BOISE01 (Washington,Zion), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 1 at BOI1</br>
+         </span>
+         <span>
+           (07:33) No Huddle Mbadinga,David rush middle for 0 yards to the BOISE01 (Newton,Sheldon; Virgin-Morgan,Jayden).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 1 at BOI1</br>
+         </span>
+         <span>
+           (06:49) No Huddle White,Jalen rush right for 1 yard gain to the BOISE00 TOUCHDOWN, clock 06:48.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI3</br>
+         </span>
+         <span>
+           PENALTY GASO False Start (Broadway,Bryson) 5 yards from BOISE03 to BOISE08. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI8</br>
+         </span>
+         <span>
+           Stewart,Gavin kick attempt good (H: Daniel,Matthew, LS: Wheeler,Jackson).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Boise St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//66.gif" /><span class='d-none d-sm-block'>Boise St.</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">06:48,BOI25, 14 plays, 75 yards, 05:41</span>
+        </div>
+        <div class="headerRight">36 - 30</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS35</br>
+         </span>
+         <span>
+           (06:48) Stewart,Gavin kickoff 59 yards to the BOISE06 fair catch by Chan,Kayden at BOISE06.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI25</br>
+         </span>
+         <span>
+           Boise St. drive start at 06:48.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI25</br>
+         </span>
+         <span>
+           (06:46) No Huddle Madsen,Maddux pass complete short right to Caples,Latrell caught at BOISE41, for 16 yards to the BOISE41 (Hill Jr.,Tracy), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI41</br>
+         </span>
+         <span>
+           (06:11) No Huddle-Shotgun Madsen,Maddux pass incomplete short left to Camper,Cameron thrown to BOISE45 QB hurried by Gilmore,Davon.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at BOI41</br>
+         </span>
+         <span>
+           (06:06) No Huddle-Shotgun Madsen,Maddux pass complete short left to Bates,Cameron caught at BOISE38, for 1 yard to the BOISE42 (Fall,Elhadj) PENALTY BOISE Holding (Terry,Austin) 10 yards from BOISE42 to BOISE32.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 19 at BOI32</br>
+         </span>
+         <span>
+           (05:52) No Huddle-Shotgun Madsen,Maddux pass complete short right to Caples,Latrell caught at BOISE45, for 13 yards to the BOISE45 (Meyers,Justin).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at BOI45</br>
+         </span>
+         <span>
+           Timeout Other, clock 05:40.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at BOI45</br>
+         </span>
+         <span>
+           (05:34) No Huddle-Shotgun Madsen,Maddux pass complete short right to Ford,Ben caught at BOISE50, for 9 yards to the GASO46 (Stroud,MJ), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS46</br>
+         </span>
+         <span>
+           (05:14) No Huddle-Shotgun Jeanty,Ashton rush middle for 5 yards gain to the GASO41 (Stampley II,Marc; Smith,TJ).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 5 at GS41</br>
+         </span>
+         <span>
+           (04:51) No Huddle-Shotgun Jeanty,Ashton rush middle for 3 yards gain to the GASO38 (Watson-Trent,Marques; Rhodes,Davion).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at GS38</br>
+         </span>
+         <span>
+           (04:14) No Huddle Madsen,Maddux pass complete short right to Caples,Latrell caught at GASO35, for 3 yards to the GASO35 (Smith,TJ), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS35</br>
+         </span>
+         <span>
+           (03:39) No Huddle-Shotgun Madsen,Maddux pass incomplete short right to Bolt,Austin thrown to GASO20 broken up by Gamble,Chance.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at GS35</br>
+         </span>
+         <span>
+           (03:35) No Huddle-Shotgun Madsen,Maddux pass complete short left to Gaines,Sire caught at GASO41, for 12 yards to the GASO23 (Watson-Trent,Marques), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS23</br>
+         </span>
+         <span>
+           (03:08) No Huddle-Shotgun Madsen,Maddux pass complete short left to Camper,Cameron caught at GASO08, for 15 yards to the GASO08 (Smith,Dorrian), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 8 at GS8</br>
+         </span>
+         <span>
+           (02:25) No Huddle Jeanty,Ashton rush right for 6 yards gain to the GASO02 (Watson-Trent,Marques).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 2 at GS2</br>
+         </span>
+         <span>
+           (01:52) No Huddle Jeanty,Ashton rush middle for 1 yard gain to the GASO01 (Gilmore,Davon).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at GS1</br>
+         </span>
+         <span>
+           Timeout Georgia Southern, clock 01:47.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at GS1</br>
+         </span>
+         <span>
+           (01:09) No Huddle-Shotgun Jeanty,Ashton rush middle for 1 yard gain to the GASO00 TOUCHDOWN, clock 01:07.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS3</br>
+         </span>
+         <span>
+           Camper,Cameron pass attempt Successful.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ga. Southern" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//253.gif" /><span class='d-none d-sm-block'>Ga. Southern</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">01:07,GS25, 5 plays, 75 yards, 02:37</span>
+        </div>
+        <div class="headerRight">36 - 37</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI35</br>
+         </span>
+         <span>
+           (01:07) Schive,Taren kickoff 65 yards to the GASO00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS25</br>
+         </span>
+         <span>
+           Georgia Southern drive start at 01:07.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS25</br>
+         </span>
+         <span>
+           (01:03) No Huddle-Shotgun Cobb,Dalen rush right for 24 yards gain to the GASO49 (Earby,Jeremiah), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS49</br>
+         </span>
+         <span>
+           (00:26) No Huddle-Shotgun French,JC pass complete deep middle to Burgess Jr.,Derwin caught at BOISE12, for 48 yards to the BOISE03 (McCoy,A&#39;Marion), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 3 at BOI3</br>
+         </span>
+         <span>
+           Start of 4th quarter, clock 15:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 3 at BOI3</br>
+         </span>
+         <span>
+           (14:59) No Huddle French,JC rush right for 0 yards to the BOISE03 (Earby,Jeremiah).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 3 at BOI3</br>
+         </span>
+         <span>
+           (14:17) No Huddle-Shotgun French,JC rush right for 0 yards to the BOISE03 (Earby,Jeremiah).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 3 at BOI3</br>
+         </span>
+         <span>
+           (13:33) No Huddle-Shotgun French,JC pass complete short middle to Johnson,Beau caught at BOISE00, for 3 yards to the BOISE00 TOUCHDOWN, clock 13:30.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI3</br>
+         </span>
+         <span>
+           Stewart,Gavin kick attempt good (H: Daniel,Matthew, LS: Wheeler,Jackson).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+</div>
+  <div style="border-bottom: 1px dotted #dcdddf;"><h1>4th Quarter</h1></div>
+<div class="drives">
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Boise St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//66.gif" /><span class='d-none d-sm-block'>Boise St.</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">13:30,BOI25, 1 plays, 75 yards, 00:13</span>
+        </div>
+        <div class="headerRight">42 - 37</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS35</br>
+         </span>
+         <span>
+           (13:30) Stewart,Gavin kickoff 65 yards to the BOISE00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI25</br>
+         </span>
+         <span>
+           Boise St. drive start at 13:30.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI25</br>
+         </span>
+         <span>
+           (13:29) No Huddle-Shotgun Jeanty,Ashton rush left for 75 yards gain to the GASO00 TOUCHDOWN, clock 13:17, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS3</br>
+         </span>
+         <span>
+           Madsen,Maddux pass attempt failed.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ga. Southern" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//253.gif" /><span class='d-none d-sm-block'>Ga. Southern</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">13:11,GS18, 8 plays, 33 yards, 03:29</span>
+        </div>
+        <div class="headerRight">42 - 37</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI35</br>
+         </span>
+         <span>
+           (13:17) Schive,Taren kickoff 65 yards to the GASO00 Buchannon,DeAndre return 18 yards to the GASO18 (Robinson,Rodney; Wilkey,Troy).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS18</br>
+         </span>
+         <span>
+           Georgia Southern drive start at 13:11.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS18</br>
+         </span>
+         <span>
+           (13:10) No Huddle-Shotgun French,JC pass complete short middle to Sanders Jr.,Marcus caught at GASO31, for 13 yards to the GASO31 (Earby,Jeremiah), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS31</br>
+         </span>
+         <span>
+           (12:47) No Huddle-Shotgun French,JC pass complete short left to Johnson,Beau caught at GASO34, for 7 yards to the GASO38 (Teubner,Alexander; Benefield,Ty).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 3 at GS38</br>
+         </span>
+         <span>
+           (12:06) No Huddle-Shotgun White,Jalen rush middle for 2 yards gain to the GASO40 (Hassanein,Ahmed; Teubner,Alexander).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at GS40</br>
+         </span>
+         <span>
+           (11:31) No Huddle French,JC rush right for 6 yards gain to the GASO46 (Robinson,Rodney), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS46</br>
+         </span>
+         <span>
+           Timeout Other, clock 11:26.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS46</br>
+         </span>
+         <span>
+           (11:08) No Huddle-Shotgun Buchannon,DeAndre rush right for 11 yards gain to the BOISE43 (Simpson,Andrew), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI43</br>
+         </span>
+         <span>
+           (10:20) No Huddle-Shotgun French,JC pass incomplete deep middle to Sanders Jr.,Marcus thrown to BOISE05 broken up by Washington,Zion QB hurried by Robinson,Rodney.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at BOI43</br>
+         </span>
+         <span>
+           (10:15) No Huddle-Shotgun French,JC pass incomplete short middle to Johnson,Beau thrown to BOISE41.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 10 at BOI43</br>
+         </span>
+         <span>
+           (10:12) No Huddle-Shotgun French,JC sacked for loss of 6 yards to the BOISE49 (Simpson,Andrew), fumble by French,JC, out of bounds at BOISE49.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 16 at BOI49</br>
+         </span>
+         <span>
+           (09:46) Smith,Alex punt 35 yards to the BOISE14 fair catch by Caples,Latrell at BOISE14.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Boise St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//66.gif" /><span class='d-none d-sm-block'>Boise St.</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">09:42,BOI14, 4 plays, 86 yards, 01:59</span>
+        </div>
+        <div class="headerRight">49 - 37</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI14</br>
+         </span>
+         <span>
+           Boise St. drive start at 09:42.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI14</br>
+         </span>
+         <span>
+           (09:40) No Huddle Madsen,Maddux pass complete short middle to Camper,Cameron caught at BOISE26, for 21 yards to the BOISE35 (Watson-Trent,Marques; Smith,TJ), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI35</br>
+         </span>
+         <span>
+           (09:04) No Huddle-Shotgun Jeanty,Ashton rush right for 18 yards gain to the GASO47, out of bounds at GASO47, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS47</br>
+         </span>
+         <span>
+           (08:33) No Huddle-Shotgun Gaines,Sire rush middle for 9 yards gain to the GASO38 (Smith,Dorrian; Rhodes,Justin).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 1 at GS38</br>
+         </span>
+         <span>
+           (07:50) No Huddle Gaines,Sire rush left for 38 yards gain to the GASO00 TOUCHDOWN, clock 07:43, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS3</br>
+         </span>
+         <span>
+           Dalmas,Jonah kick attempt good (H: Ferguson-Reynolds,James, LS: Hutton,Mason).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ga. Southern" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//253.gif" /><span class='d-none d-sm-block'>Ga. Southern</span></div></div>
+        <div class="headerLeft">DOWNS <br/><span style="font-size: 8px;">07:36,GS25, 4 plays, 0 yards, 00:21</span>
+        </div>
+        <div class="headerRight">49 - 37</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI35</br>
+         </span>
+         <span>
+           (07:43) Schive,Taren kickoff 65 yards to the GASO00 Buchannon,DeAndre return 25 yards to the GASO25 (Phelps,Boen).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS25</br>
+         </span>
+         <span>
+           Georgia Southern drive start at 07:36.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS25</br>
+         </span>
+         <span>
+           (07:35) No Huddle-Shotgun French,JC pass incomplete deep middle to Cobb,Dalen thrown to GASO45.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at GS25</br>
+         </span>
+         <span>
+           (07:29) No Huddle-Shotgun French,JC pass incomplete short left to Arnold,OJ thrown to GASO22.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 10 at GS25</br>
+         </span>
+         <span>
+           (07:25) No Huddle-Shotgun French,JC pass incomplete short right to Dallas,Josh thrown to GASO41 broken up by Washington,Zion.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 10 at GS25</br>
+         </span>
+         <span>
+           (07:20) No Huddle-Shotgun French,JC pass incomplete short right to Burgess Jr.,Derwin thrown to GASO35, TURNOVER ON DOWNS.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Boise St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//66.gif" /><span class='d-none d-sm-block'>Boise St.</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">07:15,GS25, 3 plays, 25 yards, 01:33</span>
+        </div>
+        <div class="headerRight">56 - 37</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS25</br>
+         </span>
+         <span>
+           Boise St. drive start at 07:15.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS25</br>
+         </span>
+         <span>
+           (07:14) No Huddle Gaines,Sire rush right for 5 yards loss to the GASO30 (Rhodes,Davion).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 15 at GS30</br>
+         </span>
+         <span>
+           (06:38) No Huddle-Shotgun Madsen,Maddux pass incomplete short middle to Camper,Cameron thrown to GASO15 PENALTY BOISE Pass Interference (Camper,Cameron) 15 yards from GASO30 to GASO45. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 30 at GS45</br>
+         </span>
+         <span>
+           Timeout Other, clock 06:34.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 30 at GS45</br>
+         </span>
+         <span>
+           (06:33) No Huddle-Shotgun Gaines,Sire rush left for 28 yards gain to the GASO17 fumbled by Gaines,Sire at GASO19 forced by Gamble,Chance recovered by BOISE Bolt,Austin at GASO17, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at GS17</br>
+         </span>
+         <span>
+           (05:47) No Huddle-Shotgun Madsen,Maddux pass complete short right to Gaines,Sire caught at GASO20, for 17 yards to the GASO00 TOUCHDOWN, clock 05:42, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS3</br>
+         </span>
+         <span>
+           Dalmas,Jonah kick attempt good (H: Ferguson-Reynolds,James, LS: Hutton,Mason).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI35</br>
+         </span>
+         <span>
+           GS ball on GS35.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ga. Southern" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//253.gif" /><span class='d-none d-sm-block'>Ga. Southern</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">05:42,GS35, 11 plays, 65 yards, 03:38</span>
+        </div>
+        <div class="headerRight">56 - 45</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI35</br>
+         </span>
+         <span>
+           (05:42) Schive,Taren kickoff 45 yards to the GASO20, out of bounds at GASO20.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS35</br>
+         </span>
+         <span>
+           Georgia Southern drive start at 05:42.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS35</br>
+         </span>
+         <span>
+           (05:42) No Huddle-Shotgun French,JC pass complete short left to White,Jalen caught at GASO30, for 0 yards to the GASO35 (Oladipo,Seyi), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at GS35</br>
+         </span>
+         <span>
+           Timeout Other, clock 05:36.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at GS35</br>
+         </span>
+         <span>
+           (05:19) No Huddle-Shotgun French,JC rush right for 8 yards gain to the GASO43 (Benefield,Ty) PENALTY GASO Holding (Strong,Chandler) 10 yards from GASO35 to GASO25. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 20 at GS25</br>
+         </span>
+         <span>
+           (05:00) No Huddle-Shotgun French,JC pass complete short middle to White,Jalen caught at GASO27, for 10 yards to the GASO35 (Teubner,Alexander), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 10 at GS35</br>
+         </span>
+         <span>
+           (04:28) No Huddle-Shotgun French,JC pass complete short middle to Dallas,Josh caught at GASO39, for 10 yards to the GASO45 (Washington,Zion), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS45</br>
+         </span>
+         <span>
+           (03:57) No Huddle-Shotgun French,JC sacked for loss of 2 yards to the GASO43 (Simpson,Andrew) PENALTY GASO Holding (Boyd,Dom) 10 yards from GASO45 to GASO35. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 20 at GS35</br>
+         </span>
+         <span>
+           Timeout Georgia Southern, clock 03:52.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 20 at GS35</br>
+         </span>
+         <span>
+           (03:49) No Huddle-Shotgun French,JC pass complete deep left to Buchannon,DeAndre caught at BOISE32, for 34 yards to the BOISE31 (Benefield,Ty), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI31</br>
+         </span>
+         <span>
+           (03:29) No Huddle-Shotgun White,Jalen rush right for 18 yards gain to the BOISE13 (Benefield,Ty), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI13</br>
+         </span>
+         <span>
+           (03:01) No Huddle-Shotgun French,JC pass incomplete short left to Burgess Jr.,Derwin thrown to BOISE07.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at BOI13</br>
+         </span>
+         <span>
+           (02:58) No Huddle-Shotgun French,JC pass incomplete short right to Cobb,Dalen thrown to BOISE00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 10 at BOI13</br>
+         </span>
+         <span>
+           (02:53) No Huddle-Shotgun French,JC pass incomplete short left to Cobb,Dalen thrown to BOISE00 broken up by Robinson,Rodney.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 10 at BOI13</br>
+         </span>
+         <span>
+           (02:44) No Huddle-Shotgun French,JC pass complete short middle to Buchannon,DeAndre caught at BOISE01, for 12 yards to the BOISE01 (Benefield,Ty), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 1 at BOI1</br>
+         </span>
+         <span>
+           (02:12) No Huddle-Shotgun French,JC pass incomplete short left to Dallas,Josh thrown to BOISE00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 1 at BOI1</br>
+         </span>
+         <span>
+           (02:06) No Huddle White,Jalen rush right for 1 yard gain to the BOISE00 TOUCHDOWN, clock 02:04.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at BOI3</br>
+         </span>
+         <span>
+           French,JC rush attempt Successful.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Boise St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//66.gif" /><span class='d-none d-sm-block'>Boise St.</span></div></div>
+        <div class="headerLeft">HALF <br/><span style="font-size: 8px;">02:03,GS44, 5 plays, 7 yards, 02:03</span>
+        </div>
+        <div class="headerRight">56 - 45</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS35</br>
+         </span>
+         <span>
+           (02:04) Smith,Alex onside kickoff 9 yards to the GASO44, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS44</br>
+         </span>
+         <span>
+           Boise St. drive start at 02:03.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS44</br>
+         </span>
+         <span>
+           (02:02) No Huddle-Shotgun Gaines,Sire rush middle for 1 yard gain to the GASO43 (Gilmore,Davon; Bullard,Latrell).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 9 at GS43</br>
+         </span>
+         <span>
+           Timeout Georgia Southern, clock 01:58.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 9 at GS43</br>
+         </span>
+         <span>
+           (01:56) No Huddle-Shotgun Gaines,Sire rush middle for 2 yards gain to the GASO41 (Gilmore,Davon; Ferguson,Jacob).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 7 at GS41</br>
+         </span>
+         <span>
+           Timeout Other, clock 01:52.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 7 at GS41</br>
+         </span>
+         <span>
+           (01:51) No Huddle-Shotgun Madsen,Maddux pass complete short right to Lauter,Matt caught at GASO40, for 8 yards to the GASO33, out of bounds at GASO33, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at GS33</br>
+         </span>
+         <span>
+           (01:12) No Huddle Boise St. rush middle for 2 yards loss to the GASO35, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 12 at GS35</br>
+         </span>
+         <span>
+           (00:35) No Huddle Boise St. rush middle for 2 yards loss to the GASO37, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 14 at GS37</br>
+         </span>
+         <span>
+           End of game, clock 00:00.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+</div>
+</div>
+
+
+
+       </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<footer>&copy; <script>document.write(new Date().getFullYear())</script> NCAA <a href="http://web1.ncaa.org/web_files/terms_and_conditions.html" title ="Terms and Conditions" target=_blank>Terms and Conditions</a> | <a href="http://web1.ncaa.org/web_files/privacy.html" target=_blank title="Our Privacy Policy">Privacy Policy</a> | <a href="mailto:ncaa_stats@ncaa.org">Contact Us</a> </footer>
+
+  <!-- /.container -->
+  <script type="text/javascript"  src="/sU0joiPwv/zplvN/xFxji/wmgXJnBU/whimQww3k9OS/ZXgTG2MrBg/bA4YBlB/oDERZ?v=94743442-ba56-a24e-40df-7388407117d0" defer></script></body>
+
+  <script charset="utf-8">
+    $(document).ready(function() {
+      $('a.remote[data-toggle="tab"]').on('show.bs.tab', function (e) {
+        var tab_id = '#' + $(this).attr('aria-controls');
+        $(tab_id).html('<br/><br/><p style="text-align: center"><img style="vertical-align:middle; text-align: center" src="/assets/ajax-loader-6913acdbf4be7d6a2908a84bdecd6cad18110f5fc6d5a07cf8c9ce78d9548700.gif" /> Loading... </p><br/><br/>');
+        $.get($(this).data('remote'), function(data){
+          $(tab_id).html(data);
+        });
+      });
+    });
+
+    function skipMask(obj){
+      if (obj.hasClass('chosen-single') || obj.hasClass('skipMask') || obj.hasClass('ui-datepicker-prev') || obj.hasClass('ui-datepicker-next') || obj.hasClass('ui-corner-all') || obj.hasClass('paginate_button') || obj.hasClass('dt-button')){
+        return true;
+      }else{
+        return false;
+      }
+    }
+
+    $(document).ajaxComplete(function(){
+      unmask();
+    });
+/*
+    $("form").on('submit', function(event){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    */
+    $(document).on('click', 'a', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    $(document).on('click', 'input.green', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+
+  </script>
+</html>

--- a/tests/fixtures/cfb_ncaa/cfb_ncaa_pbp_5362535.html
+++ b/tests/fixtures/cfb_ncaa/cfb_ncaa_pbp_5362535.html
@@ -1,0 +1,2548 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<META HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=UTF-8">
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="">
+<meta name="author" content="">
+<meta name="version" content="321d28433e9f7a188596117e6f342ec4a84fb4ed">
+<META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<link rel="shortcut icon" href="/assets/favicon-405088046a5f2bab8eedeacfae7636975c095e9c8decd8c28e3fd0e65c2f51c4.ico" type="image/vnd.microsoft.icon">
+
+<title>NCAA Statistics</title>
+
+<!-- Bootstrap core CSS -->
+
+<!--
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+-->
+<!--
+<link rel="stylesheet" href="https://cdn.datatables.net/2.0.0/css/dataTables.bootstrap4.css" crossorigin="anonymous">
+-->
+<link rel="stylesheet" media="all" href="/assets/application-789c3971842ee3597428ccbebd021716b3231e9cbd0a00a184c3b2d6c8e5f152.css" />
+
+
+<script src="/assets/application-9232576bb3cb000ac0841ff2af81251908ec17312a3c5eb72bf1a32f9754800c.js"></script>
+<!--
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+-->
+<!--
+<script src="https://cdn.datatables.net/2.0.0/js/dataTables.bootstrap4.js" crossorigin="anonymous"></script>
+-->
+
+<meta name="csrf-param" content="authenticity_token" />
+<meta name="csrf-token" content="Y5WeSBR0eFo1Zxzd/cddqDb1PTzYtwyedfcSFBka9UVAAiwptUnC7nRTZUV2tv8CdYPZzeN53IwoYWEZ3fsd4Q==" />
+
+<style>
+.grid {clear: all}
+.grid-item, .name {text-align: center;}
+h1 img {max-height: 33px;}
+
+</style>
+<!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+<!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+      <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+    <![endif]-->
+
+
+<script>(window.BOOMR_mq=window.BOOMR_mq||[]).push(["addVar",{"rua.upush":"false","rua.cpush":"false","rua.upre":"false","rua.cpre":"false","rua.uprl":"false","rua.cprl":"false","rua.cprf":"false","rua.trans":"","rua.cook":"false","rua.ims":"false","rua.ufprl":"false","rua.cfprl":"false","rua.isuxp":"false","rua.texp":"norulematch","rua.ceh":"false","rua.ueh":"false","rua.ieh.st":"0"}]);</script>
+                                <script>!function(e){var n="https://s.go-mpulse.net/boomerang/";if("False"=="True")e.BOOMR_config=e.BOOMR_config||{},e.BOOMR_config.PageParams=e.BOOMR_config.PageParams||{},e.BOOMR_config.PageParams.pci=!0,n="https://s2.go-mpulse.net/boomerang/";if(window.BOOMR_API_key="EVKJV-AGD2E-W66AE-NT84S-K5LTF",function(){function e(){if(!r){var e=document.createElement("script");e.id="boomr-scr-as",e.src=window.BOOMR.url,e.async=!0,o.appendChild(e),r=!0}}function t(e){r=!0;var n,t,a,i,d=document,O=window;if(window.BOOMR.snippetMethod=e?"if":"i",t=function(e,n){var t=d.createElement("script");t.id=n||"boomr-if-as",t.src=window.BOOMR.url,BOOMR_lstart=(new Date).getTime(),e=e||d.body,e.appendChild(t)},!window.addEventListener&&window.attachEvent&&navigator.userAgent.match(/MSIE [67]\./))return window.BOOMR.snippetMethod="s",void t(o,"boomr-async");a=document.createElement("IFRAME"),a.src="about:blank",a.title="",a.role="presentation",a.loading="eager",i=(a.frameElement||a).style,i.width=0,i.height=0,i.border=0,i.display="none",o.appendChild(a);try{O=a.contentWindow,d=O.document.open()}catch(_){n=document.domain,a.src="javascript:var d=document.open();d.domain='"+n+"';void 0;",O=a.contentWindow,d=O.document.open()}if(n)d._boomrl=function(){this.domain=n,t()},d.write("<bo"+"dy onload='document._boomrl();'>");else if(O._boomrl=function(){t()},O.addEventListener)O.addEventListener("load",O._boomrl,!1);else if(O.attachEvent)O.attachEvent("onload",O._boomrl);d.close()}function a(e){window.BOOMR_onload=e&&e.timeStamp||(new Date).getTime()}if(!window.BOOMR||!window.BOOMR.version&&!window.BOOMR.snippetExecuted){window.BOOMR=window.BOOMR||{},window.BOOMR.snippetStart=(new Date).getTime(),window.BOOMR.snippetExecuted=!0,window.BOOMR.snippetVersion=14,window.BOOMR.url=n+"EVKJV-AGD2E-W66AE-NT84S-K5LTF";var i=document.currentScript||document.getElementsByTagName("script")[0],o=i.parentNode,r=!1,d=document.createElement("link");if(d.relList&&"function"==typeof d.relList.supports&&d.relList.supports("preload")&&"as"in d)window.BOOMR.snippetMethod="p",d.href=window.BOOMR.url,d.rel="preload",d.as="script",d.addEventListener("load",e),d.addEventListener("error",function(){t(!0)}),setTimeout(function(){if(!r)t(!0)},3e3),BOOMR_lstart=(new Date).getTime(),o.appendChild(d);else t(!1);if(window.addEventListener)window.addEventListener("load",a,!1);else if(window.attachEvent)window.attachEvent("onload",a)}}(),"".length>0)if(e&&"performance"in e&&e.performance&&"function"==typeof e.performance.setResourceTimingBufferSize)e.performance.setResourceTimingBufferSize();!function(){if(BOOMR=e.BOOMR||{},BOOMR.plugins=BOOMR.plugins||{},!BOOMR.plugins.AK){var n=""=="true"?1:0,t="",a="dbqoncfyk4sly2szrzpq-f-3829f04b7-clientnsv4-s.akamaihd.net",i="false"=="true"?2:1,o={"ak.v":"41","ak.cp":"1168236","ak.ai":parseInt("215853",10),"ak.ol":"0","ak.cr":41,"ak.ipv":4,"ak.proto":"h2","ak.rid":"1e1c9e2a","ak.r":40932,"ak.a2":n,"ak.m":"a","ak.n":"essl","ak.cport":43678,"ak.gh":"23.56.236.39","ak.quicv":"","ak.tlsv":"tls1.3","ak.0rtt":"","ak.0rtt.ed":"","ak.csrc":"-","ak.acc":"","ak.t":"1784254047","ak.ak":"hOBiQwZUYzCg5VSAfCLimQ==tM40sJZQUBAMudcwZaiXmojk4gg4at/XfidpILAIDbv87GHyi2xdLWDyL8rJcS7UhYQvtP2ar7/ghvl78A643W3WAER/9iWV3nNT/ZfXBaM1+9y8jx8KVI+pyCwDE/GMAN3gNv/svKrifDmjhVk082AtO2ajKIfDrbHJH4822oHOf/LEY02Do/yRGJvZJMPvQXunfhTh8V3E8SRU5t4ClLaWbFLnmdbcbtFwDqQNSCCM3V6T8Ph+Z7MtlnUpRdU4Gpw1jYoCsWDJ6a/KhV0sAaH4ZBuvRjbYxB1aNcY5ZlxxFhl4K4sQ+7YrKS6ogJJwwUSEPQdorYbbnmEjvVKlV3yiOmHrYpZkMvwGnvVdfIV0sGKw9FCiuA8e1YDCKR6c4M1QGSxMz9HqmM4wt9xuKjcqqxEoflfeYOJlDvBmcBw=","ak.pv":"93","ak.dpoabenc":"","ak.tf":i};if(""!==t)o["ak.ruds"]=t;var r={i:!1,av:function(n){var t="http.initiator";if(n&&(!n[t]||"spa_hard"===n[t]))o["ak.feo"]=void 0!==e.aFeoApplied?1:0,BOOMR.addVar(o)},rv:function(){var e=["ak.cport","ak.cr","ak.csrc","ak.gh","ak.ipv","ak.m","ak.n","ak.ol","ak.proto","ak.quicv","ak.tlsv","ak.0rtt","ak.0rtt.ed","ak.r","ak.acc","ak.t","ak.tf"];BOOMR.removeVar(e)}};BOOMR.plugins.AK={akVars:o,akDNSPreFetchDomain:a,init:function(){if(!r.i){var e=BOOMR.subscribe;e("before_beacon",r.av,null,null),e("onbeacon",r.rv,null,null),r.i=!0}return this},is_complete:function(){return!0}}}}()}(window);</script></head>
+
+  <script>
+
+    
+  //initialize tooltip
+  $(document).ready(function() {
+    //$("body").tooltip({ selector: '[data-toggle=tooltip]' });
+    $('[data-toggle="tooltip"]').tooltip();
+  });
+
+  $(document).ready(function() {
+    $( "#org_name" ).autocomplete({
+      source: '/team/search',
+      select: function( event, ui ) {
+        $("#org_id").val(ui.item.vid);
+        $("#id").val(ui.item.vid);
+        $('#sport_btn').click();
+      }
+    });
+  });
+
+  var body = 'body';
+
+  $.ajaxSetup ({
+    // Disable caching of AJAX responses
+    cache: false
+  });
+
+  function changeSport(field){
+    var el = $(field);
+    var tmList = el.parent().next().find('.new-team-year')[0];
+    if (tmList == null){
+      tmList = el.nextAll('.new-team-year')[0];
+    }
+    $.ajax({
+      url: "/game_sport_year_ctls/"+el.val()+"/available_teams",
+      dataType: "script",
+      success: function(data, status){
+        $(tmList).empty();
+        $(tmList).append(("<option value=''>Select team</option>"));
+        $.each(JSON.parse(data), function(k, v){
+          $(tmList).append($("<option></option>")
+              .attr("value", v["id"])
+              .text(v["member_org"]["name_tabular"]));
+        });
+        $(tmList).trigger("chosen:updated");
+      }
+    });
+  }
+
+    function set_process_styles(fld, start_color, end_color){
+       $('#'+fld).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    var downImage = "/assets/down12.gif";
+    var rightImage = "/assets/right12.gif";
+
+    function highlight(div_id){
+      $(div_id).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    function show_hide_rows(attr_val, link_id){
+      $('#'+attr_val).toggle();
+      if ($('#'+attr_val).is(':visible')) {
+        $('#'+link_id).attr('src', downImage);
+      }else{
+        $('#'+link_id).attr('src', rightImage);
+      }
+    }
+
+    function mask(label){
+      $('body').mask(label);
+    }
+    function unmask(){
+      $('body').unmask();
+    }
+
+    var winHeight = "auto";
+    var winWidth = "auto";
+    var maxHeight = 700;
+    var maxWidth = 1400;
+    var minHeight = 100;
+    var minWidth = 200;
+    
+    var modalOptions = {"width": winWidth,
+                        "height": winHeight,
+                        "maxHeight": maxHeight,
+                        "maxWidth": maxWidth,
+                        "minHeight": minHeight,
+                        "minWidth": minWidth};
+
+    function dialog(url, title){
+
+      $("#stats_app_dialog").dialog({modal:true, minWidth:minWidth, minHeight:minHeight, maxWidth:maxWidth, maxHeight:maxHeight, width:winWidth, height:winHeight, title:title, closeOnEscape: false});
+    
+      modalOptions.title = title;
+    
+      $("#stats_app_dialog").dialog("option", modalOptions);
+    
+      $("#stats_app_dialog").html("Loading...");
+      $("#stats_app_dialog").load(url).dialog('open');
+    }
+
+    function addDatePicker(){
+    $('.adddatepicker').each(function(i, obj){
+      $(obj).datepicker({ 
+        showOn: 'both', 
+        buttonImage: '/assets/calendar.gif', 
+        buttonImageOnly: true,
+      });
+    });
+    }
+
+   $(document).ready(function() {
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   });
+
+   function setClassInputFields(){
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   }
+
+   function isValidDateFormat(dateStr){
+     const regex = /^([1-9]|0[1-9]|1[0-2])\/([1-9]|0[1-9]|[12][0-9]|3[01])\/(19|20)\d{2}$/;
+     if (!regex.test(dateStr)) {
+       return false;
+     }else{
+       return true;
+     }
+   }
+
+  </script>
+
+
+<body style="font-size: .75rem;" onload="if (top != self) { top.location=self.location; }" >
+
+      <header>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0">
+        <a class="navbar-brand mr-0 mr-md-2" href="/" aria-label="statistics">
+                          <img alt="NCAA" style="margin-left: 24px; margin-right: 0; margin-top: 6px;" src="/assets/ncaa-fbc4d0406ae731b47babcc3fca53775b5955ef372bf8b8e998ca9a513e468b8f.svg" />
+                          <span class="title" class="dark-blue-font">Statistics</span>
+        </a>
+       </nav>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0" style="background-color: var(--color-dark-blue) !important;">
+  <button class="navbar-toggler bg-white" type="button" data-toggle="collapse" data-target="#navbarTogglerDemo01" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarTogglerDemo01">
+        <ul class="navbar-nav mr-auto mt-2 mt-lg-0 justify-content-center">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle skipMask" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Rankings
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+          <a class="dropdown-item" href="/rankings">National Rankings</a>
+          <a class="dropdown-item" href="/active_career_leaders">Active Career Leaders</a>
+        </div>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/contests/livestream_scoreboards">Scoreboard</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/selection_rankings/nitty_gritties">Selection Rankings</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/head_coaches">Head Coaches</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/search/players">Players</a>
+      </li>
+     </ul>
+
+    <form onsubmit="mask(&#39;Loading&#39;);" id="change_team_form" style="display:inline;" class="form-inline my-2 my-lg-0" action="/team/index" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="xv/qFU1Tdufyka323V4gSdBPfZtYcvkTr726e7pcAKtVZGJB728sskvYjli/79hHJLY7Pbutpi5GIH1puPpRFQ==" />
+  <div style="display:none;">
+  <input type="submit" name="commit" value="Submit" id="sport_btn" data-disable-with="Submit" />
+  </div>
+    <div id="team_autocomplete" class="ui-widget">
+      <input type="search" name="org_name" id="org_name" style="width:200px; font-size: 12px !important" class="form-control mr-sm-2" placeholder="Team Search" />
+      <input type="hidden" name="org_id" id="org_id" />
+    </div>
+</form>  </div>
+  </nav>
+</nav>
+      </header>
+
+       <div id="stats_app_dialog" style="display:none;">
+        </div>
+
+<div class="card p-1">
+  <div class="card-body application contests p-0">
+    <h3 class="card-title p-0"></h3>
+    <div class="container-fluid p-0">
+      <div class="row align-items-center justify-content-center p-0">
+        <div class="col-sm-12 p-0">
+          <br/>
+
+<br/>
+
+<style>
+.winner{
+  --display: flex;
+  vertical-align: middle;
+}
+.winner:before{
+  content: '\25BA';
+  --display: flex;
+  --align-items: center;
+  vertical-align: middle;
+}
+div.center {
+  margin: auto;
+  width: 50%;
+  --border: 3px solid green;
+  padding: 10px;
+}
+</style>
+
+   <div class="table-responsive">
+   <table align="center">
+     <tr>
+   <td>
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589196"><img class="large_logo_image" alt="Merrimack" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//410.gif" /></a>
+   </td>
+   <td valign="center" class="grey_text d-none d-sm-table-cell" nowrap>
+     <span style="font-size:18px">
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589196">Merrimack Warriors</a>
+     </span><br/>
+       0-1, Conf 0-0
+   </td>
+   <td valign="center" class="">
+   </td>
+   <td valign="center" style="font-size:36px; color: grey">
+     6
+   </td>
+     <td style="padding: 0px 30px 0px 30px"  class="d-none d-md-table-cell">
+       <table style="border-collapse: collapse">
+         <tr>
+           <td class="grey_border_bottom"></td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">1</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">2</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">3</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">4</td>
+           <td width="20px" align="right" style="font-weight:bold" class="grey_border_bottom">S</td>
+         </tr>
+           <tr>
+             <td>Merrimack</td>
+               <td class="grey_text" align="right">0</td>
+               <td class="grey_text" align="right">0</td>
+               <td class="grey_text" align="right">0</td>
+               <td class="grey_text" align="right">6</td>
+             <td align="right" style="font-weight:bold">6</td>
+           </tr>
+           <tr>
+             <td>Air Force</td>
+               <td class="grey_text" align="right">7</td>
+               <td class="grey_text" align="right">7</td>
+               <td class="grey_text" align="right">0</td>
+               <td class="grey_text" align="right">7</td>
+             <td align="right" style="font-weight:bold">21</td>
+           </tr>
+         <tr>
+           <td class="grey_text" colspan="6">08/31/2024 03:30 PM</td>
+         </tr>
+         <tr>
+           <td nowrap class="grey_text" colspan="6">Falcon Stadium (U.S. Air Force Academy, CO)</td>
+         </tr>
+         <tr>
+           <td nowrap class="grey_text" colspan="6">Attendance: 31,658</td>
+         </tr>
+       </table>
+     </td>
+   <td>
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589002"><img class="large_logo_image" alt="Air Force" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//721.gif" /></a>
+   </td>
+   <td valign="center" class="grey_text d-none d-sm-table-cell" nowrap>
+     <span style="font-size:18px">
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589002">Air Force Falcons</a>
+     </span><br/>
+       1-0, Conf 0-0
+   </td>
+   <td valign="center" class="winner">
+   </td>
+   <td valign="center" style="font-size:36px; color: black">
+     21
+   </td>
+     </tr>
+     <tr>
+       <td colspan="10" class="grey_border_bottom grey_border_top">
+         <table cellpadding="10px">
+           <tr>
+             <td style="font-size: 16px;"><a href="/contests/5362535/box_score">Box Score</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5362535/team_stats">Team Stats</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5362535/individual_stats">Individual Stats</a></td>
+             <td style="font-size: 16px;">Play By Play</td>
+             <td style="font-size: 16px;"><a href="/contests/5362535/drives">Drives</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5362535/officials">Officials</a></td>
+           </tr>
+         </table>
+       </td>
+     </tr>
+   </table>
+ </div>
+
+
+<br/>
+
+  <script>
+ $( function() {
+    $( ".drives" ).accordion({
+      collapsible: true,
+      heightStyle: "content",
+      header: "h5",
+      active: false
+    });
+  } );
+
+ function showScoringPlays(){
+   $('.non_scoring_play').hide();
+ }
+ function showAllPlays(){
+   $('.non_scoring_play').show();
+   $('.drives').accordion("refresh");
+   $('.drives').accordion("option", "active", false);
+ }
+</script>
+
+<style>
+ .ui-state-default, .ui-widget-content .ui-state-default, .ui-widget-header .ui-state-default {
+   overflow: auto;
+ }
+ .ui-state-default, .ui-widget-content .ui-state-default, .ui-widget-header .ui-state-default {
+    border: 1px solid #CCCCCC;
+    background: white;
+    background-image: none;
+    font-weight: normal;
+    color: #808080;
+}
+
+ .headerRight {
+  float: right;
+}
+.headerLeft {
+  float: left;
+}
+.under{
+text-decoration : underline;
+}
+</style>
+
+<div style="width: 50%; margin-left: auto; margin-right: auto;">
+  <div class="headerRight"><a class="skipMask" href="javascript:showAllPlays();">All Drives</a> | <a class="skipMask" href="javascript:showScoringPlays();">Scoring Drives</a></div>
+  <div style="border-bottom: 1px dotted #dcdddf;"><h1>1st Quarter</h1></div>
+<div class="drives">
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Merrimack" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//410.gif" /><span class='d-none d-sm-block'>Merrimack</span></div></div>
+        <div class="headerLeft">FUMB <br/><span style="font-size: 8px;">14:53,MC9, 4 plays, 29 yards, 02:00</span>
+        </div>
+        <div class="headerRight">0 - 0</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF35</br>
+         </span>
+         <span>
+           Tubbs,Reagan kickoff 65 yards to the MC00 Wadley,Donovan return 17 yards to the MC17 (Aihie,Osaro) PENALTY MC Personal Foul (Addo,Josh) 8 yards from MC17 to MC09.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC9</br>
+         </span>
+         <span>
+           Merrimack drive start at 14:53.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC9</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai rush left for 3 yards gain to the MC12 (Uyl,Grant).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at MC12</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai pass complete short left to McDonald,Jalen caught at MC09, for 4 yards to the MC16 (Santiago,David).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 3 at MC16</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Corbett,Jermaine rush middle for 3 yards loss to the MC13 (Santiago,David; Zdroik,Payton).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 6 at MC13</br>
+         </span>
+         <span>
+           Peterson,Cole punt 45 yards to the AF42 fair catch by Harris,Cade at AF42 PENALTY AF Personal Foul (Breier,Cameron) 15 yards from MC13 to MC28, 1ST DOWN. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC28</br>
+         </span>
+         <span>
+           No Huddle-Shotgun McCusker,Gavin rush left for 10 yards gain to the MC38 fumbled by McCusker,Gavin at MC36 forced by Santiago,David recovered by AF Uyl,Grant at MC38, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Air Force" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//721.gif" /><span class='d-none d-sm-block'>Air Force</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">12:53,MC38, 13 plays, 38 yards, 06:51</span>
+        </div>
+        <div class="headerRight">0 - 7</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC38</br>
+         </span>
+         <span>
+           Air Force drive start at 12:53.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC38</br>
+         </span>
+         <span>
+           No Huddle Carson,Dylan rush middle for 1 yard gain to the MC37 (Thompson,Jay).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 9 at MC37</br>
+         </span>
+         <span>
+           No Huddle Carson,Dylan rush middle for 1 yard loss to the MC38 fumbled by Carson,Dylan at MC38 recovered by AF Carson,Dylan at MC38, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 10 at MC38</br>
+         </span>
+         <span>
+           No Huddle Busha,John pass incomplete short middle thrown to MC35 broken up by Lenon,Nicholas QB hurried by Lenon,Nicholas.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 10 at MC38</br>
+         </span>
+         <span>
+           Busha,John pass complete short right to Smith,Quin caught at MC26, for 12 yards to the MC26, out of bounds at MC26, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC26</br>
+         </span>
+         <span>
+           Carson,Dylan rush middle for 4 yards gain to the MC22 (Roberts,Brandon).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 6 at MC22</br>
+         </span>
+         <span>
+           Carson,Dylan rush middle for 4 yards gain to the MC18 (Cooper,Rajahn).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at MC18</br>
+         </span>
+         <span>
+           Carson,Dylan rush middle for 2 yards gain to the MC16 (Cooper,Rajahn), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC16</br>
+         </span>
+         <span>
+           PENALTY MC Offside (Wilborn Jr.,James) 5 yards from MC16 to MC11. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 5 at MC11</br>
+         </span>
+         <span>
+           Carson,Dylan rush middle for 2 yards gain to the MC09 (Leavy,Tyler).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 3 at MC9</br>
+         </span>
+         <span>
+           (08:58) Carson,Dylan rush left for 2 yards gain to the MC07 (Rosemond Jr.,Garry).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at MC7</br>
+         </span>
+         <span>
+           Busha,John rush middle for 2 yards gain to the MC05 (Leavy,Tyler), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 5 at MC5</br>
+         </span>
+         <span>
+           Gist,Terrence rush middle for 1 yard gain to the MC04 (Sims,Kendal).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 4 at MC4</br>
+         </span>
+         <span>
+           (06:55) Busha,John rush right for 2 yards gain to the MC02 (Addo,Josh).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at MC2</br>
+         </span>
+         <span>
+           Harris,Cade rush left for 2 yards gain to the MC00 TOUCHDOWN, clock 06:02.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC3</br>
+         </span>
+         <span>
+           Dapore,Matthew kick attempt good (H: Bay,Carson, LS: Chesney,Kurt).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Merrimack" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//410.gif" /><span class='d-none d-sm-block'>Merrimack</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">06:02,MC25, 3 plays, -9 yards, 02:14</span>
+        </div>
+        <div class="headerRight">0 - 7</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF35</br>
+         </span>
+         <span>
+           Tubbs,Reagan kickoff 65 yards to the MC00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC25</br>
+         </span>
+         <span>
+           Merrimack drive start at 06:02.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai rush right for 0 yards to the MC25 (Goff,Camby).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at MC25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Corbett,Jermaine rush middle for 4 yards gain to the MC29 (Santiago,David; Bellamy,Jamari).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at MC29</br>
+         </span>
+         <span>
+           PENALTY MC False Start (Birdow,Cole) 5 yards from MC29 to MC24. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 11 at MC24</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai pass complete short left to Wadley,Donovan caught at MC21, for 7 yards to the MC31 (Aihie,Osaro) PENALTY MC UNS: Unsportsmanlike Conduct (Wadley,Donovan) 15 yards from MC31 to MC16.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 19 at MC16</br>
+         </span>
+         <span>
+           Peterson,Cole punt 58 yards to the AF26 Harris,Cade return 24 yards to the MC50 (Maryland,Nasir).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Air Force" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//721.gif" /><span class='d-none d-sm-block'>Air Force</span></div></div>
+        <div class="headerLeft">DOWNS <br/><span style="font-size: 8px;">03:48,MC50, 4 plays, 9 yards, 02:03</span>
+        </div>
+        <div class="headerRight">0 - 7</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC50</br>
+         </span>
+         <span>
+           Air Force drive start at 03:48.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC50</br>
+         </span>
+         <span>
+           No Huddle Calvert,Aiden rush left for 0 yards to the MC50 (Georges,Marc Christian).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at MC50</br>
+         </span>
+         <span>
+           Gist,Terrence rush middle for 4 yards gain to the MC46 (Sabri,Malek).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at MC46</br>
+         </span>
+         <span>
+           Busha,John pass complete short right to Frew,Kade caught at MC44, for 5 yards to the MC41 (Williams,Donte).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 1 at MC41</br>
+         </span>
+         <span>
+           No Huddle Calvert,Aiden rush right for 0 yards to the MC41 (Williams,Donte), out of bounds, TURNOVER ON DOWNS.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Merrimack" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//410.gif" /><span class='d-none d-sm-block'>Merrimack</span></div></div>
+        <div class="headerLeft">DOWNS <br/><span style="font-size: 8px;">01:45,MC41, 4 plays, 5 yards, 01:33</span>
+        </div>
+        <div class="headerRight">0 - 7</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC41</br>
+         </span>
+         <span>
+           Merrimack drive start at 01:45.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC41</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Corbett,Jermaine rush middle for 1 yard gain to the MC42 (Zdroik,Payton).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 9 at MC42</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai pass incomplete deep left to Wadley,Donovan thrown to AF36.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 9 at MC42</br>
+         </span>
+         <span>
+           PENALTY MC Delay Of Game  5 yards from MC42 to MC37. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 14 at MC37</br>
+         </span>
+         <span>
+           (01:05) No Huddle-Shotgun Anthony,Malakai pass complete short right to Mason,Jelani caught at MC50, for 13 yards to the MC50 (Gaillard, Jr.,Jerome).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 1 at MC50</br>
+         </span>
+         <span>
+           Timeout Merrimack, clock 00:24.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 1 at MC50</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai rush left for 4 yards loss to the MC46 (Zdroik,Payton), TURNOVER ON DOWNS.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Air Force" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//721.gif" /><span class='d-none d-sm-block'>Air Force</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">00:12,MC46, 3 plays, 4 yards, 01:04</span>
+        </div>
+        <div class="headerRight">0 - 7</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC46</br>
+         </span>
+         <span>
+           Air Force drive start at 00:12.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC46</br>
+         </span>
+         <span>
+           No Huddle Busha,John pass incomplete deep middle to Smith,Quin thrown to MC10.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at MC46</br>
+         </span>
+         <span>
+           No Huddle Frew,Kade rush left for 4 yards gain to the MC42 (Roberts,Brandon; Addo,Josh).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at MC42</br>
+         </span>
+         <span>
+           Start of 2nd quarter, clock 15:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at MC42</br>
+         </span>
+         <span>
+           No Huddle Frew,Kade rush middle for 0 yards to the MC42 (Lenon,Nicholas).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 6 at MC42</br>
+         </span>
+         <span>
+           Bay,Carson punt 42 yards to the MC00, Touchback, TURNOVER ON DOWNS.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+</div>
+  <div style="border-bottom: 1px dotted #dcdddf;"><h1>2nd Quarter</h1></div>
+<div class="drives">
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Merrimack" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//410.gif" /><span class='d-none d-sm-block'>Merrimack</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">14:08,MC20, 3 plays, 4 yards, 02:46</span>
+        </div>
+        <div class="headerRight">0 - 7</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC20</br>
+         </span>
+         <span>
+           Merrimack drive start at 14:08.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC20</br>
+         </span>
+         <span>
+           No Huddle-Shotgun McDonald,Jalen rush left for 3 yards gain to the MC23 (Uyl,Grant; Tomasi,James).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at MC23</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai pass complete short left to Corbett,Jermaine caught at MC20, for 1 yard to the MC24 (Bellamy,Jamari), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at MC24</br>
+         </span>
+         <span>
+           Timeout Merrimack, clock 12:39.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at MC24</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai rush right for 8 yards gain to the MC32 (Aihie,Osaro) PENALTY MC Holding (Smith,Brandon) 10 yards from MC24 to MC14. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 16 at MC14</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Corbett,Jermaine rush middle for 10 yards gain to the MC24 (Goff,Camby; Tuioti-Mariner,Lincoln).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 6 at MC24</br>
+         </span>
+         <span>
+           Peterson,Cole punt 48 yards to the AF28, out of bounds at AF28.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Air Force" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//721.gif" /><span class='d-none d-sm-block'>Air Force</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">11:22,AF28, 8 plays, 23 yards, 03:51</span>
+        </div>
+        <div class="headerRight">0 - 7</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF28</br>
+         </span>
+         <span>
+           Air Force drive start at 11:22.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF28</br>
+         </span>
+         <span>
+           Allen,Owen rush middle for 4 yards gain to the AF32 (Compoh,Jason).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 6 at AF32</br>
+         </span>
+         <span>
+           PENALTY MC Offside (Rufo,Adrian) 5 yards from AF32 to AF37. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 1 at AF37</br>
+         </span>
+         <span>
+           No Huddle Allen,Owen rush right for 1 yard gain to the AF38 (Sims,Kendal), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF38</br>
+         </span>
+         <span>
+           No Huddle Allen,Owen rush middle for 5 yards gain to the AF43 (Addo,Josh).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 5 at AF43</br>
+         </span>
+         <span>
+           Allen,Owen rush middle for 4 yards gain to the AF47 (Frazier,DJ).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at AF47</br>
+         </span>
+         <span>
+           Allen,Owen rush middle for 2 yards gain to the AF49 (Lenon,Nicholas; Matthews,Wes), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF49</br>
+         </span>
+         <span>
+           Gist,Terrence rush middle for 2 yards gain to the MC49 (Sims,Kendal).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 8 at MC49</br>
+         </span>
+         <span>
+           Busha,John pass incomplete short right to Fleischmann,Bruin thrown to MC45.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 8 at MC49</br>
+         </span>
+         <span>
+           Busha,John pass incomplete short left to Harris,Cade thrown to MC40 broken up by Rosemond Jr.,Garry.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 8 at MC49</br>
+         </span>
+         <span>
+           Bay,Carson punt 43 yards to the MC06 McDonald,Jalen return 5 yards to the MC11 fumbled by McDonald,Jalen at MC11 recovered by AF Brown,Levi at MC11, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Air Force" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//721.gif" /><span class='d-none d-sm-block'>Air Force</span></div></div>
+        <div class="headerLeft">FGA <br/><span style="font-size: 8px;">07:31,MC11, 4 plays, 2 yards, 01:50</span>
+        </div>
+        <div class="headerRight">0 - 7</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC11</br>
+         </span>
+         <span>
+           Air Force drive start at 07:31.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC11</br>
+         </span>
+         <span>
+           Allen,Owen rush middle for 3 yards gain to the MC08 (Hogan,Markieth; Lenon,Nicholas).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at MC8</br>
+         </span>
+         <span>
+           Allen,Owen rush middle for 3 yards gain to the MC05 (Jackson,Grant; Addo,Josh).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 4 at MC5</br>
+         </span>
+         <span>
+           Harris,Cade rush right for 4 yards loss to the MC09 (Jackson,Grant), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 8 at MC9</br>
+         </span>
+         <span>
+           Dapore,Matthew field goal attempt from 26 yards NO GOOD (H: Bay,Carson, LS: Chesney,Kurt), clock 05:41.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Merrimack" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//410.gif" /><span class='d-none d-sm-block'>Merrimack</span></div></div>
+        <div class="headerLeft">FGA <br/><span style="font-size: 8px;">05:41,MC20, 8 plays, 61 yards, 03:53</span>
+        </div>
+        <div class="headerRight">0 - 7</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC20</br>
+         </span>
+         <span>
+           Merrimack drive start at 05:41.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC20</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai rush right for 9 yards gain to the MC29 (Beard,K.C.; Uyl,Grant).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 1 at MC29</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Corbett,Jermaine rush middle for 33 yards gain to the AF38 (Brown,Levi), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF38</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai pass complete short left to McDonald,Jalen caught at AF42, for 7 yards to the AF31 (Santiago,David).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 3 at AF31</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai pass complete short left to Yocum,Ty caught at AF28, for 7 yards to the AF24 (Goff,Camby), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF24</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai rush right for 6 yards gain to the AF18 (Brown,Levi).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 4 at AF18</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai sacked for loss of 5 yards to the AF23 (Zdroik,Payton), fumble by Anthony,Malakai recovered by MC Anthony,Malakai at AF23, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 9 at AF23</br>
+         </span>
+         <span>
+           Timeout Other, clock 02:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 9 at AF23</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai pass complete short right to Corbett,Jermaine caught at AF28, for 4 yards to the AF19 (Uyl,Grant).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 5 at AF19</br>
+         </span>
+         <span>
+           Thai,Carlton field goal attempt from 36 yards NO GOOD (H: Peterson,Cole, LS: Smith,Christian), clock 01:48.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Air Force" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//721.gif" /><span class='d-none d-sm-block'>Air Force</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">01:48,AF20, 11 plays, 80 yards, 01:32</span>
+        </div>
+        <div class="headerRight">0 - 14</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF20</br>
+         </span>
+         <span>
+           Air Force drive start at 01:48.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF20</br>
+         </span>
+         <span>
+           No Huddle Harris,Cade rush right for 11 yards gain to the AF31 (Jordan III,Tre), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF31</br>
+         </span>
+         <span>
+           No Huddle Busha,John pass incomplete short right to Alexander,Kendin thrown to AF41.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at AF31</br>
+         </span>
+         <span>
+           Shotgun Busha,John pass complete short right to Harris,Cade caught at AF37, for 6 yards to the AF37, out of bounds at AF37.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 4 at AF37</br>
+         </span>
+         <span>
+           Shotgun Gist,Terrence rush middle for 4 yards gain to the AF41 (Frazier,DJ; Leavy,Tyler), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF41</br>
+         </span>
+         <span>
+           Shotgun Busha,John pass incomplete short right to Harris,Cade thrown to MC48 PENALTY MC Holding (Rosemond Jr.,Garry) 10 yards from AF41 to MC49, 1ST DOWN. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC49</br>
+         </span>
+         <span>
+           Shotgun Busha,John pass complete short right to Latham,Tylor caught at MC43, for 6 yards to the MC43 (Williams,Donte).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 4 at MC43</br>
+         </span>
+         <span>
+           Shotgun Busha,John pass complete deep right to Roberson,Tre caught at MC22, for 21 yards to the MC22, out of bounds at MC22, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC22</br>
+         </span>
+         <span>
+           Timeout Merrimack, clock 00:46.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC22</br>
+         </span>
+         <span>
+           No Huddle Busha,John pass incomplete deep middle to Alexander,Kendin thrown to MC00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at MC22</br>
+         </span>
+         <span>
+           Busha,John rush middle for 8 yards gain to the MC14 (Compoh,Jason).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at MC14</br>
+         </span>
+         <span>
+           Timeout Air Force, clock 00:37.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at MC14</br>
+         </span>
+         <span>
+           No Huddle Gist,Terrence rush middle for 6 yards gain to the MC08 (Compoh,Jason; Frazier,DJ), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 8 at MC8</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Busha,John rush left for 4 yards gain to the MC04 (Georges,Marc Christian).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 4 at MC4</br>
+         </span>
+         <span>
+           Timeout Air Force, clock 00:20.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 4 at MC4</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Harris,Cade rush left for 4 yards gain to the MC00 TOUCHDOWN, clock 00:16.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC3</br>
+         </span>
+         <span>
+           Dapore,Matthew kick attempt good (H: Bay,Carson, LS: Chesney,Kurt).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Merrimack" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//410.gif" /><span class='d-none d-sm-block'>Merrimack</span></div></div>
+        <div class="headerLeft">HALF <br/><span style="font-size: 8px;">00:09,MC28, 1 plays, 8 yards, 00:09</span>
+        </div>
+        <div class="headerRight">0 - 14</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF35</br>
+         </span>
+         <span>
+           Tubbs,Reagan kickoff 61 yards to the MC04 McDonald,Jalen return 24 yards to the MC28 (Gaillard, Jr.,Jerome).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC28</br>
+         </span>
+         <span>
+           Merrimack drive start at 00:09.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC28</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Corbett,Jermaine rush middle for 8 yards gain to the MC36 (Uyl,Grant; Adams,Jackson).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 2 at MC36</br>
+         </span>
+         <span>
+           End of game, clock 00:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC35</br>
+         </span>
+         <span>
+           AF will receive; MC will defend South end-zone.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC35</br>
+         </span>
+         <span>
+           Start of 3rd quarter, clock 15:00.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+</div>
+  <div style="border-bottom: 1px dotted #dcdddf;"><h1>3rd Quarter</h1></div>
+<div class="drives">
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Air Force" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//721.gif" /><span class='d-none d-sm-block'>Air Force</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">15:00,AF25, 3 plays, 3 yards, 01:30</span>
+        </div>
+        <div class="headerRight">0 - 14</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC35</br>
+         </span>
+         <span>
+           Thai,Carlton kickoff 65 yards to the AF00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF25</br>
+         </span>
+         <span>
+           Air Force drive start at 15:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF25</br>
+         </span>
+         <span>
+           No Huddle Gist,Terrence rush middle for 1 yard gain to the AF26 (Leavy,Tyler).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 9 at AF26</br>
+         </span>
+         <span>
+           Gist,Terrence rush left for 2 yards gain to the AF28 (Frazier,DJ; Sims,Kendal).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 7 at AF28</br>
+         </span>
+         <span>
+           Shotgun Busha,John pass incomplete short left to Harris,Cade thrown to AF34.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 7 at AF28</br>
+         </span>
+         <span>
+           Freer,Luke punt 45 yards to the MC27 Rosemond Jr.,Garry return 10 yards to the MC37 (Burr,Are&#39;an), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Merrimack" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//410.gif" /><span class='d-none d-sm-block'>Merrimack</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">13:30,MC37, 5 plays, 2 yards, 03:16</span>
+        </div>
+        <div class="headerRight">0 - 14</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC37</br>
+         </span>
+         <span>
+           Merrimack drive start at 13:30.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC37</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai rush middle for 3 yards gain to the MC40 (Goff,Camby; Bellamy,Jamari).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at MC40</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai pass incomplete deep middle to Sweitzer,Seth thrown to AF37.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 7 at MC40</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai sacked for loss of 10 yards to the MC30 (Uyl,Grant) PENALTY AF Holding (Bellamy,Jamari) 10 yards from MC40 to MC50, 1ST DOWN. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC50</br>
+         </span>
+         <span>
+           Timeout Other, clock 12:28.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC50</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Corbett,Jermaine rush left for 0 yards to the MC50 (Adams,Jackson) PENALTY MC Holding (Johnson,Amir) 10 yards from MC50 to MC40. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 20 at MC40</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai pass complete short left to Dunn,Jared caught at MC35, for 0 yards to the MC40 (Williams,Trey).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 20 at MC40</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai pass complete short right to McDonald,Jalen caught at MC39, for 9 yards to the MC49 (Brown,Levi).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 11 at MC49</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai pass incomplete short right to Corbett,Jermaine thrown to AF49.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 11 at MC49</br>
+         </span>
+         <span>
+           Peterson,Cole punt 49 yards to the AF02 PENALTY MC Holding (Maryland,Nasir) 10 yards from MC49 to MC39. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 21 at MC39</br>
+         </span>
+         <span>
+           Peterson,Cole punt 47 yards to the AF14 fair catch by Harris,Cade at AF14.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Air Force" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//721.gif" /><span class='d-none d-sm-block'>Air Force</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">10:14,AF14, 3 plays, 1 yards, 01:23</span>
+        </div>
+        <div class="headerRight">0 - 14</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF14</br>
+         </span>
+         <span>
+           Air Force drive start at 10:14.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 12 at AF12</br>
+         </span>
+         <span>
+           Timeout Other, clock 10:14.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF14</br>
+         </span>
+         <span>
+           Harris,Cade rush right for 2 yards loss to the AF12 (Nichols,Jabari).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 12 at AF12</br>
+         </span>
+         <span>
+           Busha,John pass incomplete short right to Smith,Quin thrown to AF23.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 12 at AF12</br>
+         </span>
+         <span>
+           Gist,Terrence rush right for 3 yards gain to the AF15 (Cooper,Rajahn).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 9 at AF15</br>
+         </span>
+         <span>
+           Freer,Luke punt 54 yards to the MC31 Rosemond Jr.,Garry return 12 yards to the MC43 (Martin,Jake; Beard,K.C.).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Merrimack" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//410.gif" /><span class='d-none d-sm-block'>Merrimack</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">08:51,MC43, 9 plays, 23 yards, 04:46</span>
+        </div>
+        <div class="headerRight">0 - 14</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC43</br>
+         </span>
+         <span>
+           Merrimack drive start at 08:51.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at MC43</br>
+         </span>
+         <span>
+           Timeout Other, clock 08:51.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC43</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai pass incomplete deep right to Corbett,Jermaine thrown to AF35 broken up by Santiago,David.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at MC43</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai pass complete short left to Corbett,Jermaine caught at MC36, for 0 yards to the MC43 (Aihie,Osaro).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 10 at MC43</br>
+         </span>
+         <span>
+           Timeout Merrimack, clock 08:07.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 10 at MC43</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai pass complete short right to Wadley,Donovan caught at AF44, for 13 yards to the AF44 (Tuioti-Mariner,Lincoln), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF44</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Corbett,Jermaine rush middle for 4 yards gain to the AF40 (Bellamy,Jamari).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 6 at AF40</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai rush right for 4 yards gain to the AF36 (Aihie,Osaro).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at AF36</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Corbett,Jermaine rush middle for 2 yards gain to the AF34 (Goff,Camby; Swartz,Aiden), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF34</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Latham,Matthias rush middle for 2 yards gain to the AF32 (Santiago,David; Aihie,Osaro).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 8 at AF32</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai rush right for 2 yards loss to the AF34 (Bellamy,Jamari).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 10 at AF34</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai pass incomplete short right to Corbett,Jermaine thrown to AF15 QB hurried by Uyl,Grant.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 10 at AF34</br>
+         </span>
+         <span>
+           Peterson,Cole punt 31 yards to the AF03, TURNOVER ON DOWNS.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Air Force" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//721.gif" /><span class='d-none d-sm-block'>Air Force</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">04:05,AF3, 10 plays, 53 yards, 06:31</span>
+        </div>
+        <div class="headerRight">0 - 14</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF3</br>
+         </span>
+         <span>
+           Air Force drive start at 04:05.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 8 at AF5</br>
+         </span>
+         <span>
+           Timeout Other, clock 04:05.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF3</br>
+         </span>
+         <span>
+           Gist,Terrence rush middle for 2 yards gain to the AF05 (Sims,Kendal).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 8 at AF5</br>
+         </span>
+         <span>
+           Gist,Terrence rush middle for 4 yards gain to the AF09 (Warrick,Bryce).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 4 at AF9</br>
+         </span>
+         <span>
+           Busha,John rush middle for 5 yards gain to the AF14, out of bounds at AF14, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF14</br>
+         </span>
+         <span>
+           Busha,John rush right for 2 yards gain to the AF16 (Williams,Donte).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 8 at AF16</br>
+         </span>
+         <span>
+           Busha,John pass complete short left to Calvert,Aiden caught at AF21, for 21 yards to the AF37 (Rosemond Jr.,Garry), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF37</br>
+         </span>
+         <span>
+           Allen,Owen rush middle for 9 yards gain to the AF46 (Hogan,Markieth; Matthews,Wes).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 1 at AF46</br>
+         </span>
+         <span>
+           Allen,Owen rush middle for 5 yards gain to the MC49 (Jordan III,Tre), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC49</br>
+         </span>
+         <span>
+           Start of 4th quarter, clock 15:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC49</br>
+         </span>
+         <span>
+           Allen,Owen rush middle for 3 yards gain to the MC46 (Thompson,Jay).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at MC46</br>
+         </span>
+         <span>
+           Allen,Owen rush left for 6 yards gain to the MC40 (Palanica Jr.,Nate; Cooper,Rajahn) PENALTY AF Holding (Lawrence,Tyler) 10 yards from MC46 to AF44. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 17 at AF44</br>
+         </span>
+         <span>
+           Shotgun Busha,John rush middle for 11 yards gain to the MC45 (Matthews,Wes).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at MC45</br>
+         </span>
+         <span>
+           Shotgun Allen,Owen rush middle for 1 yard gain to the MC44 (Thompson,Jay).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 5 at MC44</br>
+         </span>
+         <span>
+           Bay,Carson punt 34 yards to the MC10 fair catch by Rosemond Jr.,Garry at MC10.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+</div>
+  <div style="border-bottom: 1px dotted #dcdddf;"><h1>4th Quarter</h1></div>
+<div class="drives">
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Merrimack" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//410.gif" /><span class='d-none d-sm-block'>Merrimack</span></div></div>
+        <div class="headerLeft">FUMB <br/><span style="font-size: 8px;">12:34,MC10, 3 plays, 9 yards, 00:51</span>
+        </div>
+        <div class="headerRight">0 - 14</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC10</br>
+         </span>
+         <span>
+           Merrimack drive start at 12:34.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 5 at MC15</br>
+         </span>
+         <span>
+           Timeout Other, clock 12:34.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC10</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai rush left for 5 yards gain to the MC15, out of bounds at MC15.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 5 at MC15</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai pass incomplete short right to Corbett,Jermaine thrown to MC10.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 5 at MC15</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai pass complete short left to Corbett,Jermaine caught at MC15, for 4 yards to the MC19 fumbled by Corbett,Jermaine at MC19 forced by Uyl,Grant recovered by AF Fisher,Luke at MC19 Fisher,Luke return 5 yards to the MC14, out of bounds at MC14.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Air Force" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//721.gif" /><span class='d-none d-sm-block'>Air Force</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">11:43,MC14, 6 plays, 14 yards, 03:12</span>
+        </div>
+        <div class="headerRight">0 - 21</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC14</br>
+         </span>
+         <span>
+           Air Force drive start at 11:43.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC14</br>
+         </span>
+         <span>
+           Shotgun Allen,Owen rush left for 4 yards gain to the MC10 (Jordan III,Tre; Frazier,DJ).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 6 at MC10</br>
+         </span>
+         <span>
+           Shotgun Allen,Owen rush middle for 5 yards gain to the MC05 (Leavy,Tyler; Sims,Kendal).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at MC5</br>
+         </span>
+         <span>
+           Shotgun Busha,John rush middle for 0 yards to the MC05 (Compoh,Jason).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 1 at MC5</br>
+         </span>
+         <span>
+           Shotgun Busha,John rush middle for 3 yards gain to the MC02 (Frazier,DJ), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 2 at MC2</br>
+         </span>
+         <span>
+           Shotgun Allen,Owen rush left for 1 yard gain to the MC01 (Sims,Kendal).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 1 at MC1</br>
+         </span>
+         <span>
+           Shotgun Calvert,Aiden rush right for 1 yard gain to the MC00 TOUCHDOWN, clock 08:31.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC3</br>
+         </span>
+         <span>
+           Dapore,Matthew kick attempt good (H: Bay,Carson, LS: Chesney,Kurt).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC25</br>
+         </span>
+         <span>
+           Timeout Other, clock 08:31.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Merrimack" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//410.gif" /><span class='d-none d-sm-block'>Merrimack</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">08:31,MC25, 3 plays, 5 yards, 01:34</span>
+        </div>
+        <div class="headerRight">0 - 21</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF35</br>
+         </span>
+         <span>
+           Tubbs,Reagan kickoff 65 yards to the MC00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC25</br>
+         </span>
+         <span>
+           Merrimack drive start at 08:31.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai pass complete short right to Wadley,Donovan caught at MC20, for 3 yards loss to the MC22 (Sanders,Elijah).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 13 at MC22</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai pass complete short left to McDonald,Jalen caught at MC28, for 8 yards to the MC30, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 5 at MC30</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Anthony,Malakai pass incomplete short middle to Mason,Jelani thrown to MC35 QB hurried by Adams,Jackson.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 5 at MC30</br>
+         </span>
+         <span>
+           Peterson,Cole punt 68 yards to the AF02, TURNOVER ON DOWNS.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Air Force" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//721.gif" /><span class='d-none d-sm-block'>Air Force</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">06:57,AF2, 5 plays, 25 yards, 03:17</span>
+        </div>
+        <div class="headerRight">0 - 21</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF2</br>
+         </span>
+         <span>
+           Air Force drive start at 06:57.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 5 at AF7</br>
+         </span>
+         <span>
+           Timeout Other, clock 06:57.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF2</br>
+         </span>
+         <span>
+           PENALTY MC Offside (Thompson,Jay) 5 yards from AF02 to AF07. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 5 at AF7</br>
+         </span>
+         <span>
+           Allen,Owen rush middle for 3 yards gain to the AF10 (Hogan,Markieth; Palanica Jr.,Nate).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 2 at AF10</br>
+         </span>
+         <span>
+           Allen,Owen rush left for 10 yards gain to the AF20 (Palanica Jr.,Nate), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF20</br>
+         </span>
+         <span>
+           Timeout Air Force, clock 05:29.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF20</br>
+         </span>
+         <span>
+           No Huddle Stone,Darius rush middle for 3 yards gain to the AF23 (Addo,Josh; Johnson,Cidney).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at AF23</br>
+         </span>
+         <span>
+           Stone,Darius rush left for 4 yards gain to the AF27 (Matthews,Wes).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 3 at AF27</br>
+         </span>
+         <span>
+           Stone,Darius rush left for 0 yards to the AF27 (Matthews,Wes).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 3 at AF27</br>
+         </span>
+         <span>
+           Timeout Merrimack, clock 03:54.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 3 at AF27</br>
+         </span>
+         <span>
+           Bay,Carson punt 37 yards to the MC36 McDonald,Jalen return 14 yards to the MC50 (Williams,Trey), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Merrimack" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//410.gif" /><span class='d-none d-sm-block'>Merrimack</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">03:40,MC50, 15 plays, 50 yards, 03:40</span>
+        </div>
+        <div class="headerRight">6 - 21</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC50</br>
+         </span>
+         <span>
+           Merrimack drive start at 03:40.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at MC50</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Pereira,Ayden pass incomplete short middle to Robinson,LJ thrown to AF35.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at MC50</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Pereira,Ayden pass complete short right to Latham,Matthias caught at MC45, for 8 yards to the AF42 (Johnson,Korey).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at AF42</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Pereira,Ayden rush right for 1 yard gain to the AF41 (Collins,Tyme).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 1 at AF41</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Latham,Matthias rush middle for 2 yards gain to the AF39 (Tillett,Andrew), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF39</br>
+         </span>
+         <span>
+           Timeout Other, clock 02:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF39</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Pereira,Ayden rush right for 8 yards gain to the AF31 (Sanders,Elijah).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 2 at AF31</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Pereira,Ayden pass incomplete short left to Palmer,Austin thrown to AF25.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at AF31</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Pereira,Ayden pass complete short right to Robinson,LJ caught at AF25, for 10 yards to the AF21 (Chen ,Kyle), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF21</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Pereira,Ayden pass incomplete short right to Robinson,LJ thrown to AF13.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at AF21</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Latham,Matthias rush middle for 4 yards gain to the AF17 (Fisher,Luke; Whitson,Brody).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at AF17</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Pereira,Ayden rush middle for 4 yards gain to the AF13 (Fisher,Luke).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 2 at AF13</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Pereira,Ayden rush middle for 2 yards gain to the AF11 (Whitson,Brody), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF11</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Pereira,Ayden pass incomplete short right to Latham,Matthias thrown to AF13.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at AF11</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Pereira,Ayden pass incomplete short middle to Latham,Matthias thrown to AF02 broken up by Burr,Are&#39;an QB hurried by Rawls, Jr.,Lukia .</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 10 at AF11</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Pereira,Ayden pass incomplete short left to Palmer,Austin thrown to AF06.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 10 at AF11</br>
+         </span>
+         <span>
+           Timeout Merrimack, clock 00:05.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 10 at AF11</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Pereira,Ayden pass complete short left to McDonald,Jalen caught at AF00, for 11 yards to the AF00 TOUCHDOWN, clock 00:00, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AF3</br>
+         </span>
+         <span>
+           End of game, clock 00:00.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+</div>
+</div>
+
+
+
+       </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<footer>&copy; <script>document.write(new Date().getFullYear())</script> NCAA <a href="http://web1.ncaa.org/web_files/terms_and_conditions.html" title ="Terms and Conditions" target=_blank>Terms and Conditions</a> | <a href="http://web1.ncaa.org/web_files/privacy.html" target=_blank title="Our Privacy Policy">Privacy Policy</a> | <a href="mailto:ncaa_stats@ncaa.org">Contact Us</a> </footer>
+
+  <!-- /.container -->
+  <script type="text/javascript"  src="/sU0joiPwv/zplvN/xFxji/wmgXJnBU/whimQww3k9OS/ZXgTG2MrBg/aXhXG2U/odkBZ?v=4752dac2-e726-7b12-e178-753af62b1738" defer></script></body>
+
+  <script charset="utf-8">
+    $(document).ready(function() {
+      $('a.remote[data-toggle="tab"]').on('show.bs.tab', function (e) {
+        var tab_id = '#' + $(this).attr('aria-controls');
+        $(tab_id).html('<br/><br/><p style="text-align: center"><img style="vertical-align:middle; text-align: center" src="/assets/ajax-loader-6913acdbf4be7d6a2908a84bdecd6cad18110f5fc6d5a07cf8c9ce78d9548700.gif" /> Loading... </p><br/><br/>');
+        $.get($(this).data('remote'), function(data){
+          $(tab_id).html(data);
+        });
+      });
+    });
+
+    function skipMask(obj){
+      if (obj.hasClass('chosen-single') || obj.hasClass('skipMask') || obj.hasClass('ui-datepicker-prev') || obj.hasClass('ui-datepicker-next') || obj.hasClass('ui-corner-all') || obj.hasClass('paginate_button') || obj.hasClass('dt-button')){
+        return true;
+      }else{
+        return false;
+      }
+    }
+
+    $(document).ajaxComplete(function(){
+      unmask();
+    });
+/*
+    $("form").on('submit', function(event){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    */
+    $(document).on('click', 'a', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    $(document).on('click', 'input.green', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+
+  </script>
+</html>


### PR DESCRIPTION
## What

Graduates the **stats.ncaa.org college-football play-by-play parser** from the
`ncaa-mfb-hoops-raw` producer repo into the library as
`sportsdataverse/cfb/cfb_ncaa_pbp.py`, exposing `parse_cfb_ncaa_pbp(html, contest_id=None, *, return_as_pandas=False)`.

The `cfb/` namespace now holds both providers for college football — ESPN
(`cfb_espn_ext` / `cfb_pbp`) and stats.ncaa.org (`cfb_ncaa_pbp`) — mirroring how
`mbb/` holds both `mbb_espn_ext` and the `mbb_ncaa_*` surface.

## Parser

One row per play, cfbfastR-style, from the `div.drives` markup:

- **Drive context** — `drive_number`, `offense`, `drive_result`, `drive_scored`
- **Situation** — `down`, `distance`, `yard_line` (+ `yard_line_side`/`_number`), `end_yard_line`
- **Classification** — `play_type` (rush/pass/kickoff/punt/field_goal/extra_point/two_point/sack/kneel/penalty/drive_start/period_marker/timeout/coin_toss); **0 unknowns** across all fixtures
- **Players** — `passer`, `rusher`, `receiver`, `kicker`, `punter`, `returner`, `tackler_1`/`tackler_2` (suffix-safe "Last,First" names, assisted-tackle split)
- **Detail** — `run_direction`, `pass_complete`/`_depth`/`_direction`, `yards_gained` (signed), `kick_yards`/`return_yards`/`punt_yards`/`fg_distance`/`fg_made`
- **Flags** — `is_first_down`, `is_touchdown`, `is_safety`, `is_fumble`, `is_turnover` (+`turnover_type`), `out_of_bounds`, `no_play`, `fair_catch`, `penalty_flag` (+team/type/player/yards)
- **`qb_scramble`** — derived frame-wide (NCAA text does not label scrambles): a rush by a player who also passes in the game
- Raw `play_text` retained; empty/unparseable input returns the documented **zero-row schema**.

## Provenance & scope

Original sdv-py code. The HTML it consumes is the Akamai-`bm-verify`-gated
`/contests/{id}/play_by_play` page, fetched by the browser transport already
shipped in `mbb_ncaa_fetch` (patchright + `--headless=new` + residential IP —
#271, rotation #276). **Discovery/capture stay producer concerns** in
`ncaa-mfb-hoops-raw`, mirroring the MBB NCAA split (the library owns the parser).

## Tests / gates

- `tests/cfb/test_cfb_ncaa_pbp.py` — **21 offline tests** on **3 real captured games**
  (schema stability, empty-input contract, down/distance/yard-line, 0-unknown
  classification, player/direction/yardage lifts, flags, `qb_scramble`, pandas
  round-trip, cross-game generalization).
- Fully typed; added to the `[tool.mypy] files` ratchet. `ruff` clean.
- Registered in the `cfb` wildcard export + regenerated `parsed/cfb.py` passthrough.
