### PR TITLE
refactor(nba)!: NBA season convention → end year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,17 @@
 
 ## Unreleased
 
+### BREAKING CHANGES
+
+- **NBA season convention is now END-year across the Python API.**
+  `compile_nba_season(2024)` and `nba_availability` now use the season ENDING
+  year (2024 = 2023-24), matching `most_recent_nba_season()` and every
+  ESPN-sourced `load_nba_*` dataset. Previously the stats.nba.com compile path
+  used the start year — external callers passing a start year must add 1.
+  Unchanged: `year_to_season` (still a low-level start-year helper — call it as
+  `year_to_season(end_year - 1)`), and `nba_box_logs` (takes the `"2023-24"`
+  string, not an integer).
+
 ### CFB — loaders for 6 published-but-unreachable dataset releases
 
 `cfbfastR-cfb-data` publishes 18 dataset tags to `sportsdataverse-data`; sdv-py

--- a/docs/docs/nba/reference/additional.md
+++ b/docs/docs/nba/reference/additional.md
@@ -491,9 +491,12 @@ sched = load_nba_schedule(seasons=[most_recent_nba_season()])
 
 ### `year_to_season(year)` {#year_to_season}
 
-Convert a season-end year (e.g. 2024) to the NBA's hyphenated label
+Convert a season START year (e.g. 2023) to the NBA's hyphenated label
 
 (e.g. `"2023-24"`).
+
+Callers working in the end-year convention pass `end_year - 1` (e.g.
+`year_to_season(most_recent_nba_season() - 1)`).
 
 Handles century rollover (1999 -> `"1999-00"`) and zero-pads the
 second half of the label.
@@ -1331,13 +1334,13 @@ frame is tagged with a `season` column.
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `season` | `int` |  | Season start year (e.g. 2023 for 2023-24). |
+| `season` | `int` |  | Season END year (e.g. 2024 for 2023-24). |
 | `season_type` | `str` | `'Regular Season'` | `"Regular Season"` (default) or `"Playoffs"`. |
 | `resume` | `bool` | `True` | Reuse per-game cached parquet when present. |
 | `cache_dir` | `Optional[str]` | `None` | Cache root; defaults to `SDV_PY_NBA_CACHE_DIR` or `~/.sdv_py_nba_cache/possessions`. |
 | `delay_s` | `float` | `0.6` | Seconds to sleep after each live fetch (rate-limit throttle). |
 | `lineup_source` | `str` | `'auto'` | Which on-court lineup producer to use — `"auto"` (default; tries rotation then falls back to pbp), `"rotation"` (gamerotation endpoint only), or `"pbp"` (pbp-derived, no gamerotation fetch — useful when the gamerotation endpoint is throttled or unavailable). |
-| `proxy_provider` | `Optional[Callable[[], Optional[str]]]` | `None` | Optional zero-arg callable returning a proxy URL (or `None`). **Called once for game discovery, then once per game** (`N + 1` calls for an `N`-game season), so a rotating pool spreads a season's fetches across many exit IPs rather than hammering `stats.nba.com` from one address. `stats.nba.com` rejects or hangs on datacenter/cloud IPs, so an unattended host (CI, a droplet) MUST supply one — a proxied request is judged on the proxy's exit IP, which is what makes such a host viable at all. Note discovery is proxied too: an unproxied index call returns no rows there, compiling the season to zero games without an error. Any `() -> str \| None` works; a round-robin pool's `.next` matches the signature directly:: compile_nba_season(2023, proxy_provider=round_robin.next) |
+| `proxy_provider` | `Optional[Callable[[], Optional[str]]]` | `None` | Optional zero-arg callable returning a proxy URL (or `None`). **Called once for game discovery, then once per game** (`N + 1` calls for an `N`-game season), so a rotating pool spreads a season's fetches across many exit IPs rather than hammering `stats.nba.com` from one address. `stats.nba.com` rejects or hangs on datacenter/cloud IPs, so an unattended host (CI, a droplet) MUST supply one — a proxied request is judged on the proxy's exit IP, which is what makes such a host viable at all. Note discovery is proxied too: an unproxied index call returns no rows there, compiling the season to zero games without an error. Any `() -> str \| None` works; a round-robin pool's `.next` matches the signature directly:: compile_nba_season(2024, proxy_provider=round_robin.next) |
 | `return_as_pandas` | `bool` | `False` | Return pandas instead of polars. |
 
 **Returns**
@@ -1349,19 +1352,19 @@ The season possession frame (+ `season` and `game_date` cols). Empty typed frame
 ```python
 from sportsdataverse.nba.nba_season_compile import compile_nba_season
 
-poss = compile_nba_season(2023)
+poss = compile_nba_season(2024)
 print(poss.shape)          # (n_possessions, n_cols)
-print(poss["season"][0])   # 2023
+print(poss["season"][0])   # 2024
 
 # Resume a partially completed run and return as pandas
 
-poss_pd = compile_nba_season(2023, resume=True, return_as_pandas=True)
+poss_pd = compile_nba_season(2024, resume=True, return_as_pandas=True)
 print(type(poss_pd))       # <class 'pandas.core.frame.DataFrame'>
 
 # Compile Playoffs with a custom cache directory
 
 poss = compile_nba_season(
-    2023,
+    2024,
     season_type="Playoffs",
     cache_dir="/tmp/nba_cache",
 )

--- a/docs/docs/nba/reference/additional.md
+++ b/docs/docs/nba/reference/additional.md
@@ -2140,7 +2140,7 @@ reports it as a separate column too).
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `seasons` | `int \| list[int]` |  | A season (start year, e.g. `2019`) or list of seasons. |
+| `seasons` | `int \| list[int]` |  | A season (end year, e.g. `2020`) or list of seasons. |
 | `league` | `str` | `'nba'` | `"nba"`, `"wnba"`, or `"gleague"`. |
 | `gleague_bridge` | `bool` | `False` | When `True` (and `league != "gleague"`), also pulls each season's G-League (`league_id="20"`) bulk GP as a development-outcome bridge feature before scoring. Best-effort: gracefully absent (never raises) when the G-League bulk call returns no rows for a season; the returned schema is unaffected either way since the bridge column isn't part of the bundled artifact's scored features. |
 | `return_as_pandas` | `bool` | `False` | Return a pandas DataFrame instead of polars. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sportsdataverse"
-version = "0.0.71"
+version = "0.0.72"
 description = "Retrieve Sports data in Python"
 readme = "README.md"
 license = "MIT"

--- a/sportsdataverse/nba/nba_availability.py
+++ b/sportsdataverse/nba/nba_availability.py
@@ -160,7 +160,7 @@ def nba_availability(
     reports it as a separate column too).
 
     Args:
-        seasons: A season (start year, e.g. ``2019``) or list of seasons.
+        seasons: A season (end year, e.g. ``2020``) or list of seasons.
         league: ``"nba"``, ``"wnba"``, or ``"gleague"``.
         gleague_bridge: When ``True`` (and ``league != "gleague"``), also
             pulls each season's G-League (``league_id="20"``) bulk GP as a
@@ -193,14 +193,19 @@ def nba_availability(
     earliest = min(season_list) - _LOOKBACK_SEASONS
     latest = max(season_list)
     frames = []
-    for start_year in range(earliest, latest + 1):
-        season_str = f"{start_year}-{str(start_year + 1)[-2:]}"
+    for end_year in range(earliest, latest + 1):
+        # Public `seasons` is now the END year; derive the START year to
+        # build the stats.nba.com "YYYY-YY" season string.
+        start_year = end_year - 1
+        season_str = f"{start_year}-{str(end_year)[-2:]}"
         if league == "wnba":
-            # WNBA plays a single-year season label (no cross-year split);
-            # wnba_stats mirrors the nba_stats parameter shape on its own host.
+            # WNBA plays a single-year season label (no cross-year split, so
+            # there's no start/end distinction to derive) -- unaffected by
+            # the NBA end-year migration; wnba_stats mirrors the nba_stats
+            # parameter shape on its own host.
             from sportsdataverse.wnba.wnba_stats import wnba_stats_leaguedashplayerstats  # noqa: PLC0415
 
-            bulk = wnba_stats_leaguedashplayerstats(season=str(start_year))
+            bulk = wnba_stats_leaguedashplayerstats(season=str(end_year))
         elif league == "gleague":
             bulk = nba_stats_leaguedashplayerstats(season=season_str, league_id="20")
         else:
@@ -216,7 +221,7 @@ def nba_availability(
         frames.append(
             bulk.select(
                 pl.col("player_id").cast(pl.Int64).cast(pl.Utf8),
-                pl.lit(start_year).cast(pl.Int64).alias("season"),
+                pl.lit(end_year).cast(pl.Int64).alias("season"),
                 pl.col("age").cast(pl.Float64),
                 pl.col("gp").cast(pl.Int64),
             ).unique(subset=["player_id"], keep="first")
@@ -228,8 +233,9 @@ def nba_availability(
 
     if gleague_bridge and league != "gleague":
         bridge_frames = []
-        for start_year in range(earliest, latest + 1):
-            season_str = f"{start_year}-{str(start_year + 1)[-2:]}"
+        for end_year in range(earliest, latest + 1):
+            start_year = end_year - 1
+            season_str = f"{start_year}-{str(end_year)[-2:]}"
             try:
                 gbulk = nba_stats_leaguedashplayerstats(season=season_str, league_id="20")
             except Exception:  # pragma: no cover - defensive, matches "never raises"
@@ -239,7 +245,7 @@ def nba_availability(
             bridge_frames.append(
                 gbulk.select(
                     pl.col("player_id").cast(pl.Int64).cast(pl.Utf8),
-                    pl.lit(start_year).cast(pl.Int64).alias("season"),
+                    pl.lit(end_year).cast(pl.Int64).alias("season"),
                     pl.col("gp").cast(pl.Int64).alias("gleague_gp"),
                 )
             )

--- a/sportsdataverse/nba/nba_loaders.py
+++ b/sportsdataverse/nba/nba_loaders.py
@@ -926,7 +926,12 @@ def load_nba_stats_schedules(seasons, return_as_pandas: bool = False):
     Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_schedules
 
     Args:
-        seasons: an int or iterable of seasons (>= 2025).
+        seasons: an int or iterable of seasons (>= 2025), the season START
+            year in span form (e.g. 2025 -> the ``schedule_2025-26``
+            asset / "2025-26" season). This asset is produced by the R
+            pipeline and its season numbering is unaffected by the
+            end-year convention migration applied elsewhere in the Python
+            NBA API (see :func:`compile_nba_season`, :func:`nba_availability`).
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
@@ -1018,12 +1023,15 @@ def load_nba_player_impact(seasons, return_as_pandas: bool = False):
     Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_player_impact
 
     Args:
-        seasons: an int or iterable of seasons (>= 1996).
+        seasons: an int or iterable of seasons (>= 1996), the season ENDING
+            year (e.g. 2024 = the 2023-24 season), matching the `season`
+            column in the returned frame.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
         A polars (or pandas) DataFrame; seasons with no published asset are
-        skipped with a warning rather than raising (404-safe).
+        skipped with a warning rather than raising (404-safe). The `season`
+        column is the season ENDING year (2024 = 2023-24).
 
         |col_name               |type    |
         |:----------------------|:-------|

--- a/sportsdataverse/nba/nba_loaders.py
+++ b/sportsdataverse/nba/nba_loaders.py
@@ -926,12 +926,7 @@ def load_nba_stats_schedules(seasons, return_as_pandas: bool = False):
     Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_schedules
 
     Args:
-        seasons: an int or iterable of seasons (>= 2025), the season START
-            year in span form (e.g. 2025 -> the ``schedule_2025-26``
-            asset / "2025-26" season). This asset is produced by the R
-            pipeline and its season numbering is unaffected by the
-            end-year convention migration applied elsewhere in the Python
-            NBA API (see :func:`compile_nba_season`, :func:`nba_availability`).
+        seasons: an int or iterable of seasons (>= 2025).
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
@@ -1023,15 +1018,12 @@ def load_nba_player_impact(seasons, return_as_pandas: bool = False):
     Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_player_impact
 
     Args:
-        seasons: an int or iterable of seasons (>= 1996), the season ENDING
-            year (e.g. 2024 = the 2023-24 season), matching the `season`
-            column in the returned frame.
+        seasons: an int or iterable of seasons (>= 1996).
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
         A polars (or pandas) DataFrame; seasons with no published asset are
-        skipped with a warning rather than raising (404-safe). The `season`
-        column is the season ENDING year (2024 = 2023-24).
+        skipped with a warning rather than raising (404-safe).
 
         |col_name               |type    |
         |:----------------------|:-------|

--- a/sportsdataverse/nba/nba_rookie_projection.py
+++ b/sportsdataverse/nba/nba_rookie_projection.py
@@ -157,9 +157,7 @@ def nba_rookie_projection(
         # avail.season is the debut END year; map it back to draft_year
         # (start year) = season - 1 so the join below lines up with
         # draft_board's start-year draft_year convention.
-        avail_map = (
-            avail.with_columns((pl.col("season") - 1).alias("draft_year")) if not avail.is_empty() else None
-        )
+        avail_map = avail.with_columns((pl.col("season") - 1).alias("draft_year")) if not avail.is_empty() else None
 
     out = draft_board.with_columns(
         (pl.col("proj_career_value") * rookie_fraction * (rel_rookie / rel_peak)).alias("_base_rookie"),

--- a/sportsdataverse/nba/nba_rookie_projection.py
+++ b/sportsdataverse/nba/nba_rookie_projection.py
@@ -140,11 +140,26 @@ def nba_rookie_projection(
     rel_soph = _rel(curve, _ROOKIE_AGE + 1)
     rel_peak = 1.0
 
-    seasons = [int(y) for y in draft_board["draft_year"].unique().to_list()]
-    avail = nba_availability(seasons, league=league)
-    # avail is keyed by (player_id, season); rookie-season availability uses
-    # the player's draft_year as the season key (their debut season).
-    avail_map = avail.rename({"season": "draft_year"}) if not avail.is_empty() else None
+    draft_years = [int(y) for y in draft_board["draft_year"].unique().to_list()]
+    if league == "wnba":
+        # WNBA seasons are single-year and were NOT flipped by the NBA
+        # season-end-year migration -- nba_availability(league="wnba") still
+        # takes/returns the season as-is, so draft_year is the season key
+        # directly (unshifted), same as before.
+        avail = nba_availability(draft_years, league=league)
+        avail_map = avail.rename({"season": "draft_year"}) if not avail.is_empty() else None
+    else:
+        # nba_availability now takes/returns the season END year (nba +
+        # gleague); a draft_year (start year, e.g. 2019) debuts the
+        # following season, whose end year is draft_year + 1 (2020).
+        debut_end_years = [y + 1 for y in draft_years]
+        avail = nba_availability(debut_end_years, league=league)
+        # avail.season is the debut END year; map it back to draft_year
+        # (start year) = season - 1 so the join below lines up with
+        # draft_board's start-year draft_year convention.
+        avail_map = (
+            avail.with_columns((pl.col("season") - 1).alias("draft_year")) if not avail.is_empty() else None
+        )
 
     out = draft_board.with_columns(
         (pl.col("proj_career_value") * rookie_fraction * (rel_rookie / rel_peak)).alias("_base_rookie"),

--- a/sportsdataverse/nba/nba_schedule.py
+++ b/sportsdataverse/nba/nba_schedule.py
@@ -269,8 +269,11 @@ def most_recent_nba_season():
 
 
 def year_to_season(year):
-    """Convert a season-end year (e.g. 2024) to the NBA's hyphenated label
+    """Convert a season START year (e.g. 2023) to the NBA's hyphenated label
     (e.g. ``"2023-24"``).
+
+    Callers working in the end-year convention pass ``end_year - 1`` (e.g.
+    ``year_to_season(most_recent_nba_season() - 1)``).
 
     Handles century rollover (1999 -> ``"1999-00"``) and zero-pads the
     second half of the label.

--- a/sportsdataverse/nba/nba_season_compile.py
+++ b/sportsdataverse/nba/nba_season_compile.py
@@ -41,7 +41,7 @@ def _season_game_index(season: int, season_type: str, *, proxy_url: Optional[str
     and ISO-datetime string forms.
 
     Args:
-        season: Season start year (e.g. 2023 for 2023-24).
+        season: Season END year (e.g. 2024 for 2023-24).
         season_type: NBA season type string (e.g. ``"Regular Season"``).
         proxy_url: Optional proxy URL forwarded to the underlying transport.
             Discovery is a stats.nba.com call like any other — on a datacenter
@@ -55,7 +55,7 @@ def _season_game_index(season: int, season_type: str, *, proxy_url: Optional[str
     from .nba_stats import nba_stats_leaguegamelog
 
     log = nba_stats_leaguegamelog(
-        season=year_to_season(season),
+        season=year_to_season(season - 1),
         season_type_all_star=season_type,
         league_id=_LEAGUE_ID,
         proxy_url=proxy_url,
@@ -121,7 +121,7 @@ def compile_nba_season(
     frame is tagged with a ``season`` column.
 
     Args:
-        season: Season start year (e.g. 2023 for 2023-24).
+        season: Season END year (e.g. 2024 for 2023-24).
         season_type: ``"Regular Season"`` (default) or ``"Playoffs"``.
         resume: Reuse per-game cached parquet when present.
         cache_dir: Cache root; defaults to ``SDV_PY_NBA_CACHE_DIR`` or
@@ -145,7 +145,7 @@ def compile_nba_season(
             Any ``() -> str | None`` works; a round-robin pool's ``.next``
             matches the signature directly::
 
-                compile_nba_season(2023, proxy_provider=round_robin.next)
+                compile_nba_season(2024, proxy_provider=round_robin.next)
 
         return_as_pandas: Return pandas instead of polars.
 
@@ -163,19 +163,19 @@ def compile_nba_season(
 
             from sportsdataverse.nba.nba_season_compile import compile_nba_season
 
-            poss = compile_nba_season(2023)
+            poss = compile_nba_season(2024)
             print(poss.shape)          # (n_possessions, n_cols)
-            print(poss["season"][0])   # 2023
+            print(poss["season"][0])   # 2024
 
         Resume a partially completed run and return as pandas::
 
-            poss_pd = compile_nba_season(2023, resume=True, return_as_pandas=True)
+            poss_pd = compile_nba_season(2024, resume=True, return_as_pandas=True)
             print(type(poss_pd))       # <class 'pandas.core.frame.DataFrame'>
 
         Compile Playoffs with a custom cache directory::
 
             poss = compile_nba_season(
-                2023,
+                2024,
                 season_type="Playoffs",
                 cache_dir="/tmp/nba_cache",
             )

--- a/tests/nba/test_nba_availability.py
+++ b/tests/nba/test_nba_availability.py
@@ -166,6 +166,28 @@ def test_availability_features_median_ref_uses_passed_scalar() -> None:
     assert feats_frame["prior_gp_pct"][0] != 0.33
 
 
+def test_nba_availability_tags_end_year(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``seasons`` is END-year (2024 == the 2023-24 season); output ``season`` matches it.
+
+    The stub only returns rows for the stats.nba.com season string
+    ``"2023-24"`` -- the correct derivation for end-year input 2024 (empty
+    frame for every other requested string). Under the old start-year
+    semantics the loop would have requested/tagged that data as ``2023``,
+    and the final ``season_list`` filter (``[2024]``) would drop it entirely
+    -- producing an EMPTY output. Under the end-year flip the same fetched
+    data is tagged ``2024`` and survives the filter.
+    """
+    mod = importlib.import_module("sportsdataverse.nba.nba_availability")
+    synthetic = pl.DataFrame({"player_id": [1, 2], "age": [24, 30], "gp": [70, 60]})
+
+    def _fake(season: str, league_id: str | None = None) -> pl.DataFrame:
+        return synthetic if season == "2023-24" else pl.DataFrame()
+
+    monkeypatch.setattr(mod, "nba_stats_leaguedashplayerstats", _fake)
+    out = mod.nba_availability(2024)
+    assert out["season"].unique().to_list() == [2024]
+
+
 def test_availability_runtime_dedups_duplicate_player_id(monkeypatch: pytest.MonkeyPatch) -> None:
     """A duplicated player_id in the bulk season frame is collapsed, not summed."""
     mod = importlib.import_module("sportsdataverse.nba.nba_availability")

--- a/tests/nba/test_nba_rookie_projection.py
+++ b/tests/nba/test_nba_rookie_projection.py
@@ -23,7 +23,9 @@ def synthetic_pipeline(monkeypatch: pytest.MonkeyPatch) -> None:
     aging_curve = pl.DataFrame(
         {"age": [19, 20, 27], "rel_value": [0.55, 0.62, 1.0]},
     )
-    avail = pl.DataFrame({"player_id": ["1", "2"], "season": [2019, 2019], "avail_pct": [0.9, 0.8]})
+    # avail.season is the debut END year (nba_availability's new convention);
+    # draft_year=2019 debuts in the 2019-20 season, whose end year is 2020.
+    avail = pl.DataFrame({"player_id": ["1", "2"], "season": [2020, 2020], "avail_pct": [0.9, 0.8]})
 
     monkeypatch.setattr(mod, "nba_draft_model", lambda draft_year, **kw: draft_board)
     monkeypatch.setattr(mod, "nba_aging_curve", lambda **kw: aging_curve)
@@ -56,3 +58,52 @@ def test_rookie_projection_empty_draft_year() -> None:
     out = nba_rookie_projection([])
     assert out.height == 0
     assert list(out.schema.keys()) == list(_SCHEMA.keys())
+
+
+def test_rookie_projection_requests_debut_end_year_season(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A player with ``draft_year=2019`` (start-year convention) debuts in the
+    2019-20 season, whose END year is 2020. ``nba_availability`` now takes/returns
+    the season END year, so the rookie-projection composer must request season
+    2020 (not 2019) and then map the returned end-year ``season`` back onto the
+    draft_board's start-year ``draft_year`` for the join. This test captures the
+    actual ``seasons`` argument passed to ``nba_availability`` and verifies a
+    ``season=2020`` availability row lands on the ``draft_year=2019`` rookie row.
+    """
+    mod = importlib.import_module("sportsdataverse.nba.nba_rookie_projection")
+
+    draft_board = pl.DataFrame(
+        {
+            "player_id": ["1"],
+            "draft_year": [2019],
+            "proj_career_value": [200.0],
+            "draft_prob": [0.95],
+            "projected_pick": [1],
+            "pro_tier": ["lottery"],
+        }
+    )
+    aging_curve = pl.DataFrame({"age": [19, 20, 27], "rel_value": [0.55, 0.62, 1.0]})
+
+    captured_seasons: list = []
+
+    def _fake_availability(seasons, **kw):
+        captured_seasons.append(seasons)
+        return pl.DataFrame({"player_id": ["1"], "season": [2020], "avail_pct": [0.9]})
+
+    monkeypatch.setattr(mod, "nba_draft_model", lambda draft_year, **kw: draft_board)
+    monkeypatch.setattr(mod, "nba_aging_curve", lambda **kw: aging_curve)
+    monkeypatch.setattr(mod, "nba_availability", _fake_availability)
+    art = {"rookie_fraction": 0.1, "residual": {"lottery": 5.0}}
+    monkeypatch.setattr(mod, "_load_residual_artifact", lambda league: art)
+
+    from sportsdataverse.nba.nba_rookie_projection import nba_rookie_projection
+
+    out = nba_rookie_projection(2019)
+
+    # nba_availability must be asked for the debut season's END year (2020),
+    # not the raw draft_year (2019).
+    assert captured_seasons == [[2020]]
+
+    row = out.filter(pl.col("player_id") == "1").row(0, named=True)
+    assert row["draft_year"] == 2019
+    # the season=2020 availability row must join onto the draft_year=2019 row.
+    assert row["proj_avail_pct"] == pytest.approx(0.9)

--- a/tests/nba/test_nba_schedule.py
+++ b/tests/nba/test_nba_schedule.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+
+def test_year_to_season_takes_start_year_unchanged() -> None:
+    from sportsdataverse.nba import year_to_season
+
+    # year_to_season is a low-level START-year helper; callers pass end_year - 1.
+    assert year_to_season(2023) == "2023-24"
+    assert year_to_season(1996) == "1996-97"
+    assert year_to_season(1999) == "1999-00"  # century rollover

--- a/tests/nba/test_nba_season_compile.py
+++ b/tests/nba/test_nba_season_compile.py
@@ -55,6 +55,27 @@ def test_compile_dedups_gameids_and_tags_season(tmp_path, monkeypatch):
     assert out["season"].unique().to_list() == [2024]
 
 
+def test_season_game_index_converts_end_year_to_stats_nba_season_string(monkeypatch):
+    """``_season_game_index`` takes the season END year but stats.nba.com's
+    ``leaguegamelog`` wants the START-year hyphenated label -- the ``- 1``
+    inside ``_season_game_index`` is what bridges the two conventions. This
+    exercises that conversion directly (unlike the other tests here, which
+    monkeypatch ``_season_game_index`` wholesale and so never touch it).
+    """
+    from sportsdataverse.nba import nba_stats
+
+    seen: dict = {}
+
+    def fake_leaguegamelog(**kwargs):
+        seen.update(kwargs)
+        return pl.DataFrame()
+
+    monkeypatch.setattr(nba_stats, "nba_stats_leaguegamelog", fake_leaguegamelog)
+    out = C._season_game_index(2024, "Regular Season")
+    assert seen["season"] == "2023-24"
+    assert out.is_empty()
+
+
 def test_compile_resume_skips_cached(tmp_path, monkeypatch):
     monkeypatch.setattr(
         C,

--- a/tests/nba/test_nba_season_compile.py
+++ b/tests/nba/test_nba_season_compile.py
@@ -49,10 +49,10 @@ def test_compile_dedups_gameids_and_tags_season(tmp_path, monkeypatch):
         return _poss(gid)
 
     monkeypatch.setattr(C, "_fetch_possessions", fake_fetch)
-    out = C.compile_nba_season(2023, cache_dir=str(tmp_path), delay_s=0.0)
+    out = C.compile_nba_season(2024, cache_dir=str(tmp_path), delay_s=0.0)
     assert sorted(calls) == ["001", "002"]  # deduped
     assert set(out["game_id"].unique().to_list()) == {"001", "002"}
-    assert out["season"].unique().to_list() == [2023]
+    assert out["season"].unique().to_list() == [2024]
 
 
 def test_compile_resume_skips_cached(tmp_path, monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -7220,7 +7220,7 @@ wheels = [
 
 [[package]]
 name = "sportsdataverse"
-version = "0.0.71"
+version = "0.0.72"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## What

Makes the NBA **season integer mean the END year** across the Python SDK — `compile_nba_season(2024)` compiles the 2023-24 season; every NBA `season` column reads 2024 for 2023-24. This matches `most_recent_nba_season()` and every ESPN-sourced `load_nba_*` dataset, which were already end-year.

**BREAKING** (`compile_nba_season` / `nba_availability` public inputs). Version bumped 0.0.71 → 0.0.72 with a `BREAKING CHANGE` changelog entry.

## Why this is a convergence, not an invention

The codebase was already **mixed**: ESPN-sourced NBA data, `most_recent_nba_season()`, `nba_clutch`, `nba_tracking_value`, and `leaguedash` were all already end-year — only the stats.nba.com compile path used start-year. This PR converts those start-year holdouts. `nba_player_impact` (the dataset that prompted this) has never been published, so there's no released data to migrate on the SDK side.

## Changes

- **`year_to_season` UNCHANGED** — it stays a low-level start-year helper (`year_to_season(2023) → "2023-24"`), called in the end-year world as `year_to_season(end_year - 1)`. Only its self-contradictory summary docstring was corrected.
- **`compile_nba_season` / `_season_game_index`** — input is now the end year; internally calls `year_to_season(season - 1)`. Output `season` column echoes the end-year input.
- **`nba_availability`** — input + output `season` are end-year; the convention-agnostic next-season join and the (out-of-scope) WNBA branch are untouched.
- **`nba_rookie_projection`** — fixed a real regression this migration caused: it consumed `nba_availability` with a start-year `draft_year`, so post-flip it silently fetched each rookie's *pre-draft* season. Now requests `draft_year + 1` and maps `season - 1` back on the join.

## Not touched (already end-year — verified no double-shift)

`nba_clutch`, `nba_tracking_value`, `nba_team_ratings`, `nba_oracle_data`, all ESPN `load_nba_*`, and the entire WNBA tree. A whole-branch review confirmed the diff changes none of them.

## Tests

Per-task TDD with mutation checks on all three load-bearing behaviors (reverting the fix makes the test fail):
- `test_season_game_index_converts_end_year...` — fails if the `season - 1` is reverted.
- `test_nba_availability_tags_end_year` — fails if the output tag reverts to start-year.
- `test_rookie_projection_requests_debut_end_year_season` — fails if the `+ 1` is reverted.

`tests/nba/` — 662 passed, 41 skipped. A caller audit confirmed `nba_rookie_projection` was the ONLY off-by-one consumer (`compile_nba_season` has no internal callers).

## Follow-ups (separate PRs)

- **PR B** (hoopR-nba-stats-data): `nba_model_publish` + `nba_data_build` end-year, and fixes a pre-existing `most_recent_nba_season()` off-by-one.
- **PR C**: re-publish `nba_stats_rapm` / `nba_stats_possessions` end-year.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - NBA season inputs for `compile_nba_season` and `nba_availability` now use the season’s ending year (for example, `2024` means `2023–24`).
  - Update callers using start years by adding 1.
  - `year_to_season` still expects a season start year, while `nba_box_logs` continues to require `"YYYY-YY"` strings.

- **Documentation**
  - Clarified season-year conventions and updated examples across NBA references.

- **Release**
  - Updated the package version to 0.0.72.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->