### PR TITLE
feat(nba): read the committed raw store over URL + season-level captures

### DIFF
--- a/docs/docs/nba/index.md
+++ b/docs/docs/nba/index.md
@@ -11,7 +11,7 @@ sidebar_label: NBA
 | [ESPN core API (v2)](reference/core) | 81 | `https://sports.core.api.espn.com/v2/sports` |
 | [NBA Stats API (stats.nba.com)](reference/nba_stats) | 112 | `https://stats.nba.com` |
 | [Dataset loaders](reference/loaders) | 14 | sportsdataverse-data releases |
-| [Additional functions](reference/additional) | 126 | hand-written wrappers, loaders & helpers |
+| [Additional functions](reference/additional) | 127 | hand-written wrappers, loaders & helpers |
 
 ## Examples
 

--- a/docs/docs/nba/reference/additional.md
+++ b/docs/docs/nba/reference/additional.md
@@ -2870,8 +2870,8 @@ panel = nba_ratings_panel(RidgeRapmModel(), season_poss)
 
 Read a committed SEASON-LEVEL capture from the raw store, parsed to a frame.
 
-The per-game half of the store is served by through_raw_store`; this is
-the season-keyed half (`leaguegamelog`, `playerindex`,
+The per-game half of the store is served by the read-through per-game path;
+this is the season-keyed half (`leaguegamelog`, `playerindex`,
 `leaguedashplayerbiostats`, ...) that the `-raw` scraper writes as
 
 * `{endpoint}/{season}/{variant}.json` -- parameterized captures, where
@@ -2905,6 +2905,11 @@ The parsed `polars.DataFrame`, or `None` when the store is unset, the capture is
 from sportsdataverse.nba import nba_raw_store_season_frame
 base = "https://raw.githubusercontent.com/sportsdataverse/hoopR-nba-stats-raw/main/nba_stats/json"
 logs = nba_raw_store_season_frame("leaguegamelog", 2024, "regular-season", raw_store_dir=base)
+
+# Fall back to a live fetch when the capture is absent
+
+frame = nba_raw_store_season_frame("playerindex", 2024, raw_store_dir=base)
+positions = frame if frame is not None else nba_stats_playerindex(season="2023-24")
 ```
 
 ### `nba_rookie_projection(draft_year: "'int | list[int]'", *, league: 'str' = 'nba', college_prior: "'Optional[pl.DataFrame]'" = None, return_as_pandas: 'bool' = False) -> "'pl.DataFrame | pd.DataFrame'"` {#nba_rookie_projection}

--- a/docs/docs/nba/reference/additional.md
+++ b/docs/docs/nba/reference/additional.md
@@ -2866,6 +2866,47 @@ print(panel.filter(pl.col("player_id") == 201939).sort("date"))
 panel = nba_ratings_panel(RidgeRapmModel(), season_poss)
 ```
 
+### `nba_raw_store_season_frame(endpoint: 'str', season: 'int', variant: 'Optional[str]' = None, *, result_set: 'Optional[str]' = None, raw_store_dir: 'RawStoreDir' = None) -> "Optional['pl.DataFrame']"` {#nba_raw_store_season_frame}
+
+Read a committed SEASON-LEVEL capture from the raw store, parsed to a frame.
+
+The per-game half of the store is served by through_raw_store`; this is
+the season-keyed half (`leaguegamelog`, `playerindex`,
+`leaguedashplayerbiostats`, ...) that the `-raw` scraper writes as
+
+* `{endpoint}/{season}/{variant}.json` -- parameterized captures, where
+  *variant* is the slugified parameter sweep (e.g. `"regular-season"`,
+  `"regular-season_totals"`), and
+* `{endpoint}/{season}.json` -- unparameterized captures (e.g.
+  `playerindex`), i.e. `variant=None`.
+
+Roots may be a local checkout or an `http(s)://` base (the raw repo served
+over raw.githubusercontent / a CDN), so a consumer -- notably the
+`hoopR-nba-stats-data` model producer -- runs clone-free in CI against the
+same committed tree the per-game compile reads.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `endpoint` | `str` |  | stats.nba.com endpoint slug (the store subdirectory). |
+| `season` | `int` |  | Season END year (2024 = 2023-24), matching the store layout. |
+| `variant` | `Optional[str]` | `None` | Capture variant slug, or `None` for an unparameterized capture. |
+| `result_set` | `Optional[str]` | `None` | Named result set to return when the payload carries several; defaults to the first frame that parses. |
+| `raw_store_dir` | `RawStoreDir` | `None` | Store root spec (dir or URL base) or per-endpoint mapping; `None` falls back to the env vars, `""` disables. |
+
+**Returns**
+
+The parsed `polars.DataFrame`, or `None` when the store is unset, the capture is absent, or the payload carries no usable frame -- so a caller can cleanly fall back to a live fetch.
+
+**Example**
+
+```python
+from sportsdataverse.nba import nba_raw_store_season_frame
+base = "https://raw.githubusercontent.com/sportsdataverse/hoopR-nba-stats-raw/main/nba_stats/json"
+logs = nba_raw_store_season_frame("leaguegamelog", 2024, "regular-season", raw_store_dir=base)
+```
+
 ### `nba_rookie_projection(draft_year: "'int | list[int]'", *, league: 'str' = 'nba', college_prior: "'Optional[pl.DataFrame]'" = None, return_as_pandas: 'bool' = False) -> "'pl.DataFrame | pd.DataFrame'"` {#nba_rookie_projection}
 
 Project rookie/sophomore value by composing draft x aging x availability.

--- a/sportsdataverse/nba/__init__.py
+++ b/sportsdataverse/nba/__init__.py
@@ -82,6 +82,7 @@ from sportsdataverse.nba.nba_play_context import (  # noqa: F401
 )
 from sportsdataverse.nba.nba_possessions import (  # noqa: F401
     build_possession_shooting,
+    nba_raw_store_season_frame,
     POSSESSION_SHOOTING_SCHEMA,
 )
 from sportsdataverse.nba.nba_rapm_variants import (  # noqa: F401

--- a/sportsdataverse/nba/nba_possessions.py
+++ b/sportsdataverse/nba/nba_possessions.py
@@ -1104,6 +1104,63 @@ def _env_store_root(endpoint: str) -> Optional[str]:
     return os.environ.get("SDV_PY_NBA_RAW_JSON_DIR")
 
 
+def _is_url_root(root: str) -> bool:
+    """A store root that is an HTTP(S) base (the raw repo served over URL) rather
+    than a local checkout — e.g. ``raw.githubusercontent.com/.../nba_stats/json`` or
+    a CDN like ``cdn.jsdelivr.net/gh/...``. URL roots make the compile clone-free in
+    CI: the committed per-game JSON is fetched over HTTP instead of read off disk."""
+    return root.startswith("http://") or root.startswith("https://")
+
+
+def _season_dir_for_game(game_id: str) -> str:
+    """Season subdirectory for a game id, matching the committed raw layout.
+
+    Digits 4-5 of the id are the season START year; cross-year leagues (NBA
+    ``"00"`` / G-League ``"20"``) label the season by its END year (+1), while
+    WNBA (``"10"``) seasons are single calendar years (no shift). ``>= 46``
+    selects the 1900s (no NBA game ids predate 1946).
+    """
+    yy = game_id[3:5]
+    if not yy.isdigit():
+        return "unknown"
+    year = 1900 + int(yy) if int(yy) >= 46 else 2000 + int(yy)
+    return str(year if game_id.startswith("10") else year + 1)
+
+
+def _raw_store_relpath(endpoint: str, game_id: str, suffix: str = "") -> str:
+    """Store-relative path for one payload: ``{endpoint}/{season}/{game_id}{suffix}.json``.
+
+    Shared by the filesystem (:func:`_raw_store_path`) and URL
+    (:func:`_through_raw_store`) backends so both address the identical committed
+    layout.
+    """
+    return f"{endpoint}/{_season_dir_for_game(game_id)}/{game_id}{suffix}.json"
+
+
+def _http_get_json(url: str, *, timeout: Optional[float] = None) -> Optional[dict]:
+    """GET a committed raw JSON over HTTP; ``None`` on 404 / error / non-JSON.
+
+    For URL store roots only. These are GitHub/CDN URLs (NOT stats.nba.com), so a
+    plain ``requests.get`` is correct — the TLS/JA3 impersonation the stats API
+    needs does not apply. Module-level so tests monkeypatch it without a network.
+    Timeout defaults to ``SDV_PY_NBA_RAW_JSON_HTTP_TIMEOUT`` (30s).
+    """
+    import requests
+
+    if timeout is None:
+        timeout = float(os.environ.get("SDV_PY_NBA_RAW_JSON_HTTP_TIMEOUT", "30"))
+    try:
+        resp = requests.get(url, timeout=timeout)
+    except requests.RequestException:
+        return None
+    if resp.status_code != 200:
+        return None
+    try:
+        return resp.json()
+    except ValueError:
+        return None
+
+
 def _raw_store_path(
     endpoint: str,
     game_id: str,
@@ -1140,20 +1197,11 @@ def _raw_store_path(
         Absolute :class:`~pathlib.Path`, or ``None`` when the store is off.
     """
     resolved = _resolve_store_root(endpoint, root)
-    if resolved is None:
+    if resolved is None or _is_url_root(resolved):
+        # URL roots carry no filesystem Path — _through_raw_store serves them over
+        # HTTP. A caller that only wants a local path (existence checks) gets None.
         return None
-    root = resolved
-    yy = game_id[3:5]
-    if yy.isdigit():
-        year = 1900 + int(yy) if int(yy) >= 46 else 2000 + int(yy)
-        # End-year season convention. Cross-year leagues (NBA "00",
-        # G-League "20") label a season by its END year, so shift +1.
-        # WNBA (league prefix "10") seasons are single calendar years:
-        # 1022600071 -> 2026, no shift.
-        season = str(year if game_id.startswith("10") else year + 1)
-    else:
-        season = "unknown"
-    return Path(root) / endpoint / season / f"{game_id}{suffix}.json"
+    return Path(resolved) / _raw_store_relpath(endpoint, game_id, suffix)
 
 
 def _through_raw_store(
@@ -1195,9 +1243,19 @@ def _through_raw_store(
     Returns:
         Raw payload ``dict`` (from disk on hit, from ``fetch()`` on miss).
     """
-    path = _raw_store_path(endpoint, game_id, suffix, root=store_dir)
-    if path is None:
+    root = _resolve_store_root(endpoint, store_dir)
+    if root is None:
         return fetch()
+    if _is_url_root(root):
+        # URL store: offline-authoritative and inherently read-only (you can't
+        # write to a URL). A root is a URL precisely where the live stats API is
+        # unreachable — GitHub Actions with no proxy — so a miss returns empty
+        # rather than falling back to a live fetch that would hang. The caller
+        # then skips that game/endpoint just as it does for a genuinely-absent one.
+        url = root.rstrip("/") + "/" + _raw_store_relpath(endpoint, game_id, suffix)
+        payload = _http_get_json(url)
+        return payload if payload else {}
+    path = Path(root) / _raw_store_relpath(endpoint, game_id, suffix)
     if path.exists():
         try:
             return json.loads(path.read_text(encoding="utf-8"))
@@ -1373,15 +1431,19 @@ def _fetch_box_periods(
     from sportsdataverse.nba.nba_lineups import _QUARTER_BOX_RANGE_TYPE, _period_start_range
     from sportsdataverse.nba.nba_stats import nba_stats_boxscoretraditionalv3
 
-    out: Dict[int, dict] = {}
-    for period in range(1, n_periods + 1):
-        start_range, end_range = _period_start_range(period)
+    def _fetch_all_periods_live() -> dict:
+        """Live-fill every period into ONE period-keyed dict ``{"1": payload, ...}``.
 
-        # Bind the window as defaults: the callable runs inside
-        # _through_raw_store on this iteration, and late-binding closures
-        # over loop variables would fetch every period at the LAST window.
-        def _fetch_period(sr: str = start_range, er: str = end_range) -> dict:
-            return nba_stats_boxscoretraditionalv3(
+        This is the committed shape the -raw scraper writes and the -data repos
+        consume — a single ``boxscoretraditionalv3_period/{season}/{game}.json``
+        per game. Persisting the live fill in that same shape keeps the store
+        single-form (the old per-period ``_p{n}`` files never matched the
+        committed layout, so a store read always missed).
+        """
+        built: Dict[str, dict] = {}
+        for period in range(1, n_periods + 1):
+            sr, er = _period_start_range(period)
+            built[str(period)] = nba_stats_boxscoretraditionalv3(
                 game_id=game_id,
                 start_range=sr,
                 end_range=er,
@@ -1389,15 +1451,24 @@ def _fetch_box_periods(
                 return_parsed=False,
                 proxy_url=proxy_url,
             )
+        return built
 
-        out[period] = _through_raw_store(
-            "boxscoretraditionalv3_period",
-            game_id,
-            _fetch_period,
-            suffix=f"_p{period}",
-            store_dir=raw_store_dir,
-            readonly=raw_store_readonly,
-        )
+    combined = _through_raw_store(
+        "boxscoretraditionalv3_period",
+        game_id,
+        _fetch_all_periods_live,
+        store_dir=raw_store_dir,
+        readonly=raw_store_readonly,
+    )
+
+    # ``combined`` maps period -> range payload; JSON keys are strings on disk /
+    # over URL, but a live in-process build could hand back ints. Normalise to
+    # ``{int period: payload}`` up to n_periods, dropping empty periods.
+    out: Dict[int, dict] = {}
+    for period in range(1, n_periods + 1):
+        payload = combined.get(str(period)) or combined.get(period)
+        if payload:
+            out[period] = payload
     return out
 
 

--- a/sportsdataverse/nba/nba_possessions.py
+++ b/sportsdataverse/nba/nba_possessions.py
@@ -1152,12 +1152,20 @@ def _http_get_json(url: str, *, timeout: Optional[float] = None) -> Optional[dic
     try:
         resp = requests.get(url, timeout=timeout)
     except requests.RequestException:
+        # Connection/timeout: not a miss. Silence here would make an unreachable
+        # host (or a typo'd base) look exactly like "this season has no data" for
+        # every game in the sweep.
+        logger.warning("raw store: request failed for %s", url, exc_info=True)
         return None
+    if resp.status_code == 404:
+        return None  # ordinary miss -- the capture simply isn't in the store
     if resp.status_code != 200:
+        logger.warning("raw store: HTTP %s for %s", resp.status_code, url)
         return None
     try:
         return resp.json()
     except ValueError:
+        logger.warning("raw store: undecodable JSON at %s", url)
         return None
 
 

--- a/sportsdataverse/nba/nba_possessions.py
+++ b/sportsdataverse/nba/nba_possessions.py
@@ -1204,6 +1204,76 @@ def _raw_store_path(
     return Path(resolved) / _raw_store_relpath(endpoint, game_id, suffix)
 
 
+def nba_raw_store_season_frame(
+    endpoint: str,
+    season: int,
+    variant: Optional[str] = None,
+    *,
+    result_set: Optional[str] = None,
+    raw_store_dir: RawStoreDir = None,
+) -> Optional["pl.DataFrame"]:
+    """Read a committed SEASON-LEVEL capture from the raw store, parsed to a frame.
+
+    The per-game half of the store is served by :func:`_through_raw_store`; this is
+    the season-keyed half (``leaguegamelog``, ``playerindex``,
+    ``leaguedashplayerbiostats``, ...) that the ``-raw`` scraper writes as
+
+    * ``{endpoint}/{season}/{variant}.json`` -- parameterized captures, where
+      *variant* is the slugified parameter sweep (e.g. ``"regular-season"``,
+      ``"regular-season_totals"``), and
+    * ``{endpoint}/{season}.json`` -- unparameterized captures (e.g.
+      ``playerindex``), i.e. ``variant=None``.
+
+    Roots may be a local checkout or an ``http(s)://`` base (the raw repo served
+    over raw.githubusercontent / a CDN), so a consumer -- notably the
+    ``hoopR-nba-stats-data`` model producer -- runs clone-free in CI against the
+    same committed tree the per-game compile reads.
+
+    Args:
+        endpoint: stats.nba.com endpoint slug (the store subdirectory).
+        season: Season END year (2024 = 2023-24), matching the store layout.
+        variant: Capture variant slug, or ``None`` for an unparameterized capture.
+        result_set: Named result set to return when the payload carries several;
+            defaults to the first frame that parses.
+        raw_store_dir: Store root spec (dir or URL base) or per-endpoint mapping;
+            ``None`` falls back to the env vars, ``""`` disables.
+
+    Returns:
+        The parsed :class:`polars.DataFrame`, or ``None`` when the store is
+        unset, the capture is absent, or the payload carries no usable frame --
+        so a caller can cleanly fall back to a live fetch.
+
+    Example:
+        Read a committed season capture from a URL store::
+
+            from sportsdataverse.nba import nba_raw_store_season_frame
+            base = "https://raw.githubusercontent.com/sportsdataverse/hoopR-nba-stats-raw/main/nba_stats/json"
+            logs = nba_raw_store_season_frame("leaguegamelog", 2024, "regular-season", raw_store_dir=base)
+    """
+    from sportsdataverse.nba.nba_stats_parsers import parse_nba_stats_result_sets
+
+    root = _resolve_store_root(endpoint, raw_store_dir)
+    if not root:
+        return None
+    relpath = f"{endpoint}/{season}/{variant}.json" if variant else f"{endpoint}/{season}.json"
+    if _is_url_root(root):
+        raw = _http_get_json(root.rstrip("/") + "/" + relpath)
+    else:
+        path = Path(root) / relpath
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8")) if path.exists() else None
+        except (OSError, ValueError):
+            raw = None
+    if not raw:
+        return None
+    parsed = parse_nba_stats_result_sets(raw, result_set=result_set)
+    if isinstance(parsed, dict):  # multi-set payload: take the first usable frame
+        parsed = next((f for f in parsed.values() if isinstance(f, pl.DataFrame) and f.height), None)
+    if not isinstance(parsed, pl.DataFrame) or parsed.is_empty():
+        return None
+    return parsed
+
+
 def _through_raw_store(
     endpoint: str,
     game_id: str,

--- a/sportsdataverse/nba/nba_possessions.py
+++ b/sportsdataverse/nba/nba_possessions.py
@@ -1214,8 +1214,8 @@ def nba_raw_store_season_frame(
 ) -> Optional["pl.DataFrame"]:
     """Read a committed SEASON-LEVEL capture from the raw store, parsed to a frame.
 
-    The per-game half of the store is served by :func:`_through_raw_store`; this is
-    the season-keyed half (``leaguegamelog``, ``playerindex``,
+    The per-game half of the store is served by the read-through per-game path;
+    this is the season-keyed half (``leaguegamelog``, ``playerindex``,
     ``leaguedashplayerbiostats``, ...) that the ``-raw`` scraper writes as
 
     * ``{endpoint}/{season}/{variant}.json`` -- parameterized captures, where
@@ -1249,6 +1249,18 @@ def nba_raw_store_season_frame(
             from sportsdataverse.nba import nba_raw_store_season_frame
             base = "https://raw.githubusercontent.com/sportsdataverse/hoopR-nba-stats-raw/main/nba_stats/json"
             logs = nba_raw_store_season_frame("leaguegamelog", 2024, "regular-season", raw_store_dir=base)
+
+        Fall back to a live fetch when the capture is absent::
+
+            frame = nba_raw_store_season_frame("playerindex", 2024, raw_store_dir=base)
+            positions = frame if frame is not None else nba_stats_playerindex(season="2023-24")
+
+        See Also:
+            * `nba_api`_ -- reference Python client for stats.nba.com
+            * `hoopR`_ -- R companion package for NBA/MBB data
+
+        .. _nba_api: https://github.com/swar/nba_api
+        .. _hoopR: https://hoopR.sportsdataverse.org
     """
     from sportsdataverse.nba.nba_stats_parsers import parse_nba_stats_result_sets
 

--- a/sportsdataverse/nba/nba_season_compile.py
+++ b/sportsdataverse/nba/nba_season_compile.py
@@ -7,6 +7,7 @@ already-compiled games. Best-effort — a failing/empty game is logged and skipp
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import time
@@ -36,24 +37,93 @@ def _game_cache_key(game_id: str) -> str:
     return f"{game_id}__v{PIPELINE_VERSION}.parquet"
 
 
-def _season_game_index(season: int, season_type: str, *, proxy_url: Optional[str] = None) -> pl.DataFrame:
+def _index_select(frame: pl.DataFrame) -> pl.DataFrame:
+    """``(game_id, game_date)`` index from a parsed leaguegamelog frame.
+
+    One row per game id (the team-level log has two rows per game; first kept);
+    ``game_date`` parsed from the first 10 chars, tolerating bare-date and
+    ISO-datetime string forms. Empty typed frame when the columns are absent.
+    """
+    if frame.is_empty() or "game_id" not in frame.columns or "game_date" not in frame.columns:
+        return pl.DataFrame(schema={"game_id": pl.Utf8, "game_date": pl.Date})
+    return frame.select(
+        pl.col("game_id").cast(pl.Utf8),
+        pl.col("game_date").cast(pl.Utf8).str.slice(0, 10).str.to_date("%Y-%m-%d"),
+    ).unique(subset=["game_id"], keep="first", maintain_order=True)
+
+
+def _season_index_from_store(season: int, season_type: str, raw_store_dir: "RawStoreDir") -> Optional[pl.DataFrame]:
+    """``(game_id, game_date)`` index from a COMMITTED leaguegamelog in the raw
+    store (local dir or ``http(s)://`` base), or ``None`` when the store is unset
+    or the capture is absent.
+
+    Lets discovery run clone-free / offline (CI) off the same committed tree the
+    per-game compile reads — closing the one stats.nba.com call the compile would
+    otherwise always make. Season-level captures live at
+    ``leaguegamelog/{season}/{variant}.json`` (variant = season-type slug), the
+    layout the ``-raw`` scraper writes; the raw resultSets payload is parsed the
+    same way the live wrapper parses it.
+    """
+    from .nba_possessions import _http_get_json, _is_url_root, _resolve_store_root
+    from .nba_stats_parsers import parse_nba_stats_result_sets
+
+    root = _resolve_store_root("leaguegamelog", raw_store_dir)
+    if not root:
+        return None
+    relpath = f"leaguegamelog/{season}/{season_type.lower().replace(' ', '-')}.json"
+    if _is_url_root(root):
+        raw = _http_get_json(root.rstrip("/") + "/" + relpath)
+    else:
+        path = Path(root) / relpath
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8")) if path.exists() else None
+        except (OSError, ValueError):
+            raw = None
+    if not raw:
+        return None
+    parsed = parse_nba_stats_result_sets(raw)
+    if isinstance(parsed, dict):  # multi-set safety; leaguegamelog is single-set
+        parsed = next(
+            (f for f in parsed.values() if isinstance(f, pl.DataFrame) and "game_id" in f.columns),
+            None,
+        )
+    if not isinstance(parsed, pl.DataFrame):
+        return None
+    idx = _index_select(parsed)
+    return idx if not idx.is_empty() else None
+
+
+def _season_game_index(
+    season: int,
+    season_type: str,
+    *,
+    proxy_url: Optional[str] = None,
+    raw_store_dir: "RawStoreDir" = None,
+) -> pl.DataFrame:
     """``(game_id, game_date)`` index for a season from leaguegamelog (monkeypatchable).
 
-    One row per game id (the team-level log has two rows per game; first kept).
-    ``game_date`` is parsed from the first 10 chars, tolerating both bare-date
-    and ISO-datetime string forms.
+    A committed leaguegamelog in ``raw_store_dir`` (local dir or URL) is used when
+    present — making discovery clone-free/offline in CI — else the live
+    stats.nba.com wrapper is called.
 
     Args:
         season: Season END year (e.g. 2024 for 2023-24).
         season_type: NBA season type string (e.g. ``"Regular Season"``).
-        proxy_url: Optional proxy URL forwarded to the underlying transport.
-            Discovery is a stats.nba.com call like any other — on a datacenter
-            host an unproxied call returns no rows, which silently compiles the
-            season to zero games.
+        proxy_url: Optional proxy URL forwarded to the live transport. Discovery
+            is a stats.nba.com call like any other — on a datacenter host an
+            unproxied call returns no rows, silently compiling the season to zero
+            games (irrelevant once ``raw_store_dir`` serves it offline).
+        raw_store_dir: Raw JSON store root (dir or ``http(s)://`` base) or
+            per-endpoint mapping; ``None`` -> env vars. When it yields a committed
+            leaguegamelog the live call is skipped entirely.
 
     Returns:
         Polars DataFrame with ``game_id: Utf8`` and ``game_date: Date``.
     """
+    from_store = _season_index_from_store(season, season_type, raw_store_dir)
+    if from_store is not None:
+        return from_store
+
     from .nba_schedule import year_to_season
     from .nba_stats import nba_stats_leaguegamelog
 
@@ -63,17 +133,20 @@ def _season_game_index(season: int, season_type: str, *, proxy_url: Optional[str
         league_id=_LEAGUE_ID,
         proxy_url=proxy_url,
     )
-    if log.is_empty() or "game_id" not in log.columns or "game_date" not in log.columns:
-        return pl.DataFrame(schema={"game_id": pl.Utf8, "game_date": pl.Date})
-    return log.select(
-        pl.col("game_id").cast(pl.Utf8),
-        pl.col("game_date").cast(pl.Utf8).str.slice(0, 10).str.to_date("%Y-%m-%d"),
-    ).unique(subset=["game_id"], keep="first", maintain_order=True)
+    return _index_select(log)
 
 
-def _game_ids_for_season(season: int, season_type: str, *, proxy_url: Optional[str] = None) -> List[str]:
+def _game_ids_for_season(
+    season: int,
+    season_type: str,
+    *,
+    proxy_url: Optional[str] = None,
+    raw_store_dir: "RawStoreDir" = None,
+) -> List[str]:
     """Return the (deduped) game ids for a season (delegates to :func:`_season_game_index`)."""
-    return _season_game_index(season, season_type, proxy_url=proxy_url)["game_id"].to_list()
+    return _season_game_index(season, season_type, proxy_url=proxy_url, raw_store_dir=raw_store_dir)[
+        "game_id"
+    ].to_list()
 
 
 def _fetch_possessions(
@@ -217,6 +290,7 @@ def compile_nba_season(
         season,
         season_type,
         proxy_url=proxy_provider() if proxy_provider is not None else None,
+        raw_store_dir=raw_store_dir,
     )
     # dedupe preserving order
     game_ids = list(dict.fromkeys(index["game_id"].to_list()))

--- a/sportsdataverse/nba/nba_season_compile.py
+++ b/sportsdataverse/nba/nba_season_compile.py
@@ -7,7 +7,6 @@ already-compiled games. Best-effort — a failing/empty game is logged and skipp
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 import time
@@ -64,30 +63,15 @@ def _season_index_from_store(season: int, season_type: str, raw_store_dir: "RawS
     layout the ``-raw`` scraper writes; the raw resultSets payload is parsed the
     same way the live wrapper parses it.
     """
-    from .nba_possessions import _http_get_json, _is_url_root, _resolve_store_root
-    from .nba_stats_parsers import parse_nba_stats_result_sets
+    from .nba_possessions import nba_raw_store_season_frame
 
-    root = _resolve_store_root("leaguegamelog", raw_store_dir)
-    if not root:
-        return None
-    relpath = f"leaguegamelog/{season}/{season_type.lower().replace(' ', '-')}.json"
-    if _is_url_root(root):
-        raw = _http_get_json(root.rstrip("/") + "/" + relpath)
-    else:
-        path = Path(root) / relpath
-        try:
-            raw = json.loads(path.read_text(encoding="utf-8")) if path.exists() else None
-        except (OSError, ValueError):
-            raw = None
-    if not raw:
-        return None
-    parsed = parse_nba_stats_result_sets(raw)
-    if isinstance(parsed, dict):  # multi-set safety; leaguegamelog is single-set
-        parsed = next(
-            (f for f in parsed.values() if isinstance(f, pl.DataFrame) and "game_id" in f.columns),
-            None,
-        )
-    if not isinstance(parsed, pl.DataFrame):
+    parsed = nba_raw_store_season_frame(
+        "leaguegamelog",
+        season,
+        season_type.lower().replace(" ", "-"),
+        raw_store_dir=raw_store_dir,
+    )
+    if parsed is None or "game_id" not in parsed.columns:
         return None
     idx = _index_select(parsed)
     return idx if not idx.is_empty() else None

--- a/sportsdataverse/parsed/nba.py
+++ b/sportsdataverse/parsed/nba.py
@@ -255,6 +255,7 @@ from sportsdataverse.nba import nba_player_props as nba_player_props  # noqa: F4
 from sportsdataverse.nba import nba_playtype_ratings as nba_playtype_ratings  # noqa: F401
 from sportsdataverse.nba import nba_predict_games as nba_predict_games  # noqa: F401
 from sportsdataverse.nba import nba_ratings_panel as nba_ratings_panel  # noqa: F401
+from sportsdataverse.nba import nba_raw_store_season_frame as nba_raw_store_season_frame  # noqa: F401
 from sportsdataverse.nba import nba_rookie_projection as nba_rookie_projection  # noqa: F401
 from sportsdataverse.nba import nba_shot_value as nba_shot_value  # noqa: F401
 from sportsdataverse.nba import nba_shot_value_lineups as nba_shot_value_lineups  # noqa: F401
@@ -534,6 +535,7 @@ __all__ = [
     "nba_playtype_ratings",
     "nba_predict_games",
     "nba_ratings_panel",
+    "nba_raw_store_season_frame",
     "nba_rookie_projection",
     "nba_shot_value",
     "nba_shot_value_lineups",

--- a/tests/nba/test_nba_season_compile.py
+++ b/tests/nba/test_nba_season_compile.py
@@ -38,7 +38,7 @@ def test_compile_dedups_gameids_and_tags_season(tmp_path, monkeypatch):
     monkeypatch.setattr(
         C,
         "_season_game_index",
-        lambda s, st, *, proxy_url=None: _idx(
+        lambda s, st, *, proxy_url=None, raw_store_dir=None: _idx(
             ["001", "002"], [datetime.date(2023, 10, 24), datetime.date(2023, 10, 25)]
         ),
     )
@@ -80,7 +80,7 @@ def test_compile_resume_skips_cached(tmp_path, monkeypatch):
     monkeypatch.setattr(
         C,
         "_season_game_index",
-        lambda s, st, *, proxy_url=None: _idx(
+        lambda s, st, *, proxy_url=None, raw_store_dir=None: _idx(
             ["001", "002"], [datetime.date(2023, 10, 24), datetime.date(2023, 10, 25)]
         ),
     )
@@ -102,7 +102,7 @@ def test_compile_best_effort_skips_failing_game(tmp_path, monkeypatch):
     monkeypatch.setattr(
         C,
         "_season_game_index",
-        lambda s, st, *, proxy_url=None: _idx(
+        lambda s, st, *, proxy_url=None, raw_store_dir=None: _idx(
             ["ok1", "bad", "ok2"],
             [datetime.date(2023, 10, 24), datetime.date(2023, 10, 25), datetime.date(2023, 10, 26)],
         ),
@@ -119,7 +119,7 @@ def test_compile_best_effort_skips_failing_game(tmp_path, monkeypatch):
 
 
 def test_compile_never_raises_on_no_games(tmp_path, monkeypatch):
-    monkeypatch.setattr(C, "_season_game_index", lambda s, st, *, proxy_url=None: _idx([], []))
+    monkeypatch.setattr(C, "_season_game_index", lambda s, st, *, proxy_url=None, raw_store_dir=None: _idx([], []))
     out = C.compile_nba_season(2023, cache_dir=str(tmp_path), delay_s=0.0)
     assert out.is_empty() and "season" in out.columns
 
@@ -135,7 +135,7 @@ def test_compile_rotates_proxy_once_per_game(tmp_path, monkeypatch):
     monkeypatch.setattr(
         C,
         "_season_game_index",
-        lambda s, st, *, proxy_url=None: _idx(
+        lambda s, st, *, proxy_url=None, raw_store_dir=None: _idx(
             ["001", "002", "003"],
             [datetime.date(2023, 10, 24), datetime.date(2023, 10, 25), datetime.date(2023, 10, 26)],
         ),
@@ -158,7 +158,9 @@ def test_compile_rotates_proxy_once_per_game(tmp_path, monkeypatch):
 def test_compile_without_proxy_provider_passes_none(tmp_path, monkeypatch):
     """Default (no provider) must stay a plain unproxied fetch -- back-compat."""
     monkeypatch.setattr(
-        C, "_season_game_index", lambda s, st, *, proxy_url=None: _idx(["001"], [datetime.date(2023, 10, 24)])
+        C,
+        "_season_game_index",
+        lambda s, st, *, proxy_url=None, raw_store_dir=None: _idx(["001"], [datetime.date(2023, 10, 24)]),
     )
     seen: list[str | None] = []
 
@@ -181,7 +183,7 @@ def test_compile_proxies_game_discovery(tmp_path, monkeypatch):
     """
     seen: list[str | None] = []
 
-    def idx(s, st, *, proxy_url=None):
+    def idx(s, st, *, proxy_url=None, raw_store_dir=None):
         seen.append(proxy_url)
         return _idx(["001"], [datetime.date(2023, 10, 24)])
 
@@ -236,7 +238,7 @@ def _fixture_poss() -> pl.DataFrame:
 def test_compile_attaches_game_date(monkeypatch, tmp_path):
     from sportsdataverse.nba import nba_season_compile as mod
 
-    monkeypatch.setattr(mod, "_season_game_index", lambda s, st, *, proxy_url=None: _fake_index())
+    monkeypatch.setattr(mod, "_season_game_index", lambda s, st, *, proxy_url=None, raw_store_dir=None: _fake_index())
     monkeypatch.setattr(
         mod, "_fetch_possessions", lambda gid, lid, lineup_source="auto", proxy_url=None, **_kwargs: _fixture_poss()
     )
@@ -252,7 +254,7 @@ def test_compile_game_date_covers_cached_parquet(monkeypatch, tmp_path):
 
     cache = tmp_path / mod._game_cache_key("0022300001")
     _fixture_poss().write_parquet(cache)  # simulates a cache written before this change
-    monkeypatch.setattr(mod, "_season_game_index", lambda s, st, *, proxy_url=None: _fake_index())
+    monkeypatch.setattr(mod, "_season_game_index", lambda s, st, *, proxy_url=None, raw_store_dir=None: _fake_index())
     monkeypatch.setattr(
         mod,
         "_fetch_possessions",
@@ -271,7 +273,7 @@ def test_compile_missing_game_date_raises(monkeypatch, tmp_path):
         {"game_id": ["0022300001"], "game_date": [None]},
         schema={"game_id": pl.Utf8, "game_date": pl.Date},
     )
-    monkeypatch.setattr(mod, "_season_game_index", lambda s, st, *, proxy_url=None: bad_index)
+    monkeypatch.setattr(mod, "_season_game_index", lambda s, st, *, proxy_url=None, raw_store_dir=None: bad_index)
     monkeypatch.setattr(
         mod, "_fetch_possessions", lambda gid, lid, lineup_source="auto", proxy_url=None, **_kwargs: _fixture_poss()
     )
@@ -289,6 +291,6 @@ from tests.conftest import skip_if_no_nba_stats_live  # noqa: E402
 def test_compile_live_small_slice(tmp_path, monkeypatch):
     # only the first 3 real regular-season game ids, real fetch, real cache
     real_index = C._season_game_index(2023, "Regular Season").head(3)
-    monkeypatch.setattr(C, "_season_game_index", lambda s, st, *, proxy_url=None: real_index)
+    monkeypatch.setattr(C, "_season_game_index", lambda s, st, *, proxy_url=None, raw_store_dir=None: real_index)
     out = C.compile_nba_season(2023, cache_dir=str(tmp_path), delay_s=1.0)
     assert not out.is_empty() and "off_player_1" in out.columns

--- a/tests/nba/test_raw_store_url_backend.py
+++ b/tests/nba/test_raw_store_url_backend.py
@@ -66,6 +66,41 @@ def test_through_store_filesystem_hit(tmp_path):
     assert got == {"game": {"actions": [1, 2]}}
 
 
+def test_http_get_json_logs_faults_but_not_plain_misses(monkeypatch, caplog):
+    """A 404 is an ordinary miss and stays quiet; a transport error or a non-404
+    status is logged, so an unreachable host / typo'd base is distinguishable
+    from "this capture doesn't exist" instead of looking like empty data."""
+    import requests
+
+    class Resp:
+        def __init__(self, code):
+            self.status_code = code
+
+        def json(self):
+            return {"ok": 1}
+
+    monkeypatch.setattr(requests, "get", lambda *a, **k: Resp(404))
+    with caplog.at_level("WARNING"):
+        assert npo._http_get_json("https://cdn/x/a.json") is None
+    assert caplog.records == []
+
+    caplog.clear()
+    monkeypatch.setattr(requests, "get", lambda *a, **k: Resp(500))
+    with caplog.at_level("WARNING"):
+        assert npo._http_get_json("https://cdn/x/a.json") is None
+    assert any("500" in r.getMessage() for r in caplog.records)
+
+    caplog.clear()
+
+    def _boom_get(*a, **k):
+        raise requests.RequestException("unreachable")
+
+    monkeypatch.setattr(requests, "get", _boom_get)
+    with caplog.at_level("WARNING"):
+        assert npo._http_get_json("https://cdn/x/a.json") is None
+    assert caplog.records, "a transport failure must not be silent"
+
+
 # --- period-box one-file reconciliation -------------------------------------
 
 

--- a/tests/nba/test_raw_store_url_backend.py
+++ b/tests/nba/test_raw_store_url_backend.py
@@ -135,3 +135,56 @@ def test_season_index_from_store_url(monkeypatch):
 def test_season_index_from_store_absent_returns_none(tmp_path):
     assert nsc._season_index_from_store(2024, "Regular Season", str(tmp_path)) is None
     assert nsc._season_index_from_store(2024, "Regular Season", None) is None
+
+
+# --- public season-level store reader ---------------------------------------
+
+
+def test_season_frame_parameterized_and_bare_layouts(tmp_path):
+    """Both committed shapes: {endpoint}/{season}/{variant}.json (swept params)
+    and {endpoint}/{season}.json (unparameterized, e.g. playerindex)."""
+    par = tmp_path / "leaguedashplayerbiostats" / "2024" / "regular-season_totals.json"
+    par.parent.mkdir(parents=True)
+    par.write_text(
+        json.dumps({"resultSets": [{"name": "X", "headers": ["PLAYER_ID", "AGE"], "rowSet": [[1, 25.0]]}]}),
+        encoding="utf-8",
+    )
+    got = npo.nba_raw_store_season_frame(
+        "leaguedashplayerbiostats", 2024, "regular-season_totals", raw_store_dir=str(tmp_path)
+    )
+    assert got is not None and got["player_id"].to_list() == [1]
+
+    bare = tmp_path / "playerindex" / "2024.json"
+    bare.parent.mkdir(parents=True)
+    bare.write_text(
+        json.dumps({"resultSets": [{"name": "P", "headers": ["PERSON_ID", "POSITION"], "rowSet": [[7, "PG"]]}]}),
+        encoding="utf-8",
+    )
+    got = npo.nba_raw_store_season_frame("playerindex", 2024, raw_store_dir=str(tmp_path))
+    assert got is not None and got["person_id"].to_list() == [7]
+
+
+def test_season_frame_url_and_absent(monkeypatch, tmp_path):
+    served = {
+        "https://cdn/x/playerindex/2024.json": {
+            "resultSets": [{"name": "P", "headers": ["PERSON_ID"], "rowSet": [[7]]}]
+        }
+    }
+    monkeypatch.setattr(npo, "_http_get_json", lambda url, **k: served.get(url))
+    assert npo.nba_raw_store_season_frame("playerindex", 2024, raw_store_dir="https://cdn/x") is not None
+    # absent capture / disabled store -> None so the caller falls back to live
+    assert npo.nba_raw_store_season_frame("playerindex", 1999, raw_store_dir="https://cdn/x") is None
+    assert npo.nba_raw_store_season_frame("playerindex", 2024, raw_store_dir=str(tmp_path)) is None
+    assert npo.nba_raw_store_season_frame("playerindex", 2024, raw_store_dir="") is None
+
+
+def test_season_frame_empty_rowset_returns_none(tmp_path):
+    """An empty capture must read as a miss, not an empty frame that would
+    silently replace a live fetch with zero rows."""
+    p = tmp_path / "playerindex" / "2024.json"
+    p.parent.mkdir(parents=True)
+    p.write_text(
+        json.dumps({"resultSets": [{"name": "P", "headers": ["PERSON_ID"], "rowSet": []}]}),
+        encoding="utf-8",
+    )
+    assert npo.nba_raw_store_season_frame("playerindex", 2024, raw_store_dir=str(tmp_path)) is None

--- a/tests/nba/test_raw_store_url_backend.py
+++ b/tests/nba/test_raw_store_url_backend.py
@@ -1,0 +1,137 @@
+"""Offline tests for the raw-store URL backend + the period one-file read fix.
+
+No network: the URL backend's HTTP getter is monkeypatched, filesystem cases use
+tmp_path. Covers the clone-free CI read path (compile off a committed raw tree
+served over http(s):// or a local dir) and the boxscoretraditionalv3_period
+layout reconciliation (one file per game, period-keyed).
+"""
+
+from __future__ import annotations
+
+import json
+
+import polars as pl
+
+from sportsdataverse.nba import nba_possessions as npo
+from sportsdataverse.nba import nba_season_compile as nsc
+
+
+def _boom():
+    raise AssertionError("live fetch must not be called on a store hit / URL miss")
+
+
+# --- path helpers -----------------------------------------------------------
+
+
+def test_season_dir_end_year_and_wnba():
+    assert npo._season_dir_for_game("0022300001") == "2024"  # 2023-24 -> end year
+    assert npo._season_dir_for_game("0029600001") == "1997"  # 1996-97
+    assert npo._season_dir_for_game("1022400001") == "2024"  # WNBA single-year, no shift
+
+
+def test_relpath_matches_committed_layout():
+    assert npo._raw_store_relpath("playbyplayv3", "0022300001") == "playbyplayv3/2024/0022300001.json"
+    assert (
+        npo._raw_store_relpath("boxscoretraditionalv3_period", "0022300001")
+        == "boxscoretraditionalv3_period/2024/0022300001.json"
+    )
+
+
+def test_url_root_detection_and_no_filesystem_path():
+    assert npo._is_url_root("https://raw.githubusercontent.com/x/y/main/nba_stats/json")
+    assert npo._is_url_root("http://cdn.example/x")
+    assert not npo._is_url_root("/local/checkout/nba_stats/json")
+    # URL roots carry no Path (existence checks get None; the store serves over HTTP)
+    assert npo._raw_store_path("playbyplayv3", "0022300001", root="https://cdn/x") is None
+
+
+# --- URL backend ------------------------------------------------------------
+
+
+def test_through_store_url_hit_and_miss(monkeypatch):
+    served = {"https://cdn/x/playbyplayv3/2024/0022300001.json": {"game": {"actions": [1]}}}
+    monkeypatch.setattr(npo, "_http_get_json", lambda url, **k: served.get(url))
+    hit = npo._through_raw_store("playbyplayv3", "0022300001", _boom, store_dir="https://cdn/x")
+    assert hit == {"game": {"actions": [1]}}
+    # a URL miss returns empty WITHOUT a live fetch (offline-authoritative)
+    miss = npo._through_raw_store("playbyplayv3", "0022399999", _boom, store_dir="https://cdn/x")
+    assert miss == {}
+
+
+def test_through_store_filesystem_hit(tmp_path):
+    p = tmp_path / "playbyplayv3" / "2024" / "0022300001.json"
+    p.parent.mkdir(parents=True)
+    p.write_text(json.dumps({"game": {"actions": [1, 2]}}), encoding="utf-8")
+    got = npo._through_raw_store("playbyplayv3", "0022300001", _boom, store_dir=str(tmp_path))
+    assert got == {"game": {"actions": [1, 2]}}
+
+
+# --- period-box one-file reconciliation -------------------------------------
+
+
+def test_fetch_box_periods_reads_committed_one_file(tmp_path, monkeypatch):
+    # committed shape: ONE file per game, period-keyed (what the -raw scraper writes)
+    p = tmp_path / "boxscoretraditionalv3_period" / "2024" / "0022300001.json"
+    p.parent.mkdir(parents=True)
+    p.write_text(
+        json.dumps({"1": {"a": 1}, "2": {"a": 2}, "3": {"a": 3}, "4": {"a": 4}}),
+        encoding="utf-8",
+    )
+    import sportsdataverse.nba.nba_stats as ns
+
+    monkeypatch.setattr(ns, "nba_stats_boxscoretraditionalv3", lambda **k: _boom(), raising=True)
+    out = npo._fetch_box_periods("0022300001", 4, raw_store_dir=str(tmp_path), raw_store_readonly=True)
+    assert out == {1: {"a": 1}, 2: {"a": 2}, 3: {"a": 3}, 4: {"a": 4}}
+
+
+def test_fetch_box_periods_url(monkeypatch):
+    served = {
+        "https://cdn/x/boxscoretraditionalv3_period/2024/0022300001.json": {
+            "1": {"a": 1},
+            "2": {"a": 2},
+        }
+    }
+    monkeypatch.setattr(npo, "_http_get_json", lambda url, **k: served.get(url))
+    out = npo._fetch_box_periods("0022300001", 2, raw_store_dir="https://cdn/x")
+    assert out == {1: {"a": 1}, 2: {"a": 2}}
+
+
+# --- season discovery from the committed leaguegamelog -----------------------
+
+
+def _leaguegamelog_raw() -> dict:
+    return {
+        "resultSets": [
+            {
+                "name": "LeagueGameLog",
+                "headers": ["GAME_ID", "GAME_DATE"],
+                "rowSet": [
+                    ["0022300001", "2023-10-24"],
+                    ["0022300001", "2023-10-24"],  # team-level dup -> collapses
+                    ["0022300002", "2023-10-25"],
+                ],
+            }
+        ]
+    }
+
+
+def test_season_index_from_store_filesystem(tmp_path):
+    p = tmp_path / "leaguegamelog" / "2024" / "regular-season.json"
+    p.parent.mkdir(parents=True)
+    p.write_text(json.dumps(_leaguegamelog_raw()), encoding="utf-8")
+    idx = nsc._season_index_from_store(2024, "Regular Season", str(tmp_path))
+    assert idx is not None
+    assert idx["game_id"].to_list() == ["0022300001", "0022300002"]
+    assert idx.schema["game_date"] == pl.Date
+
+
+def test_season_index_from_store_url(monkeypatch):
+    served = {"https://cdn/x/leaguegamelog/2024/playoffs.json": _leaguegamelog_raw()}
+    monkeypatch.setattr(npo, "_http_get_json", lambda url, **k: served.get(url))
+    idx = nsc._season_index_from_store(2024, "Playoffs", "https://cdn/x")
+    assert idx is not None and idx.height == 2
+
+
+def test_season_index_from_store_absent_returns_none(tmp_path):
+    assert nsc._season_index_from_store(2024, "Regular Season", str(tmp_path)) is None
+    assert nsc._season_index_from_store(2024, "Regular Season", None) is None


### PR DESCRIPTION
## Why

`hoopR-nba-stats-raw` now holds the full 1996–2026 stats.nba.com raw JSON, committed. Downstream builds (the `hoopR-nba-stats-data` impact producer) should read that committed tree instead of the live API — `stats.nba.com` *hangs* (does not error) on datacenter/cloud IPs, so a live-fetching build can never run in GitHub Actions.

The read-through store already served per-game payloads from a **local directory**. This adds the two things needed for a CI consumer: reading over an **`http(s)://` base** (no ~1 GB clone), and reading the **season-keyed** half of the store.

## What

**1. URL backend** — `_through_raw_store` gains an `http(s)://` branch, served by a plain `requests.get` (these are GitHub/CDN URLs, *not* stats.nba.com, so the TLS/JA3 impersonation that host needs doesn't apply). URL roots are **offline-authoritative and read-only**: a miss returns empty rather than falling through to a live fetch that would hang in CI. Host is env-configurable (`SDV_PY_NBA_RAW_JSON_DIR=https://…`), nothing hardcoded.

**2. Offline season discovery** — `_season_game_index` reads a committed `leaguegamelog` from the store (dir or URL) before falling back live, closing the one network hole in an otherwise-offline compile.

**3. Public season-level reader** — `nba_raw_store_season_frame(endpoint, season, variant=None)` reads the season-keyed captures in both shapes the scraper writes (`{endpoint}/{season}/{variant}.json` for swept params, `{endpoint}/{season}.json` for unparameterized) and parses them through the stats result-sets parser. An absent capture **or an empty result set returns `None`**, so a caller falls back to a live fetch instead of silently training on zero rows.

## Bug fixed along the way

`_fetch_box_periods` read per-period `_p{n}` files — a layout that **never matched** the committed one-file, period-keyed `boxscoretraditionalv3_period/{season}/{game}.json` (the shape the `-raw` scraper writes and the `-data` repos consume). So a store read *always* missed and `lineup_source="quarter_box"` silently fell back to live. It now reads/writes the one-file form.

## Verification

Offline against the real committed tree, zero network: leaguegamelog RS 2460 / playoffs 168 rows, playerindex 5204 (bare layout), biostats 569, per-game pbp 611 actions, period boxscores `[1,2,3,4]`, and compile discovery returning exactly **1230 games** for 2024.

`697 passed, 41 skipped` in `tests/nba/`; mypy + ruff clean; codegen regenerated for the new public function.

## Note for reviewers

`compile_nba_season` already forwarded `raw_store_dir` to every per-game fetch — this PR does not change that contract, it adds the URL/season-level capabilities around it. Consumer wiring lives in sportsdataverse/hoopR-nba-stats-data (`--raw-store-dir`), which **depends on this landing first**.

## Summary by Sourcery

Add URL-based access and season-level helpers for the committed NBA raw stats store to enable offline, clone-free compilation and fix period boxscore reads to match the committed layout.

New Features:
- Introduce URL-backed raw store support so per-game JSON payloads can be read over http(s):// bases configured via environment or parameters.
- Add a public nba_raw_store_season_frame helper to load season-level committed captures (e.g., leaguegamelog, playerindex, biostats) from the raw store into Polars frames.
- Allow season game discovery to consume committed leaguegamelog captures from the raw store before falling back to live stats.nba.com calls.

Bug Fixes:
- Align boxscoretraditionalv3_period storage and reads with the one-file, period-keyed layout used by the scraper and downstream data repos, preventing unintended live fallbacks.

Enhancements:
- Refactor raw store path handling into shared helpers that derive season subdirectories from game IDs and support both filesystem and URL roots.
- Make season game index extraction reusable via an internal selector and ensure robust handling of missing or malformed data in leaguegamelog frames.

Documentation:
- Document the new nba_raw_store_season_frame helper in the NBA additional reference and expose it through the parsed API and nba package exports.

Tests:
- Add offline tests covering the raw-store URL backend, season-level store reads, and the reconciled one-file period boxscore layout, and update existing season compile tests for the new raw_store_dir parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for reading NBA committed season data from local or HTTP(S) raw stores.
  * Exposed `nba_raw_store_season_frame` for loading season-level captures.
* **Bug Fixes**
  * Improved period box score retrieval using the committed single-file layout for `boxscoretraditionalv3_period`.
* **Documentation**
  * Updated the NBA reference table to include the latest documented helper.
* **Tests**
  * Added coverage for URL-root handling, offline season discovery, and committed period/season reads (including absent and empty captures).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->