### PR TITLE
feat(schemas): declare raw provider payload shapes for the -raw repos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -638,4 +638,5 @@ files = [
     "sportsdataverse/mbb/mbb_player_core.py",
     "sportsdataverse/wnba/wnba_player_core.py",
     "sportsdataverse/wbb/wbb_player_core.py",
+    "sportsdataverse/schemas/__init__.py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,7 +220,7 @@ exclude = ["tests*", "docs*", "examples*", "archive*"]
 [tool.setuptools.package-data]
 # ``py.typed`` is the PEP 561 marker that tells downstream type checkers this
 # package ships inline type information.
-sportsdataverse = ["cfb/models/*", "cricket/models/*", "mbb/data/*", "mbb/models/*", "mlb/models/*", "nba/models/*", "nfl/models/*", "nhl/models/*", "wbb/data/*", "py.typed"]
+sportsdataverse = ["cfb/models/*", "cricket/models/*", "mbb/data/*", "mbb/models/*", "mlb/models/*", "nba/models/*", "nfl/models/*", "nhl/models/*", "wbb/data/*", "schemas/raw/*.yaml", "py.typed"]
 
 
 [tool.isort]

--- a/sportsdataverse/schemas/__init__.py
+++ b/sportsdataverse/schemas/__init__.py
@@ -85,6 +85,26 @@ def load_raw_schema(name: str) -> dict[str, Any]:
     Raises:
         KeyError: If ``name`` is not a declared payload family.
         ImportError: If PyYAML is not installed.
+        TypeError: If the schema file does not parse to a mapping.
+
+    Example:
+        Quick start::
+
+            from sportsdataverse.schemas import load_raw_schema
+
+            schema = load_raw_schema("espn_summary")
+            print(sorted(schema["required"]))
+
+        Inspect what a family tolerates::
+
+            print(schema["additional_properties"])   # True -- unknown keys allowed
+
+        See Also:
+            * `wehoop-wbb-raw`_ -- the archive whose payloads these describe
+            * `wehoop`_ -- the R client that consumes the reshaped output
+
+        .. _wehoop-wbb-raw: https://github.com/sportsdataverse/wehoop-wbb-raw
+        .. _wehoop: https://wehoop.sportsdataverse.org
     """
     if name not in RAW_SCHEMAS:
         raise KeyError(f"unknown raw payload family {name!r}; expected one of {sorted(RAW_SCHEMAS)}")
@@ -100,7 +120,13 @@ def load_raw_schema(name: str) -> dict[str, Any]:
             "`pip install pyyaml` or `pip install sportsdataverse[all]`."
         ) from exc
     path = files("sportsdataverse.schemas").joinpath("raw", f"{name}.yaml")
-    return yaml.safe_load(path.read_text(encoding="utf-8"))
+    schema = yaml.safe_load(path.read_text(encoding="utf-8"))
+    # safe_load returns whatever the document is. A schema that parsed to a
+    # list or a bare string would otherwise fail much later, inside .get() on
+    # a caller's behalf, with an error that points nowhere near the cause.
+    if not isinstance(schema, dict):
+        raise TypeError(f"raw schema {name!r} parsed to {type(schema).__name__}, expected a mapping")
+    return schema
 
 
 def validate_payload(name: str, payload: Any) -> list[str]:
@@ -118,6 +144,32 @@ def validate_payload(name: str, payload: Any) -> list[str]:
 
     Raises:
         KeyError: If ``name`` is not a declared payload family.
+
+    Example:
+        Quick start::
+
+            import json
+            from sportsdataverse.schemas import validate_payload
+
+            payload = json.loads(open("wbb/json/final/401811123.json").read())
+            problems = validate_payload("espn_summary", payload)
+            print(problems)   # [] when the payload matches
+
+        Fail a scrape on a bad capture::
+
+            if validate_payload("espn_team_stats", payload):
+                raise AssertionError("refusing to persist a non-conforming payload")
+
+        Scan an archive for damage::
+
+            bad = [p for p in paths if validate_payload("espn_team_stats", load(p))]
+
+        See Also:
+            * `wehoop-wbb-raw`_ -- the archive whose payloads these describe
+            * `hoopR`_ -- the men's-basketball sibling with the same tree shape
+
+        .. _wehoop-wbb-raw: https://github.com/sportsdataverse/wehoop-wbb-raw
+        .. _hoopR: https://hoopR.sportsdataverse.org
     """
     schema = load_raw_schema(name)
     if not isinstance(payload, dict):

--- a/sportsdataverse/schemas/__init__.py
+++ b/sportsdataverse/schemas/__init__.py
@@ -1,0 +1,153 @@
+"""Declared shapes for the raw provider payloads committed in the SDV ``-raw`` repos.
+
+The ``-raw`` repos archive provider payloads verbatim and the ``-data`` repos
+reshape them into released datasets. Between those two steps there was nothing
+that said what a payload is *supposed* to look like, so a provider dropping a
+key surfaced as a silently-null column several datasets downstream.
+
+**Strict on types, permissive on extras.** Two independent knobs that pull
+opposite ways:
+
+* Unknown keys are allowed (``additional_properties: true``). ESPN adds fields
+  routinely; forbidding them would red a daily cron for a non-event.
+* ``required`` lists only the keys some parser actually depends on, so a
+  *missing* ``boxscore`` or ``plays`` is a red test on the file at scrape time.
+* Types are **not** coerced. A numeric-string id stays a string here. Lax
+  validation would quietly turn ``"401811123"`` into an int and ``5`` into
+  ``5.0`` -- the float-origin-id and Int-width join-key failures this project
+  keeps hitting. Where a payload genuinely ships two shapes (ESPN's
+  ``winprobability`` is a list in most games and a dict in some), the schema
+  declares the union explicitly rather than widening to "any".
+
+Every schema here was derived from real committed captures. Do not edit one to
+make a test pass without re-sampling the payloads it describes.
+
+Example:
+    Validate a captured payload::
+
+        import json
+        from sportsdataverse.schemas import validate_payload
+
+        payload = json.loads(open("wbb/json/final/401811123.json").read())
+        problems = validate_payload("espn_summary", payload)
+        if problems:
+            raise AssertionError("\\n".join(problems))
+
+    Inspect a declared shape::
+
+        from sportsdataverse.schemas import RAW_SCHEMAS, load_raw_schema
+
+        print(sorted(RAW_SCHEMAS))
+        print(load_raw_schema("espn_officials")["required"])
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from importlib.resources import files
+from typing import Any
+
+__all__ = ["RAW_SCHEMAS", "load_raw_schema", "validate_payload"]
+
+#: Every payload family with a declared shape. Keys are schema names; values
+#: are one-line descriptions of the tree location the payload is archived at.
+RAW_SCHEMAS: dict[str, str] = {
+    "espn_summary": "<lg>/json/{raw,final}/<game_id>.json",
+    "espn_game_rosters": "<lg>/game_rosters/json/<game_id>.json",
+    "espn_officials": "<lg>/officials/json/<game_id>.json",
+    "espn_player_core": "<lg>/player_core/json/<athlete_id>.json",
+    "espn_standings": "<lg>/standings/json/<season>.json",
+    "espn_team_stats": "<lg>/team_stats/json/<season>/<team_id>.json",
+    "espn_player_season_stats": "<lg>/player_season_stats/json/<season>/<athlete_id>.json",
+}
+
+_TYPES: dict[str, type | tuple[type, ...]] = {
+    "dict": dict,
+    "list": list,
+    "str": str,
+    "int": int,
+    "float": (int, float),
+    "bool": bool,
+}
+
+
+@lru_cache(maxsize=None)
+def load_raw_schema(name: str) -> dict[str, Any]:
+    """Load a raw-payload schema by name.
+
+    Args:
+        name: A key of :data:`RAW_SCHEMAS`, e.g. ``"espn_summary"``.
+
+    Returns:
+        The parsed schema: ``{name, description, additional_properties,
+        required, optional}``.
+
+    Raises:
+        KeyError: If ``name`` is not a declared payload family.
+        ImportError: If PyYAML is not installed.
+    """
+    if name not in RAW_SCHEMAS:
+        raise KeyError(f"unknown raw payload family {name!r}; expected one of {sorted(RAW_SCHEMAS)}")
+    # PyYAML is a build/CI-time dependency here, not a runtime one, so it is
+    # imported lazily. The base package must always import cleanly (same
+    # precedent as curl_cffi and psutil); only callers that actually read a
+    # schema need the parser.
+    try:
+        import yaml
+    except ImportError as exc:  # pragma: no cover - guarded by test_yaml_guidance
+        raise ImportError(
+            "Reading raw payload schemas requires PyYAML. Install it with "
+            "`pip install pyyaml` or `pip install sportsdataverse[all]`."
+        ) from exc
+    path = files("sportsdataverse.schemas").joinpath("raw", f"{name}.yaml")
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def validate_payload(name: str, payload: Any) -> list[str]:
+    """Check a payload against its declared shape.
+
+    Args:
+        name: A key of :data:`RAW_SCHEMAS`.
+        payload: The parsed JSON payload.
+
+    Returns:
+        A list of human-readable problems. An empty list means the payload
+        matches: every required key is present with a declared type, and every
+        present optional key has a declared type. Unknown keys are ignored by
+        design.
+
+    Raises:
+        KeyError: If ``name`` is not a declared payload family.
+    """
+    schema = load_raw_schema(name)
+    if not isinstance(payload, dict):
+        return [f"{name}: payload is {type(payload).__name__}, expected dict"]
+
+    problems: list[str] = []
+    for key, declared in (schema.get("required") or {}).items():
+        if key not in payload:
+            problems.append(f"{name}: missing required key {key!r}")
+            continue
+        problems.extend(_check(name, key, payload[key], declared))
+    for key, declared in (schema.get("optional") or {}).items():
+        # An absent optional key and an explicit null are both "not provided".
+        if payload.get(key) is not None:
+            problems.extend(_check(name, key, payload[key], declared))
+    return problems
+
+
+def _check(name: str, key: str, value: Any, declared: str) -> list[str]:
+    """Type-check one key. ``declared`` may be a union like ``"list|dict"``."""
+    alternatives = [alt.strip() for alt in str(declared).split("|")]
+    unknown = [alt for alt in alternatives if alt not in _TYPES]
+    if unknown:
+        return [f"{name}: schema declares unknown type {unknown[0]!r} for {key!r}"]
+
+    # bool subclasses int in Python, so `isinstance(True, int)` is True. A
+    # boolean where a number was declared is a defect, not a narrow int.
+    if isinstance(value, bool) and "bool" not in alternatives:
+        return [f"{name}: {key!r} is bool, expected {declared}"]
+
+    if any(isinstance(value, _TYPES[alt]) for alt in alternatives):
+        return []
+    return [f"{name}: {key!r} is {type(value).__name__}, expected {declared}"]

--- a/sportsdataverse/schemas/raw/espn_game_rosters.yaml
+++ b/sportsdataverse/schemas/raw/espn_game_rosters.yaml
@@ -1,0 +1,32 @@
+name: espn_game_rosters
+description: >-
+  ESPN payload archived at <lg>/game_rosters/json/<game_id>.json. NOTE: despite
+  the directory name this is a full Site v2 *summary* payload, not a
+  roster-shaped one -- the per-game roster is read out of its boxscore. It is a
+  different summary variant from <lg>/json/final: it carries meta, news, and
+  wallclockAvailable, and omits espnWP, predictor, season, teamInfo, timeouts.
+# Derived from 200 randomly sampled wehoop-wbb-raw captures (2026-08-01):
+# 16 keys present in every file; `article` in only 10%.
+additional_properties: true
+required:
+  header: dict
+  boxscore: dict
+  plays: list
+  gameInfo: dict
+optional:
+  # list in every game_rosters capture sampled; dict occurs in the sibling
+  # json/final variant, so the union is declared for both.
+  winprobability: list|dict
+  article: dict|list
+  meta: dict
+  news: dict
+  standings: dict
+  format: dict
+  leaders: list
+  broadcasts: list
+  videos: list
+  pickcenter: list
+  againstTheSpread: list
+  odds: list
+  wallclockAvailable: bool
+  gameId: int|str

--- a/sportsdataverse/schemas/raw/espn_officials.yaml
+++ b/sportsdataverse/schemas/raw/espn_officials.yaml
@@ -1,0 +1,16 @@
+name: espn_officials
+description: >-
+  ESPN Core v2 paginated collection archived at
+  <lg>/officials/json/<game_id>.json. NOT an {"officials": [...]} document --
+  it is the generic Core v2 envelope, so the officials live under `items` and
+  are read by the shared parse_items path.
+# Derived from 200 randomly sampled wehoop-wbb-raw captures (2026-08-01):
+# all five envelope keys present in every file.
+additional_properties: true
+required:
+  items: list
+  count: int
+optional:
+  pageIndex: int
+  pageSize: int
+  pageCount: int

--- a/sportsdataverse/schemas/raw/espn_player_core.yaml
+++ b/sportsdataverse/schemas/raw/espn_player_core.yaml
@@ -1,0 +1,51 @@
+name: espn_player_core
+description: >-
+  ESPN Core v2 athlete resource archived at
+  <lg>/player_core/json/<athlete_id>.json. Athlete identity and bio; the
+  payload is flat (no season segment) because a core record is per-athlete.
+# Derived from 200 randomly sampled wehoop-wbb-raw captures (2026-08-01).
+# `id` is a numeric STRING here -- the string->Int64 conversion belongs at the
+# build boundary, not in this schema, which describes what ESPN sends.
+additional_properties: true
+required:
+  id: str
+  displayName: str
+optional:
+  $ref: str
+  uid: str
+  guid: str
+  type: str
+  slug: str
+  firstName: str
+  lastName: str
+  fullName: str
+  shortName: str
+  middleName: str
+  alternateIds: dict
+  birthPlace: dict
+  position: dict
+  status: dict
+  linked: bool
+  active: bool
+  # Sparse in real captures: links 98%, team 98%, jersey 87%, statistics 86%,
+  # experience 86%, statisticslog 86%, height/displayHeight 80%,
+  # birthCountry/flag 78%, headshot 24%, hand 12%, and a long tail below 3%.
+  links: list
+  team: dict
+  jersey: str
+  statistics: dict
+  statisticslog: dict
+  experience: dict
+  height: float
+  displayHeight: str
+  weight: float
+  displayWeight: str
+  birthCountry: dict
+  flag: dict
+  headshot: dict
+  hand: dict
+  age: int
+  dateOfBirth: str
+  college: dict
+  proAthlete: dict
+  draft: dict

--- a/sportsdataverse/schemas/raw/espn_player_season_stats.yaml
+++ b/sportsdataverse/schemas/raw/espn_player_season_stats.yaml
@@ -1,0 +1,15 @@
+name: espn_player_season_stats
+description: >-
+  ESPN Web v3 player season statistics archived at
+  <lg>/player_season_stats/json/<season>/<athlete_id>.json. Carries NO athlete
+  identity -- only the filename holds the athlete id, which is why the
+  player_core family exists alongside it.
+# Derived from 200 randomly sampled wehoop-wbb-raw captures (2026-08-01):
+# all four keys present in every file.
+additional_properties: true
+required:
+  categories: list
+  teams: dict
+optional:
+  filters: list
+  glossary: list

--- a/sportsdataverse/schemas/raw/espn_standings.yaml
+++ b/sportsdataverse/schemas/raw/espn_standings.yaml
@@ -1,0 +1,21 @@
+name: espn_standings
+description: >-
+  ESPN group/season resource archived at <lg>/standings/json/<season>.json. NOT
+  a {"standings": {...}} document -- it is the top-level group node, and the
+  standings tables hang off `children` (conferences) and `season`.
+# Derived from all 24 committed wehoop-wbb-raw standings captures (2026-08-01):
+# all ten keys present in every file.
+additional_properties: true
+required:
+  id: str
+  children: list
+optional:
+  uid: str
+  name: str
+  abbreviation: str
+  shortName: str
+  parent: dict
+  season: dict
+  seasons: list
+  links: list
+  standings: dict

--- a/sportsdataverse/schemas/raw/espn_summary.yaml
+++ b/sportsdataverse/schemas/raw/espn_summary.yaml
@@ -1,0 +1,45 @@
+name: espn_summary
+description: >-
+  ESPN Site v2 game summary payload, archived at <lg>/json/raw/<game_id>.json
+  (as fetched) and <lg>/json/final/<game_id>.json (same payload plus gameId and
+  playByPlaySource). Source of pbp, team_box, player_box, shots, and the
+  win-probability join.
+# Derived from 400 randomly sampled wehoop-wbb-raw wbb/json/final captures
+# (2026-08-01): all 21 keys were present in every file. `required` is limited
+# to the four a parser cannot proceed without, so a payload that loses a
+# peripheral section still builds.
+additional_properties: true
+required:
+  header: dict
+  boxscore: dict
+  plays: list
+  gameInfo: dict
+optional:
+  # Observed as BOTH list and dict across real captures -- a single-type
+  # declaration reds the daily job on legitimate data.
+  winprobability: list|dict
+  article: dict|list
+  predictor: dict|list
+  leaders: list
+  standings: dict
+  broadcasts: list
+  videos: list
+  pickcenter: list
+  againstTheSpread: list
+  odds: list
+  espnWP: dict
+  teamInfo: dict
+  format: dict
+  # json/raw and json/final are NOT the same payload plus two keys: the
+  # raw->final step also converts `timeouts` and `season` from list to dict.
+  # Verified across 300 sampled captures of each (2026-08-01) -- raw was a
+  # list in 300/300, final a dict in 300/300.
+  timeouts: list|dict
+  season: list|dict
+  news: dict
+  meta: dict
+  wallclockAvailable: bool
+  # Present in json/final only; json/raw is the payload exactly as fetched.
+  # Observed as int in final captures; str tolerated for older captures.
+  gameId: int|str
+  playByPlaySource: str

--- a/sportsdataverse/schemas/raw/espn_team_stats.yaml
+++ b/sportsdataverse/schemas/raw/espn_team_stats.yaml
@@ -1,0 +1,16 @@
+name: espn_team_stats
+description: >-
+  ESPN Web v3 team season statistics archived at
+  <lg>/team_stats/json/<season>/<team_id>.json. The stat categories live under
+  `results`; `requestedSeason` records the season asked for, which can differ
+  from `season` when ESPN falls back.
+# Derived from 200 randomly sampled wehoop-wbb-raw captures (2026-08-01):
+# all five keys present in every file.
+additional_properties: true
+required:
+  results: dict
+  team: dict
+optional:
+  season: dict
+  requestedSeason: dict
+  status: str

--- a/tests/test_raw_schemas.py
+++ b/tests/test_raw_schemas.py
@@ -103,6 +103,27 @@ def test_unknown_schema_name_raises():
         load_raw_schema("espn_not_a_real_family")
 
 
+def test_non_mapping_schema_fails_at_the_source(tmp_path, monkeypatch):
+    """yaml.safe_load returns whatever the document is. A schema that parsed to
+    a list must fail here, not later inside a caller's .get()."""
+    import sportsdataverse.schemas as schemas_mod
+
+    class _FakePath:
+        def joinpath(self, *_parts):
+            return self
+
+        def read_text(self, encoding="utf-8"):
+            return "- not\n- a mapping\n"
+
+    schemas_mod.load_raw_schema.cache_clear()
+    monkeypatch.setattr(schemas_mod, "files", lambda _pkg: _FakePath())
+    try:
+        with pytest.raises(TypeError, match="expected a mapping"):
+            schemas_mod.load_raw_schema("espn_summary")
+    finally:
+        schemas_mod.load_raw_schema.cache_clear()
+
+
 def test_yaml_is_not_a_module_level_dependency():
     """PyYAML is a build/CI-time dep, not a runtime one. A module-level import
     would make `pip install sportsdataverse` unable to import this package."""

--- a/tests/test_raw_schemas.py
+++ b/tests/test_raw_schemas.py
@@ -1,0 +1,143 @@
+"""Declared shapes for the raw provider payloads committed in the -raw repos.
+
+Every schema in this suite was derived from real committed captures, not from
+the ESPN docs or from guesswork -- an earlier draft guessed four of seven
+payload shapes wrong (``game_rosters`` is a full *summary* payload, not a
+roster payload; ``officials`` is the Core v2 pagination envelope).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sportsdataverse.schemas import RAW_SCHEMAS, load_raw_schema, validate_payload
+
+
+@pytest.mark.parametrize("name", sorted(RAW_SCHEMAS))
+def test_schema_loads_and_declares_required(name):
+    schema = load_raw_schema(name)
+    assert schema["required"], f"{name} declares no required keys"
+    assert schema["additional_properties"] is True
+
+
+def test_registry_matches_the_shipped_yaml_files():
+    """A schema file with no registry entry is unreachable; the reverse crashes."""
+    from importlib.resources import files
+
+    shipped = {
+        p.name.removesuffix(".yaml")
+        for p in files("sportsdataverse.schemas").joinpath("raw").iterdir()
+        if p.name.endswith(".yaml")
+    }
+    assert shipped == set(RAW_SCHEMAS)
+
+
+def test_validate_accepts_unknown_keys():
+    """ESPN adds fields routinely; unknown keys are not a defect signal."""
+    payload = {
+        "header": {},
+        "boxscore": {},
+        "plays": [],
+        "gameInfo": {},
+        "someBrandNewEspnKey": 1,
+    }
+    assert validate_payload("espn_summary", payload) == []
+
+
+def test_validate_reports_missing_required_key():
+    payload = {"header": {}, "boxscore": {}, "gameInfo": {}}  # no "plays"
+    problems = validate_payload("espn_summary", payload)
+    assert any("plays" in p for p in problems)
+
+
+def test_validate_reports_wrong_type_without_coercing():
+    payload = {"header": {}, "boxscore": {}, "plays": {}, "gameInfo": {}}
+    problems = validate_payload("espn_summary", payload)
+    assert any("plays" in p and "list" in p for p in problems)
+
+
+@pytest.mark.parametrize("value", [[], {}])
+def test_union_typed_key_accepts_either_form(value):
+    """winprobability is a list in most payloads and a dict in some. Both are
+    real; a single-type declaration would red the daily job on real data."""
+    payload = {
+        "header": {},
+        "boxscore": {},
+        "plays": [],
+        "gameInfo": {},
+        "winprobability": value,
+    }
+    assert validate_payload("espn_summary", payload) == []
+
+
+def test_union_typed_key_still_rejects_a_third_type():
+    payload = {
+        "header": {},
+        "boxscore": {},
+        "plays": [],
+        "gameInfo": {},
+        "winprobability": "nope",
+    }
+    problems = validate_payload("espn_summary", payload)
+    assert any("winprobability" in p for p in problems)
+
+
+def test_null_optional_is_not_a_type_error():
+    payload = {"header": {}, "boxscore": {}, "plays": [], "gameInfo": {}, "odds": None}
+    assert validate_payload("espn_summary", payload) == []
+
+
+def test_bool_is_not_accepted_where_int_is_declared():
+    """bool subclasses int in Python; a True page count is a defect."""
+    payload = {"count": True, "items": [], "pageIndex": 1, "pageSize": 25, "pageCount": 1}
+    problems = validate_payload("espn_officials", payload)
+    assert any("count" in p and "bool" in p for p in problems)
+
+
+def test_non_dict_payload_is_reported_not_raised():
+    assert validate_payload("espn_summary", []) == ["espn_summary: payload is list, expected dict"]
+
+
+def test_unknown_schema_name_raises():
+    with pytest.raises(KeyError):
+        load_raw_schema("espn_not_a_real_family")
+
+
+def test_yaml_is_not_a_module_level_dependency():
+    """PyYAML is a build/CI-time dep, not a runtime one. A module-level import
+    would make `pip install sportsdataverse` unable to import this package."""
+    from sportsdataverse import schemas
+
+    assert not hasattr(schemas, "yaml"), "yaml must be imported lazily inside load_raw_schema, not at module level"
+
+
+def test_missing_pyyaml_gives_actionable_guidance(monkeypatch):
+    import sys
+
+    from sportsdataverse import schemas
+
+    schemas.load_raw_schema.cache_clear()
+    monkeypatch.setitem(sys.modules, "yaml", None)  # makes `import yaml` raise
+    try:
+        with pytest.raises(ImportError, match="pip install pyyaml"):
+            schemas.load_raw_schema("espn_summary")
+    finally:
+        schemas.load_raw_schema.cache_clear()
+
+
+@pytest.mark.parametrize(
+    "name,required",
+    [
+        ("espn_summary", {"header", "boxscore", "plays", "gameInfo"}),
+        ("espn_game_rosters", {"header", "boxscore", "plays", "gameInfo"}),
+        ("espn_officials", {"items", "count"}),
+        ("espn_player_core", {"id", "displayName"}),
+        ("espn_standings", {"id", "children"}),
+        ("espn_team_stats", {"results", "team"}),
+        ("espn_player_season_stats", {"categories", "teams"}),
+    ],
+)
+def test_required_keys_match_what_was_observed(name, required):
+    """Pins the observed-universal keys. Loosening one of these means a parser
+    can now be handed a payload it cannot read."""
+    assert required <= set(load_raw_schema(name)["required"])


### PR DESCRIPTION
Adds `sportsdataverse.schemas` — declared shapes for the seven ESPN payload families archived in the `-raw` repos.

## Why

The `-raw` repos archive provider payloads verbatim and the `-data` repos reshape them. Between those steps nothing said what a payload is *supposed* to look like, so a provider dropping a key surfaced as a silently-null column several datasets downstream.

## Contract

**Strict on types, permissive on extras** — two knobs that pull opposite ways:

- Unknown keys allowed (`additional_properties: true`). ESPN adds fields routinely; forbidding them would red a daily cron for a non-event.
- `required` lists only keys a parser actually depends on, so a missing `boxscore`/`plays` is a red test on the file at scrape time.
- Types are **not** coerced. Lax validation turns `"401811123"` into an int and `5` into `5.0` — the float-origin-id and int-width join-key failures this repo keeps hitting.

## Derived from real captures, not docs

Validated against ~3,000 committed `wehoop-wbb-raw` payloads. An earlier draft guessed four of seven shapes wrong. What the data actually says:

| finding | consequence |
|---|---|
| `<lg>/game_rosters/json/` holds full **summary** payloads, not roster payloads | schema mirrors summary |
| `<lg>/officials/json/` is the Core v2 `{count, items, pageCount, ...}` envelope | not `{"officials": [...]}` |
| `<lg>/standings/json/` is a group/season resource | not `{"standings": {...}}` |
| `json/raw` → `json/final` also converts `timeouts` and `season` from list to dict | both declared as unions |
| `winprobability` / `article` / `predictor` are list **or** dict | union types supported |

## Already caught a real defect

Running these against the full committed tree found **7 of 7,025 `team_stats` captures are persisted ESPN *error* bodies** (`{"error","message","status",...}` and `{"code","detail"}`), not stats. Because the raw tree is the checkpoint and captured files are never re-fetched, every rebuild since has silently produced no stats for those team-seasons. Fix belongs in the `-raw` repo and is tracked there.

## Notes

- PyYAML is imported **lazily** — it is a build/CI-time dep, so a module-level import would break plain `pip install sportsdataverse`.
- 27 tests; ruff and the codegen drift gate both clean.

## Summary by Sourcery

Declare and validate canonical schemas for archived ESPN raw provider payloads used across sportsdataverse.

New Features:
- Introduce a schemas module exposing raw payload schema metadata and a validate_payload helper for ESPN provider captures.
- Add YAML-based schema definitions for ESPN summary, game_rosters, officials, standings, player core, team stats, and player season stats payload families.

Enhancements:
- Register raw schema files as packaged data so downstream tooling and tests can load them from the installed distribution.

Tests:
- Add a dedicated test suite ensuring schemas load correctly, registry and shipped YAML stay in sync, validation behavior around required/optional/union-typed keys is enforced, and PyYAML remains a lazy dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added schema definitions for ESPN game, player, team, standings, officials, and statistics data.
  * Added tools to load schemas and validate raw payloads, including required fields, supported types, and optional fields.
  * Validation permits additional unknown fields while providing clear errors for invalid data.

* **Bug Fixes**
  * Ensured raw YAML schemas are included in packaged distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->