### PR TITLE
feat(mbb,wbb): add loaders for the 4 published model dataset releases

### DIFF
--- a/docs/docs/mbb/index.md
+++ b/docs/docs/mbb/index.md
@@ -9,7 +9,7 @@ sidebar_label: MBB
 | [ESPN site API (v2)](reference/site) | 25 | `https://site.api.espn.com/apis/site/v2/sports` |
 | [ESPN web API (v3)](reference/web) | 5 | `https://site.web.api.espn.com/apis/common/v3/sports` |
 | [ESPN core API (v2)](reference/core) | 86 | `https://sports.core.api.espn.com/v2/sports` |
-| [Dataset loaders](reference/loaders) | 11 | sportsdataverse-data releases |
+| [Dataset loaders](reference/loaders) | 13 | sportsdataverse-data releases |
 | [Additional functions](reference/additional) | 304 | hand-written wrappers, loaders & helpers |
 
 ## Examples

--- a/docs/docs/mbb/reference/loaders.md
+++ b/docs/docs/mbb/reference/loaders.md
@@ -18,6 +18,8 @@ flowchart LR
 | `load_mbb_player_boxscore` | [espn_mens_college_basketball_player_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_mens_college_basketball_player_boxscores) | — |
 | `load_mbb_schedule` | [espn_mens_college_basketball_schedules](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_mens_college_basketball_schedules) | — |
 | `load_mbb_team_boxscore` | [espn_mens_college_basketball_team_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_mens_college_basketball_team_boxscores) | — |
+| `load_mbb_ratings` | [mbb_ratings](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/mbb_ratings) | — |
+| `load_mbb_player_value` | [mbb_player_value](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/mbb_player_value) | — |
 | `load_mbb_shots` | [espn_mens_college_basketball_shots](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_mens_college_basketball_shots) | — |
 | `load_mbb_standings` | [espn_mens_college_basketball_standings](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_mens_college_basketball_standings) | — |
 | `load_mbb_player_season_stats` | [espn_mens_college_basketball_player_season_stats](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_mens_college_basketball_player_season_stats) | — |
@@ -313,6 +315,49 @@ Release: [espn_mens_college_basketball_team_boxscores](https://github.com/sports
 
 ```python
 load_mbb_team_boxscore(seasons=2024)
+```
+
+## `load_mbb_ratings`
+
+Release: [mbb_ratings](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/mbb_ratings) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/mbb_ratings/mbb_ratings_{season}.parquet`
+### Returns
+
+| col_name | type |
+|---|---|
+| `season` | Int64 |
+| `team_id` | String |
+| `adj_o` | Float64 |
+| `adj_d` | Float64 |
+| `adj_em` | Float64 |
+| `adj_tempo` | Float64 |
+| `raw_o` | Float64 |
+| `raw_d` | Float64 |
+| `games` | Int64 |
+| `rank` | Int64 |
+| `adj_em_z` | Float64 |
+
+```python
+load_mbb_ratings(seasons=2025)
+```
+
+## `load_mbb_player_value`
+
+Release: [mbb_player_value](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/mbb_player_value) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/mbb_player_value/mbb_player_value_{season}.parquet`
+### Returns
+
+| col_name | type |
+|---|---|
+| `player_id` | String |
+| `player` | String |
+| `season` | Int64 |
+| `team_id` | String |
+| `min` | Float64 |
+| `box_obpm` | Float64 |
+| `box_dbpm` | Float64 |
+| `box_bpm` | Float64 |
+
+```python
+load_mbb_player_value(seasons=2025)
 ```
 
 ## `load_mbb_shots`

--- a/docs/docs/wbb/index.md
+++ b/docs/docs/wbb/index.md
@@ -9,7 +9,7 @@ sidebar_label: WBB
 | [ESPN site API (v2)](reference/site) | 25 | `https://site.api.espn.com/apis/site/v2/sports` |
 | [ESPN web API (v3)](reference/web) | 5 | `https://site.web.api.espn.com/apis/common/v3/sports` |
 | [ESPN core API (v2)](reference/core) | 85 | `https://sports.core.api.espn.com/v2/sports` |
-| [Dataset loaders](reference/loaders) | 11 | sportsdataverse-data releases |
+| [Dataset loaders](reference/loaders) | 13 | sportsdataverse-data releases |
 | [Additional functions](reference/additional) | 281 | hand-written wrappers, loaders & helpers |
 
 ## Examples

--- a/docs/docs/wbb/reference/loaders.md
+++ b/docs/docs/wbb/reference/loaders.md
@@ -18,6 +18,8 @@ flowchart LR
 | `load_wbb_player_boxscore` | [espn_womens_college_basketball_player_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_womens_college_basketball_player_boxscores) | — |
 | `load_wbb_schedule` | [espn_womens_college_basketball_schedules](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_womens_college_basketball_schedules) | — |
 | `load_wbb_team_boxscore` | [espn_womens_college_basketball_team_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_womens_college_basketball_team_boxscores) | — |
+| `load_wbb_ratings` | [wbb_ratings](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wbb_ratings) | — |
+| `load_wbb_player_value` | [wbb_player_value](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wbb_player_value) | — |
 | `load_wbb_game_rosters` | [espn_womens_college_basketball_game_rosters](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_womens_college_basketball_game_rosters) | — |
 | `load_wbb_officials` | [espn_womens_college_basketball_officials](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_womens_college_basketball_officials) | — |
 | `load_wbb_player_season_stats` | [espn_womens_college_basketball_player_season_stats](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_womens_college_basketball_player_season_stats) | — |
@@ -311,6 +313,49 @@ Release: [espn_womens_college_basketball_team_boxscores](https://github.com/spor
 
 ```python
 load_wbb_team_boxscore(seasons=2024)
+```
+
+## `load_wbb_ratings`
+
+Release: [wbb_ratings](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wbb_ratings) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/wbb_ratings/wbb_ratings_{season}.parquet`
+### Returns
+
+| col_name | type |
+|---|---|
+| `season` | Int64 |
+| `team_id` | String |
+| `adj_o` | Float64 |
+| `adj_d` | Float64 |
+| `adj_em` | Float64 |
+| `adj_tempo` | Float64 |
+| `raw_o` | Float64 |
+| `raw_d` | Float64 |
+| `games` | Int64 |
+| `rank` | Int64 |
+| `adj_em_z` | Float64 |
+
+```python
+load_wbb_ratings(seasons=2025)
+```
+
+## `load_wbb_player_value`
+
+Release: [wbb_player_value](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wbb_player_value) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/wbb_player_value/wbb_player_value_{season}.parquet`
+### Returns
+
+| col_name | type |
+|---|---|
+| `player_id` | String |
+| `player` | String |
+| `season` | Int64 |
+| `team_id` | String |
+| `min` | Float64 |
+| `box_obpm` | Float64 |
+| `box_dbpm` | Float64 |
+| `box_bpm` | Float64 |
+
+```python
+load_wbb_player_value(seasons=2025)
 ```
 
 ## `load_wbb_game_rosters`

--- a/sportsdataverse/mbb/mbb_loaders.py
+++ b/sportsdataverse/mbb/mbb_loaders.py
@@ -18,6 +18,8 @@ __all__ = [
     "load_mbb_player_boxscore",
     "load_mbb_schedule",
     "load_mbb_team_boxscore",
+    "load_mbb_ratings",
+    "load_mbb_player_value",
     "load_mbb_shots",
     "load_mbb_standings",
     "load_mbb_player_season_stats",
@@ -423,6 +425,105 @@ def load_mbb_team_boxscore(seasons, return_as_pandas: bool = False):
         frames.append(df)
     if missing:
         cli_warn("load_mbb_team_boxscore: no data for season(s) {missing} (skipped)".format(missing=missing))
+    # diagonal: per-season release schemas can drift (columns added/dropped
+    # over the years) -- union columns, null-fill gaps.
+    out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
+
+
+def load_mbb_ratings(seasons, return_as_pandas: bool = False):
+    """Load mbb_ratings (sportsdataverse-data release).
+
+    Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/mbb_ratings
+
+    Args:
+        seasons: an int or iterable of seasons (>= 2006).
+        return_as_pandas: return a pandas DataFrame instead of polars.
+
+    Returns:
+        A polars (or pandas) DataFrame; seasons with no published asset are
+        skipped with a warning rather than raising (404-safe).
+
+        |col_name  |type    |
+        |:---------|:-------|
+        |season    |Int64   |
+        |team_id   |String  |
+        |adj_o     |Float64 |
+        |adj_d     |Float64 |
+        |adj_em    |Float64 |
+        |adj_tempo |Float64 |
+        |raw_o     |Float64 |
+        |raw_d     |Float64 |
+        |games     |Int64   |
+        |rank      |Int64   |
+        |adj_em_z  |Float64 |
+
+    Example:
+        Quick start::
+
+            load_mbb_ratings(seasons=2025)
+    """
+    frames, missing = [], []
+    for season in _as_season_list(seasons):
+        if int(season) < 2006:
+            raise SeasonNotFoundError("season cannot be less than 2006")
+        df = _read_release_parquet(
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/mbb_ratings/mbb_ratings_{season}.parquet"
+        )
+        if df is None:
+            missing.append(season)
+            continue
+        frames.append(df)
+    if missing:
+        cli_warn("load_mbb_ratings: no data for season(s) {missing} (skipped)".format(missing=missing))
+    # diagonal: per-season release schemas can drift (columns added/dropped
+    # over the years) -- union columns, null-fill gaps.
+    out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
+
+
+def load_mbb_player_value(seasons, return_as_pandas: bool = False):
+    """Load mbb_player_value (sportsdataverse-data release).
+
+    Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/mbb_player_value
+
+    Args:
+        seasons: an int or iterable of seasons (>= 2006).
+        return_as_pandas: return a pandas DataFrame instead of polars.
+
+    Returns:
+        A polars (or pandas) DataFrame; seasons with no published asset are
+        skipped with a warning rather than raising (404-safe).
+
+        |col_name  |type    |
+        |:---------|:-------|
+        |player_id |String  |
+        |player    |String  |
+        |season    |Int64   |
+        |team_id   |String  |
+        |min       |Float64 |
+        |box_obpm  |Float64 |
+        |box_dbpm  |Float64 |
+        |box_bpm   |Float64 |
+
+    Example:
+        Quick start::
+
+            load_mbb_player_value(seasons=2025)
+    """
+    frames, missing = [], []
+    for season in _as_season_list(seasons):
+        if int(season) < 2006:
+            raise SeasonNotFoundError("season cannot be less than 2006")
+        df = _read_release_parquet(
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/mbb_player_value/mbb_player_value_{season}.parquet"
+        )
+        if df is None:
+            missing.append(season)
+            continue
+        frames.append(df)
+    if missing:
+        cli_warn("load_mbb_player_value: no data for season(s) {missing} (skipped)".format(missing=missing))
     # diagonal: per-season release schemas can drift (columns added/dropped
     # over the years) -- union columns, null-fill gaps.
     out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()

--- a/sportsdataverse/parsed/mbb.py
+++ b/sportsdataverse/parsed/mbb.py
@@ -376,6 +376,8 @@ from sportsdataverse.mbb import load_mbb_officials as load_mbb_officials  # noqa
 from sportsdataverse.mbb import load_mbb_pbp as load_mbb_pbp  # noqa: F401
 from sportsdataverse.mbb import load_mbb_player_boxscore as load_mbb_player_boxscore  # noqa: F401
 from sportsdataverse.mbb import load_mbb_player_season_stats as load_mbb_player_season_stats  # noqa: F401
+from sportsdataverse.mbb import load_mbb_player_value as load_mbb_player_value  # noqa: F401
+from sportsdataverse.mbb import load_mbb_ratings as load_mbb_ratings  # noqa: F401
 from sportsdataverse.mbb import load_mbb_rosters as load_mbb_rosters  # noqa: F401
 from sportsdataverse.mbb import load_mbb_schedule as load_mbb_schedule  # noqa: F401
 from sportsdataverse.mbb import load_mbb_shots as load_mbb_shots  # noqa: F401
@@ -893,6 +895,8 @@ __all__ = [
     "load_mbb_pbp",
     "load_mbb_player_boxscore",
     "load_mbb_player_season_stats",
+    "load_mbb_player_value",
+    "load_mbb_ratings",
     "load_mbb_rosters",
     "load_mbb_schedule",
     "load_mbb_shots",

--- a/sportsdataverse/parsed/wbb.py
+++ b/sportsdataverse/parsed/wbb.py
@@ -367,6 +367,8 @@ from sportsdataverse.wbb import load_wbb_officials as load_wbb_officials  # noqa
 from sportsdataverse.wbb import load_wbb_pbp as load_wbb_pbp  # noqa: F401
 from sportsdataverse.wbb import load_wbb_player_boxscore as load_wbb_player_boxscore  # noqa: F401
 from sportsdataverse.wbb import load_wbb_player_season_stats as load_wbb_player_season_stats  # noqa: F401
+from sportsdataverse.wbb import load_wbb_player_value as load_wbb_player_value  # noqa: F401
+from sportsdataverse.wbb import load_wbb_ratings as load_wbb_ratings  # noqa: F401
 from sportsdataverse.wbb import load_wbb_rosters as load_wbb_rosters  # noqa: F401
 from sportsdataverse.wbb import load_wbb_schedule as load_wbb_schedule  # noqa: F401
 from sportsdataverse.wbb import load_wbb_shots as load_wbb_shots  # noqa: F401
@@ -852,6 +854,8 @@ __all__ = [
     "load_wbb_pbp",
     "load_wbb_player_boxscore",
     "load_wbb_player_season_stats",
+    "load_wbb_player_value",
+    "load_wbb_ratings",
     "load_wbb_rosters",
     "load_wbb_schedule",
     "load_wbb_shots",

--- a/sportsdataverse/wbb/wbb_loaders.py
+++ b/sportsdataverse/wbb/wbb_loaders.py
@@ -18,6 +18,8 @@ __all__ = [
     "load_wbb_player_boxscore",
     "load_wbb_schedule",
     "load_wbb_team_boxscore",
+    "load_wbb_ratings",
+    "load_wbb_player_value",
     "load_wbb_game_rosters",
     "load_wbb_officials",
     "load_wbb_player_season_stats",
@@ -421,6 +423,105 @@ def load_wbb_team_boxscore(seasons, return_as_pandas: bool = False):
         frames.append(df)
     if missing:
         cli_warn("load_wbb_team_boxscore: no data for season(s) {missing} (skipped)".format(missing=missing))
+    # diagonal: per-season release schemas can drift (columns added/dropped
+    # over the years) -- union columns, null-fill gaps.
+    out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
+
+
+def load_wbb_ratings(seasons, return_as_pandas: bool = False):
+    """Load wbb_ratings (sportsdataverse-data release).
+
+    Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wbb_ratings
+
+    Args:
+        seasons: an int or iterable of seasons (>= 2008).
+        return_as_pandas: return a pandas DataFrame instead of polars.
+
+    Returns:
+        A polars (or pandas) DataFrame; seasons with no published asset are
+        skipped with a warning rather than raising (404-safe).
+
+        |col_name  |type    |
+        |:---------|:-------|
+        |season    |Int64   |
+        |team_id   |String  |
+        |adj_o     |Float64 |
+        |adj_d     |Float64 |
+        |adj_em    |Float64 |
+        |adj_tempo |Float64 |
+        |raw_o     |Float64 |
+        |raw_d     |Float64 |
+        |games     |Int64   |
+        |rank      |Int64   |
+        |adj_em_z  |Float64 |
+
+    Example:
+        Quick start::
+
+            load_wbb_ratings(seasons=2025)
+    """
+    frames, missing = [], []
+    for season in _as_season_list(seasons):
+        if int(season) < 2008:
+            raise SeasonNotFoundError("season cannot be less than 2008")
+        df = _read_release_parquet(
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/wbb_ratings/wbb_ratings_{season}.parquet"
+        )
+        if df is None:
+            missing.append(season)
+            continue
+        frames.append(df)
+    if missing:
+        cli_warn("load_wbb_ratings: no data for season(s) {missing} (skipped)".format(missing=missing))
+    # diagonal: per-season release schemas can drift (columns added/dropped
+    # over the years) -- union columns, null-fill gaps.
+    out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
+
+
+def load_wbb_player_value(seasons, return_as_pandas: bool = False):
+    """Load wbb_player_value (sportsdataverse-data release).
+
+    Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wbb_player_value
+
+    Args:
+        seasons: an int or iterable of seasons (>= 2014).
+        return_as_pandas: return a pandas DataFrame instead of polars.
+
+    Returns:
+        A polars (or pandas) DataFrame; seasons with no published asset are
+        skipped with a warning rather than raising (404-safe).
+
+        |col_name  |type    |
+        |:---------|:-------|
+        |player_id |String  |
+        |player    |String  |
+        |season    |Int64   |
+        |team_id   |String  |
+        |min       |Float64 |
+        |box_obpm  |Float64 |
+        |box_dbpm  |Float64 |
+        |box_bpm   |Float64 |
+
+    Example:
+        Quick start::
+
+            load_wbb_player_value(seasons=2025)
+    """
+    frames, missing = [], []
+    for season in _as_season_list(seasons):
+        if int(season) < 2014:
+            raise SeasonNotFoundError("season cannot be less than 2014")
+        df = _read_release_parquet(
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/wbb_player_value/wbb_player_value_{season}.parquet"
+        )
+        if df is None:
+            missing.append(season)
+            continue
+        frames.append(df)
+    if missing:
+        cli_warn("load_wbb_player_value: no data for season(s) {missing} (skipped)".format(missing=missing))
     # diagonal: per-season release schemas can drift (columns added/dropped
     # over the years) -- union columns, null-fill gaps.
     out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()

--- a/tests/mbb/test_mbb_model_loaders.py
+++ b/tests/mbb/test_mbb_model_loaders.py
@@ -1,0 +1,65 @@
+"""Contract tests for the ``load_mbb_ratings`` / ``load_mbb_player_value`` loaders.
+
+Mirrors ``test_cfb_loaders_ratings.py``: pins each loader's declared
+returns-schema to the producer module's schema constant so a compute schema
+change cannot silently leave the published returns-table lying.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import polars as pl
+import yaml
+
+import sportsdataverse.mbb.mbb_box_bpm  # noqa: F401
+import sportsdataverse.mbb.mbb_team_ratings  # noqa: F401
+
+_ratings_mod = sys.modules["sportsdataverse.mbb.mbb_team_ratings"]
+_bpm_mod = sys.modules["sportsdataverse.mbb.mbb_box_bpm"]
+
+_ROOT = Path(__file__).resolve().parents[2]
+_SCHEMAS = _ROOT / "tools" / "codegen" / "schemas" / "loader_schemas.yaml"
+_RELEASES = _ROOT / "tools" / "codegen" / "endpoints" / "releases.yaml"
+
+_POLARS_BY_NAME = {"Int64": pl.Int64, "Float64": pl.Float64, "String": pl.Utf8, "Utf8": pl.Utf8}
+
+
+def _declared(fn: str) -> list[dict]:
+    return yaml.safe_load(_SCHEMAS.read_text(encoding="utf-8"))[fn]
+
+
+def _entry(fn: str) -> dict:
+    loaders = yaml.safe_load(_RELEASES.read_text(encoding="utf-8"))["loaders"]
+    return next(ld for ld in loaders if ld["fn"] == fn)
+
+
+def _assert_schema_matches(declared: list[dict], produced: dict) -> None:
+    assert [c["name"] for c in declared] == list(produced.keys())
+    for col in declared:
+        assert _POLARS_BY_NAME[col["type"]] == produced[col["name"]], col["name"]
+
+
+def test_ratings_declared_schema_matches_the_producer() -> None:
+    _assert_schema_matches(_declared("load_mbb_ratings"), _ratings_mod._RATINGS_SCHEMA)
+
+
+def test_player_value_declared_schema_matches_the_producer() -> None:
+    _assert_schema_matches(_declared("load_mbb_player_value"), _bpm_mod._SCHEMA)
+
+
+def test_loader_entries_point_at_the_published_tags_and_floor() -> None:
+    r = _entry("load_mbb_ratings")
+    assert (r["tag"], r["base"], r["min_season"]) == ("mbb_ratings", "sdv_releases", 2006)
+    assert r["url"] == "mbb_ratings/mbb_ratings_{season}.parquet"
+
+    v = _entry("load_mbb_player_value")
+    assert (v["tag"], v["base"], v["min_season"]) == ("mbb_player_value", "sdv_releases", 2006)
+    assert v["url"] == "mbb_player_value/mbb_player_value_{season}.parquet"
+
+
+def test_loaders_are_exported() -> None:
+    from sportsdataverse.mbb import load_mbb_player_value, load_mbb_ratings
+
+    assert callable(load_mbb_ratings) and callable(load_mbb_player_value)

--- a/tests/wbb/test_wbb_model_loaders.py
+++ b/tests/wbb/test_wbb_model_loaders.py
@@ -1,0 +1,65 @@
+"""Contract tests for the ``load_wbb_ratings`` / ``load_wbb_player_value`` loaders.
+
+The wbb compute wrappers (``wbb_team_ratings`` / ``wbb_box_bpm``) delegate to
+the mbb engine with ``league="womens"``, so the output schemas ARE the mbb
+schema constants -- pin the wbb loaders against those same constants.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import polars as pl
+import yaml
+
+import sportsdataverse.mbb.mbb_box_bpm  # noqa: F401
+import sportsdataverse.mbb.mbb_team_ratings  # noqa: F401
+
+_ratings_mod = sys.modules["sportsdataverse.mbb.mbb_team_ratings"]
+_bpm_mod = sys.modules["sportsdataverse.mbb.mbb_box_bpm"]
+
+_ROOT = Path(__file__).resolve().parents[2]
+_SCHEMAS = _ROOT / "tools" / "codegen" / "schemas" / "loader_schemas.yaml"
+_RELEASES = _ROOT / "tools" / "codegen" / "endpoints" / "releases.yaml"
+
+_POLARS_BY_NAME = {"Int64": pl.Int64, "Float64": pl.Float64, "String": pl.Utf8, "Utf8": pl.Utf8}
+
+
+def _declared(fn: str) -> list[dict]:
+    return yaml.safe_load(_SCHEMAS.read_text(encoding="utf-8"))[fn]
+
+
+def _entry(fn: str) -> dict:
+    loaders = yaml.safe_load(_RELEASES.read_text(encoding="utf-8"))["loaders"]
+    return next(ld for ld in loaders if ld["fn"] == fn)
+
+
+def _assert_schema_matches(declared: list[dict], produced: dict) -> None:
+    assert [c["name"] for c in declared] == list(produced.keys())
+    for col in declared:
+        assert _POLARS_BY_NAME[col["type"]] == produced[col["name"]], col["name"]
+
+
+def test_ratings_declared_schema_matches_the_producer() -> None:
+    _assert_schema_matches(_declared("load_wbb_ratings"), _ratings_mod._RATINGS_SCHEMA)
+
+
+def test_player_value_declared_schema_matches_the_producer() -> None:
+    _assert_schema_matches(_declared("load_wbb_player_value"), _bpm_mod._SCHEMA)
+
+
+def test_loader_entries_point_at_the_published_tags_and_floor() -> None:
+    r = _entry("load_wbb_ratings")
+    assert (r["tag"], r["base"], r["min_season"]) == ("wbb_ratings", "sdv_releases", 2008)
+    assert r["url"] == "wbb_ratings/wbb_ratings_{season}.parquet"
+
+    v = _entry("load_wbb_player_value")
+    assert (v["tag"], v["base"], v["min_season"]) == ("wbb_player_value", "sdv_releases", 2014)
+    assert v["url"] == "wbb_player_value/wbb_player_value_{season}.parquet"
+
+
+def test_loaders_are_exported() -> None:
+    from sportsdataverse.wbb import load_wbb_player_value, load_wbb_ratings
+
+    assert callable(load_wbb_ratings) and callable(load_wbb_player_value)

--- a/tools/codegen/endpoints/releases.yaml
+++ b/tools/codegen/endpoints/releases.yaml
@@ -293,6 +293,22 @@ loaders:
   min_season: 2002
   example_args:
     seasons: 2024
+- fn: load_mbb_ratings
+  league: mbb
+  base: sdv_releases
+  url: mbb_ratings/mbb_ratings_{season}.parquet
+  tag: mbb_ratings
+  min_season: 2006
+  example_args:
+    seasons: 2025
+- fn: load_mbb_player_value
+  league: mbb
+  base: sdv_releases
+  url: mbb_player_value/mbb_player_value_{season}.parquet
+  tag: mbb_player_value
+  min_season: 2006
+  example_args:
+    seasons: 2025
 - fn: load_nba_pbp
   league: nba
   base: sdv_releases
@@ -389,6 +405,22 @@ loaders:
   min_season: 2002
   example_args:
     seasons: 2024
+- fn: load_wbb_ratings
+  league: wbb
+  base: sdv_releases
+  url: wbb_ratings/wbb_ratings_{season}.parquet
+  tag: wbb_ratings
+  min_season: 2008
+  example_args:
+    seasons: 2025
+- fn: load_wbb_player_value
+  league: wbb
+  base: sdv_releases
+  url: wbb_player_value/wbb_player_value_{season}.parquet
+  tag: wbb_player_value
+  min_season: 2014
+  example_args:
+    seasons: 2025
 - fn: load_wnba_pbp
   league: wnba
   base: sdv_releases

--- a/tools/codegen/schemas/loader_schemas.yaml
+++ b/tools/codegen/schemas/loader_schemas.yaml
@@ -3894,6 +3894,46 @@ load_mbb_team_boxscore:
   type: String
 - name: opponent_team_score
   type: Int32
+load_mbb_ratings:
+- name: season
+  type: Int64
+- name: team_id
+  type: String
+- name: adj_o
+  type: Float64
+- name: adj_d
+  type: Float64
+- name: adj_em
+  type: Float64
+- name: adj_tempo
+  type: Float64
+- name: raw_o
+  type: Float64
+- name: raw_d
+  type: Float64
+- name: games
+  type: Int64
+- name: rank
+  type: Int64
+- name: adj_em_z
+  type: Float64
+load_mbb_player_value:
+- name: player_id
+  type: String
+- name: player
+  type: String
+- name: season
+  type: Int64
+- name: team_id
+  type: String
+- name: min
+  type: Float64
+- name: box_obpm
+  type: Float64
+- name: box_dbpm
+  type: Float64
+- name: box_bpm
+  type: Float64
 load_mbb_team_season_stats:
 - name: season
   type: Int32
@@ -8171,6 +8211,46 @@ load_wbb_team_boxscore:
   type: String
 - name: opponent_team_score
   type: Int32
+load_wbb_ratings:
+- name: season
+  type: Int64
+- name: team_id
+  type: String
+- name: adj_o
+  type: Float64
+- name: adj_d
+  type: Float64
+- name: adj_em
+  type: Float64
+- name: adj_tempo
+  type: Float64
+- name: raw_o
+  type: Float64
+- name: raw_d
+  type: Float64
+- name: games
+  type: Int64
+- name: rank
+  type: Int64
+- name: adj_em_z
+  type: Float64
+load_wbb_player_value:
+- name: player_id
+  type: String
+- name: player
+  type: String
+- name: season
+  type: Int64
+- name: team_id
+  type: String
+- name: min
+  type: Float64
+- name: box_obpm
+  type: Float64
+- name: box_dbpm
+  type: Float64
+- name: box_bpm
+  type: Float64
 load_wbb_team_season_stats:
 - name: season
   type: Int32


### PR DESCRIPTION
## What

Consumer half of **publication-plan Phase 3a** — `load_mbb_ratings` / `load_mbb_player_value` / `load_wbb_ratings` / `load_wbb_player_value` over the sportsdataverse-data tags published 07-16/17.

## Floors (probed per tag, not inherited from the 2002 boxscore loaders)

| Loader | Floor | Why |
|---|---|---|
| `load_mbb_ratings`, `load_mbb_player_value` | 2006 | 2002 has no team_box asset; 2003–05 are 2–23 teams (genuine archival thinness — flag TRUE, stats absent) |
| `load_wbb_ratings` | 2008 | after the boxscoreAvailable-flag fix (#275) + throttle-retry re-extraction (wehoop-wbb-data#14), 2008 has 260 teams with ≥5 games — better than the originally-published 2014 |
| `load_wbb_player_value` | 2014 | `wbb_box_bpm`'s ≥10-games hygiene floor is unreachable on partial archival coverage (~4 captured games/team pre-2014) |

## Verification

Declared returns-schemas pinned to the producer modules' `_RATINGS_SCHEMA` / `_SCHEMA` constants by contract tests (8 passing); `generate.py --check` clean; no uv.lock churn.