### PR TITLE
fix(nba): raw store never persists an empty {} payload

### DIFF
--- a/sportsdataverse/nba/nba_possessions.py
+++ b/sportsdataverse/nba/nba_possessions.py
@@ -1207,6 +1207,16 @@ def _through_raw_store(
     ro = bool(os.environ.get("SDV_PY_NBA_RAW_JSON_READONLY")) if readonly is None else readonly
     if ro:
         return payload
+    # Never persist an empty/dataless payload. A stats.nba.com fetch that
+    # returns a bare ``{}`` (a transient failure, an empty envelope, or a
+    # genuinely-dataless endpoint like gamerotation for very old games) is
+    # indistinguishable from a real capture once on disk, and a present file
+    # counts as a cache HIT that never refetches — so caching ``{}`` poisons
+    # the game permanently. Leaving it unwritten keeps it retryable. A valid
+    # payload for these endpoints always carries ``resultSets``/``resource``,
+    # so it is never falsy.
+    if not payload:
+        return payload
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         tmp = path.parent / (path.name + ".tmp")

--- a/tests/nba/test_raw_json_store.py
+++ b/tests/nba/test_raw_json_store.py
@@ -26,6 +26,24 @@ def _fetch_boom() -> dict:
     raise AssertionError("network fetch should not have been called")
 
 
+def test_empty_payload_not_persisted(monkeypatch, tmp_path):
+    # A bare {} (transient failure / dataless endpoint) must NOT be cached —
+    # caching it would poison the game with a permanent hit that never
+    # refetches. It stays retryable: returned to the caller, absent on disk.
+    monkeypatch.setenv("SDV_PY_NBA_RAW_JSON_DIR", str(tmp_path))
+    calls = {"n": 0}
+
+    def _fetch_empty() -> dict:
+        calls["n"] += 1
+        return {}
+
+    assert _through_raw_store("gamerotation", "0029600001", _fetch_empty) == {}
+    assert not (tmp_path / "gamerotation").exists()
+    # Still a miss on the next call -> refetched, not served from a cached {}.
+    assert _through_raw_store("gamerotation", "0029600001", _fetch_empty) == {}
+    assert calls["n"] == 2
+
+
 def test_disabled_is_passthrough(monkeypatch, tmp_path):
     monkeypatch.delenv("SDV_PY_NBA_RAW_JSON_DIR", raising=False)
     assert _raw_store_path("playbyplayv3", "0022300001") is None


### PR DESCRIPTION
## Problem
The backfill left **2,732 empty `{}` rotation files** in hoopR-nba-stats-raw (37% of all rotation files). ~1,100 each in 1996/1997 are genuine (no rotation data that far back), but **2023 alone has 311 empty of 431**, plus ~200 across 2022/2024/2025 — modern games that provably have rotation (62-78 rows in non-empty files). Those are transient scrape failures persisted as `{}`.

A present file is a cache **hit** that never refetches, so a cached `{}` poisons the game permanently: downstream possession/lineup building silently falls back to pbp-inferred lineups instead of authoritative rotation.

## Fix
`_through_raw_store` skips persisting any falsy payload (`{}`/`None`), so a dataless/failed fetch stays retryable instead of cached. Valid payloads for these endpoints always carry `resultSets`/`resource` and are never falsy. Shared helper, so the WNBA store benefits too.

## Test plan
- `tests/nba/test_raw_json_store.py::test_empty_payload_not_persisted`: `{}` returned to caller, not written, still a miss on the next call (refetched).
- `tests/nba/ + tests/wnba/` store suites: 21 passed. ruff + mypy clean. Private-function-only change, no reference-doc regeneration.

Remediation (separate, ops): delete existing empty `{}` files in both raw repos and re-sweep so failures recover real rotation while the guard keeps genuine gaps unwritten.

## Summary by Sourcery

Prevent caching of empty raw JSON payloads for NBA (and shared WNBA) stats endpoints to avoid permanently persisting dataless responses.

Bug Fixes:
- Avoid persisting empty `{}` payloads from stats endpoints so transient failures do not become permanent cache hits.

Tests:
- Add a regression test ensuring empty payloads are not written to disk and are refetched on subsequent calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented empty NBA data responses from being saved as cached results.
  * Ensured failed or empty fetches remain retryable instead of causing persistent stale data.

* **Tests**
  * Added coverage verifying empty responses are returned without creating cache files and are fetched again on subsequent attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->