### PR TITLE
feat(cfb): stats.ncaa.org college-football box / drives / officials parsers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -311,6 +311,7 @@ files = [
     "sportsdataverse/cfb/cfb_advanced_stats.py",
     "sportsdataverse/cfb/cfb_field_position.py",
     "sportsdataverse/cfb/cfb_ncaa_pbp.py",
+    "sportsdataverse/cfb/cfb_ncaa_box.py",
     "sportsdataverse/cfb/cfb_opponent_adjust.py",
     "sportsdataverse/cfb/cfb_crosswalk.py",
     "sportsdataverse/cfb/cfb_fox_ext.py",

--- a/sportsdataverse/cfb/__init__.py
+++ b/sportsdataverse/cfb/__init__.py
@@ -7,6 +7,7 @@ from sportsdataverse.cfb.cfb_loaders import *
 from sportsdataverse.cfb.cfb_loaders_extra import *
 from sportsdataverse.cfb.cfb_pbp import *
 from sportsdataverse.cfb.cfb_ncaa_pbp import *
+from sportsdataverse.cfb.cfb_ncaa_box import *
 from sportsdataverse.cfb.cfb_adjusted_epa import *
 from sportsdataverse.cfb.cfb_advanced_stats import *
 from sportsdataverse.cfb.cfb_field_position import *

--- a/sportsdataverse/cfb/cfb_ncaa_box.py
+++ b/sportsdataverse/cfb/cfb_ncaa_box.py
@@ -1,0 +1,384 @@
+"""Parse stats.ncaa.org college-football (NCAA sport code ``MFB``) game-detail
+pages other than play-by-play into tidy polars frames.
+
+One parser per stats.ncaa.org tab of a contest (all bm-verify-gated, fetched via
+the shared browser transport in :mod:`sportsdataverse.mbb.mbb_ncaa_fetch`):
+
+* :func:`parse_cfb_ncaa_drives` -- ``/contests/{id}/drives`` (drive-level box).
+* :func:`parse_cfb_ncaa_team_stats` -- ``/contests/{id}/team_stats`` (team box,
+  **with per-quarter breakdown** -- one row per category/stat/period).
+* :func:`parse_cfb_ncaa_player_stats` -- ``/contests/{id}/individual_stats``
+  (individual player box; a ``dict`` of one frame per stat category).
+* :func:`parse_cfb_ncaa_officials` -- ``/contests/{id}/officials`` (officiating crew).
+* :func:`parse_cfb_ncaa_linescore` -- the linescore + game info (date/venue/
+  attendance) block shared by every tab.
+
+**Provenance.** Original sdv-py code, built against a real capture (contest
+5362283, California @ Auburn 2024-09-07). Empty/unparseable input returns a
+zero-row frame (or empty dict) with the documented schema. The play-by-play tab
+is parsed separately by :func:`sportsdataverse.cfb.cfb_ncaa_pbp.parse_cfb_ncaa_pbp`.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any, Union
+
+import polars as pl
+from bs4 import BeautifulSoup
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+__all__ = [
+    "DRIVES_SCHEMA",
+    "LINESCORE_SCHEMA",
+    "OFFICIALS_SCHEMA",
+    "TEAM_STATS_SCHEMA",
+    "parse_cfb_ncaa_drives",
+    "parse_cfb_ncaa_linescore",
+    "parse_cfb_ncaa_officials",
+    "parse_cfb_ncaa_player_stats",
+    "parse_cfb_ncaa_team_stats",
+]
+
+_QUARTER_RE = re.compile(r"^(?:(\d+)(?:st|nd|rd|th)\s+Quarter|OT\s*\d*)$", re.I)
+_COMPETITOR_ID_RE = re.compile(r"competitor_(\d+)_year_stat_category_(\d+)_data_table")
+
+
+def _cells(tr: "Any") -> "list[str]":
+    return [c.get_text(" ", strip=True) for c in tr.find_all(["th", "td"])]
+
+
+def _rows(table: "Any") -> "list[list[str]]":
+    return [_cells(tr) for tr in table.find_all("tr")]
+
+
+def _cid(contest_id: "str | int | None") -> "str | None":
+    return str(contest_id) if contest_id is not None else None
+
+
+def _finish(rows: "list[dict]", schema: dict, return_as_pandas: bool) -> "Union[pl.DataFrame, pd.DataFrame]":
+    df = pl.DataFrame(rows, schema=schema) if rows else pl.DataFrame(schema=schema)
+    return df.to_pandas() if return_as_pandas else df
+
+
+def _linescore_table(soup: "BeautifulSoup") -> "Any":
+    """The 6-row linescore table (header ``['', '1', '2', ...,'S']`` + team rows)."""
+    for t in soup.find_all("table"):
+        trs = t.find_all("tr")
+        if not trs:
+            continue
+        hdr = _cells(trs[0])
+        if len(hdr) >= 3 and hdr[0] == "" and hdr[-1] == "S" and hdr[1] == "1":
+            return t
+    return None
+
+
+def _teams(soup: "BeautifulSoup") -> "tuple[str | None, str | None]":
+    """(away, home) team names -- the first two team rows of the linescore."""
+    t = _linescore_table(soup)
+    if t is None:
+        return None, None
+    names = [r[0] for r in _rows(t)[1:] if r and r[0] and not _QUARTER_RE.match(r[0])]
+    names = [n for n in names if not re.match(r"^\d", n) and "Stadium" not in n and "Attendance" not in n]
+    away = names[0] if len(names) > 0 else None
+    home = names[1] if len(names) > 1 else None
+    return away, home
+
+
+# --- drives ---------------------------------------------------------------
+
+DRIVES_SCHEMA: "dict[str, pl.DataType]" = {
+    "contest_id": pl.Utf8,
+    "drive_number": pl.Int64,
+    "quarter": pl.Int64,
+    "team": pl.Utf8,
+    "start_period": pl.Int64,
+    "start_how": pl.Utf8,
+    "start_clock": pl.Utf8,
+    "start_yard_line": pl.Utf8,
+    "end_period": pl.Int64,
+    "end_how": pl.Utf8,
+    "end_clock": pl.Utf8,
+    "end_yard_line": pl.Utf8,
+}
+
+
+def _int(v: str) -> "int | None":
+    return int(v) if v and v.lstrip("-").isdigit() else None
+
+
+def parse_cfb_ncaa_drives(
+    html: str, contest_id: "str | int | None" = None, *, return_as_pandas: bool = False
+) -> "Union[pl.DataFrame, pd.DataFrame]":
+    """Parse the ``/contests/{id}/drives`` page -> one row per drive.
+
+    Columns: ``drive_number``, ``quarter``, ``team``, ``start_period``/``start_how``
+    (KO/PUNT/DOWNS/…)/``start_clock``/``start_yard_line``, and the ``end_*``
+    equivalents (``end_how`` = TD/FGA/PUNT/DOWNS/…).
+    """
+    soup = BeautifulSoup(html or "", "html.parser")
+    cid = _cid(contest_id)
+    table = soup.find("table", id="public_game_drives_data_table")
+    rows: "list[dict]" = []
+    if table is not None:
+        for r in _rows(table)[1:]:
+            if len(r) < 11 or not (r[0] or "").isdigit():
+                continue
+            rows.append(
+                {
+                    "contest_id": cid,
+                    "drive_number": _int(r[0]),
+                    "quarter": _int(r[1]),
+                    "team": r[2] or None,
+                    "start_period": _int(r[3]),
+                    "start_how": r[4] or None,
+                    "start_clock": r[5] or None,
+                    "start_yard_line": r[6] or None,
+                    "end_period": _int(r[7]),
+                    "end_how": r[8] or None,
+                    "end_clock": r[9] or None,
+                    "end_yard_line": r[10] or None,
+                }
+            )
+    return _finish(rows, DRIVES_SCHEMA, return_as_pandas)
+
+
+# --- officials ------------------------------------------------------------
+
+OFFICIALS_SCHEMA: "dict[str, pl.DataType]" = {
+    "contest_id": pl.Utf8,
+    "role": pl.Utf8,
+    "official": pl.Utf8,
+}
+
+
+def parse_cfb_ncaa_officials(
+    html: str, contest_id: "str | int | None" = None, *, return_as_pandas: bool = False
+) -> "Union[pl.DataFrame, pd.DataFrame]":
+    """Parse the ``/contests/{id}/officials`` page -> one row per official.
+
+    ``role`` is populated when the crew is listed with positions (Referee, Umpire,
+    …); when the page lists only names it is null.
+    """
+    soup = BeautifulSoup(html or "", "html.parser")
+    cid = _cid(contest_id)
+    rows: "list[dict]" = []
+    for t in soup.find_all("table"):
+        trs = t.find_all("tr")
+        if not trs:
+            continue
+        hdr = _cells(trs[0])
+        # the officials data table has a short header ("Official" / "Role","Official");
+        # the tab-nav row also contains "Officials" but has many cells -- exclude it.
+        if len(hdr) > 3 or not any("official" in h.lower() for h in hdr):
+            continue
+        two_col = len(hdr) >= 2
+        for r in _rows(t)[1:]:
+            if not r or not any(r):
+                continue
+            role = r[0] if two_col and len(r) >= 2 else None
+            name = r[1] if two_col and len(r) >= 2 else r[0]
+            if name:
+                rows.append({"contest_id": cid, "role": role or None, "official": name})
+        break  # only the first officials table
+    return _finish(rows, OFFICIALS_SCHEMA, return_as_pandas)
+
+
+# --- team stats (by period) ----------------------------------------------
+
+TEAM_STATS_SCHEMA: "dict[str, pl.DataType]" = {
+    "contest_id": pl.Utf8,
+    "category": pl.Utf8,
+    "stat": pl.Utf8,
+    "period": pl.Utf8,
+    "away_team": pl.Utf8,
+    "away_value": pl.Utf8,
+    "home_team": pl.Utf8,
+    "home_value": pl.Utf8,
+}
+
+
+def parse_cfb_ncaa_team_stats(
+    html: str, contest_id: "str | int | None" = None, *, return_as_pandas: bool = False
+) -> "Union[pl.DataFrame, pd.DataFrame]":
+    """Parse the ``/contests/{id}/team_stats`` page -> one row per category/stat/period.
+
+    ``period`` is ``"total"`` for the game total and ``"1st Quarter"`` / … / ``"OT"``
+    for the per-quarter breakdown that stats.ncaa.org nests under each stat.
+    """
+    soup = BeautifulSoup(html or "", "html.parser")
+    cid = _cid(contest_id)
+    table = soup.find("table", id="rankings_table")
+    rows: "list[dict]" = []
+    if table is not None:
+        away_team, home_team = None, None
+        category, stat = None, None
+        for r in _rows(table):
+            ne = [c for c in r if c]
+            if not ne:
+                continue
+            if len(ne) >= 3 and ne[0] in ("Period Stats", "Team Stats"):
+                away_team, home_team = ne[1], ne[2]
+                continue
+            if len(ne) == 1:  # a category section header (Rushing, Passing, ...)
+                category = ne[0]
+                stat = None
+                continue
+            if len(r) >= 3:
+                label, away_v, home_v = r[0], r[1], r[2]
+                if _QUARTER_RE.match(label or ""):
+                    period = label  # per-quarter row for the current stat
+                else:
+                    stat = label
+                    period = "total"
+                rows.append(
+                    {
+                        "contest_id": cid,
+                        "category": category,
+                        "stat": stat,
+                        "period": period,
+                        "away_team": away_team,
+                        "away_value": away_v or None,
+                        "home_team": home_team,
+                        "home_value": home_v or None,
+                    }
+                )
+    return _finish(rows, TEAM_STATS_SCHEMA, return_as_pandas)
+
+
+# --- individual player stats ---------------------------------------------
+
+_CATEGORY_HINTS = [
+    ("rushing", ("Rush Attempts", "Yds/Rush")),
+    ("passing", ("Pass Attempts", "Completions")),
+    ("receiving", ("Rec", "Receiving Yards")),
+    ("defense", ("Tackles", "Solo", "Sacks")),
+    ("kicking", ("FG Made", "FGM", "XP Made")),
+    ("punting", ("Punts", "Punt Yds")),
+    ("kick_returns", ("Kick Ret", "KR Yds")),
+    ("punt_returns", ("Punt Ret", "PR Yds")),
+]
+
+
+def _category_of(header: "list[str]") -> str:
+    hset = set(header)
+    for name, hints in _CATEGORY_HINTS:
+        if any(h in hset for h in hints):
+            return name
+    return "other"
+
+
+def parse_cfb_ncaa_player_stats(
+    html: str, contest_id: "str | int | None" = None, *, return_as_pandas: bool = False
+) -> "dict[str, Union[pl.DataFrame, pd.DataFrame]]":
+    """Parse the ``/contests/{id}/individual_stats`` page.
+
+    Returns a ``dict`` keyed by stat category (``"rushing"``, ``"passing"``,
+    ``"receiving"``, …) -> a frame of that category's player rows across both
+    teams. Each frame carries ``contest_id``, ``team_id``, ``number``, ``name``,
+    ``position`` + the category's stat columns (snake-cased). Empty input -> ``{}``.
+    """
+    soup = BeautifulSoup(html or "", "html.parser")
+    cid = _cid(contest_id)
+    buckets: "dict[str, list[dict]]" = {}
+    for t in soup.find_all("table"):
+        m = _COMPETITOR_ID_RE.match(t.get("id") or "")
+        if not m:
+            continue
+        team_id = m.group(1)
+        trs = t.find_all("tr")
+        if len(trs) < 2:
+            continue
+        header = _cells(trs[0])
+        cat = _category_of(header)
+        # stat columns = everything past the fixed #/Name/P triple
+        stat_cols = [re.sub(r"[^\w]+", "_", c).strip("_").lower() for c in header[3:]]
+        for r in _rows(t)[1:]:
+            if len(r) < 3 or not any(r):
+                continue
+            row = {
+                "contest_id": cid,
+                "team_id": team_id,
+                "number": r[0] or None,
+                "name": r[1] or None,
+                "position": r[2] or None,
+            }
+            for col, val in zip(stat_cols, r[3:]):
+                row[col] = val or None
+            buckets.setdefault(cat, []).append(row)
+    out: "dict" = {}
+    for cat, rows in buckets.items():
+        df = pl.DataFrame(rows)
+        out[cat] = df.to_pandas() if return_as_pandas else df
+    return out
+
+
+# --- linescore + game info ------------------------------------------------
+
+LINESCORE_SCHEMA: "dict[str, pl.DataType]" = {
+    "contest_id": pl.Utf8,
+    "team": pl.Utf8,
+    "home_away": pl.Utf8,
+    "period": pl.Utf8,
+    "points": pl.Int64,
+    "final": pl.Int64,
+    "game_date": pl.Utf8,
+    "venue": pl.Utf8,
+    "attendance": pl.Int64,
+}
+
+
+def parse_cfb_ncaa_linescore(
+    html: str, contest_id: "str | int | None" = None, *, return_as_pandas: bool = False
+) -> "Union[pl.DataFrame, pd.DataFrame]":
+    """Parse the shared linescore + game-info block -> one row per team/period.
+
+    ``period`` is the quarter label (``"1"``..``"4"``, plus ``"OT"`` variants when
+    present); ``points`` the score that period; ``final`` the team's final; and
+    ``game_date`` / ``venue`` / ``attendance`` the game-info line repeated per row.
+    """
+    soup = BeautifulSoup(html or "", "html.parser")
+    cid = _cid(contest_id)
+    table = _linescore_table(soup)
+    rows: "list[dict]" = []
+    if table is not None:
+        all_rows = _rows(table)
+        header = all_rows[0]  # ['', '1', '2', '3', '4', 'S']
+        periods = header[1:-1]  # quarter labels
+        # game-info lines (date / venue / attendance) are single-cell rows below
+        game_date, venue, attendance = None, None, None
+        team_rows = []
+        for r in all_rows[1:]:
+            ne = [c for c in r if c]
+            if len(r) >= len(header) and r[0] and not _QUARTER_RE.match(r[0]):
+                team_rows.append(r)
+            elif len(ne) == 1:
+                v = ne[0]
+                if re.search(r"\d{1,2}/\d{1,2}/\d{2,4}", v):
+                    game_date = v
+                elif "Attendance" in v:
+                    mnum = re.search(r"([\d,]+)", v)
+                    attendance = int(mnum.group(1).replace(",", "")) if mnum else None
+                elif "Stadium" in v or "(" in v:
+                    venue = v
+        for idx, tr in enumerate(team_rows):
+            team = tr[0]
+            final = _int(tr[-1])
+            home_away = "away" if idx == 0 else "home"
+            for pi, period in enumerate(periods):
+                rows.append(
+                    {
+                        "contest_id": cid,
+                        "team": team,
+                        "home_away": home_away,
+                        "period": period,
+                        "points": _int(tr[1 + pi]),
+                        "final": final,
+                        "game_date": game_date,
+                        "venue": venue,
+                        "attendance": attendance,
+                    }
+                )
+    return _finish(rows, LINESCORE_SCHEMA, return_as_pandas)

--- a/sportsdataverse/parsed/cfb.py
+++ b/sportsdataverse/parsed/cfb.py
@@ -418,7 +418,12 @@ from sportsdataverse.cfb import load_recruit_classes as load_recruit_classes  # 
 from sportsdataverse.cfb import make_ratings_compute_results as make_ratings_compute_results  # noqa: F401
 from sportsdataverse.cfb import most_recent_cfb_season as most_recent_cfb_season  # noqa: F401
 from sportsdataverse.cfb import normalize_team_roster_columns as normalize_team_roster_columns  # noqa: F401
+from sportsdataverse.cfb import parse_cfb_ncaa_drives as parse_cfb_ncaa_drives  # noqa: F401
+from sportsdataverse.cfb import parse_cfb_ncaa_linescore as parse_cfb_ncaa_linescore  # noqa: F401
+from sportsdataverse.cfb import parse_cfb_ncaa_officials as parse_cfb_ncaa_officials  # noqa: F401
 from sportsdataverse.cfb import parse_cfb_ncaa_pbp as parse_cfb_ncaa_pbp  # noqa: F401
+from sportsdataverse.cfb import parse_cfb_ncaa_player_stats as parse_cfb_ncaa_player_stats  # noqa: F401
+from sportsdataverse.cfb import parse_cfb_ncaa_team_stats as parse_cfb_ncaa_team_stats  # noqa: F401
 from sportsdataverse.cfb import parse_on3_rankings as parse_on3_rankings  # noqa: F401
 from sportsdataverse.cfb import parse_on3_rdb as parse_on3_rdb  # noqa: F401
 from sportsdataverse.cfb import parse_on3_team_rankings as parse_on3_team_rankings  # noqa: F401
@@ -731,7 +736,12 @@ __all__ = [
     "on3_transfers_best_available",
     "on3_transfers_latest",
     "on3_videos_video_key",
+    "parse_cfb_ncaa_drives",
+    "parse_cfb_ncaa_linescore",
+    "parse_cfb_ncaa_officials",
     "parse_cfb_ncaa_pbp",
+    "parse_cfb_ncaa_player_stats",
+    "parse_cfb_ncaa_team_stats",
     "parse_on3_rankings",
     "parse_on3_rdb",
     "parse_on3_team_rankings",

--- a/tests/cfb/test_cfb_ncaa_box.py
+++ b/tests/cfb/test_cfb_ncaa_box.py
@@ -1,0 +1,143 @@
+"""Offline tests for the stats.ncaa.org college-football box-score parsers.
+
+Parses a committed real capture (contest 5362283, California @ Auburn 2024-09-07):
+the drives, officials, team_stats (by-period), individual_stats, and box_score
+(linescore) tabs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+
+from sportsdataverse.cfb.cfb_ncaa_box import (
+    DRIVES_SCHEMA,
+    LINESCORE_SCHEMA,
+    OFFICIALS_SCHEMA,
+    TEAM_STATS_SCHEMA,
+    parse_cfb_ncaa_drives,
+    parse_cfb_ncaa_linescore,
+    parse_cfb_ncaa_officials,
+    parse_cfb_ncaa_player_stats,
+    parse_cfb_ncaa_team_stats,
+)
+
+FIX = Path(__file__).resolve().parents[1] / "fixtures" / "cfb_ncaa"
+
+
+def _rd(name: str) -> str:
+    return (FIX / f"mfb_{name}_5362283.html").read_text(encoding="utf-8")
+
+
+# --- drives ---------------------------------------------------------------
+
+
+def test_drives_schema_and_rows() -> None:
+    df = parse_cfb_ncaa_drives(_rd("drives"), contest_id="5362283")
+    assert df.columns == list(DRIVES_SCHEMA.keys())
+    assert df.height >= 20  # a full game of drives
+    # drive_number is a clean 1..N sequence
+    assert df.get_column("drive_number").to_list() == list(range(1, df.height + 1))
+    assert df.get_column("quarter").is_between(1, 5).all()
+
+
+def test_drives_start_end_vocab() -> None:
+    df = parse_cfb_ncaa_drives(_rd("drives"), contest_id="5362283")
+    assert df.get_column("start_how").is_not_null().all()
+    ends = set(df.get_column("end_how").unique().to_list())
+    assert {"TD", "PUNT", "DOWNS"} <= ends  # football drive outcomes
+    # yard lines look like TEAM+number when present
+    yl = df.filter(pl.col("start_yard_line").is_not_null())
+    assert yl.get_column("start_yard_line").str.contains(r"^[A-Z]{2,4}\d+$").all()
+
+
+def test_drives_empty() -> None:
+    df = parse_cfb_ncaa_drives("")
+    assert df.height == 0 and df.columns == list(DRIVES_SCHEMA.keys())
+
+
+# --- officials ------------------------------------------------------------
+
+
+def test_officials_extracted_not_nav() -> None:
+    df = parse_cfb_ncaa_officials(_rd("officials"), contest_id="5362283")
+    assert df.columns == list(OFFICIALS_SCHEMA.keys())
+    assert df.height >= 1
+    assert "Riley Johnson" in df.get_column("official").to_list()
+    # never captures a nav tab as an official
+    assert not set(df.get_column("official").to_list()) & {"Box Score", "Play By Play"}
+
+
+def test_officials_empty() -> None:
+    assert parse_cfb_ncaa_officials("").height == 0
+
+
+# --- team stats (by period) ----------------------------------------------
+
+
+def test_team_stats_has_per_quarter_breakdown() -> None:
+    df = parse_cfb_ncaa_team_stats(_rd("team_stats"), contest_id="5362283")
+    assert df.columns == list(TEAM_STATS_SCHEMA.keys())
+    assert df.height > 0
+    ra = df.filter(pl.col("stat") == "Rush Attempts")
+    periods = set(ra.get_column("period").to_list())
+    assert "total" in periods
+    assert {"1st Quarter", "2nd Quarter", "3rd Quarter", "4th Quarter"} <= periods
+    # every period carries an away + home value (structure faithfully extracted;
+    # NCAA's per-quarter values are recorded as-is and do not necessarily sum to
+    # the total, so that is not asserted).
+    assert ra.get_column("away_value").is_not_null().all()
+    assert ra.get_column("home_value").is_not_null().all()
+    assert int(ra.filter(pl.col("period") == "total").get_column("away_value")[0]) == 34
+    assert {"Rushing", "Passing", "Receiving"} <= set(df.get_column("category").unique().to_list())
+
+
+def test_team_stats_teams_labeled() -> None:
+    df = parse_cfb_ncaa_team_stats(_rd("team_stats"), contest_id="5362283")
+    assert df.get_column("away_team").unique().to_list() == ["California"]
+    assert df.get_column("home_team").unique().to_list() == ["Auburn"]
+
+
+# --- individual player stats ---------------------------------------------
+
+
+def test_player_stats_categories() -> None:
+    d = parse_cfb_ncaa_player_stats(_rd("individual_stats"), contest_id="5362283")
+    assert {"rushing", "passing", "receiving"} <= set(d.keys())
+    passing = d["passing"]
+    for c in ("contest_id", "team_id", "name", "position", "pass_attempts", "completions", "pass_yards"):
+        assert c in passing.columns
+    # Mendoza's game line: 25/36, 233, 2 TD
+    m = passing.filter(pl.col("name") == "Fernando Mendoza")
+    assert m.height == 1
+    row = m.row(0, named=True)
+    assert row["pass_attempts"] == "36" and row["completions"] == "25" and row["pass_yards"] == "233"
+
+
+def test_player_stats_two_teams() -> None:
+    d = parse_cfb_ncaa_player_stats(_rd("individual_stats"), contest_id="5362283")
+    assert d["rushing"].get_column("team_id").n_unique() == 2
+
+
+def test_player_stats_empty() -> None:
+    assert parse_cfb_ncaa_player_stats("") == {}
+
+
+# --- linescore ------------------------------------------------------------
+
+
+def test_linescore_teams_periods_meta() -> None:
+    df = parse_cfb_ncaa_linescore(_rd("box_score"), contest_id="5362283")
+    assert df.columns == list(LINESCORE_SCHEMA.keys())
+    assert set(df.get_column("home_away").unique().to_list()) == {"away", "home"}
+    # California away, final 21; Auburn home, final 14
+    cal = df.filter(pl.col("team") == "California")
+    assert cal.get_column("final").unique().to_list() == [21]
+    assert cal.get_column("points").cast(pl.Int64).sum() == 21  # quarters sum to final
+    assert df.get_column("attendance").unique().to_list() == [88043]
+
+
+def test_linescore_empty() -> None:
+    df = parse_cfb_ncaa_linescore("")
+    assert df.height == 0 and df.columns == list(LINESCORE_SCHEMA.keys())

--- a/tests/fixtures/cfb_ncaa/README.md
+++ b/tests/fixtures/cfb_ncaa/README.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [cfb_ncaa fixtures](#cfb_ncaa-fixtures)
+  - [Box-score tabs (contest 5362283 — California @ Auburn, 2024-09-07)](#box-score-tabs-contest-5362283--california--auburn-2024-09-07)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -21,6 +22,19 @@ Consumed by `tests/cfb/test_cfb_ncaa_pbp.py` (offline parser tests).
 | `cfb_ncaa_pbp_5336803.html` | 5336803 | <https://stats.ncaa.org/contests/5336803/play_by_play> | 2026-07-16 |
 | `cfb_ncaa_pbp_5361446.html` | 5361446 | <https://stats.ncaa.org/contests/5361446/play_by_play> | 2026-07-16 |
 
-The full 6-game capture corpus lives in the `ncaa-mfb-hoops-raw` producer repo;
+The full 6-game capture corpus lives in the `ncaa-mfb-football-raw` producer repo;
 three games are vendored here to prove the parser generalizes across games
 (0 unknown play types on every game).
+
+## Box-score tabs (contest 5362283 — California @ Auburn, 2024-09-07)
+
+Consumed by `tests/cfb/test_cfb_ncaa_box.py`. The other stats.ncaa.org tabs of one
+game, for the box/drives/officials parsers in `cfb/cfb_ncaa_box.py`:
+
+| file | tab | source URL |
+|---|---|---|
+| `mfb_drives_5362283.html` | Drives | <https://stats.ncaa.org/contests/5362283/drives> |
+| `mfb_team_stats_5362283.html` | Team Stats (by period) | <https://stats.ncaa.org/contests/5362283/team_stats> |
+| `mfb_individual_stats_5362283.html` | Individual Stats | <https://stats.ncaa.org/contests/5362283/individual_stats> |
+| `mfb_officials_5362283.html` | Officials | <https://stats.ncaa.org/contests/5362283/officials> |
+| `mfb_box_score_5362283.html` | Box Score (linescore + game info) | <https://stats.ncaa.org/contests/5362283/box_score> |

--- a/tests/fixtures/cfb_ncaa/mfb_box_score_5362283.html
+++ b/tests/fixtures/cfb_ncaa/mfb_box_score_5362283.html
@@ -1,0 +1,755 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<META HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=UTF-8">
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="">
+<meta name="author" content="">
+<meta name="version" content="321d28433e9f7a188596117e6f342ec4a84fb4ed">
+<META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<link rel="shortcut icon" href="/assets/favicon-405088046a5f2bab8eedeacfae7636975c095e9c8decd8c28e3fd0e65c2f51c4.ico" type="image/vnd.microsoft.icon">
+
+<title>NCAA Statistics</title>
+
+<!-- Bootstrap core CSS -->
+
+<!--
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+-->
+<!--
+<link rel="stylesheet" href="https://cdn.datatables.net/2.0.0/css/dataTables.bootstrap4.css" crossorigin="anonymous">
+-->
+<link rel="stylesheet" media="all" href="/assets/application-789c3971842ee3597428ccbebd021716b3231e9cbd0a00a184c3b2d6c8e5f152.css" />
+
+
+<script src="/assets/application-9232576bb3cb000ac0841ff2af81251908ec17312a3c5eb72bf1a32f9754800c.js"></script>
+<!--
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+-->
+<!--
+<script src="https://cdn.datatables.net/2.0.0/js/dataTables.bootstrap4.js" crossorigin="anonymous"></script>
+-->
+
+<meta name="csrf-param" content="authenticity_token" />
+<meta name="csrf-token" content="wk9vRmbrRQTpNWip9rvkIBwP9OuXAavaiDlbIo9aCvXVSBpZK8UIjY78/zft1Jq7C299ZhfgzZe+xESNBOowgQ==" />
+
+<style>
+.grid {clear: all}
+.grid-item, .name {text-align: center;}
+h1 img {max-height: 33px;}
+
+</style>
+<!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+<!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+      <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+    <![endif]-->
+
+
+<script>(window.BOOMR_mq=window.BOOMR_mq||[]).push(["addVar",{"rua.upush":"false","rua.cpush":"false","rua.upre":"false","rua.cpre":"false","rua.uprl":"false","rua.cprl":"false","rua.cprf":"false","rua.trans":"","rua.cook":"false","rua.ims":"false","rua.ufprl":"false","rua.cfprl":"false","rua.isuxp":"false","rua.texp":"norulematch","rua.ceh":"false","rua.ueh":"false","rua.ieh.st":"0"}]);</script>
+                                <script>!function(e){var n="https://s.go-mpulse.net/boomerang/";if("False"=="True")e.BOOMR_config=e.BOOMR_config||{},e.BOOMR_config.PageParams=e.BOOMR_config.PageParams||{},e.BOOMR_config.PageParams.pci=!0,n="https://s2.go-mpulse.net/boomerang/";if(window.BOOMR_API_key="EVKJV-AGD2E-W66AE-NT84S-K5LTF",function(){function e(){if(!r){var e=document.createElement("script");e.id="boomr-scr-as",e.src=window.BOOMR.url,e.async=!0,o.appendChild(e),r=!0}}function t(e){r=!0;var n,t,a,i,d=document,O=window;if(window.BOOMR.snippetMethod=e?"if":"i",t=function(e,n){var t=d.createElement("script");t.id=n||"boomr-if-as",t.src=window.BOOMR.url,BOOMR_lstart=(new Date).getTime(),e=e||d.body,e.appendChild(t)},!window.addEventListener&&window.attachEvent&&navigator.userAgent.match(/MSIE [67]\./))return window.BOOMR.snippetMethod="s",void t(o,"boomr-async");a=document.createElement("IFRAME"),a.src="about:blank",a.title="",a.role="presentation",a.loading="eager",i=(a.frameElement||a).style,i.width=0,i.height=0,i.border=0,i.display="none",o.appendChild(a);try{O=a.contentWindow,d=O.document.open()}catch(_){n=document.domain,a.src="javascript:var d=document.open();d.domain='"+n+"';void 0;",O=a.contentWindow,d=O.document.open()}if(n)d._boomrl=function(){this.domain=n,t()},d.write("<bo"+"dy onload='document._boomrl();'>");else if(O._boomrl=function(){t()},O.addEventListener)O.addEventListener("load",O._boomrl,!1);else if(O.attachEvent)O.attachEvent("onload",O._boomrl);d.close()}function a(e){window.BOOMR_onload=e&&e.timeStamp||(new Date).getTime()}if(!window.BOOMR||!window.BOOMR.version&&!window.BOOMR.snippetExecuted){window.BOOMR=window.BOOMR||{},window.BOOMR.snippetStart=(new Date).getTime(),window.BOOMR.snippetExecuted=!0,window.BOOMR.snippetVersion=14,window.BOOMR.url=n+"EVKJV-AGD2E-W66AE-NT84S-K5LTF";var i=document.currentScript||document.getElementsByTagName("script")[0],o=i.parentNode,r=!1,d=document.createElement("link");if(d.relList&&"function"==typeof d.relList.supports&&d.relList.supports("preload")&&"as"in d)window.BOOMR.snippetMethod="p",d.href=window.BOOMR.url,d.rel="preload",d.as="script",d.addEventListener("load",e),d.addEventListener("error",function(){t(!0)}),setTimeout(function(){if(!r)t(!0)},3e3),BOOMR_lstart=(new Date).getTime(),o.appendChild(d);else t(!1);if(window.addEventListener)window.addEventListener("load",a,!1);else if(window.attachEvent)window.attachEvent("onload",a)}}(),"".length>0)if(e&&"performance"in e&&e.performance&&"function"==typeof e.performance.setResourceTimingBufferSize)e.performance.setResourceTimingBufferSize();!function(){if(BOOMR=e.BOOMR||{},BOOMR.plugins=BOOMR.plugins||{},!BOOMR.plugins.AK){var n=""=="true"?1:0,t="cookiepresent",a="ntaveg5yk4sly2sz563a-f-42d46722e-clientnsv4-s.akamaihd.net",i="false"=="true"?2:1,o={"ak.v":"41","ak.cp":"1168236","ak.ai":parseInt("215853",10),"ak.ol":"0","ak.cr":10,"ak.ipv":4,"ak.proto":"h2","ak.rid":"20c5ab05","ak.r":40932,"ak.a2":n,"ak.m":"a","ak.n":"essl","ak.cport":53000,"ak.gh":"23.56.236.39","ak.quicv":"","ak.tlsv":"tls1.3","ak.0rtt":"","ak.0rtt.ed":"","ak.csrc":"-","ak.acc":"","ak.t":"1784278966","ak.ak":"hOBiQwZUYzCg5VSAfCLimQ==DW8yf/uXfA7ddFm/CMlZjqHg40bhIZB8b/WLNpQs/4YL/iMdg5ZwcEd04d7IU7/BVnLJx4poiNlxzoSIrb96LbzVhVxOrV62QpBuojjqhalxGslvPVZonsbNMVJaXJ01XTv2j9rgsKs1Lx9G2uUIw5yNX3VsQYLV/8MsdkppGE8rxg/3iroulE7AjGVdw+QSmrPueyUZ9dUxf0W3UB1jsfIQ6YEqy3p371TJRDPLMxu/IaoR54jJ0YNtPk5Otzcs7fK147kaAMvjmozSOR5BQlLewqp8brKh8RYciYcCvcjhpxnBggsqcjPYixyItWAoFRveDWjaYRbou/E3ZI0DuX2XkIeRITPl3cBRZkr+s1bEVN92QihVA+os1XzUgugSzKhWJJcjsH7nzC2fIg3J8ydXu+a9k5SHiNenbPIHZ9Q=","ak.pv":"93","ak.dpoabenc":"","ak.tf":i};if(""!==t)o["ak.ruds"]=t;var r={i:!1,av:function(n){var t="http.initiator";if(n&&(!n[t]||"spa_hard"===n[t]))o["ak.feo"]=void 0!==e.aFeoApplied?1:0,BOOMR.addVar(o)},rv:function(){var e=["ak.cport","ak.cr","ak.csrc","ak.gh","ak.ipv","ak.m","ak.n","ak.ol","ak.proto","ak.quicv","ak.tlsv","ak.0rtt","ak.0rtt.ed","ak.r","ak.acc","ak.t","ak.tf"];BOOMR.removeVar(e)}};BOOMR.plugins.AK={akVars:o,akDNSPreFetchDomain:a,init:function(){if(!r.i){var e=BOOMR.subscribe;e("before_beacon",r.av,null,null),e("onbeacon",r.rv,null,null),r.i=!0}return this},is_complete:function(){return!0}}}}()}(window);</script></head>
+
+  <script>
+
+    
+  //initialize tooltip
+  $(document).ready(function() {
+    //$("body").tooltip({ selector: '[data-toggle=tooltip]' });
+    $('[data-toggle="tooltip"]').tooltip();
+  });
+
+  $(document).ready(function() {
+    $( "#org_name" ).autocomplete({
+      source: '/team/search',
+      select: function( event, ui ) {
+        $("#org_id").val(ui.item.vid);
+        $("#id").val(ui.item.vid);
+        $('#sport_btn').click();
+      }
+    });
+  });
+
+  var body = 'body';
+
+  $.ajaxSetup ({
+    // Disable caching of AJAX responses
+    cache: false
+  });
+
+  function changeSport(field){
+    var el = $(field);
+    var tmList = el.parent().next().find('.new-team-year')[0];
+    if (tmList == null){
+      tmList = el.nextAll('.new-team-year')[0];
+    }
+    $.ajax({
+      url: "/game_sport_year_ctls/"+el.val()+"/available_teams",
+      dataType: "script",
+      success: function(data, status){
+        $(tmList).empty();
+        $(tmList).append(("<option value=''>Select team</option>"));
+        $.each(JSON.parse(data), function(k, v){
+          $(tmList).append($("<option></option>")
+              .attr("value", v["id"])
+              .text(v["member_org"]["name_tabular"]));
+        });
+        $(tmList).trigger("chosen:updated");
+      }
+    });
+  }
+
+    function set_process_styles(fld, start_color, end_color){
+       $('#'+fld).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    var downImage = "/assets/down12.gif";
+    var rightImage = "/assets/right12.gif";
+
+    function highlight(div_id){
+      $(div_id).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    function show_hide_rows(attr_val, link_id){
+      $('#'+attr_val).toggle();
+      if ($('#'+attr_val).is(':visible')) {
+        $('#'+link_id).attr('src', downImage);
+      }else{
+        $('#'+link_id).attr('src', rightImage);
+      }
+    }
+
+    function mask(label){
+      $('body').mask(label);
+    }
+    function unmask(){
+      $('body').unmask();
+    }
+
+    var winHeight = "auto";
+    var winWidth = "auto";
+    var maxHeight = 700;
+    var maxWidth = 1400;
+    var minHeight = 100;
+    var minWidth = 200;
+    
+    var modalOptions = {"width": winWidth,
+                        "height": winHeight,
+                        "maxHeight": maxHeight,
+                        "maxWidth": maxWidth,
+                        "minHeight": minHeight,
+                        "minWidth": minWidth};
+
+    function dialog(url, title){
+
+      $("#stats_app_dialog").dialog({modal:true, minWidth:minWidth, minHeight:minHeight, maxWidth:maxWidth, maxHeight:maxHeight, width:winWidth, height:winHeight, title:title, closeOnEscape: false});
+    
+      modalOptions.title = title;
+    
+      $("#stats_app_dialog").dialog("option", modalOptions);
+    
+      $("#stats_app_dialog").html("Loading...");
+      $("#stats_app_dialog").load(url).dialog('open');
+    }
+
+    function addDatePicker(){
+    $('.adddatepicker').each(function(i, obj){
+      $(obj).datepicker({ 
+        showOn: 'both', 
+        buttonImage: '/assets/calendar.gif', 
+        buttonImageOnly: true,
+      });
+    });
+    }
+
+   $(document).ready(function() {
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   });
+
+   function setClassInputFields(){
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   }
+
+   function isValidDateFormat(dateStr){
+     const regex = /^([1-9]|0[1-9]|1[0-2])\/([1-9]|0[1-9]|[12][0-9]|3[01])\/(19|20)\d{2}$/;
+     if (!regex.test(dateStr)) {
+       return false;
+     }else{
+       return true;
+     }
+   }
+
+  </script>
+
+
+<body style="font-size: .75rem;" onload="if (top != self) { top.location=self.location; }" >
+
+      <header>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0">
+        <a class="navbar-brand mr-0 mr-md-2" href="/" aria-label="statistics">
+                          <img alt="NCAA" style="margin-left: 24px; margin-right: 0; margin-top: 6px;" src="/assets/ncaa-fbc4d0406ae731b47babcc3fca53775b5955ef372bf8b8e998ca9a513e468b8f.svg" />
+                          <span class="title" class="dark-blue-font">Statistics</span>
+        </a>
+       </nav>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0" style="background-color: var(--color-dark-blue) !important;">
+  <button class="navbar-toggler bg-white" type="button" data-toggle="collapse" data-target="#navbarTogglerDemo01" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarTogglerDemo01">
+        <ul class="navbar-nav mr-auto mt-2 mt-lg-0 justify-content-center">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle skipMask" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Rankings
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+          <a class="dropdown-item" href="/rankings">National Rankings</a>
+          <a class="dropdown-item" href="/active_career_leaders">Active Career Leaders</a>
+        </div>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/contests/livestream_scoreboards">Scoreboard</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/selection_rankings/nitty_gritties">Selection Rankings</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/head_coaches">Head Coaches</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/search/players">Players</a>
+      </li>
+     </ul>
+
+    <form onsubmit="mask(&#39;Loading&#39;);" id="change_team_form" style="display:inline;" class="form-inline my-2 my-lg-0" action="/team/index" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="Ukpo0AFIEPOuhenZAjl+C/pMwYhdup9wG1ISEWUSRtvyPEEfoqZ4tkFpmjy7l+ElZ7b0i/rQvomRoCA5hkKKXg==" />
+  <div style="display:none;">
+  <input type="submit" name="commit" value="Submit" id="sport_btn" data-disable-with="Submit" />
+  </div>
+    <div id="team_autocomplete" class="ui-widget">
+      <input type="search" name="org_name" id="org_name" style="width:200px; font-size: 12px !important" class="form-control mr-sm-2" placeholder="Team Search" />
+      <input type="hidden" name="org_id" id="org_id" />
+    </div>
+</form>  </div>
+  </nav>
+</nav>
+      </header>
+
+       <div id="stats_app_dialog" style="display:none;">
+        </div>
+
+<div class="card p-1">
+  <div class="card-body application contests p-0">
+    <h3 class="card-title p-0"></h3>
+    <div class="container-fluid p-0">
+      <div class="row align-items-center justify-content-center p-0">
+        <div class="col-sm-12 p-0">
+              <br/>
+
+<br/>
+
+<style>
+.winner{
+  --display: flex;
+  vertical-align: middle;
+}
+.winner:before{
+  content: '\25BA';
+  --display: flex;
+  --align-items: center;
+  vertical-align: middle;
+}
+div.center {
+  margin: auto;
+  width: 50%;
+  --border: 3px solid green;
+  padding: 10px;
+}
+</style>
+
+   <div class="table-responsive">
+   <table align="center">
+     <tr>
+   <td>
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589036"><img class="large_logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" /></a>
+   </td>
+   <td valign="center" class="grey_text d-none d-sm-table-cell" nowrap>
+     <span style="font-size:18px">
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589036">California Golden Bears</a>
+     </span><br/>
+       2-0, Conf 0-0
+   </td>
+   <td valign="center" class="winner">
+   </td>
+   <td valign="center" style="font-size:36px; color: black">
+     21
+   </td>
+     <td style="padding: 0px 30px 0px 30px"  class="d-none d-md-table-cell">
+       <table style="border-collapse: collapse">
+         <tr>
+           <td class="grey_border_bottom"></td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">1</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">2</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">3</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">4</td>
+           <td width="20px" align="right" style="font-weight:bold" class="grey_border_bottom">S</td>
+         </tr>
+           <tr>
+             <td>California</td>
+               <td class="grey_text" align="right">7</td>
+               <td class="grey_text" align="right">7</td>
+               <td class="grey_text" align="right">0</td>
+               <td class="grey_text" align="right">7</td>
+             <td align="right" style="font-weight:bold">21</td>
+           </tr>
+           <tr>
+             <td>Auburn</td>
+               <td class="grey_text" align="right">7</td>
+               <td class="grey_text" align="right">0</td>
+               <td class="grey_text" align="right">0</td>
+               <td class="grey_text" align="right">7</td>
+             <td align="right" style="font-weight:bold">14</td>
+           </tr>
+         <tr>
+           <td class="grey_text" colspan="6">09/07/2024 03:30 PM</td>
+         </tr>
+         <tr>
+           <td nowrap class="grey_text" colspan="6">Jordan-Hare Stadium (Auburn, AL)</td>
+         </tr>
+         <tr>
+           <td nowrap class="grey_text" colspan="6">Attendance: 88,043</td>
+         </tr>
+       </table>
+     </td>
+   <td>
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589027"><img class="large_logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" /></a>
+   </td>
+   <td valign="center" class="grey_text d-none d-sm-table-cell" nowrap>
+     <span style="font-size:18px">
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589027">Auburn Tigers</a>
+     </span><br/>
+       1-1, Conf 0-0
+   </td>
+   <td valign="center" class="">
+   </td>
+   <td valign="center" style="font-size:36px; color: grey">
+     14
+   </td>
+     </tr>
+     <tr>
+       <td colspan="10" class="grey_border_bottom grey_border_top">
+         <table cellpadding="10px">
+           <tr>
+             <td style="font-size: 16px;">Box Score</td>
+             <td style="font-size: 16px;"><a href="/contests/5362283/team_stats">Team Stats</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5362283/individual_stats">Individual Stats</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5362283/play_by_play">Play By Play</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5362283/drives">Drives</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5362283/officials">Officials</a></td>
+           </tr>
+         </table>
+       </td>
+     </tr>
+   </table>
+ </div>
+
+ <table align="center">
+   <tr>
+     <td valign="top">
+<table id="game_leaders_table" class="display dataTable roundedCorners" width="200px">
+  <thead>
+    <tr>
+      <th class="box_score_summary_th" colspan="9">Game Leaders</th>
+    </tr>
+    <tr>
+    <th></th>
+    <th align="left" width="10%" nowrap><div class='row'><img class="logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" /><span class='d-none d-sm-block'>California</span></div></th>
+    <th align="left" width="10%" nowrap><div class='row'><img class="logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" /><span class='d-none d-sm-block'>Auburn</span></div></th>
+  </tr>
+  </thead>
+  <tbody>
+      <tr>
+        <td nowrap>Rushing</td>
+        <td nowrap>
+            <a target="PLAYER_HISTORY" class="skipMask" href="/player/game_by_game?game_sport_year_ctl_id=16680&amp;org_id=107&amp;stats_player_seq=2844962">Jaivian Thomas</a>
+            <br/>
+            <span class="grey_text">
+              8 Car, 53 Yds, 1 TD
+            </span>
+        </td>
+        <td nowrap>
+            <a target="PLAYER_HISTORY" class="skipMask" href="/player/game_by_game?game_sport_year_ctl_id=16680&amp;org_id=37&amp;stats_player_seq=2546509">Jarquez Hunter</a>
+            <br/>
+            <span class="grey_text">
+              12 Car, 68 Yds
+            </span>
+        </td>
+      </tr>
+      <tr>
+        <td nowrap>Passing</td>
+        <td nowrap>
+            <a target="PLAYER_HISTORY" class="skipMask" href="/player/game_by_game?game_sport_year_ctl_id=16680&amp;org_id=107&amp;stats_player_seq=2738127">Fernando Mendoza</a>
+            <br/>
+            <span class="grey_text">
+              25-36, 233 Yds, 2 TD
+            </span>
+        </td>
+        <td nowrap>
+            <a target="PLAYER_HISTORY" class="skipMask" href="/player/game_by_game?game_sport_year_ctl_id=16680&amp;org_id=37&amp;stats_player_seq=2241903">Payton Thorne</a>
+            <br/>
+            <span class="grey_text">
+              14-27, 165 Yds, 1 TD, 4 Int
+            </span>
+        </td>
+      </tr>
+      <tr>
+        <td nowrap>Receiving</td>
+        <td nowrap>
+            <a target="PLAYER_HISTORY" class="skipMask" href="/player/game_by_game?game_sport_year_ctl_id=16680&amp;org_id=107&amp;stats_player_seq=2735636">Jonathan Brady</a>
+            <br/>
+            <span class="grey_text">
+              4 Rec, 63 Yds
+            </span>
+        </td>
+        <td nowrap>
+            <a target="PLAYER_HISTORY" class="skipMask" href="/player/game_by_game?game_sport_year_ctl_id=16680&amp;org_id=37&amp;stats_player_seq=3005856">Cam Coleman</a>
+            <br/>
+            <span class="grey_text">
+              2 Rec, 53 Yds
+            </span>
+        </td>
+      </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="10" style="border-top: 0px solid white"></td></tr>
+  </tfoot>
+</table>
+     </td>
+     <td valign="top" rowspan="2">
+<table id="scoring_summary_table" class="display dataTable roundedCorners" width="200px">
+  <thead>
+    <tr>
+      <th class="box_score_summary_th" colspan="9">Scoring Summary</th>
+    </tr>
+  <tr>
+    <th>Period</th>
+    <th align="right">Clock</th>
+    <th>Has Ball</th>
+    <th>Play</th>
+    <th align="right">Plays</th>
+    <th align="right">Yards</th>
+    <th align="right">TOP</th>
+    <th align="right" width="10%" nowrap><div class='row'><img class="logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" /><span class='d-none d-sm-block'>California</span></div></th>
+    <th align="right" width="10%" nowrap><div class='row'><img class="logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" /><span class='d-none d-sm-block'>Auburn</span></div></th>
+  </tr>
+  </thead>
+  <tbody>
+      <tr>
+        <td>1</td>
+        <td align="right">11:42</td>
+        <td><img class="logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" /></td>
+        <td>
+            (11:46) No Huddle-Shotgun Thorne,Payton pass complete short right to Lambert-Smith,KeAndre caught at Cal00 (McGough,Towns kick attempt good (H: Chapman,Oscar)
+        </td>
+        <td align="right"><a class="skipMask" data-remote="true" href="/contests/game_drives/3423368/game_period_plays">8</a></td>
+        <td align="right">75</td>
+        <td align="right">03:18</td>
+        <td align="right">0</td>
+        <td align="right">7</td>
+      <tr>
+        <td>1</td>
+        <td align="right">07:17</td>
+        <td><img class="logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" /></td>
+        <td>
+            (07:18) Shotgun Mendoza,Fernando pass complete short right to Hunter,Nyziah caught at Auburn00 (Coe,Ryan kick attempt good (H: Wilson,Lachlan)
+        </td>
+        <td align="right"><a class="skipMask" data-remote="true" href="/contests/game_drives/3423381/game_period_plays">8</a></td>
+        <td align="right">75</td>
+        <td align="right">04:25</td>
+        <td align="right">7</td>
+        <td align="right">7</td>
+      <tr>
+        <td>2</td>
+        <td align="right">10:39</td>
+        <td><img class="logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" /></td>
+        <td>
+            (10:43) Shotgun Mendoza,Fernando pass complete short right to Hunter,Nyziah caught at Auburn00 (Coe,Ryan kick attempt good (H: Wilson,Lachlan)
+        </td>
+        <td align="right"><a class="skipMask" data-remote="true" href="/contests/game_drives/3423383/game_period_plays">3</a></td>
+        <td align="right">21</td>
+        <td align="right">01:30</td>
+        <td align="right">14</td>
+        <td align="right">7</td>
+      <tr>
+        <td>4</td>
+        <td align="right">11:27</td>
+        <td><img class="logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" /></td>
+        <td>
+            (11:33) No Huddle-Shotgun Thomas,Jaivian rush right for 32 yards gain to the Auburn00 TOUCHDOWN (Coe,Ryan kick attempt good (H: Wilson,Lachlan)
+        </td>
+        <td align="right"><a class="skipMask" data-remote="true" href="/contests/game_drives/3423390/game_period_plays">2</a></td>
+        <td align="right">36</td>
+        <td align="right">00:49</td>
+        <td align="right">21</td>
+        <td align="right">7</td>
+      <tr>
+        <td>4</td>
+        <td align="right">06:06</td>
+        <td><img class="logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" /></td>
+        <td>
+            No Huddle-Shotgun Thorne,Payton rush right for 2 yards gain to the Cal00 TOUCHDOWN (McGough,Towns kick attempt good (H: Chapman,Oscar)
+        </td>
+        <td align="right"><a class="skipMask" data-remote="true" href="/contests/game_drives/3423378/game_period_plays">12</a></td>
+        <td align="right">75</td>
+        <td align="right">05:21</td>
+        <td align="right">21</td>
+        <td align="right">14</td>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="10" style="border-top: 0px solid white"></td></tr>
+  </tfoot>
+</table>
+     </td>
+   </tr>
+   <tr>
+     <td valign="top">
+<table id="team_stats_table" class="dataTable roundedCorners" width="200px">
+  <thead>
+    <tr>
+      <th class="box_score_summary_th" colspan="9">Team Stats</th>
+    </tr>
+  </tr>
+  </thead>
+  <tbody>
+
+      <tr>
+        <td>
+          <table class="display dataTable">
+            <thead>
+            <tr>
+              <th colspan="9">TOP</th>
+            </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td nowrap><div class='row'><img class="logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" /><span class='d-none d-sm-block'>California</span></div></td>
+                <td width="80%">
+                  <div class="stat_bar_container">
+                    <div class="stat_bar" style="width: 59.32203389830508%; background-color: grey;"></div>
+                  </div>
+                </td>
+                <td width="5%">35:16</td>
+              </tr>
+              <tr>
+                <td nowrap><div class='row'><img class="logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" /><span class='d-none d-sm-block'>Auburn</span></div></td>
+                <td width="80%">
+                  <div class="stat_bar_container">
+                    <div class="stat_bar" style="width: 40.67796610169492%; background-color: blue;"></div>
+                  </div>
+                </td>
+                <td width="5%">24:44</td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <table class="display dataTable">
+            <thead>
+            <tr>
+              <th colspan="9">Rush Yds</th>
+            </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td nowrap><div class='row'><img class="logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" /><span class='d-none d-sm-block'>California</span></div></td>
+                <td width="80%">
+                  <div class="stat_bar_container">
+                    <div class="stat_bar" style="width: 45.0%; background-color: grey;"></div>
+                  </div>
+                </td>
+                <td width="5%">99</td>
+              </tr>
+              <tr>
+                <td nowrap><div class='row'><img class="logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" /><span class='d-none d-sm-block'>Auburn</span></div></td>
+                <td width="80%">
+                  <div class="stat_bar_container">
+                    <div class="stat_bar" style="width: 55.00000000000001%; background-color: blue;"></div>
+                  </div>
+                </td>
+                <td width="5%">121</td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <table class="display dataTable">
+            <thead>
+            <tr>
+              <th colspan="9">Pass Yds</th>
+            </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td nowrap><div class='row'><img class="logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" /><span class='d-none d-sm-block'>California</span></div></td>
+                <td width="80%">
+                  <div class="stat_bar_container">
+                    <div class="stat_bar" style="width: 58.5427135678392%; background-color: grey;"></div>
+                  </div>
+                </td>
+                <td width="5%">233</td>
+              </tr>
+              <tr>
+                <td nowrap><div class='row'><img class="logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" /><span class='d-none d-sm-block'>Auburn</span></div></td>
+                <td width="80%">
+                  <div class="stat_bar_container">
+                    <div class="stat_bar" style="width: 41.45728643216081%; background-color: blue;"></div>
+                  </div>
+                </td>
+                <td width="5%">165</td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <table class="display dataTable">
+            <thead>
+            <tr>
+              <th colspan="9">Takeaways</th>
+            </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td nowrap><div class='row'><img class="logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" /><span class='d-none d-sm-block'>California</span></div></td>
+                <td width="80%">
+                  <div class="stat_bar_container">
+                    <div class="stat_bar" style="width: 100.0%; background-color: grey;"></div>
+                  </div>
+                </td>
+                <td width="5%">5</td>
+              </tr>
+              <tr>
+                <td nowrap><div class='row'><img class="logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" /><span class='d-none d-sm-block'>Auburn</span></div></td>
+                <td width="80%">
+                  <div class="stat_bar_container">
+                    <div class="stat_bar" style="width: 0%; background-color: blue;"></div>
+                  </div>
+                </td>
+                <td width="5%">0</td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <table class="display dataTable">
+            <thead>
+            <tr>
+              <th colspan="9">First Downs</th>
+            </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td nowrap><div class='row'><img class="logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" /><span class='d-none d-sm-block'>California</span></div></td>
+                <td width="80%">
+                  <div class="stat_bar_container">
+                    <div class="stat_bar" style="width: 52.94117647058824%; background-color: grey;"></div>
+                  </div>
+                </td>
+                <td width="5%">18</td>
+              </tr>
+              <tr>
+                <td nowrap><div class='row'><img class="logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" /><span class='d-none d-sm-block'>Auburn</span></div></td>
+                <td width="80%">
+                  <div class="stat_bar_container">
+                    <div class="stat_bar" style="width: 47.05882352941176%; background-color: blue;"></div>
+                  </div>
+                </td>
+                <td width="5%">16</td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="10" style="border-top: 0px solid white"></td></tr>
+  </tfoot>
+</table>
+     </td>
+   </tr>
+ </table>
+
+
+
+
+       </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<footer>&copy; <script>document.write(new Date().getFullYear())</script> NCAA <a href="http://web1.ncaa.org/web_files/terms_and_conditions.html" title ="Terms and Conditions" target=_blank>Terms and Conditions</a> | <a href="http://web1.ncaa.org/web_files/privacy.html" target=_blank title="Our Privacy Policy">Privacy Policy</a> | <a href="mailto:ncaa_stats@ncaa.org">Contact Us</a> </footer>
+
+  <!-- /.container -->
+  <script type="text/javascript"  src="/sU0joiPwv/zplvN/xFxji/wmgXJnBU/whimQww3k9OS/ZXgTG2MrBg/I0sONT4/dCDpZ?v=72c54ec5-e129-c4ef-7c10-871b401d1738" defer></script></body>
+
+  <script charset="utf-8">
+    $(document).ready(function() {
+      $('a.remote[data-toggle="tab"]').on('show.bs.tab', function (e) {
+        var tab_id = '#' + $(this).attr('aria-controls');
+        $(tab_id).html('<br/><br/><p style="text-align: center"><img style="vertical-align:middle; text-align: center" src="/assets/ajax-loader-6913acdbf4be7d6a2908a84bdecd6cad18110f5fc6d5a07cf8c9ce78d9548700.gif" /> Loading... </p><br/><br/>');
+        $.get($(this).data('remote'), function(data){
+          $(tab_id).html(data);
+        });
+      });
+    });
+
+    function skipMask(obj){
+      if (obj.hasClass('chosen-single') || obj.hasClass('skipMask') || obj.hasClass('ui-datepicker-prev') || obj.hasClass('ui-datepicker-next') || obj.hasClass('ui-corner-all') || obj.hasClass('paginate_button') || obj.hasClass('dt-button')){
+        return true;
+      }else{
+        return false;
+      }
+    }
+
+    $(document).ajaxComplete(function(){
+      unmask();
+    });
+/*
+    $("form").on('submit', function(event){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    */
+    $(document).on('click', 'a', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    $(document).on('click', 'input.green', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+
+  </script>
+</html>

--- a/tests/fixtures/cfb_ncaa/mfb_drives_5362283.html
+++ b/tests/fixtures/cfb_ncaa/mfb_drives_5362283.html
@@ -1,0 +1,972 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<META HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=UTF-8">
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="">
+<meta name="author" content="">
+<meta name="version" content="321d28433e9f7a188596117e6f342ec4a84fb4ed">
+<META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<link rel="shortcut icon" href="/assets/favicon-405088046a5f2bab8eedeacfae7636975c095e9c8decd8c28e3fd0e65c2f51c4.ico" type="image/vnd.microsoft.icon">
+
+<title>NCAA Statistics</title>
+
+<!-- Bootstrap core CSS -->
+
+<!--
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+-->
+<!--
+<link rel="stylesheet" href="https://cdn.datatables.net/2.0.0/css/dataTables.bootstrap4.css" crossorigin="anonymous">
+-->
+<link rel="stylesheet" media="all" href="/assets/application-789c3971842ee3597428ccbebd021716b3231e9cbd0a00a184c3b2d6c8e5f152.css" />
+
+
+<script src="/assets/application-9232576bb3cb000ac0841ff2af81251908ec17312a3c5eb72bf1a32f9754800c.js"></script>
+<!--
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+-->
+<!--
+<script src="https://cdn.datatables.net/2.0.0/js/dataTables.bootstrap4.js" crossorigin="anonymous"></script>
+-->
+
+<meta name="csrf-param" content="authenticity_token" />
+<meta name="csrf-token" content="SrkF6oeANxtZbcnjDaJot2MpndeD1BsF3LMG5+Roqzp07onzgbyiXUJuQIKEYfqG7ZOdN6foWzQ+YBsfwdLc0g==" />
+
+<style>
+.grid {clear: all}
+.grid-item, .name {text-align: center;}
+h1 img {max-height: 33px;}
+
+</style>
+<!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+<!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+      <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+    <![endif]-->
+
+
+<script>(window.BOOMR_mq=window.BOOMR_mq||[]).push(["addVar",{"rua.upush":"false","rua.cpush":"false","rua.upre":"false","rua.cpre":"false","rua.uprl":"false","rua.cprl":"false","rua.cprf":"false","rua.trans":"","rua.cook":"false","rua.ims":"false","rua.ufprl":"false","rua.cfprl":"false","rua.isuxp":"false","rua.texp":"norulematch","rua.ceh":"false","rua.ueh":"false","rua.ieh.st":"0"}]);</script>
+                                <script>!function(e){var n="https://s.go-mpulse.net/boomerang/";if("False"=="True")e.BOOMR_config=e.BOOMR_config||{},e.BOOMR_config.PageParams=e.BOOMR_config.PageParams||{},e.BOOMR_config.PageParams.pci=!0,n="https://s2.go-mpulse.net/boomerang/";if(window.BOOMR_API_key="EVKJV-AGD2E-W66AE-NT84S-K5LTF",function(){function e(){if(!r){var e=document.createElement("script");e.id="boomr-scr-as",e.src=window.BOOMR.url,e.async=!0,o.appendChild(e),r=!0}}function t(e){r=!0;var n,t,a,i,d=document,O=window;if(window.BOOMR.snippetMethod=e?"if":"i",t=function(e,n){var t=d.createElement("script");t.id=n||"boomr-if-as",t.src=window.BOOMR.url,BOOMR_lstart=(new Date).getTime(),e=e||d.body,e.appendChild(t)},!window.addEventListener&&window.attachEvent&&navigator.userAgent.match(/MSIE [67]\./))return window.BOOMR.snippetMethod="s",void t(o,"boomr-async");a=document.createElement("IFRAME"),a.src="about:blank",a.title="",a.role="presentation",a.loading="eager",i=(a.frameElement||a).style,i.width=0,i.height=0,i.border=0,i.display="none",o.appendChild(a);try{O=a.contentWindow,d=O.document.open()}catch(_){n=document.domain,a.src="javascript:var d=document.open();d.domain='"+n+"';void 0;",O=a.contentWindow,d=O.document.open()}if(n)d._boomrl=function(){this.domain=n,t()},d.write("<bo"+"dy onload='document._boomrl();'>");else if(O._boomrl=function(){t()},O.addEventListener)O.addEventListener("load",O._boomrl,!1);else if(O.attachEvent)O.attachEvent("onload",O._boomrl);d.close()}function a(e){window.BOOMR_onload=e&&e.timeStamp||(new Date).getTime()}if(!window.BOOMR||!window.BOOMR.version&&!window.BOOMR.snippetExecuted){window.BOOMR=window.BOOMR||{},window.BOOMR.snippetStart=(new Date).getTime(),window.BOOMR.snippetExecuted=!0,window.BOOMR.snippetVersion=14,window.BOOMR.url=n+"EVKJV-AGD2E-W66AE-NT84S-K5LTF";var i=document.currentScript||document.getElementsByTagName("script")[0],o=i.parentNode,r=!1,d=document.createElement("link");if(d.relList&&"function"==typeof d.relList.supports&&d.relList.supports("preload")&&"as"in d)window.BOOMR.snippetMethod="p",d.href=window.BOOMR.url,d.rel="preload",d.as="script",d.addEventListener("load",e),d.addEventListener("error",function(){t(!0)}),setTimeout(function(){if(!r)t(!0)},3e3),BOOMR_lstart=(new Date).getTime(),o.appendChild(d);else t(!1);if(window.addEventListener)window.addEventListener("load",a,!1);else if(window.attachEvent)window.attachEvent("onload",a)}}(),"".length>0)if(e&&"performance"in e&&e.performance&&"function"==typeof e.performance.setResourceTimingBufferSize)e.performance.setResourceTimingBufferSize();!function(){if(BOOMR=e.BOOMR||{},BOOMR.plugins=BOOMR.plugins||{},!BOOMR.plugins.AK){var n=""=="true"?1:0,t="cookiepresent",a="ntaveg5yk4sly2sz6azq-f-bbb1dd83b-clientnsv4-s.akamaihd.net",i="false"=="true"?2:1,o={"ak.v":"41","ak.cp":"1168236","ak.ai":parseInt("215853",10),"ak.ol":"0","ak.cr":8,"ak.ipv":4,"ak.proto":"h2","ak.rid":"20c70d78","ak.r":40932,"ak.a2":n,"ak.m":"a","ak.n":"essl","ak.cport":53220,"ak.gh":"23.56.236.39","ak.quicv":"","ak.tlsv":"tls1.3","ak.0rtt":"","ak.0rtt.ed":"","ak.csrc":"-","ak.acc":"","ak.t":"1784279091","ak.ak":"hOBiQwZUYzCg5VSAfCLimQ==Z18+4cBNDNLw2kGQKRIl6wunEMBiEi7t+3Gu3YwB/K3thj7LtskKDRz9g+L2xnPB9tgMfZBzqGsE31q1MWE8kIxW4aLBzaHMTD9wtqCZdAc0FRwI+l1NyB2gbuA5JmCfn51Ei4ngWQfP/V97UA1Xw4y+6hLKuV89hSRDoZbd4Cc2Eh7D1ZdG7j+twsIA5HHseXVNgAv1RhEIhbpScstcs0puKSICS1AlKuzmQgBglp1jC2ALFzhHUvylIAKc0T/GTjVMNkPojEtNnJSB4M2wDvn8ObUs3hXi6mqBqfoFBhUThiw3rf9WyUPLa5IxAd8wVMLtxEGMwwFhvxXtQZ0lEiVfvMSekzlzJ5F0bWHxKUYnGbPjP+3Yo++8pO2rj2dp48t8aeE3kd6S5VxSynltztH/ZJJ5DNPhRozFMwqkOQA=","ak.pv":"93","ak.dpoabenc":"","ak.tf":i};if(""!==t)o["ak.ruds"]=t;var r={i:!1,av:function(n){var t="http.initiator";if(n&&(!n[t]||"spa_hard"===n[t]))o["ak.feo"]=void 0!==e.aFeoApplied?1:0,BOOMR.addVar(o)},rv:function(){var e=["ak.cport","ak.cr","ak.csrc","ak.gh","ak.ipv","ak.m","ak.n","ak.ol","ak.proto","ak.quicv","ak.tlsv","ak.0rtt","ak.0rtt.ed","ak.r","ak.acc","ak.t","ak.tf"];BOOMR.removeVar(e)}};BOOMR.plugins.AK={akVars:o,akDNSPreFetchDomain:a,init:function(){if(!r.i){var e=BOOMR.subscribe;e("before_beacon",r.av,null,null),e("onbeacon",r.rv,null,null),r.i=!0}return this},is_complete:function(){return!0}}}}()}(window);</script></head>
+
+  <script>
+
+    
+  //initialize tooltip
+  $(document).ready(function() {
+    //$("body").tooltip({ selector: '[data-toggle=tooltip]' });
+    $('[data-toggle="tooltip"]').tooltip();
+  });
+
+  $(document).ready(function() {
+    $( "#org_name" ).autocomplete({
+      source: '/team/search',
+      select: function( event, ui ) {
+        $("#org_id").val(ui.item.vid);
+        $("#id").val(ui.item.vid);
+        $('#sport_btn').click();
+      }
+    });
+  });
+
+  var body = 'body';
+
+  $.ajaxSetup ({
+    // Disable caching of AJAX responses
+    cache: false
+  });
+
+  function changeSport(field){
+    var el = $(field);
+    var tmList = el.parent().next().find('.new-team-year')[0];
+    if (tmList == null){
+      tmList = el.nextAll('.new-team-year')[0];
+    }
+    $.ajax({
+      url: "/game_sport_year_ctls/"+el.val()+"/available_teams",
+      dataType: "script",
+      success: function(data, status){
+        $(tmList).empty();
+        $(tmList).append(("<option value=''>Select team</option>"));
+        $.each(JSON.parse(data), function(k, v){
+          $(tmList).append($("<option></option>")
+              .attr("value", v["id"])
+              .text(v["member_org"]["name_tabular"]));
+        });
+        $(tmList).trigger("chosen:updated");
+      }
+    });
+  }
+
+    function set_process_styles(fld, start_color, end_color){
+       $('#'+fld).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    var downImage = "/assets/down12.gif";
+    var rightImage = "/assets/right12.gif";
+
+    function highlight(div_id){
+      $(div_id).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    function show_hide_rows(attr_val, link_id){
+      $('#'+attr_val).toggle();
+      if ($('#'+attr_val).is(':visible')) {
+        $('#'+link_id).attr('src', downImage);
+      }else{
+        $('#'+link_id).attr('src', rightImage);
+      }
+    }
+
+    function mask(label){
+      $('body').mask(label);
+    }
+    function unmask(){
+      $('body').unmask();
+    }
+
+    var winHeight = "auto";
+    var winWidth = "auto";
+    var maxHeight = 700;
+    var maxWidth = 1400;
+    var minHeight = 100;
+    var minWidth = 200;
+    
+    var modalOptions = {"width": winWidth,
+                        "height": winHeight,
+                        "maxHeight": maxHeight,
+                        "maxWidth": maxWidth,
+                        "minHeight": minHeight,
+                        "minWidth": minWidth};
+
+    function dialog(url, title){
+
+      $("#stats_app_dialog").dialog({modal:true, minWidth:minWidth, minHeight:minHeight, maxWidth:maxWidth, maxHeight:maxHeight, width:winWidth, height:winHeight, title:title, closeOnEscape: false});
+    
+      modalOptions.title = title;
+    
+      $("#stats_app_dialog").dialog("option", modalOptions);
+    
+      $("#stats_app_dialog").html("Loading...");
+      $("#stats_app_dialog").load(url).dialog('open');
+    }
+
+    function addDatePicker(){
+    $('.adddatepicker').each(function(i, obj){
+      $(obj).datepicker({ 
+        showOn: 'both', 
+        buttonImage: '/assets/calendar.gif', 
+        buttonImageOnly: true,
+      });
+    });
+    }
+
+   $(document).ready(function() {
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   });
+
+   function setClassInputFields(){
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   }
+
+   function isValidDateFormat(dateStr){
+     const regex = /^([1-9]|0[1-9]|1[0-2])\/([1-9]|0[1-9]|[12][0-9]|3[01])\/(19|20)\d{2}$/;
+     if (!regex.test(dateStr)) {
+       return false;
+     }else{
+       return true;
+     }
+   }
+
+  </script>
+
+
+<body style="font-size: .75rem;" onload="if (top != self) { top.location=self.location; }" >
+
+      <header>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0">
+        <a class="navbar-brand mr-0 mr-md-2" href="/" aria-label="statistics">
+                          <img alt="NCAA" style="margin-left: 24px; margin-right: 0; margin-top: 6px;" src="/assets/ncaa-fbc4d0406ae731b47babcc3fca53775b5955ef372bf8b8e998ca9a513e468b8f.svg" />
+                          <span class="title" class="dark-blue-font">Statistics</span>
+        </a>
+       </nav>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0" style="background-color: var(--color-dark-blue) !important;">
+  <button class="navbar-toggler bg-white" type="button" data-toggle="collapse" data-target="#navbarTogglerDemo01" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarTogglerDemo01">
+        <ul class="navbar-nav mr-auto mt-2 mt-lg-0 justify-content-center">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle skipMask" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Rankings
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+          <a class="dropdown-item" href="/rankings">National Rankings</a>
+          <a class="dropdown-item" href="/active_career_leaders">Active Career Leaders</a>
+        </div>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/contests/livestream_scoreboards">Scoreboard</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/selection_rankings/nitty_gritties">Selection Rankings</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/head_coaches">Head Coaches</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/search/players">Players</a>
+      </li>
+     </ul>
+
+    <form onsubmit="mask(&#39;Loading&#39;);" id="change_team_form" style="display:inline;" class="form-inline my-2 my-lg-0" action="/team/index" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="oGN0AHzsNuHiaWMMtqokGLeFl9sjQ8pdZPuUkxA1yeBGBAXUEMRW0oOyD9zksyHdRj+3+lm0f8GKRt0+RUnNDA==" />
+  <div style="display:none;">
+  <input type="submit" name="commit" value="Submit" id="sport_btn" data-disable-with="Submit" />
+  </div>
+    <div id="team_autocomplete" class="ui-widget">
+      <input type="search" name="org_name" id="org_name" style="width:200px; font-size: 12px !important" class="form-control mr-sm-2" placeholder="Team Search" />
+      <input type="hidden" name="org_id" id="org_id" />
+    </div>
+</form>  </div>
+  </nav>
+</nav>
+      </header>
+
+       <div id="stats_app_dialog" style="display:none;">
+        </div>
+
+<div class="card p-1">
+  <div class="card-body application contests p-0">
+    <h3 class="card-title p-0"></h3>
+    <div class="container-fluid p-0">
+      <div class="row align-items-center justify-content-center p-0">
+        <div class="col-sm-12 p-0">
+        
+<br/>
+
+<br/>
+
+<style>
+.winner{
+  --display: flex;
+  vertical-align: middle;
+}
+.winner:before{
+  content: '\25BA';
+  --display: flex;
+  --align-items: center;
+  vertical-align: middle;
+}
+div.center {
+  margin: auto;
+  width: 50%;
+  --border: 3px solid green;
+  padding: 10px;
+}
+</style>
+
+   <div class="table-responsive">
+   <table align="center">
+     <tr>
+   <td>
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589036"><img class="large_logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" /></a>
+   </td>
+   <td valign="center" class="grey_text d-none d-sm-table-cell" nowrap>
+     <span style="font-size:18px">
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589036">California Golden Bears</a>
+     </span><br/>
+       2-0, Conf 0-0
+   </td>
+   <td valign="center" class="winner">
+   </td>
+   <td valign="center" style="font-size:36px; color: black">
+     21
+   </td>
+     <td style="padding: 0px 30px 0px 30px"  class="d-none d-md-table-cell">
+       <table style="border-collapse: collapse">
+         <tr>
+           <td class="grey_border_bottom"></td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">1</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">2</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">3</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">4</td>
+           <td width="20px" align="right" style="font-weight:bold" class="grey_border_bottom">S</td>
+         </tr>
+           <tr>
+             <td>California</td>
+               <td class="grey_text" align="right">7</td>
+               <td class="grey_text" align="right">7</td>
+               <td class="grey_text" align="right">0</td>
+               <td class="grey_text" align="right">7</td>
+             <td align="right" style="font-weight:bold">21</td>
+           </tr>
+           <tr>
+             <td>Auburn</td>
+               <td class="grey_text" align="right">7</td>
+               <td class="grey_text" align="right">0</td>
+               <td class="grey_text" align="right">0</td>
+               <td class="grey_text" align="right">7</td>
+             <td align="right" style="font-weight:bold">14</td>
+           </tr>
+         <tr>
+           <td class="grey_text" colspan="6">09/07/2024 03:30 PM</td>
+         </tr>
+         <tr>
+           <td nowrap class="grey_text" colspan="6">Jordan-Hare Stadium (Auburn, AL)</td>
+         </tr>
+         <tr>
+           <td nowrap class="grey_text" colspan="6">Attendance: 88,043</td>
+         </tr>
+       </table>
+     </td>
+   <td>
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589027"><img class="large_logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" /></a>
+   </td>
+   <td valign="center" class="grey_text d-none d-sm-table-cell" nowrap>
+     <span style="font-size:18px">
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589027">Auburn Tigers</a>
+     </span><br/>
+       1-1, Conf 0-0
+   </td>
+   <td valign="center" class="">
+   </td>
+   <td valign="center" style="font-size:36px; color: grey">
+     14
+   </td>
+     </tr>
+     <tr>
+       <td colspan="10" class="grey_border_bottom grey_border_top">
+         <table cellpadding="10px">
+           <tr>
+             <td style="font-size: 16px;"><a href="/contests/5362283/box_score">Box Score</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5362283/team_stats">Team Stats</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5362283/individual_stats">Individual Stats</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5362283/play_by_play">Play By Play</a></td>
+             <td style="font-size: 16px;">Drives</td>
+             <td style="font-size: 16px;"><a href="/contests/5362283/officials">Officials</a></td>
+           </tr>
+         </table>
+       </td>
+     </tr>
+   </table>
+ </div>
+
+
+<br/>
+ <script>
+var public_game_drives_data_table = null;
+  $(document).ready(function() {
+    public_game_drives_data_table = $('#public_game_drives_data_table').DataTable({
+      "dom": 'BRC<"clear">frtip',
+      "order": [[ 0, "asc" ]],
+      "pageLength": 100,
+      "buttons": [
+      { "extend": 'copy',
+        "exportOptions": {
+          //"columns":  exportableColumns
+        },
+        "footer": true
+      },
+      { "extend": 'excel',
+        "exportOptions": {
+          //"columns":  exportableColumns
+        },
+        "footer": true
+      }
+      ]
+    });
+
+  } );
+  </script>
+
+
+<table id="public_game_drives_data_table"  class="display dataTable" >
+  <thead>
+    <tr>
+        <th>Drive #</th>
+        <th>Quarter</th>
+        <th>Team</th>
+        <th>Start Period</th>
+        <th>Start How</th>
+        <th>Clock</th>
+        <th>Ball on</th>
+        <th>End Period</th>
+        <th>End How</th>
+        <th>Clock</th>
+        <th>End on</th>
+        <th># Plays</th>
+        <th>Yards</th>
+        <th>Time of possession</th>
+        <th>Redzone</th>
+        <th align="right" width="10%" nowrap><div class='row'><img class="logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" /><span class='d-none d-sm-block'>California</span></div></th>
+        <th align="right" width="10%" nowrap><div class='row'><img class="logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" /><span class='d-none d-sm-block'>Auburn</span></div></th>
+    </tr>
+  </thead>
+  <tbody>
+
+    <tr>
+      <td>1</td>
+      <td>1</td>
+      <td><div class='row'><img class="logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" /><span class='d-none d-sm-block'>Auburn</span></div></td>
+      <td>1</td>
+      <td>KO</td>
+      <td>15:00</td>
+      <td>AUB25</td>
+      <td>1</td>
+      <td>TD</td>
+      <td>11:42</td>
+      <td></td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3423368/game_period_plays">8</a></td>
+      <td>75</td>
+      <td>03:18</td>
+      <td>Y</td>
+      <td align="right">0</td>
+      <td align="right">7</td>
+    </tr>
+    <tr>
+      <td>2</td>
+      <td>1</td>
+      <td><div class='row'><img class="logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" /><span class='d-none d-sm-block'>California</span></div></td>
+      <td>1</td>
+      <td>KO</td>
+      <td>11:42</td>
+      <td>CAL25</td>
+      <td>1</td>
+      <td>TD</td>
+      <td>07:17</td>
+      <td></td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3423381/game_period_plays">8</a></td>
+      <td>75</td>
+      <td>04:25</td>
+      <td>Y</td>
+      <td align="right">7</td>
+      <td align="right">7</td>
+    </tr>
+    <tr>
+      <td>3</td>
+      <td>1</td>
+      <td><div class='row'><img class="logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" /><span class='d-none d-sm-block'>Auburn</span></div></td>
+      <td>1</td>
+      <td>KO</td>
+      <td>07:17</td>
+      <td>AUB25</td>
+      <td>1</td>
+      <td>DOWNS</td>
+      <td>04:56</td>
+      <td>CAL48</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3423369/game_period_plays">6</a></td>
+      <td>27</td>
+      <td>02:21</td>
+      <td></td>
+      <td align="right">7</td>
+      <td align="right">7</td>
+    </tr>
+    <tr>
+      <td>4</td>
+      <td>1</td>
+      <td><div class='row'><img class="logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" /><span class='d-none d-sm-block'>California</span></div></td>
+      <td>1</td>
+      <td>DOWNS</td>
+      <td>04:56</td>
+      <td>CAL48</td>
+      <td>2</td>
+      <td>FGA</td>
+      <td>12:15</td>
+      <td>AUB7</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3423382/game_period_plays">13</a></td>
+      <td>45</td>
+      <td>07:41</td>
+      <td>Y</td>
+      <td align="right">7</td>
+      <td align="right">7</td>
+    </tr>
+    <tr>
+      <td>5</td>
+      <td>2</td>
+      <td><div class='row'><img class="logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" /><span class='d-none d-sm-block'>Auburn</span></div></td>
+      <td>2</td>
+      <td>FGA</td>
+      <td>12:15</td>
+      <td>AUB20</td>
+      <td>2</td>
+      <td>INT</td>
+      <td>12:09</td>
+      <td>AUB20</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3423370/game_period_plays">1</a></td>
+      <td>0</td>
+      <td>00:06</td>
+      <td></td>
+      <td align="right">7</td>
+      <td align="right">7</td>
+    </tr>
+    <tr>
+      <td>6</td>
+      <td>2</td>
+      <td><div class='row'><img class="logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" /><span class='d-none d-sm-block'>California</span></div></td>
+      <td>2</td>
+      <td>INT</td>
+      <td>12:09</td>
+      <td>AUB21</td>
+      <td>2</td>
+      <td>TD</td>
+      <td>10:39</td>
+      <td></td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3423383/game_period_plays">3</a></td>
+      <td>21</td>
+      <td>01:30</td>
+      <td>Y</td>
+      <td align="right">14</td>
+      <td align="right">7</td>
+    </tr>
+    <tr>
+      <td>7</td>
+      <td>2</td>
+      <td><div class='row'><img class="logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" /><span class='d-none d-sm-block'>Auburn</span></div></td>
+      <td>2</td>
+      <td>KO</td>
+      <td>10:39</td>
+      <td>AUB25</td>
+      <td>2</td>
+      <td>PUNT</td>
+      <td>09:16</td>
+      <td>AUB31</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3423371/game_period_plays">3</a></td>
+      <td>6</td>
+      <td>01:23</td>
+      <td></td>
+      <td align="right">14</td>
+      <td align="right">7</td>
+    </tr>
+    <tr>
+      <td>8</td>
+      <td>2</td>
+      <td><div class='row'><img class="logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" /><span class='d-none d-sm-block'>California</span></div></td>
+      <td>2</td>
+      <td>PUNT</td>
+      <td>09:16</td>
+      <td>CAL15</td>
+      <td>2</td>
+      <td>PUNT</td>
+      <td>04:44</td>
+      <td>AUB41</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3423384/game_period_plays">7</a></td>
+      <td>44</td>
+      <td>04:32</td>
+      <td></td>
+      <td align="right">14</td>
+      <td align="right">7</td>
+    </tr>
+    <tr>
+      <td>9</td>
+      <td>2</td>
+      <td><div class='row'><img class="logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" /><span class='d-none d-sm-block'>Auburn</span></div></td>
+      <td>2</td>
+      <td>PUNT</td>
+      <td>04:44</td>
+      <td>AUB20</td>
+      <td>2</td>
+      <td>PUNT</td>
+      <td>03:22</td>
+      <td>AUB24</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3423372/game_period_plays">3</a></td>
+      <td>4</td>
+      <td>01:22</td>
+      <td></td>
+      <td align="right">14</td>
+      <td align="right">7</td>
+    </tr>
+    <tr>
+      <td>10</td>
+      <td>2</td>
+      <td><div class='row'><img class="logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" /><span class='d-none d-sm-block'>California</span></div></td>
+      <td>2</td>
+      <td>PUNT</td>
+      <td>03:22</td>
+      <td>CAL36</td>
+      <td>2</td>
+      <td>PUNT</td>
+      <td>00:58</td>
+      <td>CAL48</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3423385/game_period_plays">6</a></td>
+      <td>12</td>
+      <td>02:24</td>
+      <td></td>
+      <td align="right">14</td>
+      <td align="right">7</td>
+    </tr>
+    <tr>
+      <td>11</td>
+      <td>2</td>
+      <td><div class='row'><img class="logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" /><span class='d-none d-sm-block'>Auburn</span></div></td>
+      <td>2</td>
+      <td>PUNT</td>
+      <td>00:58</td>
+      <td>AUB12</td>
+      <td>2</td>
+      <td>FGA</td>
+      <td>00:00</td>
+      <td>CAL43</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3423373/game_period_plays">6</a></td>
+      <td>45</td>
+      <td>00:58</td>
+      <td></td>
+      <td align="right">14</td>
+      <td align="right">7</td>
+    </tr>
+    <tr>
+      <td>12</td>
+      <td>3</td>
+      <td><div class='row'><img class="logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" /><span class='d-none d-sm-block'>California</span></div></td>
+      <td>3</td>
+      <td>KO</td>
+      <td>15:00</td>
+      <td>CAL25</td>
+      <td>3</td>
+      <td>PUNT</td>
+      <td>11:54</td>
+      <td>CAL40</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3423386/game_period_plays">6</a></td>
+      <td>15</td>
+      <td>03:06</td>
+      <td></td>
+      <td align="right">14</td>
+      <td align="right">7</td>
+    </tr>
+    <tr>
+      <td>13</td>
+      <td>3</td>
+      <td><div class='row'><img class="logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" /><span class='d-none d-sm-block'>Auburn</span></div></td>
+      <td>3</td>
+      <td>PUNT</td>
+      <td>11:54</td>
+      <td>AUB2</td>
+      <td>3</td>
+      <td>PUNT</td>
+      <td>06:35</td>
+      <td>AUB33</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3423374/game_period_plays">8</a></td>
+      <td>31</td>
+      <td>05:19</td>
+      <td></td>
+      <td align="right">14</td>
+      <td align="right">7</td>
+    </tr>
+    <tr>
+      <td>14</td>
+      <td>3</td>
+      <td><div class='row'><img class="logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" /><span class='d-none d-sm-block'>California</span></div></td>
+      <td>3</td>
+      <td>PUNT</td>
+      <td>06:35</td>
+      <td>CAL22</td>
+      <td>3</td>
+      <td>PUNT</td>
+      <td>04:53</td>
+      <td>CAL48</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3423387/game_period_plays">5</a></td>
+      <td>26</td>
+      <td>01:42</td>
+      <td></td>
+      <td align="right">14</td>
+      <td align="right">7</td>
+    </tr>
+    <tr>
+      <td>15</td>
+      <td>3</td>
+      <td><div class='row'><img class="logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" /><span class='d-none d-sm-block'>Auburn</span></div></td>
+      <td>3</td>
+      <td>PUNT</td>
+      <td>04:53</td>
+      <td>AUB2</td>
+      <td>3</td>
+      <td>PUNT</td>
+      <td>01:34</td>
+      <td>AUB15</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3423375/game_period_plays">5</a></td>
+      <td>13</td>
+      <td>03:19</td>
+      <td></td>
+      <td align="right">14</td>
+      <td align="right">7</td>
+    </tr>
+    <tr>
+      <td>16</td>
+      <td>3</td>
+      <td><div class='row'><img class="logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" /><span class='d-none d-sm-block'>California</span></div></td>
+      <td>3</td>
+      <td>PUNT</td>
+      <td>01:34</td>
+      <td>CAL44</td>
+      <td>3</td>
+      <td>PUNT</td>
+      <td>00:07</td>
+      <td>CAL45</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3423388/game_period_plays">3</a></td>
+      <td>1</td>
+      <td>01:27</td>
+      <td></td>
+      <td align="right">14</td>
+      <td align="right">7</td>
+    </tr>
+    <tr>
+      <td>17</td>
+      <td>3</td>
+      <td><div class='row'><img class="logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" /><span class='d-none d-sm-block'>Auburn</span></div></td>
+      <td>3</td>
+      <td>PUNT</td>
+      <td>00:07</td>
+      <td>AUB34</td>
+      <td>3</td>
+      <td>INT</td>
+      <td>00:00</td>
+      <td>AUB34</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3423376/game_period_plays">1</a></td>
+      <td>0</td>
+      <td>00:07</td>
+      <td></td>
+      <td align="right">14</td>
+      <td align="right">7</td>
+    </tr>
+    <tr>
+      <td>18</td>
+      <td>4</td>
+      <td><div class='row'><img class="logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" /><span class='d-none d-sm-block'>California</span></div></td>
+      <td>4</td>
+      <td>INT</td>
+      <td>15:00</td>
+      <td>AUB47</td>
+      <td>4</td>
+      <td>FGA</td>
+      <td>12:55</td>
+      <td>AUB37</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3423389/game_period_plays">7</a></td>
+      <td>10</td>
+      <td>02:05</td>
+      <td></td>
+      <td align="right">14</td>
+      <td align="right">7</td>
+    </tr>
+    <tr>
+      <td>19</td>
+      <td>4</td>
+      <td><div class='row'><img class="logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" /><span class='d-none d-sm-block'>Auburn</span></div></td>
+      <td>4</td>
+      <td>FGA</td>
+      <td>12:55</td>
+      <td>AUB37</td>
+      <td>4</td>
+      <td>FUMB</td>
+      <td>12:16</td>
+      <td>AUB36</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3423377/game_period_plays">2</a></td>
+      <td>-1</td>
+      <td>00:39</td>
+      <td></td>
+      <td align="right">14</td>
+      <td align="right">7</td>
+    </tr>
+    <tr>
+      <td>20</td>
+      <td>4</td>
+      <td><div class='row'><img class="logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" /><span class='d-none d-sm-block'>California</span></div></td>
+      <td>4</td>
+      <td>FUMB</td>
+      <td>12:16</td>
+      <td>AUB36</td>
+      <td>4</td>
+      <td>TD</td>
+      <td>11:27</td>
+      <td></td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3423390/game_period_plays">2</a></td>
+      <td>36</td>
+      <td>00:49</td>
+      <td></td>
+      <td align="right">21</td>
+      <td align="right">7</td>
+    </tr>
+    <tr>
+      <td>21</td>
+      <td>4</td>
+      <td><div class='row'><img class="logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" /><span class='d-none d-sm-block'>Auburn</span></div></td>
+      <td>4</td>
+      <td>KO</td>
+      <td>11:27</td>
+      <td>AUB25</td>
+      <td>4</td>
+      <td>TD</td>
+      <td>06:06</td>
+      <td></td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3423378/game_period_plays">12</a></td>
+      <td>75</td>
+      <td>05:21</td>
+      <td>Y</td>
+      <td align="right">21</td>
+      <td align="right">14</td>
+    </tr>
+    <tr>
+      <td>22</td>
+      <td>4</td>
+      <td><div class='row'><img class="logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" /><span class='d-none d-sm-block'>California</span></div></td>
+      <td>4</td>
+      <td>KO</td>
+      <td>06:06</td>
+      <td>CAL25</td>
+      <td>4</td>
+      <td>PUNT</td>
+      <td>02:40</td>
+      <td>AUB46</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3423391/game_period_plays">8</a></td>
+      <td>29</td>
+      <td>03:26</td>
+      <td></td>
+      <td align="right">21</td>
+      <td align="right">14</td>
+    </tr>
+    <tr>
+      <td>23</td>
+      <td>4</td>
+      <td><div class='row'><img class="logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" /><span class='d-none d-sm-block'>Auburn</span></div></td>
+      <td>4</td>
+      <td>PUNT</td>
+      <td>02:40</td>
+      <td>AUB20</td>
+      <td>4</td>
+      <td>INT</td>
+      <td>02:13</td>
+      <td>AUB32</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3423379/game_period_plays">2</a></td>
+      <td>12</td>
+      <td>00:27</td>
+      <td></td>
+      <td align="right">21</td>
+      <td align="right">14</td>
+    </tr>
+    <tr>
+      <td>24</td>
+      <td>4</td>
+      <td><div class='row'><img class="logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" /><span class='d-none d-sm-block'>California</span></div></td>
+      <td>4</td>
+      <td>INT</td>
+      <td>02:13</td>
+      <td>CAL44</td>
+      <td>4</td>
+      <td>PUNT</td>
+      <td>00:28</td>
+      <td>CAL49</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3423392/game_period_plays">3</a></td>
+      <td>5</td>
+      <td>01:45</td>
+      <td></td>
+      <td align="right">21</td>
+      <td align="right">14</td>
+    </tr>
+    <tr>
+      <td>25</td>
+      <td>4</td>
+      <td><div class='row'><img class="logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" /><span class='d-none d-sm-block'>Auburn</span></div></td>
+      <td>4</td>
+      <td>PUNT</td>
+      <td>00:28</td>
+      <td>AUB20</td>
+      <td>4</td>
+      <td>INT</td>
+      <td>00:24</td>
+      <td>AUB20</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3423380/game_period_plays">1</a></td>
+      <td>0</td>
+      <td>00:04</td>
+      <td></td>
+      <td align="right">21</td>
+      <td align="right">14</td>
+    </tr>
+    <tr>
+      <td>26</td>
+      <td>4</td>
+      <td><div class='row'><img class="logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" /><span class='d-none d-sm-block'>California</span></div></td>
+      <td>4</td>
+      <td>INT</td>
+      <td>00:24</td>
+      <td>AUB45</td>
+      <td>4</td>
+      <td>HALF</td>
+      <td>00:00</td>
+      <td>AUB47</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3423393/game_period_plays">1</a></td>
+      <td>-2</td>
+      <td>00:24</td>
+      <td></td>
+      <td align="right">21</td>
+      <td align="right">14</td>
+    </tr>
+  </tbody>
+</table>
+
+<br />
+
+       </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<footer>&copy; <script>document.write(new Date().getFullYear())</script> NCAA <a href="http://web1.ncaa.org/web_files/terms_and_conditions.html" title ="Terms and Conditions" target=_blank>Terms and Conditions</a> | <a href="http://web1.ncaa.org/web_files/privacy.html" target=_blank title="Our Privacy Policy">Privacy Policy</a> | <a href="mailto:ncaa_stats@ncaa.org">Contact Us</a> </footer>
+
+  <!-- /.container -->
+  <script type="text/javascript"  src="/sU0joiPwv/zplvN/xFxji/wmgXJnBU/whimQww3k9OS/ZXgTG2MrBg/I0sONT4/dCDpZ?v=7f425604-69b0-66b7-891c-c42cb7f21738" defer></script></body>
+
+  <script charset="utf-8">
+    $(document).ready(function() {
+      $('a.remote[data-toggle="tab"]').on('show.bs.tab', function (e) {
+        var tab_id = '#' + $(this).attr('aria-controls');
+        $(tab_id).html('<br/><br/><p style="text-align: center"><img style="vertical-align:middle; text-align: center" src="/assets/ajax-loader-6913acdbf4be7d6a2908a84bdecd6cad18110f5fc6d5a07cf8c9ce78d9548700.gif" /> Loading... </p><br/><br/>');
+        $.get($(this).data('remote'), function(data){
+          $(tab_id).html(data);
+        });
+      });
+    });
+
+    function skipMask(obj){
+      if (obj.hasClass('chosen-single') || obj.hasClass('skipMask') || obj.hasClass('ui-datepicker-prev') || obj.hasClass('ui-datepicker-next') || obj.hasClass('ui-corner-all') || obj.hasClass('paginate_button') || obj.hasClass('dt-button')){
+        return true;
+      }else{
+        return false;
+      }
+    }
+
+    $(document).ajaxComplete(function(){
+      unmask();
+    });
+/*
+    $("form").on('submit', function(event){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    */
+    $(document).on('click', 'a', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    $(document).on('click', 'input.green', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+
+  </script>
+</html>

--- a/tests/fixtures/cfb_ncaa/mfb_individual_stats_5362283.html
+++ b/tests/fixtures/cfb_ncaa/mfb_individual_stats_5362283.html
@@ -1,0 +1,5032 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<META HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=UTF-8">
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="">
+<meta name="author" content="">
+<meta name="version" content="321d28433e9f7a188596117e6f342ec4a84fb4ed">
+<META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<link rel="shortcut icon" href="/assets/favicon-405088046a5f2bab8eedeacfae7636975c095e9c8decd8c28e3fd0e65c2f51c4.ico" type="image/vnd.microsoft.icon">
+
+<title>NCAA Statistics</title>
+
+<!-- Bootstrap core CSS -->
+
+<!--
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+-->
+<!--
+<link rel="stylesheet" href="https://cdn.datatables.net/2.0.0/css/dataTables.bootstrap4.css" crossorigin="anonymous">
+-->
+<link rel="stylesheet" media="all" href="/assets/application-789c3971842ee3597428ccbebd021716b3231e9cbd0a00a184c3b2d6c8e5f152.css" />
+
+
+<script src="/assets/application-9232576bb3cb000ac0841ff2af81251908ec17312a3c5eb72bf1a32f9754800c.js"></script>
+<!--
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+-->
+<!--
+<script src="https://cdn.datatables.net/2.0.0/js/dataTables.bootstrap4.js" crossorigin="anonymous"></script>
+-->
+
+<meta name="csrf-param" content="authenticity_token" />
+<meta name="csrf-token" content="NeUPr1MITNDC+GAsUssEhJa/sq7NLsW0GJj2w+TNtMEi4nqwHiYBWaUx97JJpHofgd87I03Po/kuZelsb32OtQ==" />
+
+<style>
+.grid {clear: all}
+.grid-item, .name {text-align: center;}
+h1 img {max-height: 33px;}
+
+</style>
+<!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+<!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+      <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+    <![endif]-->
+
+
+<script>(window.BOOMR_mq=window.BOOMR_mq||[]).push(["addVar",{"rua.upush":"false","rua.cpush":"false","rua.upre":"false","rua.cpre":"false","rua.uprl":"false","rua.cprl":"false","rua.cprf":"false","rua.trans":"","rua.cook":"false","rua.ims":"false","rua.ufprl":"false","rua.cfprl":"false","rua.isuxp":"false","rua.texp":"norulematch","rua.ceh":"false","rua.ueh":"false","rua.ieh.st":"0"}]);</script>
+                                <script>!function(e){var n="https://s.go-mpulse.net/boomerang/";if("False"=="True")e.BOOMR_config=e.BOOMR_config||{},e.BOOMR_config.PageParams=e.BOOMR_config.PageParams||{},e.BOOMR_config.PageParams.pci=!0,n="https://s2.go-mpulse.net/boomerang/";if(window.BOOMR_API_key="EVKJV-AGD2E-W66AE-NT84S-K5LTF",function(){function e(){if(!r){var e=document.createElement("script");e.id="boomr-scr-as",e.src=window.BOOMR.url,e.async=!0,o.appendChild(e),r=!0}}function t(e){r=!0;var n,t,a,i,d=document,O=window;if(window.BOOMR.snippetMethod=e?"if":"i",t=function(e,n){var t=d.createElement("script");t.id=n||"boomr-if-as",t.src=window.BOOMR.url,BOOMR_lstart=(new Date).getTime(),e=e||d.body,e.appendChild(t)},!window.addEventListener&&window.attachEvent&&navigator.userAgent.match(/MSIE [67]\./))return window.BOOMR.snippetMethod="s",void t(o,"boomr-async");a=document.createElement("IFRAME"),a.src="about:blank",a.title="",a.role="presentation",a.loading="eager",i=(a.frameElement||a).style,i.width=0,i.height=0,i.border=0,i.display="none",o.appendChild(a);try{O=a.contentWindow,d=O.document.open()}catch(_){n=document.domain,a.src="javascript:var d=document.open();d.domain='"+n+"';void 0;",O=a.contentWindow,d=O.document.open()}if(n)d._boomrl=function(){this.domain=n,t()},d.write("<bo"+"dy onload='document._boomrl();'>");else if(O._boomrl=function(){t()},O.addEventListener)O.addEventListener("load",O._boomrl,!1);else if(O.attachEvent)O.attachEvent("onload",O._boomrl);d.close()}function a(e){window.BOOMR_onload=e&&e.timeStamp||(new Date).getTime()}if(!window.BOOMR||!window.BOOMR.version&&!window.BOOMR.snippetExecuted){window.BOOMR=window.BOOMR||{},window.BOOMR.snippetStart=(new Date).getTime(),window.BOOMR.snippetExecuted=!0,window.BOOMR.snippetVersion=14,window.BOOMR.url=n+"EVKJV-AGD2E-W66AE-NT84S-K5LTF";var i=document.currentScript||document.getElementsByTagName("script")[0],o=i.parentNode,r=!1,d=document.createElement("link");if(d.relList&&"function"==typeof d.relList.supports&&d.relList.supports("preload")&&"as"in d)window.BOOMR.snippetMethod="p",d.href=window.BOOMR.url,d.rel="preload",d.as="script",d.addEventListener("load",e),d.addEventListener("error",function(){t(!0)}),setTimeout(function(){if(!r)t(!0)},3e3),BOOMR_lstart=(new Date).getTime(),o.appendChild(d);else t(!1);if(window.addEventListener)window.addEventListener("load",a,!1);else if(window.attachEvent)window.attachEvent("onload",a)}}(),"".length>0)if(e&&"performance"in e&&e.performance&&"function"==typeof e.performance.setResourceTimingBufferSize)e.performance.setResourceTimingBufferSize();!function(){if(BOOMR=e.BOOMR||{},BOOMR.plugins=BOOMR.plugins||{},!BOOMR.plugins.AK){var n=""=="true"?1:0,t="cookiepresent",a="ntaveg5yk4sly2sz564q-f-e137de63e-clientnsv4-s.akamaihd.net",i="false"=="true"?2:1,o={"ak.v":"41","ak.cp":"1168236","ak.ai":parseInt("215853",10),"ak.ol":"0","ak.cr":16,"ak.ipv":4,"ak.proto":"h2","ak.rid":"20c5b2e4","ak.r":40932,"ak.a2":n,"ak.m":"a","ak.n":"essl","ak.cport":53000,"ak.gh":"23.56.236.39","ak.quicv":"","ak.tlsv":"tls1.3","ak.0rtt":"","ak.0rtt.ed":"","ak.csrc":"-","ak.acc":"","ak.t":"1784278969","ak.ak":"hOBiQwZUYzCg5VSAfCLimQ==LmNwp4K8Clq38q3BxGPRU2VNxPoAJ5Ai+4k6yYRZDauQGidHgvH6+hcAhiH7vC2VDxGfi3bA4PfJNsZIWY2OzD5kSxFBUpcZ8lY+fFuqR+Mdmpq4kMHSoHy6wV8nMJHBYVXEpfxDKdAP/S30y/gheERFeJ/i+DyvUitBfjObXq2+BMbsSWSMYmlC/pGfDnW+ZF3aA4LmgzFs0qM+F9/D3I6F452txsjeB5C4xA+aY6ca9o82+J3h5w8y6/ALLg9mp5ZAG2lkqF4CcTWxX6gypOYlbLmWdKHbt/bMIuoEWOn26oLiY+HeHtFOjhigdDTJad/pGufyri/q9rI5AEE0RUboo11v1t2wfe27Po8afCZjTvOCYkyPtDesBSBD9S5DXc6ynMRsiXxKAOeNKYvLq3ZeT++vwWJBO1RVADSfuPs=","ak.pv":"93","ak.dpoabenc":"","ak.tf":i};if(""!==t)o["ak.ruds"]=t;var r={i:!1,av:function(n){var t="http.initiator";if(n&&(!n[t]||"spa_hard"===n[t]))o["ak.feo"]=void 0!==e.aFeoApplied?1:0,BOOMR.addVar(o)},rv:function(){var e=["ak.cport","ak.cr","ak.csrc","ak.gh","ak.ipv","ak.m","ak.n","ak.ol","ak.proto","ak.quicv","ak.tlsv","ak.0rtt","ak.0rtt.ed","ak.r","ak.acc","ak.t","ak.tf"];BOOMR.removeVar(e)}};BOOMR.plugins.AK={akVars:o,akDNSPreFetchDomain:a,init:function(){if(!r.i){var e=BOOMR.subscribe;e("before_beacon",r.av,null,null),e("onbeacon",r.rv,null,null),r.i=!0}return this},is_complete:function(){return!0}}}}()}(window);</script></head>
+
+  <script>
+
+    
+  //initialize tooltip
+  $(document).ready(function() {
+    //$("body").tooltip({ selector: '[data-toggle=tooltip]' });
+    $('[data-toggle="tooltip"]').tooltip();
+  });
+
+  $(document).ready(function() {
+    $( "#org_name" ).autocomplete({
+      source: '/team/search',
+      select: function( event, ui ) {
+        $("#org_id").val(ui.item.vid);
+        $("#id").val(ui.item.vid);
+        $('#sport_btn').click();
+      }
+    });
+  });
+
+  var body = 'body';
+
+  $.ajaxSetup ({
+    // Disable caching of AJAX responses
+    cache: false
+  });
+
+  function changeSport(field){
+    var el = $(field);
+    var tmList = el.parent().next().find('.new-team-year')[0];
+    if (tmList == null){
+      tmList = el.nextAll('.new-team-year')[0];
+    }
+    $.ajax({
+      url: "/game_sport_year_ctls/"+el.val()+"/available_teams",
+      dataType: "script",
+      success: function(data, status){
+        $(tmList).empty();
+        $(tmList).append(("<option value=''>Select team</option>"));
+        $.each(JSON.parse(data), function(k, v){
+          $(tmList).append($("<option></option>")
+              .attr("value", v["id"])
+              .text(v["member_org"]["name_tabular"]));
+        });
+        $(tmList).trigger("chosen:updated");
+      }
+    });
+  }
+
+    function set_process_styles(fld, start_color, end_color){
+       $('#'+fld).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    var downImage = "/assets/down12.gif";
+    var rightImage = "/assets/right12.gif";
+
+    function highlight(div_id){
+      $(div_id).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    function show_hide_rows(attr_val, link_id){
+      $('#'+attr_val).toggle();
+      if ($('#'+attr_val).is(':visible')) {
+        $('#'+link_id).attr('src', downImage);
+      }else{
+        $('#'+link_id).attr('src', rightImage);
+      }
+    }
+
+    function mask(label){
+      $('body').mask(label);
+    }
+    function unmask(){
+      $('body').unmask();
+    }
+
+    var winHeight = "auto";
+    var winWidth = "auto";
+    var maxHeight = 700;
+    var maxWidth = 1400;
+    var minHeight = 100;
+    var minWidth = 200;
+    
+    var modalOptions = {"width": winWidth,
+                        "height": winHeight,
+                        "maxHeight": maxHeight,
+                        "maxWidth": maxWidth,
+                        "minHeight": minHeight,
+                        "minWidth": minWidth};
+
+    function dialog(url, title){
+
+      $("#stats_app_dialog").dialog({modal:true, minWidth:minWidth, minHeight:minHeight, maxWidth:maxWidth, maxHeight:maxHeight, width:winWidth, height:winHeight, title:title, closeOnEscape: false});
+    
+      modalOptions.title = title;
+    
+      $("#stats_app_dialog").dialog("option", modalOptions);
+    
+      $("#stats_app_dialog").html("Loading...");
+      $("#stats_app_dialog").load(url).dialog('open');
+    }
+
+    function addDatePicker(){
+    $('.adddatepicker').each(function(i, obj){
+      $(obj).datepicker({ 
+        showOn: 'both', 
+        buttonImage: '/assets/calendar.gif', 
+        buttonImageOnly: true,
+      });
+    });
+    }
+
+   $(document).ready(function() {
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   });
+
+   function setClassInputFields(){
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   }
+
+   function isValidDateFormat(dateStr){
+     const regex = /^([1-9]|0[1-9]|1[0-2])\/([1-9]|0[1-9]|[12][0-9]|3[01])\/(19|20)\d{2}$/;
+     if (!regex.test(dateStr)) {
+       return false;
+     }else{
+       return true;
+     }
+   }
+
+  </script>
+
+
+<body style="font-size: .75rem;" onload="if (top != self) { top.location=self.location; }" >
+
+      <header>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0">
+        <a class="navbar-brand mr-0 mr-md-2" href="/" aria-label="statistics">
+                          <img alt="NCAA" style="margin-left: 24px; margin-right: 0; margin-top: 6px;" src="/assets/ncaa-fbc4d0406ae731b47babcc3fca53775b5955ef372bf8b8e998ca9a513e468b8f.svg" />
+                          <span class="title" class="dark-blue-font">Statistics</span>
+        </a>
+       </nav>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0" style="background-color: var(--color-dark-blue) !important;">
+  <button class="navbar-toggler bg-white" type="button" data-toggle="collapse" data-target="#navbarTogglerDemo01" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarTogglerDemo01">
+        <ul class="navbar-nav mr-auto mt-2 mt-lg-0 justify-content-center">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle skipMask" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Rankings
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+          <a class="dropdown-item" href="/rankings">National Rankings</a>
+          <a class="dropdown-item" href="/active_career_leaders">Active Career Leaders</a>
+        </div>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/contests/livestream_scoreboards">Scoreboard</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/selection_rankings/nitty_gritties">Selection Rankings</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/head_coaches">Head Coaches</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/search/players">Players</a>
+      </li>
+     </ul>
+
+    <form onsubmit="mask(&#39;Loading&#39;);" id="change_team_form" style="display:inline;" class="form-inline my-2 my-lg-0" action="/team/index" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="R0yoonyFtHvHM/X3BU4AuG0FNp6H2pr0C0A7cNBjJaTnOoFt32vcPijfhhK84J+W8P8DnSCwuw2BsglYMzPpIQ==" />
+  <div style="display:none;">
+  <input type="submit" name="commit" value="Submit" id="sport_btn" data-disable-with="Submit" />
+  </div>
+    <div id="team_autocomplete" class="ui-widget">
+      <input type="search" name="org_name" id="org_name" style="width:200px; font-size: 12px !important" class="form-control mr-sm-2" placeholder="Team Search" />
+      <input type="hidden" name="org_id" id="org_id" />
+    </div>
+</form>  </div>
+  </nav>
+</nav>
+      </header>
+
+       <div id="stats_app_dialog" style="display:none;">
+        </div>
+
+<div class="card p-1">
+  <div class="card-body application contests p-0">
+    <h3 class="card-title p-0"></h3>
+    <div class="container-fluid p-0">
+      <div class="row align-items-center justify-content-center p-0">
+        <div class="col-sm-12 p-0">
+          <br/>
+
+<br/>
+
+<style>
+.winner{
+  --display: flex;
+  vertical-align: middle;
+}
+.winner:before{
+  content: '\25BA';
+  --display: flex;
+  --align-items: center;
+  vertical-align: middle;
+}
+div.center {
+  margin: auto;
+  width: 50%;
+  --border: 3px solid green;
+  padding: 10px;
+}
+</style>
+
+   <div class="table-responsive">
+   <table align="center">
+     <tr>
+   <td>
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589036"><img class="large_logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" /></a>
+   </td>
+   <td valign="center" class="grey_text d-none d-sm-table-cell" nowrap>
+     <span style="font-size:18px">
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589036">California Golden Bears</a>
+     </span><br/>
+       2-0, Conf 0-0
+   </td>
+   <td valign="center" class="winner">
+   </td>
+   <td valign="center" style="font-size:36px; color: black">
+     21
+   </td>
+     <td style="padding: 0px 30px 0px 30px"  class="d-none d-md-table-cell">
+       <table style="border-collapse: collapse">
+         <tr>
+           <td class="grey_border_bottom"></td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">1</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">2</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">3</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">4</td>
+           <td width="20px" align="right" style="font-weight:bold" class="grey_border_bottom">S</td>
+         </tr>
+           <tr>
+             <td>California</td>
+               <td class="grey_text" align="right">7</td>
+               <td class="grey_text" align="right">7</td>
+               <td class="grey_text" align="right">0</td>
+               <td class="grey_text" align="right">7</td>
+             <td align="right" style="font-weight:bold">21</td>
+           </tr>
+           <tr>
+             <td>Auburn</td>
+               <td class="grey_text" align="right">7</td>
+               <td class="grey_text" align="right">0</td>
+               <td class="grey_text" align="right">0</td>
+               <td class="grey_text" align="right">7</td>
+             <td align="right" style="font-weight:bold">14</td>
+           </tr>
+         <tr>
+           <td class="grey_text" colspan="6">09/07/2024 03:30 PM</td>
+         </tr>
+         <tr>
+           <td nowrap class="grey_text" colspan="6">Jordan-Hare Stadium (Auburn, AL)</td>
+         </tr>
+         <tr>
+           <td nowrap class="grey_text" colspan="6">Attendance: 88,043</td>
+         </tr>
+       </table>
+     </td>
+   <td>
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589027"><img class="large_logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" /></a>
+   </td>
+   <td valign="center" class="grey_text d-none d-sm-table-cell" nowrap>
+     <span style="font-size:18px">
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589027">Auburn Tigers</a>
+     </span><br/>
+       1-1, Conf 0-0
+   </td>
+   <td valign="center" class="">
+   </td>
+   <td valign="center" style="font-size:36px; color: grey">
+     14
+   </td>
+     </tr>
+     <tr>
+       <td colspan="10" class="grey_border_bottom grey_border_top">
+         <table cellpadding="10px">
+           <tr>
+             <td style="font-size: 16px;"><a href="/contests/5362283/box_score">Box Score</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5362283/team_stats">Team Stats</a></td>
+             <td style="font-size: 16px;">Individual Stats</td>
+             <td style="font-size: 16px;"><a href="/contests/5362283/play_by_play">Play By Play</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5362283/drives">Drives</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5362283/officials">Officials</a></td>
+           </tr>
+         </table>
+       </td>
+     </tr>
+   </table>
+ </div>
+
+
+<br/>
+
+ <div class="row justify-content-md-center">
+
+<div class="row">
+      <div class="col p-2">
+              <script>
+        var competitor_7676000_year_stat_category_15083_period_stats_hash = {};
+      </script>
+
+
+      <div class="card p-0 table-responsive">
+        <div class="card-header" style="background-color: white;">
+          <div class="row">
+            <div>
+            <a target="TEAM_WIN" class="skipMask" href="/teams/589036"><img class="logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" />California</a> Rushing
+            </div>
+            <div class="ml-auto small"><a class="skipMask" href="javascript:togglePeriodStats(competitor_7676000_year_stat_category_15083_data_table);">Period Stats</a></div>
+          </div>
+        </div>
+        <div class="card-body">
+        <table class="display dataTable small_font" id="competitor_7676000_year_stat_category_15083_data_table">
+          <thead>
+          <tr>
+            <th class="no_padding  d-none d-sm-table-cell">#</th>
+            <th class="no_padding ">Name</th>
+            <th class="no_padding  d-none d-sm-table-cell">P</th>
+              <th class="no_padding">Rush<br/><br/>Attempts</th>
+              <th class="no_padding">Rush<br/>Yds<br/>Gained</th>
+              <th class="no_padding">Rush<br/>Yds<br/>Lost</th>
+              <th class="no_padding">Yds/Rush</th>
+              <th class="no_padding">Rush<br/>TDs</th>
+              <th class="no_padding">Rush<br/>Long</th>
+          </tr>
+          </thead>
+          <tbody>
+
+                      <tr id="game_player_773558911_year_stat_category_15083" >
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              2
+            </td>
+            <td nowrap class="no_padding ">
+                <a target="PLAYER_HISTORY" class="skipMask" href="/players/8906198">Kadarius Calloway</a>
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              RB
+            </td>
+              <td class="no_padding " data-order="8">8</td>
+              <td class="no_padding " data-order="15">15</td>
+              <td class="no_padding " data-order="4">4</td>
+              <td class="no_padding " data-order="1.38">1.38</td>
+              <td class="no_padding " data-order="0">0</td>
+              <td class="no_padding " data-order="6">6</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">-1.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">2</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">2.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">2</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">6</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">13</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">3</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1.67</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">6</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7676000_year_stat_category_15083_period_stats_hash[773558911] = periodStatsArray;
+            </script>
+
+                      <tr id="game_player_773558922_year_stat_category_15083" >
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              15
+            </td>
+            <td nowrap class="no_padding ">
+                <a target="PLAYER_HISTORY" class="skipMask" href="/players/8642096">Fernando Mendoza</a>
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              QB
+            </td>
+              <td class="no_padding " data-order="5">5</td>
+              <td class="no_padding " data-order="22">22</td>
+              <td class="no_padding " data-order="10">10</td>
+              <td class="no_padding " data-order="2.40">2.40</td>
+              <td class="no_padding " data-order="0">0</td>
+              <td class="no_padding " data-order="10">10</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">2</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">12</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">6.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">10</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">2</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">10</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">-5.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">10</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">10.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">10</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7676000_year_stat_category_15083_period_stats_hash[773558922] = periodStatsArray;
+            </script>
+
+                      <tr id="game_player_773558905_year_stat_category_15083" >
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              1
+            </td>
+            <td nowrap class="no_padding ">
+                <a target="PLAYER_HISTORY" class="skipMask" href="/players/8609967">Jaydn Ott</a>
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              RB
+            </td>
+              <td class="no_padding " data-order="10">10</td>
+              <td class="no_padding " data-order="18">18</td>
+              <td class="no_padding " data-order="7">7</td>
+              <td class="no_padding " data-order="1.10">1.10</td>
+              <td class="no_padding " data-order="0">0</td>
+              <td class="no_padding " data-order="6">6</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">3</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">2</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">4</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">-0.67</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">2</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">4</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">13</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">3.25</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">6</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">2</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">3</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1.50</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">3</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">3</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">-3.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7676000_year_stat_category_15083_period_stats_hash[773558905] = periodStatsArray;
+            </script>
+
+                      <tr id="game_player_773558898_year_stat_category_15083" >
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              7
+            </td>
+            <td nowrap class="no_padding ">
+                <a target="PLAYER_HISTORY" class="skipMask" href="/players/8906236">Chandler Rogers</a>
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              QB
+            </td>
+              <td class="no_padding " data-order="2">2</td>
+              <td class="no_padding " data-order="14">14</td>
+              <td class="no_padding " data-order="0">0</td>
+              <td class="no_padding " data-order="7.00">7.00</td>
+              <td class="no_padding " data-order="0">0</td>
+              <td class="no_padding " data-order="14">14</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">2</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">14</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">14</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7676000_year_stat_category_15083_period_stats_hash[773558898] = periodStatsArray;
+            </script>
+
+                      <tr id="game_player_773558907_year_stat_category_15083" >
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              25
+            </td>
+            <td nowrap class="no_padding ">
+                <a target="PLAYER_HISTORY" class="skipMask" href="/players/8629402">Jaivian Thomas</a>
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              RB
+            </td>
+              <td class="no_padding " data-order="8">8</td>
+              <td class="no_padding " data-order="57">57</td>
+              <td class="no_padding " data-order="4">4</td>
+              <td class="no_padding " data-order="6.63">6.63</td>
+              <td class="no_padding " data-order="1">1</td>
+              <td class="no_padding " data-order="32">32</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">2</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">9</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">4.50</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">4</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">-4.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">4</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">4.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">4</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">4</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">44</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">11.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">32</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7676000_year_stat_category_15083_period_stats_hash[773558907] = periodStatsArray;
+            </script>
+
+                      <tr id="game_player_773558931_year_stat_category_15083" style='background-color: #f9f9f9 !important'>
+            <td nowrap class="no_padding d-none d-sm-table-cell tbody_border_top">
+            </td>
+            <td nowrap class="no_padding tbody_border_top">
+                TEAM
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell tbody_border_top">
+            </td>
+              <td class="no_padding tbody_border_top" data-order="-">32</td>
+              <td class="no_padding tbody_border_top" data-order="-">0</td>
+              <td class="no_padding tbody_border_top" data-order="-">2</td>
+              <td class="no_padding tbody_border_top" data-order="-">-0.06</td>
+              <td class="no_padding tbody_border_top" data-order="-">0</td>
+              <td class="no_padding tbody_border_top" data-order="-">0</td>
+          </tr>
+
+                    <tr id="game_player_773558930_year_stat_category_15083" style='background-color: #f9f9f9 !important'>
+            <td nowrap class="no_padding d-none d-sm-table-cell tbody_border_top">
+            </td>
+            <td nowrap class="no_padding tbody_border_top">
+                 California
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell tbody_border_top">
+            </td>
+              <td class="no_padding tbody_border_top" data-order="-">34</td>
+              <td class="no_padding tbody_border_top" data-order="-">126</td>
+              <td class="no_padding tbody_border_top" data-order="-">27</td>
+              <td class="no_padding tbody_border_top" data-order="-">2.91</td>
+              <td class="no_padding tbody_border_top" data-order="-">1</td>
+              <td class="no_padding tbody_border_top" data-order="-">32</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">14</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">23</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">4</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1.36</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">10</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">14</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">13</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">15</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">-0.14</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">6</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">8</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">9</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1.13</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">4</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">30</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">81</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">10</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">2.37</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">32</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7676000_year_stat_category_15083_period_stats_hash[773558930] = periodStatsArray;
+            </script>
+
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <script>
+        var noSortType = $.fn.dataTable.absoluteOrderNumber( [
+        { value: '-', position: 'bottom' }
+      ] );
+        var competitor_7676000_year_stat_category_15083_data_table = null;
+        $(document).ready(function() {
+          competitor_7676000_year_stat_category_15083_data_table = $('#competitor_7676000_year_stat_category_15083_data_table').DataTable({
+            //"sDom": 't',
+            "bPaginate": false,
+            "bInfo": false,
+            "bFilter": false,
+            "order": [[3, "desc"]],
+            "columns": [
+              {orderable: false, type: noSortType},
+              {orderable: false, type: noSortType},
+              {orderable: false, type: noSortType},
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} 
+            ]
+          })
+
+          for (let key in competitor_7676000_year_stat_category_15083_period_stats_hash){
+             child_array = [];
+             for (row of competitor_7676000_year_stat_category_15083_period_stats_hash[key]){
+               console.log(row);
+               child_array.push(row);
+             }
+            competitor_7676000_year_stat_category_15083_data_table.row('#game_player_'+key+'_year_stat_category_15083').child(child_array);
+           }
+
+       });
+
+       function togglePeriodStats(data_table){
+         $('[id^=game_player_]').each( function(x){
+           console.log($(this).attr('id'));
+           c = data_table.row('#'+$(this).attr('id')).child;
+           if (c.isShown()){
+             c.hide();
+           }else{
+             c.show();
+           }
+         });
+       }
+
+
+
+
+    </script>
+
+      </div>
+      <div class="col p-2">
+              <script>
+        var competitor_7675999_year_stat_category_15083_period_stats_hash = {};
+      </script>
+
+
+      <div class="card p-0 table-responsive">
+        <div class="card-header" style="background-color: white;">
+          <div class="row">
+            <div>
+            <a target="TEAM_WIN" class="skipMask" href="/teams/589027"><img class="logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" />Auburn</a> Rushing
+            </div>
+            <div class="ml-auto small"><a class="skipMask" href="javascript:togglePeriodStats(competitor_7675999_year_stat_category_15083_data_table);">Period Stats</a></div>
+          </div>
+        </div>
+        <div class="card-body">
+        <table class="display dataTable small_font" id="competitor_7675999_year_stat_category_15083_data_table">
+          <thead>
+          <tr>
+            <th class="no_padding  d-none d-sm-table-cell">#</th>
+            <th class="no_padding ">Name</th>
+            <th class="no_padding  d-none d-sm-table-cell">P</th>
+              <th class="no_padding">Rush<br/><br/>Attempts</th>
+              <th class="no_padding">Rush<br/>Yds<br/>Gained</th>
+              <th class="no_padding">Rush<br/>Yds<br/>Lost</th>
+              <th class="no_padding">Yds/Rush</th>
+              <th class="no_padding">Rush<br/>TDs</th>
+              <th class="no_padding">Rush<br/>Long</th>
+          </tr>
+          </thead>
+          <tbody>
+
+                      <tr id="game_player_773558851_year_stat_category_15083" >
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              0
+            </td>
+            <td nowrap class="no_padding ">
+                <a target="PLAYER_HISTORY" class="skipMask" href="/players/8618721">Damari Alston</a>
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              RB
+            </td>
+              <td class="no_padding " data-order="2">2</td>
+              <td class="no_padding " data-order="10">10</td>
+              <td class="no_padding " data-order="0">0</td>
+              <td class="no_padding " data-order="5.00">5.00</td>
+              <td class="no_padding " data-order="0">0</td>
+              <td class="no_padding " data-order="7">7</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">2</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">10</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">5.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7675999_year_stat_category_15083_period_stats_hash[773558851] = periodStatsArray;
+            </script>
+
+                      <tr id="game_player_773558856_year_stat_category_15083" >
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              23
+            </td>
+            <td nowrap class="no_padding ">
+                <a target="PLAYER_HISTORY" class="skipMask" href="/players/8617067">Jeremiah Cobb</a>
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              RB
+            </td>
+              <td class="no_padding " data-order="1">1</td>
+              <td class="no_padding " data-order="0">0</td>
+              <td class="no_padding " data-order="0">0</td>
+              <td class="no_padding " data-order="0">0</td>
+              <td class="no_padding " data-order="0">0</td>
+              <td class="no_padding " data-order="0">0</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7675999_year_stat_category_15083_period_stats_hash[773558856] = periodStatsArray;
+            </script>
+
+                      <tr id="game_player_773558845_year_stat_category_15083" >
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              27
+            </td>
+            <td nowrap class="no_padding ">
+                <a target="PLAYER_HISTORY" class="skipMask" href="/players/8647762">Jarquez Hunter</a>
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              RB
+            </td>
+              <td class="no_padding " data-order="12">12</td>
+              <td class="no_padding " data-order="77">77</td>
+              <td class="no_padding " data-order="9">9</td>
+              <td class="no_padding " data-order="5.67">5.67</td>
+              <td class="no_padding " data-order="0">0</td>
+              <td class="no_padding " data-order="27">27</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">2</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">3</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1.50</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">2</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">2</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">27</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">13.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">27</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">5</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">40</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">8.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">18</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">3</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">8</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">-0.33</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7675999_year_stat_category_15083_period_stats_hash[773558845] = periodStatsArray;
+            </script>
+
+                      <tr id="game_player_773558829_year_stat_category_15083" >
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              1
+            </td>
+            <td nowrap class="no_padding ">
+                <a target="PLAYER_HISTORY" class="skipMask" href="/players/8647754">Payton Thorne</a>
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              QB
+            </td>
+              <td class="no_padding " data-order="15">15</td>
+              <td class="no_padding " data-order="69">69</td>
+              <td class="no_padding " data-order="26">26</td>
+              <td class="no_padding " data-order="2.87">2.87</td>
+              <td class="no_padding " data-order="1">1</td>
+              <td class="no_padding " data-order="19">19</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">6</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">37</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">6.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">19</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">5</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">11</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">25</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">-2.80</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">8</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">4</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">21</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">5.25</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">9</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7675999_year_stat_category_15083_period_stats_hash[773558829] = periodStatsArray;
+            </script>
+
+                      <tr id="game_player_773558875_year_stat_category_15083" style='background-color: #f9f9f9 !important'>
+            <td nowrap class="no_padding d-none d-sm-table-cell tbody_border_top">
+            </td>
+            <td nowrap class="no_padding tbody_border_top">
+                TEAM
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell tbody_border_top">
+            </td>
+              <td class="no_padding tbody_border_top" data-order="-">27</td>
+              <td class="no_padding tbody_border_top" data-order="-">0</td>
+              <td class="no_padding tbody_border_top" data-order="-">0</td>
+              <td class="no_padding tbody_border_top" data-order="-">0</td>
+              <td class="no_padding tbody_border_top" data-order="-">0</td>
+              <td class="no_padding tbody_border_top" data-order="-">0</td>
+          </tr>
+
+                    <tr id="game_player_773558874_year_stat_category_15083" style='background-color: #f9f9f9 !important'>
+            <td nowrap class="no_padding d-none d-sm-table-cell tbody_border_top">
+            </td>
+            <td nowrap class="no_padding tbody_border_top">
+                 Auburn
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell tbody_border_top">
+            </td>
+              <td class="no_padding tbody_border_top" data-order="-">30</td>
+              <td class="no_padding tbody_border_top" data-order="-">156</td>
+              <td class="no_padding tbody_border_top" data-order="-">35</td>
+              <td class="no_padding tbody_border_top" data-order="-">4.03</td>
+              <td class="no_padding tbody_border_top" data-order="-">1</td>
+              <td class="no_padding tbody_border_top" data-order="-">27</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">6</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">3</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0.50</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">2</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">16</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">64</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">2</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">3.88</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">27</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">21</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">61</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">25</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1.71</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">18</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">14</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">28</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">8</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1.43</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">9</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7675999_year_stat_category_15083_period_stats_hash[773558874] = periodStatsArray;
+            </script>
+
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <script>
+        var noSortType = $.fn.dataTable.absoluteOrderNumber( [
+        { value: '-', position: 'bottom' }
+      ] );
+        var competitor_7675999_year_stat_category_15083_data_table = null;
+        $(document).ready(function() {
+          competitor_7675999_year_stat_category_15083_data_table = $('#competitor_7675999_year_stat_category_15083_data_table').DataTable({
+            //"sDom": 't',
+            "bPaginate": false,
+            "bInfo": false,
+            "bFilter": false,
+            "order": [[3, "desc"]],
+            "columns": [
+              {orderable: false, type: noSortType},
+              {orderable: false, type: noSortType},
+              {orderable: false, type: noSortType},
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} 
+            ]
+          })
+
+          for (let key in competitor_7675999_year_stat_category_15083_period_stats_hash){
+             child_array = [];
+             for (row of competitor_7675999_year_stat_category_15083_period_stats_hash[key]){
+               console.log(row);
+               child_array.push(row);
+             }
+            competitor_7675999_year_stat_category_15083_data_table.row('#game_player_'+key+'_year_stat_category_15083').child(child_array);
+           }
+
+       });
+
+       function togglePeriodStats(data_table){
+         $('[id^=game_player_]').each( function(x){
+           console.log($(this).attr('id'));
+           c = data_table.row('#'+$(this).attr('id')).child;
+           if (c.isShown()){
+             c.hide();
+           }else{
+             c.show();
+           }
+         });
+       }
+
+
+
+
+    </script>
+
+      </div>
+</div>
+<div class="row">
+      <div class="col p-2">
+              <script>
+        var competitor_7676000_year_stat_category_15085_period_stats_hash = {};
+      </script>
+
+
+      <div class="card p-0 table-responsive">
+        <div class="card-header" style="background-color: white;">
+          <div class="row">
+            <div>
+            <a target="TEAM_WIN" class="skipMask" href="/teams/589036"><img class="logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" />California</a> Passing
+            </div>
+            <div class="ml-auto small"><a class="skipMask" href="javascript:togglePeriodStats(competitor_7676000_year_stat_category_15085_data_table);">Period Stats</a></div>
+          </div>
+        </div>
+        <div class="card-body">
+        <table class="display dataTable small_font" id="competitor_7676000_year_stat_category_15085_data_table">
+          <thead>
+          <tr>
+            <th class="no_padding  d-none d-sm-table-cell">#</th>
+            <th class="no_padding ">Name</th>
+            <th class="no_padding  d-none d-sm-table-cell">P</th>
+              <th class="no_padding">Pass<br/><br/>Attempts</th>
+              <th class="no_padding">Completions</th>
+              <th class="no_padding">Pass<br/><br/>Yards</th>
+              <th class="no_padding">Interceptions</th>
+              <th class="no_padding">Pass<br/>TDs</th>
+              <th class="no_padding">Pass<br/><br/>Eff</th>
+              <th class="no_padding">Yds<br/>Per<br/>Completion</th>
+              <th class="no_padding">Pct</th>
+              <th class="no_padding">Long<br/>Pass</th>
+          </tr>
+          </thead>
+          <tbody>
+
+                      <tr id="game_player_773558922_year_stat_category_15085" >
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              15
+            </td>
+            <td nowrap class="no_padding ">
+                <a target="PLAYER_HISTORY" class="skipMask" href="/players/8642096">Fernando Mendoza</a>
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              QB
+            </td>
+              <td class="no_padding " data-order="36">36</td>
+              <td class="no_padding " data-order="25">25</td>
+              <td class="no_padding " data-order="233">233</td>
+              <td class="no_padding " data-order="0">0</td>
+              <td class="no_padding " data-order="2">2</td>
+              <td class="no_padding " data-order="142.14">142.14</td>
+              <td class="no_padding " data-order="9.320">9.320</td>
+              <td class="no_padding " data-order="0.694">0.694</td>
+              <td class="no_padding " data-order="25">25</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">9</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">8</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">95</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">214.22</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">11.875</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0.889</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">25</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">12</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">11</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">110</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">196.17</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">10.000</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0.917</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">18</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">10</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">4</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">18</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">55.12</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">4.500</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0.400</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">9</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">5</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">2</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">10</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">56.80</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">5.000</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0.400</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7676000_year_stat_category_15085_period_stats_hash[773558922] = periodStatsArray;
+            </script>
+
+                    <tr id="game_player_773558930_year_stat_category_15085" style='background-color: #f9f9f9 !important'>
+            <td nowrap class="no_padding d-none d-sm-table-cell tbody_border_top">
+            </td>
+            <td nowrap class="no_padding tbody_border_top">
+                 California
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell tbody_border_top">
+            </td>
+              <td class="no_padding tbody_border_top" data-order="-">36</td>
+              <td class="no_padding tbody_border_top" data-order="-">25</td>
+              <td class="no_padding tbody_border_top" data-order="-">233</td>
+              <td class="no_padding tbody_border_top" data-order="-">0</td>
+              <td class="no_padding tbody_border_top" data-order="-">2</td>
+              <td class="no_padding tbody_border_top" data-order="-">142.14</td>
+              <td class="no_padding tbody_border_top" data-order="-">9.320</td>
+              <td class="no_padding tbody_border_top" data-order="-">0.694</td>
+              <td class="no_padding tbody_border_top" data-order="-">25</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">9</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">8</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">95</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">214.22</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">11.875</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0.889</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">25</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">12</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">11</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">110</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">196.17</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">10.000</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0.917</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">18</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">10</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">4</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">18</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">55.12</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">4.500</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0.400</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">9</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">5</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">2</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">10</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">56.80</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">5.000</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0.400</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7676000_year_stat_category_15085_period_stats_hash[773558930] = periodStatsArray;
+            </script>
+
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <script>
+        var noSortType = $.fn.dataTable.absoluteOrderNumber( [
+        { value: '-', position: 'bottom' }
+      ] );
+        var competitor_7676000_year_stat_category_15085_data_table = null;
+        $(document).ready(function() {
+          competitor_7676000_year_stat_category_15085_data_table = $('#competitor_7676000_year_stat_category_15085_data_table').DataTable({
+            //"sDom": 't',
+            "bPaginate": false,
+            "bInfo": false,
+            "bFilter": false,
+            "order": [[5, "desc"]],
+            "columns": [
+              {orderable: false, type: noSortType},
+              {orderable: false, type: noSortType},
+              {orderable: false, type: noSortType},
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} 
+            ]
+          })
+
+          for (let key in competitor_7676000_year_stat_category_15085_period_stats_hash){
+             child_array = [];
+             for (row of competitor_7676000_year_stat_category_15085_period_stats_hash[key]){
+               console.log(row);
+               child_array.push(row);
+             }
+            competitor_7676000_year_stat_category_15085_data_table.row('#game_player_'+key+'_year_stat_category_15085').child(child_array);
+           }
+
+       });
+
+       function togglePeriodStats(data_table){
+         $('[id^=game_player_]').each( function(x){
+           console.log($(this).attr('id'));
+           c = data_table.row('#'+$(this).attr('id')).child;
+           if (c.isShown()){
+             c.hide();
+           }else{
+             c.show();
+           }
+         });
+       }
+
+
+
+
+    </script>
+
+      </div>
+      <div class="col p-2">
+              <script>
+        var competitor_7675999_year_stat_category_15085_period_stats_hash = {};
+      </script>
+
+
+      <div class="card p-0 table-responsive">
+        <div class="card-header" style="background-color: white;">
+          <div class="row">
+            <div>
+            <a target="TEAM_WIN" class="skipMask" href="/teams/589027"><img class="logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" />Auburn</a> Passing
+            </div>
+            <div class="ml-auto small"><a class="skipMask" href="javascript:togglePeriodStats(competitor_7675999_year_stat_category_15085_data_table);">Period Stats</a></div>
+          </div>
+        </div>
+        <div class="card-body">
+        <table class="display dataTable small_font" id="competitor_7675999_year_stat_category_15085_data_table">
+          <thead>
+          <tr>
+            <th class="no_padding  d-none d-sm-table-cell">#</th>
+            <th class="no_padding ">Name</th>
+            <th class="no_padding  d-none d-sm-table-cell">P</th>
+              <th class="no_padding">Pass<br/><br/>Attempts</th>
+              <th class="no_padding">Completions</th>
+              <th class="no_padding">Pass<br/><br/>Yards</th>
+              <th class="no_padding">Interceptions</th>
+              <th class="no_padding">Pass<br/>TDs</th>
+              <th class="no_padding">Pass<br/><br/>Eff</th>
+              <th class="no_padding">Yds<br/>Per<br/>Completion</th>
+              <th class="no_padding">Pct</th>
+              <th class="no_padding">Long<br/>Pass</th>
+          </tr>
+          </thead>
+          <tbody>
+
+                      <tr id="game_player_773558829_year_stat_category_15085" >
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              1
+            </td>
+            <td nowrap class="no_padding ">
+                <a target="PLAYER_HISTORY" class="skipMask" href="/players/8647754">Payton Thorne</a>
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              QB
+            </td>
+              <td class="no_padding " data-order="27">27</td>
+              <td class="no_padding " data-order="14">14</td>
+              <td class="no_padding " data-order="165">165</td>
+              <td class="no_padding " data-order="4">4</td>
+              <td class="no_padding " data-order="1">1</td>
+              <td class="no_padding " data-order="85.78">85.78</td>
+              <td class="no_padding " data-order="11.786">11.786</td>
+              <td class="no_padding " data-order="0.519">0.519</td>
+              <td class="no_padding " data-order="41">41</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">11</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">6</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">106</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">165.49</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">17.667</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0.545</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">41</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">4</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">-10.30</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7.000</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0.250</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">2</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">8</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">-16.40</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">8.000</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0.500</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">8</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">10</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">6</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">44</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">2</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">56.96</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7.333</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0.600</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">13</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7675999_year_stat_category_15085_period_stats_hash[773558829] = periodStatsArray;
+            </script>
+
+                    <tr id="game_player_773558874_year_stat_category_15085" style='background-color: #f9f9f9 !important'>
+            <td nowrap class="no_padding d-none d-sm-table-cell tbody_border_top">
+            </td>
+            <td nowrap class="no_padding tbody_border_top">
+                 Auburn
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell tbody_border_top">
+            </td>
+              <td class="no_padding tbody_border_top" data-order="-">27</td>
+              <td class="no_padding tbody_border_top" data-order="-">14</td>
+              <td class="no_padding tbody_border_top" data-order="-">165</td>
+              <td class="no_padding tbody_border_top" data-order="-">4</td>
+              <td class="no_padding tbody_border_top" data-order="-">1</td>
+              <td class="no_padding tbody_border_top" data-order="-">85.78</td>
+              <td class="no_padding tbody_border_top" data-order="-">11.786</td>
+              <td class="no_padding tbody_border_top" data-order="-">0.519</td>
+              <td class="no_padding tbody_border_top" data-order="-">41</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">11</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">6</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">106</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">165.49</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">17.667</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0.545</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">41</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">4</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">-10.30</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7.000</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0.250</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">2</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">8</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">-16.40</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">8.000</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0.500</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">8</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">10</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">6</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">44</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">2</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">56.96</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7.333</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0.600</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">13</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7675999_year_stat_category_15085_period_stats_hash[773558874] = periodStatsArray;
+            </script>
+
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <script>
+        var noSortType = $.fn.dataTable.absoluteOrderNumber( [
+        { value: '-', position: 'bottom' }
+      ] );
+        var competitor_7675999_year_stat_category_15085_data_table = null;
+        $(document).ready(function() {
+          competitor_7675999_year_stat_category_15085_data_table = $('#competitor_7675999_year_stat_category_15085_data_table').DataTable({
+            //"sDom": 't',
+            "bPaginate": false,
+            "bInfo": false,
+            "bFilter": false,
+            "order": [[5, "desc"]],
+            "columns": [
+              {orderable: false, type: noSortType},
+              {orderable: false, type: noSortType},
+              {orderable: false, type: noSortType},
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} 
+            ]
+          })
+
+          for (let key in competitor_7675999_year_stat_category_15085_period_stats_hash){
+             child_array = [];
+             for (row of competitor_7675999_year_stat_category_15085_period_stats_hash[key]){
+               console.log(row);
+               child_array.push(row);
+             }
+            competitor_7675999_year_stat_category_15085_data_table.row('#game_player_'+key+'_year_stat_category_15085').child(child_array);
+           }
+
+       });
+
+       function togglePeriodStats(data_table){
+         $('[id^=game_player_]').each( function(x){
+           console.log($(this).attr('id'));
+           c = data_table.row('#'+$(this).attr('id')).child;
+           if (c.isShown()){
+             c.hide();
+           }else{
+             c.show();
+           }
+         });
+       }
+
+
+
+
+    </script>
+
+      </div>
+</div>
+<div class="row">
+      <div class="col p-2">
+              <script>
+        var competitor_7676000_year_stat_category_15086_period_stats_hash = {};
+      </script>
+
+
+      <div class="card p-0 table-responsive">
+        <div class="card-header" style="background-color: white;">
+          <div class="row">
+            <div>
+            <a target="TEAM_WIN" class="skipMask" href="/teams/589036"><img class="logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" />California</a> Receiving
+            </div>
+            <div class="ml-auto small"><a class="skipMask" href="javascript:togglePeriodStats(competitor_7676000_year_stat_category_15086_data_table);">Period Stats</a></div>
+          </div>
+        </div>
+        <div class="card-body">
+        <table class="display dataTable small_font" id="competitor_7676000_year_stat_category_15086_data_table">
+          <thead>
+          <tr>
+            <th class="no_padding  d-none d-sm-table-cell">#</th>
+            <th class="no_padding ">Name</th>
+            <th class="no_padding  d-none d-sm-table-cell">P</th>
+              <th class="no_padding">Rec</th>
+              <th class="no_padding">Receiving<br/>Yards</th>
+              <th class="no_padding">Yards<br/>Per<br/>Reception</th>
+              <th class="no_padding">Rec<br/>TD</th>
+              <th class="no_padding">Long<br/>Rec</th>
+          </tr>
+          </thead>
+          <tbody>
+
+                      <tr id="game_player_773558890_year_stat_category_15086" >
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              11
+            </td>
+            <td nowrap class="no_padding ">
+                <a target="PLAYER_HISTORY" class="skipMask" href="/players/8610232">Mavin Anderson</a>
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              WR
+            </td>
+              <td class="no_padding " data-order="4">4</td>
+              <td class="no_padding " data-order="31">31</td>
+              <td class="no_padding " data-order="7.75">7.75</td>
+              <td class="no_padding " data-order="0">0</td>
+              <td class="no_padding " data-order="12">12</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">2</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">15</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7.50</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">12</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">9</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">9.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">9</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7676000_year_stat_category_15086_period_stats_hash[773558890] = periodStatsArray;
+            </script>
+
+                      <tr id="game_player_773558899_year_stat_category_15086" >
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              6
+            </td>
+            <td nowrap class="no_padding ">
+                <a target="PLAYER_HISTORY" class="skipMask" href="/players/8906229">Jonathan Brady</a>
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              WR
+            </td>
+              <td class="no_padding " data-order="4">4</td>
+              <td class="no_padding " data-order="63">63</td>
+              <td class="no_padding " data-order="15.75">15.75</td>
+              <td class="no_padding " data-order="0">0</td>
+              <td class="no_padding " data-order="25">25</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">3</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">50</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">16.67</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">25</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">13</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">13.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">13</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7676000_year_stat_category_15086_period_stats_hash[773558899] = periodStatsArray;
+            </script>
+
+                      <tr id="game_player_773558884_year_stat_category_15086" >
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              10
+            </td>
+            <td nowrap class="no_padding ">
+                <a target="PLAYER_HISTORY" class="skipMask" href="/players/8906251">Corey Dyches</a>
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              TE
+            </td>
+              <td class="no_padding " data-order="1">1</td>
+              <td class="no_padding " data-order="3">3</td>
+              <td class="no_padding " data-order="3.00">3.00</td>
+              <td class="no_padding " data-order="0">0</td>
+              <td class="no_padding " data-order="3">3</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">3</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">3.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">3</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7676000_year_stat_category_15086_period_stats_hash[773558884] = periodStatsArray;
+            </script>
+
+                      <tr id="game_player_773558903_year_stat_category_15086" >
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              87
+            </td>
+            <td nowrap class="no_padding ">
+                <a target="PLAYER_HISTORY" class="skipMask" href="/players/8609111">Jack Endries</a>
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              TE
+            </td>
+              <td class="no_padding " data-order="3">3</td>
+              <td class="no_padding " data-order="23">23</td>
+              <td class="no_padding " data-order="7.67">7.67</td>
+              <td class="no_padding " data-order="0">0</td>
+              <td class="no_padding " data-order="8">8</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">3</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">23</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7.67</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">8</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7676000_year_stat_category_15086_period_stats_hash[773558903] = periodStatsArray;
+            </script>
+
+                      <tr id="game_player_773558892_year_stat_category_15086" >
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              83
+            </td>
+            <td nowrap class="no_padding ">
+                <a target="PLAYER_HISTORY" class="skipMask" href="/players/8648014">Trond Grizzell</a>
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              WR
+            </td>
+              <td class="no_padding " data-order="1">1</td>
+              <td class="no_padding " data-order="6">6</td>
+              <td class="no_padding " data-order="6.00">6.00</td>
+              <td class="no_padding " data-order="0">0</td>
+              <td class="no_padding " data-order="6">6</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">6</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">6.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">6</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7676000_year_stat_category_15086_period_stats_hash[773558892] = periodStatsArray;
+            </script>
+
+                      <tr id="game_player_773558906_year_stat_category_15086" >
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              13
+            </td>
+            <td nowrap class="no_padding ">
+                <a target="PLAYER_HISTORY" class="skipMask" href="/players/8654664">Nyziah Hunter</a>
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              WR
+            </td>
+              <td class="no_padding " data-order="4">4</td>
+              <td class="no_padding " data-order="44">44</td>
+              <td class="no_padding " data-order="11.00">11.00</td>
+              <td class="no_padding " data-order="2">2</td>
+              <td class="no_padding " data-order="19">19</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">19</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">19.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">19</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">13</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">13.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">13</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">9</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">9.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">9</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">3</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">3.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">3</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7676000_year_stat_category_15086_period_stats_hash[773558906] = periodStatsArray;
+            </script>
+
+                      <tr id="game_player_773558912_year_stat_category_15086" >
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              8
+            </td>
+            <td nowrap class="no_padding ">
+                <a target="PLAYER_HISTORY" class="skipMask" href="/players/8906238">Mikey Matthews</a>
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              WR
+            </td>
+              <td class="no_padding " data-order="3">3</td>
+              <td class="no_padding " data-order="7">7</td>
+              <td class="no_padding " data-order="2.33">2.33</td>
+              <td class="no_padding " data-order="0">0</td>
+              <td class="no_padding " data-order="5">5</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">5</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">5.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">5</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">2</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">2</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">3</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7676000_year_stat_category_15086_period_stats_hash[773558912] = periodStatsArray;
+            </script>
+
+                      <tr id="game_player_773558923_year_stat_category_15086" >
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              9
+            </td>
+            <td nowrap class="no_padding ">
+                <a target="PLAYER_HISTORY" class="skipMask" href="/players/8603025">Mason Starling</a>
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              WR
+            </td>
+              <td class="no_padding " data-order="3">3</td>
+              <td class="no_padding " data-order="42">42</td>
+              <td class="no_padding " data-order="14.00">14.00</td>
+              <td class="no_padding " data-order="0">0</td>
+              <td class="no_padding " data-order="18">18</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">3</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">42</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">14.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">18</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7676000_year_stat_category_15086_period_stats_hash[773558923] = periodStatsArray;
+            </script>
+
+                      <tr id="game_player_773558907_year_stat_category_15086" >
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              25
+            </td>
+            <td nowrap class="no_padding ">
+                <a target="PLAYER_HISTORY" class="skipMask" href="/players/8629402">Jaivian Thomas</a>
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              RB
+            </td>
+              <td class="no_padding " data-order="2">2</td>
+              <td class="no_padding " data-order="14">14</td>
+              <td class="no_padding " data-order="7.00">7.00</td>
+              <td class="no_padding " data-order="0">0</td>
+              <td class="no_padding " data-order="7">7</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7676000_year_stat_category_15086_period_stats_hash[773558907] = periodStatsArray;
+            </script>
+
+                    <tr id="game_player_773558930_year_stat_category_15086" style='background-color: #f9f9f9 !important'>
+            <td nowrap class="no_padding d-none d-sm-table-cell tbody_border_top">
+            </td>
+            <td nowrap class="no_padding tbody_border_top">
+                 California
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell tbody_border_top">
+            </td>
+              <td class="no_padding tbody_border_top" data-order="-">25</td>
+              <td class="no_padding tbody_border_top" data-order="-">233</td>
+              <td class="no_padding tbody_border_top" data-order="-">9.32</td>
+              <td class="no_padding tbody_border_top" data-order="-">2</td>
+              <td class="no_padding tbody_border_top" data-order="-">25</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">8</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">95</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">11.88</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">25</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">11</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">110</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">10.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">18</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">4</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">18</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">4.50</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">9</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">2</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">10</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">5.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7676000_year_stat_category_15086_period_stats_hash[773558930] = periodStatsArray;
+            </script>
+
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <script>
+        var noSortType = $.fn.dataTable.absoluteOrderNumber( [
+        { value: '-', position: 'bottom' }
+      ] );
+        var competitor_7676000_year_stat_category_15086_data_table = null;
+        $(document).ready(function() {
+          competitor_7676000_year_stat_category_15086_data_table = $('#competitor_7676000_year_stat_category_15086_data_table').DataTable({
+            //"sDom": 't',
+            "bPaginate": false,
+            "bInfo": false,
+            "bFilter": false,
+            "order": [[4, "desc"]],
+            "columns": [
+              {orderable: false, type: noSortType},
+              {orderable: false, type: noSortType},
+              {orderable: false, type: noSortType},
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} 
+            ]
+          })
+
+          for (let key in competitor_7676000_year_stat_category_15086_period_stats_hash){
+             child_array = [];
+             for (row of competitor_7676000_year_stat_category_15086_period_stats_hash[key]){
+               console.log(row);
+               child_array.push(row);
+             }
+            competitor_7676000_year_stat_category_15086_data_table.row('#game_player_'+key+'_year_stat_category_15086').child(child_array);
+           }
+
+       });
+
+       function togglePeriodStats(data_table){
+         $('[id^=game_player_]').each( function(x){
+           console.log($(this).attr('id'));
+           c = data_table.row('#'+$(this).attr('id')).child;
+           if (c.isShown()){
+             c.hide();
+           }else{
+             c.show();
+           }
+         });
+       }
+
+
+
+
+    </script>
+
+      </div>
+      <div class="col p-2">
+              <script>
+        var competitor_7675999_year_stat_category_15086_period_stats_hash = {};
+      </script>
+
+
+      <div class="card p-0 table-responsive">
+        <div class="card-header" style="background-color: white;">
+          <div class="row">
+            <div>
+            <a target="TEAM_WIN" class="skipMask" href="/teams/589027"><img class="logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" />Auburn</a> Receiving
+            </div>
+            <div class="ml-auto small"><a class="skipMask" href="javascript:togglePeriodStats(competitor_7675999_year_stat_category_15086_data_table);">Period Stats</a></div>
+          </div>
+        </div>
+        <div class="card-body">
+        <table class="display dataTable small_font" id="competitor_7675999_year_stat_category_15086_data_table">
+          <thead>
+          <tr>
+            <th class="no_padding  d-none d-sm-table-cell">#</th>
+            <th class="no_padding ">Name</th>
+            <th class="no_padding  d-none d-sm-table-cell">P</th>
+              <th class="no_padding">Rec</th>
+              <th class="no_padding">Receiving<br/>Yards</th>
+              <th class="no_padding">Yards<br/>Per<br/>Reception</th>
+              <th class="no_padding">Rec<br/>TD</th>
+              <th class="no_padding">Long<br/>Rec</th>
+          </tr>
+          </thead>
+          <tbody>
+
+                      <tr id="game_player_773558851_year_stat_category_15086" >
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              0
+            </td>
+            <td nowrap class="no_padding ">
+                <a target="PLAYER_HISTORY" class="skipMask" href="/players/8618721">Damari Alston</a>
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              RB
+            </td>
+              <td class="no_padding " data-order="1">1</td>
+              <td class="no_padding " data-order="2">2</td>
+              <td class="no_padding " data-order="2.00">2.00</td>
+              <td class="no_padding " data-order="0">0</td>
+              <td class="no_padding " data-order="2">2</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">2</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">2.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">2</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7675999_year_stat_category_15086_period_stats_hash[773558851] = periodStatsArray;
+            </script>
+
+                      <tr id="game_player_773558867_year_stat_category_15086" >
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              8
+            </td>
+            <td nowrap class="no_padding ">
+                <a target="PLAYER_HISTORY" class="skipMask" href="/players/8963755">Cam Coleman</a>
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              WR
+            </td>
+              <td class="no_padding " data-order="2">2</td>
+              <td class="no_padding " data-order="53">53</td>
+              <td class="no_padding " data-order="26.50">26.50</td>
+              <td class="no_padding " data-order="0">0</td>
+              <td class="no_padding " data-order="41">41</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">41</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">41.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">41</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">12</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">12.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">12</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7675999_year_stat_category_15086_period_stats_hash[773558867] = periodStatsArray;
+            </script>
+
+                      <tr id="game_player_773558833_year_stat_category_15086" >
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              13
+            </td>
+            <td nowrap class="no_padding ">
+                <a target="PLAYER_HISTORY" class="skipMask" href="/players/8624717">Rivaldo Fairweather</a>
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              TE
+            </td>
+              <td class="no_padding " data-order="2">2</td>
+              <td class="no_padding " data-order="23">23</td>
+              <td class="no_padding " data-order="11.50">11.50</td>
+              <td class="no_padding " data-order="0">0</td>
+              <td class="no_padding " data-order="16">16</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">16</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">16.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">16</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7675999_year_stat_category_15086_period_stats_hash[773558833] = periodStatsArray;
+            </script>
+
+                      <tr id="game_player_773558835_year_stat_category_15086" >
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              87
+            </td>
+            <td nowrap class="no_padding ">
+                <a target="PLAYER_HISTORY" class="skipMask" href="/players/8963994">Brandon Frazier</a>
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              TE
+            </td>
+              <td class="no_padding " data-order="1">1</td>
+              <td class="no_padding " data-order="16">16</td>
+              <td class="no_padding " data-order="16.00">16.00</td>
+              <td class="no_padding " data-order="0">0</td>
+              <td class="no_padding " data-order="16">16</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">16</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">16.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">16</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7675999_year_stat_category_15086_period_stats_hash[773558835] = periodStatsArray;
+            </script>
+
+                      <tr id="game_player_773558845_year_stat_category_15086" >
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              27
+            </td>
+            <td nowrap class="no_padding ">
+                <a target="PLAYER_HISTORY" class="skipMask" href="/players/8647762">Jarquez Hunter</a>
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              RB
+            </td>
+              <td class="no_padding " data-order="3">3</td>
+              <td class="no_padding " data-order="11">11</td>
+              <td class="no_padding " data-order="3.67">3.67</td>
+              <td class="no_padding " data-order="0">0</td>
+              <td class="no_padding " data-order="8">8</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">3</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">3.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">3</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">8</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">8.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">8</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7675999_year_stat_category_15086_period_stats_hash[773558845] = periodStatsArray;
+            </script>
+
+                      <tr id="game_player_773558843_year_stat_category_15086" >
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              5
+            </td>
+            <td nowrap class="no_padding ">
+                <a target="PLAYER_HISTORY" class="skipMask" href="/players/8963736">KeAndre Lambert-Smith</a>
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              WR
+            </td>
+              <td class="no_padding " data-order="2">2</td>
+              <td class="no_padding " data-order="30">30</td>
+              <td class="no_padding " data-order="15.00">15.00</td>
+              <td class="no_padding " data-order="1">1</td>
+              <td class="no_padding " data-order="15">15</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">2</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">30</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">15.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">15</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7675999_year_stat_category_15086_period_stats_hash[773558843] = periodStatsArray;
+            </script>
+
+                      <tr id="game_player_773558820_year_stat_category_15086" >
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              14
+            </td>
+            <td nowrap class="no_padding ">
+                <a target="PLAYER_HISTORY" class="skipMask" href="/players/8963824">Robert Lewis</a>
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              WR
+            </td>
+              <td class="no_padding " data-order="2">2</td>
+              <td class="no_padding " data-order="17">17</td>
+              <td class="no_padding " data-order="8.50">8.50</td>
+              <td class="no_padding " data-order="0">0</td>
+              <td class="no_padding " data-order="12">12</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">2</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">17</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">8.50</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">12</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7675999_year_stat_category_15086_period_stats_hash[773558820] = periodStatsArray;
+            </script>
+
+                      <tr id="game_player_773558869_year_stat_category_15086" >
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              11
+            </td>
+            <td nowrap class="no_padding ">
+                <a target="PLAYER_HISTORY" class="skipMask" href="/players/8963842">Malcolm Simmons</a>
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell ">
+              WR
+            </td>
+              <td class="no_padding " data-order="1">1</td>
+              <td class="no_padding " data-order="13">13</td>
+              <td class="no_padding " data-order="13.00">13.00</td>
+              <td class="no_padding " data-order="0">0</td>
+              <td class="no_padding " data-order="13">13</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">13</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">13.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">13</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7675999_year_stat_category_15086_period_stats_hash[773558869] = periodStatsArray;
+            </script>
+
+                    <tr id="game_player_773558874_year_stat_category_15086" style='background-color: #f9f9f9 !important'>
+            <td nowrap class="no_padding d-none d-sm-table-cell tbody_border_top">
+            </td>
+            <td nowrap class="no_padding tbody_border_top">
+                 Auburn
+            </td>
+            <td nowrap class="no_padding d-none d-sm-table-cell tbody_border_top">
+            </td>
+              <td class="no_padding tbody_border_top" data-order="-">14</td>
+              <td class="no_padding tbody_border_top" data-order="-">165</td>
+              <td class="no_padding tbody_border_top" data-order="-">11.79</td>
+              <td class="no_padding tbody_border_top" data-order="-">1</td>
+              <td class="no_padding tbody_border_top" data-order="-">41</td>
+          </tr>
+
+                          <script>
+              periodStatsArray = [];
+          </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">1st Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">6</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">106</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">17.67</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">41</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">2nd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">3rd Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">1</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">8</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">8.00</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">8</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              str              = '<tr><td nowrap class="no_padding d-none d-sm-table-cell"></td><td nowrap class="no_padding">4th Quarter</td><td nowrap class="no_padding d-none d-sm-table-cell"></td>';
+            </script>
+                <script>
+                  str = str + '<td class="no_padding">6</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">44</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">7.33</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">0</td>';
+              </script>
+                <script>
+                  str = str + '<td class="no_padding">13</td>';
+              </script>
+            <script>
+              periodStatsArray.push($(str+'</tr>').toArray());
+            </script>
+            <script>
+              competitor_7675999_year_stat_category_15086_period_stats_hash[773558874] = periodStatsArray;
+            </script>
+
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <script>
+        var noSortType = $.fn.dataTable.absoluteOrderNumber( [
+        { value: '-', position: 'bottom' }
+      ] );
+        var competitor_7675999_year_stat_category_15086_data_table = null;
+        $(document).ready(function() {
+          competitor_7675999_year_stat_category_15086_data_table = $('#competitor_7675999_year_stat_category_15086_data_table').DataTable({
+            //"sDom": 't',
+            "bPaginate": false,
+            "bInfo": false,
+            "bFilter": false,
+            "order": [[4, "desc"]],
+            "columns": [
+              {orderable: false, type: noSortType},
+              {orderable: false, type: noSortType},
+              {orderable: false, type: noSortType},
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} ,
+                {orderSequence: ["desc", "asc"], type: noSortType} 
+            ]
+          })
+
+          for (let key in competitor_7675999_year_stat_category_15086_period_stats_hash){
+             child_array = [];
+             for (row of competitor_7675999_year_stat_category_15086_period_stats_hash[key]){
+               console.log(row);
+               child_array.push(row);
+             }
+            competitor_7675999_year_stat_category_15086_data_table.row('#game_player_'+key+'_year_stat_category_15086').child(child_array);
+           }
+
+       });
+
+       function togglePeriodStats(data_table){
+         $('[id^=game_player_]').each( function(x){
+           console.log($(this).attr('id'));
+           c = data_table.row('#'+$(this).attr('id')).child;
+           if (c.isShown()){
+             c.hide();
+           }else{
+             c.show();
+           }
+         });
+       }
+
+
+
+
+    </script>
+
+      </div>
+</div>
+</div>
+
+
+
+
+       </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<footer>&copy; <script>document.write(new Date().getFullYear())</script> NCAA <a href="http://web1.ncaa.org/web_files/terms_and_conditions.html" title ="Terms and Conditions" target=_blank>Terms and Conditions</a> | <a href="http://web1.ncaa.org/web_files/privacy.html" target=_blank title="Our Privacy Policy">Privacy Policy</a> | <a href="mailto:ncaa_stats@ncaa.org">Contact Us</a> </footer>
+
+  <!-- /.container -->
+  <script type="text/javascript"  src="/sU0joiPwv/zplvN/xFxji/wmgXJnBU/whimQww3k9OS/ZXgTG2MrBg/I0sONT4/dCDpZ?v=72c54ec5-e129-c4ef-7c10-871b401d1738" defer></script></body>
+
+  <script charset="utf-8">
+    $(document).ready(function() {
+      $('a.remote[data-toggle="tab"]').on('show.bs.tab', function (e) {
+        var tab_id = '#' + $(this).attr('aria-controls');
+        $(tab_id).html('<br/><br/><p style="text-align: center"><img style="vertical-align:middle; text-align: center" src="/assets/ajax-loader-6913acdbf4be7d6a2908a84bdecd6cad18110f5fc6d5a07cf8c9ce78d9548700.gif" /> Loading... </p><br/><br/>');
+        $.get($(this).data('remote'), function(data){
+          $(tab_id).html(data);
+        });
+      });
+    });
+
+    function skipMask(obj){
+      if (obj.hasClass('chosen-single') || obj.hasClass('skipMask') || obj.hasClass('ui-datepicker-prev') || obj.hasClass('ui-datepicker-next') || obj.hasClass('ui-corner-all') || obj.hasClass('paginate_button') || obj.hasClass('dt-button')){
+        return true;
+      }else{
+        return false;
+      }
+    }
+
+    $(document).ajaxComplete(function(){
+      unmask();
+    });
+/*
+    $("form").on('submit', function(event){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    */
+    $(document).on('click', 'a', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    $(document).on('click', 'input.green', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+
+  </script>
+</html>

--- a/tests/fixtures/cfb_ncaa/mfb_officials_5362283.html
+++ b/tests/fixtures/cfb_ncaa/mfb_officials_5362283.html
@@ -1,0 +1,462 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<META HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=UTF-8">
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="">
+<meta name="author" content="">
+<meta name="version" content="321d28433e9f7a188596117e6f342ec4a84fb4ed">
+<META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<link rel="shortcut icon" href="/assets/favicon-405088046a5f2bab8eedeacfae7636975c095e9c8decd8c28e3fd0e65c2f51c4.ico" type="image/vnd.microsoft.icon">
+
+<title>NCAA Statistics</title>
+
+<!-- Bootstrap core CSS -->
+
+<!--
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+-->
+<!--
+<link rel="stylesheet" href="https://cdn.datatables.net/2.0.0/css/dataTables.bootstrap4.css" crossorigin="anonymous">
+-->
+<link rel="stylesheet" media="all" href="/assets/application-789c3971842ee3597428ccbebd021716b3231e9cbd0a00a184c3b2d6c8e5f152.css" />
+
+
+<script src="/assets/application-9232576bb3cb000ac0841ff2af81251908ec17312a3c5eb72bf1a32f9754800c.js"></script>
+<!--
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+-->
+<!--
+<script src="https://cdn.datatables.net/2.0.0/js/dataTables.bootstrap4.js" crossorigin="anonymous"></script>
+-->
+
+<meta name="csrf-param" content="authenticity_token" />
+<meta name="csrf-token" content="qGI/yKYOglIsWI1y6NhmBQhDstQLkWU40KSxtLr/3yiWNbPRoDIXFDdbBBNhG/Q0hvmyNC+tJQkyd6xMn0WowA==" />
+
+<style>
+.grid {clear: all}
+.grid-item, .name {text-align: center;}
+h1 img {max-height: 33px;}
+
+</style>
+<!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+<!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+      <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+    <![endif]-->
+
+
+<script>(window.BOOMR_mq=window.BOOMR_mq||[]).push(["addVar",{"rua.upush":"false","rua.cpush":"false","rua.upre":"false","rua.cpre":"false","rua.uprl":"false","rua.cprl":"false","rua.cprf":"false","rua.trans":"","rua.cook":"false","rua.ims":"false","rua.ufprl":"false","rua.cfprl":"false","rua.isuxp":"false","rua.texp":"norulematch","rua.ceh":"false","rua.ueh":"false","rua.ieh.st":"0"}]);</script>
+                                <script>!function(e){var n="https://s.go-mpulse.net/boomerang/";if("False"=="True")e.BOOMR_config=e.BOOMR_config||{},e.BOOMR_config.PageParams=e.BOOMR_config.PageParams||{},e.BOOMR_config.PageParams.pci=!0,n="https://s2.go-mpulse.net/boomerang/";if(window.BOOMR_API_key="EVKJV-AGD2E-W66AE-NT84S-K5LTF",function(){function e(){if(!r){var e=document.createElement("script");e.id="boomr-scr-as",e.src=window.BOOMR.url,e.async=!0,o.appendChild(e),r=!0}}function t(e){r=!0;var n,t,a,i,d=document,O=window;if(window.BOOMR.snippetMethod=e?"if":"i",t=function(e,n){var t=d.createElement("script");t.id=n||"boomr-if-as",t.src=window.BOOMR.url,BOOMR_lstart=(new Date).getTime(),e=e||d.body,e.appendChild(t)},!window.addEventListener&&window.attachEvent&&navigator.userAgent.match(/MSIE [67]\./))return window.BOOMR.snippetMethod="s",void t(o,"boomr-async");a=document.createElement("IFRAME"),a.src="about:blank",a.title="",a.role="presentation",a.loading="eager",i=(a.frameElement||a).style,i.width=0,i.height=0,i.border=0,i.display="none",o.appendChild(a);try{O=a.contentWindow,d=O.document.open()}catch(_){n=document.domain,a.src="javascript:var d=document.open();d.domain='"+n+"';void 0;",O=a.contentWindow,d=O.document.open()}if(n)d._boomrl=function(){this.domain=n,t()},d.write("<bo"+"dy onload='document._boomrl();'>");else if(O._boomrl=function(){t()},O.addEventListener)O.addEventListener("load",O._boomrl,!1);else if(O.attachEvent)O.attachEvent("onload",O._boomrl);d.close()}function a(e){window.BOOMR_onload=e&&e.timeStamp||(new Date).getTime()}if(!window.BOOMR||!window.BOOMR.version&&!window.BOOMR.snippetExecuted){window.BOOMR=window.BOOMR||{},window.BOOMR.snippetStart=(new Date).getTime(),window.BOOMR.snippetExecuted=!0,window.BOOMR.snippetVersion=14,window.BOOMR.url=n+"EVKJV-AGD2E-W66AE-NT84S-K5LTF";var i=document.currentScript||document.getElementsByTagName("script")[0],o=i.parentNode,r=!1,d=document.createElement("link");if(d.relList&&"function"==typeof d.relList.supports&&d.relList.supports("preload")&&"as"in d)window.BOOMR.snippetMethod="p",d.href=window.BOOMR.url,d.rel="preload",d.as="script",d.addEventListener("load",e),d.addEventListener("error",function(){t(!0)}),setTimeout(function(){if(!r)t(!0)},3e3),BOOMR_lstart=(new Date).getTime(),o.appendChild(d);else t(!1);if(window.addEventListener)window.addEventListener("load",a,!1);else if(window.attachEvent)window.attachEvent("onload",a)}}(),"".length>0)if(e&&"performance"in e&&e.performance&&"function"==typeof e.performance.setResourceTimingBufferSize)e.performance.setResourceTimingBufferSize();!function(){if(BOOMR=e.BOOMR||{},BOOMR.plugins=BOOMR.plugins||{},!BOOMR.plugins.AK){var n=""=="true"?1:0,t="cookiepresent",a="ntaveg5yk4sly2sz6a2a-f-15a04c657-clientnsv4-s.akamaihd.net",i="false"=="true"?2:1,o={"ak.v":"41","ak.cp":"1168236","ak.ai":parseInt("215853",10),"ak.ol":"0","ak.cr":24,"ak.ipv":4,"ak.proto":"h2","ak.rid":"20c7115e","ak.r":40932,"ak.a2":n,"ak.m":"a","ak.n":"essl","ak.cport":53220,"ak.gh":"23.56.236.39","ak.quicv":"","ak.tlsv":"tls1.3","ak.0rtt":"","ak.0rtt.ed":"","ak.csrc":"-","ak.acc":"","ak.t":"1784279092","ak.ak":"hOBiQwZUYzCg5VSAfCLimQ==EUGqGjoSIIIdw8qzzcrXve3HfcV3SUu0Yo/SR0iAUI/p4snTQPfgLQPpTEYXPqfbC1iW3vvZLlNCozyY/asEMH0r250Gh0gkIP/GnlOyjOjdiEhZVun42gEzQFA6HDXdFf3Vwx1MuofuDhpx18+OqzQ+Mgrq88bdrBvj25xL2EgXQKPXHoKrCx89vRmI63otQwUAXv2phGB3TMC+Weet0T8GichAF9XAwhHPw/bP3EtOOpvFgvaDP5p8K4kMBAFn/VdpLmHYhg43Lfdpwc8ovuZIbf+qMyVRisBTUldX90aM0bpkvTYqPG1O6s+DPwsz+eVe0yjQhV/S7ykQwEgKkCqQpbZdCdzk74sKQzCB2+YcJyBDGs7ghq6tT7eqdUFYOKD0h/Rvvy+Dnt8O8727oXDEdf3Cqsr14uYdqBj2Cok=","ak.pv":"93","ak.dpoabenc":"","ak.tf":i};if(""!==t)o["ak.ruds"]=t;var r={i:!1,av:function(n){var t="http.initiator";if(n&&(!n[t]||"spa_hard"===n[t]))o["ak.feo"]=void 0!==e.aFeoApplied?1:0,BOOMR.addVar(o)},rv:function(){var e=["ak.cport","ak.cr","ak.csrc","ak.gh","ak.ipv","ak.m","ak.n","ak.ol","ak.proto","ak.quicv","ak.tlsv","ak.0rtt","ak.0rtt.ed","ak.r","ak.acc","ak.t","ak.tf"];BOOMR.removeVar(e)}};BOOMR.plugins.AK={akVars:o,akDNSPreFetchDomain:a,init:function(){if(!r.i){var e=BOOMR.subscribe;e("before_beacon",r.av,null,null),e("onbeacon",r.rv,null,null),r.i=!0}return this},is_complete:function(){return!0}}}}()}(window);</script></head>
+
+  <script>
+
+    
+  //initialize tooltip
+  $(document).ready(function() {
+    //$("body").tooltip({ selector: '[data-toggle=tooltip]' });
+    $('[data-toggle="tooltip"]').tooltip();
+  });
+
+  $(document).ready(function() {
+    $( "#org_name" ).autocomplete({
+      source: '/team/search',
+      select: function( event, ui ) {
+        $("#org_id").val(ui.item.vid);
+        $("#id").val(ui.item.vid);
+        $('#sport_btn').click();
+      }
+    });
+  });
+
+  var body = 'body';
+
+  $.ajaxSetup ({
+    // Disable caching of AJAX responses
+    cache: false
+  });
+
+  function changeSport(field){
+    var el = $(field);
+    var tmList = el.parent().next().find('.new-team-year')[0];
+    if (tmList == null){
+      tmList = el.nextAll('.new-team-year')[0];
+    }
+    $.ajax({
+      url: "/game_sport_year_ctls/"+el.val()+"/available_teams",
+      dataType: "script",
+      success: function(data, status){
+        $(tmList).empty();
+        $(tmList).append(("<option value=''>Select team</option>"));
+        $.each(JSON.parse(data), function(k, v){
+          $(tmList).append($("<option></option>")
+              .attr("value", v["id"])
+              .text(v["member_org"]["name_tabular"]));
+        });
+        $(tmList).trigger("chosen:updated");
+      }
+    });
+  }
+
+    function set_process_styles(fld, start_color, end_color){
+       $('#'+fld).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    var downImage = "/assets/down12.gif";
+    var rightImage = "/assets/right12.gif";
+
+    function highlight(div_id){
+      $(div_id).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    function show_hide_rows(attr_val, link_id){
+      $('#'+attr_val).toggle();
+      if ($('#'+attr_val).is(':visible')) {
+        $('#'+link_id).attr('src', downImage);
+      }else{
+        $('#'+link_id).attr('src', rightImage);
+      }
+    }
+
+    function mask(label){
+      $('body').mask(label);
+    }
+    function unmask(){
+      $('body').unmask();
+    }
+
+    var winHeight = "auto";
+    var winWidth = "auto";
+    var maxHeight = 700;
+    var maxWidth = 1400;
+    var minHeight = 100;
+    var minWidth = 200;
+    
+    var modalOptions = {"width": winWidth,
+                        "height": winHeight,
+                        "maxHeight": maxHeight,
+                        "maxWidth": maxWidth,
+                        "minHeight": minHeight,
+                        "minWidth": minWidth};
+
+    function dialog(url, title){
+
+      $("#stats_app_dialog").dialog({modal:true, minWidth:minWidth, minHeight:minHeight, maxWidth:maxWidth, maxHeight:maxHeight, width:winWidth, height:winHeight, title:title, closeOnEscape: false});
+    
+      modalOptions.title = title;
+    
+      $("#stats_app_dialog").dialog("option", modalOptions);
+    
+      $("#stats_app_dialog").html("Loading...");
+      $("#stats_app_dialog").load(url).dialog('open');
+    }
+
+    function addDatePicker(){
+    $('.adddatepicker').each(function(i, obj){
+      $(obj).datepicker({ 
+        showOn: 'both', 
+        buttonImage: '/assets/calendar.gif', 
+        buttonImageOnly: true,
+      });
+    });
+    }
+
+   $(document).ready(function() {
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   });
+
+   function setClassInputFields(){
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   }
+
+   function isValidDateFormat(dateStr){
+     const regex = /^([1-9]|0[1-9]|1[0-2])\/([1-9]|0[1-9]|[12][0-9]|3[01])\/(19|20)\d{2}$/;
+     if (!regex.test(dateStr)) {
+       return false;
+     }else{
+       return true;
+     }
+   }
+
+  </script>
+
+
+<body style="font-size: .75rem;" onload="if (top != self) { top.location=self.location; }" >
+
+      <header>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0">
+        <a class="navbar-brand mr-0 mr-md-2" href="/" aria-label="statistics">
+                          <img alt="NCAA" style="margin-left: 24px; margin-right: 0; margin-top: 6px;" src="/assets/ncaa-fbc4d0406ae731b47babcc3fca53775b5955ef372bf8b8e998ca9a513e468b8f.svg" />
+                          <span class="title" class="dark-blue-font">Statistics</span>
+        </a>
+       </nav>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0" style="background-color: var(--color-dark-blue) !important;">
+  <button class="navbar-toggler bg-white" type="button" data-toggle="collapse" data-target="#navbarTogglerDemo01" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarTogglerDemo01">
+        <ul class="navbar-nav mr-auto mt-2 mt-lg-0 justify-content-center">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle skipMask" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Rankings
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+          <a class="dropdown-item" href="/rankings">National Rankings</a>
+          <a class="dropdown-item" href="/active_career_leaders">Active Career Leaders</a>
+        </div>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/contests/livestream_scoreboards">Scoreboard</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/selection_rankings/nitty_gritties">Selection Rankings</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/head_coaches">Head Coaches</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/search/players">Players</a>
+      </li>
+     </ul>
+
+    <form onsubmit="mask(&#39;Loading&#39;);" id="change_team_form" style="display:inline;" class="form-inline my-2 my-lg-0" action="/team/index" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="+ywZQM5bWRs24jKRT/0V205tcvw/m/7vDOsaXiM7bMgdS2iUonM5KFc5XkEd5BAev9dS3UVsS3PiVlPzdkdoJA==" />
+  <div style="display:none;">
+  <input type="submit" name="commit" value="Submit" id="sport_btn" data-disable-with="Submit" />
+  </div>
+    <div id="team_autocomplete" class="ui-widget">
+      <input type="search" name="org_name" id="org_name" style="width:200px; font-size: 12px !important" class="form-control mr-sm-2" placeholder="Team Search" />
+      <input type="hidden" name="org_id" id="org_id" />
+    </div>
+</form>  </div>
+  </nav>
+</nav>
+      </header>
+
+       <div id="stats_app_dialog" style="display:none;">
+        </div>
+
+<div class="card p-1">
+  <div class="card-body application contests p-0">
+    <h3 class="card-title p-0"></h3>
+    <div class="container-fluid p-0">
+      <div class="row align-items-center justify-content-center p-0">
+        <div class="col-sm-12 p-0">
+        
+<br/>
+
+<br/>
+
+<style>
+.winner{
+  --display: flex;
+  vertical-align: middle;
+}
+.winner:before{
+  content: '\25BA';
+  --display: flex;
+  --align-items: center;
+  vertical-align: middle;
+}
+div.center {
+  margin: auto;
+  width: 50%;
+  --border: 3px solid green;
+  padding: 10px;
+}
+</style>
+
+   <div class="table-responsive">
+   <table align="center">
+     <tr>
+   <td>
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589036"><img class="large_logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" /></a>
+   </td>
+   <td valign="center" class="grey_text d-none d-sm-table-cell" nowrap>
+     <span style="font-size:18px">
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589036">California Golden Bears</a>
+     </span><br/>
+       2-0, Conf 0-0
+   </td>
+   <td valign="center" class="winner">
+   </td>
+   <td valign="center" style="font-size:36px; color: black">
+     21
+   </td>
+     <td style="padding: 0px 30px 0px 30px"  class="d-none d-md-table-cell">
+       <table style="border-collapse: collapse">
+         <tr>
+           <td class="grey_border_bottom"></td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">1</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">2</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">3</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">4</td>
+           <td width="20px" align="right" style="font-weight:bold" class="grey_border_bottom">S</td>
+         </tr>
+           <tr>
+             <td>California</td>
+               <td class="grey_text" align="right">7</td>
+               <td class="grey_text" align="right">7</td>
+               <td class="grey_text" align="right">0</td>
+               <td class="grey_text" align="right">7</td>
+             <td align="right" style="font-weight:bold">21</td>
+           </tr>
+           <tr>
+             <td>Auburn</td>
+               <td class="grey_text" align="right">7</td>
+               <td class="grey_text" align="right">0</td>
+               <td class="grey_text" align="right">0</td>
+               <td class="grey_text" align="right">7</td>
+             <td align="right" style="font-weight:bold">14</td>
+           </tr>
+         <tr>
+           <td class="grey_text" colspan="6">09/07/2024 03:30 PM</td>
+         </tr>
+         <tr>
+           <td nowrap class="grey_text" colspan="6">Jordan-Hare Stadium (Auburn, AL)</td>
+         </tr>
+         <tr>
+           <td nowrap class="grey_text" colspan="6">Attendance: 88,043</td>
+         </tr>
+       </table>
+     </td>
+   <td>
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589027"><img class="large_logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" /></a>
+   </td>
+   <td valign="center" class="grey_text d-none d-sm-table-cell" nowrap>
+     <span style="font-size:18px">
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589027">Auburn Tigers</a>
+     </span><br/>
+       1-1, Conf 0-0
+   </td>
+   <td valign="center" class="">
+   </td>
+   <td valign="center" style="font-size:36px; color: grey">
+     14
+   </td>
+     </tr>
+     <tr>
+       <td colspan="10" class="grey_border_bottom grey_border_top">
+         <table cellpadding="10px">
+           <tr>
+             <td style="font-size: 16px;"><a href="/contests/5362283/box_score">Box Score</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5362283/team_stats">Team Stats</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5362283/individual_stats">Individual Stats</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5362283/play_by_play">Play By Play</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5362283/drives">Drives</a></td>
+             <td style="font-size: 16px;">Officials</td>
+           </tr>
+         </table>
+       </td>
+     </tr>
+   </table>
+ </div>
+
+
+<br/>
+ <script>
+var public_game_drives_data_table = null;
+  $(document).ready(function() {
+    public_game_drives_data_table = $('#public_game_drives_data_table').DataTable({
+      "dom": 'BRC<"clear">frtip',
+      "order": [[ 0, "asc" ]],
+      "pageLength": 100,
+      "buttons": [
+      { "extend": 'copy',
+        "exportOptions": {
+          //"columns":  exportableColumns
+        },
+        "footer": true
+      },
+      { "extend": 'excel',
+        "exportOptions": {
+          //"columns":  exportableColumns
+        },
+        "footer": true
+      }
+      ]
+    });
+
+  } );
+  </script>
+
+
+<table class="dataTable display" align="center" style="width:400px">
+  <thead>
+    <tr>
+      <th>Official</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Riley Johnson</td>
+    </tr>
+  </tbody>
+</table>
+
+       </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<footer>&copy; <script>document.write(new Date().getFullYear())</script> NCAA <a href="http://web1.ncaa.org/web_files/terms_and_conditions.html" title ="Terms and Conditions" target=_blank>Terms and Conditions</a> | <a href="http://web1.ncaa.org/web_files/privacy.html" target=_blank title="Our Privacy Policy">Privacy Policy</a> | <a href="mailto:ncaa_stats@ncaa.org">Contact Us</a> </footer>
+
+  <!-- /.container -->
+  <script type="text/javascript"  src="/sU0joiPwv/zplvN/xFxji/wmgXJnBU/whimQww3k9OS/ZXgTG2MrBg/I0sONT4/dCDpZ?v=7f425604-69b0-66b7-891c-c42cb7f21738" defer></script></body>
+
+  <script charset="utf-8">
+    $(document).ready(function() {
+      $('a.remote[data-toggle="tab"]').on('show.bs.tab', function (e) {
+        var tab_id = '#' + $(this).attr('aria-controls');
+        $(tab_id).html('<br/><br/><p style="text-align: center"><img style="vertical-align:middle; text-align: center" src="/assets/ajax-loader-6913acdbf4be7d6a2908a84bdecd6cad18110f5fc6d5a07cf8c9ce78d9548700.gif" /> Loading... </p><br/><br/>');
+        $.get($(this).data('remote'), function(data){
+          $(tab_id).html(data);
+        });
+      });
+    });
+
+    function skipMask(obj){
+      if (obj.hasClass('chosen-single') || obj.hasClass('skipMask') || obj.hasClass('ui-datepicker-prev') || obj.hasClass('ui-datepicker-next') || obj.hasClass('ui-corner-all') || obj.hasClass('paginate_button') || obj.hasClass('dt-button')){
+        return true;
+      }else{
+        return false;
+      }
+    }
+
+    $(document).ajaxComplete(function(){
+      unmask();
+    });
+/*
+    $("form").on('submit', function(event){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    */
+    $(document).on('click', 'a', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    $(document).on('click', 'input.green', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+
+  </script>
+</html>

--- a/tests/fixtures/cfb_ncaa/mfb_team_stats_5362283.html
+++ b/tests/fixtures/cfb_ncaa/mfb_team_stats_5362283.html
@@ -1,0 +1,2177 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<META HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=UTF-8">
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="">
+<meta name="author" content="">
+<meta name="version" content="321d28433e9f7a188596117e6f342ec4a84fb4ed">
+<META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<link rel="shortcut icon" href="/assets/favicon-405088046a5f2bab8eedeacfae7636975c095e9c8decd8c28e3fd0e65c2f51c4.ico" type="image/vnd.microsoft.icon">
+
+<title>NCAA Statistics</title>
+
+<!-- Bootstrap core CSS -->
+
+<!--
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+-->
+<!--
+<link rel="stylesheet" href="https://cdn.datatables.net/2.0.0/css/dataTables.bootstrap4.css" crossorigin="anonymous">
+-->
+<link rel="stylesheet" media="all" href="/assets/application-789c3971842ee3597428ccbebd021716b3231e9cbd0a00a184c3b2d6c8e5f152.css" />
+
+
+<script src="/assets/application-9232576bb3cb000ac0841ff2af81251908ec17312a3c5eb72bf1a32f9754800c.js"></script>
+<!--
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+-->
+<!--
+<script src="https://cdn.datatables.net/2.0.0/js/dataTables.bootstrap4.js" crossorigin="anonymous"></script>
+-->
+
+<meta name="csrf-param" content="authenticity_token" />
+<meta name="csrf-token" content="ILipX4rgyOjEvtIM7rEuBjIBueuhQmb785z1u7L6cTKH0OKZMXDI+cxjtYv9c5AIn7TlvLgXabjDiGygkucP6Q==" />
+
+<style>
+.grid {clear: all}
+.grid-item, .name {text-align: center;}
+h1 img {max-height: 33px;}
+
+</style>
+<!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+<!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+      <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+    <![endif]-->
+
+
+<script>(window.BOOMR_mq=window.BOOMR_mq||[]).push(["addVar",{"rua.upush":"false","rua.cpush":"false","rua.upre":"false","rua.cpre":"false","rua.uprl":"false","rua.cprl":"false","rua.cprf":"false","rua.trans":"","rua.cook":"false","rua.ims":"false","rua.ufprl":"false","rua.cfprl":"false","rua.isuxp":"false","rua.texp":"norulematch","rua.ceh":"false","rua.ueh":"false","rua.ieh.st":"0"}]);</script>
+                                <script>!function(e){var n="https://s.go-mpulse.net/boomerang/";if("False"=="True")e.BOOMR_config=e.BOOMR_config||{},e.BOOMR_config.PageParams=e.BOOMR_config.PageParams||{},e.BOOMR_config.PageParams.pci=!0,n="https://s2.go-mpulse.net/boomerang/";if(window.BOOMR_API_key="EVKJV-AGD2E-W66AE-NT84S-K5LTF",function(){function e(){if(!r){var e=document.createElement("script");e.id="boomr-scr-as",e.src=window.BOOMR.url,e.async=!0,o.appendChild(e),r=!0}}function t(e){r=!0;var n,t,a,i,d=document,O=window;if(window.BOOMR.snippetMethod=e?"if":"i",t=function(e,n){var t=d.createElement("script");t.id=n||"boomr-if-as",t.src=window.BOOMR.url,BOOMR_lstart=(new Date).getTime(),e=e||d.body,e.appendChild(t)},!window.addEventListener&&window.attachEvent&&navigator.userAgent.match(/MSIE [67]\./))return window.BOOMR.snippetMethod="s",void t(o,"boomr-async");a=document.createElement("IFRAME"),a.src="about:blank",a.title="",a.role="presentation",a.loading="eager",i=(a.frameElement||a).style,i.width=0,i.height=0,i.border=0,i.display="none",o.appendChild(a);try{O=a.contentWindow,d=O.document.open()}catch(_){n=document.domain,a.src="javascript:var d=document.open();d.domain='"+n+"';void 0;",O=a.contentWindow,d=O.document.open()}if(n)d._boomrl=function(){this.domain=n,t()},d.write("<bo"+"dy onload='document._boomrl();'>");else if(O._boomrl=function(){t()},O.addEventListener)O.addEventListener("load",O._boomrl,!1);else if(O.attachEvent)O.attachEvent("onload",O._boomrl);d.close()}function a(e){window.BOOMR_onload=e&&e.timeStamp||(new Date).getTime()}if(!window.BOOMR||!window.BOOMR.version&&!window.BOOMR.snippetExecuted){window.BOOMR=window.BOOMR||{},window.BOOMR.snippetStart=(new Date).getTime(),window.BOOMR.snippetExecuted=!0,window.BOOMR.snippetVersion=14,window.BOOMR.url=n+"EVKJV-AGD2E-W66AE-NT84S-K5LTF";var i=document.currentScript||document.getElementsByTagName("script")[0],o=i.parentNode,r=!1,d=document.createElement("link");if(d.relList&&"function"==typeof d.relList.supports&&d.relList.supports("preload")&&"as"in d)window.BOOMR.snippetMethod="p",d.href=window.BOOMR.url,d.rel="preload",d.as="script",d.addEventListener("load",e),d.addEventListener("error",function(){t(!0)}),setTimeout(function(){if(!r)t(!0)},3e3),BOOMR_lstart=(new Date).getTime(),o.appendChild(d);else t(!1);if(window.addEventListener)window.addEventListener("load",a,!1);else if(window.attachEvent)window.attachEvent("onload",a)}}(),"".length>0)if(e&&"performance"in e&&e.performance&&"function"==typeof e.performance.setResourceTimingBufferSize)e.performance.setResourceTimingBufferSize();!function(){if(BOOMR=e.BOOMR||{},BOOMR.plugins=BOOMR.plugins||{},!BOOMR.plugins.AK){var n=""=="true"?1:0,t="cookiepresent",a="ntaveg5yk4sly2sz573q-f-107d65375-clientnsv4-s.akamaihd.net",i="false"=="true"?2:1,o={"ak.v":"41","ak.cp":"1168236","ak.ai":parseInt("215853",10),"ak.ol":"0","ak.cr":12,"ak.ipv":4,"ak.proto":"h2","ak.rid":"20c66646","ak.r":40932,"ak.a2":n,"ak.m":"a","ak.n":"essl","ak.cport":53108,"ak.gh":"23.56.236.39","ak.quicv":"","ak.tlsv":"tls1.3","ak.0rtt":"","ak.0rtt.ed":"","ak.csrc":"-","ak.acc":"","ak.t":"1784279031","ak.ak":"hOBiQwZUYzCg5VSAfCLimQ==AoVAV77VYRiT8am9jAL+EerPimTu1bIF4MGbWSCaS5IP0hs0zoelLP0IDSRi5NQUe7iQpzA4dS75lKD6PQ/P3zfOtJDfR0K09XpXf69/I4QnTFr6zltcfQ/WUdNnoCpPOa4aXlglr5Bh2ixfMqVnZGBKd+9PXDfxwr3+70kWqwCzs5omv4/+2/bBHDNMEIhicC1EgIbBReofvPvHI2GHNmvFgvxNd0OJV+RgYnZMQXLx8okJvSmhahs8jkU1b6DvtWffNDd41VYxiLMpGTMZP4S9JdyhGJj3PBVaUtlIyfRAQOZMez2ppEzlvwHXzuEYbClTYtTaxL2AVVhvr87+Nhykn152q2er1sCvXVabFcvktn8xhl3kypUIzqM+7LgUsLeLzL9AstE1WErLzO4TSFpNoBv/RdR2kDZb1hknuq8=","ak.pv":"93","ak.dpoabenc":"","ak.tf":i};if(""!==t)o["ak.ruds"]=t;var r={i:!1,av:function(n){var t="http.initiator";if(n&&(!n[t]||"spa_hard"===n[t]))o["ak.feo"]=void 0!==e.aFeoApplied?1:0,BOOMR.addVar(o)},rv:function(){var e=["ak.cport","ak.cr","ak.csrc","ak.gh","ak.ipv","ak.m","ak.n","ak.ol","ak.proto","ak.quicv","ak.tlsv","ak.0rtt","ak.0rtt.ed","ak.r","ak.acc","ak.t","ak.tf"];BOOMR.removeVar(e)}};BOOMR.plugins.AK={akVars:o,akDNSPreFetchDomain:a,init:function(){if(!r.i){var e=BOOMR.subscribe;e("before_beacon",r.av,null,null),e("onbeacon",r.rv,null,null),r.i=!0}return this},is_complete:function(){return!0}}}}()}(window);</script></head>
+
+  <script>
+
+    
+  //initialize tooltip
+  $(document).ready(function() {
+    //$("body").tooltip({ selector: '[data-toggle=tooltip]' });
+    $('[data-toggle="tooltip"]').tooltip();
+  });
+
+  $(document).ready(function() {
+    $( "#org_name" ).autocomplete({
+      source: '/team/search',
+      select: function( event, ui ) {
+        $("#org_id").val(ui.item.vid);
+        $("#id").val(ui.item.vid);
+        $('#sport_btn').click();
+      }
+    });
+  });
+
+  var body = 'body';
+
+  $.ajaxSetup ({
+    // Disable caching of AJAX responses
+    cache: false
+  });
+
+  function changeSport(field){
+    var el = $(field);
+    var tmList = el.parent().next().find('.new-team-year')[0];
+    if (tmList == null){
+      tmList = el.nextAll('.new-team-year')[0];
+    }
+    $.ajax({
+      url: "/game_sport_year_ctls/"+el.val()+"/available_teams",
+      dataType: "script",
+      success: function(data, status){
+        $(tmList).empty();
+        $(tmList).append(("<option value=''>Select team</option>"));
+        $.each(JSON.parse(data), function(k, v){
+          $(tmList).append($("<option></option>")
+              .attr("value", v["id"])
+              .text(v["member_org"]["name_tabular"]));
+        });
+        $(tmList).trigger("chosen:updated");
+      }
+    });
+  }
+
+    function set_process_styles(fld, start_color, end_color){
+       $('#'+fld).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    var downImage = "/assets/down12.gif";
+    var rightImage = "/assets/right12.gif";
+
+    function highlight(div_id){
+      $(div_id).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    function show_hide_rows(attr_val, link_id){
+      $('#'+attr_val).toggle();
+      if ($('#'+attr_val).is(':visible')) {
+        $('#'+link_id).attr('src', downImage);
+      }else{
+        $('#'+link_id).attr('src', rightImage);
+      }
+    }
+
+    function mask(label){
+      $('body').mask(label);
+    }
+    function unmask(){
+      $('body').unmask();
+    }
+
+    var winHeight = "auto";
+    var winWidth = "auto";
+    var maxHeight = 700;
+    var maxWidth = 1400;
+    var minHeight = 100;
+    var minWidth = 200;
+    
+    var modalOptions = {"width": winWidth,
+                        "height": winHeight,
+                        "maxHeight": maxHeight,
+                        "maxWidth": maxWidth,
+                        "minHeight": minHeight,
+                        "minWidth": minWidth};
+
+    function dialog(url, title){
+
+      $("#stats_app_dialog").dialog({modal:true, minWidth:minWidth, minHeight:minHeight, maxWidth:maxWidth, maxHeight:maxHeight, width:winWidth, height:winHeight, title:title, closeOnEscape: false});
+    
+      modalOptions.title = title;
+    
+      $("#stats_app_dialog").dialog("option", modalOptions);
+    
+      $("#stats_app_dialog").html("Loading...");
+      $("#stats_app_dialog").load(url).dialog('open');
+    }
+
+    function addDatePicker(){
+    $('.adddatepicker').each(function(i, obj){
+      $(obj).datepicker({ 
+        showOn: 'both', 
+        buttonImage: '/assets/calendar.gif', 
+        buttonImageOnly: true,
+      });
+    });
+    }
+
+   $(document).ready(function() {
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   });
+
+   function setClassInputFields(){
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   }
+
+   function isValidDateFormat(dateStr){
+     const regex = /^([1-9]|0[1-9]|1[0-2])\/([1-9]|0[1-9]|[12][0-9]|3[01])\/(19|20)\d{2}$/;
+     if (!regex.test(dateStr)) {
+       return false;
+     }else{
+       return true;
+     }
+   }
+
+  </script>
+
+
+<body style="font-size: .75rem;" onload="if (top != self) { top.location=self.location; }" >
+
+      <header>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0">
+        <a class="navbar-brand mr-0 mr-md-2" href="/" aria-label="statistics">
+                          <img alt="NCAA" style="margin-left: 24px; margin-right: 0; margin-top: 6px;" src="/assets/ncaa-fbc4d0406ae731b47babcc3fca53775b5955ef372bf8b8e998ca9a513e468b8f.svg" />
+                          <span class="title" class="dark-blue-font">Statistics</span>
+        </a>
+       </nav>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0" style="background-color: var(--color-dark-blue) !important;">
+  <button class="navbar-toggler bg-white" type="button" data-toggle="collapse" data-target="#navbarTogglerDemo01" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarTogglerDemo01">
+        <ul class="navbar-nav mr-auto mt-2 mt-lg-0 justify-content-center">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle skipMask" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Rankings
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+          <a class="dropdown-item" href="/rankings">National Rankings</a>
+          <a class="dropdown-item" href="/active_career_leaders">Active Career Leaders</a>
+        </div>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/contests/livestream_scoreboards">Scoreboard</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/selection_rankings/nitty_gritties">Selection Rankings</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/head_coaches">Head Coaches</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/search/players">Players</a>
+      </li>
+     </ul>
+
+    <form onsubmit="mask(&#39;Loading&#39;);" id="change_team_form" style="display:inline;" class="form-inline my-2 my-lg-0" action="/team/index" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="UNisc3Y5LpH3Y4U12XyPBrE4slc32uhYrOVorAyWbBfOb3r6tjzPdfqWwlPVSJlS9zaPgFdGyXRaV58AWtvUaQ==" />
+  <div style="display:none;">
+  <input type="submit" name="commit" value="Submit" id="sport_btn" data-disable-with="Submit" />
+  </div>
+    <div id="team_autocomplete" class="ui-widget">
+      <input type="search" name="org_name" id="org_name" style="width:200px; font-size: 12px !important" class="form-control mr-sm-2" placeholder="Team Search" />
+      <input type="hidden" name="org_id" id="org_id" />
+    </div>
+</form>  </div>
+  </nav>
+</nav>
+      </header>
+
+       <div id="stats_app_dialog" style="display:none;">
+        </div>
+
+<div class="card p-1">
+  <div class="card-body application contests p-0">
+    <h3 class="card-title p-0"></h3>
+    <div class="container-fluid p-0">
+      <div class="row align-items-center justify-content-center p-0">
+        <div class="col-sm-12 p-0">
+          <br/>
+
+<br/>
+
+<style>
+.winner{
+  --display: flex;
+  vertical-align: middle;
+}
+.winner:before{
+  content: '\25BA';
+  --display: flex;
+  --align-items: center;
+  vertical-align: middle;
+}
+div.center {
+  margin: auto;
+  width: 50%;
+  --border: 3px solid green;
+  padding: 10px;
+}
+</style>
+
+   <div class="table-responsive">
+   <table align="center">
+     <tr>
+   <td>
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589036"><img class="large_logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" /></a>
+   </td>
+   <td valign="center" class="grey_text d-none d-sm-table-cell" nowrap>
+     <span style="font-size:18px">
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589036">California Golden Bears</a>
+     </span><br/>
+       2-0, Conf 0-0
+   </td>
+   <td valign="center" class="winner">
+   </td>
+   <td valign="center" style="font-size:36px; color: black">
+     21
+   </td>
+     <td style="padding: 0px 30px 0px 30px"  class="d-none d-md-table-cell">
+       <table style="border-collapse: collapse">
+         <tr>
+           <td class="grey_border_bottom"></td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">1</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">2</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">3</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">4</td>
+           <td width="20px" align="right" style="font-weight:bold" class="grey_border_bottom">S</td>
+         </tr>
+           <tr>
+             <td>California</td>
+               <td class="grey_text" align="right">7</td>
+               <td class="grey_text" align="right">7</td>
+               <td class="grey_text" align="right">0</td>
+               <td class="grey_text" align="right">7</td>
+             <td align="right" style="font-weight:bold">21</td>
+           </tr>
+           <tr>
+             <td>Auburn</td>
+               <td class="grey_text" align="right">7</td>
+               <td class="grey_text" align="right">0</td>
+               <td class="grey_text" align="right">0</td>
+               <td class="grey_text" align="right">7</td>
+             <td align="right" style="font-weight:bold">14</td>
+           </tr>
+         <tr>
+           <td class="grey_text" colspan="6">09/07/2024 03:30 PM</td>
+         </tr>
+         <tr>
+           <td nowrap class="grey_text" colspan="6">Jordan-Hare Stadium (Auburn, AL)</td>
+         </tr>
+         <tr>
+           <td nowrap class="grey_text" colspan="6">Attendance: 88,043</td>
+         </tr>
+       </table>
+     </td>
+   <td>
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589027"><img class="large_logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" /></a>
+   </td>
+   <td valign="center" class="grey_text d-none d-sm-table-cell" nowrap>
+     <span style="font-size:18px">
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589027">Auburn Tigers</a>
+     </span><br/>
+       1-1, Conf 0-0
+   </td>
+   <td valign="center" class="">
+   </td>
+   <td valign="center" style="font-size:36px; color: grey">
+     14
+   </td>
+     </tr>
+     <tr>
+       <td colspan="10" class="grey_border_bottom grey_border_top">
+         <table cellpadding="10px">
+           <tr>
+             <td style="font-size: 16px;"><a href="/contests/5362283/box_score">Box Score</a></td>
+             <td style="font-size: 16px;">Team Stats</td>
+             <td style="font-size: 16px;"><a href="/contests/5362283/individual_stats">Individual Stats</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5362283/play_by_play">Play By Play</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5362283/drives">Drives</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5362283/officials">Officials</a></td>
+           </tr>
+         </table>
+       </td>
+     </tr>
+   </table>
+ </div>
+
+
+<br/>
+
+ <div class="row justify-content-md-center">
+   <div class="col" style="max-width: 700px;">
+  <div class="container">
+      <div class="table-responsive">
+<table id="rankings_table" class="display dataTable roundedCorners">
+  <thead>
+  <tr>
+    <th>
+      <div class="small">
+        <a class="skipMask" href="javascript:toggleTeamPeriodStats();">Period Stats</a>
+     </div>
+    </th>
+    <th align="center" width="200px"><div class='row'><img class="logo_image" alt="California" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//107.gif" /><span class='d-none d-sm-block'>California</span></div></th>
+    <th align="center" width="200px"><div class='row'><img class="logo_image" alt="Auburn" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//37.gif" /><span class='d-none d-sm-block'>Auburn</span></div></th>
+  </tr>
+  </thead>
+  <tbody>
+   <tr class="grey_heading">
+     <td colspan="3" style="font-weight: bold;">Rushing</td>
+   </tr>
+        <tr >
+       <td nowrap>Rush <br/>Attempts</td>
+       <td class="text-center" align="left">34
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 53.125%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">30
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 46.875%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1st Quarter</td>
+       <td class="text-center" align="left">14
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 70.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">6
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 30.0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2nd Quarter</td>
+       <td class="text-center" align="left">14
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 46.666666666666664%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">16
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 53.333333333333336%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3rd Quarter</td>
+       <td class="text-center" align="left">8
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 27.586206896551722%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">21
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 72.41379310344827%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4th Quarter</td>
+       <td class="text-center" align="left">30
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 68.18181818181817%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">14
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 31.818181818181817%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+
+        <tr >
+       <td nowrap>Rush Yds<br/>Gained</td>
+       <td class="text-center" align="left">126
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 44.680851063829785%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">156
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 55.319148936170215%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1st Quarter</td>
+       <td class="text-center" align="left">23
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 88.46153846153845%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">3
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 11.538461538461538%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2nd Quarter</td>
+       <td class="text-center" align="left">13
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 16.883116883116884%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">64
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 83.11688311688312%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3rd Quarter</td>
+       <td class="text-center" align="left">9
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 12.857142857142856%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">61
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 87.14285714285714%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4th Quarter</td>
+       <td class="text-center" align="left">81
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 74.31192660550458%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">28
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 25.688073394495415%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+
+        <tr >
+       <td nowrap>Rush Yds<br/>Lost</td>
+       <td class="text-center" align="left">27
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 43.54838709677419%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">35
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 56.451612903225815%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1st Quarter</td>
+       <td class="text-center" align="left">4
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 100.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2nd Quarter</td>
+       <td class="text-center" align="left">15
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 88.23529411764706%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">2
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 11.76470588235294%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3rd Quarter</td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">25
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 100.0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4th Quarter</td>
+       <td class="text-center" align="left">10
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 55.55555555555556%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">8
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 44.44444444444444%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+
+        <tr >
+       <td nowrap>Yds/Rush</td>
+       <td class="text-center" align="left">2.91
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 41.930835734870314%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">4.03
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 58.06916426512968%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1st Quarter</td>
+       <td class="text-center" align="left">1.36
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 73.11827956989248%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">0.50
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 26.881720430107524%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2nd Quarter</td>
+       <td class="text-center" align="left">-0.14
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: -3.7433155080213907%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">3.88
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 103.74331550802138%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3rd Quarter</td>
+       <td class="text-center" align="left">1.13
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 39.78873239436619%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">1.71
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 60.2112676056338%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4th Quarter</td>
+       <td class="text-center" align="left">2.37
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 62.36842105263158%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">1.43
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 37.631578947368425%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+
+        <tr >
+       <td nowrap>Rush<br/>TDs</td>
+       <td class="text-center" align="left">1
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 50.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">1
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 50.0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1st Quarter</td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2nd Quarter</td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3rd Quarter</td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4th Quarter</td>
+       <td class="text-center" align="left">1
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 50.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">1
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 50.0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+
+        <tr >
+       <td nowrap>Rush Long</td>
+       <td class="text-center" align="left">32
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 54.23728813559322%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">27
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 45.76271186440678%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1st Quarter</td>
+       <td class="text-center" align="left">10
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 83.33333333333334%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">2
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 16.666666666666664%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2nd Quarter</td>
+       <td class="text-center" align="left">6
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 18.181818181818183%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">27
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 81.81818181818183%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3rd Quarter</td>
+       <td class="text-center" align="left">4
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 18.181818181818183%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">18
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 81.81818181818183%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4th Quarter</td>
+       <td class="text-center" align="left">32
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 78.04878048780488%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">9
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 21.951219512195124%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+
+   <tr class="grey_heading">
+     <td colspan="3" style="font-weight: bold;">Receiving</td>
+   </tr>
+        <tr >
+       <td nowrap>Rec</td>
+       <td class="text-center" align="left">25
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 64.1025641025641%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">14
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 35.8974358974359%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1st Quarter</td>
+       <td class="text-center" align="left">8
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 57.14285714285714%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">6
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 42.857142857142854%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2nd Quarter</td>
+       <td class="text-center" align="left">11
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 91.66666666666666%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">1
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 8.333333333333332%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3rd Quarter</td>
+       <td class="text-center" align="left">4
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 80.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">1
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 20.0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4th Quarter</td>
+       <td class="text-center" align="left">2
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 25.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">6
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 75.0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+
+        <tr >
+       <td nowrap>Receiving<br/>Yards</td>
+       <td class="text-center" align="left">233
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 58.5427135678392%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">165
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 41.45728643216081%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1st Quarter</td>
+       <td class="text-center" align="left">95
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 47.2636815920398%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">106
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 52.736318407960205%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2nd Quarter</td>
+       <td class="text-center" align="left">110
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 94.01709401709401%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">7
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 5.982905982905983%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3rd Quarter</td>
+       <td class="text-center" align="left">18
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 69.23076923076923%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">8
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 30.76923076923077%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4th Quarter</td>
+       <td class="text-center" align="left">10
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 18.51851851851852%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">44
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 81.48148148148148%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+
+        <tr >
+       <td nowrap>Yards Per<br/>Reception</td>
+       <td class="text-center" align="left">9.32
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 44.14969208905732%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">11.79
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 55.850307910942675%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1st Quarter</td>
+       <td class="text-center" align="left">11.88
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 40.203045685279186%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">17.67
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 59.79695431472081%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2nd Quarter</td>
+       <td class="text-center" align="left">10.00
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 58.82352941176471%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">7.00
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 41.17647058823529%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3rd Quarter</td>
+       <td class="text-center" align="left">4.50
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 36.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">8.00
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 64.0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4th Quarter</td>
+       <td class="text-center" align="left">5.00
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 40.55150040551501%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">7.33
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 59.44849959448499%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+
+        <tr >
+       <td nowrap>Rec TD</td>
+       <td class="text-center" align="left">2
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 66.66666666666666%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">1
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 33.33333333333333%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1st Quarter</td>
+       <td class="text-center" align="left">1
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 50.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">1
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 50.0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2nd Quarter</td>
+       <td class="text-center" align="left">1
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 100.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3rd Quarter</td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4th Quarter</td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+
+        <tr >
+       <td nowrap>Long Rec</td>
+       <td class="text-center" align="left">25
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 37.878787878787875%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">41
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 62.121212121212125%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1st Quarter</td>
+       <td class="text-center" align="left">25
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 37.878787878787875%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">41
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 62.121212121212125%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2nd Quarter</td>
+       <td class="text-center" align="left">18
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 72.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">7
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 28.000000000000004%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3rd Quarter</td>
+       <td class="text-center" align="left">9
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 52.94117647058824%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">8
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 47.05882352941176%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4th Quarter</td>
+       <td class="text-center" align="left">7
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 35.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">13
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 65.0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+
+   <tr class="grey_heading">
+     <td colspan="3" style="font-weight: bold;">Passing</td>
+   </tr>
+        <tr >
+       <td nowrap>Pass <br/>Attempts</td>
+       <td class="text-center" align="left">36
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 57.14285714285714%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">27
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 42.857142857142854%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1st Quarter</td>
+       <td class="text-center" align="left">9
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 45.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">11
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 55.00000000000001%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2nd Quarter</td>
+       <td class="text-center" align="left">12
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 75.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">4
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 25.0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3rd Quarter</td>
+       <td class="text-center" align="left">10
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 83.33333333333334%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">2
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 16.666666666666664%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4th Quarter</td>
+       <td class="text-center" align="left">5
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 33.33333333333333%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">10
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 66.66666666666666%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+
+        <tr >
+       <td nowrap>Completions</td>
+       <td class="text-center" align="left">25
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 64.1025641025641%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">14
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 35.8974358974359%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1st Quarter</td>
+       <td class="text-center" align="left">8
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 57.14285714285714%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">6
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 42.857142857142854%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2nd Quarter</td>
+       <td class="text-center" align="left">11
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 91.66666666666666%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">1
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 8.333333333333332%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3rd Quarter</td>
+       <td class="text-center" align="left">4
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 80.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">1
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 20.0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4th Quarter</td>
+       <td class="text-center" align="left">2
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 25.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">6
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 75.0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+
+        <tr >
+       <td nowrap>Pass <br/>Yards</td>
+       <td class="text-center" align="left">233
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 58.5427135678392%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">165
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 41.45728643216081%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1st Quarter</td>
+       <td class="text-center" align="left">95
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 47.2636815920398%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">106
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 52.736318407960205%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2nd Quarter</td>
+       <td class="text-center" align="left">110
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 94.01709401709401%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">7
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 5.982905982905983%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3rd Quarter</td>
+       <td class="text-center" align="left">18
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 69.23076923076923%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">8
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 30.76923076923077%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4th Quarter</td>
+       <td class="text-center" align="left">10
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 18.51851851851852%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">44
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 81.48148148148148%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+
+        <tr >
+       <td nowrap>Interceptions</td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">4
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 100.0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1st Quarter</td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2nd Quarter</td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">1
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 100.0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3rd Quarter</td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">1
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 100.0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4th Quarter</td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">2
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 100.0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+
+        <tr >
+       <td nowrap>Pass<br/>TDs</td>
+       <td class="text-center" align="left">2
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 66.66666666666666%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">1
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 33.33333333333333%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1st Quarter</td>
+       <td class="text-center" align="left">1
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 50.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">1
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 50.0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2nd Quarter</td>
+       <td class="text-center" align="left">1
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 100.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3rd Quarter</td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4th Quarter</td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+
+        <tr >
+       <td nowrap>Pass <br/>Eff</td>
+       <td class="text-center" align="left">142.14
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 62.36398736398736%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">85.78
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 37.63601263601264%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1st Quarter</td>
+       <td class="text-center" align="left">214.22
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 56.416739090358426%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">165.49
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 43.58326090964157%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2nd Quarter</td>
+       <td class="text-center" align="left">196.17
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 105.5415075052456%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">-10.30
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: -5.541507505245603%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3rd Quarter</td>
+       <td class="text-center" align="left">55.12
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 142.35537190082644%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">-16.40
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: -42.35537190082644%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4th Quarter</td>
+       <td class="text-center" align="left">56.80
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 49.929676511954995%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">56.96
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 50.07032348804501%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+
+        <tr >
+       <td nowrap>Yds Per<br/>Completion</td>
+       <td class="text-center" align="left">9.320
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 44.15805931962475%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">11.786
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 55.841940680375245%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1st Quarter</td>
+       <td class="text-center" align="left">11.875
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 40.197007650125244%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">17.667
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 59.80299234987476%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2nd Quarter</td>
+       <td class="text-center" align="left">10.000
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 58.82352941176471%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">7.000
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 41.17647058823529%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3rd Quarter</td>
+       <td class="text-center" align="left">4.500
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 36.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">8.000
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 64.0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4th Quarter</td>
+       <td class="text-center" align="left">5.000
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 40.541636260439475%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">7.333
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 59.458363739560525%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+
+        <tr >
+       <td nowrap>Pct</td>
+       <td class="text-center" align="left">0.694
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 57.213520197856546%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">0.519
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 42.78647980214345%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1st Quarter</td>
+       <td class="text-center" align="left">0.889
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 61.994421199442115%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">0.545
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 38.00557880055788%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2nd Quarter</td>
+       <td class="text-center" align="left">0.917
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 78.57754927163667%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">0.250
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 21.422450728363323%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3rd Quarter</td>
+       <td class="text-center" align="left">0.400
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 44.44444444444445%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">0.500
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 55.55555555555556%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4th Quarter</td>
+       <td class="text-center" align="left">0.400
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 40.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">0.600
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 60.0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+
+        <tr >
+       <td nowrap>Long Pass</td>
+       <td class="text-center" align="left">25
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 37.878787878787875%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">41
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 62.121212121212125%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1st Quarter</td>
+       <td class="text-center" align="left">25
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 37.878787878787875%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">41
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 62.121212121212125%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2nd Quarter</td>
+       <td class="text-center" align="left">18
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 72.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">7
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 28.000000000000004%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3rd Quarter</td>
+       <td class="text-center" align="left">9
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 52.94117647058824%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">8
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 47.05882352941176%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4th Quarter</td>
+       <td class="text-center" align="left">7
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 35.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">13
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 65.0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+
+   <tr class="grey_heading">
+     <td colspan="3" style="font-weight: bold;">First Downs</td>
+   </tr>
+        <tr >
+       <td nowrap>FD</td>
+       <td class="text-center" align="left">18
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 52.94117647058824%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">16
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 47.05882352941176%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1st Quarter</td>
+       <td class="text-center" align="left">6
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 60.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">4
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 40.0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2nd Quarter</td>
+       <td class="text-center" align="left">6
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 75.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">2
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 25.0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3rd Quarter</td>
+       <td class="text-center" align="left">2
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 33.33333333333333%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">4
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 66.66666666666666%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4th Quarter</td>
+       <td class="text-center" align="left">4
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 40.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">6
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 60.0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+
+        <tr >
+       <td nowrap>Rushing <br>First Downs</td>
+       <td class="text-center" align="left">7
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 58.333333333333336%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">5
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 41.66666666666667%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1st Quarter</td>
+       <td class="text-center" align="left">2
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 100.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2nd Quarter</td>
+       <td class="text-center" align="left">1
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 33.33333333333333%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">2
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 66.66666666666666%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3rd Quarter</td>
+       <td class="text-center" align="left">1
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 25.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">3
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 75.0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4th Quarter</td>
+       <td class="text-center" align="left">3
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 100.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+
+        <tr >
+       <td nowrap>Passing <br>First Downs</td>
+       <td class="text-center" align="left">10
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 58.82352941176471%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">7
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 41.17647058823529%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1st Quarter</td>
+       <td class="text-center" align="left">4
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 50.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">4
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 50.0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2nd Quarter</td>
+       <td class="text-center" align="left">5
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 100.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3rd Quarter</td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4th Quarter</td>
+       <td class="text-center" align="left">1
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 25.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">3
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 75.0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+
+        <tr >
+       <td nowrap>First Downs <br>by Penalty</td>
+       <td class="text-center" align="left">1
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 20.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">4
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="200px" style="max-width: 200px">
+                    <div class="stat_bar" style="width: 80.0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1st Quarter</td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2nd Quarter</td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3rd Quarter</td>
+       <td class="text-center" align="left">1
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 50.0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">1
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 50.0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+            <tr class='period_stat'>
+       <td nowrap>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4th Quarter</td>
+       <td class="text-center" align="left">0
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 0%; background-color: grey;"></div>
+                  </div>
+       </td>
+       <td class="text-center" align="left">3
+                           <div class="mx-auto stat_bar_container d-none d-sm-block" width="100px" style="max-width: 100px">
+                    <div class="stat_bar" style="width: 100.0%; background-color: blue;"></div>
+                  </div>
+       </td>
+     </tr>
+
+
+  </tbody>
+  <tfoot>
+  <tr>
+    <td colspan="5"></td>
+  </tr>
+  </tfoot>
+</table>
+</div>
+<script>
+//$('#rankings_table').css("width", "800px");
+$('.period_stat').hide();
+function toggleTeamPeriodStats(){
+  $('.period_stat').toggle();
+}
+</script>
+  </div>
+  </div>
+</div>
+</div>
+
+
+
+       </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<footer>&copy; <script>document.write(new Date().getFullYear())</script> NCAA <a href="http://web1.ncaa.org/web_files/terms_and_conditions.html" title ="Terms and Conditions" target=_blank>Terms and Conditions</a> | <a href="http://web1.ncaa.org/web_files/privacy.html" target=_blank title="Our Privacy Policy">Privacy Policy</a> | <a href="mailto:ncaa_stats@ncaa.org">Contact Us</a> </footer>
+
+  <!-- /.container -->
+  <script type="text/javascript"  src="/sU0joiPwv/zplvN/xFxji/wmgXJnBU/whimQww3k9OS/ZXgTG2MrBg/I0sONT4/dCDpZ?v=d52419d4-1a82-8387-d9f9-9442aa021738" defer></script></body>
+
+  <script charset="utf-8">
+    $(document).ready(function() {
+      $('a.remote[data-toggle="tab"]').on('show.bs.tab', function (e) {
+        var tab_id = '#' + $(this).attr('aria-controls');
+        $(tab_id).html('<br/><br/><p style="text-align: center"><img style="vertical-align:middle; text-align: center" src="/assets/ajax-loader-6913acdbf4be7d6a2908a84bdecd6cad18110f5fc6d5a07cf8c9ce78d9548700.gif" /> Loading... </p><br/><br/>');
+        $.get($(this).data('remote'), function(data){
+          $(tab_id).html(data);
+        });
+      });
+    });
+
+    function skipMask(obj){
+      if (obj.hasClass('chosen-single') || obj.hasClass('skipMask') || obj.hasClass('ui-datepicker-prev') || obj.hasClass('ui-datepicker-next') || obj.hasClass('ui-corner-all') || obj.hasClass('paginate_button') || obj.hasClass('dt-button')){
+        return true;
+      }else{
+        return false;
+      }
+    }
+
+    $(document).ajaxComplete(function(){
+      unmask();
+    });
+/*
+    $("form").on('submit', function(event){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    */
+    $(document).on('click', 'a', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    $(document).on('click', 'input.green', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+
+  </script>
+</html>


### PR DESCRIPTION
## What

Adds `sportsdataverse/cfb/cfb_ncaa_box.py` — parsers for the **non-pbp** stats.ncaa.org
college-football (`MFB`) game-detail tabs, closing the box-score/drives/officials gap
(pbp was already covered by `cfb_ncaa_pbp`). One parser per tab, all returning tidy
polars frames (pandas via `return_as_pandas=True`), empty input → documented zero-row
frame (or `{}`):

| function | tab | output |
|---|---|---|
| `parse_cfb_ncaa_drives` | `/drives` | one row per drive — `drive_number`, `quarter`, `team`, start/end `period`/`how`(KO/PUNT/DOWNS/TD/FGA/…)/`clock`/`yard_line` |
| `parse_cfb_ncaa_team_stats` | `/team_stats` | **team box with per-quarter breakdown** — one row per `category`/`stat`/`period` (`total` + `1st..4th Quarter`), `away`/`home` team + value |
| `parse_cfb_ncaa_player_stats` | `/individual_stats` | `dict` of one frame per category (`rushing`/`passing`/`receiving`/…), player rows + team total, `team_id` keyed |
| `parse_cfb_ncaa_officials` | `/officials` | one row per official (`role`/`official`); excludes the tab-nav row |
| `parse_cfb_ncaa_linescore` | `/box_score` | one row per team/period — `points`, `final`, + `game_date`/`venue`/`attendance` |

## Validation (real capture — contest 5362283, California @ Auburn, 2024-09-07)

- **Drives**: 26 drives, clean 1..N sequence, `end_how` ∈ {TD, PUNT, DOWNS, FGA, FUMB, INT, HALF}
- **Team stats**: per-quarter breakdown present for every stat (total + 4 quarters); Rushing/Passing/Receiving/First-Downs categories; away=California / home=Auburn
- **Player stats**: rushing/passing/receiving frames; Mendoza 25/36, 233, 2 TD extracted correctly
- **Officials**: extracts "Riley Johnson" (not a nav tab)
- **Linescore**: Cal 21 (away) / Auburn 14 (home), quarters sum to final, attendance 88,043
- Fully typed (mypy ratchet), ruff clean, 12 offline tests. 5 real fixtures vendored.

## Notes

- **"By period"**: team stats carry a genuine per-quarter breakdown; individual player
  stats are full-game only (stats.ncaa.org football doesn't publish per-quarter player
  lines). NCAA's per-quarter team values are recorded as-is and don't necessarily sum
  to the total — extracted faithfully, not "corrected".
- Producer capture (`ncaa-mfb-football-raw`) already fetches these pages; a future change
  can bundle all tabs. This PR is the library parser layer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NCAA college football box-score parsers for drives, officials, team statistics, player statistics, and linescores.
  * Supports structured Polars or pandas output, contest metadata, quarter-by-quarter details, and empty-result handling.
  * Exposed the new parsing helpers through the college football package and legacy parsing interface.

* **Tests**
  * Added comprehensive offline coverage and representative NCAA game fixtures for all new parsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->