### PR TITLE
fix(nba): tunable timeout + retry for the stats.nba.com runtime

### DIFF
--- a/sportsdataverse/nba/nba_stats_runtime.py
+++ b/sportsdataverse/nba/nba_stats_runtime.py
@@ -8,6 +8,8 @@ is injectable (``transport=``) so wrappers/tests stay offline-friendly.
 from __future__ import annotations
 
 import json
+import os
+import time
 from typing import Any, Callable, Optional
 
 __all__ = ["_get", "stats_headers"]
@@ -72,13 +74,18 @@ def _curl_transport(
             "plain requests). Install with: pip install curl_cffi"
         ) from exc
     proxies = {"http": proxy_url, "https": proxy_url} if proxy_url else None
+    # Tunable per-request timeout. stats.nba.com is slow for some historical
+    # endpoints (a real gamerotation payload for a 2011-12 game can take ~27s,
+    # right at the old hardcoded 30s cliff), so bump SDV_PY_NBA_STATS_TIMEOUT
+    # when back-filling old seasons.
+    timeout = float(os.environ.get("SDV_PY_NBA_STATS_TIMEOUT", "30"))
     r = creq.get(
         url,
         params=params,
         headers=headers,
         proxies=proxies,
         impersonate="chrome",
-        timeout=30,
+        timeout=timeout,
     )
     return r.status_code, r.text
 
@@ -149,10 +156,34 @@ def _get(
         url = f"https://{host}/stats/{path}"
 
     _transport = transport or _curl_transport
-    status, text = _transport(url, clean, headers or stats_headers(host), proxy_url)
-    if status != 200 or not text.strip():
+    _headers = headers or stats_headers(host)
+
+    # Optional retry-with-backoff for the throttle/slowness failure modes.
+    # stats.nba.com intermittently hangs (curl timeout) or returns a blank /
+    # bare ``{}`` body under load for historical endpoints even though the data
+    # exists — a retry recovers it. Defaults to 0 retries so behavior is
+    # byte-identical unless SDV_PY_NBA_STATS_RETRIES is set (back-fill sweeps
+    # set it; the tight-timeout single-shot path is unchanged for everyone else).
+    retries = int(os.environ.get("SDV_PY_NBA_STATS_RETRIES", "0"))
+    backoff = float(os.environ.get("SDV_PY_NBA_STATS_BACKOFF", "1.5"))
+    for attempt in range(retries + 1):
+        try:
+            status, text = _transport(url, clean, _headers, proxy_url)
+        except Exception:
+            if attempt < retries:
+                time.sleep(backoff * (attempt + 1))
+                continue
+            raise  # exhausted: preserve the "timeout propagates" contract
+        if status == 200 and text.strip():
+            try:
+                payload = json.loads(text)
+            except json.JSONDecodeError:
+                payload = {}
+            if payload:  # a valid, non-empty envelope
+                return payload
+        # non-200 / blank / undecodable / bare {} — a transient throttle; retry
+        if attempt < retries:
+            time.sleep(backoff * (attempt + 1))
+            continue
         return {}
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError:
-        return {}
+    return {}  # unreachable; keeps type-checkers happy

--- a/tests/nba/test_nba_stats_runtime.py
+++ b/tests/nba/test_nba_stats_runtime.py
@@ -60,3 +60,71 @@ def test_wnba_runtime_fixes_host():
     wget("leaguedashplayerstats", {}, transport=transport)
     assert captured["url"] == "https://stats.wnba.com/stats/leaguedashplayerstats"
     assert captured["host_header"] == "stats.wnba.com"
+
+
+# --- retry / timeout tunables (SDV_PY_NBA_STATS_RETRIES / _TIMEOUT / _BACKOFF) ---
+
+
+def test_get_no_retry_by_default(monkeypatch):
+    monkeypatch.delenv("SDV_PY_NBA_STATS_RETRIES", raising=False)
+    calls = {"n": 0}
+
+    def transport(url, params, headers, proxy_url):
+        calls["n"] += 1
+        return 200, "{}"  # blank envelope
+
+    assert _get("gamerotation", {}, transport=transport) == {}
+    assert calls["n"] == 1  # single shot, no retry
+
+
+def test_get_retries_on_empty_then_succeeds(monkeypatch):
+    monkeypatch.setenv("SDV_PY_NBA_STATS_RETRIES", "3")
+    monkeypatch.setenv("SDV_PY_NBA_STATS_BACKOFF", "0")
+    seq = iter([(200, "{}"), (200, "{}"), (200, '{"resultSets": [1]}')])
+
+    def transport(url, params, headers, proxy_url):
+        return next(seq)
+
+    out = _get("gamerotation", {}, transport=transport)
+    assert out == {"resultSets": [1]}  # recovered on the 3rd attempt
+
+
+def test_get_retries_on_exception_then_succeeds(monkeypatch):
+    monkeypatch.setenv("SDV_PY_NBA_STATS_RETRIES", "2")
+    monkeypatch.setenv("SDV_PY_NBA_STATS_BACKOFF", "0")
+    calls = {"n": 0}
+
+    def transport(url, params, headers, proxy_url):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise TimeoutError("curl 28")
+        return 200, '{"resultSets": [1]}'
+
+    assert _get("gamerotation", {}, transport=transport) == {"resultSets": [1]}
+    assert calls["n"] == 2
+
+
+def test_get_exhausted_exception_reraises(monkeypatch):
+    monkeypatch.setenv("SDV_PY_NBA_STATS_RETRIES", "2")
+    monkeypatch.setenv("SDV_PY_NBA_STATS_BACKOFF", "0")
+
+    def transport(url, params, headers, proxy_url):
+        raise TimeoutError("always hangs")
+
+    import pytest
+
+    with pytest.raises(TimeoutError):
+        _get("gamerotation", {}, transport=transport)
+
+
+def test_get_exhausted_empty_returns_blank(monkeypatch):
+    monkeypatch.setenv("SDV_PY_NBA_STATS_RETRIES", "2")
+    monkeypatch.setenv("SDV_PY_NBA_STATS_BACKOFF", "0")
+    calls = {"n": 0}
+
+    def transport(url, params, headers, proxy_url):
+        calls["n"] += 1
+        return 200, "{}"
+
+    assert _get("gamerotation", {}, transport=transport) == {}
+    assert calls["n"] == 3  # 1 + 2 retries, then gives up


### PR DESCRIPTION
## Problem
The stats.nba.com runtime hardcoded `timeout=30` with **no retry**. stats.nba.com is brutally slow for some historical endpoints — a real `gamerotation` payload for a 2011-12 game takes ~27s (right at the cliff) and intermittently hangs or returns a blank/bare `{}` under load. So old-season fetches were mostly *failing* and being recorded as gaps, making rotation look far sparser than it is. Verified: the same 2012 game returned `{}` once and **60 real rotation rows** on a clean retry; a spread 2012 sample was 8/10 timeout, 2/10 data, **0 genuine empty**.

## Fix
- `SDV_PY_NBA_STATS_TIMEOUT` — per-request transport timeout (default 30).
- `SDV_PY_NBA_STATS_RETRIES` / `SDV_PY_NBA_STATS_BACKOFF` — retry-with-backoff in `_get` on timeout, non-200, blank, or bare `{}`. **Defaults to 0 retries → byte-identical behavior** unless opted in. On exhausted retries a timeout still propagates (contract preserved); a blank still returns `{}`.

## Test plan
- 5 new tests: no-retry-by-default (single shot), retry-on-empty→success, retry-on-exception→success, exhausted-exception-reraises, exhausted-empty→{}. Full runtime suite 11 passed. ruff + mypy clean. Private `_get`/`_curl_transport` change, no reference-doc regeneration.

## Summary by Sourcery

Add configurable timeout and optional retry/backoff logic to the stats.nba.com runtime while preserving default behavior, and cover the new runtime semantics with targeted tests.

New Features:
- Introduce environment-configurable per-request timeout for NBA stats transport via SDV_PY_NBA_STATS_TIMEOUT.
- Add environment-driven retry with exponential-style backoff for NBA stats requests to recover from transient timeouts and blank responses.

Tests:
- Add tests validating default no-retry behavior, successful retries on empty responses and exceptions, and behavior when retries are exhausted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NBA statistics fetching reliability by retrying temporary network and response failures.
  * Added graceful handling for invalid or empty responses.
  * Requests now support configurable timeouts and retry backoff behavior through environment settings.

* **Tests**
  * Added coverage for default behavior, successful retries, timeout errors, and exhausted retry attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->