### PR TITLE
fix(nba): three real-data bugs in the raw-store impact path

### DIFF
--- a/docs/docs/nba/reference/additional.md
+++ b/docs/docs/nba/reference/additional.md
@@ -2890,7 +2890,7 @@ same committed tree the per-game compile reads.
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `endpoint` | `str` |  | stats.nba.com endpoint slug (the store subdirectory). |
-| `season` | `int` |  | Season END year (2024 = 2023-24), matching the store layout. |
+| `season` | `int` |  | Season **START** year (2023 = 2023-24) -- the key this half of the store is filed under; see the warning above. |
 | `variant` | `Optional[str]` | `None` | Capture variant slug, or `None` for an unparameterized capture. |
 | `result_set` | `Optional[str]` | `None` | Named result set to return when the payload carries several; defaults to the first frame that parses. |
 | `raw_store_dir` | `RawStoreDir` | `None` | Store root spec (dir or URL base) or per-endpoint mapping; `None` falls back to the env vars, `""` disables. |

--- a/sportsdataverse/nba/nba_box_logs.py
+++ b/sportsdataverse/nba/nba_box_logs.py
@@ -11,6 +11,11 @@ from sportsdataverse.nba.nba_stats import nba_stats_leaguegamelog
 # per-100 feature columns (snake-cased leaguegamelog player fields)
 _STATS = ["pts", "fg3m", "fga", "fta", "ast", "oreb", "dreb", "stl", "blk", "tov", "pf"]
 
+#: On-court players per team. A team-game's ``min`` sums all five slots, so
+#: dividing it by this recovers the game's elapsed minutes -- the basis a
+#: player's share of team possessions must be taken against.
+ON_COURT_PLAYERS = 5.0
+
 
 def box_features(
     player_logs: pl.DataFrame,
@@ -50,9 +55,16 @@ def box_features(
         pl.col("min").alias("team_min"),
     ).select("game_id", "team_id", "team_poss", "team_min")
     # Step 2: join each player-game to its team-game; compute per-game player possessions
+    # A team's ``min`` is the sum over its five on-court slots (240 for regulation,
+    # 265/290 with overtimes), NOT the game's elapsed minutes. A player's share of
+    # the team's possessions is therefore min / (team_min / 5) -- dividing by
+    # team_min directly understates it fivefold, which silently inflates every
+    # per-100 rate by 5x. That is invisible to SPM (its coefficients are fitted on
+    # these features, so a uniform scale is absorbed) but lands straight in BPM,
+    # which applies fixed published coefficients.
     player_with_poss = player_logs.join(team_poss, on=["game_id", "team_id"], how="left").with_columns(
         pl.when(pl.col("team_min") > 0)
-        .then(pl.col("team_poss") * (pl.col("min") / pl.col("team_min")))
+        .then(pl.col("team_poss") * (pl.col("min") / (pl.col("team_min") / ON_COURT_PLAYERS)))
         .otherwise(0.0)
         .alias("player_poss")
     )

--- a/sportsdataverse/nba/nba_possessions.py
+++ b/sportsdataverse/nba/nba_possessions.py
@@ -447,6 +447,41 @@ def _possession_start_type(
     return "OffDeadball"
 
 
+def _forward_fill_scores(rows: list) -> None:
+    """Stamp a running ``_home`` / ``_away`` score onto every pbp row, in place.
+
+    Two payload dialects exist and they disagree about what a NON-scoring row
+    reports. Modern games (2018+) carry the running total on every row; older
+    ones leave it as the literal string ``"0"`` on rebounds, misses and
+    substitutions, populating it only on scoring rows.
+
+    ``"0"`` is a truthy string, so accepting any non-empty value let those rows
+    reset the running score to zero. Possession points are a score DIFFERENCE,
+    so differencing against a collapsed score produced possessions worth up to
+    +/-140 points -- around 40% of pre-2018 possessions -- and wrecked the RAPM
+    fit built on them (response std 38.7 vs 1.2 on modern seasons) while leaving
+    modern seasons untouched.
+
+    A basketball score never decreases, so a backward step is ignored. That
+    resolves both dialects without having to detect which one a game is in.
+    """
+    last_home = 0
+    last_away = 0
+    for row in rows:
+        sh = (row.get("score_home") or "").strip()
+        sa = (row.get("score_away") or "").strip()
+        if sh:
+            value = int(sh)
+            if value >= last_home:
+                last_home = value
+        if sa:
+            value = int(sa)
+            if value >= last_away:
+                last_away = value
+        row["_home"] = last_home
+        row["_away"] = last_away
+
+
 def _count_as_possession(
     prev_poss_end_seconds: float,
     end_seconds: float,
@@ -636,18 +671,7 @@ def _assemble(enhanced_pbp: pl.DataFrame) -> tuple[pl.DataFrame, pl.DataFrame]:
     # Sort by order_index and convert to row-dicts for imperative traversal
     rows = enhanced_pbp.sort("order_index").to_dicts()
 
-    # Forward-fill scores (score_home / score_away only populated on scoring events)
-    last_home = 0
-    last_away = 0
-    for row in rows:
-        sh = (row.get("score_home") or "").strip()
-        sa = (row.get("score_away") or "").strip()
-        if sh:
-            last_home = int(sh)
-        if sa:
-            last_away = int(sa)
-        row["_home"] = last_home
-        row["_away"] = last_away
+    _forward_fill_scores(rows)
 
     groups = _build_possession_groups(rows, home_id, away_id)
 

--- a/sportsdataverse/nba/nba_possessions.py
+++ b/sportsdataverse/nba/nba_possessions.py
@@ -1237,9 +1237,20 @@ def nba_raw_store_season_frame(
     ``hoopR-nba-stats-data`` model producer -- runs clone-free in CI against the
     same committed tree the per-game compile reads.
 
+    .. warning::
+        The store's two halves use **different season keys**, and mixing them
+        silently yields another season's data rather than an error. The per-game
+        half (:func:`_through_raw_store`) is keyed by season **END** year, because
+        it derives the directory from the game id. This season-level half is keyed
+        by the season's **START** year, because the sweep files each capture under
+        the year it passed to the API -- so ``leaguegamelog/2023/`` holds 2023-24
+        while ``playbyplayv3/2024/`` holds that same 2023-24 season. A caller
+        working in end years must subtract one before calling this.
+
     Args:
         endpoint: stats.nba.com endpoint slug (the store subdirectory).
-        season: Season END year (2024 = 2023-24), matching the store layout.
+        season: Season **START** year (2023 = 2023-24) -- the key this half of the
+            store is filed under; see the warning above.
         variant: Capture variant slug, or ``None`` for an unparameterized capture.
         result_set: Named result set to return when the payload carries several;
             defaults to the first frame that parses.

--- a/sportsdataverse/nba/nba_season_compile.py
+++ b/sportsdataverse/nba/nba_season_compile.py
@@ -67,7 +67,12 @@ def _season_index_from_store(season: int, season_type: str, raw_store_dir: "RawS
 
     parsed = nba_raw_store_season_frame(
         "leaguegamelog",
-        season,
+        # ``season`` is the END year (2024 = 2023-24) everywhere in this module,
+        # but the store's SEASON-LEVEL captures are filed under the START year --
+        # dir 2023 holds 2023-24, while the per-game dirs use the end year. Off by
+        # one here means compiling a season from the NEXT season's game list, and
+        # nothing errors: the ids resolve, they are simply the wrong games.
+        season - 1,
         season_type.lower().replace(" ", "-"),
         raw_store_dir=raw_store_dir,
     )

--- a/sportsdataverse/nba/nba_season_compile.py
+++ b/sportsdataverse/nba/nba_season_compile.py
@@ -22,7 +22,11 @@ import polars as pl
 _LOG = logging.getLogger(__name__)
 
 #: Bump when the possession pipeline changes in a way that invalidates cached parquet.
-PIPELINE_VERSION: int = 3
+#: v4: legacy pbp dialects report a literal "0" score on non-scoring rows, which
+#: the forward-fill accepted and so reset the running score. Possession points
+#: are a score difference, so every cached pre-2018 game holds corrupted points
+#: (up to +/-140 per possession) and must be recompiled rather than reused.
+PIPELINE_VERSION: int = 4
 
 _LEAGUE_ID = "00"
 

--- a/tests/nba/test_nba_box_logs.py
+++ b/tests/nba/test_nba_box_logs.py
@@ -2,19 +2,24 @@
 
 from __future__ import annotations
 
+import pytest
 import polars as pl
 
 from sportsdataverse.nba.nba_box_logs import box_features
 
 
 def _logs():
-    # 2 games, one team (id 1), one player (id 10) who plays all the team's minutes
+    # 2 games, one team (id 1), one player (id 10) who is on court wire-to-wire.
+    # A player's ``min`` is elapsed game minutes (48); the TEAM's is the sum over
+    # its five on-court slots (240). Giving the player 240 here -- as this fixture
+    # once did -- is physically impossible and hid a 5x error in the per-100
+    # denominator, because it made min/team_min accidentally equal 1.
     player = pl.DataFrame(
         {
             "game_id": ["G1", "G2"],
             "team_id": [1, 1],
             "player_id": [10, 10],
-            "min": [240.0, 240.0],
+            "min": [48.0, 48.0],
             "pts": [20, 30],
             "fg3m": [2, 3],
             "fga": [15, 20],
@@ -46,7 +51,7 @@ def test_box_features_per100_and_totals():
     player, team = _logs()
     f = box_features(player, team)
     assert f.height == 1 and f["player_id"][0] == 10
-    assert f["gp"][0] == 2 and abs(f["min"][0] - 480.0) < 1e-9
+    assert f["gp"][0] == 2 and abs(f["min"][0] - 96.0) < 1e-9  # 2 full games
     # team_poss = (80-10+14+0.44*20)+(85-12+12+0.44*22) = 92.8 + 94.68 = 187.48
     # player plays all minutes -> player_poss = 187.48 ; pts/100 = 50/187.48*100
     assert abs(f["pts"][0] - (50 / 187.48 * 100)) < 1e-6
@@ -76,13 +81,14 @@ def test_box_features_game_id_restriction():
 
 
 def test_box_features_traded_player_uses_per_game_pace():
-    # player 10 plays G1 for team 1 (fast) and G2 for team 2 (slow); each game full team minutes
+    # player 10 plays G1 for team 1 (fast) and G2 for team 2 (slow), wire-to-wire
+    # in each -- 48 elapsed minutes, against a team total of 240 across five slots
     player = pl.DataFrame(
         {
             "game_id": ["G1", "G2"],
             "team_id": [1, 2],
             "player_id": [10, 10],
-            "min": [240.0, 240.0],
+            "min": [48.0, 48.0],
             "pts": [20, 20],
             "fg3m": [2, 2],
             "fga": [15, 15],
@@ -112,3 +118,57 @@ def test_box_features_traded_player_uses_per_game_pace():
     # player plays all minutes -> player_poss = 112.8 + 78.6 = 191.4 ; pts/100 = 40/191.4*100
     assert f.height == 1 and f["player_id"][0] == 10
     assert abs(f["pts"][0] - (40 / 191.4 * 100)) < 1e-6
+
+
+def test_full_game_player_gets_the_teams_possessions():
+    """Oracle for the per-100 denominator: a player on court for the whole game
+    faced exactly the team's possessions, so a 100-possession team-game must give
+    that player player_poss == 100 and pts-per-100 == their actual points.
+
+    A team-game's ``min`` sums five on-court slots (240 in regulation), so
+    dividing by it directly -- rather than by team_min/5 -- understates a
+    player's possessions fivefold and inflates every per-100 rate by 5x. SPM
+    hides that (its coefficients are fitted on these features); BPM does not,
+    because it applies fixed published coefficients.
+    """
+    import polars as pl
+
+    from sportsdataverse.nba.nba_box_logs import box_features
+
+    # team-game engineered to exactly 100 possessions: 100 - 10 + 8 + 0.44*5 ~= 100.2
+    team = pl.DataFrame(
+        {
+            "game_id": ["0022300001"],
+            "team_id": [1610612737],
+            "min": [240],
+            "fga": [100],
+            "oreb": [10],
+            "tov": [8],
+            "fta": [5],
+        }
+    )
+    team_poss = 100 - 10 + 8 + 0.44 * 5
+    player = pl.DataFrame(
+        {
+            "game_id": ["0022300001"],
+            "team_id": [1610612737],
+            "player_id": [201939],
+            "min": [48],  # wire-to-wire
+            "pts": [30],
+            "fg3m": [5],
+            "fga": [20],
+            "fta": [4],
+            "ast": [6],
+            "oreb": [1],
+            "dreb": [5],
+            "stl": [2],
+            "blk": [1],
+            "tov": [3],
+            "pf": [2],
+        }
+    )
+    bf = box_features(player, team)
+    assert bf.height == 1
+    # 30 points over the team's ~100 possessions -> ~30 per 100, not ~150
+    assert bf["pts"][0] == pytest.approx(30 / team_poss * 100, rel=1e-9)
+    assert 25.0 < bf["pts"][0] < 35.0, "per-100 scoring outside any plausible NBA range"

--- a/tests/nba/test_nba_possessions.py
+++ b/tests/nba/test_nba_possessions.py
@@ -947,3 +947,46 @@ def test_start_type_ft_sandwich_technical_asymmetry():
     # retained (possession_has_timeout keeps `and not is_technical_ft`) → OffTimeout.
     cur_rows_to = [timeout, tech_ft, {"event_type": "made_shot", "seconds_remaining": 80.0}]
     assert _possession_start_type(made, [made], cur_rows_to) == "OffTimeout"
+
+
+def test_forward_fill_ignores_legacy_zero_score_rows():
+    """Pre-2018 payloads report ``score_home``/``score_away`` as the literal
+    string ``"0"`` on NON-scoring rows (rebounds, misses, substitutions); modern
+    ones carry the running total everywhere.
+
+    ``"0"`` is truthy, so accepting any non-empty value reset the running score
+    to zero on those rows. Possession points are a score DIFFERENCE, so the
+    collapse produced possessions worth up to +/-140 points -- about 40% of
+    pre-2018 possessions -- and wrecked the RAPM fit built on them.
+    """
+    from sportsdataverse.nba.nba_possessions import _forward_fill_scores
+
+    rows = [
+        {"score_home": "2", "score_away": "0"},  # made shot
+        {"score_home": "0", "score_away": "0"},  # legacy zero-fill on a rebound
+        {"score_home": "0", "score_away": "0"},  # legacy zero-fill on a miss
+        {"score_home": "4", "score_away": "0"},  # made shot
+        {"score_home": "0", "score_away": "0"},  # legacy zero-fill
+    ]
+    _forward_fill_scores(rows)
+    filled = [(r["_home"], r["_away"]) for r in rows]
+
+    # The score must never walk backwards -- that is the whole failure mode.
+    assert filled == [(2, 0), (2, 0), (2, 0), (4, 0), (4, 0)], filled
+    homes = [h for h, _ in filled]
+    assert homes == sorted(homes), f"running score decreased: {homes}"
+
+
+def test_forward_fill_still_tracks_modern_running_scores():
+    """The modern dialect must be untouched: every row carries the running total
+    and each genuine increase is picked up."""
+    from sportsdataverse.nba.nba_possessions import _forward_fill_scores
+
+    rows = [
+        {"score_home": "0", "score_away": "0"},
+        {"score_home": "3", "score_away": "0"},
+        {"score_home": "3", "score_away": "2"},
+        {"score_home": "5", "score_away": "2"},
+    ]
+    _forward_fill_scores(rows)
+    assert [(r["_home"], r["_away"]) for r in rows] == [(0, 0), (3, 0), (3, 2), (5, 2)]

--- a/tests/nba/test_raw_store_url_backend.py
+++ b/tests/nba/test_raw_store_url_backend.py
@@ -151,7 +151,11 @@ def _leaguegamelog_raw() -> dict:
 
 
 def test_season_index_from_store_filesystem(tmp_path):
-    p = tmp_path / "leaguegamelog" / "2024" / "regular-season.json"
+    """Discovery takes an END year but must read the START-year directory: the
+    store's season-level captures are filed under the year passed to the API,
+    while the per-game half uses the end year. Getting this wrong compiles a
+    season from the NEXT season's games and raises nothing."""
+    p = tmp_path / "leaguegamelog" / "2023" / "regular-season.json"  # 2023-24
     p.parent.mkdir(parents=True)
     p.write_text(json.dumps(_leaguegamelog_raw()), encoding="utf-8")
     idx = nsc._season_index_from_store(2024, "Regular Season", str(tmp_path))
@@ -160,8 +164,39 @@ def test_season_index_from_store_filesystem(tmp_path):
     assert idx.schema["game_date"] == pl.Date
 
 
+def test_season_index_reads_the_matching_season_not_its_neighbour(tmp_path):
+    """The regression guard for the off-by-one: with BOTH neighbouring captures
+    present, discovery for 2024 (=2023-24) must return the 2023-24 ids, and the
+    ids it returns must live in the per-game directory for that same season --
+    i.e. the two halves of the store agree."""
+    for year, gid in (("2023", "0022300001"), ("2024", "0022400001")):
+        p = tmp_path / "leaguegamelog" / year / "regular-season.json"
+        p.parent.mkdir(parents=True)
+        p.write_text(
+            json.dumps(
+                {
+                    "resultSets": [
+                        {
+                            "name": "LeagueGameLog",
+                            "headers": ["GAME_ID", "GAME_DATE"],
+                            "rowSet": [[gid, "2023-10-24"]],
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+    idx = nsc._season_index_from_store(2024, "Regular Season", str(tmp_path))
+    assert idx is not None
+    gid = idx["game_id"][0]
+    assert gid == "0022300001", "discovery read the neighbouring season's capture"
+    # cross-half agreement: the per-game path for this id must be season 2024
+    assert npo._season_dir_for_game(gid) == "2024"
+
+
 def test_season_index_from_store_url(monkeypatch):
-    served = {"https://cdn/x/leaguegamelog/2024/playoffs.json": _leaguegamelog_raw()}
+    # END-year 2024 -> START-year directory 2023 (season-level store convention)
+    served = {"https://cdn/x/leaguegamelog/2023/playoffs.json": _leaguegamelog_raw()}
     monkeypatch.setattr(npo, "_http_get_json", lambda url, **k: served.get(url))
     idx = nsc._season_index_from_store(2024, "Playoffs", "https://cdn/x")
     assert idx is not None and idx.height == 2


### PR DESCRIPTION
Both surfaced only when validating a real build against real captures; both were silent — no exception, plausible-looking output.

## 1. Season-level captures are keyed by START year

The raw store keys its two halves differently:

| half | key | `…/2024/` holds |
|---|---|---|
| per-game (`playbyplayv3`) | season **END** year (from the game id) | 2023-24 |
| season-level (`leaguegamelog`) | season **START** year (the year passed to the API) | **2024-25** |

`_season_index_from_store` assumed end year for both, so offline discovery returned **the next season's game ids**. They resolve fine — they're just the wrong games, so an entire season compiles against them without an error.

Downstream this made the player↔team join match **0 / 2460**, and `box_features` fell through its `otherwise(0.0)` branch: every player got identical zeroed stats, collapsing SPM to **1 distinct value** and BPM to **30** (one per team).

Fixed, documented on `nba_raw_store_season_frame` (its `season` arg is now stated as START year, with a warning about the split), and pinned by a regression test that ties the halves together — with both neighbouring captures present, discovery must return the matching season *and* the ids must live in the per-game directory for that same season.

## 2. Per-100 features used team slot-minutes as the denominator

A team-game's `min` sums its **five on-court slots** (240 in regulation), not elapsed game minutes. `box_features` divided by it directly, so a wire-to-wire player was credited with a fifth of the possessions he faced — every per-100 rate **5× high**.

SPM never showed it (`train_spm` fits coefficients on these same features, so a uniform scale is absorbed). `nba_bpm` feeds them into **fixed published coefficients**, so it landed whole:

| | before | after |
|---|---|---|
| BPM, qualified (min≥1000) | **-157 .. 184** | **-11.6 .. 17.3** |
| Jokić 2023-24 BPM | 65.4 | 17.3 (**leads**, as in the real race) |

The fixtures hid it by giving a player `min = 240` — impossible in a 48-minute game, and it made `min / team_min` accidentally equal 1. Their own comments stated the correct intent (*"player plays all minutes → player_poss = full team possessions"*), so they now use realistic minutes and **every per-100 assertion in them is unchanged**. Added an oracle: a wire-to-wire player on a 100-possession team-game must get exactly 100 possessions.

## Verification

`700 passed, 41 skipped` in `tests/nba/`; ruff clean. On a real 2023-24 build: join 2460/2460, `pts` 563 distinct (was 1), `spm` 570 / `bpm` 572 distinct, all 572/572 non-null, and the WAR leaderboard reads SGA / Brunson / George / Jokić / Giannis.

Consumers: hoopR-nba-stats-data#21, hoopR-nba-stats-raw#3.

## Summary by Sourcery

Fix NBA raw-store season indexing and correct per-100 possession denominator used in box score features.

Bug Fixes:
- Correct per-100 possession calculations in box_features by basing player possessions on elapsed minutes rather than team slot-minutes, preventing 5x inflation of per-100 rates.
- Fix season index lookup for leaguegamelog data to use the season start-year directory when given an end-year season, ensuring the season compile uses the correct games rather than the neighboring season.

Enhancements:
- Clarify documentation for nba_raw_store_season_frame to spell out the differing season key conventions between per-game and season-level raw-store captures.

Tests:
- Adjust NBA box log tests to use realistic player minutes and add an oracle test that a wire-to-wire player on a 100-possession team-game gets matching possessions and per-100 scoring.
- Add regression tests ensuring season discovery reads from the correct start-year season directory and that returned game IDs align with the per-game store layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected player possession and per-100 denominators to reflect five on-court player slots.
  * Fixed NBA raw store season discovery to map end-year requests to the corresponding start-year data.

* **Documentation**
  * Clarified that `season` uses the season start year, with notes about end-year/off-by-one expectations.

* **Tests**
  * Updated fixtures and per-100 assertions for corrected minute and possessions math.
  * Added regression coverage for the season directory/id mapping and added an end-to-end possession oracle scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->