### PR TITLE
fix(nba): nba_player_positions dedups to one row per player_id

### DIFF
--- a/sportsdataverse/nba/nba_player_positions.py
+++ b/sportsdataverse/nba/nba_player_positions.py
@@ -71,7 +71,16 @@ def nba_player_positions(
     get = fetch if fetch is not None else nba_stats_playerindex
     raw: pl.DataFrame = get(season=season, league_id=league_id)
     id_col = "person_id" if "person_id" in raw.columns else "player_id"
-    return raw.select(
-        pl.col(id_col).cast(pl.Int64).alias("player_id"),
-        pl.col("position").map_elements(_position_to_num, return_dtype=pl.Float64).alias("position_num"),
+    return (
+        raw.select(
+            pl.col(id_col).cast(pl.Int64).alias("player_id"),
+            pl.col("position").map_elements(_position_to_num, return_dtype=pl.Float64).alias("position_num"),
+        )
+        # One row per player_id (the documented grain). The playerindex lists a
+        # mid-season-traded player once per team, so without this a traded
+        # player's duplicate player_id fans out through the position join in
+        # nba_bpm/nba_spm. Listed position is a player attribute (identical
+        # across a player's team rows), so keeping the first is deterministic
+        # and lossless.
+        .unique(subset=["player_id"], keep="first", maintain_order=True)
     )

--- a/tests/nba/test_nba_player_positions.py
+++ b/tests/nba/test_nba_player_positions.py
@@ -28,3 +28,16 @@ def test_nba_player_positions_parses_playerindex() -> None:
     assert df.columns == ["player_id", "position_num"]
     assert df["player_id"].to_list() == [1, 2, 3]
     assert df["position_num"].to_list() == [1.5, 4.25, 3.0]  # G=1.5, F-C=(3.5+5)/2=4.25
+
+
+def test_nba_player_positions_dedups_traded_player() -> None:
+    # A mid-season-traded player is listed once per team in the playerindex.
+    # The output must stay one row per player_id (its documented grain), else
+    # the duplicate fans out through the position join in nba_bpm/nba_spm.
+    def fake(**kw: object) -> pl.DataFrame:
+        return pl.DataFrame({"person_id": [10, 20, 10], "position": ["PG", "C", "PG"]})
+
+    df = nba_player_positions("2015-16", fetch=fake)
+    assert df.height == df["player_id"].n_unique() == 2
+    assert df["player_id"].to_list() == [10, 20]  # order preserved, first kept
+    assert df["position_num"].to_list() == [1.0, 5.0]


### PR DESCRIPTION
## Problem
`nba_player_positions` ended with a bare `raw.select(...)` — no dedup. The stats.nba.com `playerindex` lists a **mid-season-traded player once per team**, so for seasons like 2015-16 the output had a duplicate `player_id`, violating its documented "one row per player_id" grain. That duplicate fans out through the `positions` join in `nba_bpm`/`nba_spm`, and the NBA model-publish builder's `_join_on_player` correctly halts with `AssertionError: bpm: duplicate player_id rows` (surfaced building the 2016 impact season).

## Fix
`.unique(subset=["player_id"], keep="first", maintain_order=True)`. Listed position is a player attribute (identical across a player's team rows), so keeping the first is deterministic and lossless.

## Test plan
- `test_nba_player_positions_dedups_traded_player`: duplicate person_id collapses to one row, order preserved.
- `tests/nba/test_nba_player_positions.py`: 3 passed. ruff + mypy clean. Body-only change, no reference-doc regeneration.

## Summary by Sourcery

Ensure nba_player_positions returns one row per player_id to prevent duplicated players propagating into downstream models.

Bug Fixes:
- Deduplicate nba_player_positions output on player_id while preserving order and using the first occurrence for traded players.

Tests:
- Add a test confirming mid-season traded players are collapsed to a single row with stable ordering and correct position mapping.