### PR TITLE
fix(rds): keep the umask-derived file mode when writing via the temp file

### DIFF
--- a/sportsdataverse/_rds.py
+++ b/sportsdataverse/_rds.py
@@ -20,8 +20,8 @@ from __future__ import annotations
 
 import gzip
 import os
+import secrets
 import struct
-import tempfile
 from contextlib import nullcontext
 from datetime import datetime, timezone
 from functools import partial
@@ -59,9 +59,36 @@ _INT32_MAX = 2**31 - 1
 _R_VERSION = (4 << 16) | (5 << 8) | 3
 _R_MIN_VERSION = (2 << 16) | (3 << 8) | 0
 
+# O_EXCL retries when claiming a temp name; a collision needs a 64-bit token clash
+_TEMP_NAME_ATTEMPTS = 8
+
 # runtime-evaluated alias: `str | datetime` needs py3.10+, floor is 3.9
 _AttrValue = Union[str, datetime]
 _ColumnWriter = Callable[[], None]
+
+
+def _create_temp_sibling(out_path: Path) -> tuple[int, Path]:
+    """Create a uniquely-named sibling of ``out_path``; return its fd and path.
+
+    ``tempfile.mkstemp`` would do this but hardcodes mode 0600, and the rename that
+    publishes the file preserves that mode -- so every output would silently become
+    owner-only. Creating with 0666 lets the kernel subtract the caller's umask, which
+    is exactly what ``open(path, "wb")`` did before the atomic-write change.
+
+    Reading the umask in-process instead (``os.umask(0)`` then restore) would mutate
+    process-global state and race any other thread creating a file in that window.
+
+    Raises:
+        OSError: If no unique name could be claimed.
+    """
+    for _ in range(_TEMP_NAME_ATTEMPTS):
+        candidate = out_path.with_name(f".{out_path.name}.{secrets.token_hex(8)}.partial")
+        try:
+            fd = os.open(candidate, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o666)
+        except FileExistsError:
+            continue
+        return fd, candidate
+    raise OSError(f"could not claim a unique temp name next to {out_path}")
 
 
 class _ByteSink(Protocol):
@@ -407,14 +434,13 @@ def write_rds(
     # filesystem and never exposes a partial file at `path`. The temp name is unique
     # per writer: two processes writing the same `path` (two compiles sharing an
     # out_dir) would otherwise interleave their bytes into one fixed temp file.
-    fd, tmp_name = tempfile.mkstemp(dir=out_path.parent, prefix=f".{out_path.name}.", suffix=".partial")
-    tmp_path = Path(tmp_name)
-    # mkstemp creates 0600 and rename preserves the mode, so without this the output
-    # would silently become owner-only -- where opening the destination directly gave
-    # the usual umask-derived 0644. Match what a plain open() would have produced.
-    _umask = os.umask(0o022)
-    os.umask(_umask)
-    os.chmod(tmp_path, 0o666 & ~_umask)
+    # Opened O_EXCL with mode 0666 rather than via tempfile.mkstemp: mkstemp forces
+    # 0600, and rename preserves the mode, so the output would silently become
+    # owner-only where opening the destination directly gave the usual 0644. Passing
+    # 0666 lets the kernel subtract the caller's umask exactly as open() would --
+    # reading the umask in-process instead would mean os.umask(), which mutates
+    # process-global state and races any other thread creating a file meanwhile.
+    fd, tmp_path = _create_temp_sibling(out_path)
     try:
         with os.fdopen(fd, "wb") as raw:
             # gzip stamps the output filename into its header, so name it for the

--- a/sportsdataverse/_rds.py
+++ b/sportsdataverse/_rds.py
@@ -409,6 +409,12 @@ def write_rds(
     # out_dir) would otherwise interleave their bytes into one fixed temp file.
     fd, tmp_name = tempfile.mkstemp(dir=out_path.parent, prefix=f".{out_path.name}.", suffix=".partial")
     tmp_path = Path(tmp_name)
+    # mkstemp creates 0600 and rename preserves the mode, so without this the output
+    # would silently become owner-only -- where opening the destination directly gave
+    # the usual umask-derived 0644. Match what a plain open() would have produced.
+    _umask = os.umask(0o022)
+    os.umask(_umask)
+    os.chmod(tmp_path, 0o666 & ~_umask)
     try:
         with os.fdopen(fd, "wb") as raw:
             # gzip stamps the output filename into its header, so name it for the


### PR DESCRIPTION
Follow-up to #296.

## Problem

The atomic-write change silently tightened permissions on every rds it produced. `tempfile.mkstemp` creates `0600`, and `rename` preserves the mode — so output that used to land at the usual umask-derived `0644` (what opening the destination directly gave) became owner-only:

```
-rw------- 1 root root 49537801 play_by_play_2026.rds
```

It survived review because it never fails anything visible: publishing works, since the same user uploads the asset. It only shows up as a mode on disk. Anything reading a compiled tree as another user or service would be denied.

## Fix

`chmod` the temp file to `0666 & ~umask` right after `mkstemp`, matching what a plain `open()` would have produced.

## Verification

Against the pre-#296 writer, same input, both compression modes:

```
compress=True : new=0o644 old=0o644 match=True bytes_identical=True
compress=False: new=0o644 old=0o644 match=True bytes_identical=True
```

104 passed / 3 skipped (`-k "rds or release"`); ruff, ruff format, mypy clean.

## Summary by Sourcery

Bug Fixes:
- Restore umask-derived file permissions when writing RDS files through a temporary file created with mkstemp, avoiding overly restrictive owner-only modes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file permission handling when exporting RDS files to ensure consistent access behavior between the temporary staging file and the final output.
  * Updated atomic export behavior to use a safer temporary-file creation strategy, reducing the chance of unexpected permission-related access issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->