### PR TITLE
fix(cfb): re-derive the adv_* declared schemas from the shipped data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,10 +226,10 @@ every season).
 | `pos_team` / `def_pos_team` | `Int64` id (`48`) | `String` name (`Ohio State Buckeyes`) |
 | `pos_team_id` / `def_pos_team_id` | — | `Int64` id |
 
-- **Affected tags** (10): `adv_team`, `adv_passing`, `adv_rushing`,
-  `adv_receiving`, `adv_defensive`, `adv_defensive_players`, `adv_turnover`,
-  `adv_drives`, `adv_situational`, `adv_specialists`. The first eight use
-  `pos_team`; `adv_defensive` and `adv_defensive_players` use `def_pos_team`.
+- **Affected tags** (10). Eight carry the offense's team and use `pos_team`:
+  `adv_team`, `adv_passing`, `adv_rushing`, `adv_receiving`, `adv_turnover`,
+  `adv_drives`, `adv_situational`, `adv_specialists`. Two carry the defense's
+  team and use `def_pos_team`: `adv_defensive`, `adv_defensive_players`.
 - **The summaries family was NOT affected** — `cfb_team_summaries`,
   `cfb_passing`, `cfb_rushing`, `cfb_receiving` already shipped `team_id` for
   the id and a readable `pos_team`, so they were deliberately left alone.
@@ -251,8 +251,18 @@ documented schema now matches what the loaders actually return. Beyond the
 - `load_cfb_adv_passing` was missing `xComp`, `CompPct`, `xCompPct`, `CPOE`,
   and declared `rush_epa` / `pen_epa` as `Null` rather than `Float64`.
 - `load_cfb_adv_defensive_players` was missing `sacks`, `sacks_yards`,
-  `pass_breakups`, `interceptions`, `interceptions_yards`, `forced_fumbles`
-  (present from 2014 on; 2004 legitimately ships the narrower 8-column shape).
+  `pass_breakups`, `forced_fumbles`, `interceptions`, `interceptions_yards`.
+
+  This block's shape **ramps in two steps**, so the union is the only honest
+  declaration. Columns absent in a requested season come back null (the loaders
+  concatenate diagonally), so a 2004–2025 pull is uniform in shape but sparse in
+  the early years:
+
+  | seasons | cols | shape |
+  |---|---|---|
+  | 2004 | 8 | fumble recoveries only |
+  | 2005–2013 | 12 | `+ sacks, sacks_yards, pass_breakups, forced_fumbles` |
+  | 2014–2025 | 14 | `+ interceptions, interceptions_yards` |
 
 `loader_schemas.yaml` drives the generated returns tables only — nothing casts
 from it — so this drift was invisible to the test suite and surfaced purely as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
+- [Unreleased](#unreleased)
+  - [CFB — `adv_*` `pos_team` now holds the team NAME, id moves to `pos_team_id` (BREAKING data change)](#cfb--adv_-pos_team-now-holds-the-team-name-id-moves-to-pos_team_id-breaking-data-change)
+  - [CFB — `adv_*` declared schemas re-derived from the shipped data](#cfb--adv_-declared-schemas-re-derived-from-the-shipped-data)
 - [0.0.73 Release: August 1, 2026](#0073-release-august-1-2026)
   - [CFB — pre-2014 `{type}_player_id` join recovered (2004 +36pp, 2005–2013 +2–8pp)](#cfb--pre-2014-type_player_id-join-recovered-2004-36pp-20052013-28pp)
   - [CFB — `adj_off/def/net` rescaled to the R `adjust_epa` netted statistic (BREAKING scale change)](#cfb--adj_offdefnet-rescaled-to-the-r-adjust_epa-netted-statistic-breaking-scale-change)
@@ -203,6 +206,58 @@
 - [0.0.5 Release: October 20, 2021](#005-release-october-20-2021)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Unreleased
+
+### CFB — `adv_*` `pos_team` now holds the team NAME, id moves to `pos_team_id` (BREAKING data change)
+
+ESPN's `advBoxScore` blocks put a **team id in a name-shaped column**. Verified
+against the published assets rather than assumed: all **235/235** distinct
+`pos_team` values in `adv_team` 2024 resolve to real teams.
+
+The producer (`cfbfastR-cfb-data`) now surfaces the id as `pos_team_id` /
+`def_pos_team_id` and fills the original column with the display name, so each
+column means what it is named. **All 10 `adv_*` tags have been rebuilt and
+republished for 2004–2025** (220 assets, 0 failures, 100% name resolution on
+every season).
+
+| | before | after |
+|---|---|---|
+| `pos_team` / `def_pos_team` | `Int64` id (`48`) | `String` name (`Ohio State Buckeyes`) |
+| `pos_team_id` / `def_pos_team_id` | — | `Int64` id |
+
+- **Affected tags** (10): `adv_team`, `adv_passing`, `adv_rushing`,
+  `adv_receiving`, `adv_defensive`, `adv_defensive_players`, `adv_turnover`,
+  `adv_drives`, `adv_situational`, `adv_specialists`. The first eight use
+  `pos_team`; `adv_defensive` and `adv_defensive_players` use `def_pos_team`.
+- **The summaries family was NOT affected** — `cfb_team_summaries`,
+  `cfb_passing`, `cfb_rushing`, `cfb_receiving` already shipped `team_id` for
+  the id and a readable `pos_team`, so they were deliberately left alone.
+- **Cross-family joins need a cast.** The two families spell this differently:
+  summaries uses `team_id` (**String**), `adv_*` uses `pos_team_id`
+  (**Int64**). Joining `cfb_team_summaries.team_id` to `adv_team.pos_team_id`
+  without casting matches nothing, silently.
+- **`espn_cfb_adv_team_gamelog` was rebuilt** for 2004–2025 off the new shape;
+  it continues to expose `team_id` + a readable `team` / `opponent`, so its
+  consumers see no change.
+
+### CFB — `adv_*` declared schemas re-derived from the shipped data
+
+The declared returns tables for all 10 `adv_*` loaders are regenerated from a
+diagonal union of real published seasons (2004/2014/2024/2025), so the
+documented schema now matches what the loaders actually return. Beyond the
+`pos_team` split this closes **pre-existing drift** the audit surfaced:
+
+- `load_cfb_adv_passing` was missing `xComp`, `CompPct`, `xCompPct`, `CPOE`,
+  and declared `rush_epa` / `pen_epa` as `Null` rather than `Float64`.
+- `load_cfb_adv_defensive_players` was missing `sacks`, `sacks_yards`,
+  `pass_breakups`, `interceptions`, `interceptions_yards`, `forced_fumbles`
+  (present from 2014 on; 2004 legitimately ships the narrower 8-column shape).
+
+`loader_schemas.yaml` drives the generated returns tables only — nothing casts
+from it — so this drift was invisible to the test suite and surfaced purely as
+incorrect published documentation. Declared-vs-shipped now diffs clean for all
+10.
 
 ## 0.0.73 Release: August 1, 2026
 

--- a/docs/docs/cfb/reference/loaders.md
+++ b/docs/docs/cfb/reference/loaders.md
@@ -975,7 +975,8 @@ Release: [espn_cfb_adv_team](https://github.com/sportsdataverse/sportsdataverse-
 
 | col_name | type |
 |---|---|
-| `pos_team` | Int64 |
+| `pos_team_id` | Int64 |
+| `pos_team` | String |
 | `rushing_highlight_yards_per_opp` | Float64 |
 | `total_pen_yards` | Int64 |
 | `EPA_penalty` | Float64 |
@@ -1066,10 +1067,12 @@ Release: [espn_cfb_adv_passing](https://github.com/sportsdataverse/sportsdataver
 
 | col_name | type |
 |---|---|
-| `pos_team` | Int64 |
+| `pos_team_id` | Int64 |
+| `pos_team` | String |
 | `passer_player_name` | String |
 | `Comp` | Int64 |
 | `Att` | Int64 |
+| `xComp` | Float64 |
 | `Yds` | Float64 |
 | `Pass_TD` | Int64 |
 | `Int` | Int64 |
@@ -1079,11 +1082,14 @@ Release: [espn_cfb_adv_passing](https://github.com/sportsdataverse/sportsdataver
 | `WPA` | Float64 |
 | `SR` | Float64 |
 | `Sck` | Int64 |
+| `CompPct` | Float64 |
+| `xCompPct` | Float64 |
+| `CPOE` | Float64 |
 | `qbr_epa` | Float64 |
 | `sack_epa` | Float64 |
 | `pass_epa` | Float64 |
-| `rush_epa` | Null |
-| `pen_epa` | Null |
+| `rush_epa` | Float64 |
+| `pen_epa` | Float64 |
 | `spread` | Float64 |
 | `era0` | Int64 |
 | `era1` | Int64 |
@@ -1105,7 +1111,8 @@ Release: [espn_cfb_adv_rushing](https://github.com/sportsdataverse/sportsdataver
 
 | col_name | type |
 |---|---|
-| `pos_team` | Int64 |
+| `pos_team_id` | Int64 |
+| `pos_team` | String |
 | `rusher_player_name` | String |
 | `Car` | Int64 |
 | `Yds` | Float64 |
@@ -1132,7 +1139,8 @@ Release: [espn_cfb_adv_receiving](https://github.com/sportsdataverse/sportsdatav
 
 | col_name | type |
 |---|---|
-| `pos_team` | Int64 |
+| `pos_team_id` | Int64 |
+| `pos_team` | String |
 | `receiver_player_name` | String |
 | `Rec` | Int64 |
 | `Tar` | Int64 |
@@ -1160,7 +1168,8 @@ Release: [espn_cfb_adv_defensive](https://github.com/sportsdataverse/sportsdatav
 
 | col_name | type |
 |---|---|
-| `def_pos_team` | Int64 |
+| `def_pos_team_id` | Int64 |
+| `def_pos_team` | String |
 | `scrimmage_plays` | Int64 |
 | `TFL` | Int64 |
 | `TFL_pass` | Int64 |
@@ -1193,13 +1202,20 @@ Release: [espn_cfb_adv_defensive_players](https://github.com/sportsdataverse/spo
 
 | col_name | type |
 |---|---|
-| `def_pos_team` | Int64 |
+| `def_pos_team_id` | Int64 |
+| `def_pos_team` | String |
 | `player_name` | String |
 | `fumble_recoveries` | Int64 |
 | `fumble_recoveries_yards` | Int64 |
 | `game_id` | Int64 |
 | `season` | Int64 |
 | `week` | Int64 |
+| `sacks` | Int64 |
+| `sacks_yards` | Int64 |
+| `pass_breakups` | Int64 |
+| `forced_fumbles` | Int64 |
+| `interceptions` | Int64 |
+| `interceptions_yards` | Int64 |
 
 ```python
 load_cfb_adv_defensive_players(seasons=2024)
@@ -1212,7 +1228,8 @@ Release: [espn_cfb_adv_drives](https://github.com/sportsdataverse/sportsdatavers
 
 | col_name | type |
 |---|---|
-| `pos_team` | Int64 |
+| `pos_team_id` | Int64 |
+| `pos_team` | String |
 | `drive_total_available_yards` | Float64 |
 | `drive_total_gained_yards` | Int64 |
 | `avg_field_position` | Float64 |
@@ -1235,7 +1252,8 @@ Release: [espn_cfb_adv_situational](https://github.com/sportsdataverse/sportsdat
 
 | col_name | type |
 |---|---|
-| `pos_team` | Int64 |
+| `pos_team_id` | Int64 |
+| `pos_team` | String |
 | `EPA_success` | Int64 |
 | `EPA_success_rate` | Float64 |
 | `EPA_success_pass` | Int64 |
@@ -1320,7 +1338,8 @@ Release: [espn_cfb_adv_specialists](https://github.com/sportsdataverse/sportsdat
 
 | col_name | type |
 |---|---|
-| `pos_team` | Int64 |
+| `pos_team_id` | Int64 |
+| `pos_team` | String |
 | `player_name` | String |
 | `punts` | Int64 |
 | `punts_yards` | Int64 |
@@ -1345,7 +1364,8 @@ Release: [espn_cfb_adv_turnover](https://github.com/sportsdataverse/sportsdatave
 
 | col_name | type |
 |---|---|
-| `pos_team` | Int64 |
+| `pos_team_id` | Int64 |
+| `pos_team` | String |
 | `turnovers` | Int64 |
 | `st_turnovers_lost` | Int64 |
 | `Int` | Int64 |

--- a/docs/src/pages/CHANGELOG.md
+++ b/docs/src/pages/CHANGELOG.md
@@ -226,10 +226,10 @@ every season).
 | `pos_team` / `def_pos_team` | `Int64` id (`48`) | `String` name (`Ohio State Buckeyes`) |
 | `pos_team_id` / `def_pos_team_id` | — | `Int64` id |
 
-- **Affected tags** (10): `adv_team`, `adv_passing`, `adv_rushing`,
-  `adv_receiving`, `adv_defensive`, `adv_defensive_players`, `adv_turnover`,
-  `adv_drives`, `adv_situational`, `adv_specialists`. The first eight use
-  `pos_team`; `adv_defensive` and `adv_defensive_players` use `def_pos_team`.
+- **Affected tags** (10). Eight carry the offense's team and use `pos_team`:
+  `adv_team`, `adv_passing`, `adv_rushing`, `adv_receiving`, `adv_turnover`,
+  `adv_drives`, `adv_situational`, `adv_specialists`. Two carry the defense's
+  team and use `def_pos_team`: `adv_defensive`, `adv_defensive_players`.
 - **The summaries family was NOT affected** — `cfb_team_summaries`,
   `cfb_passing`, `cfb_rushing`, `cfb_receiving` already shipped `team_id` for
   the id and a readable `pos_team`, so they were deliberately left alone.
@@ -251,8 +251,18 @@ documented schema now matches what the loaders actually return. Beyond the
 - `load_cfb_adv_passing` was missing `xComp`, `CompPct`, `xCompPct`, `CPOE`,
   and declared `rush_epa` / `pen_epa` as `Null` rather than `Float64`.
 - `load_cfb_adv_defensive_players` was missing `sacks`, `sacks_yards`,
-  `pass_breakups`, `interceptions`, `interceptions_yards`, `forced_fumbles`
-  (present from 2014 on; 2004 legitimately ships the narrower 8-column shape).
+  `pass_breakups`, `forced_fumbles`, `interceptions`, `interceptions_yards`.
+
+  This block's shape **ramps in two steps**, so the union is the only honest
+  declaration. Columns absent in a requested season come back null (the loaders
+  concatenate diagonally), so a 2004–2025 pull is uniform in shape but sparse in
+  the early years:
+
+  | seasons | cols | shape |
+  |---|---|---|
+  | 2004 | 8 | fumble recoveries only |
+  | 2005–2013 | 12 | `+ sacks, sacks_yards, pass_breakups, forced_fumbles` |
+  | 2014–2025 | 14 | `+ interceptions, interceptions_yards` |
 
 `loader_schemas.yaml` drives the generated returns tables only — nothing casts
 from it — so this drift was invisible to the test suite and surfaced purely as

--- a/docs/src/pages/CHANGELOG.md
+++ b/docs/src/pages/CHANGELOG.md
@@ -2,6 +2,9 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
+- [Unreleased](#unreleased)
+  - [CFB — `adv_*` `pos_team` now holds the team NAME, id moves to `pos_team_id` (BREAKING data change)](#cfb--adv_-pos_team-now-holds-the-team-name-id-moves-to-pos_team_id-breaking-data-change)
+  - [CFB — `adv_*` declared schemas re-derived from the shipped data](#cfb--adv_-declared-schemas-re-derived-from-the-shipped-data)
 - [0.0.73 Release: August 1, 2026](#0073-release-august-1-2026)
   - [CFB — pre-2014 `{type}_player_id` join recovered (2004 +36pp, 2005–2013 +2–8pp)](#cfb--pre-2014-type_player_id-join-recovered-2004-36pp-20052013-28pp)
   - [CFB — `adj_off/def/net` rescaled to the R `adjust_epa` netted statistic (BREAKING scale change)](#cfb--adj_offdefnet-rescaled-to-the-r-adjust_epa-netted-statistic-breaking-scale-change)
@@ -203,6 +206,58 @@
 - [0.0.5 Release: October 20, 2021](#005-release-october-20-2021)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Unreleased
+
+### CFB — `adv_*` `pos_team` now holds the team NAME, id moves to `pos_team_id` (BREAKING data change)
+
+ESPN's `advBoxScore` blocks put a **team id in a name-shaped column**. Verified
+against the published assets rather than assumed: all **235/235** distinct
+`pos_team` values in `adv_team` 2024 resolve to real teams.
+
+The producer (`cfbfastR-cfb-data`) now surfaces the id as `pos_team_id` /
+`def_pos_team_id` and fills the original column with the display name, so each
+column means what it is named. **All 10 `adv_*` tags have been rebuilt and
+republished for 2004–2025** (220 assets, 0 failures, 100% name resolution on
+every season).
+
+| | before | after |
+|---|---|---|
+| `pos_team` / `def_pos_team` | `Int64` id (`48`) | `String` name (`Ohio State Buckeyes`) |
+| `pos_team_id` / `def_pos_team_id` | — | `Int64` id |
+
+- **Affected tags** (10): `adv_team`, `adv_passing`, `adv_rushing`,
+  `adv_receiving`, `adv_defensive`, `adv_defensive_players`, `adv_turnover`,
+  `adv_drives`, `adv_situational`, `adv_specialists`. The first eight use
+  `pos_team`; `adv_defensive` and `adv_defensive_players` use `def_pos_team`.
+- **The summaries family was NOT affected** — `cfb_team_summaries`,
+  `cfb_passing`, `cfb_rushing`, `cfb_receiving` already shipped `team_id` for
+  the id and a readable `pos_team`, so they were deliberately left alone.
+- **Cross-family joins need a cast.** The two families spell this differently:
+  summaries uses `team_id` (**String**), `adv_*` uses `pos_team_id`
+  (**Int64**). Joining `cfb_team_summaries.team_id` to `adv_team.pos_team_id`
+  without casting matches nothing, silently.
+- **`espn_cfb_adv_team_gamelog` was rebuilt** for 2004–2025 off the new shape;
+  it continues to expose `team_id` + a readable `team` / `opponent`, so its
+  consumers see no change.
+
+### CFB — `adv_*` declared schemas re-derived from the shipped data
+
+The declared returns tables for all 10 `adv_*` loaders are regenerated from a
+diagonal union of real published seasons (2004/2014/2024/2025), so the
+documented schema now matches what the loaders actually return. Beyond the
+`pos_team` split this closes **pre-existing drift** the audit surfaced:
+
+- `load_cfb_adv_passing` was missing `xComp`, `CompPct`, `xCompPct`, `CPOE`,
+  and declared `rush_epa` / `pen_epa` as `Null` rather than `Float64`.
+- `load_cfb_adv_defensive_players` was missing `sacks`, `sacks_yards`,
+  `pass_breakups`, `interceptions`, `interceptions_yards`, `forced_fumbles`
+  (present from 2014 on; 2004 legitimately ships the narrower 8-column shape).
+
+`loader_schemas.yaml` drives the generated returns tables only — nothing casts
+from it — so this drift was invisible to the test suite and surfaced purely as
+incorrect published documentation. Declared-vs-shipped now diffs clean for all
+10.
 
 ## 0.0.73 Release: August 1, 2026
 

--- a/sportsdataverse/cfb/cfb_loaders.py
+++ b/sportsdataverse/cfb/cfb_loaders.py
@@ -1433,7 +1433,8 @@ def load_cfb_adv_team(seasons, return_as_pandas: bool = False):
 
         |col_name                           |type    |
         |:----------------------------------|:-------|
-        |pos_team                           |Int64   |
+        |pos_team_id                        |Int64   |
+        |pos_team                           |String  |
         |rushing_highlight_yards_per_opp    |Float64 |
         |total_pen_yards                    |Int64   |
         |EPA_penalty                        |Float64 |
@@ -1552,10 +1553,12 @@ def load_cfb_adv_passing(seasons, return_as_pandas: bool = False):
 
         |col_name           |type    |
         |:------------------|:-------|
-        |pos_team           |Int64   |
+        |pos_team_id        |Int64   |
+        |pos_team           |String  |
         |passer_player_name |String  |
         |Comp               |Int64   |
         |Att                |Int64   |
+        |xComp              |Float64 |
         |Yds                |Float64 |
         |Pass_TD            |Int64   |
         |Int                |Int64   |
@@ -1565,11 +1568,14 @@ def load_cfb_adv_passing(seasons, return_as_pandas: bool = False):
         |WPA                |Float64 |
         |SR                 |Float64 |
         |Sck                |Int64   |
+        |CompPct            |Float64 |
+        |xCompPct           |Float64 |
+        |CPOE               |Float64 |
         |qbr_epa            |Float64 |
         |sack_epa           |Float64 |
         |pass_epa           |Float64 |
-        |rush_epa           |Null    |
-        |pen_epa            |Null    |
+        |rush_epa           |Float64 |
+        |pen_epa            |Float64 |
         |spread             |Float64 |
         |era0               |Int64   |
         |era1               |Int64   |
@@ -1619,7 +1625,8 @@ def load_cfb_adv_rushing(seasons, return_as_pandas: bool = False):
 
         |col_name           |type    |
         |:------------------|:-------|
-        |pos_team           |Int64   |
+        |pos_team_id        |Int64   |
+        |pos_team           |String  |
         |rusher_player_name |String  |
         |Car                |Int64   |
         |Yds                |Float64 |
@@ -1674,7 +1681,8 @@ def load_cfb_adv_receiving(seasons, return_as_pandas: bool = False):
 
         |col_name             |type    |
         |:--------------------|:-------|
-        |pos_team             |Int64   |
+        |pos_team_id          |Int64   |
+        |pos_team             |String  |
         |receiver_player_name |String  |
         |Rec                  |Int64   |
         |Tar                  |Int64   |
@@ -1730,7 +1738,8 @@ def load_cfb_adv_defensive(seasons, return_as_pandas: bool = False):
 
         |col_name              |type    |
         |:---------------------|:-------|
-        |def_pos_team          |Int64   |
+        |def_pos_team_id       |Int64   |
+        |def_pos_team          |String  |
         |scrimmage_plays       |Int64   |
         |TFL                   |Int64   |
         |TFL_pass              |Int64   |
@@ -1791,13 +1800,20 @@ def load_cfb_adv_defensive_players(seasons, return_as_pandas: bool = False):
 
         |col_name                |type   |
         |:-----------------------|:------|
-        |def_pos_team            |Int64  |
+        |def_pos_team_id         |Int64  |
+        |def_pos_team            |String |
         |player_name             |String |
         |fumble_recoveries       |Int64  |
         |fumble_recoveries_yards |Int64  |
         |game_id                 |Int64  |
         |season                  |Int64  |
         |week                    |Int64  |
+        |sacks                   |Int64  |
+        |sacks_yards             |Int64  |
+        |pass_breakups           |Int64  |
+        |forced_fumbles          |Int64  |
+        |interceptions           |Int64  |
+        |interceptions_yards     |Int64  |
 
     Example:
         Quick start::
@@ -1838,7 +1854,8 @@ def load_cfb_adv_drives(seasons, return_as_pandas: bool = False):
 
         |col_name                      |type    |
         |:-----------------------------|:-------|
-        |pos_team                      |Int64   |
+        |pos_team_id                   |Int64   |
+        |pos_team                      |String  |
         |drive_total_available_yards   |Float64 |
         |drive_total_gained_yards      |Int64   |
         |avg_field_position            |Float64 |
@@ -1889,7 +1906,8 @@ def load_cfb_adv_situational(seasons, return_as_pandas: bool = False):
 
         |col_name                         |type    |
         |:--------------------------------|:-------|
-        |pos_team                         |Int64   |
+        |pos_team_id                      |Int64   |
+        |pos_team                         |String  |
         |EPA_success                      |Int64   |
         |EPA_success_rate                 |Float64 |
         |EPA_success_pass                 |Int64   |
@@ -2002,7 +2020,8 @@ def load_cfb_adv_specialists(seasons, return_as_pandas: bool = False):
 
         |col_name           |type   |
         |:------------------|:------|
-        |pos_team           |Int64  |
+        |pos_team_id        |Int64  |
+        |pos_team           |String |
         |player_name        |String |
         |punts              |Int64  |
         |punts_yards        |Int64  |
@@ -2055,7 +2074,8 @@ def load_cfb_adv_turnover(seasons, return_as_pandas: bool = False):
 
         |col_name                 |type    |
         |:------------------------|:-------|
-        |pos_team                 |Int64   |
+        |pos_team_id              |Int64   |
+        |pos_team                 |String  |
         |turnovers                |Int64   |
         |st_turnovers_lost        |Int64   |
         |Int                      |Int64   |

--- a/tools/codegen/schemas/loader_schemas.yaml
+++ b/tools/codegen/schemas/loader_schemas.yaml
@@ -1,6 +1,8 @@
 load_cfb_adv_defensive:
-- name: def_pos_team
+- name: def_pos_team_id
   type: Int64
+- name: def_pos_team
+  type: String
 - name: scrimmage_plays
   type: Int64
 - name: TFL
@@ -42,8 +44,10 @@ load_cfb_adv_defensive:
 - name: week
   type: Int64
 load_cfb_adv_defensive_players:
-- name: def_pos_team
+- name: def_pos_team_id
   type: Int64
+- name: def_pos_team
+  type: String
 - name: player_name
   type: String
 - name: fumble_recoveries
@@ -56,9 +60,23 @@ load_cfb_adv_defensive_players:
   type: Int64
 - name: week
   type: Int64
-load_cfb_adv_drives:
-- name: pos_team
+- name: sacks
   type: Int64
+- name: sacks_yards
+  type: Int64
+- name: pass_breakups
+  type: Int64
+- name: forced_fumbles
+  type: Int64
+- name: interceptions
+  type: Int64
+- name: interceptions_yards
+  type: Int64
+load_cfb_adv_drives:
+- name: pos_team_id
+  type: Int64
+- name: pos_team
+  type: String
 - name: drive_total_available_yards
   type: Float64
 - name: drive_total_gained_yards
@@ -80,14 +98,18 @@ load_cfb_adv_drives:
 - name: week
   type: Int64
 load_cfb_adv_passing:
-- name: pos_team
+- name: pos_team_id
   type: Int64
+- name: pos_team
+  type: String
 - name: passer_player_name
   type: String
 - name: Comp
   type: Int64
 - name: Att
   type: Int64
+- name: xComp
+  type: Float64
 - name: Yds
   type: Float64
 - name: Pass_TD
@@ -106,6 +128,12 @@ load_cfb_adv_passing:
   type: Float64
 - name: Sck
   type: Int64
+- name: CompPct
+  type: Float64
+- name: xCompPct
+  type: Float64
+- name: CPOE
+  type: Float64
 - name: qbr_epa
   type: Float64
 - name: sack_epa
@@ -113,9 +141,9 @@ load_cfb_adv_passing:
 - name: pass_epa
   type: Float64
 - name: rush_epa
-  type: 'Null'
+  type: Float64
 - name: pen_epa
-  type: 'Null'
+  type: Float64
 - name: spread
   type: Float64
 - name: era0
@@ -135,8 +163,10 @@ load_cfb_adv_passing:
 - name: week
   type: Int64
 load_cfb_adv_receiving:
-- name: pos_team
+- name: pos_team_id
   type: Int64
+- name: pos_team
+  type: String
 - name: receiver_player_name
   type: String
 - name: Rec
@@ -168,8 +198,10 @@ load_cfb_adv_receiving:
 - name: week
   type: Int64
 load_cfb_adv_rushing:
-- name: pos_team
+- name: pos_team_id
   type: Int64
+- name: pos_team
+  type: String
 - name: rusher_player_name
   type: String
 - name: Car
@@ -199,8 +231,10 @@ load_cfb_adv_rushing:
 - name: week
   type: Int64
 load_cfb_adv_situational:
-- name: pos_team
+- name: pos_team_id
   type: Int64
+- name: pos_team
+  type: String
 - name: EPA_success
   type: Int64
 - name: EPA_success_rate
@@ -346,8 +380,10 @@ load_cfb_adv_situational:
 - name: week
   type: Int64
 load_cfb_adv_specialists:
-- name: pos_team
+- name: pos_team_id
   type: Int64
+- name: pos_team
+  type: String
 - name: player_name
   type: String
 - name: punts
@@ -373,8 +409,10 @@ load_cfb_adv_specialists:
 - name: field_goals_yards
   type: Int64
 load_cfb_adv_team:
-- name: pos_team
+- name: pos_team_id
   type: Int64
+- name: pos_team
+  type: String
 - name: rushing_highlight_yards_per_opp
   type: Float64
 - name: total_pen_yards
@@ -532,8 +570,10 @@ load_cfb_adv_team:
 - name: week
   type: Int64
 load_cfb_adv_turnover:
-- name: pos_team
+- name: pos_team_id
   type: Int64
+- name: pos_team
+  type: String
 - name: turnovers
   type: Int64
 - name: st_turnovers_lost


### PR DESCRIPTION
Follow-up to [cfbfastR-cfb-data#28](https://github.com/sportsdataverse/cfbfastR-cfb-data/pull/28). All 10 `adv_*` tags were rebuilt and republished for **2004-2025** (220 assets, 0 failures, 100% name resolution on every season) so that `pos_team` / `def_pos_team` hold the team **name** and the id moved to `pos_team_id` / `def_pos_team_id`. The declared returns tables still described the old shape.

## Re-derived from real data, not one snapshot

Schemas come from a **diagonal union of 2004/2014/2024/2025**. `adv_defensive_players` legitimately ships **8 columns in 2004 and 14 from 2014 on**, so a single-season snapshot would either under-declare the modern shape or imply 2004 has columns it does not. The union gives the widest shape with correctly widened dtypes and leaves **no `Null` dtypes**.

## Also closes pre-existing drift

The audit surfaced gaps unrelated to the `pos_team` change:

| loader | was wrong |
|---|---|
| `load_cfb_adv_passing` | missing `xComp`, `CompPct`, `xCompPct`, `CPOE`; `rush_epa` / `pen_epa` declared `Null` instead of `Float64` |
| `load_cfb_adv_defensive_players` | missing `sacks`, `sacks_yards`, `pass_breakups`, `interceptions`, `interceptions_yards`, `forced_fumbles` |

`loader_schemas.yaml` drives the generated returns tables only — **nothing casts from it** — so none of this could ever fail a test. It surfaced purely as incorrect published documentation, which is why it went unnoticed.

## Verification

- **declared-vs-shipped diffs clean for all 10** loaders (0 mismatches, 0 undeclared, 0 declared-but-absent)
- loader count in `loader_schemas.yaml` preserved at 155
- `generate.py --check` → all generated files current
- `ruff format` + `ruff check` → clean
- `uv run pytest` → **4,743 passed**, 260 skipped, 10 xfailed, **0 failed**

## Note for consumers

The two CFB families spell the team id differently: summaries uses `team_id` (**String**), `adv_*` uses `pos_team_id` (**Int64**). Joining `cfb_team_summaries.team_id` to `adv_team.pos_team_id` without a cast matches nothing, silently. Called out in the CHANGELOG.

No version bump — this is documentation-only on the sdv-py side (the breaking change is in the already-published data), and the docs site tracks `main`.

## Summary by Sourcery

Align CFB advanced (`adv_*`) loader schemas and documentation with the updated data where team identifiers are separated from team names, and close previously undocumented schema drift.

Bug Fixes:
- Correctly document additional advanced passing metrics and defensive player stats that were already present in the shipped data but missing from the declared schemas.

Enhancements:
- Split team identifier and team name columns across all CFB `adv_*` loaders by introducing `pos_team_id` / `def_pos_team_id` alongside string `pos_team` / `def_pos_team` in the declared schemas and loader docstrings.
- Regenerate CFB `adv_*` schema tables so all documented column types (e.g., `rush_epa`, `pen_epa`) match the actual loader outputs.

Build:
- Refresh `loader_schemas.yaml` entries for all CFB `adv_*` loaders so generated returns tables accurately reflect the shipped data.

Documentation:
- Update CHANGELOG and CFB loader reference pages to describe the `pos_team`/`pos_team_id` data change, the regenerated `adv_*` schemas, and the new/updated columns and types for advanced loaders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Advanced college football datasets now provide readable team names alongside numeric team IDs.
  * Advanced passing data includes expected-completion and completion-quality metrics.
  * Defensive-player data now includes sack, pass-breakup, forced-fumble, interception, and related yardage statistics.

* **Bug Fixes**
  * Regenerated dataset schemas to accurately reflect published data, including corrected columns and data types across 2004–2025 seasons.
  * Updated documentation with revised field definitions, season-dependent availability, and the breaking team-field changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->