### PR TITLE
fix(mbb): honor the empty-in/empty-out contract for missing-season boxscores

### DIFF
--- a/sportsdataverse/mbb/mbb_team_ratings.py
+++ b/sportsdataverse/mbb/mbb_team_ratings.py
@@ -30,6 +30,31 @@ if TYPE_CHECKING:
     import pandas as pd
 
 
+_EFF_SCHEMA: dict[str, pl.DataType] = {
+    "game_id": pl.Utf8,
+    "season": pl.Int64,
+    "date": pl.Date,
+    "team_id": pl.Utf8,
+    "opp_team_id": pl.Utf8,
+    "is_home": pl.Boolean,
+    "neutral_site": pl.Boolean,
+    "poss": pl.Float64,
+    "off_eff": pl.Float64,
+    "def_eff": pl.Float64,
+}
+
+_BOX_REQUIRED = (
+    "game_id",
+    "team_id",
+    "field_goals_attempted",
+    "offensive_rebounds",
+    "turnovers",
+    "free_throws_attempted",
+    "team_score",
+)
+_SCHED_REQUIRED = ("game_id", "season", "date", "home_team_id", "away_team_id", "neutral_site")
+
+
 def raw_game_efficiency(schedule: pl.DataFrame, team_box: pl.DataFrame) -> pl.DataFrame:
     """Per-team, per-game possessions + raw offensive/defensive efficiency.
 
@@ -62,6 +87,17 @@ def raw_game_efficiency(schedule: pl.DataFrame, team_box: pl.DataFrame) -> pl.Da
             from sportsdataverse.mbb.mbb_team_ratings import raw_game_efficiency
             eff = raw_game_efficiency(load_mbb_schedule([2024]), load_mbb_team_boxscore([2024]))
     """
+    # A season with no released boxscore asset comes back from the loader as a
+    # COLUMN-LESS empty frame (e.g. WBB 2003) -- selecting game_id off it
+    # raises ColumnNotFoundError instead of honoring the documented
+    # empty-in/empty-out contract. Guard on emptiness AND required columns.
+    if (
+        schedule.height == 0
+        or team_box.height == 0
+        or any(c not in team_box.columns for c in _BOX_REQUIRED)
+        or any(c not in schedule.columns for c in _SCHED_REQUIRED)
+    ):
+        return pl.DataFrame(schema=_EFF_SCHEMA)
     box = team_box.select(
         pl.col("game_id").cast(pl.Utf8),
         pl.col("team_id").cast(pl.Utf8),

--- a/tests/mbb/test_mbb_team_ratings.py
+++ b/tests/mbb/test_mbb_team_ratings.py
@@ -260,3 +260,41 @@ def test_mbb_team_ratings_empty_seasons(monkeypatch):
     out = mod.mbb_team_ratings([2024])
     assert out.columns == _RATINGS_COLUMNS
     assert out.height == 0
+
+
+def test_mbb_team_ratings_missing_season_columnless_frames(monkeypatch):
+    """A season with no released boxscore asset comes back COLUMN-LESS from the
+    loader (it warns "no data for season(s) [...] (skipped)" and returns a frame
+    with no columns at all -- e.g. WBB 2003). This crashed raw_game_efficiency
+    with ColumnNotFoundError instead of honoring the documented
+    empty-in/empty-out contract."""
+    import importlib
+
+    mod = importlib.import_module("sportsdataverse.mbb.mbb_team_ratings")
+
+    sched = pl.DataFrame(
+        {
+            "game_id": ["G1"],
+            "season": [2002],
+            "date": [datetime.date(2002, 1, 1)],
+            "home_team_id": ["A"],
+            "away_team_id": ["B"],
+            "neutral_site": [False],
+        }
+    )
+    monkeypatch.setattr(mod, "load_mbb_schedule", lambda seasons: sched)
+    monkeypatch.setattr(mod, "load_mbb_team_boxscore", lambda seasons: pl.DataFrame())
+
+    out = mod.mbb_team_ratings([2002])
+    assert out.columns == _RATINGS_COLUMNS
+    assert out.height == 0
+
+
+def test_raw_game_efficiency_columnless_inputs_return_typed_empty():
+    import importlib
+
+    mod = importlib.import_module("sportsdataverse.mbb.mbb_team_ratings")
+
+    out = raw_game_efficiency(pl.DataFrame(), pl.DataFrame())
+    assert out.height == 0
+    assert dict(out.schema) == dict(mod._EFF_SCHEMA)


### PR DESCRIPTION
## What

`raw_game_efficiency` crashed with `ColumnNotFoundError: unable to find column \"game_id\"; valid columns: []` when a season has no released boxscore asset — the loader warns `no data for season(s) [...] (skipped)` and returns a **column-less** empty frame (e.g. WBB 2003), which the function's select choked on instead of honoring its documented *"Empty input returns that schema with zero rows"* contract.

## Change

Guard on emptiness AND required columns at the function boundary, returning a typed `_EFF_SCHEMA` empty. One guard covers all callers — `mbb_team_ratings` and the `wbb_team_ratings` wrapper inherit it.

## Verification

- Two new regression tests: the column-less missing-season path through the orchestrator, and `raw_game_efficiency` on column-less inputs pinning the typed-empty schema (7/7 in the file).
- Live repro: `wbb_team_ratings(2003)` crashed this morning; now returns 0 rows cleanly.

Found during the wbb_ratings dataset backfill (probing season floors); tracked as chip task_1002f171.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty or incomplete basketball data inputs.
  * Prevented errors when season data is unavailable or missing expected columns.
  * Ensured empty results retain the expected table structure and data types.

* **Tests**
  * Added coverage for empty, columnless data responses and correctly typed empty results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->