### PR TITLE
fix(nba): scan all rows when inferring result-set schemas

### DIFF
--- a/sportsdataverse/nba/nba_stats_parsers.py
+++ b/sportsdataverse/nba/nba_stats_parsers.py
@@ -141,7 +141,13 @@ def _to_frame(rs: dict) -> pl.DataFrame:
     norm = [r for r in norm if len(r) == len(headers)]
     if norm:
         try:
-            return pl.DataFrame(norm, schema=headers, orient="row")
+            # infer_schema_length=None scans EVERY row before choosing dtypes.
+            # The default (100) infers Null for a column whose first rows are
+            # all null, then errors when a real value appears deeper in the
+            # rowSet — and the except below would silently turn a 3k-row
+            # payload into an empty frame (observed: WNBA 1998 leaguegamelog,
+            # PLUS_MINUS null until late in the season).
+            return pl.DataFrame(norm, schema=headers, orient="row", infer_schema_length=None)
         except Exception:
             pass
     return pl.DataFrame(schema={h: pl.Utf8 for h in headers})

--- a/tests/nba/test_nba_stats_parsers.py
+++ b/tests/nba/test_nba_stats_parsers.py
@@ -84,3 +84,16 @@ def test_parse_ragged_rows_returns_zero_row_frame():
     raw = {"resultSets": [{"name": "X", "headers": ["A", "B"], "rowSet": [[1]]}]}  # row width != headers
     df = parse_nba_stats_result_sets(raw, result_set="X")
     assert isinstance(df, pl.DataFrame) and df.height == 0
+
+
+def test_parse_null_prefix_column_keeps_all_rows():
+    # A column that is null for the first 100+ rows and numeric later must not
+    # collapse the whole set to an empty frame (polars' default
+    # infer_schema_length=100 inferred Null, then errored on the late number
+    # and the never-raise contract swallowed it — observed on the WNBA 1998
+    # leaguegamelog player capture, PLUS_MINUS null until late in the season).
+    rows = [[i, None] for i in range(150)] + [[150, 3.5]]
+    raw = {"resultSets": [{"name": "X", "headers": ["A", "PLUS_MINUS"], "rowSet": rows}]}
+    df = parse_nba_stats_result_sets(raw, result_set="X")
+    assert df.height == 151
+    assert df["plus_minus"][150] == 3.5


### PR DESCRIPTION
## Summary

`parse_nba_stats_result_sets` silently emptied any result set whose column is null for the first 100+ rows and typed later — polars' default `infer_schema_length=100` inferred `Null`, the first late value raised, and the parser's never-raise contract swallowed it into a zero-row frame.

Observed on the real WNBA 1998 `leaguegamelog` player capture (`PLUS_MINUS` null until late in the season): a 2,953-row payload parsed to `(0, 32)`, which made the committed-store read report "no usable frame" and fall through to a live fetch — the parser bug masqueraded as a store miss.

Fix: `infer_schema_length=None` (scan every row before choosing dtypes).

## Tests

- New regression test `test_parse_null_prefix_column_keeps_all_rows` — verified to FAIL on the pre-fix parser and pass with the fix.
- Full `tests/nba/test_nba_stats_parsers.py`: 11/11 pass; codegen `--check` clean.

## Summary by Sourcery

Ensure NBA stats result-set parsing preserves rows when columns start with long null prefixes.

Bug Fixes:
- Prevent parse_nba_stats_result_sets from collapsing non-empty result sets to empty frames when a column is null for the initial rows and typed later.

Tests:
- Add a regression test verifying that result sets with a long initial run of nulls in a numeric column retain all rows and the late non-null value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed NBA statistics parsing so columns with leading null values retain later numeric data.
  * Prevented valid rows from being dropped or truncated during parsing.

* **Tests**
  * Added coverage for long result sets with initially null columns to verify all rows and late values are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->