### PR TITLE
fix(nba)!: raw store season dirs use league-aware END-year convention

### DIFF
--- a/sportsdataverse/nba/nba_possessions.py
+++ b/sportsdataverse/nba/nba_possessions.py
@@ -1118,9 +1118,11 @@ def _raw_store_path(
     the same precedence as ``compile_nba_season``'s ``cache_dir``). The root
     is canonically a ``hoopR-nba-stats-raw`` checkout's ``nba_stats/json``
     directory. Layout: ``{root}/{endpoint}/{season}/{game_id}{suffix}.json``,
-    where ``season`` is the start year decoded from digits 4-5 of the game id
-    (``0029600001`` -> ``1996``, ``0022300001`` -> ``2023``; NBA game ids
-    before 1946 don't exist, so ``>= 46`` selects the 1900s).
+    where ``season`` is the season END year — the NBA stats pipeline's
+    end-year convention, matching ``compile_nba_season`` (digits 4-5 of the
+    game id are the start year, so ``0029600001`` -> ``1997`` for 1996-97
+    and ``0022300001`` -> ``2024`` for 2023-24; NBA game ids before 1946
+    don't exist, so ``>= 46`` selects the 1900s).
 
     Args:
         endpoint: stats.nba.com endpoint slug (e.g. ``"playbyplayv3"``).
@@ -1143,7 +1145,12 @@ def _raw_store_path(
     root = resolved
     yy = game_id[3:5]
     if yy.isdigit():
-        season = str(1900 + int(yy)) if int(yy) >= 46 else str(2000 + int(yy))
+        year = 1900 + int(yy) if int(yy) >= 46 else 2000 + int(yy)
+        # End-year season convention. Cross-year leagues (NBA "00",
+        # G-League "20") label a season by its END year, so shift +1.
+        # WNBA (league prefix "10") seasons are single calendar years:
+        # 1022600071 -> 2026, no shift.
+        season = str(year if game_id.startswith("10") else year + 1)
     else:
         season = "unknown"
     return Path(root) / endpoint / season / f"{game_id}{suffix}.json"

--- a/tests/nba/test_raw_json_store.py
+++ b/tests/nba/test_raw_json_store.py
@@ -37,7 +37,7 @@ def test_miss_persists_then_hits_without_network(monkeypatch, tmp_path):
     monkeypatch.setenv("SDV_PY_NBA_RAW_JSON_DIR", str(tmp_path))
     out = _through_raw_store("playbyplayv3", "0022300001", _fetch_ok)
     assert out == PAYLOAD
-    stored = tmp_path / "playbyplayv3" / "2023" / "0022300001.json"
+    stored = tmp_path / "playbyplayv3" / "2024" / "0022300001.json"
     assert stored.exists()
     assert json.loads(stored.read_text(encoding="utf-8")) == PAYLOAD
     # Hit path: a fetch that raises proves the network is not touched.
@@ -50,7 +50,7 @@ def test_explicit_store_dir_beats_env(monkeypatch, tmp_path):
     monkeypatch.setenv("SDV_PY_NBA_RAW_JSON_DIR", str(env_root))
     out = _through_raw_store("playbyplayv3", "0022300001", _fetch_ok, store_dir=arg_root)
     assert out == PAYLOAD
-    assert (arg_root / "playbyplayv3" / "2023" / "0022300001.json").exists()
+    assert (arg_root / "playbyplayv3" / "2024" / "0022300001.json").exists()
     assert not env_root.exists()
 
 
@@ -68,8 +68,8 @@ def test_mapping_routes_endpoints_independently(monkeypatch, tmp_path):
     }
     _through_raw_store("playbyplayv3", "0022300001", _fetch_ok, store_dir=spec)
     _through_raw_store("gamerotation", "0022300001", _fetch_ok, store_dir=spec)
-    assert (tmp_path / "pbp_tree" / "playbyplayv3" / "2023" / "0022300001.json").exists()
-    assert (tmp_path / "default_tree" / "gamerotation" / "2023" / "0022300001.json").exists()
+    assert (tmp_path / "pbp_tree" / "playbyplayv3" / "2024" / "0022300001.json").exists()
+    assert (tmp_path / "default_tree" / "gamerotation" / "2024" / "0022300001.json").exists()
     # An empty-string mapping entry disables just that endpoint.
     spec_off = {"gamerotation": "", "*": tmp_path / "default_tree"}
     assert _raw_store_path("gamerotation", "0022300001", root=spec_off) is None
@@ -80,8 +80,8 @@ def test_per_endpoint_env_beats_generic_env(monkeypatch, tmp_path):
     monkeypatch.setenv("SDV_PY_NBA_RAW_JSON_DIR_GAMEROTATION", str(tmp_path / "rot_tree"))
     _through_raw_store("gamerotation", "0022300001", _fetch_ok)
     _through_raw_store("playbyplayv3", "0022300001", _fetch_ok)
-    assert (tmp_path / "rot_tree" / "gamerotation" / "2023" / "0022300001.json").exists()
-    assert (tmp_path / "generic" / "playbyplayv3" / "2023" / "0022300001.json").exists()
+    assert (tmp_path / "rot_tree" / "gamerotation" / "2024" / "0022300001.json").exists()
+    assert (tmp_path / "generic" / "playbyplayv3" / "2024" / "0022300001.json").exists()
 
 
 def test_explicit_readonly_beats_env(monkeypatch, tmp_path):
@@ -93,7 +93,7 @@ def test_explicit_readonly_beats_env(monkeypatch, tmp_path):
     # readonly=False with the env var SET: writes anyway (arg wins).
     monkeypatch.setenv("SDV_PY_NBA_RAW_JSON_READONLY", "1")
     _through_raw_store("playbyplayv3", "0022300001", _fetch_ok, readonly=False)
-    assert (tmp_path / "playbyplayv3" / "2023" / "0022300001.json").exists()
+    assert (tmp_path / "playbyplayv3" / "2024" / "0022300001.json").exists()
 
 
 def test_readonly_reads_but_never_writes(monkeypatch, tmp_path):
@@ -103,7 +103,7 @@ def test_readonly_reads_but_never_writes(monkeypatch, tmp_path):
     assert _through_raw_store("playbyplayv3", "0022300001", _fetch_ok) == PAYLOAD
     assert not (tmp_path / "playbyplayv3").exists()
     # Hit: still served from the store without a fetch.
-    stored = tmp_path / "playbyplayv3" / "2023" / "0022300001.json"
+    stored = tmp_path / "playbyplayv3" / "2024" / "0022300001.json"
     stored.parent.mkdir(parents=True)
     stored.write_text(json.dumps(PAYLOAD), encoding="utf-8")
     assert _through_raw_store("playbyplayv3", "0022300001", _fetch_boom) == PAYLOAD
@@ -111,7 +111,7 @@ def test_readonly_reads_but_never_writes(monkeypatch, tmp_path):
 
 def test_corrupt_file_refetches_and_rewrites(monkeypatch, tmp_path):
     monkeypatch.setenv("SDV_PY_NBA_RAW_JSON_DIR", str(tmp_path))
-    stored = tmp_path / "playbyplayv3" / "2023" / "0022300001.json"
+    stored = tmp_path / "playbyplayv3" / "2024" / "0022300001.json"
     stored.parent.mkdir(parents=True)
     stored.write_text("{torn", encoding="utf-8")
     assert _through_raw_store("playbyplayv3", "0022300001", _fetch_ok) == PAYLOAD
@@ -120,7 +120,13 @@ def test_corrupt_file_refetches_and_rewrites(monkeypatch, tmp_path):
 
 @pytest.mark.parametrize(
     ("game_id", "season"),
-    [("0029600001", "1996"), ("0022300001", "2023"), ("0024600001", "1946")],
+    [
+        ("0029600001", "1997"),  # NBA 1996-97 -> end year
+        ("0022300001", "2024"),  # NBA 2023-24 -> end year
+        ("0024600001", "1947"),  # NBA 1946-47 -> end year
+        ("1022600071", "2026"),  # WNBA 2026 -> calendar year, no shift
+        ("1042400413", "2024"),  # WNBA 2024 playoffs -> calendar year
+    ],
 )
 def test_season_decoding(monkeypatch, tmp_path, game_id, season):
     monkeypatch.setenv("SDV_PY_NBA_RAW_JSON_DIR", str(tmp_path))


### PR DESCRIPTION
## Summary

- `_raw_store_path` season directories now follow the pipeline's END-year convention for cross-year leagues (`0029600001` → `1997/` for 1996-97), replacing the start-year decode shipped in #290.
- League-aware: WNBA game ids (league prefix `10`) are single-calendar-year seasons and do not shift (`1022600071` → `2026/`) — this unblocks the wehoop-wnba-stats-raw sweep.
- Companion migrations already landed: hoopR-nba-stats-raw@e067dfc renamed all existing season dirs (+1), and its batcher label shift was dropped (95ad0fa).

## Test plan

- `tests/nba/test_raw_json_store.py` season-decoding cases cover NBA regular/playoffs/1940s and WNBA regular/playoffs ids (15 tests green).
- Full `tests/nba/ + tests/wnba/`: 739 passed, 64 skipped. `ruff` + `mypy` clean; `generate.py --check` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected raw play-by-play storage paths to use the appropriate end-year season convention.
  * Added special handling for WNBA game identifiers.
  * Improved read-only behavior so cached data is used without network access or unintended writes.
* **Tests**
  * Expanded coverage for season decoding, WNBA scenarios, storage routing, and read-only access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->