### PR TITLE
fix(cfb): walk back to the newest available teams crosswalk for future-season projections

### DIFF
--- a/sportsdataverse/cfb/cfb_recruiting_projection.py
+++ b/sportsdataverse/cfb/cfb_recruiting_projection.py
@@ -40,17 +40,29 @@ _PROJECTION_SCHEMA: dict[str, pl.PolarsDataType] = {
 
 
 def _crosswalk_names_to_espn(seasons: list[int]) -> pl.DataFrame:
-    """``norm_key`` (school+mascot, normalized) -> ESPN team id (Utf8)."""
-    xw = load_cfb_teams_crosswalk(max(seasons))
-    assert isinstance(xw, pl.DataFrame)
-    return (
-        xw.select(
-            pl.col("norm_key").cast(pl.Utf8),
-            pl.col("espn_team_id").cast(pl.Int64).cast(pl.Utf8).alias("espn_id"),
-        )
-        .drop_nulls()
-        .unique(subset=["norm_key"])
-    )
+    """``norm_key`` (school+mascot, normalized) -> ESPN team id (Utf8).
+
+    The crosswalk asset trails the calendar (capped at 2025 while a 2026
+    projection is already meaningful after early signing), and a missing
+    season comes back from the loader as a column-less empty frame -- so walk
+    back season by season to the newest crosswalk that exists (team name ->
+    ESPN id identity barely changes year to year) instead of crashing on the
+    select. All-missing degrades to a typed empty per the empty-in/empty-out
+    convention.
+    """
+    for season in range(max(seasons), 2013, -1):  # crosswalk asset floor is 2014
+        xw = load_cfb_teams_crosswalk(season)
+        assert isinstance(xw, pl.DataFrame)
+        if xw.height > 0 and "norm_key" in xw.columns:
+            return (
+                xw.select(
+                    pl.col("norm_key").cast(pl.Utf8),
+                    pl.col("espn_team_id").cast(pl.Int64).cast(pl.Utf8).alias("espn_id"),
+                )
+                .drop_nulls()
+                .unique(subset=["norm_key"])
+            )
+    return pl.DataFrame(schema={"norm_key": pl.Utf8, "espn_id": pl.Utf8})
 
 
 def _load_talent(seasons: list[int], division: str) -> pl.DataFrame:

--- a/tests/cfb/test_cfb_recruiting_projection.py
+++ b/tests/cfb/test_cfb_recruiting_projection.py
@@ -114,3 +114,31 @@ def test_projection_empty_history_returns_schema(monkeypatch) -> None:
     assert out.height == 0
     for col in ("season", "team_id", "pred_wins", "pred_margin"):
         assert col in out.columns
+
+
+def test_crosswalk_falls_back_to_newest_available_season(monkeypatch):
+    """The crosswalk asset trails the calendar (capped at 2025 while a 2026
+    projection is meaningful after early signing); a missing season comes back
+    COLUMN-LESS from the loader and used to crash the select. Walk back to the
+    newest crosswalk that exists instead."""
+    calls: list[int] = []
+
+    def fake_xw(season):
+        calls.append(season)
+        if season >= 2026:
+            return pl.DataFrame()  # the loader's missing-season shape
+        return pl.DataFrame({"norm_key": ["georgia bulldogs"], "espn_team_id": [61]})
+
+    monkeypatch.setattr(_mod, "load_cfb_teams_crosswalk", fake_xw)
+
+    xw = _mod._crosswalk_names_to_espn([2026])
+    assert calls == [2026, 2025]
+    assert xw["espn_id"].to_list() == ["61"]
+
+
+def test_crosswalk_all_seasons_missing_returns_typed_empty(monkeypatch):
+    monkeypatch.setattr(_mod, "load_cfb_teams_crosswalk", lambda season: pl.DataFrame())
+
+    xw = _mod._crosswalk_names_to_espn([2026])
+    assert xw.height == 0
+    assert xw.columns == ["norm_key", "espn_id"]


### PR DESCRIPTION
## What

The teams-crosswalk asset trails the calendar (capped at 2025 while a 2026 recruiting projection is already meaningful after early signing), and a missing season comes back from the loader as a **column-less** empty frame that `_crosswalk_names_to_espn`'s select crashed on — the `cfb_recruiting_proj` 2016:2026 backfill died on season 2026 over it (2016:2025 published fine).

## Change

Walk back season by season to the newest crosswalk that exists (team-name → ESPN-id identity barely changes year to year); all-missing degrades to a typed empty per the empty-in/empty-out convention (same family as #280).

## Tests

Two new tests (fallback resolves via 2025 with the exact call sequence pinned; all-missing → typed empty); recruiting projection suite 5/5.

Unblocks publishing the 2026 season into the live `cfb_recruiting_proj` tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved college football recruiting projections by automatically using the newest available historical school crosswalk when the requested season is unavailable.
  - Added graceful handling for cases where no crosswalk data exists, preventing lookup errors and returning an empty result with the expected structure.

- **Tests**
  - Added coverage for historical-season fallback and fully missing crosswalk scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->