### PR TITLE
feat(nba): human-readable player and team columns for model outputs

### DIFF
--- a/docs/docs/nba/index.md
+++ b/docs/docs/nba/index.md
@@ -11,7 +11,7 @@ sidebar_label: NBA
 | [ESPN core API (v2)](reference/core) | 81 | `https://sports.core.api.espn.com/v2/sports` |
 | [NBA Stats API (stats.nba.com)](reference/nba_stats) | 112 | `https://stats.nba.com` |
 | [Dataset loaders](reference/loaders) | 14 | sportsdataverse-data releases |
-| [Additional functions](reference/additional) | 127 | hand-written wrappers, loaders & helpers |
+| [Additional functions](reference/additional) | 128 | hand-written wrappers, loaders & helpers |
 
 ## Examples
 

--- a/docs/docs/nba/reference/additional.md
+++ b/docs/docs/nba/reference/additional.md
@@ -2694,6 +2694,40 @@ ages = nba_player_ages("2023-24")
 print(ages.head())
 ```
 
+### `nba_player_identity(player_logs: 'pl.DataFrame') -> 'pl.DataFrame'` {#nba_player_identity}
+
+Human-readable identity for every player in a season's box logs.
+
+Model outputs key on `player_id` alone, which makes them unusable without a
+second lookup -- a leaderboard reads `1628983` instead of
+`Shai Gilgeous-Alexander`. This derives the display columns from the season's
+own game logs, so they are **season-accurate**: a player's team is what he
+actually played for that year, not his current one (which is what a player
+directory would give and would silently mislabel every historical season).
+
+A traded player has rows for several teams. `team_*` is his **primary** team
+by minutes -- the one a reader means when they say "his team that season" --
+and `teams` lists every abbreviation he appeared for, in descending minutes,
+so a trade is visible rather than silently collapsed.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `player_logs` | `DataFrame` |  | Per-player-per-game rows from `leaguegamelog` (the `player_or_team="P"` variant), carrying `player_id`, `player_name`, `team_id`, `team_abbreviation`, `team_name` and `min`. |
+
+**Returns**
+
+One row per `player_id` with `PLAYER_IDENTITY_SCHEMA`. An empty input gives the zero-row frame with that schema, so callers can join unconditionally.
+
+**Example**
+
+```python
+from sportsdataverse.nba import nba_box_logs, nba_player_identity
+logs = nba_box_logs("2023-24")
+named = ratings.join(nba_player_identity(logs["player"]), on="player_id", how="left")
+```
+
 ### `nba_player_positions(season: 'str', *, league_id: 'str' = '00', fetch: 'Optional[Callable[..., pl.DataFrame]]' = None) -> 'pl.DataFrame'` {#nba_player_positions}
 
 Fetch league-wide listed positions for a season as numeric 1-5.

--- a/docs/docs/nba/reference/additional.md
+++ b/docs/docs/nba/reference/additional.md
@@ -2718,14 +2718,25 @@ so a trade is visible rather than silently collapsed.
 
 **Returns**
 
-One row per `player_id` with `PLAYER_IDENTITY_SCHEMA`. An empty input gives the zero-row frame with that schema, so callers can join unconditionally.
+One row per `player_id` with `PLAYER_IDENTITY_SCHEMA`. An empty input -- or one missing any required column, `min` included -- gives the zero-row frame with that schema, so callers can join unconditionally. `min` is required rather than optional: without it every team totals zero minutes and "primary team" quietly degrades to whichever `team_id` sorts first, which looks like an answer but is not one.
 
 **Example**
 
 ```python
-from sportsdataverse.nba import nba_box_logs, nba_player_identity
-logs = nba_box_logs("2023-24")
-named = ratings.join(nba_player_identity(logs["player"]), on="player_id", how="left")
+import polars as pl
+from sportsdataverse.nba import nba_player_identity
+
+logs = pl.DataFrame({
+    "player_id": [1628983],
+    "player_name": ["Shai Gilgeous-Alexander"],
+    "team_id": [1610612760],
+    "team_abbreviation": ["OKC"],
+    "team_name": ["Oklahoma City Thunder"],
+    "min": [34.0],
+})
+ratings = pl.DataFrame({"player_id": [1628983], "war": [21.9]})
+named = ratings.join(nba_player_identity(logs), on="player_id", how="left")
+print(named.select("player_name", "team_name", "war"))
 ```
 
 ### `nba_player_positions(season: 'str', *, league_id: 'str' = '00', fetch: 'Optional[Callable[..., pl.DataFrame]]' = None) -> 'pl.DataFrame'` {#nba_player_positions}

--- a/docs/docs/nba/reference/loaders.md
+++ b/docs/docs/nba/reference/loaders.md
@@ -654,6 +654,11 @@ Release: [nba_player_impact](https://github.com/sportsdataverse/sportsdataverse-
 | col_name | type |
 |---|---|
 | `player_id` | Int64 |
+| `player_name` | Utf8 |
+| `team_id` | Int64 |
+| `team_abbreviation` | Utf8 |
+| `team_name` | Utf8 |
+| `teams` | Utf8 |
 | `o_rapm` | Float64 |
 | `d_rapm` | Float64 |
 | `rapm` | Float64 |

--- a/sportsdataverse/nba/__init__.py
+++ b/sportsdataverse/nba/__init__.py
@@ -33,7 +33,12 @@ from sportsdataverse.nba.nba_model_validation import (  # noqa: F401
     validate_model,
     walk_forward,
 )
-from sportsdataverse.nba.nba_box_logs import box_features, nba_box_logs  # noqa: F401
+from sportsdataverse.nba.nba_box_logs import (  # noqa: F401
+    PLAYER_IDENTITY_SCHEMA,
+    box_features,
+    nba_box_logs,
+    nba_player_identity,
+)
 from sportsdataverse.nba.nba_spm import (  # noqa: F401
     NbaSpmModel,
     SpmCoefficients,

--- a/sportsdataverse/nba/nba_box_logs.py
+++ b/sportsdataverse/nba/nba_box_logs.py
@@ -164,15 +164,33 @@ def nba_player_identity(player_logs: pl.DataFrame) -> pl.DataFrame:
 
     Returns:
         One row per ``player_id`` with :data:`PLAYER_IDENTITY_SCHEMA`. An empty
-        input gives the zero-row frame with that schema, so callers can join
-        unconditionally.
+        input -- or one missing any required column, ``min`` included -- gives the
+        zero-row frame with that schema, so callers can join unconditionally.
+        ``min`` is required rather than optional: without it every team totals
+        zero minutes and "primary team" quietly degrades to whichever ``team_id``
+        sorts first, which looks like an answer but is not one.
+
+    Raises:
+        None: a malformed frame yields the typed zero-row frame instead of
+        raising, so a caller can join unconditionally.
 
     Example:
         Attach names to a model output::
 
-            from sportsdataverse.nba import nba_box_logs, nba_player_identity
-            logs = nba_box_logs("2023-24")
-            named = ratings.join(nba_player_identity(logs["player"]), on="player_id", how="left")
+            import polars as pl
+            from sportsdataverse.nba import nba_player_identity
+
+            logs = pl.DataFrame({
+                "player_id": [1628983],
+                "player_name": ["Shai Gilgeous-Alexander"],
+                "team_id": [1610612760],
+                "team_abbreviation": ["OKC"],
+                "team_name": ["Oklahoma City Thunder"],
+                "min": [34.0],
+            })
+            ratings = pl.DataFrame({"player_id": [1628983], "war": [21.9]})
+            named = ratings.join(nba_player_identity(logs), on="player_id", how="left")
+            print(named.select("player_name", "team_name", "war"))
 
         See Also:
             * `nba_api`_ -- reference Python client for stats.nba.com
@@ -181,23 +199,34 @@ def nba_player_identity(player_logs: pl.DataFrame) -> pl.DataFrame:
         .. _nba_api: https://github.com/swar/nba_api
         .. _hoopR: https://hoopR.sportsdataverse.org
     """
-    need = {"player_id", "player_name", "team_id", "team_abbreviation", "team_name"}
+    # ``min`` is required, not optional: without it every team totals zero minutes
+    # and the "primary" team degrades to whichever team_id sorts first -- a wrong
+    # answer wearing the shape of a right one. Refuse rather than guess.
+    need = {"player_id", "player_name", "team_id", "team_abbreviation", "team_name", "min"}
     if player_logs.is_empty() or not need.issubset(set(player_logs.columns)):
         return pl.DataFrame(schema=PLAYER_IDENTITY_SCHEMA)
 
-    minutes = pl.col("min") if "min" in player_logs.columns else pl.lit(0.0)
     per_team = (
-        player_logs.with_columns(minutes.fill_null(0.0).cast(pl.Float64).alias("_min"))
+        player_logs.with_columns(pl.col("min").fill_null(0.0).cast(pl.Float64).alias("_min"))
         .group_by(["player_id", "team_id", "team_abbreviation", "team_name"])
         .agg(pl.col("_min").sum().alias("_team_min"), pl.col("player_name").last().alias("player_name"))
-        # Ties would otherwise resolve by group_by's nondeterministic output order,
-        # so break them on team_id to keep a rebuild byte-identical.
-        .sort(["player_id", "_team_min", "team_id"], descending=[False, True, False])
     )
-    primary = per_team.group_by("player_id").first()
-    teams = per_team.group_by("player_id").agg(pl.col("team_abbreviation").str.join(",").alias("teams"))
+    # Order the teams INSIDE each aggregation rather than pre-sorting and trusting
+    # group_by to preserve that order -- polars only guarantees preservation with
+    # maintain_order, so a pre-sort would leave BOTH the primary pick and the teams
+    # string resting on undocumented behaviour. Ties break on team_id so a rebuild
+    # stays byte-identical.
+    _by, _desc = ["_team_min", "team_id"], [True, False]
+    _first = lambda c: pl.col(c).sort_by(_by, descending=_desc).first().alias(c)  # noqa: E731
     return (
-        primary.join(teams, on="player_id", how="left")
+        per_team.group_by("player_id")
+        .agg(
+            _first("player_name"),
+            _first("team_id"),
+            _first("team_abbreviation"),
+            _first("team_name"),
+            pl.col("team_abbreviation").sort_by(_by, descending=_desc).str.join(",").alias("teams"),
+        )
         .select(
             pl.col("player_id").cast(pl.Int64),
             pl.col("player_name").cast(pl.Utf8),

--- a/sportsdataverse/nba/nba_box_logs.py
+++ b/sportsdataverse/nba/nba_box_logs.py
@@ -128,3 +128,83 @@ def nba_box_logs(
         season_type_all_star=season_type,
     )
     return {"player": player, "team": team}
+
+
+#: Identity columns :func:`nba_player_identity` emits, in output order.
+PLAYER_IDENTITY_SCHEMA: Dict[str, pl.DataType] = {
+    "player_id": pl.Int64,
+    "player_name": pl.Utf8,
+    "team_id": pl.Int64,
+    "team_abbreviation": pl.Utf8,
+    "team_name": pl.Utf8,
+    "teams": pl.Utf8,
+}
+
+
+def nba_player_identity(player_logs: pl.DataFrame) -> pl.DataFrame:
+    """Human-readable identity for every player in a season's box logs.
+
+    Model outputs key on ``player_id`` alone, which makes them unusable without a
+    second lookup -- a leaderboard reads ``1628983`` instead of
+    ``Shai Gilgeous-Alexander``. This derives the display columns from the season's
+    own game logs, so they are **season-accurate**: a player's team is what he
+    actually played for that year, not his current one (which is what a player
+    directory would give and would silently mislabel every historical season).
+
+    A traded player has rows for several teams. ``team_*`` is his **primary** team
+    by minutes -- the one a reader means when they say "his team that season" --
+    and ``teams`` lists every abbreviation he appeared for, in descending minutes,
+    so a trade is visible rather than silently collapsed.
+
+    Args:
+        player_logs: Per-player-per-game rows from ``leaguegamelog`` (the
+            ``player_or_team="P"`` variant), carrying ``player_id``,
+            ``player_name``, ``team_id``, ``team_abbreviation``, ``team_name``
+            and ``min``.
+
+    Returns:
+        One row per ``player_id`` with :data:`PLAYER_IDENTITY_SCHEMA`. An empty
+        input gives the zero-row frame with that schema, so callers can join
+        unconditionally.
+
+    Example:
+        Attach names to a model output::
+
+            from sportsdataverse.nba import nba_box_logs, nba_player_identity
+            logs = nba_box_logs("2023-24")
+            named = ratings.join(nba_player_identity(logs["player"]), on="player_id", how="left")
+
+        See Also:
+            * `nba_api`_ -- reference Python client for stats.nba.com
+            * `hoopR`_ -- R companion package for NBA/MBB data
+
+        .. _nba_api: https://github.com/swar/nba_api
+        .. _hoopR: https://hoopR.sportsdataverse.org
+    """
+    need = {"player_id", "player_name", "team_id", "team_abbreviation", "team_name"}
+    if player_logs.is_empty() or not need.issubset(set(player_logs.columns)):
+        return pl.DataFrame(schema=PLAYER_IDENTITY_SCHEMA)
+
+    minutes = pl.col("min") if "min" in player_logs.columns else pl.lit(0.0)
+    per_team = (
+        player_logs.with_columns(minutes.fill_null(0.0).cast(pl.Float64).alias("_min"))
+        .group_by(["player_id", "team_id", "team_abbreviation", "team_name"])
+        .agg(pl.col("_min").sum().alias("_team_min"), pl.col("player_name").last().alias("player_name"))
+        # Ties would otherwise resolve by group_by's nondeterministic output order,
+        # so break them on team_id to keep a rebuild byte-identical.
+        .sort(["player_id", "_team_min", "team_id"], descending=[False, True, False])
+    )
+    primary = per_team.group_by("player_id").first()
+    teams = per_team.group_by("player_id").agg(pl.col("team_abbreviation").str.join(",").alias("teams"))
+    return (
+        primary.join(teams, on="player_id", how="left")
+        .select(
+            pl.col("player_id").cast(pl.Int64),
+            pl.col("player_name").cast(pl.Utf8),
+            pl.col("team_id").cast(pl.Int64),
+            pl.col("team_abbreviation").cast(pl.Utf8),
+            pl.col("team_name").cast(pl.Utf8),
+            pl.col("teams").cast(pl.Utf8),
+        )
+        .sort("player_id")
+    )

--- a/sportsdataverse/nba/nba_loaders.py
+++ b/sportsdataverse/nba/nba_loaders.py
@@ -1028,6 +1028,11 @@ def load_nba_player_impact(seasons, return_as_pandas: bool = False):
         |col_name               |type    |
         |:----------------------|:-------|
         |player_id              |Int64   |
+        |player_name            |Utf8    |
+        |team_id                |Int64   |
+        |team_abbreviation      |Utf8    |
+        |team_name              |Utf8    |
+        |teams                  |Utf8    |
         |o_rapm                 |Float64 |
         |d_rapm                 |Float64 |
         |rapm                   |Float64 |

--- a/sportsdataverse/parsed/nba.py
+++ b/sportsdataverse/parsed/nba.py
@@ -250,6 +250,7 @@ from sportsdataverse.nba import nba_matchup_drapm as nba_matchup_drapm  # noqa: 
 from sportsdataverse.nba import nba_pbp_disk as nba_pbp_disk  # noqa: F401
 from sportsdataverse.nba import nba_play_context as nba_play_context  # noqa: F401
 from sportsdataverse.nba import nba_player_ages as nba_player_ages  # noqa: F401
+from sportsdataverse.nba import nba_player_identity as nba_player_identity  # noqa: F401
 from sportsdataverse.nba import nba_player_positions as nba_player_positions  # noqa: F401
 from sportsdataverse.nba import nba_player_props as nba_player_props  # noqa: F401
 from sportsdataverse.nba import nba_playtype_ratings as nba_playtype_ratings  # noqa: F401
@@ -530,6 +531,7 @@ __all__ = [
     "nba_pbp_disk",
     "nba_play_context",
     "nba_player_ages",
+    "nba_player_identity",
     "nba_player_positions",
     "nba_player_props",
     "nba_playtype_ratings",

--- a/tests/nba/test_nba_box_logs.py
+++ b/tests/nba/test_nba_box_logs.py
@@ -172,3 +172,52 @@ def test_full_game_player_gets_the_teams_possessions():
     # 30 points over the team's ~100 possessions -> ~30 per 100, not ~150
     assert bf["pts"][0] == pytest.approx(30 / team_poss * 100, rel=1e-9)
     assert 25.0 < bf["pts"][0] < 35.0, "per-100 scoring outside any plausible NBA range"
+
+
+def _idlogs():
+    """Two players; one traded mid-season (more minutes with the second team)."""
+    import polars as pl
+
+    return pl.DataFrame(
+        {
+            "game_id": ["G1", "G2", "G3", "G1"],
+            "player_id": [10, 10, 10, 20],
+            "player_name": ["Traded Guy", "Traded Guy", "Traded Guy", "Stayer"],
+            "team_id": [1, 1, 2, 3],
+            "team_abbreviation": ["AAA", "AAA", "BBB", "CCC"],
+            "team_name": ["Alpha Aces", "Alpha Aces", "Beta Bears", "Gamma Cats"],
+            "min": [10.0, 10.0, 30.0, 25.0],
+        }
+    )
+
+
+def test_player_identity_primary_team_is_by_minutes_and_lists_all():
+    """A trade must be visible, not silently collapsed: team_* is the team the
+    player actually spent most minutes with, and `teams` shows every stop."""
+    from sportsdataverse.nba.nba_box_logs import nba_player_identity
+
+    out = nba_player_identity(_idlogs())
+    assert out.height == 2
+    traded = out.filter(out["player_id"] == 10).to_dicts()[0]
+    # 30 minutes with BBB beats 20 with AAA -> BBB is primary
+    assert traded["team_abbreviation"] == "BBB"
+    assert traded["team_name"] == "Beta Bears"
+    assert traded["teams"] == "BBB,AAA"  # descending minutes
+    assert traded["player_name"] == "Traded Guy"
+    stayer = out.filter(out["player_id"] == 20).to_dicts()[0]
+    assert stayer["teams"] == "CCC" and stayer["team_name"] == "Gamma Cats"
+
+
+def test_player_identity_empty_and_missing_columns_give_typed_frame():
+    """Callers join this unconditionally, so a bad input must not raise."""
+    import polars as pl
+
+    from sportsdataverse.nba.nba_box_logs import (
+        PLAYER_IDENTITY_SCHEMA,
+        nba_player_identity,
+    )
+
+    for bad in (pl.DataFrame(), pl.DataFrame({"player_id": [1]})):
+        out = nba_player_identity(bad)
+        assert out.height == 0
+        assert out.columns == list(PLAYER_IDENTITY_SCHEMA)

--- a/tests/nba/test_nba_box_logs.py
+++ b/tests/nba/test_nba_box_logs.py
@@ -209,7 +209,14 @@ def test_player_identity_primary_team_is_by_minutes_and_lists_all():
 
 
 def test_player_identity_empty_and_missing_columns_give_typed_frame():
-    """Callers join this unconditionally, so a bad input must not raise."""
+    """Callers join this unconditionally, so a bad input must not raise -- and the
+    frame must carry the DTYPES too, or a downstream join on player_id silently
+    mismatches on a Null column instead of failing loudly.
+
+    A frame missing ``min`` is malformed, not merely minute-less: aggregating it
+    would total zero minutes for every team and pick a "primary" team by team_id
+    order -- a wrong answer wearing the shape of a right one.
+    """
     import polars as pl
 
     from sportsdataverse.nba.nba_box_logs import (
@@ -217,7 +224,42 @@ def test_player_identity_empty_and_missing_columns_give_typed_frame():
         nba_player_identity,
     )
 
-    for bad in (pl.DataFrame(), pl.DataFrame({"player_id": [1]})):
+    complete = _idlogs()
+    for bad in (
+        pl.DataFrame(),
+        pl.DataFrame({"player_id": [1]}),
+        complete.drop("min"),  # the silent-degradation case
+        complete.drop("team_name"),
+    ):
         out = nba_player_identity(bad)
         assert out.height == 0
-        assert out.columns == list(PLAYER_IDENTITY_SCHEMA)
+        assert dict(out.schema) == PLAYER_IDENTITY_SCHEMA
+
+
+def test_player_identity_primary_team_does_not_depend_on_group_order():
+    """The primary pick and the `teams` order must come from an explicit sort, not
+    from group_by happening to preserve a prior one -- polars only guarantees that
+    with maintain_order, so relying on it is undocumented behaviour that holds
+    until it doesn't."""
+    import polars as pl
+
+    from sportsdataverse.nba.nba_box_logs import nba_player_identity
+
+    n = 200
+    logs = pl.DataFrame(
+        {
+            "game_id": [f"G{i}" for i in range(n) for _ in (0, 1)],
+            "player_id": [i for i in range(n) for _ in (0, 1)],
+            "player_name": [f"P{i}" for i in range(n) for _ in (0, 1)],
+            # the HIGH-minutes team deliberately carries the LOWER team_id, so a
+            # team_id-ordered fallback would pick the wrong club
+            "team_id": [t for _ in range(n) for t in (900, 100)],
+            "team_abbreviation": [a for _ in range(n) for a in ("HI", "LO")],
+            "team_name": [t for _ in range(n) for t in ("High Id", "Low Id")],
+            "min": [m for _ in range(n) for m in (5.0, 50.0)],
+        }
+    )
+    out = nba_player_identity(logs)
+    assert out.height == n
+    assert out.filter(pl.col("team_abbreviation") != "LO").height == 0
+    assert out.filter(pl.col("teams") != "LO,HI").height == 0

--- a/tests/nba/test_nba_loaders.py
+++ b/tests/nba/test_nba_loaders.py
@@ -17,6 +17,13 @@ from sportsdataverse.nba import nba_loaders
 # with tools/codegen/schemas/loader_schemas.yaml::load_nba_player_impact.
 _IMPACT_SCHEMA = {
     "player_id": pl.Int64,
+    # Identity columns are part of the published contract: a fixture without them
+    # lets the round-trip test pass while the release has changed underneath it.
+    "player_name": pl.Utf8,
+    "team_id": pl.Int64,
+    "team_abbreviation": pl.Utf8,
+    "team_name": pl.Utf8,
+    "teams": pl.Utf8,
     "o_rapm": pl.Float64,
     "d_rapm": pl.Float64,
     "rapm": pl.Float64,
@@ -42,9 +49,11 @@ _IMPACT_SCHEMA = {
 
 
 def _impact_row(season: int) -> pl.DataFrame:
-    return pl.DataFrame({c: pl.Series([0], dtype=t) for c, t in _IMPACT_SCHEMA.items()}).with_columns(
-        pl.lit(season, dtype=pl.Int64).alias("season")
-    )
+    # Seed each column with a value of its OWN dtype -- a hardcoded 0 cannot build
+    # the Utf8 identity columns.
+    return pl.DataFrame(
+        {c: pl.Series(["x"] if t == pl.Utf8 else [0], dtype=t) for c, t in _IMPACT_SCHEMA.items()}
+    ).with_columns(pl.lit(season, dtype=pl.Int64).alias("season"))
 
 
 def test_load_nba_player_impact_round_trips_schema(monkeypatch):

--- a/tools/codegen/schemas/loader_schemas.yaml
+++ b/tools/codegen/schemas/loader_schemas.yaml
@@ -4458,6 +4458,16 @@ load_nba_player_boxscore:
 load_nba_player_impact:
 - name: player_id
   type: Int64
+- name: player_name
+  type: Utf8
+- name: team_id
+  type: Int64
+- name: team_abbreviation
+  type: Utf8
+- name: team_name
+  type: Utf8
+- name: teams
+  type: Utf8
 - name: o_rapm
   type: Float64
 - name: d_rapm


### PR DESCRIPTION
`nba_player_impact` shipped as a wall of `player_id`s. Validating it, the WAR leaderboard read `1628983` and I had to recognise the number to know it was Shai Gilgeous-Alexander — every consumer would have to rebuild the same crosswalk.

## What

`nba_player_identity()` derives `player_name`, `team_id`, `team_abbreviation`, `team_name` and `teams` from a season's own game logs.

Two consequences follow from that source choice:

- **Season-accurate.** A player *directory* reports whoever the player suits up for **today**, which would mislabel every historical season. Taking it from that season's logs means 1996-97 correctly reads *Michael Jordan / CHI / Chicago Bulls*.
- **Trades stay visible.** `team_*` is the club he logged the most minutes for; `teams` lists each stop in descending minutes (`"MIA,PHI"`) rather than collapsing to one and losing the other. Verified against Kyle Lowry and P.J. Tucker 2023-24.

Ties in the minutes sort break on `team_id` — `group_by` output order alone is not deterministic, so without that a rebuild would not be byte-identical.

Empty or missing-column input returns the typed zero-row frame, so callers can join unconditionally.

## Published result

30 seasons rebuilt and republished; verified through the live loader:

```
1997: Michael Jordan          CHI  Chicago Bulls          32.3 WAR
2025: Shai Gilgeous-Alexander OKC  Oklahoma City Thunder  21.9 WAR
```

Name coverage is complete except **4 rows of 20,660** (1997, 2018) that appear in possession lineups but have no box-log rows at all (`min`/`gp` are null too). That is an upstream gap, and they are left null rather than dropped — losing a player who has a real RAPM would be worse than an honest null.

## Note

The documented schema is edited in `tools/codegen/schemas/loader_schemas.yaml`. `nba_loaders.py` is generated and marked `DO NOT EDIT` — I edited it first and the next codegen run silently reverted it.

`704 passed`; ruff + mypy clean. Producer side: sportsdataverse/hoopR-nba-stats-data.

## Summary by Sourcery

Add a helper to derive season-accurate player and team identity metadata from NBA box logs and expose it in RAPM model outputs.

New Features:
- Introduce nba_player_identity helper to compute human-readable player and team identity columns from per-game box logs.
- Expose PLAYER_IDENTITY_SCHEMA and nba_player_identity through the public NBA module and parsed namespace.
- Augment nba_player_impact loader outputs with player_name and team-level identity columns for easier downstream use.

Enhancements:
- Document nba_player_identity in the NBA additional reference and update loader documentation to describe the enriched nba_player_impact schema.
- Increase the documented count of additional NBA helper functions to reflect the new API.

Tests:
- Add tests covering traded-player handling, ordering, and empty/malformed-input behavior for nba_player_identity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added NBA player identity enrichment that returns season-accurate player identity with player name and team details.
  - Correctly handles traded players by selecting a “primary” team by minutes and listing all teams played for in minutes order.
  - Exposed via the main NBA API and the legacy deprecated namespace.

- **Documentation**
  - Documented the new identity function and its input requirements and behavior for empty/missing-column inputs.
  - Updated `load_nba_player_impact` return schema to include player and team fields.
  - Updated NBA API function summary count.

- **Tests**
  - Added and strengthened identity and loader schema validation tests (including ordering and typed empty-frame behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->