### PR TITLE
feat(mbb): player_id column on NCAA roster parser

### DIFF
--- a/sportsdataverse/mbb/mbb_ncaa_schedule.py
+++ b/sportsdataverse/mbb/mbb_ncaa_schedule.py
@@ -92,7 +92,12 @@ _ROSTER_SCHEMA: Dict[str, type] = {
     "player": pl.Utf8,
     "clean_name": pl.Utf8,
     "ht_inches": pl.Int64,
+    # Python-only additive vs the bigballR oracle: the stats.ncaa.org player id
+    # from each row's ``/players/{id}`` link (Utf8 -- NCAA ids stay strings).
+    "player_id": pl.Utf8,
 }
+
+_PLAYER_HREF_RE = re.compile(r"/players/(\d+)")
 
 
 def _cell(el: "Tag") -> str:
@@ -347,8 +352,10 @@ def parse_ncaa_bb_team_roster(html: str, team_id: int) -> pl.DataFrame:
     Returns:
         One row per player: ``gp``, ``gs``, ``jersey``, ``name``, ``class``,
         ``position``, ``height``, ``hometown``, ``high_school``, ``player``,
-        ``clean_name``, ``ht_inches``. Zero-row frame with the same schema
-        when the page has no roster table.
+        ``clean_name``, ``ht_inches``, ``player_id`` (the stats.ncaa.org id
+        from the row's ``/players/{id}`` link -- Utf8, Python-only additive
+        vs the bigballR oracle). Zero-row frame with the same schema when
+        the page has no roster table.
 
     Example:
         Parse an on-disk capture::
@@ -365,6 +372,7 @@ def parse_ncaa_bb_team_roster(html: str, team_id: int) -> pl.DataFrame:
     header = [_cell(th) for th in table.find_all("th")][:9]  # R [, 1:9]
     snake = [_ROSTER_HEADER_SNAKE.get(h, underscore(h.replace(" ", "_"))) for h in header]
     records: List[List[Optional[str]]] = []
+    player_ids: List[Optional[str]] = []
     for tr in table.find_all("tr"):
         cells = tr.find_all("td")
         if not cells:
@@ -372,15 +380,23 @@ def parse_ncaa_bb_team_roster(html: str, team_id: int) -> pl.DataFrame:
         values: List[Optional[str]] = [_cell(td) for td in cells[:9]]
         values.extend([None] * (len(header) - len(values)))
         records.append(values)
+        pid: Optional[str] = None
+        for a in tr.find_all("a", href=True):
+            m = _PLAYER_HREF_RE.search(a["href"])
+            if m:
+                pid = m.group(1)
+                break
+        player_ids.append(pid)
 
     data: Dict[str, List[Optional[str]]] = {col: [rec[i] for rec in records] for i, col in enumerate(snake)}
     names = data.get("name", [None] * len(records))
     heights = data.get("height", [None] * len(records))
     data["player"] = [_normalize_v2_name(n) if n is not None else None for n in names]
     data["clean_name"] = list(names)
-    df = pl.DataFrame(data, schema={c: pl.Utf8 for c in [*snake, "player", "clean_name"]})
+    data["player_id"] = player_ids
+    df = pl.DataFrame(data, schema={c: pl.Utf8 for c in [*snake, "player", "clean_name", "player_id"]})
     return df.with_columns(pl.Series("ht_inches", [_ht_inches(h) for h in heights], dtype=pl.Int64)).select(
-        [c for c in _ROSTER_SCHEMA if c in [*snake, "player", "clean_name", "ht_inches"]]
+        [c for c in _ROSTER_SCHEMA if c in [*snake, "player", "clean_name", "ht_inches", "player_id"]]
     )
 
 

--- a/sportsdataverse/mbb/mbb_ncaa_schedule.py
+++ b/sportsdataverse/mbb/mbb_ncaa_schedule.py
@@ -336,10 +336,11 @@ def parse_ncaa_bb_team_roster(html: str, team_id: int) -> pl.DataFrame:
     """Parse a ``stats.ncaa.org/teams/{team_id}/roster`` page.
 
     Pure core of bigballR ``get_team_roster`` (all_functions.R:1709-1845):
-    the site's first 9 roster columns (snake_cased) plus the three derived
+    the site's first 9 roster columns (snake_cased) plus the four derived
     columns -- ``player`` (the normalized ``FIRST.LAST`` join key, byte-
     matching the play-by-play name normalization), ``clean_name`` (the raw
-    display name) and ``ht_inches``.
+    display name), ``ht_inches``, and ``player_id`` (from the row's
+    ``/players/{id}`` link).
 
     Rows are emitted in raw page order; the R oracle's chromote-rendered
     DataTable re-sorts alphabetically (see module docstring).

--- a/tests/mbb/test_mbb_ncaa_schedule_parity.py
+++ b/tests/mbb/test_mbb_ncaa_schedule_parity.py
@@ -130,7 +130,14 @@ class TestRosterParity:
         )
 
     def test_contract_columns(self, roster_df: pl.DataFrame) -> None:
-        assert list(roster_df.columns) == list(ROSTER_SCHEMA)
+        # player_id is Python-only additive (from the /players/{id} hrefs);
+        # the R oracle never had it, so it sits outside ROSTER_SCHEMA.
+        assert list(roster_df.columns) == [*ROSTER_SCHEMA, "player_id"]
+
+    def test_player_id_from_hrefs(self, roster_df: pl.DataFrame) -> None:
+        ids = roster_df.get_column("player_id").drop_nulls()
+        assert ids.len() == roster_df.height  # every fixture row carries a link
+        assert ids.str.contains(r"^\d+$").all()
 
 
 class TestTeamIds:
@@ -168,7 +175,7 @@ class TestPublicSurface:
 
     def test_roster_pandas(self) -> None:
         out = ncaa_mbb_team_roster(TEAM_ID, fetcher=_FakeFetcher(), return_as_pandas=True)
-        assert list(out.columns) == list(ROSTER_SCHEMA)
+        assert list(out.columns) == [*ROSTER_SCHEMA, "player_id"]
 
     def test_improper_request(self) -> None:
         with pytest.raises(ValueError):


### PR DESCRIPTION
Adds a `player_id` (Utf8) column to `parse_ncaa_bb_team_roster` / `ncaa_mbb_team_roster`, extracted from each roster row's `/players/{id}` link.

- Python-only additive vs the bigballR oracle (oracle parity assertions unchanged and green; contract tests updated to expect the extra column).
- New regression test asserts every fixture row yields a numeric id.
- Motivation: the ncaa-mbb-hoops raw/data pipeline needs roster<->pbp id matching; the `player` FIRST.LAST key already byte-matches pbp normalization, and `player_id` now provides the durable numeric id alongside it.

Validated live: 3-team capture through the Decodo transport — every player row id-bearing.

Full mbb+wbb suite: 215 passed, 17 skipped, 1 xfailed.

## Summary by Sourcery

Add stats.ncaa.org player identifiers to NCAA men’s basketball roster parsing and enforce their presence in tests.

New Features:
- Include a Utf8 `player_id` column in `parse_ncaa_bb_team_roster` and `ncaa_mbb_team_roster` outputs, populated from each row’s `/players/{id}` link.

Enhancements:
- Update roster parsing schema and docstring to expose the new `player_id` field alongside existing player name and height metadata.

Tests:
- Extend parity and contract tests to expect the `player_id` column and assert that every roster fixture row yields a numeric player id.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * NCAA basketball roster data now includes each player’s numeric NCAA player ID.
  * The new `player_id` field is consistently available in roster outputs, including empty results.

* **Tests**
  * Added validation to ensure roster records contain numeric player IDs.
  * Updated compatibility checks for the expanded roster data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->