### PR TITLE
fix(cfb): canonicalize team_id to Int64 at the loader boundary + describe loader returns tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Unreleased](#unreleased)
+  - [CFB — `team_id` canonicalized to `Int64` at the loader boundary](#cfb--team_id-canonicalized-to-int64-at-the-loader-boundary)
+  - [Docs — loader returns tables now carry column descriptions](#docs--loader-returns-tables-now-carry-column-descriptions)
   - [CFB — `adv_*` `pos_team` now holds the team NAME, id moves to `pos_team_id` (BREAKING data change)](#cfb--adv_-pos_team-now-holds-the-team-name-id-moves-to-pos_team_id-breaking-data-change)
   - [CFB — `adv_*` declared schemas re-derived from the shipped data](#cfb--adv_-declared-schemas-re-derived-from-the-shipped-data)
 - [0.0.73 Release: August 1, 2026](#0073-release-august-1-2026)
@@ -208,6 +210,65 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Unreleased
+
+### CFB — `team_id` canonicalized to `Int64` at the loader boundary
+
+The same ESPN team id shipped with **three different dtypes** across the CFB
+release surface, which makes a cross-dataset join match **nothing** — silently,
+with no error and a structurally valid frame:
+
+| dtype | datasets |
+|---|---|
+| `Int64` | 13 — all `adv_*`, `drives`, `game_rosters`, `linescores`, `player_box`, `team_box`, `adv_team_gamelog` |
+| `String` | 8 — `passing`, `receiving`, `rushing`, `team_summaries`(+`_weekly`), `ratings`(+`_weekly`), `recruiting_proj` |
+| `Int32` | 1 — `team_info` |
+
+All nine non-`Int64` loaders now normalize on read, so
+`load_cfb_team_summaries(...)` joined to `load_cfb_adv_team(...)` on
+`team_id`/`pos_team_id` resolves **134/134** teams where it previously matched 0.
+
+- **Fixed at the boundary, not by republishing.** The published assets are
+  untouched; the loader pins the dtype on read, per the repo's "one dtype per id,
+  cast at the boundary" rule. No breaking change for anyone reading the parquet
+  directly.
+- **New `id_int64:` key in `releases.yaml`** declares which id columns a loader
+  canonicalizes; the generated loader emits a `_cast_ids_int64` call. Declaring it
+  is the whole change — no hand-edits to generated loaders.
+- **Lossless or refused, never silent.** `_cast_ids_int64` converts only when every
+  non-null value survives a round-trip. `"007"` casts cleanly to `7` and `1.5`
+  truncates to `1` — both change the id, so both leave the column untouched. A
+  "no new nulls" check alone would let both through. Float-origin ids go straight
+  to `Int64` rather than through a string (which would yield `"123.0"`).
+- Covered by `tests/codegen/test_id_casts.py`, including a manifest gate that fails
+  if a loader declares `id_int64` without emitting the call, or declares a
+  canonicalized column as anything other than `Int64`.
+- The two producer-schema contract tests now apply the declared `id_int64` overlay:
+  a returns table documents the **loader's** output, not the raw asset, so a
+  boundary cast is an expected divergence rather than a docs lie.
+
+### Docs — loader returns tables now carry column descriptions
+
+Generated loader returns tables rendered `col_name | type` only, while endpoint
+tables carried a third `description` column. Loader tables now match, resolving
+descriptions from `manual_column_descriptions.yaml` (keyed by the loader's own
+function name) and falling back to the R-package column dict — so shared columns
+like `game_id` / `season` / `week` fill in automatically.
+
+This exposed ~5,850 loader columns to the description coverage ratchet, which had
+never globbed `loader_schemas.yaml` — so those blanks were **invisible** to a gate
+whose stated intent is "every return-table column renders a description". The
+extractor now sees them (59% already covered) and the remainder is tracked via the
+existing `_DEFERRED_BUCKETS` mechanism, mirroring the `nba_stats` decision.
+
+The first documented use is `load_cfb_adv_defensive_players`, whose column
+availability is season-dependent and previously undiscoverable without loading
+several seasons and diffing them:
+
+| seasons | cols | shape |
+|---|---|---|
+| 2004 | 8 | fumble recoveries only |
+| 2005–2013 | 12 | `+ sacks, sacks_yards, pass_breakups, forced_fumbles` |
+| 2014–2025 | 14 | `+ interceptions, interceptions_yards` |
 
 ### CFB — `adv_*` `pos_team` now holds the team NAME, id moves to `pos_team_id` (BREAKING data change)
 

--- a/docs/docs/cfb/reference/loaders.md
+++ b/docs/docs/cfb/reference/loaders.md
@@ -55,370 +55,370 @@ flowchart LR
 Release: [espn_cfb_pbp](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_cfb_pbp) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_cfb_pbp/play_by_play_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `id` | Int32 |
-| `sequenceNumber` | String |
-| `text` | String |
-| `awayScore` | Int32 |
-| `homeScore` | Int32 |
-| `scoringPlay` | Boolean |
-| `priority` | Boolean |
-| `modified` | String |
-| `statYardage` | Int32 |
-| `type.id` | String |
-| `type.text` | String |
-| `period.number` | Int32 |
-| `clock.displayValue` | String |
-| `start.down` | Int32 |
-| `start.distance` | Int32 |
-| `start.yardLine` | Int32 |
-| `start.yardsToEndzone` | Int32 |
-| `start.downDistanceText` | String |
-| `start.shortDownDistanceText` | String |
-| `start.possessionText` | String |
-| `start.team.id` | Int32 |
-| `end.down` | Int32 |
-| `end.distance` | Int32 |
-| `end.yardLine` | Int32 |
-| `end.yardsToEndzone` | Int32 |
-| `end.downDistanceText` | String |
-| `end.shortDownDistanceText` | String |
-| `end.possessionText` | String |
-| `end.team.id` | Int32 |
-| `drive.id` | String |
-| `drive.displayResult` | String |
-| `drive.isScore` | Boolean |
-| `drive.team.shortDisplayName` | String |
-| `drive.team.displayName` | String |
-| `drive.team.name` | String |
-| `drive.team.abbreviation` | String |
-| `drive.yards` | Int32 |
-| `drive.offensivePlays` | Int32 |
-| `drive.result` | String |
-| `drive.description` | String |
-| `drive.shortDisplayResult` | String |
-| `drive.timeElapsed.displayValue` | String |
-| `drive.start.period.number` | Int32 |
-| `drive.start.period.type` | String |
-| `drive.start.yardLine` | Int32 |
-| `drive.start.clock.displayValue` | String |
-| `drive.start.text` | String |
-| `drive.end.period.number` | Int32 |
-| `drive.end.period.type` | String |
-| `drive.end.yardLine` | Int32 |
-| `drive.end.clock.displayValue` | String |
-| `game_id` | Int32 |
-| `season` | Int32 |
-| `seasonType` | Int32 |
-| `homeTeamId` | Int32 |
-| `awayTeamId` | Int32 |
-| `homeTeamName` | String |
-| `awayTeamName` | String |
-| `homeTeamMascot` | String |
-| `awayTeamMascot` | String |
-| `homeTeamAbbrev` | String |
-| `awayTeamAbbrev` | String |
-| `homeTeamNameAlt` | String |
-| `awayTeamNameAlt` | String |
-| `homeTeamSpread` | Float64 |
-| `gameSpread` | Float64 |
-| `gameSpreadAvailable` | Boolean |
-| `overUnder` | Float64 |
-| `homeFavorite` | Boolean |
-| `clock.minutes` | String |
-| `clock.seconds` | String |
-| `half` | Int32 |
-| `lead_half` | Int32 |
-| `start.TimeSecsRem` | Int32 |
-| `start.adj_TimeSecsRem` | Int32 |
-| `lead_text` | String |
-| `lead_start_team` | String |
-| `lead_start_yardsToEndzone` | Int32 |
-| `lead_start_down` | Int32 |
-| `lead_start_distance` | Int32 |
-| `lead_scoringPlay` | Boolean |
-| `text_dupe` | Boolean |
-| `game_play_number` | Int32 |
-| `start.pos_team.id` | Int32 |
-| `start.def_pos_team.id` | Int32 |
-| `end.def_team.id` | Int32 |
-| `end.pos_team.id` | Int32 |
-| `end.def_pos_team.id` | Int32 |
-| `start.pos_team.name` | String |
-| `start.def_pos_team.name` | String |
-| `end.pos_team.name` | String |
-| `end.def_pos_team.name` | String |
-| `start.is_home` | Boolean |
-| `end.is_home` | Boolean |
-| `homeTimeoutCalled` | Boolean |
-| `awayTimeoutCalled` | Boolean |
-| `end.homeTeamTimeouts` | Int32 |
-| `end.awayTeamTimeouts` | Int32 |
-| `start.homeTeamTimeouts` | Int32 |
-| `start.awayTeamTimeouts` | Int32 |
-| `end.TimeSecsRem` | Int32 |
-| `end.adj_TimeSecsRem` | Int32 |
-| `start.posTeamTimeouts` | Int32 |
-| `start.defPosTeamTimeouts` | Int32 |
-| `end.posTeamTimeouts` | Int32 |
-| `end.defPosTeamTimeouts` | Int32 |
-| `firstHalfKickoffTeamId` | Int32 |
-| `period` | Int32 |
-| `start.yard` | Int32 |
-| `end.yard` | Int32 |
-| `playType` | String |
-| `week` | Int32 |
-| `end_of_half` | Boolean |
-| `down_1` | Boolean |
-| `down_2` | Boolean |
-| `down_3` | Boolean |
-| `down_4` | Boolean |
-| `down_1_end` | Boolean |
-| `down_2_end` | Boolean |
-| `down_3_end` | Boolean |
-| `down_4_end` | Boolean |
-| `scoring_play` | Boolean |
-| `td_play` | Boolean |
-| `touchdown` | Boolean |
-| `td_check` | Boolean |
-| `safety` | Boolean |
-| `fumble_vec` | Boolean |
-| `forced_fumble` | Boolean |
-| `kickoff_play` | Boolean |
-| `kickoff_tb` | Boolean |
-| `kickoff_onside` | Boolean |
-| `kickoff_oob` | Boolean |
-| `kickoff_fair_catch` | Boolean |
-| `kickoff_downed` | Boolean |
-| `kick_play` | Boolean |
-| `kickoff_safety` | Boolean |
-| `punt` | Boolean |
-| `punt_play` | Boolean |
-| `punt_tb` | Boolean |
-| `punt_oob` | Boolean |
-| `punt_fair_catch` | Boolean |
-| `punt_downed` | Boolean |
-| `punt_safety` | Boolean |
-| `penalty_safety` | Boolean |
-| `punt_blocked` | Boolean |
-| `rush` | Boolean |
-| `pass` | Boolean |
-| `sack_vec` | Boolean |
-| `pos_team` | Int32 |
-| `def_pos_team` | Int32 |
-| `is_home` | Boolean |
-| `HA_score_diff` | Int32 |
-| `lag_homeScore` | Int32 |
-| `lag_awayScore` | Int32 |
-| `start.homeScore` | Int32 |
-| `start.awayScore` | Int32 |
-| `end.homeScore` | Int32 |
-| `end.awayScore` | Int32 |
-| `pos_team_score` | Int32 |
-| `def_pos_team_score` | Int32 |
-| `start.pos_team_score` | Int32 |
-| `start.def_pos_team_score` | Int32 |
-| `start.pos_score_diff` | Int32 |
-| `end.pos_team_score` | Int32 |
-| `end.def_pos_team_score` | Int32 |
-| `end.pos_score_diff` | Int32 |
-| `lag_pos_team` | Int32 |
-| `lead_pos_team` | Int32 |
-| `lead_pos_team2` | Int32 |
-| `pos_score_diff` | Int32 |
-| `lag_pos_score_diff` | Int32 |
-| `pos_score_pts` | Int32 |
-| `pos_score_diff_start` | Int32 |
-| `start.pos_team_receives_2H_kickoff` | Boolean |
-| `end.pos_team_receives_2H_kickoff` | Boolean |
-| `change_of_poss` | Int32 |
-| `penalty_flag` | Boolean |
-| `penalty_declined` | Boolean |
-| `penalty_no_play` | Boolean |
-| `penalty_offset` | Boolean |
-| `penalty_1st_conv` | Boolean |
-| `penalty_in_text` | Boolean |
-| `sack` | Boolean |
-| `int` | Boolean |
-| `int_td` | Boolean |
-| `completion` | Boolean |
-| `pass_attempt` | Boolean |
-| `target` | Boolean |
-| `pass_breakup` | Boolean |
-| `pass_td` | Boolean |
-| `rush_td` | Boolean |
-| `turnover_vec` | Boolean |
-| `offense_score_play` | Boolean |
-| `defense_score_play` | Boolean |
-| `downs_turnover` | Boolean |
-| `fg_attempt` | Boolean |
-| `fg_made` | Boolean |
-| `pos_unit` | String |
-| `def_pos_unit` | String |
-| `lead_play_type` | String |
-| `sp` | Boolean |
-| `play` | Boolean |
-| `scrimmage_play` | Boolean |
-| `change_of_pos_team` | Boolean |
-| `pos_score_diff_end` | Int32 |
-| `fumble_lost` | Boolean |
-| `fumble_recovered` | Boolean |
-| `receiver_player_name` | String |
-| `passer_player_name` | String |
-| `new_down` | Int32 |
-| `new_distance` | Int32 |
-| `middle_8` | Boolean |
-| `rz_play` | Boolean |
-| `scoring_opp` | Boolean |
-| `stuffed_run` | Boolean |
-| `stopped_run` | Boolean |
-| `opportunity_run` | Boolean |
-| `highlight_run` | Boolean |
-| `short_rush_success` | Boolean |
-| `short_rush_attempt` | Boolean |
-| `power_rush_success` | Boolean |
-| `power_rush_attempt` | Boolean |
-| `early_down` | Boolean |
-| `late_down` | Boolean |
-| `early_down_pass` | Boolean |
-| `early_down_rush` | Boolean |
-| `late_down_pass` | Boolean |
-| `late_down_rush` | Boolean |
-| `standard_down` | Boolean |
-| `passing_down` | Boolean |
-| `TFL` | Boolean |
-| `TFL_pass` | Boolean |
-| `TFL_rush` | Boolean |
-| `havoc` | Boolean |
-| `start.pos_team_spread` | Float64 |
-| `start.elapsed_share` | Float64 |
-| `start.spread_time` | Float64 |
-| `end.pos_team_spread` | Float64 |
-| `end.elapsed_share` | Float64 |
-| `end.spread_time` | Float64 |
-| `start.yardsToEndzone.touchback` | Int32 |
-| `EP_start_touchback` | Float64 |
-| `EP_start` | Float64 |
-| `EP_end` | Float64 |
-| `lag_change_of_pos_team` | Boolean |
-| `EPA` | Float64 |
-| `def_EPA` | Float64 |
-| `EPA_scrimmage` | Float64 |
-| `EPA_pass` | Float64 |
-| `EPA_explosive` | Boolean |
-| `EPA_non_explosive` | Float64 |
-| `EPA_explosive_pass` | Boolean |
-| `EPA_explosive_rush` | Boolean |
-| `first_down_created` | Boolean |
-| `EPA_success` | Boolean |
-| `EPA_success_early_down` | Boolean |
-| `EPA_success_early_down_pass` | Boolean |
-| `EPA_success_early_down_rush` | Boolean |
-| `EPA_success_late_down` | Boolean |
-| `EPA_success_late_down_pass` | Boolean |
-| `EPA_success_late_down_rush` | Boolean |
-| `EPA_success_standard_down` | Boolean |
-| `EPA_success_passing_down` | Boolean |
-| `EPA_success_pass` | Boolean |
-| `EPA_success_rush` | Boolean |
-| `EPA_success_rush_EPA` | Boolean |
-| `EPA_middle_8_success` | Boolean |
-| `EPA_middle_8_success_pass` | Boolean |
-| `EPA_middle_8_success_rush` | Boolean |
-| `EPA_sp` | Float64 |
-| `start.ExpScoreDiff_touchback` | Float64 |
-| `start.ExpScoreDiff` | Float64 |
-| `start.ExpScoreDiff_Time_Ratio_touchback` | Float64 |
-| `start.ExpScoreDiff_Time_Ratio` | Float64 |
-| `end.ExpScoreDiff` | Float64 |
-| `end.ExpScoreDiff_Time_Ratio` | Float64 |
-| `wp_before` | Float64 |
-| `wp_touchback` | Float64 |
-| `def_wp_before` | Float64 |
-| `home_wp_before` | Float64 |
-| `away_wp_before` | Float64 |
-| `lead_wp_before` | Float64 |
-| `lead_wp_before2` | Float64 |
-| `wp_after` | Float64 |
-| `def_wp_after` | Float64 |
-| `home_wp_after` | Float64 |
-| `away_wp_after` | Float64 |
-| `wpa` | Float64 |
-| `drive_start` | Int32 |
-| `drive_stopped` | Boolean |
-| `drive_play_index` | Int32 |
-| `drive_offense_plays` | Int32 |
-| `prog_drive_EPA` | Float64 |
-| `prog_drive_WPA` | Float64 |
-| `drive_offense_yards` | Int32 |
-| `drive_total_yards` | Int32 |
-| `qbr_epa` | Float64 |
-| `weight` | Float64 |
-| `non_fumble_sack` | Boolean |
-| `pass_epa` | Float64 |
-| `pass_weight` | Float64 |
-| `action_play` | Boolean |
-| `athlete_name` | String |
-| `type.abbreviation` | String |
-| `lag_half` | String |
-| `lag_scoringPlay` | Boolean |
-| `lag_HA_score_diff` | Int32 |
-| `net_HA_score_pts` | Int32 |
-| `H_score_diff` | Int32 |
-| `A_score_diff` | Int32 |
-| `yds_rushed` | Int32 |
-| `rusher_player_name` | String |
-| `adj_rush_yardage` | Int32 |
-| `line_yards` | Float64 |
-| `second_level_yards` | Float64 |
-| `open_field_yards` | Int32 |
-| `highlight_yards` | Float64 |
-| `opp_highlight_yards` | Float64 |
-| `lag_EP_end` | Float64 |
-| `EP_between` | Float64 |
-| `EPA_rush` | Float64 |
-| `EPA_success_EPA` | Float64 |
-| `EPA_success_passing_down_EPA` | Float64 |
-| `rush_epa` | Float64 |
-| `rush_weight` | Float64 |
-| `penalty_detail` | String |
-| `penalty_text` | String |
-| `yds_penalty` | Int32 |
-| `EPA_penalty` | Float64 |
-| `pen_epa` | Float64 |
-| `pen_weight` | Float64 |
-| `yds_punt_gained` | Int32 |
-| `yds_punt_return` | Int32 |
-| `punter_player_name` | String |
-| `punt_return_player_name` | String |
-| `EPA_punt` | Float64 |
-| `EPA_success_standard_down_EPA` | Float64 |
-| `yds_receiving` | Int32 |
-| `EPA_success_pass_EPA` | Float64 |
-| `interception_player_name` | String |
-| `scoringType.name` | String |
-| `scoringType.displayName` | String |
-| `scoringType.abbreviation` | String |
-| `yds_kickoff_return` | Int32 |
-| `kickoff_player_name` | String |
-| `kickoff_return_player_name` | String |
-| `down` | Int32 |
-| `distance` | Int32 |
-| `EPA_kickoff` | Float64 |
-| `yds_fg` | Int32 |
-| `EPA_fg` | Float64 |
-| `fumble_player_name` | String |
-| `fumble_recovered_player_name` | String |
-| `yds_sacked` | Int32 |
-| `sack_epa` | Float64 |
-| `sack_weight` | Float64 |
-| `date` | String |
-| `fg_kicker_player_name` | String |
-| `yds_int_return` | Int32 |
-| `yds_punted` | Int32 |
-| `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') |
-| `game_date` | Date |
+| col_name | type | description |
+|---|---|---|
+| `id` | Int32 | 247Sports referencing id for the recruit. |
+| `sequenceNumber` | String | Broadcast sequence order number. |
+| `text` | String | Full play description. |
+| `awayScore` | Int32 | Away team score after the goal. |
+| `homeScore` | Int32 | Home team score after the goal. |
+| `scoringPlay` | Boolean |  |
+| `priority` | Boolean | `TRUE` if ESPN flags the play as a priority highlight. |
+| `modified` | String | ISO timestamp the play record was last modified. |
+| `statYardage` | Int32 |  |
+| `type.id` | String |  |
+| `type.text` | String |  |
+| `period.number` | Int32 |  |
+| `clock.displayValue` | String |  |
+| `start.down` | Int32 |  |
+| `start.distance` | Int32 |  |
+| `start.yardLine` | Int32 |  |
+| `start.yardsToEndzone` | Int32 |  |
+| `start.downDistanceText` | String |  |
+| `start.shortDownDistanceText` | String |  |
+| `start.possessionText` | String |  |
+| `start.team.id` | Int32 |  |
+| `end.down` | Int32 |  |
+| `end.distance` | Int32 |  |
+| `end.yardLine` | Int32 |  |
+| `end.yardsToEndzone` | Int32 |  |
+| `end.downDistanceText` | String |  |
+| `end.shortDownDistanceText` | String |  |
+| `end.possessionText` | String |  |
+| `end.team.id` | Int32 |  |
+| `drive.id` | String |  |
+| `drive.displayResult` | String |  |
+| `drive.isScore` | Boolean |  |
+| `drive.team.shortDisplayName` | String |  |
+| `drive.team.displayName` | String |  |
+| `drive.team.name` | String |  |
+| `drive.team.abbreviation` | String |  |
+| `drive.yards` | Int32 |  |
+| `drive.offensivePlays` | Int32 |  |
+| `drive.result` | String |  |
+| `drive.description` | String |  |
+| `drive.shortDisplayResult` | String |  |
+| `drive.timeElapsed.displayValue` | String |  |
+| `drive.start.period.number` | Int32 |  |
+| `drive.start.period.type` | String |  |
+| `drive.start.yardLine` | Int32 |  |
+| `drive.start.clock.displayValue` | String |  |
+| `drive.start.text` | String |  |
+| `drive.end.period.number` | Int32 |  |
+| `drive.end.period.type` | String |  |
+| `drive.end.yardLine` | Int32 |  |
+| `drive.end.clock.displayValue` | String |  |
+| `game_id` | Int32 | ESPN game identifier. |
+| `season` | Int32 | Season (4-digit year). |
+| `seasonType` | Int32 |  |
+| `homeTeamId` | Int32 |  |
+| `awayTeamId` | Int32 |  |
+| `homeTeamName` | String |  |
+| `awayTeamName` | String |  |
+| `homeTeamMascot` | String |  |
+| `awayTeamMascot` | String |  |
+| `homeTeamAbbrev` | String |  |
+| `awayTeamAbbrev` | String |  |
+| `homeTeamNameAlt` | String |  |
+| `awayTeamNameAlt` | String |  |
+| `homeTeamSpread` | Float64 |  |
+| `gameSpread` | Float64 |  |
+| `gameSpreadAvailable` | Boolean |  |
+| `overUnder` | Float64 |  |
+| `homeFavorite` | Boolean |  |
+| `clock.minutes` | String |  |
+| `clock.seconds` | String |  |
+| `half` | Int32 | Half indicator (1 or 2). |
+| `lead_half` | Int32 | A lead column on the half |
+| `start.TimeSecsRem` | Int32 |  |
+| `start.adj_TimeSecsRem` | Int32 |  |
+| `lead_text` | String |  |
+| `lead_start_team` | String |  |
+| `lead_start_yardsToEndzone` | Int32 |  |
+| `lead_start_down` | Int32 |  |
+| `lead_start_distance` | Int32 |  |
+| `lead_scoringPlay` | Boolean |  |
+| `text_dupe` | Boolean |  |
+| `game_play_number` | Int32 | Sequential play number within the game (excludes timeouts/end markers). |
+| `start.pos_team.id` | Int32 |  |
+| `start.def_pos_team.id` | Int32 |  |
+| `end.def_team.id` | Int32 |  |
+| `end.pos_team.id` | Int32 |  |
+| `end.def_pos_team.id` | Int32 |  |
+| `start.pos_team.name` | String |  |
+| `start.def_pos_team.name` | String |  |
+| `end.pos_team.name` | String |  |
+| `end.def_pos_team.name` | String |  |
+| `start.is_home` | Boolean |  |
+| `end.is_home` | Boolean |  |
+| `homeTimeoutCalled` | Boolean |  |
+| `awayTimeoutCalled` | Boolean |  |
+| `end.homeTeamTimeouts` | Int32 |  |
+| `end.awayTeamTimeouts` | Int32 |  |
+| `start.homeTeamTimeouts` | Int32 |  |
+| `start.awayTeamTimeouts` | Int32 |  |
+| `end.TimeSecsRem` | Int32 |  |
+| `end.adj_TimeSecsRem` | Int32 |  |
+| `start.posTeamTimeouts` | Int32 |  |
+| `start.defPosTeamTimeouts` | Int32 |  |
+| `end.posTeamTimeouts` | Int32 |  |
+| `end.defPosTeamTimeouts` | Int32 |  |
+| `firstHalfKickoffTeamId` | Int32 |  |
+| `period` | Int32 | Period (quarter) number. |
+| `start.yard` | Int32 |  |
+| `end.yard` | Int32 |  |
+| `playType` | String |  |
+| `week` | Int32 | Game week of the season. |
+| `end_of_half` | Boolean | Binary flag for the last play of a half. |
+| `down_1` | Boolean |  |
+| `down_2` | Boolean |  |
+| `down_3` | Boolean |  |
+| `down_4` | Boolean |  |
+| `down_1_end` | Boolean |  |
+| `down_2_end` | Boolean |  |
+| `down_3_end` | Boolean |  |
+| `down_4_end` | Boolean |  |
+| `scoring_play` | Boolean | `TRUE` if the play resulted in a score. |
+| `td_play` | Boolean | Binary flag for a touchdown play. |
+| `touchdown` | Boolean | Binary flag for a touchdown (duplicate of td_play for downstream use). |
+| `td_check` | Boolean |  |
+| `safety` | Boolean | Binary flag for a safety. |
+| `fumble_vec` | Boolean | Binary flag for a play involving a fumble. |
+| `forced_fumble` | Boolean |  |
+| `kickoff_play` | Boolean | Binary flag for a kickoff play. |
+| `kickoff_tb` | Boolean | Binary flag for a kickoff touchback. |
+| `kickoff_onside` | Boolean | Binary flag for an onside kickoff attempt. |
+| `kickoff_oob` | Boolean | Binary flag for a kickoff out of bounds. |
+| `kickoff_fair_catch` | Boolean | Binary flag for a kickoff fair catch. |
+| `kickoff_downed` | Boolean | Binary flag for a kickoff downed in the field of play. |
+| `kick_play` | Boolean | Binary flag for any kicking play (kickoff or field goal). |
+| `kickoff_safety` | Boolean | Binary flag for a kickoff safety. |
+| `punt` | Boolean | Binary flag for a punt play. |
+| `punt_play` | Boolean | Binary flag for any punt-related play (includes blocks/returns). |
+| `punt_tb` | Boolean | Binary flag for a punt touchback. |
+| `punt_oob` | Boolean | Binary flag for a punt out of bounds. |
+| `punt_fair_catch` | Boolean | Binary flag for a punt fair catch. |
+| `punt_downed` | Boolean | Binary flag for a punt downed in the field of play. |
+| `punt_safety` | Boolean | Binary flag for a punt safety. |
+| `penalty_safety` | Boolean | Binary flag for a safety scored on a penalty. |
+| `punt_blocked` | Boolean | Binary flag for a blocked punt. |
+| `rush` | Boolean | Binary flag for a rushing play. |
+| `pass` | Boolean | Binary flag for a passing play (includes sacks). |
+| `sack_vec` | Boolean | Binary flag for a sack play. |
+| `pos_team` | Int32 | Team name in possession at the start of the play (offense, kickoff-aware). |
+| `def_pos_team` | Int32 | Team name on defense at the start of the play. |
+| `is_home` | Boolean | Whether the subject team was the home team. |
+| `HA_score_diff` | Int32 |  |
+| `lag_homeScore` | Int32 |  |
+| `lag_awayScore` | Int32 |  |
+| `start.homeScore` | Int32 |  |
+| `start.awayScore` | Int32 |  |
+| `end.homeScore` | Int32 |  |
+| `end.awayScore` | Int32 |  |
+| `pos_team_score` | Int32 | Score for the team in possession at the start of the play. |
+| `def_pos_team_score` | Int32 | Score for the defensive team at the start of the play. |
+| `start.pos_team_score` | Int32 |  |
+| `start.def_pos_team_score` | Int32 |  |
+| `start.pos_score_diff` | Int32 |  |
+| `end.pos_team_score` | Int32 |  |
+| `end.def_pos_team_score` | Int32 |  |
+| `end.pos_score_diff` | Int32 |  |
+| `lag_pos_team` | Int32 | Possession team on the previous play (lag value). |
+| `lead_pos_team` | Int32 | Possession team on the next play (lead value). |
+| `lead_pos_team2` | Int32 | Possession team two plays ahead (lead 2 of pos_team). |
+| `pos_score_diff` | Int32 | Score differential from the possession team's perspective. |
+| `lag_pos_score_diff` | Int32 | pos_score_diff from the previous play (lag value). |
+| `pos_score_pts` | Int32 | Points scored on the play attributed to the possession team. |
+| `pos_score_diff_start` | Int32 | Score differential for the possession team at the start of the play. |
+| `start.pos_team_receives_2H_kickoff` | Boolean |  |
+| `end.pos_team_receives_2H_kickoff` | Boolean |  |
+| `change_of_poss` | Int32 | Binary flag for change of possession on the play (CFBD offense field). |
+| `penalty_flag` | Boolean | TRUE when a penalty was flagged on the play. |
+| `penalty_declined` | Boolean | TRUE when the penalty was declined. |
+| `penalty_no_play` | Boolean | TRUE when the penalty nullified the play (no play counted). |
+| `penalty_offset` | Boolean | TRUE when offsetting penalties were called. |
+| `penalty_1st_conv` | Boolean | TRUE when the penalty resulted in a first down conversion. |
+| `penalty_in_text` | Boolean |  |
+| `sack` | Boolean | Binary flag for a sack (duplicate of sack_vec for downstream use). |
+| `int` | Boolean | Binary flag for an interception. |
+| `int_td` | Boolean | Binary flag for an interception returned for a touchdown. |
+| `completion` | Boolean | Binary flag for a completed pass. |
+| `pass_attempt` | Boolean | Binary flag for a pass attempt. |
+| `target` | Boolean | Binary flag for a targeted receiver on the play. |
+| `pass_breakup` | Boolean |  |
+| `pass_td` | Boolean | Binary flag for a passing touchdown. |
+| `rush_td` | Boolean | Binary flag for a rushing touchdown. |
+| `turnover_vec` | Boolean | Binary flag for any play classified as a turnover. |
+| `offense_score_play` | Boolean | Binary flag for an offensive scoring play. |
+| `defense_score_play` | Boolean | Binary flag for a defensive scoring play. |
+| `downs_turnover` | Boolean | Binary flag for a turnover on downs. |
+| `fg_attempt` | Boolean |  |
+| `fg_made` | Boolean | TRUE when the field goal attempt was successful. |
+| `pos_unit` | String | Possession-team unit label (offense or special teams). |
+| `def_pos_unit` | String | Defensive possession-team unit label (defense or special teams). |
+| `lead_play_type` | String | Play type on the next play (lead value). |
+| `sp` | Boolean | Binary indicator for whether or not a score occurred on the play. |
+| `play` | Boolean | Binary flag indicating the row is a counted play (excludes end markers/timeouts/penalties). |
+| `scrimmage_play` | Boolean |  |
+| `change_of_pos_team` | Boolean | Binary flag for change of possession-team on the play. |
+| `pos_score_diff_end` | Int32 |  |
+| `fumble_lost` | Boolean | Binary indicator for if the fumble was lost. |
+| `fumble_recovered` | Boolean |  |
+| `receiver_player_name` | String | Name of the receiver on a passing play. |
+| `passer_player_name` | String | Name of the passer on a passing play. |
+| `new_down` | Int32 |  |
+| `new_distance` | Int32 |  |
+| `middle_8` | Boolean | TRUE for plays in the middle-8 window (final 4 min of 1H, first 4 min of 2H). |
+| `rz_play` | Boolean | Binary flag for a red-zone play (yards_to_goal <= 20). |
+| `scoring_opp` | Boolean | Binary flag for a scoring opportunity (yards_to_goal <= 40). |
+| `stuffed_run` | Boolean | Binary flag for a stuffed run (zero or negative yards gained). |
+| `stopped_run` | Boolean |  |
+| `opportunity_run` | Boolean |  |
+| `highlight_run` | Boolean |  |
+| `short_rush_success` | Boolean |  |
+| `short_rush_attempt` | Boolean |  |
+| `power_rush_success` | Boolean |  |
+| `power_rush_attempt` | Boolean |  |
+| `early_down` | Boolean |  |
+| `late_down` | Boolean |  |
+| `early_down_pass` | Boolean |  |
+| `early_down_rush` | Boolean |  |
+| `late_down_pass` | Boolean |  |
+| `late_down_rush` | Boolean |  |
+| `standard_down` | Boolean |  |
+| `passing_down` | Boolean |  |
+| `TFL` | Boolean |  |
+| `TFL_pass` | Boolean |  |
+| `TFL_rush` | Boolean |  |
+| `havoc` | Boolean |  |
+| `start.pos_team_spread` | Float64 |  |
+| `start.elapsed_share` | Float64 |  |
+| `start.spread_time` | Float64 |  |
+| `end.pos_team_spread` | Float64 |  |
+| `end.elapsed_share` | Float64 |  |
+| `end.spread_time` | Float64 |  |
+| `start.yardsToEndzone.touchback` | Int32 |  |
+| `EP_start_touchback` | Float64 |  |
+| `EP_start` | Float64 |  |
+| `EP_end` | Float64 |  |
+| `lag_change_of_pos_team` | Boolean | change_of_pos_team from the previous play (lag value). |
+| `EPA` | Float64 | Expected Points Added on the play (cfbfastR EPA model output). |
+| `def_EPA` | Float64 | EPA for the defensive team on the play (sign-flipped offense EPA). |
+| `EPA_scrimmage` | Float64 |  |
+| `EPA_pass` | Float64 |  |
+| `EPA_explosive` | Boolean |  |
+| `EPA_non_explosive` | Float64 |  |
+| `EPA_explosive_pass` | Boolean |  |
+| `EPA_explosive_rush` | Boolean |  |
+| `first_down_created` | Boolean |  |
+| `EPA_success` | Boolean |  |
+| `EPA_success_early_down` | Boolean |  |
+| `EPA_success_early_down_pass` | Boolean |  |
+| `EPA_success_early_down_rush` | Boolean |  |
+| `EPA_success_late_down` | Boolean |  |
+| `EPA_success_late_down_pass` | Boolean |  |
+| `EPA_success_late_down_rush` | Boolean |  |
+| `EPA_success_standard_down` | Boolean |  |
+| `EPA_success_passing_down` | Boolean |  |
+| `EPA_success_pass` | Boolean |  |
+| `EPA_success_rush` | Boolean |  |
+| `EPA_success_rush_EPA` | Boolean |  |
+| `EPA_middle_8_success` | Boolean |  |
+| `EPA_middle_8_success_pass` | Boolean |  |
+| `EPA_middle_8_success_rush` | Boolean |  |
+| `EPA_sp` | Float64 |  |
+| `start.ExpScoreDiff_touchback` | Float64 |  |
+| `start.ExpScoreDiff` | Float64 |  |
+| `start.ExpScoreDiff_Time_Ratio_touchback` | Float64 |  |
+| `start.ExpScoreDiff_Time_Ratio` | Float64 |  |
+| `end.ExpScoreDiff` | Float64 |  |
+| `end.ExpScoreDiff_Time_Ratio` | Float64 |  |
+| `wp_before` | Float64 | Win probability for the possession team before the play (0-1). |
+| `wp_touchback` | Float64 |  |
+| `def_wp_before` | Float64 | Win probability for the defensive team before the play (0-1). |
+| `home_wp_before` | Float64 | Home team win probability before the play (0-1). |
+| `away_wp_before` | Float64 | Away team win probability before the play (0-1). |
+| `lead_wp_before` | Float64 | Win probability on the next play (lead of wp_before). |
+| `lead_wp_before2` | Float64 | Win probability two plays ahead (lead 2 of wp_before). |
+| `wp_after` | Float64 | Win probability for the possession team after the play (0-1). |
+| `def_wp_after` | Float64 | Win probability for the defensive team after the play (0-1). |
+| `home_wp_after` | Float64 | Home team win probability after the play (0-1). |
+| `away_wp_after` | Float64 | Away team win probability after the play (0-1). |
+| `wpa` | Float64 | Win Probability Added on the play (cfbfastR WP model output). |
+| `drive_start` | Int32 |  |
+| `drive_stopped` | Boolean |  |
+| `drive_play_index` | Int32 |  |
+| `drive_offense_plays` | Int32 |  |
+| `prog_drive_EPA` | Float64 |  |
+| `prog_drive_WPA` | Float64 |  |
+| `drive_offense_yards` | Int32 |  |
+| `drive_total_yards` | Int32 |  |
+| `qbr_epa` | Float64 |  |
+| `weight` | Float64 | Listed weight (lbs). |
+| `non_fumble_sack` | Boolean |  |
+| `pass_epa` | Float64 |  |
+| `pass_weight` | Float64 |  |
+| `action_play` | Boolean |  |
+| `athlete_name` | String | Player full name. |
+| `type.abbreviation` | String |  |
+| `lag_half` | String | A lag column on the half |
+| `lag_scoringPlay` | Boolean |  |
+| `lag_HA_score_diff` | Int32 |  |
+| `net_HA_score_pts` | Int32 |  |
+| `H_score_diff` | Int32 |  |
+| `A_score_diff` | Int32 |  |
+| `yds_rushed` | Int32 | Rushing yards gained on the play. |
+| `rusher_player_name` | String | Name of the rusher on a rushing play. |
+| `adj_rush_yardage` | Int32 |  |
+| `line_yards` | Float64 |  |
+| `second_level_yards` | Float64 |  |
+| `open_field_yards` | Int32 |  |
+| `highlight_yards` | Float64 |  |
+| `opp_highlight_yards` | Float64 |  |
+| `lag_EP_end` | Float64 |  |
+| `EP_between` | Float64 |  |
+| `EPA_rush` | Float64 |  |
+| `EPA_success_EPA` | Float64 |  |
+| `EPA_success_passing_down_EPA` | Float64 |  |
+| `rush_epa` | Float64 |  |
+| `rush_weight` | Float64 |  |
+| `penalty_detail` | String | Parsed penalty description extracted from play text. |
+| `penalty_text` | String | TRUE when penalty information is detectable in the play text. |
+| `yds_penalty` | Int32 | Yardage assessed on the penalty. |
+| `EPA_penalty` | Float64 |  |
+| `pen_epa` | Float64 |  |
+| `pen_weight` | Float64 |  |
+| `yds_punt_gained` | Int32 | Net yards gained on the punt (punt distance minus return). |
+| `yds_punt_return` | Int32 | Yards gained on the punt return. |
+| `punter_player_name` | String | Name of the punter. |
+| `punt_return_player_name` | String |  |
+| `EPA_punt` | Float64 |  |
+| `EPA_success_standard_down_EPA` | Float64 |  |
+| `yds_receiving` | Int32 | Receiving yards gained on the play. |
+| `EPA_success_pass_EPA` | Float64 |  |
+| `interception_player_name` | String | Name of the defender credited with the interception. |
+| `scoringType.name` | String |  |
+| `scoringType.displayName` | String |  |
+| `scoringType.abbreviation` | String |  |
+| `yds_kickoff_return` | Int32 | Yards gained on the kickoff return. |
+| `kickoff_player_name` | String | Name of the kickoff specialist. |
+| `kickoff_return_player_name` | String |  |
+| `down` | Int32 | Down of the play (1-4). |
+| `distance` | Int32 | Yards to gain for a first down (or to the goal line in goal-to-go situations). |
+| `EPA_kickoff` | Float64 |  |
+| `yds_fg` | Int32 | Distance of the field goal attempt in yards. |
+| `EPA_fg` | Float64 |  |
+| `fumble_player_name` | String | Name of the player who fumbled. |
+| `fumble_recovered_player_name` | String | Name of the player who recovered the fumble. |
+| `yds_sacked` | Int32 | Yards lost on the sack. |
+| `sack_epa` | Float64 |  |
+| `sack_weight` | Float64 |  |
+| `date` | String | Date of the poll release. |
+| `fg_kicker_player_name` | String | Name of the field goal kicker. |
+| `yds_int_return` | Int32 | Yards gained on an interception return. |
+| `yds_punted` | Int32 | Yards the ball traveled on the punt. |
+| `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') | Game start date/time (ISO 8601). |
+| `game_date` | Date | Kickoff date-time (ISO 8601, UTC). |
 
 ```python
 load_cfb_pbp(seasons=2024)
@@ -429,23 +429,23 @@ load_cfb_pbp(seasons=2024)
 Release: [cfb_ratings](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_ratings) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/cfb_ratings/cfb_ratings_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int64 |
-| `team_id` | String |
-| `adj_off_epa` | Float64 |
-| `adj_def_epa` | Float64 |
-| `adj_st_epa` | Float64 |
-| `adj_net` | Float64 |
-| `fei_off` | Float64 |
-| `fei_def` | Float64 |
-| `fei_net` | Float64 |
-| `games` | Int64 |
-| `off_pace` | Float64 |
-| `off_rank` | Int64 |
-| `def_rank` | Int64 |
-| `net_rank` | Int64 |
-| `net_z` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int64 | Season (4-digit year). |
+| `team_id` | Int64 | ESPN team id. |
+| `adj_off_epa` | Float64 |  |
+| `adj_def_epa` | Float64 |  |
+| `adj_st_epa` | Float64 |  |
+| `adj_net` | Float64 |  |
+| `fei_off` | Float64 |  |
+| `fei_def` | Float64 |  |
+| `fei_net` | Float64 |  |
+| `games` | Int64 | Number of games included in the ATS summary. |
+| `off_pace` | Float64 |  |
+| `off_rank` | Int64 |  |
+| `def_rank` | Int64 |  |
+| `net_rank` | Int64 |  |
+| `net_z` | Float64 |  |
 
 ```python
 load_cfb_ratings(seasons=2024)
@@ -456,13 +456,13 @@ load_cfb_ratings(seasons=2024)
 Release: [cfb_recruiting_proj](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_recruiting_proj) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/cfb_recruiting_proj/cfb_recruiting_proj_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int64 |
-| `team_id` | String |
-| `pred_wins` | Float64 |
-| `pred_margin` | Float64 |
-| `pred_net_epa` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int64 | Season (4-digit year). |
+| `team_id` | Int64 | ESPN team id. |
+| `pred_wins` | Float64 |  |
+| `pred_margin` | Float64 |  |
+| `pred_net_epa` | Float64 |  |
 
 ```python
 load_cfb_recruiting_proj(seasons=2024)
@@ -473,26 +473,26 @@ load_cfb_recruiting_proj(seasons=2024)
 Release: [cfbfastR-data](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfbfastR-data) · asset `https://raw.githubusercontent.com/sportsdataverse/cfbfastR-data/main/rosters/parquet/cfb_rosters_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `athlete_id` | String |
-| `first_name` | String |
-| `last_name` | String |
-| `team` | String |
-| `weight` | Int32 |
-| `height` | Int32 |
-| `jersey` | Int32 |
-| `year` | Int32 |
-| `position` | String |
-| `home_city` | String |
-| `home_state` | String |
-| `home_country` | String |
-| `home_latitude` | String |
-| `home_longitude` | String |
-| `home_county_fips` | String |
-| `recruit_ids` | List(Int32) |
-| `headshot_url` | String |
-| `season` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `athlete_id` | String | ESPN athlete id. |
+| `first_name` | String | Athlete first name. |
+| `last_name` | String | Athlete last name. |
+| `team` | String | Team name. |
+| `weight` | Int32 | Listed weight (lbs). |
+| `height` | Int32 | Listed height (inches). |
+| `jersey` | Int32 | Jersey number. |
+| `year` | Int32 | Four-digit season year (e.g. 2019). |
+| `position` | String | Athlete position. |
+| `home_city` | String | Hometown of the athlete. |
+| `home_state` | String | Hometown state of the athlete. |
+| `home_country` | String | Hometown country of the athlete. |
+| `home_latitude` | String | Hometown latitude. |
+| `home_longitude` | String | Hometown longitude. |
+| `home_county_fips` | String | Hometown FIPS code. |
+| `recruit_ids` | List(Int32) |  |
+| `headshot_url` | String | Player ESPN headshot url. |
+| `season` | Int32 | Season (4-digit year). |
 
 ```python
 load_cfb_rosters(seasons=2024)
@@ -503,39 +503,39 @@ load_cfb_rosters(seasons=2024)
 Release: [cfbfastR-data](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfbfastR-data) · asset `https://raw.githubusercontent.com/sportsdataverse/cfbfastR-data/main/schedules/parquet/cfb_schedules_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int32 |
-| `season` | Int32 |
-| `week` | Int32 |
-| `season_type` | String |
-| `start_date` | String |
-| `start_time_tbd` | Boolean |
-| `completed` | Boolean |
-| `neutral_site` | Boolean |
-| `conference_game` | Boolean |
-| `attendance` | Int32 |
-| `venue_id` | Int32 |
-| `venue` | String |
-| `home_id` | Int32 |
-| `home_team` | String |
-| `home_conference` | String |
-| `home_division` | String |
-| `home_points` | Int32 |
-| `home_post_win_prob` | Boolean |
-| `home_pregame_elo` | Int32 |
-| `home_postgame_elo` | Int32 |
-| `away_id` | Int32 |
-| `away_team` | String |
-| `away_conference` | String |
-| `away_division` | String |
-| `away_points` | Int32 |
-| `away_post_win_prob` | Boolean |
-| `away_pregame_elo` | Int32 |
-| `away_postgame_elo` | Int32 |
-| `excitement_index` | Boolean |
-| `highlights` | Boolean |
-| `notes` | String |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int32 | ESPN game identifier. |
+| `season` | Int32 | Season (4-digit year). |
+| `week` | Int32 | Game week of the season. |
+| `season_type` | String | ESPN season type (2 = regular, 3 = postseason). |
+| `start_date` | String | Season start timestamp (ISO 8601, UTC). |
+| `start_time_tbd` | Boolean | TRUE/FALSE flag for if the game's start time is to be determined. |
+| `completed` | Boolean | `TRUE` if the game is complete. |
+| `neutral_site` | Boolean | TRUE/FALSE flag for if the game took place at a neutral site. |
+| `conference_game` | Boolean | TRUE/FALSE flag for this game qualifying as a conference game. |
+| `attendance` | Int32 | Reported attendance at the game. |
+| `venue_id` | Int32 | Referencing venue id. |
+| `venue` | String | Venue name. |
+| `home_id` | Int32 | Home team referencing id. |
+| `home_team` | String | Home team name. |
+| `home_conference` | String | Home team conference. |
+| `home_division` | String | Home team division. |
+| `home_points` | Int32 | Home team total points scored in the game so far. |
+| `home_post_win_prob` | Boolean | Home team post-game win probability. |
+| `home_pregame_elo` | Int32 | Home team pre-game ELO rating. |
+| `home_postgame_elo` | Int32 | Home team post-game ELO rating. |
+| `away_id` | Int32 | Away team referencing id. |
+| `away_team` | String | Away team name. |
+| `away_conference` | String | Away team conference. |
+| `away_division` | String | Away team division. |
+| `away_points` | Int32 | Away team total points scored in the game so far. |
+| `away_post_win_prob` | Boolean | Away team post-game win probability. |
+| `away_pregame_elo` | Int32 | Away team pre-game ELO rating. |
+| `away_postgame_elo` | Int32 | Away team post-game ELO rating. |
+| `excitement_index` | Boolean | Game excitement index. |
+| `highlights` | Boolean | Game highlight urls. |
+| `notes` | String | Game notes. |
 
 ```python
 load_cfb_schedule(seasons=2024)
@@ -546,36 +546,36 @@ load_cfb_schedule(seasons=2024)
 Release: [cfbfastR-data](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfbfastR-data) · asset `https://raw.githubusercontent.com/sportsdataverse/cfbfastR-data/main/team_info/parquet/cfb_team_info_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `team_id` | Int32 |
-| `school` | String |
-| `mascot` | String |
-| `abbreviation` | String |
-| `alt_name1` | String |
-| `alt_name2` | String |
-| `alt_name3` | String |
-| `conference` | String |
-| `classification` | String |
-| `color` | String |
-| `alt_color` | String |
-| `logo` | String |
-| `logo_2` | String |
-| `twitter` | String |
-| `venue_id` | Int32 |
-| `venue_name` | String |
-| `city` | String |
-| `state` | String |
-| `zip` | String |
-| `country_code` | String |
-| `timezone` | String |
-| `latitude` | Float64 |
-| `longitude` | Float64 |
-| `elevation` | String |
-| `capacity` | Int32 |
-| `year_constructed` | Int32 |
-| `grass` | Boolean |
-| `dome` | Boolean |
+| col_name | type | description |
+|---|---|---|
+| `team_id` | Int64 | ESPN team id. |
+| `school` | String | Team name. |
+| `mascot` | String | Team mascot. |
+| `abbreviation` | String | Metric abbreviation. |
+| `alt_name1` | String | Team alternate name 1 (as it appears in `play_text`). |
+| `alt_name2` | String | Team alternate name 2 (as it appears in `play_text`). |
+| `alt_name3` | String | Team alternate name 3 (as it appears in `play_text`). |
+| `conference` | String | Conference of the team. |
+| `classification` | String | Conference classification (fbs, fcs, ii, iii). |
+| `color` | String | Primary team color (hex, no `#`). |
+| `alt_color` | String | Team color (alternate). |
+| `logo` | String | Team or league logo URL. |
+| `logo_2` | String |  |
+| `twitter` | String |  |
+| `venue_id` | Int32 | Referencing venue id. |
+| `venue_name` | String | Full name of the franchise's venue. |
+| `city` | String | Venue city. |
+| `state` | String | Venue state. |
+| `zip` | String | Team/venue zip code. |
+| `country_code` | String | Team/venue country code. |
+| `timezone` | String | Time zone in which the venue resides (i.e. Eastern Time -> "America/New_York"). |
+| `latitude` | Float64 | Venue latitude in decimal degrees. |
+| `longitude` | Float64 | Venue longitude in decimal degrees. |
+| `elevation` | String | Venue elevation above sea level. |
+| `capacity` | Int32 | Stadium capacity. |
+| `year_constructed` | Int32 | Year in which the venue was constructed. |
+| `grass` | Boolean | TRUE/FALSE response on whether the field is grass or not. |
+| `dome` | Boolean | TRUE/FALSE response to whether the venue has a dome or not. |
 
 ```python
 load_cfb_team_info(seasons=2024)
@@ -586,19 +586,19 @@ load_cfb_team_info(seasons=2024)
 Release: [cfb_crosswalk](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_crosswalk) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/cfb_crosswalk/cfb_teams_crosswalk_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `norm_key` | String |
-| `espn_team_id` | Int64 |
-| `espn_team` | String |
-| `espn_abbreviation` | String |
-| `fox_team_id` | String |
-| `fox_team` | String |
-| `fox_abbreviation` | String |
-| `yahoo_team_id` | String |
-| `yahoo_team` | String |
-| `yahoo_abbreviation` | String |
-| `matched_sources` | String |
+| col_name | type | description |
+|---|---|---|
+| `norm_key` | String |  |
+| `espn_team_id` | Int64 | ESPN team id (canonical key). |
+| `espn_team` | String |  |
+| `espn_abbreviation` | String | ESPN abbreviation. |
+| `fox_team_id` | String | Fox Bifrost team id (NA if unmatched). |
+| `fox_team` | String |  |
+| `fox_abbreviation` | String |  |
+| `yahoo_team_id` | String | Yahoo team id (NA placeholder). |
+| `yahoo_team` | String |  |
+| `yahoo_abbreviation` | String |  |
+| `matched_sources` | String |  |
 
 ```python
 load_cfb_teams_crosswalk(seasons=2024)
@@ -609,19 +609,19 @@ load_cfb_teams_crosswalk(seasons=2024)
 Release: [cfb_crosswalk](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_crosswalk) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/cfb_crosswalk/cfb_schedule_crosswalk_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `matchup_key` | String |
-| `espn_game_id` | Int64 |
-| `fox_game_id` | String |
-| `yahoo_game_id` | String |
-| `yahoo_global_game_id` | String |
-| `home_team` | String |
-| `away_team` | String |
-| `espn_date` | String |
-| `fox_date` | String |
-| `yahoo_date` | String |
-| `matched_sources` | String |
+| col_name | type | description |
+|---|---|---|
+| `matchup_key` | String |  |
+| `espn_game_id` | Int64 | ESPN game id (NA for bart-only rows). |
+| `fox_game_id` | String | Fox game id (NA placeholder). |
+| `yahoo_game_id` | String | Yahoo game id (NA placeholder). |
+| `yahoo_global_game_id` | String |  |
+| `home_team` | String | Home team name. |
+| `away_team` | String | Away team name. |
+| `espn_date` | String |  |
+| `fox_date` | String |  |
+| `yahoo_date` | String |  |
+| `matched_sources` | String |  |
 
 ```python
 load_cfb_schedule_crosswalk(seasons=2024)
@@ -632,29 +632,29 @@ load_cfb_schedule_crosswalk(seasons=2024)
 Release: [espn_cfb_team_box](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_cfb_team_box) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_cfb_team_box/team_box_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `firstDowns` | String |
-| `thirdDownEff` | String |
-| `fourthDownEff` | String |
-| `totalYards` | String |
-| `netPassingYards` | String |
-| `completionAttempts` | String |
-| `yardsPerPass` | String |
-| `rushingYards` | String |
-| `rushingAttempts` | String |
-| `yardsPerRushAttempt` | String |
-| `totalPenaltiesYards` | String |
-| `turnovers` | String |
-| `fumblesLost` | String |
-| `interceptions` | String |
-| `possessionTime` | String |
-| `team_id` | Int64 |
-| `team_abbreviation` | String |
-| `team_name` | String |
-| `home_away` | String |
-| `game_id` | Int64 |
-| `season` | Int64 |
+| col_name | type | description |
+|---|---|---|
+| `firstDowns` | String |  |
+| `thirdDownEff` | String |  |
+| `fourthDownEff` | String |  |
+| `totalYards` | String |  |
+| `netPassingYards` | String |  |
+| `completionAttempts` | String |  |
+| `yardsPerPass` | String |  |
+| `rushingYards` | String |  |
+| `rushingAttempts` | String |  |
+| `yardsPerRushAttempt` | String |  |
+| `totalPenaltiesYards` | String |  |
+| `turnovers` | String | Turnovers total. |
+| `fumblesLost` | String |  |
+| `interceptions` | String | Passing interceptions. |
+| `possessionTime` | String |  |
+| `team_id` | Int64 | ESPN team id. |
+| `team_abbreviation` | String | Team abbreviation; `team_detail = TRUE` only. |
+| `team_name` | String | Team nickname; `team_detail = TRUE` only. |
+| `home_away` | String | `home` or `away`. |
+| `game_id` | Int64 | ESPN game identifier. |
+| `season` | Int64 | Season (4-digit year). |
 
 ```python
 load_cfb_team_box(seasons=2024)
@@ -665,54 +665,54 @@ load_cfb_team_box(seasons=2024)
 Release: [espn_cfb_player_box](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_cfb_player_box) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_cfb_player_box/player_box_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `completions/passingAttempts` | String |
-| `passingYards` | String |
-| `yardsPerPassAttempt` | String |
-| `passingTouchdowns` | String |
-| `interceptions` | String |
-| `adjQBR` | String |
-| `category` | String |
-| `athlete_id` | Int64 |
-| `athlete_name` | String |
-| `jersey` | Null |
-| `team_id` | Int64 |
-| `rushingAttempts` | String |
-| `rushingYards` | String |
-| `yardsPerRushAttempt` | String |
-| `rushingTouchdowns` | String |
-| `longRushing` | String |
-| `receptions` | String |
-| `receivingYards` | String |
-| `yardsPerReception` | String |
-| `receivingTouchdowns` | String |
-| `longReception` | String |
-| `interceptionYards` | String |
-| `interceptionTouchdowns` | String |
-| `puntReturns` | String |
-| `puntReturnYards` | String |
-| `yardsPerPuntReturn` | String |
-| `longPuntReturn` | String |
-| `puntReturnTouchdowns` | String |
-| `fieldGoalsMade/fieldGoalAttempts` | String |
-| `fieldGoalPct` | String |
-| `longFieldGoalMade` | String |
-| `extraPointsMade/extraPointAttempts` | String |
-| `totalKickingPoints` | String |
-| `punts` | String |
-| `puntYards` | String |
-| `grossAvgPuntYards` | String |
-| `touchbacks` | String |
-| `puntsInside20` | String |
-| `longPunt` | String |
-| `game_id` | Int64 |
-| `season` | Int64 |
-| `stat_1` | String |
-| `stat_2` | String |
-| `stat_3` | String |
-| `stat_4` | String |
-| `stat_5` | String |
+| col_name | type | description |
+|---|---|---|
+| `completions/passingAttempts` | String |  |
+| `passingYards` | String |  |
+| `yardsPerPassAttempt` | String |  |
+| `passingTouchdowns` | String |  |
+| `interceptions` | String | Passing interceptions. |
+| `adjQBR` | String |  |
+| `category` | String | CFBD stats category name (e.g. passing, rushing, defensive). |
+| `athlete_id` | Int64 | ESPN athlete id. |
+| `athlete_name` | String | Player full name. |
+| `jersey` | Null | Jersey number. |
+| `team_id` | Int64 | ESPN team id. |
+| `rushingAttempts` | String |  |
+| `rushingYards` | String |  |
+| `yardsPerRushAttempt` | String |  |
+| `rushingTouchdowns` | String |  |
+| `longRushing` | String |  |
+| `receptions` | String | The number of pass receptions. Lateral receptions officially don't count as reception. |
+| `receivingYards` | String |  |
+| `yardsPerReception` | String |  |
+| `receivingTouchdowns` | String |  |
+| `longReception` | String |  |
+| `interceptionYards` | String |  |
+| `interceptionTouchdowns` | String |  |
+| `puntReturns` | String |  |
+| `puntReturnYards` | String |  |
+| `yardsPerPuntReturn` | String |  |
+| `longPuntReturn` | String |  |
+| `puntReturnTouchdowns` | String |  |
+| `fieldGoalsMade/fieldGoalAttempts` | String |  |
+| `fieldGoalPct` | String |  |
+| `longFieldGoalMade` | String |  |
+| `extraPointsMade/extraPointAttempts` | String |  |
+| `totalKickingPoints` | String |  |
+| `punts` | String |  |
+| `puntYards` | String |  |
+| `grossAvgPuntYards` | String |  |
+| `touchbacks` | String |  |
+| `puntsInside20` | String |  |
+| `longPunt` | String |  |
+| `game_id` | Int64 | ESPN game identifier. |
+| `season` | Int64 | Season (4-digit year). |
+| `stat_1` | String |  |
+| `stat_2` | String |  |
+| `stat_3` | String |  |
+| `stat_4` | String |  |
+| `stat_5` | String |  |
 
 ```python
 load_cfb_player_box(seasons=2024)
@@ -723,28 +723,28 @@ load_cfb_player_box(seasons=2024)
 Release: [espn_cfb_drives](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_cfb_drives) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_cfb_drives/drives_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `drive_id` | String |
-| `team_id` | Int64 |
-| `result` | String |
-| `display_result` | String |
-| `short_display_result` | String |
-| `description` | String |
-| `yards` | Int64 |
-| `offensive_plays` | Int64 |
-| `is_score` | Boolean |
-| `start_period` | Int64 |
-| `start_yard_line` | Int64 |
-| `start_clock` | String |
-| `start_text` | String |
-| `end_period` | Int64 |
-| `end_yard_line` | Int64 |
-| `end_clock` | String |
-| `time_elapsed` | String |
-| `n_plays` | Int64 |
-| `game_id` | Int64 |
-| `season` | Int64 |
+| col_name | type | description |
+|---|---|---|
+| `drive_id` | String | CFBD drive identifier the play belongs to. |
+| `team_id` | Int64 | ESPN team id. |
+| `result` | String | Drive result code (e.g. `PUNT`, `TD`). |
+| `display_result` | String | Drive-result label (e.g. `Punt`, `Touchdown`). |
+| `short_display_result` | String | Short drive-result label. |
+| `description` | String | ESPN's description of the stat. |
+| `yards` | Int64 | Total yards gained on the drive. |
+| `offensive_plays` | Int64 | Number of offensive plays on the drive. |
+| `is_score` | Boolean | `TRUE` if the drive resulted in a score. |
+| `start_period` | Int64 | Period (quarter) in which the drive starts. |
+| `start_yard_line` | Int64 | Yard line at the start of the play. |
+| `start_clock` | String | Game clock display value at the start of the drive. |
+| `start_text` | String | Field-position text at the start of the drive. |
+| `end_period` | Int64 | Period (quarter) in which the drive ends. |
+| `end_yard_line` | Int64 | Yard line at the end of the play. |
+| `end_clock` | String | Game clock display value at the end of the drive. |
+| `time_elapsed` | String | Elapsed game time for the drive (`MM:SS`). |
+| `n_plays` | Int64 |  |
+| `game_id` | Int64 | ESPN game identifier. |
+| `season` | Int64 | Season (4-digit year). |
 
 ```python
 load_cfb_drives(seasons=2024)
@@ -755,76 +755,76 @@ load_cfb_drives(seasons=2024)
 Release: [espn_cfb_play_participants](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_cfb_play_participants) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_cfb_play_participants/play_participants_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int64 |
-| `play_id` | Int64 |
-| `kicker_player_name` | String |
-| `returner_player_name` | String |
-| `passer_player_name` | String |
-| `receiver_player_name` | String |
-| `rusher_player_name` | String |
-| `penalized_player_name` | String |
-| `scorer_player_name` | String |
-| `pass_defender_player_name` | String |
-| `punter_player_name` | String |
-| `pat_scorer_player_name` | String |
-| `sacked_by_player_name` | String |
-| `kicker_player_id` | String |
-| `returner_player_id` | String |
-| `passer_player_id` | String |
-| `receiver_player_id` | String |
-| `rusher_player_id` | String |
-| `penalized_player_id` | String |
-| `scorer_player_id` | String |
-| `pass_defender_player_id` | String |
-| `punter_player_id` | String |
-| `pat_scorer_player_id` | String |
-| `sacked_by_player_id` | String |
-| `kicker_player_names` | String |
-| `returner_player_names` | String |
-| `passer_player_names` | String |
-| `receiver_player_names` | String |
-| `rusher_player_names` | String |
-| `penalized_player_names` | String |
-| `scorer_player_names` | String |
-| `pass_defender_player_names` | String |
-| `punter_player_names` | String |
-| `pat_scorer_player_names` | String |
-| `sacked_by_player_names` | String |
-| `kicker_player_ids` | String |
-| `returner_player_ids` | String |
-| `passer_player_ids` | String |
-| `receiver_player_ids` | String |
-| `rusher_player_ids` | String |
-| `penalized_player_ids` | String |
-| `scorer_player_ids` | String |
-| `pass_defender_player_ids` | String |
-| `punter_player_ids` | String |
-| `pat_scorer_player_ids` | String |
-| `sacked_by_player_ids` | String |
-| `season` | Int64 |
-| `week` | Int64 |
-| `recoverer_player_name` | String |
-| `recoverer_player_id` | String |
-| `recoverer_player_names` | String |
-| `recoverer_player_ids` | String |
-| `tackler_player_name` | String |
-| `assisted_by_player_name` | String |
-| `forced_by_player_name` | String |
-| `tackler_player_id` | String |
-| `assisted_by_player_id` | String |
-| `forced_by_player_id` | String |
-| `tackler_player_names` | String |
-| `assisted_by_player_names` | String |
-| `forced_by_player_names` | String |
-| `tackler_player_ids` | String |
-| `assisted_by_player_ids` | String |
-| `forced_by_player_ids` | String |
-| `pat_passer_player_name` | String |
-| `pat_passer_player_id` | String |
-| `pat_passer_player_names` | String |
-| `pat_passer_player_ids` | String |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int64 | ESPN game identifier. |
+| `play_id` | Int64 | ESPN play id. |
+| `kicker_player_name` | String | String name for the kicker on FG or kickoff. |
+| `returner_player_name` | String |  |
+| `passer_player_name` | String | Name of the passer on a passing play. |
+| `receiver_player_name` | String | Name of the receiver on a passing play. |
+| `rusher_player_name` | String | Name of the rusher on a rushing play. |
+| `penalized_player_name` | String |  |
+| `scorer_player_name` | String |  |
+| `pass_defender_player_name` | String |  |
+| `punter_player_name` | String | Name of the punter. |
+| `pat_scorer_player_name` | String |  |
+| `sacked_by_player_name` | String |  |
+| `kicker_player_id` | String | Unique identifier for the kicker on FG or kickoff. |
+| `returner_player_id` | String |  |
+| `passer_player_id` | String | Unique identifier for the player that attempted the pass. |
+| `receiver_player_id` | String | Unique identifier for the receiver that was targeted on the pass. |
+| `rusher_player_id` | String | Unique identifier for the player that attempted the run. |
+| `penalized_player_id` | String |  |
+| `scorer_player_id` | String |  |
+| `pass_defender_player_id` | String |  |
+| `punter_player_id` | String | Unique identifier for the punter. |
+| `pat_scorer_player_id` | String |  |
+| `sacked_by_player_id` | String |  |
+| `kicker_player_names` | String |  |
+| `returner_player_names` | String |  |
+| `passer_player_names` | String |  |
+| `receiver_player_names` | String |  |
+| `rusher_player_names` | String |  |
+| `penalized_player_names` | String |  |
+| `scorer_player_names` | String |  |
+| `pass_defender_player_names` | String |  |
+| `punter_player_names` | String |  |
+| `pat_scorer_player_names` | String |  |
+| `sacked_by_player_names` | String |  |
+| `kicker_player_ids` | String |  |
+| `returner_player_ids` | String |  |
+| `passer_player_ids` | String |  |
+| `receiver_player_ids` | String |  |
+| `rusher_player_ids` | String |  |
+| `penalized_player_ids` | String |  |
+| `scorer_player_ids` | String |  |
+| `pass_defender_player_ids` | String |  |
+| `punter_player_ids` | String |  |
+| `pat_scorer_player_ids` | String |  |
+| `sacked_by_player_ids` | String |  |
+| `season` | Int64 | Season (4-digit year). |
+| `week` | Int64 | Game week of the season. |
+| `recoverer_player_name` | String |  |
+| `recoverer_player_id` | String |  |
+| `recoverer_player_names` | String |  |
+| `recoverer_player_ids` | String |  |
+| `tackler_player_name` | String |  |
+| `assisted_by_player_name` | String |  |
+| `forced_by_player_name` | String |  |
+| `tackler_player_id` | String |  |
+| `assisted_by_player_id` | String |  |
+| `forced_by_player_id` | String |  |
+| `tackler_player_names` | String |  |
+| `assisted_by_player_names` | String |  |
+| `forced_by_player_names` | String |  |
+| `tackler_player_ids` | String |  |
+| `assisted_by_player_ids` | String |  |
+| `forced_by_player_ids` | String |  |
+| `pat_passer_player_name` | String |  |
+| `pat_passer_player_id` | String |  |
+| `pat_passer_player_names` | String |  |
+| `pat_passer_player_ids` | String |  |
 
 ```python
 load_cfb_play_participants(seasons=2024)
@@ -835,80 +835,80 @@ load_cfb_play_participants(seasons=2024)
 Release: [espn_cfb_game_rosters](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_cfb_game_rosters) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_cfb_game_rosters/game_rosters_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `athlete_id` | Int64 |
-| `athlete_uid` | String |
-| `athlete_guid` | String |
-| `athlete_type` | String |
-| `first_name` | String |
-| `last_name` | String |
-| `full_name` | String |
-| `athlete_display_name` | String |
-| `short_name` | String |
-| `weight` | Float64 |
-| `display_weight` | String |
-| `height` | Float64 |
-| `display_height` | String |
-| `age` | Float64 |
-| `date_of_birth` | String |
-| `slug` | String |
-| `jersey` | String |
-| `linked` | Boolean |
-| `active` | Boolean |
-| `alternate_ids_sdr` | String |
-| `birth_place_city` | String |
-| `birth_place_state` | String |
-| `experience_years` | Float64 |
-| `experience_display_value` | String |
-| `experience_abbreviation` | String |
-| `status_id` | String |
-| `status_name` | String |
-| `status_type` | String |
-| `status_abbreviation` | String |
-| `birth_place_country` | String |
-| `birth_country_alternate_id` | String |
-| `birth_country_abbreviation` | String |
-| `flag_href` | String |
-| `flag_alt` | String |
-| `flag_rel` | String |
-| `starter` | Boolean |
-| `valid` | Boolean |
-| `did_not_play` | Boolean |
-| `athlete_href` | String |
-| `position_href` | String |
-| `statistics_href` | String |
-| `team_id` | Int64 |
-| `order` | Int64 |
-| `home_away` | String |
-| `winner` | Boolean |
-| `team_guid` | String |
-| `team_uid` | String |
-| `team_slug` | String |
-| `team_location` | String |
-| `team_name` | String |
-| `team_nickname` | String |
-| `team_abbreviation` | String |
-| `team_display_name` | String |
-| `team_short_display_name` | String |
-| `team_color` | String |
-| `team_alternate_color` | String |
-| `is_active` | Boolean |
-| `is_all_star` | Boolean |
-| `team_alternate_ids_sdr` | String |
-| `logo_href` | String |
-| `logo_dark_href` | String |
-| `game_id` | Int64 |
-| `season` | Int64 |
-| `week` | Int64 |
-| `draft_display_text` | String |
-| `draft_round` | Float64 |
-| `draft_year` | Float64 |
-| `draft_selection` | Float64 |
-| `draft_team_href` | String |
-| `middle_name` | String |
-| `headshot_href` | String |
-| `headshot_alt` | String |
+| col_name | type | description |
+|---|---|---|
+| `athlete_id` | Int64 | ESPN athlete id. |
+| `athlete_uid` | String | ESPN athlete UID (universal identifier). |
+| `athlete_guid` | String | ESPN athlete GUID. |
+| `athlete_type` | String | Athlete type / class. |
+| `first_name` | String | Athlete first name. |
+| `last_name` | String | Athlete last name. |
+| `full_name` | String | Venue full name (e.g. `Tenney Stadium`). |
+| `athlete_display_name` | String | Player display name; `athlete_detail = TRUE` only. |
+| `short_name` | String | Ranking source short name (e.g. `AP Poll`). |
+| `weight` | Float64 | Listed weight (lbs). |
+| `display_weight` | String | Human-readable weight (e.g. `205 lbs`). |
+| `height` | Float64 | Listed height (inches). |
+| `display_height` | String | Human-readable height (e.g. `6' 1"`). |
+| `age` | Float64 | Player age (in years). |
+| `date_of_birth` | String | Player date of birth (if published). |
+| `slug` | String | URL slug for the team. |
+| `jersey` | String | Jersey number. |
+| `linked` | Boolean | TRUE if the record is linked to a related entity. |
+| `active` | Boolean | `TRUE` if the player was active for the game. |
+| `alternate_ids_sdr` | String | Alternate ids sdr. |
+| `birth_place_city` | String | Birth place city. |
+| `birth_place_state` | String | Birth place state. |
+| `experience_years` | Float64 | Years of experience. |
+| `experience_display_value` | String | Experience display value. |
+| `experience_abbreviation` | String | Experience abbreviation. |
+| `status_id` | String | ESPN commitment status id. |
+| `status_name` | String | Status-type key (e.g. `STATUS_FINAL`). |
+| `status_type` | String | Status type. |
+| `status_abbreviation` | String | Status abbreviation. |
+| `birth_place_country` | String | Birth place country. |
+| `birth_country_alternate_id` | String |  |
+| `birth_country_abbreviation` | String | Birth country abbreviation. |
+| `flag_href` | String |  |
+| `flag_alt` | String |  |
+| `flag_rel` | String |  |
+| `starter` | Boolean | `TRUE` if the athlete started the game. |
+| `valid` | Boolean | `TRUE` if the roster entry is flagged valid by ESPN. |
+| `did_not_play` | Boolean | `TRUE` if the athlete did not play. |
+| `athlete_href` | String |  |
+| `position_href` | String |  |
+| `statistics_href` | String |  |
+| `team_id` | Int64 | ESPN team id. |
+| `order` | Int64 | Team order within the competition (0 = first). |
+| `home_away` | String | `home` or `away`. |
+| `winner` | Boolean | `TRUE` if this team won the game. |
+| `team_guid` | String | ESPN team GUID. |
+| `team_uid` | String | ESPN universal team identifier (UID format 's:40~l:...~t:...'). |
+| `team_slug` | String | Team slug for the stat row. |
+| `team_location` | String | Team location / school name; `team_detail = TRUE` only. |
+| `team_name` | String | Team nickname; `team_detail = TRUE` only. |
+| `team_nickname` | String | Team nickname label; `team_detail = TRUE` only. |
+| `team_abbreviation` | String | Team abbreviation; `team_detail = TRUE` only. |
+| `team_display_name` | String | Full team display name; `team_detail = TRUE` only. |
+| `team_short_display_name` | String | Short team display name; `team_detail = TRUE` only. |
+| `team_color` | String | Primary team color; `team_detail = TRUE` only. |
+| `team_alternate_color` | String | Alternate team color; `team_detail = TRUE` only. |
+| `is_active` | Boolean | Whether the team is currently active. |
+| `is_all_star` | Boolean | Whether the team is an all-star team. |
+| `team_alternate_ids_sdr` | String |  |
+| `logo_href` | String | URL of the default team logo. |
+| `logo_dark_href` | String | URL of the dark-variant team logo. |
+| `game_id` | Int64 | ESPN game identifier. |
+| `season` | Int64 | Season (4-digit year). |
+| `week` | Int64 | Game week of the season. |
+| `draft_display_text` | String | Draft display text. |
+| `draft_round` | Float64 | Round of the draft selection. |
+| `draft_year` | Float64 | Draft year (4-digit). |
+| `draft_selection` | Float64 | Draft selection. |
+| `draft_team_href` | String |  |
+| `middle_name` | String | Middle name of the player. |
+| `headshot_href` | String | URL of the athlete headshot image. |
+| `headshot_alt` | String | Alternative-text label for the headshot. |
 
 ```python
 load_cfb_game_rosters(seasons=2024)
@@ -919,13 +919,13 @@ load_cfb_game_rosters(seasons=2024)
 Release: [espn_cfb_linescores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_cfb_linescores) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_cfb_linescores/linescores_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `team_id` | Int64 |
-| `period` | Int64 |
-| `value` | String |
-| `game_id` | Int64 |
-| `season` | Int64 |
+| col_name | type | description |
+|---|---|---|
+| `team_id` | Int64 | ESPN team id. |
+| `period` | Int64 | Period (quarter) number. |
+| `value` | String | Metric value. |
+| `game_id` | Int64 | ESPN game identifier. |
+| `season` | Int64 | Season (4-digit year). |
 
 ```python
 load_cfb_linescores(seasons=2024)
@@ -936,17 +936,17 @@ load_cfb_linescores(seasons=2024)
 Release: [espn_cfb_betting](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_cfb_betting) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_cfb_betting/betting_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int64 |
-| `season` | Int64 |
-| `week` | Int64 |
-| `game_spread` | Float64 |
-| `over_under` | Float64 |
-| `home_favorite` | Boolean |
-| `home_team_spread` | Float64 |
-| `game_spread_available` | Boolean |
-| `odds_source` | String |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int64 | ESPN game identifier. |
+| `season` | Int64 | Season (4-digit year). |
+| `week` | Int64 | Game week of the season. |
+| `game_spread` | Float64 | Game spread in (-X Team) format. There are almost none, I would recommend not trusting any of these three columns |
+| `over_under` | Float64 | Pre-game over/under total from the selected provider. |
+| `home_favorite` | Boolean | `TRUE` if the home team is the favorite. |
+| `home_team_spread` | Float64 | The game spread with respect to the home team |
+| `game_spread_available` | Boolean | Logical (TRUE/FALSE) indicating whether the spread was available from ESPN. Basically, I would just not recommend using any of the spread information, I think I defaulted a lot of them to -2.5 for the home team. Most games probably do not have spread information. This column should really be listed first |
+| `odds_source` | String |  |
 
 ```python
 load_cfb_betting(seasons=2024)
@@ -957,12 +957,12 @@ load_cfb_betting(seasons=2024)
 Release: [espn_cfb_power_index](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_cfb_power_index) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_cfb_power_index/power_index_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `$ref` | String |
-| `game_id` | Int64 |
-| `season` | Int64 |
-| `week` | Int64 |
+| col_name | type | description |
+|---|---|---|
+| `$ref` | String |  |
+| `game_id` | Int64 | ESPN game identifier. |
+| `season` | Int64 | Season (4-digit year). |
+| `week` | Int64 | Game week of the season. |
 
 ```python
 load_cfb_power_index(seasons=2024)
@@ -973,88 +973,88 @@ load_cfb_power_index(seasons=2024)
 Release: [espn_cfb_adv_team](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_cfb_adv_team) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_cfb_adv_team/adv_team_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `pos_team_id` | Int64 |
-| `pos_team` | String |
-| `rushing_highlight_yards_per_opp` | Float64 |
-| `total_pen_yards` | Int64 |
-| `EPA_penalty` | Float64 |
-| `penalty_first_downs_created` | Int64 |
-| `penalty_first_downs_created_rate` | Float64 |
-| `penalties` | Int64 |
-| `penalty_yards` | Int64 |
-| `special_teams_plays` | Int64 |
-| `EPA_sp` | Float64 |
-| `EPA_special_teams` | Float64 |
-| `field_goals` | Int64 |
-| `EPA_fg` | Float64 |
-| `punt_plays` | Int64 |
-| `EPA_punt` | Float64 |
-| `kickoff_plays` | Int64 |
-| `EPA_kickoff` | Float64 |
-| `rushes` | Int64 |
-| `rush_yards` | Float64 |
-| `yards_per_rush` | Float64 |
-| `rushing_power_rate` | Float64 |
-| `rushing_first_downs_created` | Int64 |
-| `rushing_first_downs_created_rate` | Float64 |
-| `EPA_rushing_overall` | Float64 |
-| `EPA_rushing_per_play` | Float64 |
-| `EPA_explosive_rushing` | Int64 |
-| `EPA_explosive_rushing_rate` | Float64 |
-| `EPA_non_explosive_rushing` | Float64 |
-| `EPA_non_explosive_rushing_per_play` | Float64 |
-| `passes` | Int64 |
-| `pass_yards` | Float64 |
-| `yards_per_pass` | Float64 |
-| `passing_first_downs_created` | Int64 |
-| `passing_first_downs_created_rate` | Float64 |
-| `EPA_passing_overall` | Float64 |
-| `EPA_passing_per_play` | Float64 |
-| `EPA_explosive_passing` | Int64 |
-| `EPA_explosive_passing_rate` | Float64 |
-| `EPA_non_explosive_passing` | Float64 |
-| `EPA_non_explosive_passing_per_play` | Float64 |
-| `scrimmage_plays` | Int64 |
-| `EPA_overall_off` | Float64 |
-| `EPA_overall_offense` | Float64 |
-| `EPA_per_play` | Float64 |
-| `EPA_non_explosive` | Float64 |
-| `EPA_non_explosive_per_play` | Float64 |
-| `EPA_explosive` | Int64 |
-| `EPA_explosive_rate` | Float64 |
-| `passes_rate` | Float64 |
-| `off_yards` | Int64 |
-| `total_off_yards` | Int64 |
-| `yards_per_play` | Float64 |
-| `EPA_plays` | Int64 |
-| `total_yards` | Int64 |
-| `EPA_overall_total` | Float64 |
-| `rushes_rate` | Float64 |
-| `first_downs_created` | Int64 |
-| `first_downs_created_rate` | Float64 |
-| `EPA_rushing_power` | Float64 |
-| `EPA_rushing_power_per_play` | Float64 |
-| `rushing_power_success` | Int64 |
-| `rushing_power_success_rate` | Float64 |
-| `rushing_power` | Int64 |
-| `rushing_stuff` | Int64 |
-| `rushing_stuff_rate` | Float64 |
-| `rushing_stopped` | Int64 |
-| `rushing_stopped_rate` | Float64 |
-| `rushing_opportunity` | Int64 |
-| `rushing_opportunity_rate` | Float64 |
-| `rushing_highlight` | Int64 |
-| `rushing_highlight_rate` | Float64 |
-| `rushing_highlight_yards` | Float64 |
-| `line_yards` | Float64 |
-| `line_yards_per_carry` | Float64 |
-| `second_level_yards` | Float64 |
-| `open_field_yards` | Float64 |
-| `game_id` | Int64 |
-| `season` | Int64 |
-| `week` | Int64 |
+| col_name | type | description |
+|---|---|---|
+| `pos_team_id` | Int64 |  |
+| `pos_team` | String | Team name in possession at the start of the play (offense, kickoff-aware). |
+| `rushing_highlight_yards_per_opp` | Float64 |  |
+| `total_pen_yards` | Int64 |  |
+| `EPA_penalty` | Float64 |  |
+| `penalty_first_downs_created` | Int64 |  |
+| `penalty_first_downs_created_rate` | Float64 |  |
+| `penalties` | Int64 | Total number of penalties. |
+| `penalty_yards` | Int64 | Yards gained (or lost) by the posteam from the penalty. |
+| `special_teams_plays` | Int64 |  |
+| `EPA_sp` | Float64 |  |
+| `EPA_special_teams` | Float64 |  |
+| `field_goals` | Int64 |  |
+| `EPA_fg` | Float64 |  |
+| `punt_plays` | Int64 |  |
+| `EPA_punt` | Float64 |  |
+| `kickoff_plays` | Int64 |  |
+| `EPA_kickoff` | Float64 |  |
+| `rushes` | Int64 |  |
+| `rush_yards` | Float64 | The number of rushing yards gained |
+| `yards_per_rush` | Float64 |  |
+| `rushing_power_rate` | Float64 |  |
+| `rushing_first_downs_created` | Int64 |  |
+| `rushing_first_downs_created_rate` | Float64 |  |
+| `EPA_rushing_overall` | Float64 |  |
+| `EPA_rushing_per_play` | Float64 |  |
+| `EPA_explosive_rushing` | Int64 |  |
+| `EPA_explosive_rushing_rate` | Float64 |  |
+| `EPA_non_explosive_rushing` | Float64 |  |
+| `EPA_non_explosive_rushing_per_play` | Float64 |  |
+| `passes` | Int64 | Passes. |
+| `pass_yards` | Float64 | Number of yards gained on pass plays |
+| `yards_per_pass` | Float64 | Team game yards per pass. |
+| `passing_first_downs_created` | Int64 |  |
+| `passing_first_downs_created_rate` | Float64 |  |
+| `EPA_passing_overall` | Float64 |  |
+| `EPA_passing_per_play` | Float64 |  |
+| `EPA_explosive_passing` | Int64 |  |
+| `EPA_explosive_passing_rate` | Float64 |  |
+| `EPA_non_explosive_passing` | Float64 |  |
+| `EPA_non_explosive_passing_per_play` | Float64 |  |
+| `scrimmage_plays` | Int64 |  |
+| `EPA_overall_off` | Float64 |  |
+| `EPA_overall_offense` | Float64 |  |
+| `EPA_per_play` | Float64 |  |
+| `EPA_non_explosive` | Float64 |  |
+| `EPA_non_explosive_per_play` | Float64 |  |
+| `EPA_explosive` | Int64 |  |
+| `EPA_explosive_rate` | Float64 |  |
+| `passes_rate` | Float64 |  |
+| `off_yards` | Int64 |  |
+| `total_off_yards` | Int64 |  |
+| `yards_per_play` | Float64 |  |
+| `EPA_plays` | Int64 |  |
+| `total_yards` | Int64 | Team total yards. |
+| `EPA_overall_total` | Float64 |  |
+| `rushes_rate` | Float64 |  |
+| `first_downs_created` | Int64 |  |
+| `first_downs_created_rate` | Float64 |  |
+| `EPA_rushing_power` | Float64 |  |
+| `EPA_rushing_power_per_play` | Float64 |  |
+| `rushing_power_success` | Int64 | Rushing power success rate. |
+| `rushing_power_success_rate` | Float64 |  |
+| `rushing_power` | Int64 |  |
+| `rushing_stuff` | Int64 |  |
+| `rushing_stuff_rate` | Float64 | Rushing stuff rate. |
+| `rushing_stopped` | Int64 |  |
+| `rushing_stopped_rate` | Float64 |  |
+| `rushing_opportunity` | Int64 |  |
+| `rushing_opportunity_rate` | Float64 |  |
+| `rushing_highlight` | Int64 |  |
+| `rushing_highlight_rate` | Float64 |  |
+| `rushing_highlight_yards` | Float64 | Opponent-adjusted offensive highlight yards per opportunity rush. |
+| `line_yards` | Float64 |  |
+| `line_yards_per_carry` | Float64 |  |
+| `second_level_yards` | Float64 |  |
+| `open_field_yards` | Float64 |  |
+| `game_id` | Int64 | ESPN game identifier. |
+| `season` | Int64 | Season (4-digit year). |
+| `week` | Int64 | Game week of the season. |
 
 ```python
 load_cfb_adv_team(seasons=2024)
@@ -1065,40 +1065,40 @@ load_cfb_adv_team(seasons=2024)
 Release: [espn_cfb_adv_passing](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_cfb_adv_passing) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_cfb_adv_passing/adv_passing_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `pos_team_id` | Int64 |
-| `pos_team` | String |
-| `passer_player_name` | String |
-| `Comp` | Int64 |
-| `Att` | Int64 |
-| `xComp` | Float64 |
-| `Yds` | Float64 |
-| `Pass_TD` | Int64 |
-| `Int` | Int64 |
-| `YPA` | Float64 |
-| `EPA` | Float64 |
-| `EPA_per_Play` | Float64 |
-| `WPA` | Float64 |
-| `SR` | Float64 |
-| `Sck` | Int64 |
-| `CompPct` | Float64 |
-| `xCompPct` | Float64 |
-| `CPOE` | Float64 |
-| `qbr_epa` | Float64 |
-| `sack_epa` | Float64 |
-| `pass_epa` | Float64 |
-| `rush_epa` | Float64 |
-| `pen_epa` | Float64 |
-| `spread` | Float64 |
-| `era0` | Int64 |
-| `era1` | Int64 |
-| `era2` | Int64 |
-| `era3` | Int64 |
-| `exp_qbr` | Float64 |
-| `game_id` | Int64 |
-| `season` | Int64 |
-| `week` | Int64 |
+| col_name | type | description |
+|---|---|---|
+| `pos_team_id` | Int64 |  |
+| `pos_team` | String | Team name in possession at the start of the play (offense, kickoff-aware). |
+| `passer_player_name` | String | Name of the passer on a passing play. |
+| `Comp` | Int64 |  |
+| `Att` | Int64 |  |
+| `xComp` | Float64 |  |
+| `Yds` | Float64 |  |
+| `Pass_TD` | Int64 |  |
+| `Int` | Int64 |  |
+| `YPA` | Float64 |  |
+| `EPA` | Float64 | Expected Points Added on the play (cfbfastR EPA model output). |
+| `EPA_per_Play` | Float64 |  |
+| `WPA` | Float64 | Win Probability Added. |
+| `SR` | Float64 |  |
+| `Sck` | Int64 |  |
+| `CompPct` | Float64 |  |
+| `xCompPct` | Float64 |  |
+| `CPOE` | Float64 |  |
+| `qbr_epa` | Float64 |  |
+| `sack_epa` | Float64 |  |
+| `pass_epa` | Float64 |  |
+| `rush_epa` | Float64 |  |
+| `pen_epa` | Float64 |  |
+| `spread` | Float64 | Pre-game point spread from the selected provider. |
+| `era0` | Int64 |  |
+| `era1` | Int64 |  |
+| `era2` | Int64 |  |
+| `era3` | Int64 |  |
+| `exp_qbr` | Float64 |  |
+| `game_id` | Int64 | ESPN game identifier. |
+| `season` | Int64 | Season (4-digit year). |
+| `week` | Int64 | Game week of the season. |
 
 ```python
 load_cfb_adv_passing(seasons=2024)
@@ -1109,24 +1109,24 @@ load_cfb_adv_passing(seasons=2024)
 Release: [espn_cfb_adv_rushing](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_cfb_adv_rushing) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_cfb_adv_rushing/adv_rushing_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `pos_team_id` | Int64 |
-| `pos_team` | String |
-| `rusher_player_name` | String |
-| `Car` | Int64 |
-| `Yds` | Float64 |
-| `Rush_TD` | Int64 |
-| `YPC` | Float64 |
-| `EPA` | Float64 |
-| `EPA_per_Play` | Float64 |
-| `WPA` | Float64 |
-| `SR` | Float64 |
-| `Fum` | Int64 |
-| `Fum_Lost` | Int64 |
-| `game_id` | Int64 |
-| `season` | Int64 |
-| `week` | Int64 |
+| col_name | type | description |
+|---|---|---|
+| `pos_team_id` | Int64 |  |
+| `pos_team` | String | Team name in possession at the start of the play (offense, kickoff-aware). |
+| `rusher_player_name` | String | Name of the rusher on a rushing play. |
+| `Car` | Int64 |  |
+| `Yds` | Float64 |  |
+| `Rush_TD` | Int64 |  |
+| `YPC` | Float64 |  |
+| `EPA` | Float64 | Expected Points Added on the play (cfbfastR EPA model output). |
+| `EPA_per_Play` | Float64 |  |
+| `WPA` | Float64 | Win Probability Added. |
+| `SR` | Float64 |  |
+| `Fum` | Int64 |  |
+| `Fum_Lost` | Int64 |  |
+| `game_id` | Int64 | ESPN game identifier. |
+| `season` | Int64 | Season (4-digit year). |
+| `week` | Int64 | Game week of the season. |
 
 ```python
 load_cfb_adv_rushing(seasons=2024)
@@ -1137,25 +1137,25 @@ load_cfb_adv_rushing(seasons=2024)
 Release: [espn_cfb_adv_receiving](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_cfb_adv_receiving) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_cfb_adv_receiving/adv_receiving_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `pos_team_id` | Int64 |
-| `pos_team` | String |
-| `receiver_player_name` | String |
-| `Rec` | Int64 |
-| `Tar` | Int64 |
-| `Yds` | Float64 |
-| `Rec_TD` | Int64 |
-| `YPT` | Float64 |
-| `EPA` | Float64 |
-| `EPA_per_Play` | Float64 |
-| `WPA` | Float64 |
-| `SR` | Float64 |
-| `Fum` | Int64 |
-| `Fum_Lost` | Int64 |
-| `game_id` | Int64 |
-| `season` | Int64 |
-| `week` | Int64 |
+| col_name | type | description |
+|---|---|---|
+| `pos_team_id` | Int64 |  |
+| `pos_team` | String | Team name in possession at the start of the play (offense, kickoff-aware). |
+| `receiver_player_name` | String | Name of the receiver on a passing play. |
+| `Rec` | Int64 |  |
+| `Tar` | Int64 |  |
+| `Yds` | Float64 |  |
+| `Rec_TD` | Int64 |  |
+| `YPT` | Float64 |  |
+| `EPA` | Float64 | Expected Points Added on the play (cfbfastR EPA model output). |
+| `EPA_per_Play` | Float64 |  |
+| `WPA` | Float64 | Win Probability Added. |
+| `SR` | Float64 |  |
+| `Fum` | Int64 |  |
+| `Fum_Lost` | Int64 |  |
+| `game_id` | Int64 | ESPN game identifier. |
+| `season` | Int64 | Season (4-digit year). |
+| `week` | Int64 | Game week of the season. |
 
 ```python
 load_cfb_adv_receiving(seasons=2024)
@@ -1166,30 +1166,30 @@ load_cfb_adv_receiving(seasons=2024)
 Release: [espn_cfb_adv_defensive](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_cfb_adv_defensive) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_cfb_adv_defensive/adv_defensive_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `def_pos_team_id` | Int64 |
-| `def_pos_team` | String |
-| `scrimmage_plays` | Int64 |
-| `TFL` | Int64 |
-| `TFL_pass` | Int64 |
-| `TFL_rush` | Int64 |
-| `havoc_total` | Int64 |
-| `havoc_total_rate` | Float64 |
-| `fumbles` | Int64 |
-| `def_int` | Int64 |
-| `drive_stopped_rate` | Float64 |
-| `num_pass_plays` | Int64 |
-| `havoc_total_pass` | Int64 |
-| `havoc_total_pass_rate` | Float64 |
-| `sacks` | Int64 |
-| `sacks_rate` | Float64 |
-| `pass_breakups` | Int64 |
-| `havoc_total_rush` | Int64 |
-| `havoc_total_rush_rate` | Float64 |
-| `game_id` | Int64 |
-| `season` | Int64 |
-| `week` | Int64 |
+| col_name | type | description |
+|---|---|---|
+| `def_pos_team_id` | Int64 |  |
+| `def_pos_team` | String | Team name on defense at the start of the play. |
+| `scrimmage_plays` | Int64 |  |
+| `TFL` | Int64 |  |
+| `TFL_pass` | Int64 |  |
+| `TFL_rush` | Int64 |  |
+| `havoc_total` | Int64 | Total havoc rate. |
+| `havoc_total_rate` | Float64 |  |
+| `fumbles` | Int64 |  |
+| `def_int` | Int64 |  |
+| `drive_stopped_rate` | Float64 |  |
+| `num_pass_plays` | Int64 |  |
+| `havoc_total_pass` | Int64 |  |
+| `havoc_total_pass_rate` | Float64 |  |
+| `sacks` | Int64 | Team sacks. |
+| `sacks_rate` | Float64 |  |
+| `pass_breakups` | Int64 |  |
+| `havoc_total_rush` | Int64 |  |
+| `havoc_total_rush_rate` | Float64 |  |
+| `game_id` | Int64 | ESPN game identifier. |
+| `season` | Int64 | Season (4-digit year). |
+| `week` | Int64 | Game week of the season. |
 
 ```python
 load_cfb_adv_defensive(seasons=2024)
@@ -1200,22 +1200,22 @@ load_cfb_adv_defensive(seasons=2024)
 Release: [espn_cfb_adv_defensive_players](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_cfb_adv_defensive_players) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_cfb_adv_defensive_players/adv_defensive_players_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `def_pos_team_id` | Int64 |
-| `def_pos_team` | String |
-| `player_name` | String |
-| `fumble_recoveries` | Int64 |
-| `fumble_recoveries_yards` | Int64 |
-| `game_id` | Int64 |
-| `season` | Int64 |
-| `week` | Int64 |
-| `sacks` | Int64 |
-| `sacks_yards` | Int64 |
-| `pass_breakups` | Int64 |
-| `forced_fumbles` | Int64 |
-| `interceptions` | Int64 |
-| `interceptions_yards` | Int64 |
+| col_name | type | description |
+|---|---|---|
+| `def_pos_team_id` | Int64 | ESPN team id of the team on defense. Present for every season 2004+. |
+| `def_pos_team` | String | Display name of the team on defense (e.g. 'Ohio State Buckeyes'). Held an ESPN team id until the 2026-08 republish; the id now lives in def_pos_team_id. |
+| `player_name` | String | Display name of the defender. |
+| `fumble_recoveries` | Int64 | Fumbles recovered by the defender. Available for every season 2004+. |
+| `fumble_recoveries_yards` | Int64 | Yards returned on the defender's fumble recoveries. Available for every season 2004+. |
+| `game_id` | Int64 | ESPN game identifier. |
+| `season` | Int64 | Season (4-digit year). |
+| `week` | Int64 | Game week of the season. |
+| `sacks` | Int64 | Sacks recorded by the defender. Available from 2005 on; null for 2004. |
+| `sacks_yards` | Int64 | Yards lost by the offense on the defender's sacks. Available from 2005 on; null for 2004. |
+| `pass_breakups` | Int64 | Passes broken up by the defender. Available from 2005 on; null for 2004. |
+| `forced_fumbles` | Int64 | Fumbles forced by the defender. Available from 2005 on; null for 2004, which ESPN ships with only the fumble-recovery statistics. |
+| `interceptions` | Int64 | Passes intercepted by the defender. Available from 2014 on; null for 2004-2013, which ESPN ships without interception statistics in this block. |
+| `interceptions_yards` | Int64 | Yards returned on the defender's interceptions. Available from 2014 on; null for 2004-2013. |
 
 ```python
 load_cfb_adv_defensive_players(seasons=2024)
@@ -1226,20 +1226,20 @@ load_cfb_adv_defensive_players(seasons=2024)
 Release: [espn_cfb_adv_drives](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_cfb_adv_drives) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_cfb_adv_drives/adv_drives_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `pos_team_id` | Int64 |
-| `pos_team` | String |
-| `drive_total_available_yards` | Float64 |
-| `drive_total_gained_yards` | Int64 |
-| `avg_field_position` | Float64 |
-| `plays_per_drive` | Float64 |
-| `yards_per_drive` | Float64 |
-| `drives` | Int64 |
-| `drive_total_gained_yards_rate` | Float64 |
-| `game_id` | Int64 |
-| `season` | Int64 |
-| `week` | Int64 |
+| col_name | type | description |
+|---|---|---|
+| `pos_team_id` | Int64 |  |
+| `pos_team` | String | Team name in possession at the start of the play (offense, kickoff-aware). |
+| `drive_total_available_yards` | Float64 |  |
+| `drive_total_gained_yards` | Int64 |  |
+| `avg_field_position` | Float64 |  |
+| `plays_per_drive` | Float64 |  |
+| `yards_per_drive` | Float64 |  |
+| `drives` | Int64 |  |
+| `drive_total_gained_yards_rate` | Float64 |  |
+| `game_id` | Int64 | ESPN game identifier. |
+| `season` | Int64 | Season (4-digit year). |
+| `week` | Int64 | Game week of the season. |
 
 ```python
 load_cfb_adv_drives(seasons=2024)
@@ -1250,82 +1250,82 @@ load_cfb_adv_drives(seasons=2024)
 Release: [espn_cfb_adv_situational](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_cfb_adv_situational) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_cfb_adv_situational/adv_situational_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `pos_team_id` | Int64 |
-| `pos_team` | String |
-| `EPA_success` | Int64 |
-| `EPA_success_rate` | Float64 |
-| `EPA_success_pass` | Int64 |
-| `EPA_success_pass_rate` | Float64 |
-| `EPA_success_rush` | Int64 |
-| `EPA_success_rush_rate` | Float64 |
-| `EPA_success_rz` | Int64 |
-| `EPA_success_rate_rz` | Float64 |
-| `EPA_success_third` | Int64 |
-| `EPA_success_rate_third` | Float64 |
-| `EPA_success_early_down` | Int64 |
-| `EPA_success_early_down_rate` | Float64 |
-| `early_downs` | Int64 |
-| `early_down_pass_rate` | Float64 |
-| `early_down_rush_rate` | Float64 |
-| `EPA_early_down` | Float64 |
-| `EPA_early_down_per_play` | Float64 |
-| `early_down_first_down` | Int64 |
-| `early_down_first_down_rate` | Float64 |
-| `early_down_pass` | Int64 |
-| `EPA_early_down_pass` | Float64 |
-| `EPA_early_down_pass_per_play` | Float64 |
-| `EPA_success_early_down_pass` | Int64 |
-| `EPA_success_early_down_pass_rate` | Float64 |
-| `early_down_rush` | Int64 |
-| `EPA_early_down_rush` | Float64 |
-| `EPA_early_down_rush_per_play` | Float64 |
-| `EPA_success_early_down_rush` | Int64 |
-| `EPA_success_early_down_rush_rate` | Float64 |
-| `middle_8` | Int64 |
-| `middle_8_pass_rate` | Float64 |
-| `middle_8_rush_rate` | Float64 |
-| `EPA_middle_8` | Float64 |
-| `EPA_middle_8_per_play` | Float64 |
-| `EPA_middle_8_success` | Int64 |
-| `EPA_middle_8_success_rate` | Float64 |
-| `middle_8_pass` | Int64 |
-| `EPA_middle_8_pass` | Float64 |
-| `EPA_middle_8_pass_per_play` | Float64 |
-| `EPA_middle_8_success_pass` | Int64 |
-| `EPA_middle_8_success_pass_rate` | Float64 |
-| `middle_8_rush` | Int64 |
-| `EPA_middle_8_rush` | Float64 |
-| `EPA_middle_8_rush_per_play` | Float64 |
-| `EPA_middle_8_success_rush` | Int64 |
-| `EPA_middle_8_success_rush_rate` | Float64 |
-| `EPA_success_late_down` | Int64 |
-| `EPA_success_late_down_pass` | Int64 |
-| `EPA_success_late_down_rush` | Int64 |
-| `late_downs` | Int64 |
-| `late_down_pass` | Int64 |
-| `late_down_rush` | Int64 |
-| `EPA_late_down` | Float64 |
-| `EPA_late_down_per_play` | Float64 |
-| `EPA_success_late_down_rate` | Float64 |
-| `EPA_success_late_down_pass_rate` | Float64 |
-| `EPA_success_late_down_rush_rate` | Float64 |
-| `late_down_pass_rate` | Float64 |
-| `late_down_rush_rate` | Float64 |
-| `EPA_success_standard_down` | Int64 |
-| `EPA_success_standard_down_rate` | Float64 |
-| `EPA_standard_down` | Float64 |
-| `EPA_standard_down_per_play` | Float64 |
-| `standard_downs` | Int64 |
-| `EPA_success_passing_down` | Int64 |
-| `EPA_success_passing_down_rate` | Float64 |
-| `EPA_passing_down` | Float64 |
-| `EPA_passing_down_per_play` | Float64 |
-| `passing_downs` | Int64 |
-| `game_id` | Int64 |
-| `season` | Int64 |
-| `week` | Int64 |
+| col_name | type | description |
+|---|---|---|
+| `pos_team_id` | Int64 |  |
+| `pos_team` | String | Team name in possession at the start of the play (offense, kickoff-aware). |
+| `EPA_success` | Int64 |  |
+| `EPA_success_rate` | Float64 |  |
+| `EPA_success_pass` | Int64 |  |
+| `EPA_success_pass_rate` | Float64 |  |
+| `EPA_success_rush` | Int64 |  |
+| `EPA_success_rush_rate` | Float64 |  |
+| `EPA_success_rz` | Int64 |  |
+| `EPA_success_rate_rz` | Float64 |  |
+| `EPA_success_third` | Int64 |  |
+| `EPA_success_rate_third` | Float64 |  |
+| `EPA_success_early_down` | Int64 |  |
+| `EPA_success_early_down_rate` | Float64 |  |
+| `early_downs` | Int64 |  |
+| `early_down_pass_rate` | Float64 |  |
+| `early_down_rush_rate` | Float64 |  |
+| `EPA_early_down` | Float64 |  |
+| `EPA_early_down_per_play` | Float64 |  |
+| `early_down_first_down` | Int64 |  |
+| `early_down_first_down_rate` | Float64 |  |
+| `early_down_pass` | Int64 |  |
+| `EPA_early_down_pass` | Float64 |  |
+| `EPA_early_down_pass_per_play` | Float64 |  |
+| `EPA_success_early_down_pass` | Int64 |  |
+| `EPA_success_early_down_pass_rate` | Float64 |  |
+| `early_down_rush` | Int64 |  |
+| `EPA_early_down_rush` | Float64 |  |
+| `EPA_early_down_rush_per_play` | Float64 |  |
+| `EPA_success_early_down_rush` | Int64 |  |
+| `EPA_success_early_down_rush_rate` | Float64 |  |
+| `middle_8` | Int64 | TRUE for plays in the middle-8 window (final 4 min of 1H, first 4 min of 2H). |
+| `middle_8_pass_rate` | Float64 |  |
+| `middle_8_rush_rate` | Float64 |  |
+| `EPA_middle_8` | Float64 |  |
+| `EPA_middle_8_per_play` | Float64 |  |
+| `EPA_middle_8_success` | Int64 |  |
+| `EPA_middle_8_success_rate` | Float64 |  |
+| `middle_8_pass` | Int64 |  |
+| `EPA_middle_8_pass` | Float64 |  |
+| `EPA_middle_8_pass_per_play` | Float64 |  |
+| `EPA_middle_8_success_pass` | Int64 |  |
+| `EPA_middle_8_success_pass_rate` | Float64 |  |
+| `middle_8_rush` | Int64 |  |
+| `EPA_middle_8_rush` | Float64 |  |
+| `EPA_middle_8_rush_per_play` | Float64 |  |
+| `EPA_middle_8_success_rush` | Int64 |  |
+| `EPA_middle_8_success_rush_rate` | Float64 |  |
+| `EPA_success_late_down` | Int64 |  |
+| `EPA_success_late_down_pass` | Int64 |  |
+| `EPA_success_late_down_rush` | Int64 |  |
+| `late_downs` | Int64 |  |
+| `late_down_pass` | Int64 |  |
+| `late_down_rush` | Int64 |  |
+| `EPA_late_down` | Float64 |  |
+| `EPA_late_down_per_play` | Float64 |  |
+| `EPA_success_late_down_rate` | Float64 |  |
+| `EPA_success_late_down_pass_rate` | Float64 |  |
+| `EPA_success_late_down_rush_rate` | Float64 |  |
+| `late_down_pass_rate` | Float64 |  |
+| `late_down_rush_rate` | Float64 |  |
+| `EPA_success_standard_down` | Int64 |  |
+| `EPA_success_standard_down_rate` | Float64 |  |
+| `EPA_standard_down` | Float64 |  |
+| `EPA_standard_down_per_play` | Float64 |  |
+| `standard_downs` | Int64 |  |
+| `EPA_success_passing_down` | Int64 |  |
+| `EPA_success_passing_down_rate` | Float64 |  |
+| `EPA_passing_down` | Float64 |  |
+| `EPA_passing_down_per_play` | Float64 |  |
+| `passing_downs` | Int64 |  |
+| `game_id` | Int64 | ESPN game identifier. |
+| `season` | Int64 | Season (4-digit year). |
+| `week` | Int64 | Game week of the season. |
 
 ```python
 load_cfb_adv_situational(seasons=2024)
@@ -1336,22 +1336,22 @@ load_cfb_adv_situational(seasons=2024)
 Release: [espn_cfb_adv_specialists](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_cfb_adv_specialists) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_cfb_adv_specialists/adv_specialists_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `pos_team_id` | Int64 |
-| `pos_team` | String |
-| `player_name` | String |
-| `punts` | Int64 |
-| `punts_yards` | Int64 |
-| `kick_returns` | Int64 |
-| `kick_returns_yards` | Int64 |
-| `punt_returns` | Int64 |
-| `punt_returns_yards` | Int64 |
-| `game_id` | Int64 |
-| `season` | Int64 |
-| `week` | Int64 |
-| `field_goals` | Int64 |
-| `field_goals_yards` | Int64 |
+| col_name | type | description |
+|---|---|---|
+| `pos_team_id` | Int64 |  |
+| `pos_team` | String | Team name in possession at the start of the play (offense, kickoff-aware). |
+| `player_name` | String | Player name. |
+| `punts` | Int64 |  |
+| `punts_yards` | Int64 |  |
+| `kick_returns` | Int64 | Number of kick returns. |
+| `kick_returns_yards` | Int64 |  |
+| `punt_returns` | Int64 | Number of punt returns. |
+| `punt_returns_yards` | Int64 |  |
+| `game_id` | Int64 | ESPN game identifier. |
+| `season` | Int64 | Season (4-digit year). |
+| `week` | Int64 | Game week of the season. |
+| `field_goals` | Int64 |  |
+| `field_goals_yards` | Int64 |  |
 
 ```python
 load_cfb_adv_specialists(seasons=2024)
@@ -1362,32 +1362,32 @@ load_cfb_adv_specialists(seasons=2024)
 Release: [espn_cfb_adv_turnover](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_cfb_adv_turnover) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_cfb_adv_turnover/adv_turnover_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `pos_team_id` | Int64 |
-| `pos_team` | String |
-| `turnovers` | Int64 |
-| `st_turnovers_lost` | Int64 |
-| `Int` | Int64 |
-| `fumbles_lost` | Int64 |
-| `pass_breakups` | Int64 |
-| `total_fumbles` | Int64 |
-| `fumbles_recovered` | Int64 |
-| `team_id` | Int64 |
-| `turnovers_pbp` | Int64 |
-| `Int_pbp` | Int64 |
-| `fumbles_lost_pbp` | Int64 |
-| `espn_sourced` | Boolean |
-| `expected_turnovers` | Float64 |
-| `expected_turnover_margin` | Float64 |
-| `turnover_margin` | Int64 |
-| `turnover_luck` | Float64 |
-| `takeaways` | Int64 |
-| `st_turnovers_gained` | Int64 |
-| `fumble_recoveries_gained` | Int64 |
-| `game_id` | Int64 |
-| `season` | Int64 |
-| `week` | Int64 |
+| col_name | type | description |
+|---|---|---|
+| `pos_team_id` | Int64 |  |
+| `pos_team` | String | Team name in possession at the start of the play (offense, kickoff-aware). |
+| `turnovers` | Int64 | Turnovers total. |
+| `st_turnovers_lost` | Int64 |  |
+| `Int` | Int64 |  |
+| `fumbles_lost` | Int64 | Fumbles lost. |
+| `pass_breakups` | Int64 |  |
+| `total_fumbles` | Int64 | Team total fumbles. |
+| `fumbles_recovered` | Int64 | Team fumbles recovered. |
+| `team_id` | Int64 | ESPN team id. |
+| `turnovers_pbp` | Int64 |  |
+| `Int_pbp` | Int64 |  |
+| `fumbles_lost_pbp` | Int64 |  |
+| `espn_sourced` | Boolean |  |
+| `expected_turnovers` | Float64 |  |
+| `expected_turnover_margin` | Float64 |  |
+| `turnover_margin` | Int64 |  |
+| `turnover_luck` | Float64 |  |
+| `takeaways` | Int64 | Takeaways. |
+| `st_turnovers_gained` | Int64 |  |
+| `fumble_recoveries_gained` | Int64 |  |
+| `game_id` | Int64 | ESPN game identifier. |
+| `season` | Int64 | Season (4-digit year). |
+| `week` | Int64 | Game week of the season. |
 
 ```python
 load_cfb_adv_turnover(seasons=2024)
@@ -1398,51 +1398,51 @@ load_cfb_adv_turnover(seasons=2024)
 Release: [espn_cfb_model_pbp](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_cfb_model_pbp) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_cfb_model_pbp/model_pbp_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int64 |
-| `id` | String |
-| `sequenceNumber` | String |
-| `game_play_number` | Int64 |
-| `drive.id` | String |
-| `season` | Int64 |
-| `week` | Int64 |
-| `period` | Int64 |
-| `pos_team` | Int64 |
-| `def_pos_team` | Int64 |
-| `start.pos_team.name` | String |
-| `homeTeamId` | Int64 |
-| `awayTeamId` | Int64 |
-| `homeTeamName` | String |
-| `awayTeamName` | String |
-| `type.text` | String |
-| `text` | String |
-| `start.down` | Int64 |
-| `start.distance` | Int64 |
-| `start.yardsToEndzone` | Int64 |
-| `pos_score_diff_start` | Int64 |
-| `start.TimeSecsRem` | Int64 |
-| `start.is_home` | Boolean |
-| `passing_down` | Boolean |
-| `pass` | Boolean |
-| `rush` | Boolean |
-| `completion` | Boolean |
-| `scoring_play` | Boolean |
-| `statYardage` | Int64 |
-| `passer_player_name` | String |
-| `ep_before` | Float64 |
-| `ep_after` | Float64 |
-| `epa` | Float64 |
-| `wp_before` | Float64 |
-| `wp_after` | Float64 |
-| `wpa` | Float64 |
-| `completion_prob` | Float64 |
-| `cpoe` | Float64 |
-| `model_pbp_version` | String |
-| `cp_model_version` | String |
-| `ep_model_version` | String |
-| `wp_model_version` | String |
-| `scored_date` | String |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int64 | ESPN game identifier. |
+| `id` | String | 247Sports referencing id for the recruit. |
+| `sequenceNumber` | String | Broadcast sequence order number. |
+| `game_play_number` | Int64 | Sequential play number within the game (excludes timeouts/end markers). |
+| `drive.id` | String |  |
+| `season` | Int64 | Season (4-digit year). |
+| `week` | Int64 | Game week of the season. |
+| `period` | Int64 | Period (quarter) number. |
+| `pos_team` | Int64 | Team name in possession at the start of the play (offense, kickoff-aware). |
+| `def_pos_team` | Int64 | Team name on defense at the start of the play. |
+| `start.pos_team.name` | String |  |
+| `homeTeamId` | Int64 |  |
+| `awayTeamId` | Int64 |  |
+| `homeTeamName` | String |  |
+| `awayTeamName` | String |  |
+| `type.text` | String |  |
+| `text` | String | Full play description. |
+| `start.down` | Int64 |  |
+| `start.distance` | Int64 |  |
+| `start.yardsToEndzone` | Int64 |  |
+| `pos_score_diff_start` | Int64 | Score differential for the possession team at the start of the play. |
+| `start.TimeSecsRem` | Int64 |  |
+| `start.is_home` | Boolean |  |
+| `passing_down` | Boolean |  |
+| `pass` | Boolean | Binary flag for a passing play (includes sacks). |
+| `rush` | Boolean | Binary flag for a rushing play. |
+| `completion` | Boolean | Binary flag for a completed pass. |
+| `scoring_play` | Boolean | `TRUE` if the play resulted in a score. |
+| `statYardage` | Int64 |  |
+| `passer_player_name` | String | Name of the passer on a passing play. |
+| `ep_before` | Float64 | Expected points value before the play (cfbfastR EPA model). |
+| `ep_after` | Float64 | Expected points value after the play (cfbfastR EPA model). |
+| `epa` | Float64 | Expected points added (EPA) by the posteam for the given play. |
+| `wp_before` | Float64 | Win probability for the possession team before the play (0-1). |
+| `wp_after` | Float64 | Win probability for the possession team after the play (0-1). |
+| `wpa` | Float64 | Win Probability Added on the play (cfbfastR WP model output). |
+| `completion_prob` | Float64 |  |
+| `cpoe` | Float64 | For a single pass play this is 1 - cp when the pass was completed or 0 - cp when the pass was incomplete. Analyzed for a whole game or season an indicator for the passer how much over or under expectation his completion percentage was. |
+| `model_pbp_version` | String |  |
+| `cp_model_version` | String |  |
+| `ep_model_version` | String |  |
+| `wp_model_version` | String |  |
+| `scored_date` | String |  |
 
 ```python
 load_cfb_model_pbp(seasons=2024)
@@ -1453,51 +1453,51 @@ load_cfb_model_pbp(seasons=2024)
 Release: [espn_cfb_passing](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_cfb_passing) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_cfb_passing/cfb_passing_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `team_id` | String |
-| `pos_team` | String |
-| `division` | String |
-| `conference` | String |
-| `season` | Int64 |
-| `player_id` | Int64 |
-| `passer_player_name` | String |
-| `plays` | UInt32 |
-| `games` | UInt32 |
-| `team_games` | UInt32 |
-| `playsgame` | Float64 |
-| `TEPA` | Float64 |
-| `EPAplay` | Float64 |
-| `EPAgame` | Float64 |
-| `yards` | Int64 |
-| `yardsplay` | Float64 |
-| `yardsgame` | Float64 |
-| `success` | Float64 |
-| `comp` | Float64 |
-| `att` | Float64 |
-| `comppct` | Float64 |
-| `passing_td` | Float64 |
-| `sacked` | UInt32 |
-| `sack_yds` | Int64 |
-| `pass_int` | UInt32 |
-| `detmer` | Float64 |
-| `detmergame` | Float64 |
-| `dropbacks` | Float64 |
-| `sack_adj_yards` | Int64 |
-| `yardsdropback` | Float64 |
-| `TEPA_rank` | Float64 |
-| `EPAgame_rank` | Float64 |
-| `EPAplay_rank` | Float64 |
-| `success_rank` | Float64 |
-| `comppct_rank` | Float64 |
-| `yards_rank` | Float64 |
-| `yardsplay_rank` | Float64 |
-| `yardsgame_rank` | Float64 |
-| `sack_adj_yards_rank` | Float64 |
-| `yardsdropback_rank` | Float64 |
-| `detmer_rank` | Float64 |
-| `detmergame_rank` | Float64 |
-| `fbs_class` | String |
+| col_name | type | description |
+|---|---|---|
+| `team_id` | Int64 | ESPN team id. |
+| `pos_team` | String | Team name in possession at the start of the play (offense, kickoff-aware). |
+| `division` | String | Division in the conference for the team. |
+| `conference` | String | Conference of the team. |
+| `season` | Int64 | Season (4-digit year). |
+| `player_id` | Int64 | ESPN player id from the roster entry. |
+| `passer_player_name` | String | Name of the passer on a passing play. |
+| `plays` | UInt32 | Total qualifying passing plays included in the WEPA calculation. |
+| `games` | UInt32 | Number of games included in the ATS summary. |
+| `team_games` | UInt32 |  |
+| `playsgame` | Float64 |  |
+| `TEPA` | Float64 |  |
+| `EPAplay` | Float64 |  |
+| `EPAgame` | Float64 |  |
+| `yards` | Int64 | Total yards gained on the drive. |
+| `yardsplay` | Float64 |  |
+| `yardsgame` | Float64 |  |
+| `success` | Float64 | Binary success-rate flag using the 50/70/100 percent down-state thresholds. |
+| `comp` | Float64 |  |
+| `att` | Float64 |  |
+| `comppct` | Float64 |  |
+| `passing_td` | Float64 | Passing touchdowns thrown. |
+| `sacked` | UInt32 |  |
+| `sack_yds` | Int64 |  |
+| `pass_int` | UInt32 |  |
+| `detmer` | Float64 |  |
+| `detmergame` | Float64 |  |
+| `dropbacks` | Float64 |  |
+| `sack_adj_yards` | Int64 |  |
+| `yardsdropback` | Float64 |  |
+| `TEPA_rank` | Float64 |  |
+| `EPAgame_rank` | Float64 |  |
+| `EPAplay_rank` | Float64 |  |
+| `success_rank` | Float64 |  |
+| `comppct_rank` | Float64 |  |
+| `yards_rank` | Float64 |  |
+| `yardsplay_rank` | Float64 |  |
+| `yardsgame_rank` | Float64 |  |
+| `sack_adj_yards_rank` | Float64 |  |
+| `yardsdropback_rank` | Float64 |  |
+| `detmer_rank` | Float64 |  |
+| `detmergame_rank` | Float64 |  |
+| `fbs_class` | String |  |
 
 ```python
 load_cfb_passing(seasons=2024)
@@ -1508,35 +1508,35 @@ load_cfb_passing(seasons=2024)
 Release: [espn_cfb_percentiles](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_cfb_percentiles) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_cfb_percentiles/cfb_percentiles_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `pctile` | Float64 |
-| `GEI` | Float64 |
-| `EPAplay` | Float64 |
-| `pass_success` | Float64 |
-| `rush_success` | Float64 |
-| `early_down_success` | Float64 |
-| `early_down_EPA` | Float64 |
-| `late_down_success` | Float64 |
-| `success` | Float64 |
-| `yardsplay` | Float64 |
-| `dropbacks` | Float64 |
-| `rushes` | Float64 |
-| `EPAdropback` | Float64 |
-| `EPArush` | Float64 |
-| `yardsdropback` | Float64 |
-| `pass_explosive` | Float64 |
-| `rush_explosive` | Float64 |
-| `explosive` | Float64 |
-| `third_down_success` | Float64 |
-| `red_zone_success` | Float64 |
-| `play_stuffed` | Float64 |
-| `nonExplosiveEpaPerPlay` | Float64 |
-| `havoc` | Float64 |
-| `yardsrush` | Float64 |
-| `lineyards` | Float64 |
-| `opportunity_run` | Float64 |
-| `third_down_distance` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `pctile` | Float64 |  |
+| `GEI` | Float64 |  |
+| `EPAplay` | Float64 |  |
+| `pass_success` | Float64 |  |
+| `rush_success` | Float64 |  |
+| `early_down_success` | Float64 |  |
+| `early_down_EPA` | Float64 |  |
+| `late_down_success` | Float64 |  |
+| `success` | Float64 | Binary success-rate flag using the 50/70/100 percent down-state thresholds. |
+| `yardsplay` | Float64 |  |
+| `dropbacks` | Float64 |  |
+| `rushes` | Float64 |  |
+| `EPAdropback` | Float64 |  |
+| `EPArush` | Float64 |  |
+| `yardsdropback` | Float64 |  |
+| `pass_explosive` | Float64 |  |
+| `rush_explosive` | Float64 |  |
+| `explosive` | Float64 |  |
+| `third_down_success` | Float64 |  |
+| `red_zone_success` | Float64 |  |
+| `play_stuffed` | Float64 |  |
+| `nonExplosiveEpaPerPlay` | Float64 |  |
+| `havoc` | Float64 |  |
+| `yardsrush` | Float64 |  |
+| `lineyards` | Float64 |  |
+| `opportunity_run` | Float64 |  |
+| `third_down_distance` | Float64 |  |
 
 ```python
 load_cfb_percentiles(seasons=2024)
@@ -1547,40 +1547,40 @@ load_cfb_percentiles(seasons=2024)
 Release: [espn_cfb_receiving](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_cfb_receiving) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_cfb_receiving/cfb_receiving_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `team_id` | String |
-| `pos_team` | String |
-| `division` | String |
-| `conference` | String |
-| `season` | Int64 |
-| `player_id` | Int64 |
-| `receiver_player_name` | String |
-| `plays` | UInt32 |
-| `games` | UInt32 |
-| `team_games` | UInt32 |
-| `playsgame` | Float64 |
-| `TEPA` | Float64 |
-| `EPAplay` | Float64 |
-| `EPAgame` | Float64 |
-| `yards` | Int64 |
-| `yardsplay` | Float64 |
-| `yardsgame` | Float64 |
-| `success` | Float64 |
-| `comp` | UInt32 |
-| `targets` | UInt32 |
-| `catchpct` | Float64 |
-| `passing_td` | Float64 |
-| `fumbles` | Float64 |
-| `TEPA_rank` | Float64 |
-| `EPAgame_rank` | Float64 |
-| `EPAplay_rank` | Float64 |
-| `success_rank` | Float64 |
-| `catchpct_rank` | Float64 |
-| `yards_rank` | Float64 |
-| `yardsplay_rank` | Float64 |
-| `yardsgame_rank` | Float64 |
-| `fbs_class` | String |
+| col_name | type | description |
+|---|---|---|
+| `team_id` | Int64 | ESPN team id. |
+| `pos_team` | String | Team name in possession at the start of the play (offense, kickoff-aware). |
+| `division` | String | Division in the conference for the team. |
+| `conference` | String | Conference of the team. |
+| `season` | Int64 | Season (4-digit year). |
+| `player_id` | Int64 | ESPN player id from the roster entry. |
+| `receiver_player_name` | String | Name of the receiver on a passing play. |
+| `plays` | UInt32 | Total qualifying passing plays included in the WEPA calculation. |
+| `games` | UInt32 | Number of games included in the ATS summary. |
+| `team_games` | UInt32 |  |
+| `playsgame` | Float64 |  |
+| `TEPA` | Float64 |  |
+| `EPAplay` | Float64 |  |
+| `EPAgame` | Float64 |  |
+| `yards` | Int64 | Total yards gained on the drive. |
+| `yardsplay` | Float64 |  |
+| `yardsgame` | Float64 |  |
+| `success` | Float64 | Binary success-rate flag using the 50/70/100 percent down-state thresholds. |
+| `comp` | UInt32 |  |
+| `targets` | UInt32 | The number of pass plays where the player was the targeted receiver. |
+| `catchpct` | Float64 |  |
+| `passing_td` | Float64 | Passing touchdowns thrown. |
+| `fumbles` | Float64 |  |
+| `TEPA_rank` | Float64 |  |
+| `EPAgame_rank` | Float64 |  |
+| `EPAplay_rank` | Float64 |  |
+| `success_rank` | Float64 |  |
+| `catchpct_rank` | Float64 |  |
+| `yards_rank` | Float64 |  |
+| `yardsplay_rank` | Float64 |  |
+| `yardsgame_rank` | Float64 |  |
+| `fbs_class` | String |  |
 
 ```python
 load_cfb_receiving(seasons=2024)
@@ -1591,36 +1591,36 @@ load_cfb_receiving(seasons=2024)
 Release: [espn_cfb_rushing](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_cfb_rushing) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_cfb_rushing/cfb_rushing_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `team_id` | String |
-| `pos_team` | String |
-| `division` | String |
-| `conference` | String |
-| `season` | Int64 |
-| `player_id` | Int64 |
-| `rusher_player_name` | String |
-| `plays` | UInt32 |
-| `games` | UInt32 |
-| `team_games` | UInt32 |
-| `playsgame` | Float64 |
-| `TEPA` | Float64 |
-| `EPAplay` | Float64 |
-| `EPAgame` | Float64 |
-| `yards` | Int64 |
-| `yardsplay` | Float64 |
-| `yardsgame` | Float64 |
-| `success` | Float64 |
-| `rushing_td` | Float64 |
-| `fumbles` | Float64 |
-| `TEPA_rank` | Float64 |
-| `EPAgame_rank` | Float64 |
-| `EPAplay_rank` | Float64 |
-| `success_rank` | Float64 |
-| `yards_rank` | Float64 |
-| `yardsplay_rank` | Float64 |
-| `yardsgame_rank` | Float64 |
-| `fbs_class` | String |
+| col_name | type | description |
+|---|---|---|
+| `team_id` | Int64 | ESPN team id. |
+| `pos_team` | String | Team name in possession at the start of the play (offense, kickoff-aware). |
+| `division` | String | Division in the conference for the team. |
+| `conference` | String | Conference of the team. |
+| `season` | Int64 | Season (4-digit year). |
+| `player_id` | Int64 | ESPN player id from the roster entry. |
+| `rusher_player_name` | String | Name of the rusher on a rushing play. |
+| `plays` | UInt32 | Total qualifying passing plays included in the WEPA calculation. |
+| `games` | UInt32 | Number of games included in the ATS summary. |
+| `team_games` | UInt32 |  |
+| `playsgame` | Float64 |  |
+| `TEPA` | Float64 |  |
+| `EPAplay` | Float64 |  |
+| `EPAgame` | Float64 |  |
+| `yards` | Int64 | Total yards gained on the drive. |
+| `yardsplay` | Float64 |  |
+| `yardsgame` | Float64 |  |
+| `success` | Float64 | Binary success-rate flag using the 50/70/100 percent down-state thresholds. |
+| `rushing_td` | Float64 | Rushing touchdowns. |
+| `fumbles` | Float64 |  |
+| `TEPA_rank` | Float64 |  |
+| `EPAgame_rank` | Float64 |  |
+| `EPAplay_rank` | Float64 |  |
+| `success_rank` | Float64 |  |
+| `yards_rank` | Float64 |  |
+| `yardsplay_rank` | Float64 |  |
+| `yardsgame_rank` | Float64 |  |
+| `fbs_class` | String |  |
 
 ```python
 load_cfb_rushing(seasons=2024)
@@ -1631,391 +1631,391 @@ load_cfb_rushing(seasons=2024)
 Release: [espn_cfb_team_summaries](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_cfb_team_summaries) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_cfb_team_summaries/cfb_team_summaries_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `team_id` | String |
-| `pos_team` | String |
-| `division` | String |
-| `conference` | String |
-| `season` | Int64 |
-| `plays_off` | UInt32 |
-| `playsgame_off` | Float64 |
-| `passrate_off` | Float64 |
-| `rushrate_off` | Float64 |
-| `havoc_off` | Float64 |
-| `explosive_off` | Float64 |
-| `TEPA_off` | Float64 |
-| `EPAplay_off` | Float64 |
-| `EPAdrive_off` | Float64 |
-| `EPAgame_off` | Float64 |
-| `yards_off` | Int64 |
-| `yardsplay_off` | Float64 |
-| `yardsgame_off` | Float64 |
-| `play_stuffed_off` | Float64 |
-| `drives_off` | UInt32 |
-| `drivesgame_off` | Float64 |
-| `yardsdrive_off` | Float64 |
-| `playsdrive_off` | Float64 |
-| `success_off` | Float64 |
-| `red_zone_success_off` | Float64 |
-| `third_down_success_off` | Float64 |
-| `third_down_distance_off` | Float64 |
-| `late_down_success_off` | Float64 |
-| `early_down_EPA_off` | Float64 |
-| `start_position_off` | Float64 |
-| `nonExplosiveEpaPerPlay_off` | Float64 |
-| `line_yards_off` | Float64 |
-| `opportunity_rate_off` | Float64 |
-| `playsgame_off_rank` | Float64 |
-| `TEPA_off_rank` | Float64 |
-| `EPAgame_off_rank` | Float64 |
-| `EPAplay_off_rank` | Float64 |
-| `EPAdrive_off_rank` | Float64 |
-| `early_down_EPA_off_rank` | Float64 |
-| `success_off_rank` | Float64 |
-| `yards_off_rank` | Float64 |
-| `yardsplay_off_rank` | Float64 |
-| `yardsgame_off_rank` | Float64 |
-| `drivesgame_off_rank` | Float64 |
-| `yardsdrive_off_rank` | Float64 |
-| `playsdrive_off_rank` | Float64 |
-| `play_stuffed_off_rank` | Float64 |
-| `red_zone_success_off_rank` | Float64 |
-| `third_down_success_off_rank` | Float64 |
-| `late_down_success_off_rank` | Float64 |
-| `third_down_distance_off_rank` | Float64 |
-| `start_position_off_rank` | Float64 |
-| `havoc_off_rank` | Float64 |
-| `explosive_off_rank` | Float64 |
-| `passrate_off_rank` | Float64 |
-| `rushrate_off_rank` | Float64 |
-| `nonExplosiveEpaPerPlay_off_rank` | Float64 |
-| `line_yards_off_rank` | Float64 |
-| `opportunity_rate_off_rank` | Float64 |
-| `plays_def` | UInt32 |
-| `playsgame_def` | Float64 |
-| `passrate_def` | Float64 |
-| `rushrate_def` | Float64 |
-| `havoc_def` | Float64 |
-| `explosive_def` | Float64 |
-| `TEPA_def` | Float64 |
-| `EPAplay_def` | Float64 |
-| `EPAdrive_def` | Float64 |
-| `EPAgame_def` | Float64 |
-| `yards_def` | Int64 |
-| `yardsplay_def` | Float64 |
-| `yardsgame_def` | Float64 |
-| `play_stuffed_def` | Float64 |
-| `drives_def` | UInt32 |
-| `drivesgame_def` | Float64 |
-| `yardsdrive_def` | Float64 |
-| `playsdrive_def` | Float64 |
-| `success_def` | Float64 |
-| `red_zone_success_def` | Float64 |
-| `third_down_success_def` | Float64 |
-| `third_down_distance_def` | Float64 |
-| `late_down_success_def` | Float64 |
-| `early_down_EPA_def` | Float64 |
-| `start_position_def` | Float64 |
-| `nonExplosiveEpaPerPlay_def` | Float64 |
-| `line_yards_def` | Float64 |
-| `opportunity_rate_def` | Float64 |
-| `playsgame_def_rank` | Float64 |
-| `TEPA_def_rank` | Float64 |
-| `EPAgame_def_rank` | Float64 |
-| `EPAplay_def_rank` | Float64 |
-| `EPAdrive_def_rank` | Float64 |
-| `early_down_EPA_def_rank` | Float64 |
-| `success_def_rank` | Float64 |
-| `yards_def_rank` | Float64 |
-| `yardsplay_def_rank` | Float64 |
-| `yardsgame_def_rank` | Float64 |
-| `drivesgame_def_rank` | Float64 |
-| `yardsdrive_def_rank` | Float64 |
-| `playsdrive_def_rank` | Float64 |
-| `play_stuffed_def_rank` | Float64 |
-| `red_zone_success_def_rank` | Float64 |
-| `third_down_success_def_rank` | Float64 |
-| `late_down_success_def_rank` | Float64 |
-| `third_down_distance_def_rank` | Float64 |
-| `start_position_def_rank` | Float64 |
-| `havoc_def_rank` | Float64 |
-| `explosive_def_rank` | Float64 |
-| `passrate_def_rank` | Float64 |
-| `rushrate_def_rank` | Float64 |
-| `nonExplosiveEpaPerPlay_def_rank` | Float64 |
-| `line_yards_def_rank` | Float64 |
-| `opportunity_rate_def_rank` | Float64 |
-| `TEPA_margin` | Float64 |
-| `EPAplay_margin` | Float64 |
-| `EPAdrive_margin` | Float64 |
-| `EPAgame_margin` | Float64 |
-| `success_margin` | Float64 |
-| `yardsplay_margin` | Float64 |
-| `TEPA_margin_rank` | Float64 |
-| `EPAgame_margin_rank` | Float64 |
-| `EPAdrive_margin_rank` | Float64 |
-| `EPAplay_margin_rank` | Float64 |
-| `success_margin_rank` | Float64 |
-| `yardsplay_margin_rank` | Float64 |
-| `start_position_margin` | Float64 |
-| `start_position_margin_rank` | Float64 |
-| `total_available_yards_off` | Float64 |
-| `total_gained_yards_off` | Int64 |
-| `available_yards_pct_off` | Float64 |
-| `available_yards_pct_off_rank` | Float64 |
-| `total_available_yards_def` | Float64 |
-| `total_gained_yards_def` | Int64 |
-| `available_yards_pct_def` | Float64 |
-| `available_yards_pct_def_rank` | Float64 |
-| `total_available_yards_margin` | Float64 |
-| `total_gained_yards_margin` | Int64 |
-| `available_yards_pct_margin` | Float64 |
-| `total_available_yards_margin_rank` | Float64 |
-| `total_gained_yards_margin_rank` | Float64 |
-| `available_yards_pct_margin_rank` | Float64 |
-| `plays_off_pass` | UInt32 |
-| `playsgame_off_pass` | Float64 |
-| `passrate_off_pass` | Float64 |
-| `rushrate_off_pass` | Float64 |
-| `havoc_off_pass` | Float64 |
-| `explosive_off_pass` | Float64 |
-| `TEPA_off_pass` | Float64 |
-| `EPAplay_off_pass` | Float64 |
-| `EPAdrive_off_pass` | Float64 |
-| `EPAgame_off_pass` | Float64 |
-| `yards_off_pass` | Int64 |
-| `yardsplay_off_pass` | Float64 |
-| `yardsgame_off_pass` | Float64 |
-| `play_stuffed_off_pass` | Float64 |
-| `drives_off_pass` | UInt32 |
-| `drivesgame_off_pass` | Float64 |
-| `yardsdrive_off_pass` | Float64 |
-| `playsdrive_off_pass` | Float64 |
-| `success_off_pass` | Float64 |
-| `red_zone_success_off_pass` | Float64 |
-| `third_down_success_off_pass` | Float64 |
-| `third_down_distance_off_pass` | Float64 |
-| `late_down_success_off_pass` | Float64 |
-| `early_down_EPA_off_pass` | Float64 |
-| `nonExplosiveEpaPerPlay_off_pass` | Float64 |
-| `line_yards_off_pass` | Float64 |
-| `opportunity_rate_off_pass` | Float64 |
-| `playsgame_off_pass_rank` | Float64 |
-| `TEPA_off_pass_rank` | Float64 |
-| `EPAgame_off_pass_rank` | Float64 |
-| `EPAplay_off_pass_rank` | Float64 |
-| `EPAdrive_off_pass_rank` | Float64 |
-| `early_down_EPA_off_pass_rank` | Float64 |
-| `success_off_pass_rank` | Float64 |
-| `yards_off_pass_rank` | Float64 |
-| `yardsplay_off_pass_rank` | Float64 |
-| `yardsgame_off_pass_rank` | Float64 |
-| `drivesgame_off_pass_rank` | Float64 |
-| `yardsdrive_off_pass_rank` | Float64 |
-| `playsdrive_off_pass_rank` | Float64 |
-| `play_stuffed_off_pass_rank` | Float64 |
-| `red_zone_success_off_pass_rank` | Float64 |
-| `third_down_success_off_pass_rank` | Float64 |
-| `late_down_success_off_pass_rank` | Float64 |
-| `third_down_distance_off_pass_rank` | Float64 |
-| `havoc_off_pass_rank` | Float64 |
-| `explosive_off_pass_rank` | Float64 |
-| `passrate_off_pass_rank` | Float64 |
-| `rushrate_off_pass_rank` | Float64 |
-| `nonExplosiveEpaPerPlay_off_pass_rank` | Float64 |
-| `line_yards_off_pass_rank` | Float64 |
-| `opportunity_rate_off_pass_rank` | Float64 |
-| `plays_def_pass` | UInt32 |
-| `playsgame_def_pass` | Float64 |
-| `passrate_def_pass` | Float64 |
-| `rushrate_def_pass` | Float64 |
-| `havoc_def_pass` | Float64 |
-| `explosive_def_pass` | Float64 |
-| `TEPA_def_pass` | Float64 |
-| `EPAplay_def_pass` | Float64 |
-| `EPAdrive_def_pass` | Float64 |
-| `EPAgame_def_pass` | Float64 |
-| `yards_def_pass` | Int64 |
-| `yardsplay_def_pass` | Float64 |
-| `yardsgame_def_pass` | Float64 |
-| `play_stuffed_def_pass` | Float64 |
-| `drives_def_pass` | UInt32 |
-| `drivesgame_def_pass` | Float64 |
-| `yardsdrive_def_pass` | Float64 |
-| `playsdrive_def_pass` | Float64 |
-| `success_def_pass` | Float64 |
-| `red_zone_success_def_pass` | Float64 |
-| `third_down_success_def_pass` | Float64 |
-| `third_down_distance_def_pass` | Float64 |
-| `late_down_success_def_pass` | Float64 |
-| `early_down_EPA_def_pass` | Float64 |
-| `nonExplosiveEpaPerPlay_def_pass` | Float64 |
-| `line_yards_def_pass` | Float64 |
-| `opportunity_rate_def_pass` | Float64 |
-| `playsgame_def_pass_rank` | Float64 |
-| `TEPA_def_pass_rank` | Float64 |
-| `EPAgame_def_pass_rank` | Float64 |
-| `EPAplay_def_pass_rank` | Float64 |
-| `EPAdrive_def_pass_rank` | Float64 |
-| `early_down_EPA_def_pass_rank` | Float64 |
-| `success_def_pass_rank` | Float64 |
-| `yards_def_pass_rank` | Float64 |
-| `yardsplay_def_pass_rank` | Float64 |
-| `yardsgame_def_pass_rank` | Float64 |
-| `drivesgame_def_pass_rank` | Float64 |
-| `yardsdrive_def_pass_rank` | Float64 |
-| `playsdrive_def_pass_rank` | Float64 |
-| `play_stuffed_def_pass_rank` | Float64 |
-| `red_zone_success_def_pass_rank` | Float64 |
-| `third_down_success_def_pass_rank` | Float64 |
-| `late_down_success_def_pass_rank` | Float64 |
-| `third_down_distance_def_pass_rank` | Float64 |
-| `havoc_def_pass_rank` | Float64 |
-| `explosive_def_pass_rank` | Float64 |
-| `passrate_def_pass_rank` | Float64 |
-| `rushrate_def_pass_rank` | Float64 |
-| `nonExplosiveEpaPerPlay_def_pass_rank` | Float64 |
-| `line_yards_def_pass_rank` | Float64 |
-| `opportunity_rate_def_pass_rank` | Float64 |
-| `TEPA_margin_pass` | Float64 |
-| `EPAplay_margin_pass` | Float64 |
-| `EPAdrive_margin_pass` | Float64 |
-| `EPAgame_margin_pass` | Float64 |
-| `success_margin_pass` | Float64 |
-| `yardsplay_margin_pass` | Float64 |
-| `TEPA_margin_pass_rank` | Float64 |
-| `EPAgame_margin_pass_rank` | Float64 |
-| `EPAdrive_margin_pass_rank` | Float64 |
-| `EPAplay_margin_pass_rank` | Float64 |
-| `success_margin_pass_rank` | Float64 |
-| `yardsplay_margin_pass_rank` | Float64 |
-| `plays_off_rush` | UInt32 |
-| `playsgame_off_rush` | Float64 |
-| `passrate_off_rush` | Float64 |
-| `rushrate_off_rush` | Float64 |
-| `havoc_off_rush` | Float64 |
-| `explosive_off_rush` | Float64 |
-| `TEPA_off_rush` | Float64 |
-| `EPAplay_off_rush` | Float64 |
-| `EPAdrive_off_rush` | Float64 |
-| `EPAgame_off_rush` | Float64 |
-| `yards_off_rush` | Int64 |
-| `yardsplay_off_rush` | Float64 |
-| `yardsgame_off_rush` | Float64 |
-| `play_stuffed_off_rush` | Float64 |
-| `drives_off_rush` | UInt32 |
-| `drivesgame_off_rush` | Float64 |
-| `yardsdrive_off_rush` | Float64 |
-| `playsdrive_off_rush` | Float64 |
-| `success_off_rush` | Float64 |
-| `red_zone_success_off_rush` | Float64 |
-| `third_down_success_off_rush` | Float64 |
-| `third_down_distance_off_rush` | Float64 |
-| `late_down_success_off_rush` | Float64 |
-| `early_down_EPA_off_rush` | Float64 |
-| `nonExplosiveEpaPerPlay_off_rush` | Float64 |
-| `line_yards_off_rush` | Float64 |
-| `opportunity_rate_off_rush` | Float64 |
-| `playsgame_off_rush_rank` | Float64 |
-| `TEPA_off_rush_rank` | Float64 |
-| `EPAgame_off_rush_rank` | Float64 |
-| `EPAplay_off_rush_rank` | Float64 |
-| `EPAdrive_off_rush_rank` | Float64 |
-| `early_down_EPA_off_rush_rank` | Float64 |
-| `success_off_rush_rank` | Float64 |
-| `yards_off_rush_rank` | Float64 |
-| `yardsplay_off_rush_rank` | Float64 |
-| `yardsgame_off_rush_rank` | Float64 |
-| `drivesgame_off_rush_rank` | Float64 |
-| `yardsdrive_off_rush_rank` | Float64 |
-| `playsdrive_off_rush_rank` | Float64 |
-| `play_stuffed_off_rush_rank` | Float64 |
-| `red_zone_success_off_rush_rank` | Float64 |
-| `third_down_success_off_rush_rank` | Float64 |
-| `late_down_success_off_rush_rank` | Float64 |
-| `third_down_distance_off_rush_rank` | Float64 |
-| `havoc_off_rush_rank` | Float64 |
-| `explosive_off_rush_rank` | Float64 |
-| `passrate_off_rush_rank` | Float64 |
-| `rushrate_off_rush_rank` | Float64 |
-| `nonExplosiveEpaPerPlay_off_rush_rank` | Float64 |
-| `line_yards_off_rush_rank` | Float64 |
-| `opportunity_rate_off_rush_rank` | Float64 |
-| `plays_def_rush` | UInt32 |
-| `playsgame_def_rush` | Float64 |
-| `passrate_def_rush` | Float64 |
-| `rushrate_def_rush` | Float64 |
-| `havoc_def_rush` | Float64 |
-| `explosive_def_rush` | Float64 |
-| `TEPA_def_rush` | Float64 |
-| `EPAplay_def_rush` | Float64 |
-| `EPAdrive_def_rush` | Float64 |
-| `EPAgame_def_rush` | Float64 |
-| `yards_def_rush` | Int64 |
-| `yardsplay_def_rush` | Float64 |
-| `yardsgame_def_rush` | Float64 |
-| `play_stuffed_def_rush` | Float64 |
-| `drives_def_rush` | UInt32 |
-| `drivesgame_def_rush` | Float64 |
-| `yardsdrive_def_rush` | Float64 |
-| `playsdrive_def_rush` | Float64 |
-| `success_def_rush` | Float64 |
-| `red_zone_success_def_rush` | Float64 |
-| `third_down_success_def_rush` | Float64 |
-| `third_down_distance_def_rush` | Float64 |
-| `late_down_success_def_rush` | Float64 |
-| `early_down_EPA_def_rush` | Float64 |
-| `nonExplosiveEpaPerPlay_def_rush` | Float64 |
-| `line_yards_def_rush` | Float64 |
-| `opportunity_rate_def_rush` | Float64 |
-| `playsgame_def_rush_rank` | Float64 |
-| `TEPA_def_rush_rank` | Float64 |
-| `EPAgame_def_rush_rank` | Float64 |
-| `EPAplay_def_rush_rank` | Float64 |
-| `EPAdrive_def_rush_rank` | Float64 |
-| `early_down_EPA_def_rush_rank` | Float64 |
-| `success_def_rush_rank` | Float64 |
-| `yards_def_rush_rank` | Float64 |
-| `yardsplay_def_rush_rank` | Float64 |
-| `yardsgame_def_rush_rank` | Float64 |
-| `drivesgame_def_rush_rank` | Float64 |
-| `yardsdrive_def_rush_rank` | Float64 |
-| `playsdrive_def_rush_rank` | Float64 |
-| `play_stuffed_def_rush_rank` | Float64 |
-| `red_zone_success_def_rush_rank` | Float64 |
-| `third_down_success_def_rush_rank` | Float64 |
-| `late_down_success_def_rush_rank` | Float64 |
-| `third_down_distance_def_rush_rank` | Float64 |
-| `havoc_def_rush_rank` | Float64 |
-| `explosive_def_rush_rank` | Float64 |
-| `passrate_def_rush_rank` | Float64 |
-| `rushrate_def_rush_rank` | Float64 |
-| `nonExplosiveEpaPerPlay_def_rush_rank` | Float64 |
-| `line_yards_def_rush_rank` | Float64 |
-| `opportunity_rate_def_rush_rank` | Float64 |
-| `TEPA_margin_rush` | Float64 |
-| `EPAplay_margin_rush` | Float64 |
-| `EPAdrive_margin_rush` | Float64 |
-| `EPAgame_margin_rush` | Float64 |
-| `success_margin_rush` | Float64 |
-| `yardsplay_margin_rush` | Float64 |
-| `TEPA_margin_rush_rank` | Float64 |
-| `EPAgame_margin_rush_rank` | Float64 |
-| `EPAdrive_margin_rush_rank` | Float64 |
-| `EPAplay_margin_rush_rank` | Float64 |
-| `success_margin_rush_rank` | Float64 |
-| `yardsplay_margin_rush_rank` | Float64 |
-| `fbs_class` | String |
-| `valid_games` | UInt32 |
-| `adj_off_epa` | Float64 |
-| `adj_def_epa` | Float64 |
-| `def_strength_faced` | Float64 |
-| `off_strength_faced` | Float64 |
-| `net_adj_epa` | Float64 |
-| `adj_off_epa_rank` | Float64 |
-| `adj_def_epa_rank` | Float64 |
-| `net_adj_epa_rank` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `team_id` | Int64 | ESPN team id. |
+| `pos_team` | String | Team name in possession at the start of the play (offense, kickoff-aware). |
+| `division` | String | Division in the conference for the team. |
+| `conference` | String | Conference of the team. |
+| `season` | Int64 | Season (4-digit year). |
+| `plays_off` | UInt32 |  |
+| `playsgame_off` | Float64 |  |
+| `passrate_off` | Float64 |  |
+| `rushrate_off` | Float64 |  |
+| `havoc_off` | Float64 |  |
+| `explosive_off` | Float64 |  |
+| `TEPA_off` | Float64 |  |
+| `EPAplay_off` | Float64 |  |
+| `EPAdrive_off` | Float64 |  |
+| `EPAgame_off` | Float64 |  |
+| `yards_off` | Int64 |  |
+| `yardsplay_off` | Float64 |  |
+| `yardsgame_off` | Float64 |  |
+| `play_stuffed_off` | Float64 |  |
+| `drives_off` | UInt32 |  |
+| `drivesgame_off` | Float64 |  |
+| `yardsdrive_off` | Float64 |  |
+| `playsdrive_off` | Float64 |  |
+| `success_off` | Float64 |  |
+| `red_zone_success_off` | Float64 |  |
+| `third_down_success_off` | Float64 |  |
+| `third_down_distance_off` | Float64 |  |
+| `late_down_success_off` | Float64 |  |
+| `early_down_EPA_off` | Float64 |  |
+| `start_position_off` | Float64 |  |
+| `nonExplosiveEpaPerPlay_off` | Float64 |  |
+| `line_yards_off` | Float64 |  |
+| `opportunity_rate_off` | Float64 |  |
+| `playsgame_off_rank` | Float64 |  |
+| `TEPA_off_rank` | Float64 |  |
+| `EPAgame_off_rank` | Float64 |  |
+| `EPAplay_off_rank` | Float64 |  |
+| `EPAdrive_off_rank` | Float64 |  |
+| `early_down_EPA_off_rank` | Float64 |  |
+| `success_off_rank` | Float64 |  |
+| `yards_off_rank` | Float64 |  |
+| `yardsplay_off_rank` | Float64 |  |
+| `yardsgame_off_rank` | Float64 |  |
+| `drivesgame_off_rank` | Float64 |  |
+| `yardsdrive_off_rank` | Float64 |  |
+| `playsdrive_off_rank` | Float64 |  |
+| `play_stuffed_off_rank` | Float64 |  |
+| `red_zone_success_off_rank` | Float64 |  |
+| `third_down_success_off_rank` | Float64 |  |
+| `late_down_success_off_rank` | Float64 |  |
+| `third_down_distance_off_rank` | Float64 |  |
+| `start_position_off_rank` | Float64 |  |
+| `havoc_off_rank` | Float64 |  |
+| `explosive_off_rank` | Float64 |  |
+| `passrate_off_rank` | Float64 |  |
+| `rushrate_off_rank` | Float64 |  |
+| `nonExplosiveEpaPerPlay_off_rank` | Float64 |  |
+| `line_yards_off_rank` | Float64 |  |
+| `opportunity_rate_off_rank` | Float64 |  |
+| `plays_def` | UInt32 |  |
+| `playsgame_def` | Float64 |  |
+| `passrate_def` | Float64 |  |
+| `rushrate_def` | Float64 |  |
+| `havoc_def` | Float64 |  |
+| `explosive_def` | Float64 |  |
+| `TEPA_def` | Float64 |  |
+| `EPAplay_def` | Float64 |  |
+| `EPAdrive_def` | Float64 |  |
+| `EPAgame_def` | Float64 |  |
+| `yards_def` | Int64 |  |
+| `yardsplay_def` | Float64 |  |
+| `yardsgame_def` | Float64 |  |
+| `play_stuffed_def` | Float64 |  |
+| `drives_def` | UInt32 |  |
+| `drivesgame_def` | Float64 |  |
+| `yardsdrive_def` | Float64 |  |
+| `playsdrive_def` | Float64 |  |
+| `success_def` | Float64 |  |
+| `red_zone_success_def` | Float64 |  |
+| `third_down_success_def` | Float64 |  |
+| `third_down_distance_def` | Float64 |  |
+| `late_down_success_def` | Float64 |  |
+| `early_down_EPA_def` | Float64 |  |
+| `start_position_def` | Float64 |  |
+| `nonExplosiveEpaPerPlay_def` | Float64 |  |
+| `line_yards_def` | Float64 |  |
+| `opportunity_rate_def` | Float64 |  |
+| `playsgame_def_rank` | Float64 |  |
+| `TEPA_def_rank` | Float64 |  |
+| `EPAgame_def_rank` | Float64 |  |
+| `EPAplay_def_rank` | Float64 |  |
+| `EPAdrive_def_rank` | Float64 |  |
+| `early_down_EPA_def_rank` | Float64 |  |
+| `success_def_rank` | Float64 |  |
+| `yards_def_rank` | Float64 |  |
+| `yardsplay_def_rank` | Float64 |  |
+| `yardsgame_def_rank` | Float64 |  |
+| `drivesgame_def_rank` | Float64 |  |
+| `yardsdrive_def_rank` | Float64 |  |
+| `playsdrive_def_rank` | Float64 |  |
+| `play_stuffed_def_rank` | Float64 |  |
+| `red_zone_success_def_rank` | Float64 |  |
+| `third_down_success_def_rank` | Float64 |  |
+| `late_down_success_def_rank` | Float64 |  |
+| `third_down_distance_def_rank` | Float64 |  |
+| `start_position_def_rank` | Float64 |  |
+| `havoc_def_rank` | Float64 |  |
+| `explosive_def_rank` | Float64 |  |
+| `passrate_def_rank` | Float64 |  |
+| `rushrate_def_rank` | Float64 |  |
+| `nonExplosiveEpaPerPlay_def_rank` | Float64 |  |
+| `line_yards_def_rank` | Float64 |  |
+| `opportunity_rate_def_rank` | Float64 |  |
+| `TEPA_margin` | Float64 |  |
+| `EPAplay_margin` | Float64 |  |
+| `EPAdrive_margin` | Float64 |  |
+| `EPAgame_margin` | Float64 |  |
+| `success_margin` | Float64 |  |
+| `yardsplay_margin` | Float64 |  |
+| `TEPA_margin_rank` | Float64 |  |
+| `EPAgame_margin_rank` | Float64 |  |
+| `EPAdrive_margin_rank` | Float64 |  |
+| `EPAplay_margin_rank` | Float64 |  |
+| `success_margin_rank` | Float64 |  |
+| `yardsplay_margin_rank` | Float64 |  |
+| `start_position_margin` | Float64 |  |
+| `start_position_margin_rank` | Float64 |  |
+| `total_available_yards_off` | Float64 |  |
+| `total_gained_yards_off` | Int64 |  |
+| `available_yards_pct_off` | Float64 |  |
+| `available_yards_pct_off_rank` | Float64 |  |
+| `total_available_yards_def` | Float64 |  |
+| `total_gained_yards_def` | Int64 |  |
+| `available_yards_pct_def` | Float64 |  |
+| `available_yards_pct_def_rank` | Float64 |  |
+| `total_available_yards_margin` | Float64 |  |
+| `total_gained_yards_margin` | Int64 |  |
+| `available_yards_pct_margin` | Float64 |  |
+| `total_available_yards_margin_rank` | Float64 |  |
+| `total_gained_yards_margin_rank` | Float64 |  |
+| `available_yards_pct_margin_rank` | Float64 |  |
+| `plays_off_pass` | UInt32 |  |
+| `playsgame_off_pass` | Float64 |  |
+| `passrate_off_pass` | Float64 |  |
+| `rushrate_off_pass` | Float64 |  |
+| `havoc_off_pass` | Float64 |  |
+| `explosive_off_pass` | Float64 |  |
+| `TEPA_off_pass` | Float64 |  |
+| `EPAplay_off_pass` | Float64 |  |
+| `EPAdrive_off_pass` | Float64 |  |
+| `EPAgame_off_pass` | Float64 |  |
+| `yards_off_pass` | Int64 |  |
+| `yardsplay_off_pass` | Float64 |  |
+| `yardsgame_off_pass` | Float64 |  |
+| `play_stuffed_off_pass` | Float64 |  |
+| `drives_off_pass` | UInt32 |  |
+| `drivesgame_off_pass` | Float64 |  |
+| `yardsdrive_off_pass` | Float64 |  |
+| `playsdrive_off_pass` | Float64 |  |
+| `success_off_pass` | Float64 |  |
+| `red_zone_success_off_pass` | Float64 |  |
+| `third_down_success_off_pass` | Float64 |  |
+| `third_down_distance_off_pass` | Float64 |  |
+| `late_down_success_off_pass` | Float64 |  |
+| `early_down_EPA_off_pass` | Float64 |  |
+| `nonExplosiveEpaPerPlay_off_pass` | Float64 |  |
+| `line_yards_off_pass` | Float64 |  |
+| `opportunity_rate_off_pass` | Float64 |  |
+| `playsgame_off_pass_rank` | Float64 |  |
+| `TEPA_off_pass_rank` | Float64 |  |
+| `EPAgame_off_pass_rank` | Float64 |  |
+| `EPAplay_off_pass_rank` | Float64 |  |
+| `EPAdrive_off_pass_rank` | Float64 |  |
+| `early_down_EPA_off_pass_rank` | Float64 |  |
+| `success_off_pass_rank` | Float64 |  |
+| `yards_off_pass_rank` | Float64 |  |
+| `yardsplay_off_pass_rank` | Float64 |  |
+| `yardsgame_off_pass_rank` | Float64 |  |
+| `drivesgame_off_pass_rank` | Float64 |  |
+| `yardsdrive_off_pass_rank` | Float64 |  |
+| `playsdrive_off_pass_rank` | Float64 |  |
+| `play_stuffed_off_pass_rank` | Float64 |  |
+| `red_zone_success_off_pass_rank` | Float64 |  |
+| `third_down_success_off_pass_rank` | Float64 |  |
+| `late_down_success_off_pass_rank` | Float64 |  |
+| `third_down_distance_off_pass_rank` | Float64 |  |
+| `havoc_off_pass_rank` | Float64 |  |
+| `explosive_off_pass_rank` | Float64 |  |
+| `passrate_off_pass_rank` | Float64 |  |
+| `rushrate_off_pass_rank` | Float64 |  |
+| `nonExplosiveEpaPerPlay_off_pass_rank` | Float64 |  |
+| `line_yards_off_pass_rank` | Float64 |  |
+| `opportunity_rate_off_pass_rank` | Float64 |  |
+| `plays_def_pass` | UInt32 |  |
+| `playsgame_def_pass` | Float64 |  |
+| `passrate_def_pass` | Float64 |  |
+| `rushrate_def_pass` | Float64 |  |
+| `havoc_def_pass` | Float64 |  |
+| `explosive_def_pass` | Float64 |  |
+| `TEPA_def_pass` | Float64 |  |
+| `EPAplay_def_pass` | Float64 |  |
+| `EPAdrive_def_pass` | Float64 |  |
+| `EPAgame_def_pass` | Float64 |  |
+| `yards_def_pass` | Int64 |  |
+| `yardsplay_def_pass` | Float64 |  |
+| `yardsgame_def_pass` | Float64 |  |
+| `play_stuffed_def_pass` | Float64 |  |
+| `drives_def_pass` | UInt32 |  |
+| `drivesgame_def_pass` | Float64 |  |
+| `yardsdrive_def_pass` | Float64 |  |
+| `playsdrive_def_pass` | Float64 |  |
+| `success_def_pass` | Float64 |  |
+| `red_zone_success_def_pass` | Float64 |  |
+| `third_down_success_def_pass` | Float64 |  |
+| `third_down_distance_def_pass` | Float64 |  |
+| `late_down_success_def_pass` | Float64 |  |
+| `early_down_EPA_def_pass` | Float64 |  |
+| `nonExplosiveEpaPerPlay_def_pass` | Float64 |  |
+| `line_yards_def_pass` | Float64 |  |
+| `opportunity_rate_def_pass` | Float64 |  |
+| `playsgame_def_pass_rank` | Float64 |  |
+| `TEPA_def_pass_rank` | Float64 |  |
+| `EPAgame_def_pass_rank` | Float64 |  |
+| `EPAplay_def_pass_rank` | Float64 |  |
+| `EPAdrive_def_pass_rank` | Float64 |  |
+| `early_down_EPA_def_pass_rank` | Float64 |  |
+| `success_def_pass_rank` | Float64 |  |
+| `yards_def_pass_rank` | Float64 |  |
+| `yardsplay_def_pass_rank` | Float64 |  |
+| `yardsgame_def_pass_rank` | Float64 |  |
+| `drivesgame_def_pass_rank` | Float64 |  |
+| `yardsdrive_def_pass_rank` | Float64 |  |
+| `playsdrive_def_pass_rank` | Float64 |  |
+| `play_stuffed_def_pass_rank` | Float64 |  |
+| `red_zone_success_def_pass_rank` | Float64 |  |
+| `third_down_success_def_pass_rank` | Float64 |  |
+| `late_down_success_def_pass_rank` | Float64 |  |
+| `third_down_distance_def_pass_rank` | Float64 |  |
+| `havoc_def_pass_rank` | Float64 |  |
+| `explosive_def_pass_rank` | Float64 |  |
+| `passrate_def_pass_rank` | Float64 |  |
+| `rushrate_def_pass_rank` | Float64 |  |
+| `nonExplosiveEpaPerPlay_def_pass_rank` | Float64 |  |
+| `line_yards_def_pass_rank` | Float64 |  |
+| `opportunity_rate_def_pass_rank` | Float64 |  |
+| `TEPA_margin_pass` | Float64 |  |
+| `EPAplay_margin_pass` | Float64 |  |
+| `EPAdrive_margin_pass` | Float64 |  |
+| `EPAgame_margin_pass` | Float64 |  |
+| `success_margin_pass` | Float64 |  |
+| `yardsplay_margin_pass` | Float64 |  |
+| `TEPA_margin_pass_rank` | Float64 |  |
+| `EPAgame_margin_pass_rank` | Float64 |  |
+| `EPAdrive_margin_pass_rank` | Float64 |  |
+| `EPAplay_margin_pass_rank` | Float64 |  |
+| `success_margin_pass_rank` | Float64 |  |
+| `yardsplay_margin_pass_rank` | Float64 |  |
+| `plays_off_rush` | UInt32 |  |
+| `playsgame_off_rush` | Float64 |  |
+| `passrate_off_rush` | Float64 |  |
+| `rushrate_off_rush` | Float64 |  |
+| `havoc_off_rush` | Float64 |  |
+| `explosive_off_rush` | Float64 |  |
+| `TEPA_off_rush` | Float64 |  |
+| `EPAplay_off_rush` | Float64 |  |
+| `EPAdrive_off_rush` | Float64 |  |
+| `EPAgame_off_rush` | Float64 |  |
+| `yards_off_rush` | Int64 |  |
+| `yardsplay_off_rush` | Float64 |  |
+| `yardsgame_off_rush` | Float64 |  |
+| `play_stuffed_off_rush` | Float64 |  |
+| `drives_off_rush` | UInt32 |  |
+| `drivesgame_off_rush` | Float64 |  |
+| `yardsdrive_off_rush` | Float64 |  |
+| `playsdrive_off_rush` | Float64 |  |
+| `success_off_rush` | Float64 |  |
+| `red_zone_success_off_rush` | Float64 |  |
+| `third_down_success_off_rush` | Float64 |  |
+| `third_down_distance_off_rush` | Float64 |  |
+| `late_down_success_off_rush` | Float64 |  |
+| `early_down_EPA_off_rush` | Float64 |  |
+| `nonExplosiveEpaPerPlay_off_rush` | Float64 |  |
+| `line_yards_off_rush` | Float64 |  |
+| `opportunity_rate_off_rush` | Float64 |  |
+| `playsgame_off_rush_rank` | Float64 |  |
+| `TEPA_off_rush_rank` | Float64 |  |
+| `EPAgame_off_rush_rank` | Float64 |  |
+| `EPAplay_off_rush_rank` | Float64 |  |
+| `EPAdrive_off_rush_rank` | Float64 |  |
+| `early_down_EPA_off_rush_rank` | Float64 |  |
+| `success_off_rush_rank` | Float64 |  |
+| `yards_off_rush_rank` | Float64 |  |
+| `yardsplay_off_rush_rank` | Float64 |  |
+| `yardsgame_off_rush_rank` | Float64 |  |
+| `drivesgame_off_rush_rank` | Float64 |  |
+| `yardsdrive_off_rush_rank` | Float64 |  |
+| `playsdrive_off_rush_rank` | Float64 |  |
+| `play_stuffed_off_rush_rank` | Float64 |  |
+| `red_zone_success_off_rush_rank` | Float64 |  |
+| `third_down_success_off_rush_rank` | Float64 |  |
+| `late_down_success_off_rush_rank` | Float64 |  |
+| `third_down_distance_off_rush_rank` | Float64 |  |
+| `havoc_off_rush_rank` | Float64 |  |
+| `explosive_off_rush_rank` | Float64 |  |
+| `passrate_off_rush_rank` | Float64 |  |
+| `rushrate_off_rush_rank` | Float64 |  |
+| `nonExplosiveEpaPerPlay_off_rush_rank` | Float64 |  |
+| `line_yards_off_rush_rank` | Float64 |  |
+| `opportunity_rate_off_rush_rank` | Float64 |  |
+| `plays_def_rush` | UInt32 |  |
+| `playsgame_def_rush` | Float64 |  |
+| `passrate_def_rush` | Float64 |  |
+| `rushrate_def_rush` | Float64 |  |
+| `havoc_def_rush` | Float64 |  |
+| `explosive_def_rush` | Float64 |  |
+| `TEPA_def_rush` | Float64 |  |
+| `EPAplay_def_rush` | Float64 |  |
+| `EPAdrive_def_rush` | Float64 |  |
+| `EPAgame_def_rush` | Float64 |  |
+| `yards_def_rush` | Int64 |  |
+| `yardsplay_def_rush` | Float64 |  |
+| `yardsgame_def_rush` | Float64 |  |
+| `play_stuffed_def_rush` | Float64 |  |
+| `drives_def_rush` | UInt32 |  |
+| `drivesgame_def_rush` | Float64 |  |
+| `yardsdrive_def_rush` | Float64 |  |
+| `playsdrive_def_rush` | Float64 |  |
+| `success_def_rush` | Float64 |  |
+| `red_zone_success_def_rush` | Float64 |  |
+| `third_down_success_def_rush` | Float64 |  |
+| `third_down_distance_def_rush` | Float64 |  |
+| `late_down_success_def_rush` | Float64 |  |
+| `early_down_EPA_def_rush` | Float64 |  |
+| `nonExplosiveEpaPerPlay_def_rush` | Float64 |  |
+| `line_yards_def_rush` | Float64 |  |
+| `opportunity_rate_def_rush` | Float64 |  |
+| `playsgame_def_rush_rank` | Float64 |  |
+| `TEPA_def_rush_rank` | Float64 |  |
+| `EPAgame_def_rush_rank` | Float64 |  |
+| `EPAplay_def_rush_rank` | Float64 |  |
+| `EPAdrive_def_rush_rank` | Float64 |  |
+| `early_down_EPA_def_rush_rank` | Float64 |  |
+| `success_def_rush_rank` | Float64 |  |
+| `yards_def_rush_rank` | Float64 |  |
+| `yardsplay_def_rush_rank` | Float64 |  |
+| `yardsgame_def_rush_rank` | Float64 |  |
+| `drivesgame_def_rush_rank` | Float64 |  |
+| `yardsdrive_def_rush_rank` | Float64 |  |
+| `playsdrive_def_rush_rank` | Float64 |  |
+| `play_stuffed_def_rush_rank` | Float64 |  |
+| `red_zone_success_def_rush_rank` | Float64 |  |
+| `third_down_success_def_rush_rank` | Float64 |  |
+| `late_down_success_def_rush_rank` | Float64 |  |
+| `third_down_distance_def_rush_rank` | Float64 |  |
+| `havoc_def_rush_rank` | Float64 |  |
+| `explosive_def_rush_rank` | Float64 |  |
+| `passrate_def_rush_rank` | Float64 |  |
+| `rushrate_def_rush_rank` | Float64 |  |
+| `nonExplosiveEpaPerPlay_def_rush_rank` | Float64 |  |
+| `line_yards_def_rush_rank` | Float64 |  |
+| `opportunity_rate_def_rush_rank` | Float64 |  |
+| `TEPA_margin_rush` | Float64 |  |
+| `EPAplay_margin_rush` | Float64 |  |
+| `EPAdrive_margin_rush` | Float64 |  |
+| `EPAgame_margin_rush` | Float64 |  |
+| `success_margin_rush` | Float64 |  |
+| `yardsplay_margin_rush` | Float64 |  |
+| `TEPA_margin_rush_rank` | Float64 |  |
+| `EPAgame_margin_rush_rank` | Float64 |  |
+| `EPAdrive_margin_rush_rank` | Float64 |  |
+| `EPAplay_margin_rush_rank` | Float64 |  |
+| `success_margin_rush_rank` | Float64 |  |
+| `yardsplay_margin_rush_rank` | Float64 |  |
+| `fbs_class` | String |  |
+| `valid_games` | UInt32 |  |
+| `adj_off_epa` | Float64 |  |
+| `adj_def_epa` | Float64 |  |
+| `def_strength_faced` | Float64 |  |
+| `off_strength_faced` | Float64 |  |
+| `net_adj_epa` | Float64 |  |
+| `adj_off_epa_rank` | Float64 |  |
+| `adj_def_epa_rank` | Float64 |  |
+| `net_adj_epa_rank` | Float64 |  |
 
 ```python
 load_cfb_team_summaries(seasons=2024)
@@ -2026,98 +2026,98 @@ load_cfb_team_summaries(seasons=2024)
 Release: [espn_cfb_adv_team_gamelog](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_cfb_adv_team_gamelog) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_cfb_adv_team_gamelog/adv_team_gamelog_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int64 |
-| `week` | Int64 |
-| `season_type` | Int32 |
-| `game_id` | Int64 |
-| `start_date` | String |
-| `team_id` | Int64 |
-| `team` | String |
-| `opponent_id` | Int64 |
-| `opponent` | String |
-| `is_home` | Boolean |
-| `neutral_site` | Boolean |
-| `points_for` | Int64 |
-| `points_against` | Int64 |
-| `margin` | Int64 |
-| `win` | Boolean |
-| `rushing_highlight_yards_per_opp` | Float64 |
-| `total_pen_yards` | Int64 |
-| `EPA_penalty` | Float64 |
-| `penalty_first_downs_created` | Int64 |
-| `penalty_first_downs_created_rate` | Float64 |
-| `penalties` | Int64 |
-| `penalty_yards` | Int64 |
-| `special_teams_plays` | Int64 |
-| `EPA_sp` | Float64 |
-| `EPA_special_teams` | Float64 |
-| `field_goals` | Int64 |
-| `EPA_fg` | Float64 |
-| `punt_plays` | Int64 |
-| `EPA_punt` | Float64 |
-| `kickoff_plays` | Int64 |
-| `EPA_kickoff` | Float64 |
-| `rushes` | Int64 |
-| `rush_yards` | Float64 |
-| `yards_per_rush` | Float64 |
-| `rushing_power_rate` | Float64 |
-| `rushing_first_downs_created` | Int64 |
-| `rushing_first_downs_created_rate` | Float64 |
-| `EPA_rushing_overall` | Float64 |
-| `EPA_rushing_per_play` | Float64 |
-| `EPA_explosive_rushing` | Int64 |
-| `EPA_explosive_rushing_rate` | Float64 |
-| `EPA_non_explosive_rushing` | Float64 |
-| `EPA_non_explosive_rushing_per_play` | Float64 |
-| `passes` | Int64 |
-| `pass_yards` | Float64 |
-| `yards_per_pass` | Float64 |
-| `passing_first_downs_created` | Int64 |
-| `passing_first_downs_created_rate` | Float64 |
-| `EPA_passing_overall` | Float64 |
-| `EPA_passing_per_play` | Float64 |
-| `EPA_explosive_passing` | Int64 |
-| `EPA_explosive_passing_rate` | Float64 |
-| `EPA_non_explosive_passing` | Float64 |
-| `EPA_non_explosive_passing_per_play` | Float64 |
-| `scrimmage_plays` | Int64 |
-| `EPA_overall_off` | Float64 |
-| `EPA_overall_offense` | Float64 |
-| `EPA_per_play` | Float64 |
-| `EPA_non_explosive` | Float64 |
-| `EPA_non_explosive_per_play` | Float64 |
-| `EPA_explosive` | Int64 |
-| `EPA_explosive_rate` | Float64 |
-| `passes_rate` | Float64 |
-| `off_yards` | Int64 |
-| `total_off_yards` | Int64 |
-| `yards_per_play` | Float64 |
-| `EPA_plays` | Int64 |
-| `total_yards` | Int64 |
-| `EPA_overall_total` | Float64 |
-| `rushes_rate` | Float64 |
-| `first_downs_created` | Int64 |
-| `first_downs_created_rate` | Float64 |
-| `EPA_rushing_power` | Float64 |
-| `EPA_rushing_power_per_play` | Float64 |
-| `rushing_power_success` | Int64 |
-| `rushing_power_success_rate` | Float64 |
-| `rushing_power` | Int64 |
-| `rushing_stuff` | Int64 |
-| `rushing_stuff_rate` | Float64 |
-| `rushing_stopped` | Int64 |
-| `rushing_stopped_rate` | Float64 |
-| `rushing_opportunity` | Int64 |
-| `rushing_opportunity_rate` | Float64 |
-| `rushing_highlight` | Int64 |
-| `rushing_highlight_rate` | Float64 |
-| `rushing_highlight_yards` | Float64 |
-| `line_yards` | Float64 |
-| `line_yards_per_carry` | Float64 |
-| `second_level_yards` | Float64 |
-| `open_field_yards` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int64 | Season (4-digit year). |
+| `week` | Int64 | Game week of the season. |
+| `season_type` | Int32 | ESPN season type (2 = regular, 3 = postseason). |
+| `game_id` | Int64 | ESPN game identifier. |
+| `start_date` | String | Season start timestamp (ISO 8601, UTC). |
+| `team_id` | Int64 | ESPN team id. |
+| `team` | String | Team name. |
+| `opponent_id` | Int64 | ESPN team id of the opponent. |
+| `opponent` | String | Opponent team name. |
+| `is_home` | Boolean | Whether the subject team was the home team. |
+| `neutral_site` | Boolean | TRUE/FALSE flag for if the game took place at a neutral site. |
+| `points_for` | Int64 | Goals/points scored. |
+| `points_against` | Int64 | Points allowed. |
+| `margin` | Int64 |  |
+| `win` | Boolean | Whether the game was a win (goalie). |
+| `rushing_highlight_yards_per_opp` | Float64 |  |
+| `total_pen_yards` | Int64 |  |
+| `EPA_penalty` | Float64 |  |
+| `penalty_first_downs_created` | Int64 |  |
+| `penalty_first_downs_created_rate` | Float64 |  |
+| `penalties` | Int64 | Total number of penalties. |
+| `penalty_yards` | Int64 | Yards gained (or lost) by the posteam from the penalty. |
+| `special_teams_plays` | Int64 |  |
+| `EPA_sp` | Float64 |  |
+| `EPA_special_teams` | Float64 |  |
+| `field_goals` | Int64 |  |
+| `EPA_fg` | Float64 |  |
+| `punt_plays` | Int64 |  |
+| `EPA_punt` | Float64 |  |
+| `kickoff_plays` | Int64 |  |
+| `EPA_kickoff` | Float64 |  |
+| `rushes` | Int64 |  |
+| `rush_yards` | Float64 | The number of rushing yards gained |
+| `yards_per_rush` | Float64 |  |
+| `rushing_power_rate` | Float64 |  |
+| `rushing_first_downs_created` | Int64 |  |
+| `rushing_first_downs_created_rate` | Float64 |  |
+| `EPA_rushing_overall` | Float64 |  |
+| `EPA_rushing_per_play` | Float64 |  |
+| `EPA_explosive_rushing` | Int64 |  |
+| `EPA_explosive_rushing_rate` | Float64 |  |
+| `EPA_non_explosive_rushing` | Float64 |  |
+| `EPA_non_explosive_rushing_per_play` | Float64 |  |
+| `passes` | Int64 | Passes. |
+| `pass_yards` | Float64 | Number of yards gained on pass plays |
+| `yards_per_pass` | Float64 | Team game yards per pass. |
+| `passing_first_downs_created` | Int64 |  |
+| `passing_first_downs_created_rate` | Float64 |  |
+| `EPA_passing_overall` | Float64 |  |
+| `EPA_passing_per_play` | Float64 |  |
+| `EPA_explosive_passing` | Int64 |  |
+| `EPA_explosive_passing_rate` | Float64 |  |
+| `EPA_non_explosive_passing` | Float64 |  |
+| `EPA_non_explosive_passing_per_play` | Float64 |  |
+| `scrimmage_plays` | Int64 |  |
+| `EPA_overall_off` | Float64 |  |
+| `EPA_overall_offense` | Float64 |  |
+| `EPA_per_play` | Float64 |  |
+| `EPA_non_explosive` | Float64 |  |
+| `EPA_non_explosive_per_play` | Float64 |  |
+| `EPA_explosive` | Int64 |  |
+| `EPA_explosive_rate` | Float64 |  |
+| `passes_rate` | Float64 |  |
+| `off_yards` | Int64 |  |
+| `total_off_yards` | Int64 |  |
+| `yards_per_play` | Float64 |  |
+| `EPA_plays` | Int64 |  |
+| `total_yards` | Int64 | Team total yards. |
+| `EPA_overall_total` | Float64 |  |
+| `rushes_rate` | Float64 |  |
+| `first_downs_created` | Int64 |  |
+| `first_downs_created_rate` | Float64 |  |
+| `EPA_rushing_power` | Float64 |  |
+| `EPA_rushing_power_per_play` | Float64 |  |
+| `rushing_power_success` | Int64 | Rushing power success rate. |
+| `rushing_power_success_rate` | Float64 |  |
+| `rushing_power` | Int64 |  |
+| `rushing_stuff` | Int64 |  |
+| `rushing_stuff_rate` | Float64 | Rushing stuff rate. |
+| `rushing_stopped` | Int64 |  |
+| `rushing_stopped_rate` | Float64 |  |
+| `rushing_opportunity` | Int64 |  |
+| `rushing_opportunity_rate` | Float64 |  |
+| `rushing_highlight` | Int64 |  |
+| `rushing_highlight_rate` | Float64 |  |
+| `rushing_highlight_yards` | Float64 | Opponent-adjusted offensive highlight yards per opportunity rush. |
+| `line_yards` | Float64 |  |
+| `line_yards_per_carry` | Float64 |  |
+| `second_level_yards` | Float64 |  |
+| `open_field_yards` | Float64 |  |
 
 ```python
 load_cfb_adv_team_gamelog(seasons=2024)
@@ -2128,24 +2128,24 @@ load_cfb_adv_team_gamelog(seasons=2024)
 Release: [cfb_ratings_weekly](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_ratings_weekly) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/cfb_ratings_weekly/cfb_ratings_weekly_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int64 |
-| `team_id` | String |
-| `adj_off_epa` | Float64 |
-| `adj_def_epa` | Float64 |
-| `adj_st_epa` | Float64 |
-| `adj_net` | Float64 |
-| `fei_off` | Float64 |
-| `fei_def` | Float64 |
-| `fei_net` | Float64 |
-| `games` | Int64 |
-| `off_pace` | Float64 |
-| `off_rank` | Int64 |
-| `def_rank` | Int64 |
-| `net_rank` | Int64 |
-| `net_z` | Float64 |
-| `through_week` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int64 | Season (4-digit year). |
+| `team_id` | Int64 | ESPN team id. |
+| `adj_off_epa` | Float64 |  |
+| `adj_def_epa` | Float64 |  |
+| `adj_st_epa` | Float64 |  |
+| `adj_net` | Float64 |  |
+| `fei_off` | Float64 |  |
+| `fei_def` | Float64 |  |
+| `fei_net` | Float64 |  |
+| `games` | Int64 | Number of games included in the ATS summary. |
+| `off_pace` | Float64 |  |
+| `off_rank` | Int64 |  |
+| `def_rank` | Int64 |  |
+| `net_rank` | Int64 |  |
+| `net_z` | Float64 |  |
+| `through_week` | Int32 |  |
 
 ```python
 load_cfb_ratings_weekly(seasons=2024)
@@ -2156,392 +2156,392 @@ load_cfb_ratings_weekly(seasons=2024)
 Release: [cfb_team_summaries_weekly](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_team_summaries_weekly) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/cfb_team_summaries_weekly/cfb_team_summaries_weekly_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `team_id` | String |
-| `pos_team` | String |
-| `division` | String |
-| `conference` | String |
-| `season` | Int64 |
-| `plays_off` | UInt32 |
-| `passrate_off` | Float64 |
-| `rushrate_off` | Float64 |
-| `havoc_off` | Float64 |
-| `explosive_off` | Float64 |
-| `TEPA_off` | Float64 |
-| `EPAplay_off` | Float64 |
-| `yards_off` | Int64 |
-| `yardsplay_off` | Float64 |
-| `play_stuffed_off` | Float64 |
-| `success_off` | Float64 |
-| `red_zone_success_off` | Float64 |
-| `third_down_success_off` | Float64 |
-| `third_down_distance_off` | Float64 |
-| `late_down_success_off` | Float64 |
-| `early_down_EPA_off` | Float64 |
-| `start_position_off` | Float64 |
-| `nonExplosiveEpaPerPlay_off` | Float64 |
-| `line_yards_off` | Float64 |
-| `opportunity_rate_off` | Float64 |
-| `playsgame_off` | Float64 |
-| `EPAdrive_off` | Float64 |
-| `EPAgame_off` | Float64 |
-| `yardsgame_off` | Float64 |
-| `drives_off` | UInt32 |
-| `drivesgame_off` | Float64 |
-| `yardsdrive_off` | Float64 |
-| `playsdrive_off` | Float64 |
-| `playsgame_off_rank` | Float64 |
-| `TEPA_off_rank` | Float64 |
-| `EPAgame_off_rank` | Float64 |
-| `EPAplay_off_rank` | Float64 |
-| `EPAdrive_off_rank` | Float64 |
-| `early_down_EPA_off_rank` | Float64 |
-| `success_off_rank` | Float64 |
-| `yards_off_rank` | Float64 |
-| `yardsplay_off_rank` | Float64 |
-| `yardsgame_off_rank` | Float64 |
-| `drivesgame_off_rank` | Float64 |
-| `yardsdrive_off_rank` | Float64 |
-| `playsdrive_off_rank` | Float64 |
-| `play_stuffed_off_rank` | Float64 |
-| `red_zone_success_off_rank` | Float64 |
-| `third_down_success_off_rank` | Float64 |
-| `late_down_success_off_rank` | Float64 |
-| `third_down_distance_off_rank` | Float64 |
-| `start_position_off_rank` | Float64 |
-| `havoc_off_rank` | Float64 |
-| `explosive_off_rank` | Float64 |
-| `passrate_off_rank` | Float64 |
-| `rushrate_off_rank` | Float64 |
-| `nonExplosiveEpaPerPlay_off_rank` | Float64 |
-| `line_yards_off_rank` | Float64 |
-| `opportunity_rate_off_rank` | Float64 |
-| `plays_def` | UInt32 |
-| `passrate_def` | Float64 |
-| `rushrate_def` | Float64 |
-| `havoc_def` | Float64 |
-| `explosive_def` | Float64 |
-| `TEPA_def` | Float64 |
-| `EPAplay_def` | Float64 |
-| `yards_def` | Int64 |
-| `yardsplay_def` | Float64 |
-| `play_stuffed_def` | Float64 |
-| `success_def` | Float64 |
-| `red_zone_success_def` | Float64 |
-| `third_down_success_def` | Float64 |
-| `third_down_distance_def` | Float64 |
-| `late_down_success_def` | Float64 |
-| `early_down_EPA_def` | Float64 |
-| `start_position_def` | Float64 |
-| `nonExplosiveEpaPerPlay_def` | Float64 |
-| `line_yards_def` | Float64 |
-| `opportunity_rate_def` | Float64 |
-| `playsgame_def` | Float64 |
-| `EPAdrive_def` | Float64 |
-| `EPAgame_def` | Float64 |
-| `yardsgame_def` | Float64 |
-| `drives_def` | UInt32 |
-| `drivesgame_def` | Float64 |
-| `yardsdrive_def` | Float64 |
-| `playsdrive_def` | Float64 |
-| `playsgame_def_rank` | Float64 |
-| `TEPA_def_rank` | Float64 |
-| `EPAgame_def_rank` | Float64 |
-| `EPAplay_def_rank` | Float64 |
-| `EPAdrive_def_rank` | Float64 |
-| `early_down_EPA_def_rank` | Float64 |
-| `success_def_rank` | Float64 |
-| `yards_def_rank` | Float64 |
-| `yardsplay_def_rank` | Float64 |
-| `yardsgame_def_rank` | Float64 |
-| `drivesgame_def_rank` | Float64 |
-| `yardsdrive_def_rank` | Float64 |
-| `playsdrive_def_rank` | Float64 |
-| `play_stuffed_def_rank` | Float64 |
-| `red_zone_success_def_rank` | Float64 |
-| `third_down_success_def_rank` | Float64 |
-| `late_down_success_def_rank` | Float64 |
-| `third_down_distance_def_rank` | Float64 |
-| `start_position_def_rank` | Float64 |
-| `havoc_def_rank` | Float64 |
-| `explosive_def_rank` | Float64 |
-| `passrate_def_rank` | Float64 |
-| `rushrate_def_rank` | Float64 |
-| `nonExplosiveEpaPerPlay_def_rank` | Float64 |
-| `line_yards_def_rank` | Float64 |
-| `opportunity_rate_def_rank` | Float64 |
-| `TEPA_margin` | Float64 |
-| `EPAplay_margin` | Float64 |
-| `EPAdrive_margin` | Float64 |
-| `EPAgame_margin` | Float64 |
-| `success_margin` | Float64 |
-| `yardsplay_margin` | Float64 |
-| `TEPA_margin_rank` | Float64 |
-| `EPAplay_margin_rank` | Float64 |
-| `EPAdrive_margin_rank` | Float64 |
-| `EPAgame_margin_rank` | Float64 |
-| `success_margin_rank` | Float64 |
-| `yardsplay_margin_rank` | Float64 |
-| `start_position_margin` | Float64 |
-| `start_position_margin_rank` | Float64 |
-| `total_available_yards_off` | Float64 |
-| `total_gained_yards_off` | Int64 |
-| `available_yards_pct_off` | Float64 |
-| `available_yards_pct_off_rank` | Float64 |
-| `total_available_yards_def` | Float64 |
-| `total_gained_yards_def` | Int64 |
-| `available_yards_pct_def` | Float64 |
-| `available_yards_pct_def_rank` | Float64 |
-| `total_available_yards_margin` | Float64 |
-| `total_gained_yards_margin` | Int64 |
-| `available_yards_pct_margin` | Float64 |
-| `total_available_yards_margin_rank` | Float64 |
-| `total_gained_yards_margin_rank` | Float64 |
-| `available_yards_pct_margin_rank` | Float64 |
-| `plays_off_pass` | UInt32 |
-| `passrate_off_pass` | Float64 |
-| `rushrate_off_pass` | Float64 |
-| `havoc_off_pass` | Float64 |
-| `explosive_off_pass` | Float64 |
-| `TEPA_off_pass` | Float64 |
-| `EPAplay_off_pass` | Float64 |
-| `yards_off_pass` | Int64 |
-| `yardsplay_off_pass` | Float64 |
-| `play_stuffed_off_pass` | Float64 |
-| `success_off_pass` | Float64 |
-| `red_zone_success_off_pass` | Float64 |
-| `third_down_success_off_pass` | Float64 |
-| `third_down_distance_off_pass` | Float64 |
-| `late_down_success_off_pass` | Float64 |
-| `early_down_EPA_off_pass` | Float64 |
-| `nonExplosiveEpaPerPlay_off_pass` | Float64 |
-| `line_yards_off_pass` | Float64 |
-| `opportunity_rate_off_pass` | Float64 |
-| `playsgame_off_pass` | Float64 |
-| `EPAdrive_off_pass` | Float64 |
-| `EPAgame_off_pass` | Float64 |
-| `yardsgame_off_pass` | Float64 |
-| `drives_off_pass` | UInt32 |
-| `drivesgame_off_pass` | Float64 |
-| `yardsdrive_off_pass` | Float64 |
-| `playsdrive_off_pass` | Float64 |
-| `playsgame_off_pass_rank` | Float64 |
-| `TEPA_off_pass_rank` | Float64 |
-| `EPAgame_off_pass_rank` | Float64 |
-| `EPAplay_off_pass_rank` | Float64 |
-| `EPAdrive_off_pass_rank` | Float64 |
-| `early_down_EPA_off_pass_rank` | Float64 |
-| `success_off_pass_rank` | Float64 |
-| `yards_off_pass_rank` | Float64 |
-| `yardsplay_off_pass_rank` | Float64 |
-| `yardsgame_off_pass_rank` | Float64 |
-| `drivesgame_off_pass_rank` | Float64 |
-| `yardsdrive_off_pass_rank` | Float64 |
-| `playsdrive_off_pass_rank` | Float64 |
-| `play_stuffed_off_pass_rank` | Float64 |
-| `red_zone_success_off_pass_rank` | Float64 |
-| `third_down_success_off_pass_rank` | Float64 |
-| `late_down_success_off_pass_rank` | Float64 |
-| `third_down_distance_off_pass_rank` | Float64 |
-| `havoc_off_pass_rank` | Float64 |
-| `explosive_off_pass_rank` | Float64 |
-| `passrate_off_pass_rank` | Float64 |
-| `rushrate_off_pass_rank` | Float64 |
-| `nonExplosiveEpaPerPlay_off_pass_rank` | Float64 |
-| `line_yards_off_pass_rank` | Float64 |
-| `opportunity_rate_off_pass_rank` | Float64 |
-| `plays_def_pass` | UInt32 |
-| `passrate_def_pass` | Float64 |
-| `rushrate_def_pass` | Float64 |
-| `havoc_def_pass` | Float64 |
-| `explosive_def_pass` | Float64 |
-| `TEPA_def_pass` | Float64 |
-| `EPAplay_def_pass` | Float64 |
-| `yards_def_pass` | Int64 |
-| `yardsplay_def_pass` | Float64 |
-| `play_stuffed_def_pass` | Float64 |
-| `success_def_pass` | Float64 |
-| `red_zone_success_def_pass` | Float64 |
-| `third_down_success_def_pass` | Float64 |
-| `third_down_distance_def_pass` | Float64 |
-| `late_down_success_def_pass` | Float64 |
-| `early_down_EPA_def_pass` | Float64 |
-| `nonExplosiveEpaPerPlay_def_pass` | Float64 |
-| `line_yards_def_pass` | Float64 |
-| `opportunity_rate_def_pass` | Float64 |
-| `playsgame_def_pass` | Float64 |
-| `EPAdrive_def_pass` | Float64 |
-| `EPAgame_def_pass` | Float64 |
-| `yardsgame_def_pass` | Float64 |
-| `drives_def_pass` | UInt32 |
-| `drivesgame_def_pass` | Float64 |
-| `yardsdrive_def_pass` | Float64 |
-| `playsdrive_def_pass` | Float64 |
-| `playsgame_def_pass_rank` | Float64 |
-| `TEPA_def_pass_rank` | Float64 |
-| `EPAgame_def_pass_rank` | Float64 |
-| `EPAplay_def_pass_rank` | Float64 |
-| `EPAdrive_def_pass_rank` | Float64 |
-| `early_down_EPA_def_pass_rank` | Float64 |
-| `success_def_pass_rank` | Float64 |
-| `yards_def_pass_rank` | Float64 |
-| `yardsplay_def_pass_rank` | Float64 |
-| `yardsgame_def_pass_rank` | Float64 |
-| `drivesgame_def_pass_rank` | Float64 |
-| `yardsdrive_def_pass_rank` | Float64 |
-| `playsdrive_def_pass_rank` | Float64 |
-| `play_stuffed_def_pass_rank` | Float64 |
-| `red_zone_success_def_pass_rank` | Float64 |
-| `third_down_success_def_pass_rank` | Float64 |
-| `late_down_success_def_pass_rank` | Float64 |
-| `third_down_distance_def_pass_rank` | Float64 |
-| `havoc_def_pass_rank` | Float64 |
-| `explosive_def_pass_rank` | Float64 |
-| `passrate_def_pass_rank` | Float64 |
-| `rushrate_def_pass_rank` | Float64 |
-| `nonExplosiveEpaPerPlay_def_pass_rank` | Float64 |
-| `line_yards_def_pass_rank` | Float64 |
-| `opportunity_rate_def_pass_rank` | Float64 |
-| `TEPA_margin_pass` | Float64 |
-| `EPAplay_margin_pass` | Float64 |
-| `EPAdrive_margin_pass` | Float64 |
-| `EPAgame_margin_pass` | Float64 |
-| `success_margin_pass` | Float64 |
-| `yardsplay_margin_pass` | Float64 |
-| `TEPA_margin_pass_rank` | Float64 |
-| `EPAplay_margin_pass_rank` | Float64 |
-| `EPAdrive_margin_pass_rank` | Float64 |
-| `EPAgame_margin_pass_rank` | Float64 |
-| `success_margin_pass_rank` | Float64 |
-| `yardsplay_margin_pass_rank` | Float64 |
-| `plays_off_rush` | UInt32 |
-| `passrate_off_rush` | Float64 |
-| `rushrate_off_rush` | Float64 |
-| `havoc_off_rush` | Float64 |
-| `explosive_off_rush` | Float64 |
-| `TEPA_off_rush` | Float64 |
-| `EPAplay_off_rush` | Float64 |
-| `yards_off_rush` | Int64 |
-| `yardsplay_off_rush` | Float64 |
-| `play_stuffed_off_rush` | Float64 |
-| `success_off_rush` | Float64 |
-| `red_zone_success_off_rush` | Float64 |
-| `third_down_success_off_rush` | Float64 |
-| `third_down_distance_off_rush` | Float64 |
-| `late_down_success_off_rush` | Float64 |
-| `early_down_EPA_off_rush` | Float64 |
-| `nonExplosiveEpaPerPlay_off_rush` | Float64 |
-| `line_yards_off_rush` | Float64 |
-| `opportunity_rate_off_rush` | Float64 |
-| `playsgame_off_rush` | Float64 |
-| `EPAdrive_off_rush` | Float64 |
-| `EPAgame_off_rush` | Float64 |
-| `yardsgame_off_rush` | Float64 |
-| `drives_off_rush` | UInt32 |
-| `drivesgame_off_rush` | Float64 |
-| `yardsdrive_off_rush` | Float64 |
-| `playsdrive_off_rush` | Float64 |
-| `playsgame_off_rush_rank` | Float64 |
-| `TEPA_off_rush_rank` | Float64 |
-| `EPAgame_off_rush_rank` | Float64 |
-| `EPAplay_off_rush_rank` | Float64 |
-| `EPAdrive_off_rush_rank` | Float64 |
-| `early_down_EPA_off_rush_rank` | Float64 |
-| `success_off_rush_rank` | Float64 |
-| `yards_off_rush_rank` | Float64 |
-| `yardsplay_off_rush_rank` | Float64 |
-| `yardsgame_off_rush_rank` | Float64 |
-| `drivesgame_off_rush_rank` | Float64 |
-| `yardsdrive_off_rush_rank` | Float64 |
-| `playsdrive_off_rush_rank` | Float64 |
-| `play_stuffed_off_rush_rank` | Float64 |
-| `red_zone_success_off_rush_rank` | Float64 |
-| `third_down_success_off_rush_rank` | Float64 |
-| `late_down_success_off_rush_rank` | Float64 |
-| `third_down_distance_off_rush_rank` | Float64 |
-| `havoc_off_rush_rank` | Float64 |
-| `explosive_off_rush_rank` | Float64 |
-| `passrate_off_rush_rank` | Float64 |
-| `rushrate_off_rush_rank` | Float64 |
-| `nonExplosiveEpaPerPlay_off_rush_rank` | Float64 |
-| `line_yards_off_rush_rank` | Float64 |
-| `opportunity_rate_off_rush_rank` | Float64 |
-| `plays_def_rush` | UInt32 |
-| `passrate_def_rush` | Float64 |
-| `rushrate_def_rush` | Float64 |
-| `havoc_def_rush` | Float64 |
-| `explosive_def_rush` | Float64 |
-| `TEPA_def_rush` | Float64 |
-| `EPAplay_def_rush` | Float64 |
-| `yards_def_rush` | Int64 |
-| `yardsplay_def_rush` | Float64 |
-| `play_stuffed_def_rush` | Float64 |
-| `success_def_rush` | Float64 |
-| `red_zone_success_def_rush` | Float64 |
-| `third_down_success_def_rush` | Float64 |
-| `third_down_distance_def_rush` | Float64 |
-| `late_down_success_def_rush` | Float64 |
-| `early_down_EPA_def_rush` | Float64 |
-| `nonExplosiveEpaPerPlay_def_rush` | Float64 |
-| `line_yards_def_rush` | Float64 |
-| `opportunity_rate_def_rush` | Float64 |
-| `playsgame_def_rush` | Float64 |
-| `EPAdrive_def_rush` | Float64 |
-| `EPAgame_def_rush` | Float64 |
-| `yardsgame_def_rush` | Float64 |
-| `drives_def_rush` | UInt32 |
-| `drivesgame_def_rush` | Float64 |
-| `yardsdrive_def_rush` | Float64 |
-| `playsdrive_def_rush` | Float64 |
-| `playsgame_def_rush_rank` | Float64 |
-| `TEPA_def_rush_rank` | Float64 |
-| `EPAgame_def_rush_rank` | Float64 |
-| `EPAplay_def_rush_rank` | Float64 |
-| `EPAdrive_def_rush_rank` | Float64 |
-| `early_down_EPA_def_rush_rank` | Float64 |
-| `success_def_rush_rank` | Float64 |
-| `yards_def_rush_rank` | Float64 |
-| `yardsplay_def_rush_rank` | Float64 |
-| `yardsgame_def_rush_rank` | Float64 |
-| `drivesgame_def_rush_rank` | Float64 |
-| `yardsdrive_def_rush_rank` | Float64 |
-| `playsdrive_def_rush_rank` | Float64 |
-| `play_stuffed_def_rush_rank` | Float64 |
-| `red_zone_success_def_rush_rank` | Float64 |
-| `third_down_success_def_rush_rank` | Float64 |
-| `late_down_success_def_rush_rank` | Float64 |
-| `third_down_distance_def_rush_rank` | Float64 |
-| `havoc_def_rush_rank` | Float64 |
-| `explosive_def_rush_rank` | Float64 |
-| `passrate_def_rush_rank` | Float64 |
-| `rushrate_def_rush_rank` | Float64 |
-| `nonExplosiveEpaPerPlay_def_rush_rank` | Float64 |
-| `line_yards_def_rush_rank` | Float64 |
-| `opportunity_rate_def_rush_rank` | Float64 |
-| `TEPA_margin_rush` | Float64 |
-| `EPAplay_margin_rush` | Float64 |
-| `EPAdrive_margin_rush` | Float64 |
-| `EPAgame_margin_rush` | Float64 |
-| `success_margin_rush` | Float64 |
-| `yardsplay_margin_rush` | Float64 |
-| `TEPA_margin_rush_rank` | Float64 |
-| `EPAplay_margin_rush_rank` | Float64 |
-| `EPAdrive_margin_rush_rank` | Float64 |
-| `EPAgame_margin_rush_rank` | Float64 |
-| `success_margin_rush_rank` | Float64 |
-| `yardsplay_margin_rush_rank` | Float64 |
-| `fbs_class` | String |
-| `valid_games` | UInt32 |
-| `adj_off_epa` | Float64 |
-| `adj_def_epa` | Float64 |
-| `off_strength_faced` | Float64 |
-| `def_strength_faced` | Float64 |
-| `net_adj_epa` | Float64 |
-| `adj_off_epa_rank` | Float64 |
-| `adj_def_epa_rank` | Float64 |
-| `net_adj_epa_rank` | Float64 |
-| `through_week` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `team_id` | Int64 | ESPN team id. |
+| `pos_team` | String | Team name in possession at the start of the play (offense, kickoff-aware). |
+| `division` | String | Division in the conference for the team. |
+| `conference` | String | Conference of the team. |
+| `season` | Int64 | Season (4-digit year). |
+| `plays_off` | UInt32 |  |
+| `passrate_off` | Float64 |  |
+| `rushrate_off` | Float64 |  |
+| `havoc_off` | Float64 |  |
+| `explosive_off` | Float64 |  |
+| `TEPA_off` | Float64 |  |
+| `EPAplay_off` | Float64 |  |
+| `yards_off` | Int64 |  |
+| `yardsplay_off` | Float64 |  |
+| `play_stuffed_off` | Float64 |  |
+| `success_off` | Float64 |  |
+| `red_zone_success_off` | Float64 |  |
+| `third_down_success_off` | Float64 |  |
+| `third_down_distance_off` | Float64 |  |
+| `late_down_success_off` | Float64 |  |
+| `early_down_EPA_off` | Float64 |  |
+| `start_position_off` | Float64 |  |
+| `nonExplosiveEpaPerPlay_off` | Float64 |  |
+| `line_yards_off` | Float64 |  |
+| `opportunity_rate_off` | Float64 |  |
+| `playsgame_off` | Float64 |  |
+| `EPAdrive_off` | Float64 |  |
+| `EPAgame_off` | Float64 |  |
+| `yardsgame_off` | Float64 |  |
+| `drives_off` | UInt32 |  |
+| `drivesgame_off` | Float64 |  |
+| `yardsdrive_off` | Float64 |  |
+| `playsdrive_off` | Float64 |  |
+| `playsgame_off_rank` | Float64 |  |
+| `TEPA_off_rank` | Float64 |  |
+| `EPAgame_off_rank` | Float64 |  |
+| `EPAplay_off_rank` | Float64 |  |
+| `EPAdrive_off_rank` | Float64 |  |
+| `early_down_EPA_off_rank` | Float64 |  |
+| `success_off_rank` | Float64 |  |
+| `yards_off_rank` | Float64 |  |
+| `yardsplay_off_rank` | Float64 |  |
+| `yardsgame_off_rank` | Float64 |  |
+| `drivesgame_off_rank` | Float64 |  |
+| `yardsdrive_off_rank` | Float64 |  |
+| `playsdrive_off_rank` | Float64 |  |
+| `play_stuffed_off_rank` | Float64 |  |
+| `red_zone_success_off_rank` | Float64 |  |
+| `third_down_success_off_rank` | Float64 |  |
+| `late_down_success_off_rank` | Float64 |  |
+| `third_down_distance_off_rank` | Float64 |  |
+| `start_position_off_rank` | Float64 |  |
+| `havoc_off_rank` | Float64 |  |
+| `explosive_off_rank` | Float64 |  |
+| `passrate_off_rank` | Float64 |  |
+| `rushrate_off_rank` | Float64 |  |
+| `nonExplosiveEpaPerPlay_off_rank` | Float64 |  |
+| `line_yards_off_rank` | Float64 |  |
+| `opportunity_rate_off_rank` | Float64 |  |
+| `plays_def` | UInt32 |  |
+| `passrate_def` | Float64 |  |
+| `rushrate_def` | Float64 |  |
+| `havoc_def` | Float64 |  |
+| `explosive_def` | Float64 |  |
+| `TEPA_def` | Float64 |  |
+| `EPAplay_def` | Float64 |  |
+| `yards_def` | Int64 |  |
+| `yardsplay_def` | Float64 |  |
+| `play_stuffed_def` | Float64 |  |
+| `success_def` | Float64 |  |
+| `red_zone_success_def` | Float64 |  |
+| `third_down_success_def` | Float64 |  |
+| `third_down_distance_def` | Float64 |  |
+| `late_down_success_def` | Float64 |  |
+| `early_down_EPA_def` | Float64 |  |
+| `start_position_def` | Float64 |  |
+| `nonExplosiveEpaPerPlay_def` | Float64 |  |
+| `line_yards_def` | Float64 |  |
+| `opportunity_rate_def` | Float64 |  |
+| `playsgame_def` | Float64 |  |
+| `EPAdrive_def` | Float64 |  |
+| `EPAgame_def` | Float64 |  |
+| `yardsgame_def` | Float64 |  |
+| `drives_def` | UInt32 |  |
+| `drivesgame_def` | Float64 |  |
+| `yardsdrive_def` | Float64 |  |
+| `playsdrive_def` | Float64 |  |
+| `playsgame_def_rank` | Float64 |  |
+| `TEPA_def_rank` | Float64 |  |
+| `EPAgame_def_rank` | Float64 |  |
+| `EPAplay_def_rank` | Float64 |  |
+| `EPAdrive_def_rank` | Float64 |  |
+| `early_down_EPA_def_rank` | Float64 |  |
+| `success_def_rank` | Float64 |  |
+| `yards_def_rank` | Float64 |  |
+| `yardsplay_def_rank` | Float64 |  |
+| `yardsgame_def_rank` | Float64 |  |
+| `drivesgame_def_rank` | Float64 |  |
+| `yardsdrive_def_rank` | Float64 |  |
+| `playsdrive_def_rank` | Float64 |  |
+| `play_stuffed_def_rank` | Float64 |  |
+| `red_zone_success_def_rank` | Float64 |  |
+| `third_down_success_def_rank` | Float64 |  |
+| `late_down_success_def_rank` | Float64 |  |
+| `third_down_distance_def_rank` | Float64 |  |
+| `start_position_def_rank` | Float64 |  |
+| `havoc_def_rank` | Float64 |  |
+| `explosive_def_rank` | Float64 |  |
+| `passrate_def_rank` | Float64 |  |
+| `rushrate_def_rank` | Float64 |  |
+| `nonExplosiveEpaPerPlay_def_rank` | Float64 |  |
+| `line_yards_def_rank` | Float64 |  |
+| `opportunity_rate_def_rank` | Float64 |  |
+| `TEPA_margin` | Float64 |  |
+| `EPAplay_margin` | Float64 |  |
+| `EPAdrive_margin` | Float64 |  |
+| `EPAgame_margin` | Float64 |  |
+| `success_margin` | Float64 |  |
+| `yardsplay_margin` | Float64 |  |
+| `TEPA_margin_rank` | Float64 |  |
+| `EPAplay_margin_rank` | Float64 |  |
+| `EPAdrive_margin_rank` | Float64 |  |
+| `EPAgame_margin_rank` | Float64 |  |
+| `success_margin_rank` | Float64 |  |
+| `yardsplay_margin_rank` | Float64 |  |
+| `start_position_margin` | Float64 |  |
+| `start_position_margin_rank` | Float64 |  |
+| `total_available_yards_off` | Float64 |  |
+| `total_gained_yards_off` | Int64 |  |
+| `available_yards_pct_off` | Float64 |  |
+| `available_yards_pct_off_rank` | Float64 |  |
+| `total_available_yards_def` | Float64 |  |
+| `total_gained_yards_def` | Int64 |  |
+| `available_yards_pct_def` | Float64 |  |
+| `available_yards_pct_def_rank` | Float64 |  |
+| `total_available_yards_margin` | Float64 |  |
+| `total_gained_yards_margin` | Int64 |  |
+| `available_yards_pct_margin` | Float64 |  |
+| `total_available_yards_margin_rank` | Float64 |  |
+| `total_gained_yards_margin_rank` | Float64 |  |
+| `available_yards_pct_margin_rank` | Float64 |  |
+| `plays_off_pass` | UInt32 |  |
+| `passrate_off_pass` | Float64 |  |
+| `rushrate_off_pass` | Float64 |  |
+| `havoc_off_pass` | Float64 |  |
+| `explosive_off_pass` | Float64 |  |
+| `TEPA_off_pass` | Float64 |  |
+| `EPAplay_off_pass` | Float64 |  |
+| `yards_off_pass` | Int64 |  |
+| `yardsplay_off_pass` | Float64 |  |
+| `play_stuffed_off_pass` | Float64 |  |
+| `success_off_pass` | Float64 |  |
+| `red_zone_success_off_pass` | Float64 |  |
+| `third_down_success_off_pass` | Float64 |  |
+| `third_down_distance_off_pass` | Float64 |  |
+| `late_down_success_off_pass` | Float64 |  |
+| `early_down_EPA_off_pass` | Float64 |  |
+| `nonExplosiveEpaPerPlay_off_pass` | Float64 |  |
+| `line_yards_off_pass` | Float64 |  |
+| `opportunity_rate_off_pass` | Float64 |  |
+| `playsgame_off_pass` | Float64 |  |
+| `EPAdrive_off_pass` | Float64 |  |
+| `EPAgame_off_pass` | Float64 |  |
+| `yardsgame_off_pass` | Float64 |  |
+| `drives_off_pass` | UInt32 |  |
+| `drivesgame_off_pass` | Float64 |  |
+| `yardsdrive_off_pass` | Float64 |  |
+| `playsdrive_off_pass` | Float64 |  |
+| `playsgame_off_pass_rank` | Float64 |  |
+| `TEPA_off_pass_rank` | Float64 |  |
+| `EPAgame_off_pass_rank` | Float64 |  |
+| `EPAplay_off_pass_rank` | Float64 |  |
+| `EPAdrive_off_pass_rank` | Float64 |  |
+| `early_down_EPA_off_pass_rank` | Float64 |  |
+| `success_off_pass_rank` | Float64 |  |
+| `yards_off_pass_rank` | Float64 |  |
+| `yardsplay_off_pass_rank` | Float64 |  |
+| `yardsgame_off_pass_rank` | Float64 |  |
+| `drivesgame_off_pass_rank` | Float64 |  |
+| `yardsdrive_off_pass_rank` | Float64 |  |
+| `playsdrive_off_pass_rank` | Float64 |  |
+| `play_stuffed_off_pass_rank` | Float64 |  |
+| `red_zone_success_off_pass_rank` | Float64 |  |
+| `third_down_success_off_pass_rank` | Float64 |  |
+| `late_down_success_off_pass_rank` | Float64 |  |
+| `third_down_distance_off_pass_rank` | Float64 |  |
+| `havoc_off_pass_rank` | Float64 |  |
+| `explosive_off_pass_rank` | Float64 |  |
+| `passrate_off_pass_rank` | Float64 |  |
+| `rushrate_off_pass_rank` | Float64 |  |
+| `nonExplosiveEpaPerPlay_off_pass_rank` | Float64 |  |
+| `line_yards_off_pass_rank` | Float64 |  |
+| `opportunity_rate_off_pass_rank` | Float64 |  |
+| `plays_def_pass` | UInt32 |  |
+| `passrate_def_pass` | Float64 |  |
+| `rushrate_def_pass` | Float64 |  |
+| `havoc_def_pass` | Float64 |  |
+| `explosive_def_pass` | Float64 |  |
+| `TEPA_def_pass` | Float64 |  |
+| `EPAplay_def_pass` | Float64 |  |
+| `yards_def_pass` | Int64 |  |
+| `yardsplay_def_pass` | Float64 |  |
+| `play_stuffed_def_pass` | Float64 |  |
+| `success_def_pass` | Float64 |  |
+| `red_zone_success_def_pass` | Float64 |  |
+| `third_down_success_def_pass` | Float64 |  |
+| `third_down_distance_def_pass` | Float64 |  |
+| `late_down_success_def_pass` | Float64 |  |
+| `early_down_EPA_def_pass` | Float64 |  |
+| `nonExplosiveEpaPerPlay_def_pass` | Float64 |  |
+| `line_yards_def_pass` | Float64 |  |
+| `opportunity_rate_def_pass` | Float64 |  |
+| `playsgame_def_pass` | Float64 |  |
+| `EPAdrive_def_pass` | Float64 |  |
+| `EPAgame_def_pass` | Float64 |  |
+| `yardsgame_def_pass` | Float64 |  |
+| `drives_def_pass` | UInt32 |  |
+| `drivesgame_def_pass` | Float64 |  |
+| `yardsdrive_def_pass` | Float64 |  |
+| `playsdrive_def_pass` | Float64 |  |
+| `playsgame_def_pass_rank` | Float64 |  |
+| `TEPA_def_pass_rank` | Float64 |  |
+| `EPAgame_def_pass_rank` | Float64 |  |
+| `EPAplay_def_pass_rank` | Float64 |  |
+| `EPAdrive_def_pass_rank` | Float64 |  |
+| `early_down_EPA_def_pass_rank` | Float64 |  |
+| `success_def_pass_rank` | Float64 |  |
+| `yards_def_pass_rank` | Float64 |  |
+| `yardsplay_def_pass_rank` | Float64 |  |
+| `yardsgame_def_pass_rank` | Float64 |  |
+| `drivesgame_def_pass_rank` | Float64 |  |
+| `yardsdrive_def_pass_rank` | Float64 |  |
+| `playsdrive_def_pass_rank` | Float64 |  |
+| `play_stuffed_def_pass_rank` | Float64 |  |
+| `red_zone_success_def_pass_rank` | Float64 |  |
+| `third_down_success_def_pass_rank` | Float64 |  |
+| `late_down_success_def_pass_rank` | Float64 |  |
+| `third_down_distance_def_pass_rank` | Float64 |  |
+| `havoc_def_pass_rank` | Float64 |  |
+| `explosive_def_pass_rank` | Float64 |  |
+| `passrate_def_pass_rank` | Float64 |  |
+| `rushrate_def_pass_rank` | Float64 |  |
+| `nonExplosiveEpaPerPlay_def_pass_rank` | Float64 |  |
+| `line_yards_def_pass_rank` | Float64 |  |
+| `opportunity_rate_def_pass_rank` | Float64 |  |
+| `TEPA_margin_pass` | Float64 |  |
+| `EPAplay_margin_pass` | Float64 |  |
+| `EPAdrive_margin_pass` | Float64 |  |
+| `EPAgame_margin_pass` | Float64 |  |
+| `success_margin_pass` | Float64 |  |
+| `yardsplay_margin_pass` | Float64 |  |
+| `TEPA_margin_pass_rank` | Float64 |  |
+| `EPAplay_margin_pass_rank` | Float64 |  |
+| `EPAdrive_margin_pass_rank` | Float64 |  |
+| `EPAgame_margin_pass_rank` | Float64 |  |
+| `success_margin_pass_rank` | Float64 |  |
+| `yardsplay_margin_pass_rank` | Float64 |  |
+| `plays_off_rush` | UInt32 |  |
+| `passrate_off_rush` | Float64 |  |
+| `rushrate_off_rush` | Float64 |  |
+| `havoc_off_rush` | Float64 |  |
+| `explosive_off_rush` | Float64 |  |
+| `TEPA_off_rush` | Float64 |  |
+| `EPAplay_off_rush` | Float64 |  |
+| `yards_off_rush` | Int64 |  |
+| `yardsplay_off_rush` | Float64 |  |
+| `play_stuffed_off_rush` | Float64 |  |
+| `success_off_rush` | Float64 |  |
+| `red_zone_success_off_rush` | Float64 |  |
+| `third_down_success_off_rush` | Float64 |  |
+| `third_down_distance_off_rush` | Float64 |  |
+| `late_down_success_off_rush` | Float64 |  |
+| `early_down_EPA_off_rush` | Float64 |  |
+| `nonExplosiveEpaPerPlay_off_rush` | Float64 |  |
+| `line_yards_off_rush` | Float64 |  |
+| `opportunity_rate_off_rush` | Float64 |  |
+| `playsgame_off_rush` | Float64 |  |
+| `EPAdrive_off_rush` | Float64 |  |
+| `EPAgame_off_rush` | Float64 |  |
+| `yardsgame_off_rush` | Float64 |  |
+| `drives_off_rush` | UInt32 |  |
+| `drivesgame_off_rush` | Float64 |  |
+| `yardsdrive_off_rush` | Float64 |  |
+| `playsdrive_off_rush` | Float64 |  |
+| `playsgame_off_rush_rank` | Float64 |  |
+| `TEPA_off_rush_rank` | Float64 |  |
+| `EPAgame_off_rush_rank` | Float64 |  |
+| `EPAplay_off_rush_rank` | Float64 |  |
+| `EPAdrive_off_rush_rank` | Float64 |  |
+| `early_down_EPA_off_rush_rank` | Float64 |  |
+| `success_off_rush_rank` | Float64 |  |
+| `yards_off_rush_rank` | Float64 |  |
+| `yardsplay_off_rush_rank` | Float64 |  |
+| `yardsgame_off_rush_rank` | Float64 |  |
+| `drivesgame_off_rush_rank` | Float64 |  |
+| `yardsdrive_off_rush_rank` | Float64 |  |
+| `playsdrive_off_rush_rank` | Float64 |  |
+| `play_stuffed_off_rush_rank` | Float64 |  |
+| `red_zone_success_off_rush_rank` | Float64 |  |
+| `third_down_success_off_rush_rank` | Float64 |  |
+| `late_down_success_off_rush_rank` | Float64 |  |
+| `third_down_distance_off_rush_rank` | Float64 |  |
+| `havoc_off_rush_rank` | Float64 |  |
+| `explosive_off_rush_rank` | Float64 |  |
+| `passrate_off_rush_rank` | Float64 |  |
+| `rushrate_off_rush_rank` | Float64 |  |
+| `nonExplosiveEpaPerPlay_off_rush_rank` | Float64 |  |
+| `line_yards_off_rush_rank` | Float64 |  |
+| `opportunity_rate_off_rush_rank` | Float64 |  |
+| `plays_def_rush` | UInt32 |  |
+| `passrate_def_rush` | Float64 |  |
+| `rushrate_def_rush` | Float64 |  |
+| `havoc_def_rush` | Float64 |  |
+| `explosive_def_rush` | Float64 |  |
+| `TEPA_def_rush` | Float64 |  |
+| `EPAplay_def_rush` | Float64 |  |
+| `yards_def_rush` | Int64 |  |
+| `yardsplay_def_rush` | Float64 |  |
+| `play_stuffed_def_rush` | Float64 |  |
+| `success_def_rush` | Float64 |  |
+| `red_zone_success_def_rush` | Float64 |  |
+| `third_down_success_def_rush` | Float64 |  |
+| `third_down_distance_def_rush` | Float64 |  |
+| `late_down_success_def_rush` | Float64 |  |
+| `early_down_EPA_def_rush` | Float64 |  |
+| `nonExplosiveEpaPerPlay_def_rush` | Float64 |  |
+| `line_yards_def_rush` | Float64 |  |
+| `opportunity_rate_def_rush` | Float64 |  |
+| `playsgame_def_rush` | Float64 |  |
+| `EPAdrive_def_rush` | Float64 |  |
+| `EPAgame_def_rush` | Float64 |  |
+| `yardsgame_def_rush` | Float64 |  |
+| `drives_def_rush` | UInt32 |  |
+| `drivesgame_def_rush` | Float64 |  |
+| `yardsdrive_def_rush` | Float64 |  |
+| `playsdrive_def_rush` | Float64 |  |
+| `playsgame_def_rush_rank` | Float64 |  |
+| `TEPA_def_rush_rank` | Float64 |  |
+| `EPAgame_def_rush_rank` | Float64 |  |
+| `EPAplay_def_rush_rank` | Float64 |  |
+| `EPAdrive_def_rush_rank` | Float64 |  |
+| `early_down_EPA_def_rush_rank` | Float64 |  |
+| `success_def_rush_rank` | Float64 |  |
+| `yards_def_rush_rank` | Float64 |  |
+| `yardsplay_def_rush_rank` | Float64 |  |
+| `yardsgame_def_rush_rank` | Float64 |  |
+| `drivesgame_def_rush_rank` | Float64 |  |
+| `yardsdrive_def_rush_rank` | Float64 |  |
+| `playsdrive_def_rush_rank` | Float64 |  |
+| `play_stuffed_def_rush_rank` | Float64 |  |
+| `red_zone_success_def_rush_rank` | Float64 |  |
+| `third_down_success_def_rush_rank` | Float64 |  |
+| `late_down_success_def_rush_rank` | Float64 |  |
+| `third_down_distance_def_rush_rank` | Float64 |  |
+| `havoc_def_rush_rank` | Float64 |  |
+| `explosive_def_rush_rank` | Float64 |  |
+| `passrate_def_rush_rank` | Float64 |  |
+| `rushrate_def_rush_rank` | Float64 |  |
+| `nonExplosiveEpaPerPlay_def_rush_rank` | Float64 |  |
+| `line_yards_def_rush_rank` | Float64 |  |
+| `opportunity_rate_def_rush_rank` | Float64 |  |
+| `TEPA_margin_rush` | Float64 |  |
+| `EPAplay_margin_rush` | Float64 |  |
+| `EPAdrive_margin_rush` | Float64 |  |
+| `EPAgame_margin_rush` | Float64 |  |
+| `success_margin_rush` | Float64 |  |
+| `yardsplay_margin_rush` | Float64 |  |
+| `TEPA_margin_rush_rank` | Float64 |  |
+| `EPAplay_margin_rush_rank` | Float64 |  |
+| `EPAdrive_margin_rush_rank` | Float64 |  |
+| `EPAgame_margin_rush_rank` | Float64 |  |
+| `success_margin_rush_rank` | Float64 |  |
+| `yardsplay_margin_rush_rank` | Float64 |  |
+| `fbs_class` | String |  |
+| `valid_games` | UInt32 |  |
+| `adj_off_epa` | Float64 |  |
+| `adj_def_epa` | Float64 |  |
+| `off_strength_faced` | Float64 |  |
+| `def_strength_faced` | Float64 |  |
+| `net_adj_epa` | Float64 |  |
+| `adj_off_epa_rank` | Float64 |  |
+| `adj_def_epa_rank` | Float64 |  |
+| `net_adj_epa_rank` | Float64 |  |
+| `through_week` | Int32 |  |
 
 ```python
 load_cfb_team_summaries_weekly(seasons=2024)

--- a/docs/docs/mbb/reference/loaders.md
+++ b/docs/docs/mbb/reference/loaders.md
@@ -33,64 +33,64 @@ flowchart LR
 Release: [espn_mens_college_basketball_pbp](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_mens_college_basketball_pbp) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_mens_college_basketball_pbp/play_by_play_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_play_number` | Int32 |
-| `id` | Float64 |
-| `sequence_number` | Int32 |
-| `type_id` | Int32 |
-| `type_text` | String |
-| `text` | String |
-| `away_score` | Int32 |
-| `home_score` | Int32 |
-| `period_number` | Int32 |
-| `period_display_value` | String |
-| `clock_display_value` | String |
-| `scoring_play` | Boolean |
-| `score_value` | Int32 |
-| `team_id` | Int32 |
-| `athlete_id_1` | Int32 |
-| `wallclock` | String |
-| `shooting_play` | Boolean |
-| `game_id` | Int32 |
-| `season` | Int32 |
-| `season_type` | Int32 |
-| `home_team_id` | Int32 |
-| `home_team_name` | String |
-| `home_team_mascot` | String |
-| `home_team_abbrev` | String |
-| `home_team_name_alt` | String |
-| `away_team_id` | Int32 |
-| `away_team_name` | String |
-| `away_team_mascot` | String |
-| `away_team_abbrev` | String |
-| `away_team_name_alt` | String |
-| `game_spread` | Float64 |
-| `home_favorite` | Boolean |
-| `game_spread_available` | Boolean |
-| `home_team_spread` | Float64 |
-| `half` | Int32 |
-| `time` | String |
-| `clock_minutes` | Int32 |
-| `clock_seconds` | Int32 |
-| `home_timeout_called` | Boolean |
-| `away_timeout_called` | Boolean |
-| `lead_period` | Int32 |
-| `lead_half` | Int32 |
-| `start_period_seconds_remaining` | Int32 |
-| `start_game_seconds_remaining` | Int32 |
-| `end_period_seconds_remaining` | Int32 |
-| `end_game_seconds_remaining` | Int32 |
-| `lag_period` | Int32 |
-| `lag_half` | Int32 |
-| `athlete_id_2` | Int32 |
-| `game_date` | Date |
-| `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') |
-| `coordinate_x_raw` | Float64 |
-| `coordinate_y_raw` | Float64 |
-| `coordinate_x` | Float64 |
-| `coordinate_y` | Float64 |
-| `media_id` | String |
+| col_name | type | description |
+|---|---|---|
+| `game_play_number` | Int32 | Sequential play number within the game. |
+| `id` | Float64 | Id. |
+| `sequence_number` | Int32 | Sequence number representing a shot-possession (V3 PBP). |
+| `type_id` | Int32 | Type identifier (numeric). |
+| `type_text` | String | Display text for the type field. |
+| `text` | String | Text description of the play / record. |
+| `away_score` | Int32 | Away team score at the time of the play. |
+| `home_score` | Int32 | Home team score at the time of the play. |
+| `period_number` | Int32 | Numeric period (1-4 for quarters; 5+ for OT). |
+| `period_display_value` | String | Period display label (e.g. '1st Quarter', 'OT'). |
+| `clock_display_value` | String | Game clock display string (e.g. '8:32'). |
+| `scoring_play` | Boolean | TRUE if the play resulted in points scored. |
+| `score_value` | Int32 | Point value of the play (2 / 3 / 1). |
+| `team_id` | Int32 | Unique team identifier. |
+| `athlete_id_1` | Int32 | Primary athlete identifier (e.g. shooter). |
+| `wallclock` | String | Wallclock. |
+| `shooting_play` | Boolean | TRUE if the play was a shooting attempt. |
+| `game_id` | Int32 | Unique game identifier. |
+| `season` | Int32 | Season year. |
+| `season_type` | Int32 | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
+| `home_team_id` | Int32 | Unique identifier for the home team. |
+| `home_team_name` | String | Home team name. |
+| `home_team_mascot` | String | Home team mascot. |
+| `home_team_abbrev` | String | Home team three-letter abbreviation. |
+| `home_team_name_alt` | String | Alternate home team name. |
+| `away_team_id` | Int32 | Unique identifier for the away team. |
+| `away_team_name` | String | Away team name. |
+| `away_team_mascot` | String | Away team mascot. |
+| `away_team_abbrev` | String | Away team three-letter abbreviation. |
+| `away_team_name_alt` | String | Alternate away team name. |
+| `game_spread` | Float64 | Game spread (signed; positive = home favored). |
+| `home_favorite` | Boolean | TRUE if the home team is the betting favorite. |
+| `game_spread_available` | Boolean | TRUE if a point spread was available. |
+| `home_team_spread` | Float64 | Home team's point spread. |
+| `half` | Int32 | Half of the game (1 or 2). |
+| `time` | String | Time / clock value. |
+| `clock_minutes` | Int32 | Clock minutes split out for convenience. |
+| `clock_seconds` | Int32 | Clock seconds split out for convenience. |
+| `home_timeout_called` | Boolean |  |
+| `away_timeout_called` | Boolean |  |
+| `lead_period` | Int32 |  |
+| `lead_half` | Int32 | A lead column on the half |
+| `start_period_seconds_remaining` | Int32 |  |
+| `start_game_seconds_remaining` | Int32 | Seconds remaining in the game at the start of the play. |
+| `end_period_seconds_remaining` | Int32 |  |
+| `end_game_seconds_remaining` | Int32 | Seconds remaining in the game at the end of the play. |
+| `lag_period` | Int32 |  |
+| `lag_half` | Int32 | A lag column on the half |
+| `athlete_id_2` | Int32 | Secondary athlete identifier (e.g. assister / fouler). |
+| `game_date` | Date | Game date (YYYY-MM-DD). |
+| `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') | Game start date/time (ISO 8601). |
+| `coordinate_x_raw` | Float64 | X coordinate as returned by the API before any adjustment. |
+| `coordinate_y_raw` | Float64 | Y coordinate as returned by the API before any adjustment. |
+| `coordinate_x` | Float64 | X coordinate on the court (half-court layout). |
+| `coordinate_y` | Float64 | Y coordinate on the court (half-court layout). |
+| `media_id` | String | Media identifier (video / image). |
 
 ```python
 load_mbb_pbp(seasons=2024)
@@ -101,63 +101,63 @@ load_mbb_pbp(seasons=2024)
 Release: [espn_mens_college_basketball_player_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_mens_college_basketball_player_boxscores) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_mens_college_basketball_player_boxscores/player_box_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int32 |
-| `season` | Int32 |
-| `season_type` | Int32 |
-| `game_date` | Date |
-| `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') |
-| `athlete_id` | Int32 |
-| `athlete_display_name` | String |
-| `team_id` | Int32 |
-| `team_name` | String |
-| `team_location` | String |
-| `team_short_display_name` | String |
-| `minutes` | Float64 |
-| `field_goals_made` | Int32 |
-| `field_goals_attempted` | Int32 |
-| `three_point_field_goals_made` | Int32 |
-| `three_point_field_goals_attempted` | Int32 |
-| `free_throws_made` | Int32 |
-| `free_throws_attempted` | Int32 |
-| `offensive_rebounds` | Int32 |
-| `defensive_rebounds` | Int32 |
-| `rebounds` | Int32 |
-| `assists` | Int32 |
-| `steals` | Int32 |
-| `blocks` | Int32 |
-| `turnovers` | Int32 |
-| `fouls` | Int32 |
-| `points` | Int32 |
-| `starter` | Boolean |
-| `ejected` | Boolean |
-| `did_not_play` | Boolean |
-| `active` | Boolean |
-| `athlete_jersey` | String |
-| `athlete_short_name` | String |
-| `athlete_headshot_href` | String |
-| `athlete_position_name` | String |
-| `athlete_position_abbreviation` | String |
-| `team_display_name` | String |
-| `team_uid` | String |
-| `team_slug` | String |
-| `team_logo` | String |
-| `team_abbreviation` | String |
-| `team_color` | String |
-| `team_alternate_color` | String |
-| `home_away` | String |
-| `team_winner` | Boolean |
-| `team_score` | Int32 |
-| `opponent_team_id` | Int32 |
-| `opponent_team_name` | String |
-| `opponent_team_location` | String |
-| `opponent_team_display_name` | String |
-| `opponent_team_abbreviation` | String |
-| `opponent_team_logo` | String |
-| `opponent_team_color` | String |
-| `opponent_team_alternate_color` | String |
-| `opponent_team_score` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int32 | Unique game identifier. |
+| `season` | Int32 | Season year. |
+| `season_type` | Int32 | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
+| `game_date` | Date | Game date (YYYY-MM-DD). |
+| `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') | Game start date/time (ISO 8601). |
+| `athlete_id` | Int32 | Unique athlete identifier (ESPN). |
+| `athlete_display_name` | String | Athlete display name (full). |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_name` | String | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_location` | String | Team city or location string. |
+| `team_short_display_name` | String | Short team display name (e.g. 'Aces'). |
+| `minutes` | Float64 | Minutes played, formatted MM:SS (V3 PT-duration parsed) or decimal minutes (V2). |
+| `field_goals_made` | Int32 | Field goals made (2-pt + 3-pt). |
+| `field_goals_attempted` | Int32 | Field goal attempts (2-pt + 3-pt). |
+| `three_point_field_goals_made` | Int32 | Three-point field goals made. |
+| `three_point_field_goals_attempted` | Int32 | Three-point field goal attempts. |
+| `free_throws_made` | Int32 | Free throws made. |
+| `free_throws_attempted` | Int32 | Free throw attempts. |
+| `offensive_rebounds` | Int32 | Offensive rebounds. |
+| `defensive_rebounds` | Int32 | Defensive rebounds. |
+| `rebounds` | Int32 | Total rebounds. |
+| `assists` | Int32 | Total assists. |
+| `steals` | Int32 | Total steals. |
+| `blocks` | Int32 | Total blocks. |
+| `turnovers` | Int32 | Total turnovers. |
+| `fouls` | Int32 | Personal fouls. |
+| `points` | Int32 | Points scored. |
+| `starter` | Boolean | TRUE if the player was in the starting lineup; FALSE otherwise. |
+| `ejected` | Boolean | TRUE if the player was ejected from the game. |
+| `did_not_play` | Boolean | TRUE if the player did not appear in the game. |
+| `active` | Boolean | TRUE if the row represents an active record (player / team / season). |
+| `athlete_jersey` | String | Athlete jersey number. |
+| `athlete_short_name` | String | Athlete short display name. |
+| `athlete_headshot_href` | String | Athlete headshot image URL. |
+| `athlete_position_name` | String | Athlete position ('Guard', 'Forward', 'Center'). |
+| `athlete_position_abbreviation` | String | Athlete position abbreviation (G / F / C). |
+| `team_display_name` | String | Full team display name. |
+| `team_uid` | String | ESPN universal team identifier (UID format 's:40~l:...~t:...'). |
+| `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
+| `team_logo` | String | Team logo image URL. |
+| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
+| `team_color` | String | Team primary color (hex without leading '#'). |
+| `team_alternate_color` | String | Team alternate color (hex without leading '#'). |
+| `home_away` | String | Game venue label ('home' or 'away'). |
+| `team_winner` | Boolean | TRUE if the team won this game. |
+| `team_score` | Int32 | Team's score / final score. |
+| `opponent_team_id` | Int32 | Unique identifier for the opponent team. |
+| `opponent_team_name` | String | Opponent team display name. |
+| `opponent_team_location` | String | Opponent team city / location. |
+| `opponent_team_display_name` | String | Opponent team full display name. |
+| `opponent_team_abbreviation` | String | Opponent team abbreviation. |
+| `opponent_team_logo` | String | Opponent team logo URL. |
+| `opponent_team_color` | String | Opponent team primary color (hex). |
+| `opponent_team_alternate_color` | String | Opponent team alternate color (hex). |
+| `opponent_team_score` | Int32 | Opponent team's score. |
 
 ```python
 load_mbb_player_boxscore(seasons=2024)
@@ -168,84 +168,84 @@ load_mbb_player_boxscore(seasons=2024)
 Release: [espn_mens_college_basketball_schedules](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_mens_college_basketball_schedules) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_mens_college_basketball_schedules/mbb_schedule_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `id` | Int32 |
-| `uid` | String |
-| `date` | String |
-| `attendance` | Float64 |
-| `time_valid` | Boolean |
-| `neutral_site` | Boolean |
-| `conference_competition` | Boolean |
-| `recent` | Boolean |
-| `start_date` | String |
-| `notes_type` | String |
-| `notes_headline` | String |
-| `type_id` | Int32 |
-| `type_abbreviation` | String |
-| `venue_id` | Int32 |
-| `venue_full_name` | String |
-| `venue_address_city` | String |
-| `venue_address_state` | String |
-| `venue_capacity` | Float64 |
-| `venue_indoor` | Boolean |
-| `status_clock` | Float64 |
-| `status_display_clock` | String |
-| `status_period` | Float64 |
-| `status_type_id` | Int32 |
-| `status_type_name` | String |
-| `status_type_state` | String |
-| `status_type_completed` | Boolean |
-| `status_type_description` | String |
-| `status_type_detail` | String |
-| `status_type_short_detail` | String |
-| `format_regulation_periods` | Float64 |
-| `home_id` | Int32 |
-| `home_uid` | String |
-| `home_location` | String |
-| `home_name` | String |
-| `home_abbreviation` | String |
-| `home_display_name` | String |
-| `home_short_display_name` | String |
-| `home_color` | String |
-| `home_alternate_color` | String |
-| `home_is_active` | Boolean |
-| `home_venue_id` | Int32 |
-| `home_logo` | String |
-| `home_conference_id` | Int32 |
-| `home_score` | Int32 |
-| `home_winner` | Boolean |
-| `away_id` | Int32 |
-| `away_uid` | String |
-| `away_location` | String |
-| `away_name` | String |
-| `away_abbreviation` | String |
-| `away_display_name` | String |
-| `away_short_display_name` | String |
-| `away_color` | String |
-| `away_alternate_color` | String |
-| `away_is_active` | Boolean |
-| `away_venue_id` | Int32 |
-| `away_logo` | String |
-| `away_conference_id` | Int32 |
-| `away_score` | Int32 |
-| `away_winner` | Boolean |
-| `game_id` | Int32 |
-| `season` | Int32 |
-| `season_type` | Int32 |
-| `status_type_alt_detail` | String |
-| `groups_id` | Int32 |
-| `groups_name` | String |
-| `groups_short_name` | String |
-| `groups_is_conference` | Boolean |
-| `tournament_id` | Int32 |
-| `game_json` | Boolean |
-| `game_json_url` | Boolean |
-| `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') |
-| `game_date` | Date |
-| `PBP` | Boolean |
-| `team_box` | Boolean |
-| `player_box` | Boolean |
+| col_name | type | description |
+|---|---|---|
+| `id` | Int32 | Id. |
+| `uid` | String | ESPN UID string. |
+| `date` | String | Date in YYYY-MM-DD format. |
+| `attendance` | Float64 | Reported attendance. |
+| `time_valid` | Boolean | Time valid. |
+| `neutral_site` | Boolean | Neutral site. |
+| `conference_competition` | Boolean | Conference competition. |
+| `recent` | Boolean | Recent. |
+| `start_date` | String | Start date (YYYY-MM-DD). |
+| `notes_type` | String | Notes type. |
+| `notes_headline` | String | Notes headline. |
+| `type_id` | Int32 | Type identifier (numeric). |
+| `type_abbreviation` | String | Type abbreviation. |
+| `venue_id` | Int32 | Unique venue identifier. |
+| `venue_full_name` | String | Venue full name. |
+| `venue_address_city` | String | Venue address city. |
+| `venue_address_state` | String | Venue address state / region. |
+| `venue_capacity` | Float64 | Venue seating capacity. |
+| `venue_indoor` | Boolean | TRUE if the venue is indoors. |
+| `status_clock` | Float64 | Status clock. |
+| `status_display_clock` | String | Status display clock. |
+| `status_period` | Float64 | Status period. |
+| `status_type_id` | Int32 | Unique identifier for status type. |
+| `status_type_name` | String | Status type name. |
+| `status_type_state` | String | Status type state. |
+| `status_type_completed` | Boolean | Status type completed. |
+| `status_type_description` | String | Status type description. |
+| `status_type_detail` | String | Status type detail. |
+| `status_type_short_detail` | String | Status type short detail. |
+| `format_regulation_periods` | Float64 | Format regulation periods. |
+| `home_id` | Int32 | Unique identifier for home. |
+| `home_uid` | String | Home team's uid. |
+| `home_location` | String | Home team's location. |
+| `home_name` | String | Home name. |
+| `home_abbreviation` | String | Home team's abbreviation. |
+| `home_display_name` | String | Home display name. |
+| `home_short_display_name` | String | Home short display name. |
+| `home_color` | String | Color code (hex) for home. |
+| `home_alternate_color` | String | Color code (hex) for home alternate. |
+| `home_is_active` | Boolean | Home team's is active. |
+| `home_venue_id` | Int32 | Unique identifier for home venue. |
+| `home_logo` | String | Home team logo URL. |
+| `home_conference_id` | Int32 | Unique identifier for home conference. |
+| `home_score` | Int32 | Home team score at the time of the play. |
+| `home_winner` | Boolean | Home team's winner. |
+| `away_id` | Int32 | Unique identifier for away. |
+| `away_uid` | String | Away team's uid. |
+| `away_location` | String | Away team's location. |
+| `away_name` | String | Away name. |
+| `away_abbreviation` | String | Away team's abbreviation. |
+| `away_display_name` | String | Away display name. |
+| `away_short_display_name` | String | Away short display name. |
+| `away_color` | String | Color code (hex) for away. |
+| `away_alternate_color` | String | Color code (hex) for away alternate. |
+| `away_is_active` | Boolean | Away team's is active. |
+| `away_venue_id` | Int32 | Unique identifier for away venue. |
+| `away_logo` | String | Away team logo URL. |
+| `away_conference_id` | Int32 | Unique identifier for away conference. |
+| `away_score` | Int32 | Away team score at the time of the play. |
+| `away_winner` | Boolean | Away team's winner. |
+| `game_id` | Int32 | Unique game identifier. |
+| `season` | Int32 | Season year. |
+| `season_type` | Int32 | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
+| `status_type_alt_detail` | String | Status type alt detail. |
+| `groups_id` | Int32 | Unique identifier for groups. |
+| `groups_name` | String | Groups name. |
+| `groups_short_name` | String | Groups short name. |
+| `groups_is_conference` | Boolean | Groups is conference. |
+| `tournament_id` | Int32 | ESPN tournament identifier. |
+| `game_json` | Boolean | Whether processed game JSON is available. |
+| `game_json_url` | Boolean | URL to the processed game JSON. |
+| `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') | Game start date/time (ISO 8601). |
+| `game_date` | Date | Game date (YYYY-MM-DD). |
+| `PBP` | Boolean | Whether play-by-play data is available. |
+| `team_box` | Boolean | Team box. |
+| `player_box` | Boolean | Player box. |
 
 ```python
 load_mbb_schedule(seasons=2024)
@@ -256,62 +256,62 @@ load_mbb_schedule(seasons=2024)
 Release: [espn_mens_college_basketball_team_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_mens_college_basketball_team_boxscores) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_mens_college_basketball_team_boxscores/team_box_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int32 |
-| `season` | Int32 |
-| `season_type` | Int32 |
-| `game_date` | Date |
-| `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') |
-| `team_id` | Int32 |
-| `team_uid` | String |
-| `team_slug` | String |
-| `team_location` | String |
-| `team_name` | String |
-| `team_abbreviation` | String |
-| `team_display_name` | String |
-| `team_short_display_name` | String |
-| `team_color` | String |
-| `team_alternate_color` | String |
-| `team_logo` | String |
-| `team_home_away` | String |
-| `team_score` | Int32 |
-| `team_winner` | Boolean |
-| `assists` | Int32 |
-| `blocks` | Int32 |
-| `defensive_rebounds` | Int32 |
-| `field_goal_pct` | Float64 |
-| `field_goals_made` | Int32 |
-| `field_goals_attempted` | Int32 |
-| `flagrant_fouls` | Int32 |
-| `fouls` | Int32 |
-| `free_throw_pct` | Float64 |
-| `free_throws_made` | Int32 |
-| `free_throws_attempted` | Int32 |
-| `largest_lead` | String |
-| `offensive_rebounds` | Int32 |
-| `steals` | Int32 |
-| `team_turnovers` | Int32 |
-| `technical_fouls` | Int32 |
-| `three_point_field_goal_pct` | Float64 |
-| `three_point_field_goals_made` | Int32 |
-| `three_point_field_goals_attempted` | Int32 |
-| `total_rebounds` | Int32 |
-| `total_technical_fouls` | Int32 |
-| `total_turnovers` | Int32 |
-| `turnovers` | Int32 |
-| `opponent_team_id` | Int32 |
-| `opponent_team_uid` | String |
-| `opponent_team_slug` | String |
-| `opponent_team_location` | String |
-| `opponent_team_name` | String |
-| `opponent_team_abbreviation` | String |
-| `opponent_team_display_name` | String |
-| `opponent_team_short_display_name` | String |
-| `opponent_team_color` | String |
-| `opponent_team_alternate_color` | String |
-| `opponent_team_logo` | String |
-| `opponent_team_score` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int32 | Unique game identifier. |
+| `season` | Int32 | Season year. |
+| `season_type` | Int32 | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
+| `game_date` | Date | Game date (YYYY-MM-DD). |
+| `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') | Game start date/time (ISO 8601). |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_uid` | String | ESPN universal team identifier (UID format 's:40~l:...~t:...'). |
+| `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
+| `team_location` | String | Team city or location string. |
+| `team_name` | String | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
+| `team_display_name` | String | Full team display name. |
+| `team_short_display_name` | String | Short team display name (e.g. 'Aces'). |
+| `team_color` | String | Team primary color (hex without leading '#'). |
+| `team_alternate_color` | String | Team alternate color (hex without leading '#'). |
+| `team_logo` | String | Team logo image URL. |
+| `team_home_away` | String | Team home away. |
+| `team_score` | Int32 | Team's score / final score. |
+| `team_winner` | Boolean | TRUE if the team won this game. |
+| `assists` | Int32 | Total assists. |
+| `blocks` | Int32 | Total blocks. |
+| `defensive_rebounds` | Int32 | Defensive rebounds. |
+| `field_goal_pct` | Float64 | Field goal percentage (0-1). |
+| `field_goals_made` | Int32 | Field goals made (2-pt + 3-pt). |
+| `field_goals_attempted` | Int32 | Field goal attempts (2-pt + 3-pt). |
+| `flagrant_fouls` | Int32 | Total flagrant fouls. |
+| `fouls` | Int32 | Personal fouls. |
+| `free_throw_pct` | Float64 | Free throw percentage (0-1). |
+| `free_throws_made` | Int32 | Free throws made. |
+| `free_throws_attempted` | Int32 | Free throw attempts. |
+| `largest_lead` | String | Largest lead during the game. |
+| `offensive_rebounds` | Int32 | Offensive rebounds. |
+| `steals` | Int32 | Total steals. |
+| `team_turnovers` | Int32 | Team turnovers (turnovers credited to the team rather than a player). |
+| `technical_fouls` | Int32 | Total technical fouls. |
+| `three_point_field_goal_pct` | Float64 | Three-point field goal percentage (0-1). |
+| `three_point_field_goals_made` | Int32 | Three-point field goals made. |
+| `three_point_field_goals_attempted` | Int32 | Three-point field goal attempts. |
+| `total_rebounds` | Int32 | Total rebounds. |
+| `total_technical_fouls` | Int32 | Total technical fouls (player + team). |
+| `total_turnovers` | Int32 | Total turnovers (player + team). |
+| `turnovers` | Int32 | Total turnovers. |
+| `opponent_team_id` | Int32 | Unique identifier for the opponent team. |
+| `opponent_team_uid` | String | Opponent team uid. |
+| `opponent_team_slug` | String | Opponent team slug. |
+| `opponent_team_location` | String | Opponent team city / location. |
+| `opponent_team_name` | String | Opponent team display name. |
+| `opponent_team_abbreviation` | String | Opponent team abbreviation. |
+| `opponent_team_display_name` | String | Opponent team full display name. |
+| `opponent_team_short_display_name` | String | Opponent team short display name. |
+| `opponent_team_color` | String | Opponent team primary color (hex). |
+| `opponent_team_alternate_color` | String | Opponent team alternate color (hex). |
+| `opponent_team_logo` | String | Opponent team logo URL. |
+| `opponent_team_score` | Int32 | Opponent team's score. |
 
 ```python
 load_mbb_team_boxscore(seasons=2024)
@@ -322,19 +322,19 @@ load_mbb_team_boxscore(seasons=2024)
 Release: [mbb_ratings](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/mbb_ratings) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/mbb_ratings/mbb_ratings_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int64 |
-| `team_id` | String |
-| `adj_o` | Float64 |
-| `adj_d` | Float64 |
-| `adj_em` | Float64 |
-| `adj_tempo` | Float64 |
-| `raw_o` | Float64 |
-| `raw_d` | Float64 |
-| `games` | Int64 |
-| `rank` | Int64 |
-| `adj_em_z` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int64 | Season year. |
+| `team_id` | String | Unique team identifier. |
+| `adj_o` | Float64 | Adj o. |
+| `adj_d` | Float64 | Adj d. |
+| `adj_em` | Float64 | Adj em. |
+| `adj_tempo` | Float64 |  |
+| `raw_o` | Float64 | Raw o. |
+| `raw_d` | Float64 | Raw d. |
+| `games` | Int64 | Games played. |
+| `rank` | Int64 | Rank. |
+| `adj_em_z` | Float64 |  |
 
 ```python
 load_mbb_ratings(seasons=2025)
@@ -345,16 +345,16 @@ load_mbb_ratings(seasons=2025)
 Release: [mbb_player_value](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/mbb_player_value) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/mbb_player_value/mbb_player_value_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `player_id` | String |
-| `player` | String |
-| `season` | Int64 |
-| `team_id` | String |
-| `min` | Float64 |
-| `box_obpm` | Float64 |
-| `box_dbpm` | Float64 |
-| `box_bpm` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `player_id` | String | Unique player identifier. |
+| `player` | String | Player name. |
+| `season` | Int64 | Season year. |
+| `team_id` | String | Unique team identifier. |
+| `min` | Float64 | Minutes played. |
+| `box_obpm` | Float64 |  |
+| `box_dbpm` | Float64 |  |
+| `box_bpm` | Float64 |  |
 
 ```python
 load_mbb_player_value(seasons=2025)
@@ -365,23 +365,23 @@ load_mbb_player_value(seasons=2025)
 Release: [espn_mens_college_basketball_shots](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_mens_college_basketball_shots) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_mens_college_basketball_shots/shots_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int32 |
-| `season` | Int32 |
-| `period_number` | Int32 |
-| `clock_display_value` | String |
-| `team_id` | Int32 |
-| `athlete_id_1` | Int32 |
-| `athlete_id_2` | Int32 |
-| `type_id` | Int32 |
-| `type_text` | String |
-| `scoring_play` | Boolean |
-| `score_value` | Int32 |
-| `coordinate_x` | Float64 |
-| `coordinate_y` | Float64 |
-| `coordinate_x_raw` | Float64 |
-| `coordinate_y_raw` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int32 | Unique game identifier. |
+| `season` | Int32 | Season year. |
+| `period_number` | Int32 | Numeric period (1-4 for quarters; 5+ for OT). |
+| `clock_display_value` | String | Game clock display string (e.g. '8:32'). |
+| `team_id` | Int32 | Unique team identifier. |
+| `athlete_id_1` | Int32 | Primary athlete identifier (e.g. shooter). |
+| `athlete_id_2` | Int32 | Secondary athlete identifier (e.g. assister / fouler). |
+| `type_id` | Int32 | Type identifier (numeric). |
+| `type_text` | String | Display text for the type field. |
+| `scoring_play` | Boolean | TRUE if the play resulted in points scored. |
+| `score_value` | Int32 | Point value of the play (2 / 3 / 1). |
+| `coordinate_x` | Float64 | X coordinate on the court (half-court layout). |
+| `coordinate_y` | Float64 | Y coordinate on the court (half-court layout). |
+| `coordinate_x_raw` | Float64 | X coordinate as returned by the API before any adjustment. |
+| `coordinate_y_raw` | Float64 | Y coordinate as returned by the API before any adjustment. |
 
 ```python
 load_mbb_shots(seasons=2025)
@@ -392,32 +392,32 @@ load_mbb_shots(seasons=2025)
 Release: [espn_mens_college_basketball_standings](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_mens_college_basketball_standings) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_mens_college_basketball_standings/standings_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int32 |
-| `group_id` | String |
-| `group_name` | String |
-| `group_abbreviation` | String |
-| `group_short_name` | String |
-| `team_id` | Int32 |
-| `team_uid` | String |
-| `team_slug` | String |
-| `team_location` | String |
-| `team_name` | String |
-| `team_abbreviation` | String |
-| `team_display_name` | String |
-| `team_short_display_name` | String |
-| `team_color` | String |
-| `team_alternate_color` | String |
-| `team_logo` | String |
-| `stat_name` | String |
-| `stat_display_name` | String |
-| `stat_short_display_name` | String |
-| `stat_description` | String |
-| `stat_abbreviation` | String |
-| `stat_type` | String |
-| `display_value` | String |
-| `value` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int32 | Season year. |
+| `group_id` | String | ESPN group id. |
+| `group_name` | String | Group name (conference / division). |
+| `group_abbreviation` | String | Group abbreviation. |
+| `group_short_name` | String |  |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_uid` | String | ESPN universal team identifier (UID format 's:40~l:...~t:...'). |
+| `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
+| `team_location` | String | Team city or location string. |
+| `team_name` | String | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
+| `team_display_name` | String | Full team display name. |
+| `team_short_display_name` | String | Short team display name (e.g. 'Aces'). |
+| `team_color` | String | Team primary color (hex without leading '#'). |
+| `team_alternate_color` | String | Team alternate color (hex without leading '#'). |
+| `team_logo` | String | Team logo image URL. |
+| `stat_name` | String | Stat key. |
+| `stat_display_name` | String | Stat display name (from `displayNames`). |
+| `stat_short_display_name` | String | Short human-readable stat name. |
+| `stat_description` | String |  |
+| `stat_abbreviation` | String |  |
+| `stat_type` | String | Stat type code (e.g. "win", "loss"). |
+| `display_value` | String | Display-formatted value. |
+| `value` | Float64 | Numeric or string value field. |
 
 ```python
 load_mbb_standings(seasons=2025)
@@ -428,23 +428,23 @@ load_mbb_standings(seasons=2025)
 Release: [espn_mens_college_basketball_player_season_stats](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_mens_college_basketball_player_season_stats) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_mens_college_basketball_player_season_stats/player_season_stats_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int32 |
-| `athlete_id` | Int32 |
-| `athlete_display_name` | String |
-| `athlete_position_abbreviation` | String |
-| `athlete_jersey` | String |
-| `team_id` | Int32 |
-| `team_slug` | String |
-| `team_display_name` | String |
-| `category` | String |
-| `stat_label` | String |
-| `stat_name` | String |
-| `stat_display_name` | String |
-| `stat_description` | String |
-| `display_value` | String |
-| `value` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int32 | Season year. |
+| `athlete_id` | Int32 | Unique athlete identifier (ESPN). |
+| `athlete_display_name` | String | Athlete display name (full). |
+| `athlete_position_abbreviation` | String | Athlete position abbreviation (G / F / C). |
+| `athlete_jersey` | String | Athlete jersey number. |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
+| `team_display_name` | String | Full team display name. |
+| `category` | String | Category label. |
+| `stat_label` | String | Human-readable label of the statistic (e.g. 'At bats'). |
+| `stat_name` | String | Stat key. |
+| `stat_display_name` | String | Stat display name (from `displayNames`). |
+| `stat_description` | String |  |
+| `display_value` | String | Display-formatted value. |
+| `value` | Float64 | Numeric or string value field. |
 
 ```python
 load_mbb_player_season_stats(seasons=2025)
@@ -455,44 +455,44 @@ load_mbb_player_season_stats(seasons=2025)
 Release: [espn_mens_college_basketball_rosters](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_mens_college_basketball_rosters) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_mens_college_basketball_rosters/rosters_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int32 |
-| `team_id` | Int32 |
-| `team_slug` | String |
-| `team_abbreviation` | String |
-| `team_display_name` | String |
-| `team_short_display_name` | String |
-| `team_color` | String |
-| `team_alternate_color` | String |
-| `team_logo` | String |
-| `athlete_id` | String |
-| `uid` | String |
-| `guid` | String |
-| `full_name` | String |
-| `display_name` | String |
-| `short_name` | String |
-| `first_name` | String |
-| `last_name` | String |
-| `jersey` | String |
-| `position_abbreviation` | String |
-| `position_name` | String |
-| `position_id` | String |
-| `height` | String |
-| `weight` | String |
-| `age` | String |
-| `date_of_birth` | String |
-| `birth_place_city` | String |
-| `birth_place_state` | String |
-| `birth_place_country` | String |
-| `experience_years` | String |
-| `experience_display_value` | String |
-| `headshot_href` | String |
-| `headshot_alt` | String |
-| `link_web` | String |
-| `status_id` | String |
-| `status_name` | String |
-| `status_type` | String |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int32 | Season year. |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
+| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
+| `team_display_name` | String | Full team display name. |
+| `team_short_display_name` | String | Short team display name (e.g. 'Aces'). |
+| `team_color` | String | Team primary color (hex without leading '#'). |
+| `team_alternate_color` | String | Team alternate color (hex without leading '#'). |
+| `team_logo` | String | Team logo image URL. |
+| `athlete_id` | String | Unique athlete identifier (ESPN). |
+| `uid` | String | ESPN UID string. |
+| `guid` | String | Stable cross-league team GUID. |
+| `full_name` | String | Player's full name. |
+| `display_name` | String | Display name. |
+| `short_name` | String | Short display name. |
+| `first_name` | String | Player's first name. |
+| `last_name` | String | Player's last name. |
+| `jersey` | String | Jersey number worn by the player. |
+| `position_abbreviation` | String | Position abbreviation ('G' / 'F' / 'C'). |
+| `position_name` | String | Listed roster position ('Guard', 'Forward', 'Center'). |
+| `position_id` | String | Unique position identifier. |
+| `height` | String | Player height (string e.g. '6-2' or inches). |
+| `weight` | String | Player weight in pounds. |
+| `age` | String | Player age (in years). |
+| `date_of_birth` | String | Date of birth (YYYY-MM-DD). |
+| `birth_place_city` | String | Birth place city. |
+| `birth_place_state` | String | Birth place state. |
+| `birth_place_country` | String | Birth place country. |
+| `experience_years` | String | Experience years. |
+| `experience_display_value` | String | Experience display value. |
+| `headshot_href` | String | Headshot image URL. |
+| `headshot_alt` | String | Alternative-text label for the headshot. |
+| `link_web` | String | Web link / URL. |
+| `status_id` | String | Status identifier. |
+| `status_name` | String | Status label. |
+| `status_type` | String | Status type. |
 
 ```python
 load_mbb_rosters(seasons=2025)
@@ -503,15 +503,15 @@ load_mbb_rosters(seasons=2025)
 Release: [espn_mens_college_basketball_officials](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_mens_college_basketball_officials) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_mens_college_basketball_officials/officials_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int32 |
-| `game_id` | Int32 |
-| `official_full_name` | String |
-| `official_display_name` | String |
-| `official_position` | String |
-| `official_position_id` | Int32 |
-| `official_order` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int32 | Season year. |
+| `game_id` | Int32 | Unique game identifier. |
+| `official_full_name` | String |  |
+| `official_display_name` | String |  |
+| `official_position` | String |  |
+| `official_position_id` | Int32 |  |
+| `official_order` | Int32 |  |
 
 ```python
 load_mbb_officials(seasons=2025)
@@ -522,30 +522,30 @@ load_mbb_officials(seasons=2025)
 Release: [espn_mens_college_basketball_game_rosters](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_mens_college_basketball_game_rosters) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_mens_college_basketball_game_rosters/game_rosters_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int32 |
-| `game_id` | String |
-| `team_id` | Int32 |
-| `team_slug` | String |
-| `team_abbreviation` | String |
-| `team_display_name` | String |
-| `home_away` | String |
-| `athlete_id` | Int32 |
-| `athlete_uid` | String |
-| `athlete_guid` | String |
-| `athlete_display_name` | String |
-| `athlete_short_name` | String |
-| `athlete_first_name` | String |
-| `athlete_last_name` | String |
-| `athlete_jersey` | String |
-| `athlete_position` | String |
-| `athlete_headshot` | String |
-| `starter` | Boolean |
-| `did_not_play` | Boolean |
-| `active` | Boolean |
-| `ejected` | Boolean |
-| `reason` | String |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int32 | Season year. |
+| `game_id` | String | Unique game identifier. |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
+| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
+| `team_display_name` | String | Full team display name. |
+| `home_away` | String | Game venue label ('home' or 'away'). |
+| `athlete_id` | Int32 | Unique athlete identifier (ESPN). |
+| `athlete_uid` | String | ESPN athlete UID (universal identifier). |
+| `athlete_guid` | String | ESPN athlete GUID. |
+| `athlete_display_name` | String | Athlete display name (full). |
+| `athlete_short_name` | String | Athlete short display name. |
+| `athlete_first_name` | String | Player first name; `athlete_detail = TRUE` only. |
+| `athlete_last_name` | String | Athlete last name. |
+| `athlete_jersey` | String | Athlete jersey number. |
+| `athlete_position` | String | Player position name; `athlete_detail = TRUE` only. |
+| `athlete_headshot` | String |  |
+| `starter` | Boolean | TRUE if the player was in the starting lineup; FALSE otherwise. |
+| `did_not_play` | Boolean | TRUE if the player did not appear in the game. |
+| `active` | Boolean | TRUE if the row represents an active record (player / team / season). |
+| `ejected` | Boolean | TRUE if the player was ejected from the game. |
+| `reason` | String | Reason. |
 
 ```python
 load_mbb_game_rosters(seasons=2025)
@@ -556,24 +556,24 @@ load_mbb_game_rosters(seasons=2025)
 Release: [espn_mens_college_basketball_team_season_stats](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_mens_college_basketball_team_season_stats) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_mens_college_basketball_team_season_stats/team_season_stats_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int32 |
-| `team_id` | Int32 |
-| `team_slug` | String |
-| `team_abbreviation` | String |
-| `team_display_name` | String |
-| `team_short_display_name` | String |
-| `team_color` | String |
-| `team_alternate_color` | String |
-| `team_logo` | String |
-| `category` | String |
-| `stat_label` | String |
-| `stat_name` | String |
-| `stat_display_name` | String |
-| `stat_description` | String |
-| `display_value` | String |
-| `value` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int32 | Season year. |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
+| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
+| `team_display_name` | String | Full team display name. |
+| `team_short_display_name` | String | Short team display name (e.g. 'Aces'). |
+| `team_color` | String | Team primary color (hex without leading '#'). |
+| `team_alternate_color` | String | Team alternate color (hex without leading '#'). |
+| `team_logo` | String | Team logo image URL. |
+| `category` | String | Category label. |
+| `stat_label` | String | Human-readable label of the statistic (e.g. 'At bats'). |
+| `stat_name` | String | Stat key. |
+| `stat_display_name` | String | Stat display name (from `displayNames`). |
+| `stat_description` | String |  |
+| `display_value` | String | Display-formatted value. |
+| `value` | Float64 | Numeric or string value field. |
 
 ```python
 load_mbb_team_season_stats(seasons=2025)

--- a/docs/docs/mlb/reference/loaders.md
+++ b/docs/docs/mlb/reference/loaders.md
@@ -31,13 +31,13 @@ flowchart LR
 Release: [mlb_game_state](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/mlb_game_state) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/mlb_game_state/mlb_re24_matrix_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `base_state` | String |
-| `outs` | Int64 |
-| `re` | Float64 |
-| `n` | UInt32 |
-| `season` | Int64 |
+| col_name | type | description |
+|---|---|---|
+| `base_state` | String |  |
+| `outs` | Int64 | Outs in the inning after the play. |
+| `re` | Float64 |  |
+| `n` | UInt32 |  |
+| `season` | Int64 | Season year. |
 
 ```python
 load_mlb_re24_matrix(seasons=2024)
@@ -48,16 +48,16 @@ load_mlb_re24_matrix(seasons=2024)
 Release: [mlb_game_state](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/mlb_game_state) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/mlb_game_state/mlb_we_table_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `inning_capped` | Int64 |
-| `half` | String |
-| `base_state` | String |
-| `outs_start` | Int64 |
-| `score_diff_bucket` | Int64 |
-| `home_win_exp` | Float64 |
-| `n` | UInt32 |
-| `season` | Int64 |
+| col_name | type | description |
+|---|---|---|
+| `inning_capped` | Int64 |  |
+| `half` | String | Half of the game (1 or 2). |
+| `base_state` | String |  |
+| `outs_start` | Int64 |  |
+| `score_diff_bucket` | Int64 |  |
+| `home_win_exp` | Float64 | Home team win expectancy before the play. |
+| `n` | UInt32 |  |
+| `season` | Int64 | Season year. |
 
 ```python
 load_mlb_we_table(seasons=2024)
@@ -68,12 +68,12 @@ load_mlb_we_table(seasons=2024)
 Release: [mlb_game_state](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/mlb_game_state) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/mlb_game_state/mlb_wpa_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | String |
-| `at_bat_index` | Int64 |
-| `wpa` | Float64 |
-| `season` | Int64 |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | String | Unique ESPN game/event identifier. |
+| `at_bat_index` | Int64 | Zero-based index of the at-bat within the game. |
+| `wpa` | Float64 | Win probability added (WPA) for the posteam. |
+| `season` | Int64 | Season year. |
 
 ```python
 load_mlb_wpa(seasons=2024)
@@ -84,15 +84,15 @@ load_mlb_wpa(seasons=2024)
 Release: [mlb_hitting_models](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/mlb_hitting_models) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/mlb_hitting_models/mlb_expected_stats_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `batter` | Int64 |
-| `season` | Int64 |
-| `pa` | Int64 |
-| `ab` | Int64 |
-| `xwoba` | Float64 |
-| `xba` | Float64 |
-| `xslg` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `batter` | Int64 | Full name of the batter for this swing record. |
+| `season` | Int64 | Season year. |
+| `pa` | Int64 |  |
+| `ab` | Int64 | At-bats. |
+| `xwoba` | Float64 |  |
+| `xba` | Float64 |  |
+| `xslg` | Float64 |  |
 
 ```python
 load_mlb_expected_stats(seasons=2024)
@@ -103,14 +103,14 @@ load_mlb_expected_stats(seasons=2024)
 Release: [mlb_hitting_models](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/mlb_hitting_models) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/mlb_hitting_models/mlb_expected_hr_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `batter` | Int64 |
-| `season` | Int64 |
-| `hr` | Int64 |
-| `xhr_neutral` | Float64 |
-| `xhr_park_adj` | Float64 |
-| `hr_above_expected` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `batter` | Int64 | Full name of the batter for this swing record. |
+| `season` | Int64 | Season year. |
+| `hr` | Int64 | Park factor for home runs. |
+| `xhr_neutral` | Float64 |  |
+| `xhr_park_adj` | Float64 |  |
+| `hr_above_expected` | Float64 |  |
 
 ```python
 load_mlb_expected_hr(seasons=2024)
@@ -121,12 +121,12 @@ load_mlb_expected_hr(seasons=2024)
 Release: [mlb_hitting_models](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/mlb_hitting_models) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/mlb_hitting_models/mlb_batter_projection_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `batter` | Int64 |
-| `age` | Int64 |
-| `proj_xwoba` | Float64 |
-| `proj_pa` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `batter` | Int64 | Full name of the batter for this swing record. |
+| `age` | Int64 | Player age (in years). |
+| `proj_xwoba` | Float64 |  |
+| `proj_pa` | Float64 |  |
 
 ```python
 load_mlb_batter_projection(seasons=2024)
@@ -137,13 +137,13 @@ load_mlb_batter_projection(seasons=2024)
 Release: [mlb_fielding_models](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/mlb_fielding_models) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/mlb_fielding_models/mlb_oaa_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `fielder_id` | String |
-| `position` | Int64 |
-| `opportunities` | UInt32 |
-| `oaa` | Float64 |
-| `season` | Int64 |
+| col_name | type | description |
+|---|---|---|
+| `fielder_id` | String |  |
+| `position` | Int64 | Listed roster position (G, F, C, etc.). |
+| `opportunities` | UInt32 |  |
+| `oaa` | Float64 |  |
+| `season` | Int64 | Season year. |
 
 ```python
 load_mlb_oaa(seasons=2024)
@@ -154,13 +154,13 @@ load_mlb_oaa(seasons=2024)
 Release: [mlb_fielding_models](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/mlb_fielding_models) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/mlb_fielding_models/mlb_catcher_framing_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `catcher_id` | String |
-| `takes` | UInt32 |
-| `framing_runs` | Float64 |
-| `strikes_gained` | Float64 |
-| `season` | Int64 |
+| col_name | type | description |
+|---|---|---|
+| `catcher_id` | String |  |
+| `takes` | UInt32 |  |
+| `framing_runs` | Float64 |  |
+| `strikes_gained` | Float64 |  |
+| `season` | Int64 | Season year. |
 
 ```python
 load_mlb_catcher_framing(seasons=2024)
@@ -171,12 +171,12 @@ load_mlb_catcher_framing(seasons=2024)
 Release: [mlb_pitching_models](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/mlb_pitching_models) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/mlb_pitching_models/mlb_xera_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `pitcher` | Int64 |
-| `season` | Int64 |
-| `x_woba` | Float64 |
-| `x_era` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `pitcher` | Int64 | Whether the position is a pitcher. |
+| `season` | Int64 | Season year. |
+| `x_woba` | Float64 |  |
+| `x_era` | Float64 |  |
 
 ```python
 load_mlb_xera(seasons=2024)
@@ -187,13 +187,13 @@ load_mlb_xera(seasons=2024)
 Release: [mlb_pitching_models](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/mlb_pitching_models) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/mlb_pitching_models/mlb_stuff_plus_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `pitcher` | Int64 |
-| `pitch_type` | String |
-| `stuff_rv_hat` | Float64 |
-| `stuff_plus` | Float64 |
-| `season` | Int64 |
+| col_name | type | description |
+|---|---|---|
+| `pitcher` | Int64 | Whether the position is a pitcher. |
+| `pitch_type` | String | Abbreviation of the pitch type thrown (e.g. FF, SL, CH). |
+| `stuff_rv_hat` | Float64 |  |
+| `stuff_plus` | Float64 |  |
+| `season` | Int64 | Season year. |
 
 ```python
 load_mlb_stuff_plus(seasons=2024)
@@ -204,12 +204,12 @@ load_mlb_stuff_plus(seasons=2024)
 Release: [mlb_pitching_models](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/mlb_pitching_models) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/mlb_pitching_models/mlb_command_plus_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `pitcher` | Int64 |
-| `location_rv_hat` | Float64 |
-| `command_plus` | Float64 |
-| `season` | Int64 |
+| col_name | type | description |
+|---|---|---|
+| `pitcher` | Int64 | Whether the position is a pitcher. |
+| `location_rv_hat` | Float64 |  |
+| `command_plus` | Float64 |  |
+| `season` | Int64 | Season year. |
 
 ```python
 load_mlb_command_plus(seasons=2024)

--- a/docs/docs/nba/reference/loaders.md
+++ b/docs/docs/nba/reference/loaders.md
@@ -34,67 +34,67 @@ flowchart LR
 Release: [espn_nba_pbp](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_nba_pbp) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_nba_pbp/play_by_play_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `id` | Float64 |
-| `sequence_number` | String |
-| `type_id` | Int32 |
-| `type_text` | String |
-| `text` | String |
-| `away_score` | Int32 |
-| `home_score` | Int32 |
-| `period_number` | Int32 |
-| `period_display_value` | String |
-| `clock_display_value` | String |
-| `scoring_play` | Boolean |
-| `score_value` | Int32 |
-| `shooting_play` | Boolean |
-| `coordinate_x_raw` | Float64 |
-| `coordinate_y_raw` | Float64 |
-| `season` | Int32 |
-| `season_type` | Int32 |
-| `away_team_id` | Int32 |
-| `away_team_name` | String |
-| `away_team_mascot` | String |
-| `away_team_abbrev` | String |
-| `away_team_name_alt` | String |
-| `home_team_id` | Int32 |
-| `home_team_name` | String |
-| `home_team_mascot` | String |
-| `home_team_abbrev` | String |
-| `home_team_name_alt` | String |
-| `home_team_spread` | Float64 |
-| `game_spread` | Float64 |
-| `home_favorite` | Boolean |
-| `game_spread_available` | Boolean |
-| `game_id` | Int32 |
-| `qtr` | Int32 |
-| `time` | String |
-| `clock_minutes` | Int32 |
-| `clock_seconds` | Float64 |
-| `half` | String |
-| `game_half` | String |
-| `lead_qtr` | Int32 |
-| `lead_game_half` | String |
-| `start_quarter_seconds_remaining` | Int32 |
-| `start_half_seconds_remaining` | Int32 |
-| `start_game_seconds_remaining` | Int32 |
-| `game_play_number` | Int32 |
-| `end_quarter_seconds_remaining` | Int32 |
-| `end_half_seconds_remaining` | Int32 |
-| `end_game_seconds_remaining` | Int32 |
-| `period` | Int32 |
-| `team_id` | Int32 |
-| `athlete_id_1` | Int32 |
-| `athlete_id_2` | Int32 |
-| `athlete_id_3` | Int32 |
-| `lag_qtr` | Int32 |
-| `lag_game_half` | String |
-| `coordinate_x` | Float64 |
-| `coordinate_y` | Float64 |
-| `game_date` | Date |
-| `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') |
-| `type_abbreviation` | String |
+| col_name | type | description |
+|---|---|---|
+| `id` | Float64 | Id. |
+| `sequence_number` | String | Sequence number representing a shot-possession (V3 PBP). |
+| `type_id` | Int32 | Type identifier (numeric). |
+| `type_text` | String | Display text for the type field. |
+| `text` | String | Text description of the play / record. |
+| `away_score` | Int32 | Away team score at the time of the play. |
+| `home_score` | Int32 | Home team score at the time of the play. |
+| `period_number` | Int32 | Numeric period (1-4 for quarters; 5+ for OT). |
+| `period_display_value` | String | Period display label (e.g. '1st Quarter', 'OT'). |
+| `clock_display_value` | String | Game clock display string (e.g. '8:32'). |
+| `scoring_play` | Boolean | TRUE if the play resulted in points scored. |
+| `score_value` | Int32 | Point value of the play (2 / 3 / 1). |
+| `shooting_play` | Boolean | TRUE if the play was a shooting attempt. |
+| `coordinate_x_raw` | Float64 | X coordinate as returned by the API before any adjustment. |
+| `coordinate_y_raw` | Float64 | Y coordinate as returned by the API before any adjustment. |
+| `season` | Int32 | Season year. |
+| `season_type` | Int32 | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
+| `away_team_id` | Int32 | Unique identifier for the away team. |
+| `away_team_name` | String | Away team name. |
+| `away_team_mascot` | String | Away team mascot. |
+| `away_team_abbrev` | String | Away team three-letter abbreviation. |
+| `away_team_name_alt` | String | Alternate away team name. |
+| `home_team_id` | Int32 | Unique identifier for the home team. |
+| `home_team_name` | String | Home team name. |
+| `home_team_mascot` | String | Home team mascot. |
+| `home_team_abbrev` | String | Home team three-letter abbreviation. |
+| `home_team_name_alt` | String | Alternate home team name. |
+| `home_team_spread` | Float64 | Home team's point spread. |
+| `game_spread` | Float64 | Game spread (signed; positive = home favored). |
+| `home_favorite` | Boolean | TRUE if the home team is the betting favorite. |
+| `game_spread_available` | Boolean | TRUE if a point spread was available. |
+| `game_id` | Int32 | Unique game identifier. |
+| `qtr` | Int32 | Quarter (1-4) or OT period (5+). |
+| `time` | String | Time / clock value. |
+| `clock_minutes` | Int32 | Clock minutes split out for convenience. |
+| `clock_seconds` | Float64 | Clock seconds split out for convenience. |
+| `half` | String | Half of the game (1 or 2). |
+| `game_half` | String | Half of the game (1 or 2). |
+| `lead_qtr` | Int32 | Quarter lead (the next-play's quarter). |
+| `lead_game_half` | String | Half lead (the next-play's half). |
+| `start_quarter_seconds_remaining` | Int32 | Seconds remaining in the period at the start of the play. |
+| `start_half_seconds_remaining` | Int32 | Seconds remaining in the half at the start of the play. |
+| `start_game_seconds_remaining` | Int32 | Seconds remaining in the game at the start of the play. |
+| `game_play_number` | Int32 | Sequential play number within the game. |
+| `end_quarter_seconds_remaining` | Int32 | Seconds remaining in the period at the end of the play. |
+| `end_half_seconds_remaining` | Int32 | Seconds remaining in the half at the end of the play. |
+| `end_game_seconds_remaining` | Int32 | Seconds remaining in the game at the end of the play. |
+| `period` | Int32 | Period of the game (1-4 quarters; 5+ for OT). |
+| `team_id` | Int32 | Unique team identifier. |
+| `athlete_id_1` | Int32 | Primary athlete identifier (e.g. shooter). |
+| `athlete_id_2` | Int32 | Secondary athlete identifier (e.g. assister / fouler). |
+| `athlete_id_3` | Int32 | Athlete id 3. |
+| `lag_qtr` | Int32 | Quarter lag (the previous-play's quarter). |
+| `lag_game_half` | String | Half lag (the previous-play's half). |
+| `coordinate_x` | Float64 | X coordinate on the court (half-court layout). |
+| `coordinate_y` | Float64 | Y coordinate on the court (half-court layout). |
+| `game_date` | Date | Game date (YYYY-MM-DD). |
+| `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') | Game start date/time (ISO 8601). |
+| `type_abbreviation` | String | Type abbreviation. |
 
 ```python
 load_nba_pbp(seasons=2024)
@@ -105,64 +105,64 @@ load_nba_pbp(seasons=2024)
 Release: [espn_nba_player_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_nba_player_boxscores) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_nba_player_boxscores/player_box_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int32 |
-| `season` | Int32 |
-| `season_type` | Int32 |
-| `game_date` | Date |
-| `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') |
-| `athlete_id` | Int32 |
-| `athlete_display_name` | String |
-| `team_id` | Int32 |
-| `team_name` | String |
-| `team_location` | String |
-| `team_short_display_name` | String |
-| `minutes` | Float64 |
-| `field_goals_made` | Int32 |
-| `field_goals_attempted` | Int32 |
-| `three_point_field_goals_made` | Int32 |
-| `three_point_field_goals_attempted` | Int32 |
-| `free_throws_made` | Int32 |
-| `free_throws_attempted` | Int32 |
-| `offensive_rebounds` | Int32 |
-| `defensive_rebounds` | Int32 |
-| `rebounds` | Int32 |
-| `assists` | Int32 |
-| `steals` | Int32 |
-| `blocks` | Int32 |
-| `turnovers` | Int32 |
-| `fouls` | Int32 |
-| `plus_minus` | String |
-| `points` | Int32 |
-| `starter` | Boolean |
-| `ejected` | Boolean |
-| `did_not_play` | Boolean |
-| `active` | Boolean |
-| `athlete_jersey` | String |
-| `athlete_short_name` | String |
-| `athlete_headshot_href` | String |
-| `athlete_position_name` | String |
-| `athlete_position_abbreviation` | String |
-| `team_display_name` | String |
-| `team_uid` | String |
-| `team_slug` | String |
-| `team_logo` | String |
-| `team_abbreviation` | String |
-| `team_color` | String |
-| `team_alternate_color` | String |
-| `home_away` | String |
-| `team_winner` | Boolean |
-| `team_score` | Int32 |
-| `opponent_team_id` | Int32 |
-| `opponent_team_name` | String |
-| `opponent_team_location` | String |
-| `opponent_team_display_name` | String |
-| `opponent_team_abbreviation` | String |
-| `opponent_team_logo` | String |
-| `opponent_team_color` | String |
-| `opponent_team_alternate_color` | String |
-| `opponent_team_score` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int32 | Unique game identifier. |
+| `season` | Int32 | Season year. |
+| `season_type` | Int32 | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
+| `game_date` | Date | Game date (YYYY-MM-DD). |
+| `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') | Game start date/time (ISO 8601). |
+| `athlete_id` | Int32 | Unique athlete identifier (ESPN). |
+| `athlete_display_name` | String | Athlete display name (full). |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_name` | String | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_location` | String | Team city or location string. |
+| `team_short_display_name` | String | Short team display name (e.g. 'Aces'). |
+| `minutes` | Float64 | Minutes played, formatted MM:SS (V3 PT-duration parsed) or decimal minutes (V2). |
+| `field_goals_made` | Int32 | Field goals made (2-pt + 3-pt). |
+| `field_goals_attempted` | Int32 | Field goal attempts (2-pt + 3-pt). |
+| `three_point_field_goals_made` | Int32 | Three-point field goals made. |
+| `three_point_field_goals_attempted` | Int32 | Three-point field goal attempts. |
+| `free_throws_made` | Int32 | Free throws made. |
+| `free_throws_attempted` | Int32 | Free throw attempts. |
+| `offensive_rebounds` | Int32 | Offensive rebounds. |
+| `defensive_rebounds` | Int32 | Defensive rebounds. |
+| `rebounds` | Int32 | Total rebounds. |
+| `assists` | Int32 | Total assists. |
+| `steals` | Int32 | Total steals. |
+| `blocks` | Int32 | Total blocks. |
+| `turnovers` | Int32 | Total turnovers. |
+| `fouls` | Int32 | Personal fouls. |
+| `plus_minus` | String | Plus/minus point differential while on court. |
+| `points` | Int32 | Points scored. |
+| `starter` | Boolean | TRUE if the player was in the starting lineup; FALSE otherwise. |
+| `ejected` | Boolean | TRUE if the player was ejected from the game. |
+| `did_not_play` | Boolean | TRUE if the player did not appear in the game. |
+| `active` | Boolean | TRUE if the row represents an active record (player / team / season). |
+| `athlete_jersey` | String | Athlete jersey number. |
+| `athlete_short_name` | String | Athlete short display name. |
+| `athlete_headshot_href` | String | Athlete headshot image URL. |
+| `athlete_position_name` | String | Athlete position ('Guard', 'Forward', 'Center'). |
+| `athlete_position_abbreviation` | String | Athlete position abbreviation (G / F / C). |
+| `team_display_name` | String | Full team display name. |
+| `team_uid` | String | ESPN universal team identifier (UID format 's:40~l:...~t:...'). |
+| `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
+| `team_logo` | String | Team logo image URL. |
+| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
+| `team_color` | String | Team primary color (hex without leading '#'). |
+| `team_alternate_color` | String | Team alternate color (hex without leading '#'). |
+| `home_away` | String | Game venue label ('home' or 'away'). |
+| `team_winner` | Boolean | TRUE if the team won this game. |
+| `team_score` | Int32 | Team's score / final score. |
+| `opponent_team_id` | Int32 | Unique identifier for the opponent team. |
+| `opponent_team_name` | String | Opponent team display name. |
+| `opponent_team_location` | String | Opponent team city / location. |
+| `opponent_team_display_name` | String | Opponent team full display name. |
+| `opponent_team_abbreviation` | String | Opponent team abbreviation. |
+| `opponent_team_logo` | String | Opponent team logo URL. |
+| `opponent_team_color` | String | Opponent team primary color (hex). |
+| `opponent_team_alternate_color` | String | Opponent team alternate color (hex). |
+| `opponent_team_score` | Int32 | Opponent team's score. |
 
 ```python
 load_nba_player_boxscore(seasons=2024)
@@ -173,75 +173,75 @@ load_nba_player_boxscore(seasons=2024)
 Release: [espn_nba_schedules](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_nba_schedules) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_nba_schedules/nba_schedule_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `id` | Int32 |
-| `uid` | String |
-| `date` | String |
-| `attendance` | Float64 |
-| `time_valid` | Boolean |
-| `neutral_site` | Boolean |
-| `conference_competition` | Boolean |
-| `recent` | Boolean |
-| `start_date` | String |
-| `notes_type` | String |
-| `notes_headline` | String |
-| `type_id` | Int32 |
-| `type_abbreviation` | String |
-| `status_clock` | Float64 |
-| `status_display_clock` | String |
-| `status_period` | Float64 |
-| `status_type_id` | Int32 |
-| `status_type_name` | String |
-| `status_type_state` | String |
-| `status_type_completed` | Boolean |
-| `status_type_description` | String |
-| `status_type_detail` | String |
-| `status_type_short_detail` | String |
-| `format_regulation_periods` | Float64 |
-| `home_id` | Int32 |
-| `home_uid` | String |
-| `home_location` | String |
-| `home_name` | String |
-| `home_abbreviation` | String |
-| `home_display_name` | String |
-| `home_short_display_name` | String |
-| `home_color` | String |
-| `home_alternate_color` | String |
-| `home_is_active` | Boolean |
-| `home_logo` | String |
-| `home_score` | Int32 |
-| `home_winner` | Boolean |
-| `away_id` | Int32 |
-| `away_uid` | String |
-| `away_location` | String |
-| `away_name` | String |
-| `away_abbreviation` | String |
-| `away_display_name` | String |
-| `away_short_display_name` | String |
-| `away_color` | String |
-| `away_alternate_color` | String |
-| `away_is_active` | Boolean |
-| `away_logo` | String |
-| `away_score` | Int32 |
-| `away_winner` | Boolean |
-| `game_id` | Int32 |
-| `season` | Int32 |
-| `season_type` | Int32 |
-| `venue_id` | Int32 |
-| `venue_full_name` | String |
-| `venue_address_city` | String |
-| `venue_address_state` | String |
-| `venue_capacity` | Float64 |
-| `venue_indoor` | Boolean |
-| `status_type_alt_detail` | String |
-| `game_json` | Boolean |
-| `game_json_url` | String |
-| `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') |
-| `game_date` | Date |
-| `PBP` | Boolean |
-| `team_box` | Boolean |
-| `player_box` | Boolean |
+| col_name | type | description |
+|---|---|---|
+| `id` | Int32 | Id. |
+| `uid` | String | ESPN UID string. |
+| `date` | String | Date in YYYY-MM-DD format. |
+| `attendance` | Float64 | Reported attendance. |
+| `time_valid` | Boolean | Time valid. |
+| `neutral_site` | Boolean | Neutral site. |
+| `conference_competition` | Boolean | Conference competition. |
+| `recent` | Boolean | Recent. |
+| `start_date` | String | Start date (YYYY-MM-DD). |
+| `notes_type` | String | Notes type. |
+| `notes_headline` | String | Notes headline. |
+| `type_id` | Int32 | Type identifier (numeric). |
+| `type_abbreviation` | String | Type abbreviation. |
+| `status_clock` | Float64 | Status clock. |
+| `status_display_clock` | String | Status display clock. |
+| `status_period` | Float64 | Status period. |
+| `status_type_id` | Int32 | Unique identifier for status type. |
+| `status_type_name` | String | Status type name. |
+| `status_type_state` | String | Status type state. |
+| `status_type_completed` | Boolean | Status type completed. |
+| `status_type_description` | String | Status type description. |
+| `status_type_detail` | String | Status type detail. |
+| `status_type_short_detail` | String | Status type short detail. |
+| `format_regulation_periods` | Float64 | Format regulation periods. |
+| `home_id` | Int32 | Unique identifier for home. |
+| `home_uid` | String | Home team's uid. |
+| `home_location` | String | Home team's location. |
+| `home_name` | String | Home name. |
+| `home_abbreviation` | String | Home team's abbreviation. |
+| `home_display_name` | String | Home display name. |
+| `home_short_display_name` | String | Home short display name. |
+| `home_color` | String | Color code (hex) for home. |
+| `home_alternate_color` | String | Color code (hex) for home alternate. |
+| `home_is_active` | Boolean | Home team's is active. |
+| `home_logo` | String | Home team logo URL. |
+| `home_score` | Int32 | Home team score at the time of the play. |
+| `home_winner` | Boolean | Home team's winner. |
+| `away_id` | Int32 | Unique identifier for away. |
+| `away_uid` | String | Away team's uid. |
+| `away_location` | String | Away team's location. |
+| `away_name` | String | Away name. |
+| `away_abbreviation` | String | Away team's abbreviation. |
+| `away_display_name` | String | Away display name. |
+| `away_short_display_name` | String | Away short display name. |
+| `away_color` | String | Color code (hex) for away. |
+| `away_alternate_color` | String | Color code (hex) for away alternate. |
+| `away_is_active` | Boolean | Away team's is active. |
+| `away_logo` | String | Away team logo URL. |
+| `away_score` | Int32 | Away team score at the time of the play. |
+| `away_winner` | Boolean | Away team's winner. |
+| `game_id` | Int32 | Unique game identifier. |
+| `season` | Int32 | Season year. |
+| `season_type` | Int32 | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
+| `venue_id` | Int32 | Unique venue identifier. |
+| `venue_full_name` | String | Venue full name. |
+| `venue_address_city` | String | Venue address city. |
+| `venue_address_state` | String | Venue address state / region. |
+| `venue_capacity` | Float64 | Venue seating capacity. |
+| `venue_indoor` | Boolean | TRUE if the venue is indoors. |
+| `status_type_alt_detail` | String | Status type alt detail. |
+| `game_json` | Boolean | Whether processed game JSON is available. |
+| `game_json_url` | String | URL to the processed game JSON. |
+| `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') | Game start date/time (ISO 8601). |
+| `game_date` | Date | Game date (YYYY-MM-DD). |
+| `PBP` | Boolean | Whether play-by-play data is available. |
+| `team_box` | Boolean | Team box. |
+| `player_box` | Boolean | Player box. |
 
 ```python
 load_nba_schedule(seasons=2024)
@@ -252,65 +252,65 @@ load_nba_schedule(seasons=2024)
 Release: [espn_nba_team_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_nba_team_boxscores) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_nba_team_boxscores/team_box_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int32 |
-| `season` | Int32 |
-| `season_type` | Int32 |
-| `game_date` | Date |
-| `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') |
-| `team_id` | Int32 |
-| `team_uid` | String |
-| `team_slug` | String |
-| `team_location` | String |
-| `team_name` | String |
-| `team_abbreviation` | String |
-| `team_display_name` | String |
-| `team_short_display_name` | String |
-| `team_color` | String |
-| `team_alternate_color` | String |
-| `team_logo` | String |
-| `team_home_away` | String |
-| `team_score` | Int32 |
-| `team_winner` | Boolean |
-| `assists` | Int32 |
-| `blocks` | Int32 |
-| `defensive_rebounds` | Int32 |
-| `fast_break_points` | String |
-| `field_goal_pct` | Float64 |
-| `field_goals_made` | Int32 |
-| `field_goals_attempted` | Int32 |
-| `flagrant_fouls` | Int32 |
-| `fouls` | Int32 |
-| `free_throw_pct` | Float64 |
-| `free_throws_made` | Int32 |
-| `free_throws_attempted` | Int32 |
-| `offensive_rebounds` | Int32 |
-| `points_in_paint` | String |
-| `steals` | Int32 |
-| `team_turnovers` | Int32 |
-| `technical_fouls` | Int32 |
-| `three_point_field_goal_pct` | Float64 |
-| `three_point_field_goals_made` | Int32 |
-| `three_point_field_goals_attempted` | Int32 |
-| `total_rebounds` | Int32 |
-| `total_technical_fouls` | Int32 |
-| `total_turnovers` | Int32 |
-| `turnover_points` | String |
-| `turnovers` | Int32 |
-| `opponent_team_id` | Int32 |
-| `opponent_team_uid` | String |
-| `opponent_team_slug` | String |
-| `opponent_team_location` | String |
-| `opponent_team_name` | String |
-| `opponent_team_abbreviation` | String |
-| `opponent_team_display_name` | String |
-| `opponent_team_short_display_name` | String |
-| `opponent_team_color` | String |
-| `opponent_team_alternate_color` | String |
-| `opponent_team_logo` | String |
-| `opponent_team_score` | Int32 |
-| `largest_lead` | String |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int32 | Unique game identifier. |
+| `season` | Int32 | Season year. |
+| `season_type` | Int32 | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
+| `game_date` | Date | Game date (YYYY-MM-DD). |
+| `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') | Game start date/time (ISO 8601). |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_uid` | String | ESPN universal team identifier (UID format 's:40~l:...~t:...'). |
+| `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
+| `team_location` | String | Team city or location string. |
+| `team_name` | String | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
+| `team_display_name` | String | Full team display name. |
+| `team_short_display_name` | String | Short team display name (e.g. 'Aces'). |
+| `team_color` | String | Team primary color (hex without leading '#'). |
+| `team_alternate_color` | String | Team alternate color (hex without leading '#'). |
+| `team_logo` | String | Team logo image URL. |
+| `team_home_away` | String | Team home away. |
+| `team_score` | Int32 | Team's score / final score. |
+| `team_winner` | Boolean | TRUE if the team won this game. |
+| `assists` | Int32 | Total assists. |
+| `blocks` | Int32 | Total blocks. |
+| `defensive_rebounds` | Int32 | Defensive rebounds. |
+| `fast_break_points` | String | Fast-break points scored. |
+| `field_goal_pct` | Float64 | Field goal percentage (0-1). |
+| `field_goals_made` | Int32 | Field goals made (2-pt + 3-pt). |
+| `field_goals_attempted` | Int32 | Field goal attempts (2-pt + 3-pt). |
+| `flagrant_fouls` | Int32 | Total flagrant fouls. |
+| `fouls` | Int32 | Personal fouls. |
+| `free_throw_pct` | Float64 | Free throw percentage (0-1). |
+| `free_throws_made` | Int32 | Free throws made. |
+| `free_throws_attempted` | Int32 | Free throw attempts. |
+| `offensive_rebounds` | Int32 | Offensive rebounds. |
+| `points_in_paint` | String | Points scored in the paint. |
+| `steals` | Int32 | Total steals. |
+| `team_turnovers` | Int32 | Team turnovers (turnovers credited to the team rather than a player). |
+| `technical_fouls` | Int32 | Total technical fouls. |
+| `three_point_field_goal_pct` | Float64 | Three-point field goal percentage (0-1). |
+| `three_point_field_goals_made` | Int32 | Three-point field goals made. |
+| `three_point_field_goals_attempted` | Int32 | Three-point field goal attempts. |
+| `total_rebounds` | Int32 | Total rebounds. |
+| `total_technical_fouls` | Int32 | Total technical fouls (player + team). |
+| `total_turnovers` | Int32 | Total turnovers (player + team). |
+| `turnover_points` | String | Turnover points. |
+| `turnovers` | Int32 | Total turnovers. |
+| `opponent_team_id` | Int32 | Unique identifier for the opponent team. |
+| `opponent_team_uid` | String | Opponent team uid. |
+| `opponent_team_slug` | String | Opponent team slug. |
+| `opponent_team_location` | String | Opponent team city / location. |
+| `opponent_team_name` | String | Opponent team display name. |
+| `opponent_team_abbreviation` | String | Opponent team abbreviation. |
+| `opponent_team_display_name` | String | Opponent team full display name. |
+| `opponent_team_short_display_name` | String | Opponent team short display name. |
+| `opponent_team_color` | String | Opponent team primary color (hex). |
+| `opponent_team_alternate_color` | String | Opponent team alternate color (hex). |
+| `opponent_team_logo` | String | Opponent team logo URL. |
+| `opponent_team_score` | Int32 | Opponent team's score. |
+| `largest_lead` | String | Largest lead during the game. |
 
 ```python
 load_nba_team_boxscore(seasons=2024)
@@ -321,30 +321,30 @@ load_nba_team_boxscore(seasons=2024)
 Release: [espn_nba_game_rosters](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_nba_game_rosters) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_nba_game_rosters/game_rosters_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int32 |
-| `game_id` | String |
-| `team_id` | Int32 |
-| `team_slug` | String |
-| `team_abbreviation` | String |
-| `team_display_name` | String |
-| `home_away` | String |
-| `athlete_id` | Int32 |
-| `athlete_uid` | String |
-| `athlete_guid` | String |
-| `athlete_display_name` | String |
-| `athlete_short_name` | String |
-| `athlete_first_name` | String |
-| `athlete_last_name` | String |
-| `athlete_jersey` | String |
-| `athlete_position` | String |
-| `athlete_headshot` | String |
-| `starter` | Boolean |
-| `did_not_play` | Boolean |
-| `active` | Boolean |
-| `ejected` | Boolean |
-| `reason` | String |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int32 | Season year. |
+| `game_id` | String | Unique game identifier. |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
+| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
+| `team_display_name` | String | Full team display name. |
+| `home_away` | String | Game venue label ('home' or 'away'). |
+| `athlete_id` | Int32 | Unique athlete identifier (ESPN). |
+| `athlete_uid` | String | ESPN athlete UID (universal identifier). |
+| `athlete_guid` | String | ESPN athlete GUID. |
+| `athlete_display_name` | String | Athlete display name (full). |
+| `athlete_short_name` | String | Athlete short display name. |
+| `athlete_first_name` | String | Player first name; `athlete_detail = TRUE` only. |
+| `athlete_last_name` | String | Athlete last name. |
+| `athlete_jersey` | String | Athlete jersey number. |
+| `athlete_position` | String | Player position name; `athlete_detail = TRUE` only. |
+| `athlete_headshot` | String |  |
+| `starter` | Boolean | TRUE if the player was in the starting lineup; FALSE otherwise. |
+| `did_not_play` | Boolean | TRUE if the player did not appear in the game. |
+| `active` | Boolean | TRUE if the row represents an active record (player / team / season). |
+| `ejected` | Boolean | TRUE if the player was ejected from the game. |
+| `reason` | String | Reason. |
 
 ```python
 load_nba_game_rosters(seasons=2002)
@@ -355,15 +355,15 @@ load_nba_game_rosters(seasons=2002)
 Release: [espn_nba_officials](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_nba_officials) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_nba_officials/officials_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int32 |
-| `game_id` | Int32 |
-| `official_full_name` | String |
-| `official_display_name` | String |
-| `official_position` | String |
-| `official_position_id` | Int32 |
-| `official_order` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int32 | Season year. |
+| `game_id` | Int32 | Unique game identifier. |
+| `official_full_name` | String |  |
+| `official_display_name` | String |  |
+| `official_position` | String |  |
+| `official_position_id` | Int32 |  |
+| `official_order` | Int32 |  |
 
 ```python
 load_nba_officials(seasons=2002)
@@ -374,23 +374,23 @@ load_nba_officials(seasons=2002)
 Release: [espn_nba_shots](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_nba_shots) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_nba_shots/shots_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int32 |
-| `season` | Int32 |
-| `period_number` | Int32 |
-| `clock_display_value` | String |
-| `team_id` | Int32 |
-| `athlete_id_1` | Int32 |
-| `athlete_id_2` | Int32 |
-| `type_id` | Int32 |
-| `type_text` | String |
-| `scoring_play` | Boolean |
-| `score_value` | Int32 |
-| `coordinate_x` | Float64 |
-| `coordinate_y` | Float64 |
-| `coordinate_x_raw` | Float64 |
-| `coordinate_y_raw` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int32 | Unique game identifier. |
+| `season` | Int32 | Season year. |
+| `period_number` | Int32 | Numeric period (1-4 for quarters; 5+ for OT). |
+| `clock_display_value` | String | Game clock display string (e.g. '8:32'). |
+| `team_id` | Int32 | Unique team identifier. |
+| `athlete_id_1` | Int32 | Primary athlete identifier (e.g. shooter). |
+| `athlete_id_2` | Int32 | Secondary athlete identifier (e.g. assister / fouler). |
+| `type_id` | Int32 | Type identifier (numeric). |
+| `type_text` | String | Display text for the type field. |
+| `scoring_play` | Boolean | TRUE if the play resulted in points scored. |
+| `score_value` | Int32 | Point value of the play (2 / 3 / 1). |
+| `coordinate_x` | Float64 | X coordinate on the court (half-court layout). |
+| `coordinate_y` | Float64 | Y coordinate on the court (half-court layout). |
+| `coordinate_x_raw` | Float64 | X coordinate as returned by the API before any adjustment. |
+| `coordinate_y_raw` | Float64 | Y coordinate as returned by the API before any adjustment. |
 
 ```python
 load_nba_shots(seasons=2002)
@@ -401,32 +401,32 @@ load_nba_shots(seasons=2002)
 Release: [espn_nba_standings](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_nba_standings) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_nba_standings/standings_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int32 |
-| `group_id` | String |
-| `group_name` | String |
-| `group_abbreviation` | String |
-| `group_short_name` | String |
-| `team_id` | Int32 |
-| `team_uid` | String |
-| `team_slug` | String |
-| `team_location` | String |
-| `team_name` | String |
-| `team_abbreviation` | String |
-| `team_display_name` | String |
-| `team_short_display_name` | String |
-| `team_color` | String |
-| `team_alternate_color` | String |
-| `team_logo` | String |
-| `stat_name` | String |
-| `stat_display_name` | String |
-| `stat_short_display_name` | String |
-| `stat_description` | String |
-| `stat_abbreviation` | String |
-| `stat_type` | String |
-| `display_value` | String |
-| `value` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int32 | Season year. |
+| `group_id` | String | ESPN group id. |
+| `group_name` | String | Group name (conference / division). |
+| `group_abbreviation` | String | Group abbreviation. |
+| `group_short_name` | String |  |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_uid` | String | ESPN universal team identifier (UID format 's:40~l:...~t:...'). |
+| `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
+| `team_location` | String | Team city or location string. |
+| `team_name` | String | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
+| `team_display_name` | String | Full team display name. |
+| `team_short_display_name` | String | Short team display name (e.g. 'Aces'). |
+| `team_color` | String | Team primary color (hex without leading '#'). |
+| `team_alternate_color` | String | Team alternate color (hex without leading '#'). |
+| `team_logo` | String | Team logo image URL. |
+| `stat_name` | String | Stat key. |
+| `stat_display_name` | String | Stat display name (from `displayNames`). |
+| `stat_short_display_name` | String | Short human-readable stat name. |
+| `stat_description` | String |  |
+| `stat_abbreviation` | String |  |
+| `stat_type` | String | Stat type code (e.g. "win", "loss"). |
+| `display_value` | String | Display-formatted value. |
+| `value` | Float64 | Numeric or string value field. |
 
 ```python
 load_nba_standings(seasons=2002)
@@ -437,23 +437,23 @@ load_nba_standings(seasons=2002)
 Release: [espn_nba_player_season_stats](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_nba_player_season_stats) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_nba_player_season_stats/player_season_stats_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int32 |
-| `athlete_id` | Int32 |
-| `athlete_display_name` | String |
-| `athlete_position_abbreviation` | String |
-| `athlete_jersey` | String |
-| `team_id` | Int32 |
-| `team_slug` | String |
-| `team_display_name` | String |
-| `category` | String |
-| `stat_label` | String |
-| `stat_name` | String |
-| `stat_display_name` | String |
-| `stat_description` | String |
-| `display_value` | String |
-| `value` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int32 | Season year. |
+| `athlete_id` | Int32 | Unique athlete identifier (ESPN). |
+| `athlete_display_name` | String | Athlete display name (full). |
+| `athlete_position_abbreviation` | String | Athlete position abbreviation (G / F / C). |
+| `athlete_jersey` | String | Athlete jersey number. |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
+| `team_display_name` | String | Full team display name. |
+| `category` | String | Category label. |
+| `stat_label` | String | Human-readable label of the statistic (e.g. 'At bats'). |
+| `stat_name` | String | Stat key. |
+| `stat_display_name` | String | Stat display name (from `displayNames`). |
+| `stat_description` | String |  |
+| `display_value` | String | Display-formatted value. |
+| `value` | Float64 | Numeric or string value field. |
 
 ```python
 load_nba_player_season_stats(seasons=2025)
@@ -464,24 +464,24 @@ load_nba_player_season_stats(seasons=2025)
 Release: [espn_nba_team_season_stats](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_nba_team_season_stats) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_nba_team_season_stats/team_season_stats_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int32 |
-| `team_id` | Int32 |
-| `team_slug` | String |
-| `team_abbreviation` | String |
-| `team_display_name` | String |
-| `team_short_display_name` | String |
-| `team_color` | String |
-| `team_alternate_color` | String |
-| `team_logo` | String |
-| `category` | String |
-| `stat_label` | String |
-| `stat_name` | String |
-| `stat_display_name` | String |
-| `stat_description` | String |
-| `display_value` | String |
-| `value` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int32 | Season year. |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
+| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
+| `team_display_name` | String | Full team display name. |
+| `team_short_display_name` | String | Short team display name (e.g. 'Aces'). |
+| `team_color` | String | Team primary color (hex without leading '#'). |
+| `team_alternate_color` | String | Team alternate color (hex without leading '#'). |
+| `team_logo` | String | Team logo image URL. |
+| `category` | String | Category label. |
+| `stat_label` | String | Human-readable label of the statistic (e.g. 'At bats'). |
+| `stat_name` | String | Stat key. |
+| `stat_display_name` | String | Stat display name (from `displayNames`). |
+| `stat_description` | String |  |
+| `display_value` | String | Display-formatted value. |
+| `value` | Float64 | Numeric or string value field. |
 
 ```python
 load_nba_team_season_stats(seasons=2025)
@@ -492,43 +492,43 @@ load_nba_team_season_stats(seasons=2025)
 Release: [espn_nba_draft](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_nba_draft) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_nba_draft/draft_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int32 |
-| `round` | Int32 |
-| `round_display_name` | String |
-| `pick` | Int32 |
-| `overall_pick` | Int32 |
-| `pick_traded` | String |
-| `pick_notes` | String |
-| `athlete_id` | Int32 |
-| `athlete_uid` | String |
-| `athlete_guid` | String |
-| `athlete_first_name` | String |
-| `athlete_last_name` | String |
-| `athlete_full_name` | String |
-| `athlete_display_name` | String |
-| `athlete_short_name` | String |
-| `athlete_height` | String |
-| `athlete_weight` | String |
-| `athlete_position_abbreviation` | String |
-| `athlete_position_name` | String |
-| `athlete_headshot_href` | String |
-| `college_id` | Int32 |
-| `college_name` | String |
-| `college_short_name` | String |
-| `college_abbreviation` | String |
-| `team_id` | Int32 |
-| `team_uid` | String |
-| `team_slug` | String |
-| `team_location` | String |
-| `team_name` | String |
-| `team_abbreviation` | String |
-| `team_display_name` | String |
-| `team_short_display_name` | String |
-| `team_color` | String |
-| `team_alternate_color` | String |
-| `team_logo` | String |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int32 | Season year. |
+| `round` | Int32 | Tournament / playoff round. |
+| `round_display_name` | String |  |
+| `pick` | Int32 | Pick number within the round. |
+| `overall_pick` | Int32 | Overall pick number in the draft. |
+| `pick_traded` | String |  |
+| `pick_notes` | String |  |
+| `athlete_id` | Int32 | Unique athlete identifier (ESPN). |
+| `athlete_uid` | String | ESPN athlete UID (universal identifier). |
+| `athlete_guid` | String | ESPN athlete GUID. |
+| `athlete_first_name` | String | Player first name; `athlete_detail = TRUE` only. |
+| `athlete_last_name` | String | Athlete last name. |
+| `athlete_full_name` | String | Drafted player full name. |
+| `athlete_display_name` | String | Athlete display name (full). |
+| `athlete_short_name` | String | Athlete short display name. |
+| `athlete_height` | String | Athlete height. |
+| `athlete_weight` | String | Athlete weight. |
+| `athlete_position_abbreviation` | String | Athlete position abbreviation (G / F / C). |
+| `athlete_position_name` | String | Athlete position ('Guard', 'Forward', 'Center'). |
+| `athlete_headshot_href` | String | Athlete headshot image URL. |
+| `college_id` | Int32 | Unique identifier for college. |
+| `college_name` | String | College / pre-draft team. |
+| `college_short_name` | String | College short name. |
+| `college_abbreviation` | String |  |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_uid` | String | ESPN universal team identifier (UID format 's:40~l:...~t:...'). |
+| `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
+| `team_location` | String | Team city or location string. |
+| `team_name` | String | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
+| `team_display_name` | String | Full team display name. |
+| `team_short_display_name` | String | Short team display name (e.g. 'Aces'). |
+| `team_color` | String | Team primary color (hex without leading '#'). |
+| `team_alternate_color` | String | Team alternate color (hex without leading '#'). |
+| `team_logo` | String | Team logo image URL. |
 
 ```python
 load_nba_draft(seasons=2025)
@@ -539,44 +539,44 @@ load_nba_draft(seasons=2025)
 Release: [espn_nba_rosters](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_nba_rosters) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_nba_rosters/rosters_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int32 |
-| `team_id` | Int32 |
-| `team_slug` | String |
-| `team_abbreviation` | String |
-| `team_display_name` | String |
-| `team_short_display_name` | String |
-| `team_color` | String |
-| `team_alternate_color` | String |
-| `team_logo` | String |
-| `athlete_id` | String |
-| `uid` | String |
-| `guid` | String |
-| `full_name` | String |
-| `display_name` | String |
-| `short_name` | String |
-| `first_name` | String |
-| `last_name` | String |
-| `jersey` | String |
-| `position_abbreviation` | String |
-| `position_name` | String |
-| `position_id` | String |
-| `height` | String |
-| `weight` | String |
-| `age` | String |
-| `date_of_birth` | String |
-| `birth_place_city` | String |
-| `birth_place_state` | String |
-| `birth_place_country` | String |
-| `experience_years` | String |
-| `experience_display_value` | String |
-| `headshot_href` | String |
-| `headshot_alt` | String |
-| `link_web` | String |
-| `status_id` | String |
-| `status_name` | String |
-| `status_type` | String |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int32 | Season year. |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
+| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
+| `team_display_name` | String | Full team display name. |
+| `team_short_display_name` | String | Short team display name (e.g. 'Aces'). |
+| `team_color` | String | Team primary color (hex without leading '#'). |
+| `team_alternate_color` | String | Team alternate color (hex without leading '#'). |
+| `team_logo` | String | Team logo image URL. |
+| `athlete_id` | String | Unique athlete identifier (ESPN). |
+| `uid` | String | ESPN UID string. |
+| `guid` | String | Stable cross-league team GUID. |
+| `full_name` | String | Player's full name. |
+| `display_name` | String | Display name. |
+| `short_name` | String | Short display name. |
+| `first_name` | String | Player's first name. |
+| `last_name` | String | Player's last name. |
+| `jersey` | String | Jersey number worn by the player. |
+| `position_abbreviation` | String | Position abbreviation ('G' / 'F' / 'C'). |
+| `position_name` | String | Listed roster position ('Guard', 'Forward', 'Center'). |
+| `position_id` | String | Unique position identifier. |
+| `height` | String | Player height (string e.g. '6-2' or inches). |
+| `weight` | String | Player weight in pounds. |
+| `age` | String | Player age (in years). |
+| `date_of_birth` | String | Date of birth (YYYY-MM-DD). |
+| `birth_place_city` | String | Birth place city. |
+| `birth_place_state` | String | Birth place state. |
+| `birth_place_country` | String | Birth place country. |
+| `experience_years` | String | Experience years. |
+| `experience_display_value` | String | Experience display value. |
+| `headshot_href` | String | Headshot image URL. |
+| `headshot_alt` | String | Alternative-text label for the headshot. |
+| `link_web` | String | Web link / URL. |
+| `status_id` | String | Status identifier. |
+| `status_name` | String | Status label. |
+| `status_type` | String | Status type. |
 
 ```python
 load_nba_rosters(seasons=2025)
@@ -587,60 +587,60 @@ load_nba_rosters(seasons=2025)
 Release: [nba_stats_schedules](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_schedules) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_schedules/schedule_{season}-26.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_date` | Date |
-| `game_id` | String |
-| `game_code` | String |
-| `game_status` | Int32 |
-| `game_status_text` | String |
-| `game_sequence` | Int32 |
-| `game_date_est` | String |
-| `game_time_est` | String |
-| `game_date_time_est` | String |
-| `game_date_utc` | String |
-| `game_time_utc` | String |
-| `game_date_time_utc` | String |
-| `away_team_time` | String |
-| `home_team_time` | String |
-| `day` | String |
-| `month_num` | Int32 |
-| `week_number` | Int32 |
-| `week_name` | String |
-| `if_necessary` | String |
-| `series_game_number` | String |
-| `game_label` | String |
-| `game_sub_label` | String |
-| `series_text` | String |
-| `arena_name` | String |
-| `arena_state` | String |
-| `arena_city` | String |
-| `postponed_status` | String |
-| `branch_link` | String |
-| `game_subtype` | String |
-| `is_neutral` | Boolean |
-| `home_team_id` | Int32 |
-| `home_team_name` | String |
-| `home_team_city` | String |
-| `home_team_tricode` | String |
-| `home_team_slug` | String |
-| `home_team_wins` | Int32 |
-| `home_team_losses` | Int32 |
-| `home_team_score` | Int32 |
-| `home_team_seed` | Int32 |
-| `away_team_id` | Int32 |
-| `away_team_name` | String |
-| `away_team_city` | String |
-| `away_team_tricode` | String |
-| `away_team_slug` | String |
-| `away_team_wins` | Int32 |
-| `away_team_losses` | Int32 |
-| `away_team_score` | Int32 |
-| `away_team_seed` | Int32 |
-| `season` | Int32 |
-| `league_id` | String |
-| `season_type_id` | String |
-| `season_type_description` | String |
+| col_name | type | description |
+|---|---|---|
+| `game_date` | Date | Game date (YYYY-MM-DD). |
+| `game_id` | String | Unique game identifier. |
+| `game_code` | String | ESPN game code (numeric identifier). |
+| `game_status` | Int32 | Game status label. |
+| `game_status_text` | String | Game status display text (e.g. 'Final', '4:32 - 4th'). |
+| `game_sequence` | Int32 | Game sequence. |
+| `game_date_est` | String | Game date est. |
+| `game_time_est` | String | Game time est. |
+| `game_date_time_est` | String | Game date time est. |
+| `game_date_utc` | String | Game date utc. |
+| `game_time_utc` | String | Game start time in UTC (ISO 8601 timestamp). |
+| `game_date_time_utc` | String | Game date time utc. |
+| `away_team_time` | String | Time / clock value. |
+| `home_team_time` | String | Time / clock value. |
+| `day` | String | Day number within the month. |
+| `month_num` | Int32 | Month num. |
+| `week_number` | Int32 | Week number. |
+| `week_name` | String | Week name. |
+| `if_necessary` | String | If necessary. |
+| `series_game_number` | String | Series game number. |
+| `game_label` | String |  |
+| `game_sub_label` | String |  |
+| `series_text` | String | Series text. |
+| `arena_name` | String | Arena name. |
+| `arena_state` | String | Arena state. |
+| `arena_city` | String | Arena city. |
+| `postponed_status` | String | Postponed status. |
+| `branch_link` | String | Branch link. |
+| `game_subtype` | String | Game subtype. |
+| `is_neutral` | Boolean |  |
+| `home_team_id` | Int32 | Unique identifier for the home team. |
+| `home_team_name` | String | Home team name. |
+| `home_team_city` | String | Home team city / location. |
+| `home_team_tricode` | String | Home team three-letter code. |
+| `home_team_slug` | String | Home team's team slug. |
+| `home_team_wins` | Int32 | Home team's team wins. |
+| `home_team_losses` | Int32 | Home team's team losses. |
+| `home_team_score` | Int32 | Home team's score. |
+| `home_team_seed` | Int32 | Home team's team seed. |
+| `away_team_id` | Int32 | Unique identifier for the away team. |
+| `away_team_name` | String | Away team name. |
+| `away_team_city` | String | Away team city / location. |
+| `away_team_tricode` | String | Away team three-letter code. |
+| `away_team_slug` | String | Away team's team slug. |
+| `away_team_wins` | Int32 | Away team's team wins. |
+| `away_team_losses` | Int32 | Away team's team losses. |
+| `away_team_score` | Int32 | Away team's score. |
+| `away_team_seed` | Int32 | Away team's team seed. |
+| `season` | Int32 | Season year. |
+| `league_id` | String | League identifier ('10' = WNBA). |
+| `season_type_id` | String | Unique identifier for season type. |
+| `season_type_description` | String | Season type description. |
 
 ```python
 load_nba_stats_schedules(seasons=2025)
@@ -651,35 +651,35 @@ load_nba_stats_schedules(seasons=2025)
 Release: [nba_player_impact](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_player_impact) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_player_impact/nba_player_impact_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `player_id` | Int64 |
-| `player_name` | Utf8 |
-| `team_id` | Int64 |
-| `team_abbreviation` | Utf8 |
-| `team_name` | Utf8 |
-| `teams` | Utf8 |
-| `o_rapm` | Float64 |
-| `d_rapm` | Float64 |
-| `rapm` | Float64 |
-| `off_poss` | Int64 |
-| `def_poss` | Int64 |
-| `o_adj_rapm` | Float64 |
-| `d_adj_rapm` | Float64 |
-| `adj_rapm` | Float64 |
-| `ospm` | Float64 |
-| `dspm` | Float64 |
-| `spm` | Float64 |
-| `min` | Float64 |
-| `gp` | Int64 |
-| `obpm` | Float64 |
-| `dbpm` | Float64 |
-| `bpm` | Float64 |
-| `war` | Float64 |
-| `darko_filtered_skill` | Float64 |
-| `darko_projected_rating` | Float64 |
-| `darko_projected_sd` | Float64 |
-| `season` | Int64 |
+| col_name | type | description |
+|---|---|---|
+| `player_id` | Int64 | Unique player identifier. |
+| `player_name` | Utf8 | Player name. |
+| `team_id` | Int64 | Unique team identifier. |
+| `team_abbreviation` | Utf8 | Short team abbreviation (e.g. 'LAS'). |
+| `team_name` | Utf8 | Full team display name (e.g. 'Las Vegas Aces'). |
+| `teams` | Utf8 | Nested list of member-team membership spans. |
+| `o_rapm` | Float64 |  |
+| `d_rapm` | Float64 |  |
+| `rapm` | Float64 |  |
+| `off_poss` | Int64 |  |
+| `def_poss` | Int64 |  |
+| `o_adj_rapm` | Float64 |  |
+| `d_adj_rapm` | Float64 |  |
+| `adj_rapm` | Float64 |  |
+| `ospm` | Float64 |  |
+| `dspm` | Float64 |  |
+| `spm` | Float64 |  |
+| `min` | Float64 | Minutes played. |
+| `gp` | Int64 | Games played. |
+| `obpm` | Float64 | Offensive box plus/minus. |
+| `dbpm` | Float64 | Defensive box plus/minus. |
+| `bpm` | Float64 | Career box plus/minus. |
+| `war` | Float64 |  |
+| `darko_filtered_skill` | Float64 |  |
+| `darko_projected_rating` | Float64 |  |
+| `darko_projected_sd` | Float64 |  |
+| `season` | Int64 | Season year. |
 
 ```python
 load_nba_player_impact(seasons=2024)

--- a/docs/docs/nhl/reference/loaders.md
+++ b/docs/docs/nhl/reference/loaders.md
@@ -43,111 +43,111 @@ flowchart LR
 Release: [nhl_pbp_full](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nhl_pbp_full) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nhl_pbp_full/play_by_play_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `event_type` | String |
-| `event` | String |
-| `description` | String |
-| `period` | Int32 |
-| `period_seconds` | Int32 |
-| `period_seconds_remaining` | Int32 |
-| `game_seconds` | Int32 |
-| `game_seconds_remaining` | Int32 |
-| `home_score` | Int32 |
-| `away_score` | Int32 |
-| `strength_state` | String |
-| `event_idx` | String |
-| `extra_attacker` | Boolean |
-| `home_skaters` | Int32 |
-| `away_skaters` | Int32 |
-| `game_id` | Int32 |
-| `period_type` | String |
-| `ordinal_num` | String |
-| `period_time` | String |
-| `period_time_remaining` | String |
-| `date_time` | String |
-| `home_final` | Int32 |
-| `away_final` | Int32 |
-| `season` | Int32 |
-| `season_type` | String |
-| `game_date` | String |
-| `game_start` | String |
-| `game_end` | String |
-| `game_length` | Int32 |
-| `game_state` | String |
-| `detailed_state` | String |
-| `venue_name` | String |
-| `venue_link` | String |
-| `home_name` | String |
-| `home_abbreviation` | String |
-| `home_division_name` | String |
-| `home_conference_name` | String |
-| `home_id` | String |
-| `away_name` | String |
-| `away_abbreviation` | String |
-| `away_division_name` | String |
-| `away_conference_name` | String |
-| `away_id` | String |
-| `event_id` | Float64 |
-| `event_team` | String |
-| `event_team_type` | String |
-| `num_on` | Int32 |
-| `players_on` | String |
-| `players_off` | String |
-| `away_on_1` | String |
-| `away_on_2` | String |
-| `away_on_3` | String |
-| `away_on_4` | String |
-| `away_on_5` | String |
-| `away_goalie` | String |
-| `ids_on` | String |
-| `ids_off` | String |
-| `secondary_type` | String |
-| `home_on_1` | String |
-| `home_on_2` | String |
-| `home_on_3` | String |
-| `home_on_4` | String |
-| `home_on_5` | String |
-| `home_goalie` | String |
-| `event_player_1_name` | String |
-| `event_player_1_type` | String |
-| `event_player_2_name` | String |
-| `event_player_2_type` | String |
-| `strength_code` | String |
-| `strength` | String |
-| `x` | Int32 |
-| `y` | Int32 |
-| `x_fixed` | Int32 |
-| `y_fixed` | Int32 |
-| `event_player_1_id` | Int32 |
-| `event_player_1_link` | String |
-| `event_player_2_id` | Int32 |
-| `event_player_2_link` | String |
-| `event_team_id` | Int32 |
-| `event_team_link` | String |
-| `event_team_abbr` | String |
-| `num_off` | Int32 |
-| `event_goalie_name` | String |
-| `shot_distance` | Float64 |
-| `shot_angle` | Float64 |
-| `event_goalie_id` | Int32 |
-| `event_goalie_link` | String |
-| `event_goalie_type` | String |
-| `event_player_3_name` | String |
-| `event_player_3_type` | String |
-| `game_winning_goal` | Boolean |
-| `empty_net` | Boolean |
-| `event_player_3_id` | Int32 |
-| `event_player_3_link` | String |
-| `event_player_4_type` | String |
-| `event_player_4_id` | Int32 |
-| `event_player_4_name` | String |
-| `event_player_4_link` | String |
-| `penalty_severity` | String |
-| `penalty_minutes` | Int32 |
-| `home_on_6` | String |
-| `venue_id` | Int32 |
-| `away_on_6` | String |
+| col_name | type | description |
+|---|---|---|
+| `event_type` | String | Standardized event type code. |
+| `event` | String | Event description label. |
+| `description` | String | Full text description of the event. |
+| `period` | Int32 | Period number. |
+| `period_seconds` | Int32 | Elapsed seconds in the period. |
+| `period_seconds_remaining` | Int32 | Seconds remaining in the period. |
+| `game_seconds` | Int32 | Elapsed seconds in the game. |
+| `game_seconds_remaining` | Int32 | Seconds remaining in regulation. |
+| `home_score` | Int32 | Home team final score. |
+| `away_score` | Int32 | Away team final score. |
+| `strength_state` | String | Strength state (e.g. 5v5, 5v4). |
+| `event_idx` | String | Sequential event index within the game. |
+| `extra_attacker` | Boolean | Whether an extra attacker was on the ice. |
+| `home_skaters` | Int32 | Number of home skaters on the ice. |
+| `away_skaters` | Int32 | Number of away skaters on the ice. |
+| `game_id` | Int32 | Unique game identifier. |
+| `period_type` | String | Period type (REG/OT/SO). |
+| `ordinal_num` | String | Inning ordinal label (e.g. 1st). |
+| `period_time` | String | Elapsed time in the period (MM:SS). |
+| `period_time_remaining` | String | Time remaining in the period (MM:SS). |
+| `date_time` | String |  |
+| `home_final` | Int32 |  |
+| `away_final` | Int32 |  |
+| `season` | Int32 | Season year (echoed from arg). |
+| `season_type` | String | Season type code (echoed from arg). |
+| `game_date` | String | Game date. |
+| `game_start` | String |  |
+| `game_end` | String |  |
+| `game_length` | Int32 |  |
+| `game_state` | String | Game state (e.g., FINAL, LIVE). |
+| `detailed_state` | String | Detailed status description (e.g. 'Scheduled', 'Pre-Game', 'In Progress'). |
+| `venue_name` | String | Name of the venue. |
+| `venue_link` | String | API link to the venue. |
+| `home_name` | String | Home team display name. |
+| `home_abbreviation` | String | Home team abbreviation. |
+| `home_division_name` | String |  |
+| `home_conference_name` | String |  |
+| `home_id` | String | Home team ESPN identifier. |
+| `away_name` | String | Away team display name. |
+| `away_abbreviation` | String | Away team abbreviation. |
+| `away_division_name` | String |  |
+| `away_conference_name` | String |  |
+| `away_id` | String | Away team ESPN identifier. |
+| `event_id` | Float64 | ESPN event id (echoed from arg). |
+| `event_team` | String | Team associated with the shift change. |
+| `event_team_type` | String | Whether the event team is home or away. |
+| `num_on` | Int32 | Number of players coming on (line change). |
+| `players_on` | String | Names of players coming on. |
+| `players_off` | String | Names of players going off. |
+| `away_on_1` | String | Name of away skater 1 on the ice. |
+| `away_on_2` | String | Name of away skater 2 on the ice. |
+| `away_on_3` | String | Name of away skater 3 on the ice. |
+| `away_on_4` | String | Name of away skater 4 on the ice. |
+| `away_on_5` | String | Name of away skater 5 on the ice. |
+| `away_goalie` | String | Name of the away goalie on the ice. |
+| `ids_on` | String | Player ids coming on. |
+| `ids_off` | String | Player ids going off. |
+| `secondary_type` | String | Secondary event type (e.g. shot type). |
+| `home_on_1` | String | Name of home skater 1 on the ice. |
+| `home_on_2` | String | Name of home skater 2 on the ice. |
+| `home_on_3` | String | Name of home skater 3 on the ice. |
+| `home_on_4` | String | Name of home skater 4 on the ice. |
+| `home_on_5` | String | Name of home skater 5 on the ice. |
+| `home_goalie` | String | Name of the home goalie on the ice. |
+| `event_player_1_name` | String | Name of the primary event player. |
+| `event_player_1_type` | String | Role of the primary event player. |
+| `event_player_2_name` | String | Name of the secondary event player. |
+| `event_player_2_type` | String | Role of the secondary event player. |
+| `strength_code` | String | Strength state code (e.g., all, even, pp, pk). |
+| `strength` | String | Strength label (Even, Power Play, Shorthanded). |
+| `x` | Int32 | Raw x-coordinate of the event. |
+| `y` | Int32 | Raw y-coordinate of the event. |
+| `x_fixed` | Int32 | Normalized x coordinate (home shoots right). |
+| `y_fixed` | Int32 | Normalized y coordinate (home shoots right). |
+| `event_player_1_id` | Int32 | Player id of the primary event player. |
+| `event_player_1_link` | String |  |
+| `event_player_2_id` | Int32 | Player id of the secondary event player. |
+| `event_player_2_link` | String |  |
+| `event_team_id` | Int32 |  |
+| `event_team_link` | String |  |
+| `event_team_abbr` | String | Abbreviation of the team credited with the event. |
+| `num_off` | Int32 | Number of players going off (line change). |
+| `event_goalie_name` | String | Name of the goalie on the event. |
+| `shot_distance` | Float64 | Distance of the shot from the net. |
+| `shot_angle` | Float64 | Angle of the shot relative to the net. |
+| `event_goalie_id` | Int32 | Player id of the goalie on the event. |
+| `event_goalie_link` | String |  |
+| `event_goalie_type` | String |  |
+| `event_player_3_name` | String | Name of the tertiary event player. |
+| `event_player_3_type` | String | Role of the tertiary event player. |
+| `game_winning_goal` | Boolean |  |
+| `empty_net` | Boolean | Whether the net was empty. |
+| `event_player_3_id` | Int32 | Player ID of the tertiary event player. |
+| `event_player_3_link` | String |  |
+| `event_player_4_type` | String |  |
+| `event_player_4_id` | Int32 |  |
+| `event_player_4_name` | String |  |
+| `event_player_4_link` | String |  |
+| `penalty_severity` | String | Severity of the penalty. |
+| `penalty_minutes` | Int32 | Penalty minutes. |
+| `home_on_6` | String | Name of home skater 6 on the ice. |
+| `venue_id` | Int32 | Venue identifier. |
+| `away_on_6` | String | Name of away skater 6 on the ice. |
 
 ```python
 load_nhl_pbp(seasons=2024)
@@ -158,58 +158,58 @@ load_nhl_pbp(seasons=2024)
 Release: [nhl_player_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nhl_player_boxscores) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nhl_player_boxscores/player_box_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `player_id` | Int32 |
-| `player_full_name` | String |
-| `link` | String |
-| `shoots_catches` | String |
-| `roster_status` | String |
-| `jersey_number` | String |
-| `position_code` | String |
-| `position_name` | String |
-| `position_type` | String |
-| `position_abbreviation` | String |
-| `skater_stats_time_on_ice` | String |
-| `skater_stats_assists` | Int32 |
-| `skater_stats_goals` | Int32 |
-| `skater_stats_shots` | Int32 |
-| `skater_stats_hits` | Int32 |
-| `skater_stats_power_play_goals` | Int32 |
-| `skater_stats_power_play_assists` | Int32 |
-| `skater_stats_penalty_minutes` | Int32 |
-| `skater_stats_face_off_wins` | Int32 |
-| `skater_stats_faceoff_taken` | Int32 |
-| `skater_stats_takeaways` | Int32 |
-| `skater_stats_giveaways` | Int32 |
-| `skater_stats_short_handed_goals` | Int32 |
-| `skater_stats_short_handed_assists` | Int32 |
-| `skater_stats_blocked` | Int32 |
-| `skater_stats_plus_minus` | Int32 |
-| `skater_stats_even_time_on_ice` | String |
-| `skater_stats_power_play_time_on_ice` | String |
-| `skater_stats_short_handed_time_on_ice` | String |
-| `home_away` | String |
-| `skater_stats_face_off_pct` | Float64 |
-| `goalie_stats_time_on_ice` | String |
-| `goalie_stats_assists` | Int32 |
-| `goalie_stats_goals` | Int32 |
-| `goalie_stats_pim` | Int32 |
-| `goalie_stats_shots` | Int32 |
-| `goalie_stats_saves` | Int32 |
-| `goalie_stats_power_play_saves` | Int32 |
-| `goalie_stats_short_handed_saves` | Int32 |
-| `goalie_stats_even_saves` | Int32 |
-| `goalie_stats_short_handed_shots_against` | Int32 |
-| `goalie_stats_even_shots_against` | Int32 |
-| `goalie_stats_power_play_shots_against` | Int32 |
-| `goalie_stats_decision` | String |
-| `goalie_stats_save_percentage` | Float64 |
-| `goalie_stats_power_play_save_percentage` | Float64 |
-| `goalie_stats_even_strength_save_percentage` | Float64 |
-| `goalie_stats_short_handed_save_percentage` | Float64 |
-| `game_id` | Int32 |
-| `season` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `player_id` | Int32 | Unique player identifier. |
+| `player_full_name` | String | Player full name. |
+| `link` | String | API link to the game feed. |
+| `shoots_catches` | String | Handedness (shoots/catches). |
+| `roster_status` | String | Payroll table the row came from: Active, IL, or Retained Salary. |
+| `jersey_number` | String | Jersey number. |
+| `position_code` | String | Player position code. |
+| `position_name` | String | Official position name (e.g. "Referee", "Linesman"). |
+| `position_type` | String | Position category (e.g. 'Pitcher', 'Infielder'). |
+| `position_abbreviation` | String | Position abbreviation. |
+| `skater_stats_time_on_ice` | String |  |
+| `skater_stats_assists` | Int32 |  |
+| `skater_stats_goals` | Int32 |  |
+| `skater_stats_shots` | Int32 |  |
+| `skater_stats_hits` | Int32 |  |
+| `skater_stats_power_play_goals` | Int32 |  |
+| `skater_stats_power_play_assists` | Int32 |  |
+| `skater_stats_penalty_minutes` | Int32 |  |
+| `skater_stats_face_off_wins` | Int32 |  |
+| `skater_stats_faceoff_taken` | Int32 |  |
+| `skater_stats_takeaways` | Int32 |  |
+| `skater_stats_giveaways` | Int32 |  |
+| `skater_stats_short_handed_goals` | Int32 |  |
+| `skater_stats_short_handed_assists` | Int32 |  |
+| `skater_stats_blocked` | Int32 |  |
+| `skater_stats_plus_minus` | Int32 |  |
+| `skater_stats_even_time_on_ice` | String |  |
+| `skater_stats_power_play_time_on_ice` | String |  |
+| `skater_stats_short_handed_time_on_ice` | String |  |
+| `home_away` | String | Home or away indicator. |
+| `skater_stats_face_off_pct` | Float64 |  |
+| `goalie_stats_time_on_ice` | String |  |
+| `goalie_stats_assists` | Int32 |  |
+| `goalie_stats_goals` | Int32 |  |
+| `goalie_stats_pim` | Int32 |  |
+| `goalie_stats_shots` | Int32 |  |
+| `goalie_stats_saves` | Int32 |  |
+| `goalie_stats_power_play_saves` | Int32 |  |
+| `goalie_stats_short_handed_saves` | Int32 |  |
+| `goalie_stats_even_saves` | Int32 |  |
+| `goalie_stats_short_handed_shots_against` | Int32 |  |
+| `goalie_stats_even_shots_against` | Int32 |  |
+| `goalie_stats_power_play_shots_against` | Int32 |  |
+| `goalie_stats_decision` | String |  |
+| `goalie_stats_save_percentage` | Float64 |  |
+| `goalie_stats_power_play_save_percentage` | Float64 |  |
+| `goalie_stats_even_strength_save_percentage` | Float64 |  |
+| `goalie_stats_short_handed_save_percentage` | Float64 |  |
+| `game_id` | Int32 | Unique game identifier. |
+| `season` | Int32 | Season year (echoed from arg). |
 
 ```python
 load_nhl_player_boxscore(seasons=2024)
@@ -220,36 +220,36 @@ load_nhl_player_boxscore(seasons=2024)
 Release: [nhl_schedules](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nhl_schedules) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nhl_schedules/nhl_schedule_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int32 |
-| `link` | String |
-| `game_type_abbreviation` | String |
-| `season_full` | Int32 |
-| `game_date_time` | Datetime(time_unit='us', time_zone='UTC') |
-| `status_abstract_game_state` | String |
-| `status_coded_game_state` | Int32 |
-| `status_detailed_state` | String |
-| `status_status_code` | Int32 |
-| `status_start_time_tbd` | Boolean |
-| `away_score` | Int32 |
-| `away_team_id` | Int32 |
-| `away_team_name` | String |
-| `away_team_link` | String |
-| `home_score` | Int32 |
-| `home_team_id` | Int32 |
-| `home_team_name` | String |
-| `home_team_link` | String |
-| `venue_name` | String |
-| `venue_link` | String |
-| `venue_id` | Int32 |
-| `content_link` | String |
-| `game_type` | String |
-| `game_date` | Date |
-| `season` | Int32 |
-| `PBP` | Boolean |
-| `team_box` | Boolean |
-| `player_box` | Boolean |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int32 | Unique game identifier. |
+| `link` | String | API link to the game feed. |
+| `game_type_abbreviation` | String |  |
+| `season_full` | Int32 | Full season label (e.g. 20212022). |
+| `game_date_time` | Datetime(time_unit='us', time_zone='UTC') | Game start date/time (ISO 8601). |
+| `status_abstract_game_state` | String | Abstract game state (e.g. 'Final'). |
+| `status_coded_game_state` | Int32 | Coded game state. |
+| `status_detailed_state` | String | Detailed game state. |
+| `status_status_code` | Int32 | Status code for the game. |
+| `status_start_time_tbd` | Boolean | Whether the start time is TBD. |
+| `away_score` | Int32 | Away team final score. |
+| `away_team_id` | Int32 | Away team identifier. |
+| `away_team_name` | String | Away team name. |
+| `away_team_link` | String | MLB Stats API relative away team link. |
+| `home_score` | Int32 | Home team final score. |
+| `home_team_id` | Int32 | Home team identifier. |
+| `home_team_name` | String | Home team name. |
+| `home_team_link` | String | MLB Stats API relative home team link. |
+| `venue_name` | String | Name of the venue. |
+| `venue_link` | String | API link to the venue. |
+| `venue_id` | Int32 | Venue identifier. |
+| `content_link` | String | API link to the game content. |
+| `game_type` | String | Game type the row belongs to. |
+| `game_date` | Date | Game date. |
+| `season` | Int32 | Season year (echoed from arg). |
+| `PBP` | Boolean | Whether play-by-play data is available. |
+| `team_box` | Boolean | Whether team box score data is available. |
+| `player_box` | Boolean | Whether player box score data is available. |
 
 ```python
 load_nhl_schedule(seasons=2024)
@@ -260,26 +260,26 @@ load_nhl_schedule(seasons=2024)
 Release: [nhl_team_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nhl_team_boxscores) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nhl_team_boxscores/team_box_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `team_id` | Int32 |
-| `team_name` | String |
-| `link` | String |
-| `abbreviation` | String |
-| `tri_code` | String |
-| `goals` | Int32 |
-| `pim` | Int32 |
-| `shots` | Int32 |
-| `power_play_percentage` | String |
-| `power_play_goals` | Int32 |
-| `power_play_opportunities` | Int32 |
-| `face_off_win_percentage` | String |
-| `blocked` | Int32 |
-| `takeaways` | Int32 |
-| `giveaways` | Int32 |
-| `hits` | Int32 |
-| `game_id` | Int32 |
-| `season` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `team_id` | Int32 | Unique team identifier. |
+| `team_name` | String | Team name. |
+| `link` | String | API link to the game feed. |
+| `abbreviation` | String | Team abbreviation. |
+| `tri_code` | String | Team three-letter code. |
+| `goals` | Int32 | Goals scored. |
+| `pim` | Int32 | Penalty minutes. |
+| `shots` | Int32 | Shots on goal. |
+| `power_play_percentage` | String |  |
+| `power_play_goals` | Int32 | Power-play goals. |
+| `power_play_opportunities` | Int32 | Power play opportunities. |
+| `face_off_win_percentage` | String |  |
+| `blocked` | Int32 |  |
+| `takeaways` | Int32 | Takeaways. |
+| `giveaways` | Int32 | Giveaways. |
+| `hits` | Int32 | Hits. |
+| `game_id` | Int32 | Unique game identifier. |
+| `season` | Int32 | Season year (echoed from arg). |
 
 ```python
 load_nhl_team_boxscore(seasons=2024)
@@ -290,18 +290,18 @@ load_nhl_team_boxscore(seasons=2024)
 Release: [nhl_game_info](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nhl_game_info) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nhl_game_info/game_info_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int32 |
-| `season` | Int32 |
-| `game_type` | String |
-| `game_date` | String |
-| `venue` | String |
-| `home_team_abbr` | String |
-| `away_team_abbr` | String |
-| `home_score` | Int32 |
-| `away_score` | Int32 |
-| `game_state` | String |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int32 | Unique game identifier. |
+| `season` | Int32 | Season year (echoed from arg). |
+| `game_type` | String | Game type the row belongs to. |
+| `game_date` | String | Game date. |
+| `venue` | String | Venue where the game was played. |
+| `home_team_abbr` | String | Home team abbreviation. |
+| `away_team_abbr` | String | Away team abbreviation. |
+| `home_score` | Int32 | Home team final score. |
+| `away_score` | Int32 | Away team final score. |
+| `game_state` | String | Game state (e.g., FINAL, LIVE). |
 
 ```python
 load_nhl_game_info(seasons=2024)
@@ -312,19 +312,19 @@ load_nhl_game_info(seasons=2024)
 Release: [nhl_game_rosters](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nhl_game_rosters) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nhl_game_rosters/game_rosters_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `player_id` | Int32 |
-| `full_name` | String |
-| `first_name` | String |
-| `last_name` | String |
-| `team_abbr` | String |
-| `team_id` | Int32 |
-| `position_code` | String |
-| `sweater_number` | Int32 |
-| `game_id` | Int32 |
-| `season` | Int32 |
-| `game_date` | String |
+| col_name | type | description |
+|---|---|---|
+| `player_id` | Int32 | Unique player identifier. |
+| `full_name` | String | Player full name. |
+| `first_name` | String | Player first name. |
+| `last_name` | String | Player last name. |
+| `team_abbr` | String | Team abbreviation. |
+| `team_id` | Int32 | Unique team identifier. |
+| `position_code` | String | Player position code. |
+| `sweater_number` | Int32 | Jersey number. |
+| `game_id` | Int32 | Unique game identifier. |
+| `season` | Int32 | Season year (echoed from arg). |
+| `game_date` | String | Game date. |
 
 ```python
 load_nhl_game_rosters(seasons=2024)
@@ -335,32 +335,32 @@ load_nhl_game_rosters(seasons=2024)
 Release: [nhl_goalie_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nhl_goalie_boxscores) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nhl_goalie_boxscores/goalie_box_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `home_away` | String |
-| `team_id` | Int32 |
-| `team_abbrev` | String |
-| `player_id` | Int32 |
-| `player_name` | String |
-| `sweater_number` | Int32 |
-| `even_strength_shots_against` | String |
-| `power_play_shots_against` | String |
-| `shorthanded_shots_against` | String |
-| `save_shots_against` | String |
-| `save_pctg` | Float64 |
-| `even_strength_goals_against` | Int32 |
-| `power_play_goals_against` | Int32 |
-| `shorthanded_goals_against` | Int32 |
-| `pim` | Int32 |
-| `goals_against` | Int32 |
-| `toi` | String |
-| `starter` | Boolean |
-| `decision` | String |
-| `shots_against` | Int32 |
-| `saves` | Int32 |
-| `game_id` | Int32 |
-| `season` | Int32 |
-| `game_date` | String |
+| col_name | type | description |
+|---|---|---|
+| `home_away` | String | Home or away indicator. |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_abbrev` | String | Team abbreviation. |
+| `player_id` | Int32 | Unique player identifier. |
+| `player_name` | String | Player name. |
+| `sweater_number` | Int32 | Jersey number. |
+| `even_strength_shots_against` | String | Even-strength shots against (saves/total). |
+| `power_play_shots_against` | String | Power-play shots against (saves/total). |
+| `shorthanded_shots_against` | String | Shorthanded shots against (saves/total). |
+| `save_shots_against` | String | Total shots against (saves/total). |
+| `save_pctg` | Float64 | Save percentage. |
+| `even_strength_goals_against` | Int32 | Even-strength goals against. |
+| `power_play_goals_against` | Int32 | Power-play goals against. |
+| `shorthanded_goals_against` | Int32 | Shorthanded goals against. |
+| `pim` | Int32 | Penalty minutes. |
+| `goals_against` | Int32 | Goals against. |
+| `toi` | String | Time on ice. |
+| `starter` | Boolean | Whether the goalie started the game. |
+| `decision` | String | Goalie decision (W/L/O). |
+| `shots_against` | Int32 | Shots faced. |
+| `saves` | Int32 | Saves made. |
+| `game_id` | Int32 | Unique game identifier. |
+| `season` | Int32 | Season year (echoed from arg). |
+| `game_date` | String | Game date. |
 
 ```python
 load_nhl_goalie_boxscores(seasons=2024)
@@ -371,18 +371,18 @@ load_nhl_goalie_boxscores(seasons=2024)
 Release: [nhl_linescore](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nhl_linescore) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nhl_linescore/linescore_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int32 |
-| `home_team_id` | Int32 |
-| `home_team_abbr` | String |
-| `home_goals` | Int32 |
-| `home_shots` | Int32 |
-| `away_team_id` | Int32 |
-| `away_team_abbr` | String |
-| `away_goals` | Int32 |
-| `away_shots` | Int32 |
-| `has_shootout` | Boolean |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int32 | Unique game identifier. |
+| `home_team_id` | Int32 | Home team identifier. |
+| `home_team_abbr` | String | Home team abbreviation. |
+| `home_goals` | Int32 | Home goals in the period. |
+| `home_shots` | Int32 | Home team shots in the period. |
+| `away_team_id` | Int32 | Away team identifier. |
+| `away_team_abbr` | String | Away team abbreviation. |
+| `away_goals` | Int32 | Away goals in the period. |
+| `away_shots` | Int32 | Away team shots in the period. |
+| `has_shootout` | Boolean | Flag for whether the game went to shootout. |
 
 ```python
 load_nhl_linescore(seasons=2024)
@@ -393,13 +393,13 @@ load_nhl_linescore(seasons=2024)
 Release: [nhl_officials](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nhl_officials) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nhl_officials/officials_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `role` | String |
-| `name` | String |
-| `game_id` | Int32 |
-| `season` | Int32 |
-| `game_date` | String |
+| col_name | type | description |
+|---|---|---|
+| `role` | String | Grouped official role (Referee/Linesperson). |
+| `name` | String | Team mascot name. |
+| `game_id` | Int32 | Unique game identifier. |
+| `season` | Int32 | Season year (echoed from arg). |
+| `game_date` | String | Game date. |
 
 ```python
 load_nhl_officials(seasons=2025)
@@ -410,61 +410,61 @@ load_nhl_officials(seasons=2025)
 Release: [nhl_pbp_full](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nhl_pbp_full) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nhl_pbp_full/play_by_play_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `event_type` | String |
-| `event` | String |
-| `secondary_type` | String |
-| `event_team_abbr` | String |
-| `event_team_type` | String |
-| `description` | String |
-| `period` | Int32 |
-| `period_type` | String |
-| `period_time` | String |
-| `period_seconds` | Int32 |
-| `period_seconds_remaining` | Int32 |
-| `period_time_remaining` | String |
-| `game_seconds` | Int32 |
-| `game_seconds_remaining` | Int32 |
-| `home_score` | Int32 |
-| `away_score` | Int32 |
-| `event_player_1_name` | String |
-| `event_player_1_type` | String |
-| `event_player_1_id` | Int32 |
-| `event_player_2_name` | String |
-| `event_player_2_type` | String |
-| `event_player_2_id` | Int32 |
-| `event_player_3_name` | String |
-| `event_player_3_type` | String |
-| `event_player_3_id` | Int32 |
-| `event_goalie_name` | String |
-| `event_goalie_id` | Int32 |
-| `penalty_severity` | String |
-| `penalty_minutes` | Int32 |
-| `empty_net` | Boolean |
-| `extra_attacker` | Boolean |
-| `x` | Int32 |
-| `y` | Int32 |
-| `x_fixed` | Int32 |
-| `y_fixed` | Int32 |
-| `shot_distance` | Float64 |
-| `shot_angle` | Float64 |
-| `home_skaters` | Int32 |
-| `away_skaters` | Int32 |
-| `players_on` | Boolean |
-| `players_off` | Boolean |
-| `game_id` | Int32 |
-| `season` | Int32 |
-| `season_type` | String |
-| `home_abbr` | String |
-| `away_abbr` | String |
-| `event_idx` | Int32 |
-| `event_id` | Int32 |
-| `away_goalie_in` | Int32 |
-| `home_goalie_in` | Int32 |
-| `reason` | String |
-| `secondaryReason` | String |
-| `xg` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `event_type` | String | Standardized event type code. |
+| `event` | String | Event description label. |
+| `secondary_type` | String | Secondary event type (e.g. shot type). |
+| `event_team_abbr` | String | Abbreviation of the team credited with the event. |
+| `event_team_type` | String | Whether the event team is home or away. |
+| `description` | String | Full text description of the event. |
+| `period` | Int32 | Period number. |
+| `period_type` | String | Period type (REG/OT/SO). |
+| `period_time` | String | Elapsed time in the period (MM:SS). |
+| `period_seconds` | Int32 | Elapsed seconds in the period. |
+| `period_seconds_remaining` | Int32 | Seconds remaining in the period. |
+| `period_time_remaining` | String | Time remaining in the period (MM:SS). |
+| `game_seconds` | Int32 | Elapsed seconds in the game. |
+| `game_seconds_remaining` | Int32 | Seconds remaining in regulation. |
+| `home_score` | Int32 | Home team final score. |
+| `away_score` | Int32 | Away team final score. |
+| `event_player_1_name` | String | Name of the primary event player. |
+| `event_player_1_type` | String | Role of the primary event player. |
+| `event_player_1_id` | Int32 | Player id of the primary event player. |
+| `event_player_2_name` | String | Name of the secondary event player. |
+| `event_player_2_type` | String | Role of the secondary event player. |
+| `event_player_2_id` | Int32 | Player id of the secondary event player. |
+| `event_player_3_name` | String | Name of the tertiary event player. |
+| `event_player_3_type` | String | Role of the tertiary event player. |
+| `event_player_3_id` | Int32 | Player ID of the tertiary event player. |
+| `event_goalie_name` | String | Name of the goalie on the event. |
+| `event_goalie_id` | Int32 | Player id of the goalie on the event. |
+| `penalty_severity` | String | Severity of the penalty. |
+| `penalty_minutes` | Int32 | Penalty minutes. |
+| `empty_net` | Boolean | Whether the net was empty. |
+| `extra_attacker` | Boolean | Whether an extra attacker was on the ice. |
+| `x` | Int32 | Raw x-coordinate of the event. |
+| `y` | Int32 | Raw y-coordinate of the event. |
+| `x_fixed` | Int32 | Normalized x coordinate (home shoots right). |
+| `y_fixed` | Int32 | Normalized y coordinate (home shoots right). |
+| `shot_distance` | Float64 | Distance of the shot from the net. |
+| `shot_angle` | Float64 | Angle of the shot relative to the net. |
+| `home_skaters` | Int32 | Number of home skaters on the ice. |
+| `away_skaters` | Int32 | Number of away skaters on the ice. |
+| `players_on` | Boolean | Names of players coming on. |
+| `players_off` | Boolean | Names of players going off. |
+| `game_id` | Int32 | Unique game identifier. |
+| `season` | Int32 | Season year (echoed from arg). |
+| `season_type` | String | Season type code (echoed from arg). |
+| `home_abbr` | String | Home team abbreviation. |
+| `away_abbr` | String | Away team abbreviation. |
+| `event_idx` | Int32 | Sequential event index within the game. |
+| `event_id` | Int32 | ESPN event id (echoed from arg). |
+| `away_goalie_in` | Int32 | Whether the away goalie is on the ice (1/0). |
+| `home_goalie_in` | Int32 | Whether the home goalie is on the ice (1/0). |
+| `reason` | String | Reason for the event (e.g. stoppage reason). |
+| `secondaryReason` | String | Secondary reason for a stoppage. |
+| `xg` | Float64 | Expected goals value for the shot event. |
 
 ```python
 load_nhl_pbp_full(seasons=2010)
@@ -475,61 +475,61 @@ load_nhl_pbp_full(seasons=2010)
 Release: [nhl_pbp_lite](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nhl_pbp_lite) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nhl_pbp_lite/play_by_play_{season}_lite.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `event_type` | String |
-| `event` | String |
-| `secondary_type` | String |
-| `event_team_abbr` | String |
-| `event_team_type` | String |
-| `description` | String |
-| `period` | Int32 |
-| `period_type` | String |
-| `period_time` | String |
-| `period_seconds` | Int32 |
-| `period_seconds_remaining` | Int32 |
-| `period_time_remaining` | String |
-| `game_seconds` | Int32 |
-| `game_seconds_remaining` | Int32 |
-| `home_score` | Int32 |
-| `away_score` | Int32 |
-| `event_player_1_name` | String |
-| `event_player_1_type` | String |
-| `event_player_1_id` | Int32 |
-| `event_player_2_name` | String |
-| `event_player_2_type` | String |
-| `event_player_2_id` | Int32 |
-| `event_player_3_name` | String |
-| `event_player_3_type` | String |
-| `event_player_3_id` | Int32 |
-| `event_goalie_name` | String |
-| `event_goalie_id` | Int32 |
-| `penalty_severity` | String |
-| `penalty_minutes` | Int32 |
-| `empty_net` | Boolean |
-| `extra_attacker` | Boolean |
-| `x` | Int32 |
-| `y` | Int32 |
-| `x_fixed` | Int32 |
-| `y_fixed` | Int32 |
-| `shot_distance` | Float64 |
-| `shot_angle` | Float64 |
-| `home_skaters` | Int32 |
-| `away_skaters` | Int32 |
-| `players_on` | Boolean |
-| `players_off` | Boolean |
-| `game_id` | Int32 |
-| `season` | Int32 |
-| `season_type` | String |
-| `home_abbr` | String |
-| `away_abbr` | String |
-| `event_idx` | Int32 |
-| `event_id` | Int32 |
-| `away_goalie_in` | Int32 |
-| `home_goalie_in` | Int32 |
-| `reason` | String |
-| `secondaryReason` | String |
-| `xg` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `event_type` | String | Standardized event type code. |
+| `event` | String | Event description label. |
+| `secondary_type` | String | Secondary event type (e.g. shot type). |
+| `event_team_abbr` | String | Abbreviation of the team credited with the event. |
+| `event_team_type` | String | Whether the event team is home or away. |
+| `description` | String | Full text description of the event. |
+| `period` | Int32 | Period number. |
+| `period_type` | String | Period type (REG/OT/SO). |
+| `period_time` | String | Elapsed time in the period (MM:SS). |
+| `period_seconds` | Int32 | Elapsed seconds in the period. |
+| `period_seconds_remaining` | Int32 | Seconds remaining in the period. |
+| `period_time_remaining` | String | Time remaining in the period (MM:SS). |
+| `game_seconds` | Int32 | Elapsed seconds in the game. |
+| `game_seconds_remaining` | Int32 | Seconds remaining in regulation. |
+| `home_score` | Int32 | Home team final score. |
+| `away_score` | Int32 | Away team final score. |
+| `event_player_1_name` | String | Name of the primary event player. |
+| `event_player_1_type` | String | Role of the primary event player. |
+| `event_player_1_id` | Int32 | Player id of the primary event player. |
+| `event_player_2_name` | String | Name of the secondary event player. |
+| `event_player_2_type` | String | Role of the secondary event player. |
+| `event_player_2_id` | Int32 | Player id of the secondary event player. |
+| `event_player_3_name` | String | Name of the tertiary event player. |
+| `event_player_3_type` | String | Role of the tertiary event player. |
+| `event_player_3_id` | Int32 | Player ID of the tertiary event player. |
+| `event_goalie_name` | String | Name of the goalie on the event. |
+| `event_goalie_id` | Int32 | Player id of the goalie on the event. |
+| `penalty_severity` | String | Severity of the penalty. |
+| `penalty_minutes` | Int32 | Penalty minutes. |
+| `empty_net` | Boolean | Whether the net was empty. |
+| `extra_attacker` | Boolean | Whether an extra attacker was on the ice. |
+| `x` | Int32 | Raw x-coordinate of the event. |
+| `y` | Int32 | Raw y-coordinate of the event. |
+| `x_fixed` | Int32 | Normalized x coordinate (home shoots right). |
+| `y_fixed` | Int32 | Normalized y coordinate (home shoots right). |
+| `shot_distance` | Float64 | Distance of the shot from the net. |
+| `shot_angle` | Float64 | Angle of the shot relative to the net. |
+| `home_skaters` | Int32 | Number of home skaters on the ice. |
+| `away_skaters` | Int32 | Number of away skaters on the ice. |
+| `players_on` | Boolean | Names of players coming on. |
+| `players_off` | Boolean | Names of players going off. |
+| `game_id` | Int32 | Unique game identifier. |
+| `season` | Int32 | Season year (echoed from arg). |
+| `season_type` | String | Season type code (echoed from arg). |
+| `home_abbr` | String | Home team abbreviation. |
+| `away_abbr` | String | Away team abbreviation. |
+| `event_idx` | Int32 | Sequential event index within the game. |
+| `event_id` | Int32 | ESPN event id (echoed from arg). |
+| `away_goalie_in` | Int32 | Whether the away goalie is on the ice (1/0). |
+| `home_goalie_in` | Int32 | Whether the home goalie is on the ice (1/0). |
+| `reason` | String | Reason for the event (e.g. stoppage reason). |
+| `secondaryReason` | String | Secondary reason for a stoppage. |
+| `xg` | Float64 | Expected goals value for the shot event. |
 
 ```python
 load_nhl_pbp_lite(seasons=2010)
@@ -540,57 +540,57 @@ load_nhl_pbp_lite(seasons=2010)
 Release: [nhl_penalties](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nhl_penalties) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nhl_penalties/penalties_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `timeInPeriod` | String |
-| `type` | String |
-| `duration` | Int32 |
-| `descKey` | String |
-| `game_id` | Int32 |
-| `period_number` | Int32 |
-| `period_type` | String |
-| `committedByPlayer.sweaterNumber` | Int32 |
-| `committedByPlayer.firstName.default` | String |
-| `committedByPlayer.firstName.cs` | String |
-| `committedByPlayer.firstName.de` | String |
-| `committedByPlayer.firstName.es` | String |
-| `committedByPlayer.firstName.fi` | String |
-| `committedByPlayer.firstName.sk` | String |
-| `committedByPlayer.firstName.sv` | String |
-| `committedByPlayer.firstName.fr` | String |
-| `committedByPlayer.lastName.default` | String |
-| `committedByPlayer.lastName.cs` | String |
-| `committedByPlayer.lastName.fi` | String |
-| `committedByPlayer.lastName.sk` | String |
-| `committedByPlayer.lastName.sv` | String |
-| `committedByPlayer.lastName.de` | String |
-| `committedByPlayer.lastName.es` | String |
-| `committedByPlayer.lastName.fr` | String |
-| `teamAbbrev.default` | String |
-| `drawnBy.sweaterNumber` | Int32 |
-| `drawnBy.firstName.default` | String |
-| `drawnBy.firstName.cs` | String |
-| `drawnBy.firstName.fi` | String |
-| `drawnBy.firstName.sk` | String |
-| `drawnBy.firstName.de` | String |
-| `drawnBy.firstName.es` | String |
-| `drawnBy.firstName.sv` | String |
-| `drawnBy.firstName.fr` | String |
-| `drawnBy.lastName.default` | String |
-| `drawnBy.lastName.cs` | String |
-| `drawnBy.lastName.fi` | String |
-| `drawnBy.lastName.sk` | String |
-| `drawnBy.lastName.sv` | String |
-| `drawnBy.lastName.de` | String |
-| `drawnBy.lastName.es` | String |
-| `drawnBy.lastName.fr` | String |
-| `servedBy.default` | String |
-| `servedBy.cs` | String |
-| `servedBy.fi` | String |
-| `servedBy.sk` | String |
-| `servedBy.de` | String |
-| `servedBy.es` | String |
-| `servedBy.sv` | String |
+| col_name | type | description |
+|---|---|---|
+| `timeInPeriod` | String | Time within the period the penalty occurred. |
+| `type` | String | Competitor type (e.g. "team"). |
+| `duration` | Int32 | Penalty duration in minutes. |
+| `descKey` | String | Penalty description key. |
+| `game_id` | Int32 | Unique game identifier. |
+| `period_number` | Int32 | Period number (1-3 regulation, 4+ OT). |
+| `period_type` | String | Period type (REG/OT/SO). |
+| `committedByPlayer.sweaterNumber` | Int32 |  |
+| `committedByPlayer.firstName.default` | String |  |
+| `committedByPlayer.firstName.cs` | String |  |
+| `committedByPlayer.firstName.de` | String |  |
+| `committedByPlayer.firstName.es` | String |  |
+| `committedByPlayer.firstName.fi` | String |  |
+| `committedByPlayer.firstName.sk` | String |  |
+| `committedByPlayer.firstName.sv` | String |  |
+| `committedByPlayer.firstName.fr` | String |  |
+| `committedByPlayer.lastName.default` | String |  |
+| `committedByPlayer.lastName.cs` | String |  |
+| `committedByPlayer.lastName.fi` | String |  |
+| `committedByPlayer.lastName.sk` | String |  |
+| `committedByPlayer.lastName.sv` | String |  |
+| `committedByPlayer.lastName.de` | String |  |
+| `committedByPlayer.lastName.es` | String |  |
+| `committedByPlayer.lastName.fr` | String |  |
+| `teamAbbrev.default` | String |  |
+| `drawnBy.sweaterNumber` | Int32 |  |
+| `drawnBy.firstName.default` | String |  |
+| `drawnBy.firstName.cs` | String |  |
+| `drawnBy.firstName.fi` | String |  |
+| `drawnBy.firstName.sk` | String |  |
+| `drawnBy.firstName.de` | String |  |
+| `drawnBy.firstName.es` | String |  |
+| `drawnBy.firstName.sv` | String |  |
+| `drawnBy.firstName.fr` | String |  |
+| `drawnBy.lastName.default` | String |  |
+| `drawnBy.lastName.cs` | String |  |
+| `drawnBy.lastName.fi` | String |  |
+| `drawnBy.lastName.sk` | String |  |
+| `drawnBy.lastName.sv` | String |  |
+| `drawnBy.lastName.de` | String |  |
+| `drawnBy.lastName.es` | String |  |
+| `drawnBy.lastName.fr` | String |  |
+| `servedBy.default` | String |  |
+| `servedBy.cs` | String |  |
+| `servedBy.fi` | String |  |
+| `servedBy.sk` | String |  |
+| `servedBy.de` | String |  |
+| `servedBy.es` | String |  |
+| `servedBy.sv` | String |  |
 
 ```python
 load_nhl_penalties(seasons=2024)
@@ -601,42 +601,42 @@ load_nhl_penalties(seasons=2024)
 Release: [nhl_player_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nhl_player_boxscores) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nhl_player_boxscores/player_box_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `home_away` | String |
-| `team_id` | Int32 |
-| `team_abbrev` | String |
-| `player_id` | Int32 |
-| `player_name` | String |
-| `sweater_number` | Int32 |
-| `position` | String |
-| `goals` | Int32 |
-| `assists` | Int32 |
-| `points` | Int32 |
-| `plus_minus` | Int32 |
-| `pim` | Int32 |
-| `hits` | Int32 |
-| `power_play_goals` | Int32 |
-| `shots_on_goal` | Int32 |
-| `faceoff_winning_pctg` | Float64 |
-| `toi` | String |
-| `blocked_shots` | Int32 |
-| `shifts` | Int32 |
-| `giveaways` | Int32 |
-| `takeaways` | Int32 |
-| `even_strength_shots_against` | String |
-| `power_play_shots_against` | String |
-| `shorthanded_shots_against` | String |
-| `save_shots_against` | String |
-| `save_pctg` | Float64 |
-| `even_strength_goals_against` | Int32 |
-| `power_play_goals_against` | Int32 |
-| `shorthanded_goals_against` | Int32 |
-| `goals_against` | Int32 |
-| `starter` | Boolean |
-| `decision` | String |
-| `shots_against` | Int32 |
-| `saves` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `home_away` | String | Home or away indicator. |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_abbrev` | String | Team abbreviation. |
+| `player_id` | Int32 | Unique player identifier. |
+| `player_name` | String | Player name. |
+| `sweater_number` | Int32 | Jersey number. |
+| `position` | String | Player position. |
+| `goals` | Int32 | Goals scored. |
+| `assists` | Int32 | Assists. |
+| `points` | Int32 | Total points (goals + assists). |
+| `plus_minus` | Int32 | Plus/minus rating. |
+| `pim` | Int32 | Penalty minutes. |
+| `hits` | Int32 | Hits. |
+| `power_play_goals` | Int32 | Power-play goals. |
+| `shots_on_goal` | Int32 | Shots on goal. |
+| `faceoff_winning_pctg` | Float64 | Faceoff win percentage. |
+| `toi` | String | Time on ice. |
+| `blocked_shots` | Int32 | Blocked shots. |
+| `shifts` | Int32 | Number of shifts. |
+| `giveaways` | Int32 | Giveaways. |
+| `takeaways` | Int32 | Takeaways. |
+| `even_strength_shots_against` | String | Even-strength shots against (saves/total). |
+| `power_play_shots_against` | String | Power-play shots against (saves/total). |
+| `shorthanded_shots_against` | String | Shorthanded shots against (saves/total). |
+| `save_shots_against` | String | Total shots against (saves/total). |
+| `save_pctg` | Float64 | Save percentage. |
+| `even_strength_goals_against` | Int32 | Even-strength goals against. |
+| `power_play_goals_against` | Int32 | Power-play goals against. |
+| `shorthanded_goals_against` | Int32 | Shorthanded goals against. |
+| `goals_against` | Int32 | Goals against. |
+| `starter` | Boolean | Whether the goalie started the game. |
+| `decision` | String | Goalie decision (W/L/O). |
+| `shots_against` | Int32 | Shots faced. |
+| `saves` | Int32 | Saves made. |
 
 ```python
 load_nhl_player_boxscores(seasons=2010)
@@ -647,17 +647,17 @@ load_nhl_player_boxscores(seasons=2010)
 Release: [nhl_rosters](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nhl_rosters) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nhl_rosters/rosters_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `player_id` | Int32 |
-| `full_name` | String |
-| `first_name` | String |
-| `last_name` | String |
-| `team_abbr` | String |
-| `team_id` | Int32 |
-| `position_code` | String |
-| `sweater_number` | Int32 |
-| `season` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `player_id` | Int32 | Unique player identifier. |
+| `full_name` | String | Player full name. |
+| `first_name` | String | Player first name. |
+| `last_name` | String | Player last name. |
+| `team_abbr` | String | Team abbreviation. |
+| `team_id` | Int32 | Unique team identifier. |
+| `position_code` | String | Player position code. |
+| `sweater_number` | Int32 | Jersey number. |
+| `season` | Int32 | Season year (echoed from arg). |
 
 ```python
 load_nhl_rosters(seasons=2010)
@@ -668,27 +668,27 @@ load_nhl_rosters(seasons=2010)
 Release: [nhl_schedules](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nhl_schedules) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nhl_schedules/nhl_schedule_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int32 |
-| `season_full` | String |
-| `game_type` | String |
-| `game_date` | String |
-| `game_time` | String |
-| `home_team_abbr` | String |
-| `away_team_abbr` | String |
-| `home_team_name` | String |
-| `away_team_name` | String |
-| `home_score` | Int32 |
-| `away_score` | Int32 |
-| `game_state` | String |
-| `venue` | String |
-| `season` | Int32 |
-| `game_json` | Boolean |
-| `game_json_url` | String |
-| `PBP` | Boolean |
-| `team_box` | Boolean |
-| `player_box` | Boolean |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int32 | Unique game identifier. |
+| `season_full` | String | Full season label (e.g. 20212022). |
+| `game_type` | String | Game type the row belongs to. |
+| `game_date` | String | Game date. |
+| `game_time` | String | Scheduled start time of the game. |
+| `home_team_abbr` | String | Home team abbreviation. |
+| `away_team_abbr` | String | Away team abbreviation. |
+| `home_team_name` | String | Home team name. |
+| `away_team_name` | String | Away team name. |
+| `home_score` | Int32 | Home team final score. |
+| `away_score` | Int32 | Away team final score. |
+| `game_state` | String | Game state (e.g., FINAL, LIVE). |
+| `venue` | String | Venue where the game was played. |
+| `season` | Int32 | Season year (echoed from arg). |
+| `game_json` | Boolean | Whether processed game JSON is available. |
+| `game_json_url` | String | URL to the processed game JSON. |
+| `PBP` | Boolean | Whether play-by-play data is available. |
+| `team_box` | Boolean | Whether team box score data is available. |
+| `player_box` | Boolean | Whether player box score data is available. |
 
 ```python
 load_nhl_schedules(seasons=2010)
@@ -699,58 +699,58 @@ load_nhl_schedules(seasons=2010)
 Release: [nhl_scoring](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nhl_scoring) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nhl_scoring/scoring_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `situationCode` | String |
-| `eventId` | Int32 |
-| `strength` | String |
-| `playerId` | Int32 |
-| `headshot` | String |
-| `highlightClipSharingUrl` | String |
-| `highlightClip` | Float64 |
-| `goalsToDate` | Int32 |
-| `awayScore` | Int32 |
-| `homeScore` | Int32 |
-| `timeInPeriod` | String |
-| `shotType` | String |
-| `goalModifier` | String |
-| `assists` | String |
-| `pptReplayUrl` | String |
-| `homeTeamDefendingSide` | String |
-| `isHome` | Boolean |
-| `game_id` | Int32 |
-| `period_number` | Int32 |
-| `period_type` | String |
-| `highlightClipSharingUrlFr` | String |
-| `highlightClipFr` | Float64 |
-| `discreteClip` | Float64 |
-| `discreteClipFr` | Float64 |
-| `firstName.default` | String |
-| `firstName.cs` | String |
-| `firstName.de` | String |
-| `firstName.es` | String |
-| `firstName.fi` | String |
-| `firstName.sk` | String |
-| `firstName.sv` | String |
-| `firstName.fr` | String |
-| `lastName.default` | String |
-| `lastName.cs` | String |
-| `lastName.fi` | String |
-| `lastName.sk` | String |
-| `lastName.sv` | String |
-| `lastName.de` | String |
-| `lastName.es` | String |
-| `lastName.fr` | String |
-| `name.default` | String |
-| `name.cs` | String |
-| `name.fi` | String |
-| `name.sk` | String |
-| `name.sv` | String |
-| `name.de` | String |
-| `name.es` | String |
-| `name.fr` | String |
-| `teamAbbrev.default` | String |
-| `leadingTeamAbbrev.default` | String |
+| col_name | type | description |
+|---|---|---|
+| `situationCode` | String | Strength/situation code for the goal. |
+| `eventId` | Int32 | Event identifier within the game. |
+| `strength` | String | Strength label (Even, Power Play, Shorthanded). |
+| `playerId` | Int32 | Player identifier involved in the event. |
+| `headshot` | String | URL to the player headshot image. |
+| `highlightClipSharingUrl` | String | Shareable URL for the goal highlight clip. |
+| `highlightClip` | Float64 | Highlight clip identifier. |
+| `goalsToDate` | Int32 | Scorer goal total to date in the season. |
+| `awayScore` | Int32 | Away team score after the goal. |
+| `homeScore` | Int32 | Home team score after the goal. |
+| `timeInPeriod` | String | Time within the period the penalty occurred. |
+| `shotType` | String | Type of shot on the goal. |
+| `goalModifier` | String | Goal modifier (e.g. empty-net, power-play). |
+| `assists` | String | Assists. |
+| `pptReplayUrl` | String | URL to the play replay, if available. |
+| `homeTeamDefendingSide` | String | Side of the ice the home team is defending. |
+| `isHome` | Boolean | Whether the scoring team is the home team. |
+| `game_id` | Int32 | Unique game identifier. |
+| `period_number` | Int32 | Period number (1-3 regulation, 4+ OT). |
+| `period_type` | String | Period type (REG/OT/SO). |
+| `highlightClipSharingUrlFr` | String |  |
+| `highlightClipFr` | Float64 |  |
+| `discreteClip` | Float64 | Discrete clip identifier. |
+| `discreteClipFr` | Float64 |  |
+| `firstName.default` | String |  |
+| `firstName.cs` | String |  |
+| `firstName.de` | String |  |
+| `firstName.es` | String |  |
+| `firstName.fi` | String |  |
+| `firstName.sk` | String |  |
+| `firstName.sv` | String |  |
+| `firstName.fr` | String |  |
+| `lastName.default` | String |  |
+| `lastName.cs` | String |  |
+| `lastName.fi` | String |  |
+| `lastName.sk` | String |  |
+| `lastName.sv` | String |  |
+| `lastName.de` | String |  |
+| `lastName.es` | String |  |
+| `lastName.fr` | String |  |
+| `name.default` | String | Team name (default language). |
+| `name.cs` | String |  |
+| `name.fi` | String |  |
+| `name.sk` | String |  |
+| `name.sv` | String |  |
+| `name.de` | String |  |
+| `name.es` | String |  |
+| `name.fr` | String | Team name (French). |
+| `teamAbbrev.default` | String |  |
+| `leadingTeamAbbrev.default` | String |  |
 
 ```python
 load_nhl_scoring(seasons=2024)
@@ -761,12 +761,12 @@ load_nhl_scoring(seasons=2024)
 Release: [nhl_scratches](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nhl_scratches) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nhl_scratches/scratches_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `id` | Int32 |
-| `firstName` | String |
-| `lastName` | String |
-| `game_id` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `id` | Int32 | Unique player identifier. |
+| `firstName` | String | Scorer first name (localized list). |
+| `lastName` | String | Scorer last name (localized list). |
+| `game_id` | Int32 | Unique game identifier. |
 
 ```python
 load_nhl_scratches(seasons=2024)
@@ -777,25 +777,25 @@ load_nhl_scratches(seasons=2024)
 Release: [nhl_shifts](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nhl_shifts) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nhl_shifts/shifts_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `event_team` | String |
-| `period` | Int32 |
-| `period_time` | String |
-| `period_seconds` | Int32 |
-| `game_seconds` | Int32 |
-| `num_on` | Int32 |
-| `players_on` | String |
-| `ids_on` | String |
-| `num_off` | Int32 |
-| `players_off` | String |
-| `ids_off` | String |
-| `event` | String |
-| `event_type` | String |
-| `game_seconds_remaining` | Int32 |
-| `game_id` | Int32 |
-| `season` | Int32 |
-| `game_date` | String |
+| col_name | type | description |
+|---|---|---|
+| `event_team` | String | Team associated with the shift change. |
+| `period` | Int32 | Period number. |
+| `period_time` | String | Elapsed time in the period (MM:SS). |
+| `period_seconds` | Int32 | Elapsed seconds in the period. |
+| `game_seconds` | Int32 | Elapsed seconds in the game. |
+| `num_on` | Int32 | Number of players coming on (line change). |
+| `players_on` | String | Names of players coming on. |
+| `ids_on` | String | Player ids coming on. |
+| `num_off` | Int32 | Number of players going off (line change). |
+| `players_off` | String | Names of players going off. |
+| `ids_off` | String | Player ids going off. |
+| `event` | String | Event description label. |
+| `event_type` | String | Standardized event type code. |
+| `game_seconds_remaining` | Int32 | Seconds remaining in regulation. |
+| `game_id` | Int32 | Unique game identifier. |
+| `season` | Int32 | Season year (echoed from arg). |
+| `game_date` | String | Game date. |
 
 ```python
 load_nhl_shifts(seasons=2025)
@@ -806,36 +806,36 @@ load_nhl_shifts(seasons=2025)
 Release: [nhl_shootout](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nhl_shootout) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nhl_shootout/shootout_summary_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `home` | Int32 |
-| `away` | Int32 |
-| `sequence` | Int32 |
-| `playerId` | Int32 |
-| `shotType` | String |
-| `result` | String |
-| `headshot` | String |
-| `gameWinner` | Boolean |
-| `homeScore` | Int32 |
-| `awayScore` | Int32 |
-| `game_id` | Int32 |
-| `season` | Int32 |
-| `game_date` | String |
-| `discreteClip` | Float64 |
-| `discreteClipFr` | Float64 |
-| `teamAbbrev.default` | String |
-| `firstName.default` | String |
-| `firstName.cs` | String |
-| `firstName.sk` | String |
-| `firstName.fi` | String |
-| `firstName.de` | String |
-| `firstName.es` | String |
-| `firstName.sv` | String |
-| `lastName.default` | String |
-| `lastName.cs` | String |
-| `lastName.fi` | String |
-| `lastName.sk` | String |
-| `lastName.sv` | String |
+| col_name | type | description |
+|---|---|---|
+| `home` | Int32 | Whether the player's team was home. |
+| `away` | Int32 | Away team shots in the period. |
+| `sequence` | Int32 | Sequence order of the season row. |
+| `playerId` | Int32 | Player identifier involved in the event. |
+| `shotType` | String | Type of shot on the goal. |
+| `result` | String | Attempt result (goal/save/miss). |
+| `headshot` | String | URL to the player headshot image. |
+| `gameWinner` | Boolean |  |
+| `homeScore` | Int32 | Home team score after the goal. |
+| `awayScore` | Int32 | Away team score after the goal. |
+| `game_id` | Int32 | Unique game identifier. |
+| `season` | Int32 | Season year (echoed from arg). |
+| `game_date` | String | Game date. |
+| `discreteClip` | Float64 | Discrete clip identifier. |
+| `discreteClipFr` | Float64 |  |
+| `teamAbbrev.default` | String |  |
+| `firstName.default` | String |  |
+| `firstName.cs` | String |  |
+| `firstName.sk` | String |  |
+| `firstName.fi` | String |  |
+| `firstName.de` | String |  |
+| `firstName.es` | String |  |
+| `firstName.sv` | String |  |
+| `lastName.default` | String |  |
+| `lastName.cs` | String |  |
+| `lastName.fi` | String |  |
+| `lastName.sk` | String |  |
+| `lastName.sv` | String |  |
 
 ```python
 load_nhl_shootout(seasons=2025)
@@ -846,17 +846,17 @@ load_nhl_shootout(seasons=2025)
 Release: [nhl_shots_by_period](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nhl_shots_by_period) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nhl_shots_by_period/shots_by_period_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `away` | Int32 |
-| `home` | Int32 |
-| `game_id` | Int32 |
-| `season` | Int32 |
-| `game_date` | String |
-| `period` | Int32 |
-| `period_type` | String |
-| `max_regulation_periods` | Int32 |
-| `ot_periods` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `away` | Int32 | Away team shots in the period. |
+| `home` | Int32 | Whether the player's team was home. |
+| `game_id` | Int32 | Unique game identifier. |
+| `season` | Int32 | Season year (echoed from arg). |
+| `game_date` | String | Game date. |
+| `period` | Int32 | Period number. |
+| `period_type` | String | Period type (REG/OT/SO). |
+| `max_regulation_periods` | Int32 |  |
+| `ot_periods` | Int32 |  |
 
 ```python
 load_nhl_shots_by_period(seasons=2025)
@@ -867,32 +867,32 @@ load_nhl_shots_by_period(seasons=2025)
 Release: [nhl_skater_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nhl_skater_boxscores) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nhl_skater_boxscores/skater_box_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `home_away` | String |
-| `team_id` | Int32 |
-| `team_abbrev` | String |
-| `player_id` | Int32 |
-| `player_name` | String |
-| `sweater_number` | Int32 |
-| `position` | String |
-| `goals` | Int32 |
-| `assists` | Int32 |
-| `points` | Int32 |
-| `plus_minus` | Int32 |
-| `pim` | Int32 |
-| `hits` | Int32 |
-| `power_play_goals` | Int32 |
-| `shots_on_goal` | Int32 |
-| `faceoff_winning_pctg` | Float64 |
-| `toi` | String |
-| `blocked_shots` | Int32 |
-| `shifts` | Int32 |
-| `giveaways` | Int32 |
-| `takeaways` | Int32 |
-| `game_id` | Int32 |
-| `season` | Int32 |
-| `game_date` | String |
+| col_name | type | description |
+|---|---|---|
+| `home_away` | String | Home or away indicator. |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_abbrev` | String | Team abbreviation. |
+| `player_id` | Int32 | Unique player identifier. |
+| `player_name` | String | Player name. |
+| `sweater_number` | Int32 | Jersey number. |
+| `position` | String | Player position. |
+| `goals` | Int32 | Goals scored. |
+| `assists` | Int32 | Assists. |
+| `points` | Int32 | Total points (goals + assists). |
+| `plus_minus` | Int32 | Plus/minus rating. |
+| `pim` | Int32 | Penalty minutes. |
+| `hits` | Int32 | Hits. |
+| `power_play_goals` | Int32 | Power-play goals. |
+| `shots_on_goal` | Int32 | Shots on goal. |
+| `faceoff_winning_pctg` | Float64 | Faceoff win percentage. |
+| `toi` | String | Time on ice. |
+| `blocked_shots` | Int32 | Blocked shots. |
+| `shifts` | Int32 | Number of shifts. |
+| `giveaways` | Int32 | Giveaways. |
+| `takeaways` | Int32 | Takeaways. |
+| `game_id` | Int32 | Unique game identifier. |
+| `season` | Int32 | Season year (echoed from arg). |
+| `game_date` | String | Game date. |
 
 ```python
 load_nhl_skater_boxscores(seasons=2024)
@@ -903,24 +903,24 @@ load_nhl_skater_boxscores(seasons=2024)
 Release: [nhl_team_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nhl_team_boxscores) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nhl_team_boxscores/team_box_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `home_away` | String |
-| `team_id` | Int32 |
-| `team_abbrev` | String |
-| `team_name` | String |
-| `goals` | Int32 |
-| `shots_on_goal` | Int32 |
-| `pim` | Int32 |
-| `hits` | Int32 |
-| `blocked_shots` | Int32 |
-| `giveaways` | Int32 |
-| `takeaways` | Int32 |
-| `power_play_goals` | Int32 |
-| `faceoff_win_pctg` | Float64 |
-| `saves` | Int32 |
-| `save_pctg` | Float64 |
-| `goals_against` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `home_away` | String | Home or away indicator. |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_abbrev` | String | Team abbreviation. |
+| `team_name` | String | Team name. |
+| `goals` | Int32 | Goals scored. |
+| `shots_on_goal` | Int32 | Shots on goal. |
+| `pim` | Int32 | Penalty minutes. |
+| `hits` | Int32 | Hits. |
+| `blocked_shots` | Int32 | Blocked shots. |
+| `giveaways` | Int32 | Giveaways. |
+| `takeaways` | Int32 | Takeaways. |
+| `power_play_goals` | Int32 | Power-play goals. |
+| `faceoff_win_pctg` | Float64 | Faceoff win percentage. |
+| `saves` | Int32 | Saves made. |
+| `save_pctg` | Float64 | Save percentage. |
+| `goals_against` | Int32 | Goals against. |
 
 ```python
 load_nhl_team_boxscores(seasons=2010)
@@ -931,32 +931,32 @@ load_nhl_team_boxscores(seasons=2010)
 Release: [nhl_three_stars](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nhl_three_stars) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nhl_three_stars/three_stars_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `star` | Int32 |
-| `playerId` | Int32 |
-| `teamAbbrev` | String |
-| `headshot` | String |
-| `sweaterNo` | Int32 |
-| `position` | String |
-| `goals` | Int32 |
-| `assists` | Int32 |
-| `points` | Int32 |
-| `game_id` | Int32 |
-| `winner_id` | Int32 |
-| `winner_name` | String |
-| `loser_id` | Int32 |
-| `loser_name` | String |
-| `goalsAgainstAverage` | Float64 |
-| `savePctg` | Float64 |
-| `name.default` | String |
-| `name.cs` | String |
-| `name.sk` | String |
-| `name.fi` | String |
-| `name.sv` | String |
-| `name.de` | String |
-| `name.es` | String |
-| `name.fr` | String |
+| col_name | type | description |
+|---|---|---|
+| `star` | Int32 | Star ranking (1, 2, or 3). |
+| `playerId` | Int32 | Player identifier involved in the event. |
+| `teamAbbrev` | String | Penalized team abbreviation (localized list). |
+| `headshot` | String | URL to the player headshot image. |
+| `sweaterNo` | Int32 | Jersey number. |
+| `position` | String | Player position. |
+| `goals` | Int32 | Goals scored. |
+| `assists` | Int32 | Assists. |
+| `points` | Int32 | Total points (goals + assists). |
+| `game_id` | Int32 | Unique game identifier. |
+| `winner_id` | Int32 | Player id of the winning goalie. |
+| `winner_name` | String | Name of the winning goalie. |
+| `loser_id` | Int32 | Player id of the losing goalie. |
+| `loser_name` | String | Name of the losing goalie. |
+| `goalsAgainstAverage` | Float64 | Goals-against average (goalies). |
+| `savePctg` | Float64 | Save percentage (goalies). |
+| `name.default` | String | Team name (default language). |
+| `name.cs` | String |  |
+| `name.sk` | String |  |
+| `name.fi` | String |  |
+| `name.sv` | String |  |
+| `name.de` | String |  |
+| `name.es` | String |  |
+| `name.fr` | String | Team name (French). |
 
 ```python
 load_nhl_three_stars(seasons=2024)

--- a/docs/docs/pwhl/reference/loaders.md
+++ b/docs/docs/pwhl/reference/loaders.md
@@ -41,87 +41,87 @@ flowchart LR
 Release: [phf_pbp](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/phf_pbp) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/phf_pbp/play_by_play_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `play_type` | String |
-| `team` | String |
-| `time` | String |
-| `play_description` | String |
-| `period_id` | Int32 |
-| `game_id` | Int32 |
-| `game_date` | String |
-| `home_team` | String |
-| `home_location` | String |
-| `home_nickname` | String |
-| `home_abbreviation` | String |
-| `home_score_total` | Int32 |
-| `away_team` | String |
-| `away_location` | String |
-| `away_nickname` | String |
-| `away_abbreviation` | String |
-| `away_score_total` | Int32 |
-| `away_goalie` | String |
-| `away_goalie_jersey` | String |
-| `goalie_change` | String |
-| `penalty` | Int32 |
-| `on_ice_situation` | String |
-| `score` | String |
-| `minute_start` | Int32 |
-| `second_start` | Int32 |
-| `clock` | String |
-| `leader` | String |
-| `away_goals` | String |
-| `home_goals` | String |
-| `sec_from_start` | Int32 |
-| `power_play_seconds` | Int32 |
-| `time_elapsed` | String |
-| `time_remaining` | String |
-| `player_name_1` | String |
-| `player_jersey_1` | String |
-| `home_skaters` | Int32 |
-| `away_skaters` | Int32 |
-| `home_goalie` | String |
-| `home_goalie_jersey` | String |
-| `player_name_2` | String |
-| `player_jersey_2` | String |
-| `shot_result` | String |
-| `goalie_involved` | String |
-| `penalty_type` | String |
-| `penalty_level` | String |
-| `penalty_length` | String |
-| `start_power_play` | Int32 |
-| `end_power_play` | Int32 |
-| `player_name_3` | String |
-| `player_jersey_3` | String |
-| `scoring_team_abbrev` | String |
-| `scoring_team_on_ice` | String |
-| `offensive_player_name_1` | String |
-| `offensive_player_name_2` | String |
-| `offensive_player_name_3` | String |
-| `offensive_player_name_4` | String |
-| `offensive_player_name_5` | String |
-| `defending_team_abbrev` | String |
-| `offensive_player_jersey_1` | String |
-| `offensive_player_jersey_2` | String |
-| `offensive_player_jersey_3` | String |
-| `offensive_player_jersey_4` | String |
-| `offensive_player_jersey_5` | String |
-| `defending_team_on_ice` | String |
-| `defensive_player_name_1` | String |
-| `defensive_player_name_2` | String |
-| `defensive_player_name_3` | String |
-| `defensive_player_name_4` | String |
-| `defensive_player_name_5` | String |
-| `defensive_player_jersey_1` | String |
-| `defensive_player_jersey_2` | String |
-| `defensive_player_jersey_3` | String |
-| `defensive_player_jersey_4` | String |
-| `defensive_player_jersey_5` | String |
-| `defensive_player_name_6` | String |
-| `defensive_player_jersey_6` | String |
-| `offensive_player_name_6` | String |
-| `offensive_player_jersey_6` | String |
-| `season` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `play_type` | String | String indicating the type of play: pass (includes sacks), run (includes scrambles), punt, field_goal, kickoff, extra_point, qb_kneel, qb_spike, no_play (timeouts and penalties), and missing for rows indicating end of play. |
+| `team` | String | Team name. |
+| `time` | String | Game clock at infraction (MM:SS). |
+| `play_description` | String |  |
+| `period_id` | Int32 | Period identifier. |
+| `game_id` | Int32 | Unique game identifier. |
+| `game_date` | String | Game date. |
+| `home_team` | String | Home team name. |
+| `home_location` | String | Home team city. |
+| `home_nickname` | String |  |
+| `home_abbreviation` | String | Home team abbreviation. |
+| `home_score_total` | Int32 |  |
+| `away_team` | String | Away team name. |
+| `away_location` | String | Away team city. |
+| `away_nickname` | String |  |
+| `away_abbreviation` | String | Away team abbreviation. |
+| `away_score_total` | Int32 |  |
+| `away_goalie` | String | Name of the away goalie on the ice. |
+| `away_goalie_jersey` | String |  |
+| `goalie_change` | String |  |
+| `penalty` | Int32 | Binary indicator for whether or not a penalty occurred. |
+| `on_ice_situation` | String |  |
+| `score` | String | Final score string. |
+| `minute_start` | Int32 | Minute mark of the period when the event started. |
+| `second_start` | Int32 | Second mark of the period when the event started. |
+| `clock` | String | Game clock time remaining (MM:SS). |
+| `leader` | String |  |
+| `away_goals` | String | Away goals in the period. |
+| `home_goals` | String | Home goals in the period. |
+| `sec_from_start` | Int32 | Seconds elapsed since the start of the game. |
+| `power_play_seconds` | Int32 |  |
+| `time_elapsed` | String | Elapsed game time for the drive (`MM:SS`). |
+| `time_remaining` | String | Time remaining. |
+| `player_name_1` | String |  |
+| `player_jersey_1` | String |  |
+| `home_skaters` | Int32 | Number of home skaters on the ice. |
+| `away_skaters` | Int32 | Number of away skaters on the ice. |
+| `home_goalie` | String | Name of the home goalie on the ice. |
+| `home_goalie_jersey` | String |  |
+| `player_name_2` | String |  |
+| `player_jersey_2` | String |  |
+| `shot_result` | String | Shot result ('Made' / 'Missed'). |
+| `goalie_involved` | String |  |
+| `penalty_type` | String | String indicating the penalty type of the first penalty in the given play. Will be `NA` if `desc` is missing the type. |
+| `penalty_level` | String |  |
+| `penalty_length` | String | Penalty length in minutes. |
+| `start_power_play` | Int32 |  |
+| `end_power_play` | Int32 |  |
+| `player_name_3` | String |  |
+| `player_jersey_3` | String |  |
+| `scoring_team_abbrev` | String |  |
+| `scoring_team_on_ice` | String |  |
+| `offensive_player_name_1` | String |  |
+| `offensive_player_name_2` | String |  |
+| `offensive_player_name_3` | String |  |
+| `offensive_player_name_4` | String |  |
+| `offensive_player_name_5` | String |  |
+| `defending_team_abbrev` | String |  |
+| `offensive_player_jersey_1` | String |  |
+| `offensive_player_jersey_2` | String |  |
+| `offensive_player_jersey_3` | String |  |
+| `offensive_player_jersey_4` | String |  |
+| `offensive_player_jersey_5` | String |  |
+| `defending_team_on_ice` | String |  |
+| `defensive_player_name_1` | String |  |
+| `defensive_player_name_2` | String |  |
+| `defensive_player_name_3` | String |  |
+| `defensive_player_name_4` | String |  |
+| `defensive_player_name_5` | String |  |
+| `defensive_player_jersey_1` | String |  |
+| `defensive_player_jersey_2` | String |  |
+| `defensive_player_jersey_3` | String |  |
+| `defensive_player_jersey_4` | String |  |
+| `defensive_player_jersey_5` | String |  |
+| `defensive_player_name_6` | String |  |
+| `defensive_player_jersey_6` | String |  |
+| `offensive_player_name_6` | String |  |
+| `offensive_player_jersey_6` | String |  |
+| `season` | Int32 | Season year (echoed from arg). |
 
 ```python
 load_phf_pbp(seasons=2023)
@@ -132,38 +132,38 @@ load_phf_pbp(seasons=2023)
 Release: [phf_player_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/phf_player_boxscores) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/phf_player_boxscores/player_box_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `player_jersey` | Int32 |
-| `player_name` | String |
-| `position` | String |
-| `goals` | Int32 |
-| `assists` | Int32 |
-| `points` | Int32 |
-| `penalty_minutes` | Int32 |
-| `shots_on_goal` | Int32 |
-| `blocks` | Int32 |
-| `giveaways` | Int32 |
-| `takeaways` | Int32 |
-| `faceoffs_won_lost` | String |
-| `faceoffs_win_pct` | Float64 |
-| `powerplay_goals` | Int32 |
-| `shorthanded_goals` | Int32 |
-| `shots` | Int32 |
-| `shots_blocked` | Int32 |
-| `faceoffs_won` | Int32 |
-| `faceoffs_lost` | Int32 |
-| `team` | String |
-| `skaters_href` | String |
-| `player_id` | String |
-| `game_id` | Int32 |
-| `minutes_played` | String |
-| `shots_against` | Int32 |
-| `goals_against` | Int32 |
-| `saves` | Int32 |
-| `save_percent` | Float64 |
-| `goalies_href` | String |
-| `season` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `player_jersey` | Int32 |  |
+| `player_name` | String | Player name. |
+| `position` | String | Player position. |
+| `goals` | Int32 | Goals scored. |
+| `assists` | Int32 | Assists. |
+| `points` | Int32 | Total points (goals + assists). |
+| `penalty_minutes` | Int32 | Penalty minutes. |
+| `shots_on_goal` | Int32 | Shots on goal. |
+| `blocks` | Int32 | Total blocks. |
+| `giveaways` | Int32 | Giveaways. |
+| `takeaways` | Int32 | Takeaways. |
+| `faceoffs_won_lost` | String |  |
+| `faceoffs_win_pct` | Float64 |  |
+| `powerplay_goals` | Int32 |  |
+| `shorthanded_goals` | Int32 | Shorthanded goals. |
+| `shots` | Int32 | Shots on goal. |
+| `shots_blocked` | Int32 |  |
+| `faceoffs_won` | Int32 | Faceoffs won in the season. |
+| `faceoffs_lost` | Int32 | Faceoffs lost in the season. |
+| `team` | String | Team name. |
+| `skaters_href` | String |  |
+| `player_id` | String | Unique player identifier. |
+| `game_id` | Int32 | Unique game identifier. |
+| `minutes_played` | String | Minutes played. |
+| `shots_against` | Int32 | Shots faced. |
+| `goals_against` | Int32 | Goals against. |
+| `saves` | Int32 | Saves made. |
+| `save_percent` | Float64 |  |
+| `goalies_href` | String |  |
+| `season` | Int32 | Season year (echoed from arg). |
 
 ```python
 load_phf_player_boxscores(seasons=2023)
@@ -174,76 +174,76 @@ load_phf_player_boxscores(seasons=2023)
 Release: [phf_schedules](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/phf_schedules) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/phf_schedules/phf_schedule_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `type` | String |
-| `id` | String |
-| `league_id` | Int32 |
-| `season_id` | Int32 |
-| `tournament_id` | Boolean |
-| `game_id` | Int32 |
-| `number` | Int32 |
-| `datetime` | Datetime(time_unit='us', time_zone='UTC') |
-| `datetime_tz` | Datetime(time_unit='us', time_zone='UTC') |
-| `time_zone` | String |
-| `time_zone_abbr` | String |
-| `updated_at` | Datetime(time_unit='us', time_zone='UTC') |
-| `created_at` | Datetime(time_unit='us', time_zone='UTC') |
-| `home_team_id` | Int32 |
-| `home_team` | String |
-| `home_team_short` | String |
-| `home_team_logo_url_full` | String |
-| `home_team_logo_url_small` | String |
-| `home_team_logo_url_medium` | String |
-| `home_team_logo_url_large` | String |
-| `home_team_logo_url_50` | String |
-| `home_team_logo_url_100` | String |
-| `home_team_logo_url_200` | String |
-| `away_team_id` | Int32 |
-| `away_team` | String |
-| `away_team_short` | String |
-| `away_team_logo_url_full` | String |
-| `away_team_logo_url_small` | String |
-| `away_team_logo_url_medium` | String |
-| `away_team_logo_url_large` | String |
-| `away_team_logo_url_50` | String |
-| `away_team_logo_url_100` | String |
-| `away_team_logo_url_200` | String |
-| `home_division_id` | Int32 |
-| `home_division` | String |
-| `away_division_id` | Int32 |
-| `away_division` | String |
-| `home_score` | Int32 |
-| `away_score` | Int32 |
-| `home_shots` | Int32 |
-| `away_shots` | Int32 |
-| `home_penalty_minutes` | Int32 |
-| `away_penalty_minutes` | Int32 |
-| `home_roster_count` | Int32 |
-| `away_roster_count` | Int32 |
-| `facility_id` | Int32 |
-| `facility` | String |
-| `facility_address` | String |
-| `rink_id` | Boolean |
-| `rink` | Boolean |
-| `game_type` | String |
-| `notes` | String |
-| `status` | String |
-| `overtime` | Boolean |
-| `shootout` | Boolean |
-| `allow_players` | Boolean |
-| `tickets_url` | String |
-| `watch_live_url` | String |
-| `external_url` | Boolean |
-| `has_play_by_play` | Boolean |
-| `highlight_color` | Boolean |
-| `attendance` | Int32 |
-| `date_group` | Date |
-| `winner` | String |
-| `season` | Int32 |
-| `PBP` | Boolean |
-| `team_box` | Boolean |
-| `player_box` | Boolean |
+| col_name | type | description |
+|---|---|---|
+| `type` | String | Competitor type (e.g. "team"). |
+| `id` | String | Unique player identifier. |
+| `league_id` | Int32 | League identifier of the team. |
+| `season_id` | Int32 | Season identifier. |
+| `tournament_id` | Boolean | ESPN tournament id parsed from the `$ref` URL. |
+| `game_id` | Int32 | Unique game identifier. |
+| `number` | Int32 | Week number as returned by the API. |
+| `datetime` | Datetime(time_unit='us', time_zone='UTC') |  |
+| `datetime_tz` | Datetime(time_unit='us', time_zone='UTC') |  |
+| `time_zone` | String |  |
+| `time_zone_abbr` | String |  |
+| `updated_at` | Datetime(time_unit='us', time_zone='UTC') |  |
+| `created_at` | Datetime(time_unit='us', time_zone='UTC') |  |
+| `home_team_id` | Int32 | Home team identifier. |
+| `home_team` | String | Home team name. |
+| `home_team_short` | String |  |
+| `home_team_logo_url_full` | String |  |
+| `home_team_logo_url_small` | String |  |
+| `home_team_logo_url_medium` | String |  |
+| `home_team_logo_url_large` | String |  |
+| `home_team_logo_url_50` | String |  |
+| `home_team_logo_url_100` | String |  |
+| `home_team_logo_url_200` | String |  |
+| `away_team_id` | Int32 | Away team identifier. |
+| `away_team` | String | Away team name. |
+| `away_team_short` | String |  |
+| `away_team_logo_url_full` | String |  |
+| `away_team_logo_url_small` | String |  |
+| `away_team_logo_url_medium` | String |  |
+| `away_team_logo_url_large` | String |  |
+| `away_team_logo_url_50` | String |  |
+| `away_team_logo_url_100` | String |  |
+| `away_team_logo_url_200` | String |  |
+| `home_division_id` | Int32 |  |
+| `home_division` | String | Home team division. |
+| `away_division_id` | Int32 |  |
+| `away_division` | String | Away team division. |
+| `home_score` | Int32 | Home team final score. |
+| `away_score` | Int32 | Away team final score. |
+| `home_shots` | Int32 | Home team shots in the period. |
+| `away_shots` | Int32 | Away team shots in the period. |
+| `home_penalty_minutes` | Int32 |  |
+| `away_penalty_minutes` | Int32 |  |
+| `home_roster_count` | Int32 |  |
+| `away_roster_count` | Int32 |  |
+| `facility_id` | Int32 |  |
+| `facility` | String |  |
+| `facility_address` | String |  |
+| `rink_id` | Boolean |  |
+| `rink` | Boolean |  |
+| `game_type` | String | Game type the row belongs to. |
+| `notes` | String | Notes flag for the pick. |
+| `status` | String | Status string (e.g. captain markers). |
+| `overtime` | Boolean | Binary indicator of whether or not game went to overtime. |
+| `shootout` | Boolean | Whether shootout data is available. |
+| `allow_players` | Boolean |  |
+| `tickets_url` | String |  |
+| `watch_live_url` | String |  |
+| `external_url` | Boolean |  |
+| `has_play_by_play` | Boolean |  |
+| `highlight_color` | Boolean |  |
+| `attendance` | Int32 | Game attendance. |
+| `date_group` | Date |  |
+| `winner` | String | Whether this competitor won the game. |
+| `season` | Int32 | Season year (echoed from arg). |
+| `PBP` | Boolean | Whether play-by-play data is available. |
+| `team_box` | Boolean | Whether team box score data is available. |
+| `player_box` | Boolean | Whether player box score data is available. |
 
 ```python
 load_phf_schedules(seasons=2023)
@@ -254,34 +254,34 @@ load_phf_schedules(seasons=2023)
 Release: [phf_team_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/phf_team_boxscores) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/phf_team_boxscores/team_box_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `team` | String |
-| `game_id` | Int32 |
-| `winner` | Boolean |
-| `total_scoring` | Int32 |
-| `successful_power_play` | Float64 |
-| `power_play_opportunities` | Float64 |
-| `power_play_percent` | Float64 |
-| `penalty_minutes` | Float64 |
-| `faceoff_percent` | Float64 |
-| `blocked_opponent_shots` | Float64 |
-| `takeaways` | Float64 |
-| `giveaways` | Float64 |
-| `period_1_shots` | Int32 |
-| `period_2_shots` | Int32 |
-| `period_3_shots` | Int32 |
-| `overtime_shots` | Int32 |
-| `shootout_made_shots` | Int32 |
-| `shootout_missed_shots` | Int32 |
-| `total_shots` | Int32 |
-| `period_1_scoring` | Int32 |
-| `period_2_scoring` | Int32 |
-| `period_3_scoring` | Int32 |
-| `overtime_scoring` | Int32 |
-| `shootout_made_scoring` | Float64 |
-| `shootout_missed_scoring` | Float64 |
-| `season` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `team` | String | Team name. |
+| `game_id` | Int32 | Unique game identifier. |
+| `winner` | Boolean | Whether this competitor won the game. |
+| `total_scoring` | Int32 |  |
+| `successful_power_play` | Float64 |  |
+| `power_play_opportunities` | Float64 | Power play opportunities. |
+| `power_play_percent` | Float64 |  |
+| `penalty_minutes` | Float64 | Penalty minutes. |
+| `faceoff_percent` | Float64 | Faceoff win percentage. |
+| `blocked_opponent_shots` | Float64 |  |
+| `takeaways` | Float64 | Takeaways. |
+| `giveaways` | Float64 | Giveaways. |
+| `period_1_shots` | Int32 |  |
+| `period_2_shots` | Int32 |  |
+| `period_3_shots` | Int32 |  |
+| `overtime_shots` | Int32 |  |
+| `shootout_made_shots` | Int32 |  |
+| `shootout_missed_shots` | Int32 |  |
+| `total_shots` | Int32 |  |
+| `period_1_scoring` | Int32 |  |
+| `period_2_scoring` | Int32 |  |
+| `period_3_scoring` | Int32 |  |
+| `overtime_scoring` | Int32 |  |
+| `shootout_made_scoring` | Float64 |  |
+| `shootout_missed_scoring` | Float64 |  |
+| `season` | Int32 | Season year (echoed from arg). |
 
 ```python
 load_phf_team_boxscores(seasons=2023)
@@ -292,32 +292,32 @@ load_phf_team_boxscores(seasons=2023)
 Release: [pwhl_game_info](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/pwhl_game_info) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/pwhl_game_info/game_info_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int32 |
-| `game_number` | String |
-| `game_date` | String |
-| `game_date_iso` | String |
-| `start_time` | String |
-| `end_time` | String |
-| `game_duration` | String |
-| `game_venue` | String |
-| `attendance` | Int32 |
-| `game_status` | String |
-| `game_season_id` | Int32 |
-| `started` | Int32 |
-| `final` | Int32 |
-| `home_team_id` | Int32 |
-| `home_team` | String |
-| `home_team_abbr` | String |
-| `home_score` | Int32 |
-| `away_team_id` | Int32 |
-| `away_team` | String |
-| `away_team_abbr` | String |
-| `away_score` | Int32 |
-| `has_shootout` | Int32 |
-| `game_report_url` | String |
-| `boxscore_url` | String |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int32 | Unique game identifier. |
+| `game_number` | String | Game number within the schedule. |
+| `game_date` | String | Game date. |
+| `game_date_iso` | String | ISO-8601 game start datetime. |
+| `start_time` | String | Shift start time (MM:SS countdown clock). |
+| `end_time` | String | Shift end time (MM:SS countdown clock). |
+| `game_duration` | String | Game length (H:MM). |
+| `game_venue` | String | Venue where the game was played. |
+| `attendance` | Int32 | Game attendance. |
+| `game_status` | String | Game status text. |
+| `game_season_id` | Int32 | HockeyTech season identifier. |
+| `started` | Int32 | Flag for whether the game has started. |
+| `final` | Int32 | Flag for whether the game is final. |
+| `home_team_id` | Int32 | Home team identifier. |
+| `home_team` | String | Home team name. |
+| `home_team_abbr` | String | Home team abbreviation. |
+| `home_score` | Int32 | Home team final score. |
+| `away_team_id` | Int32 | Away team identifier. |
+| `away_team` | String | Away team name. |
+| `away_team_abbr` | String | Away team abbreviation. |
+| `away_score` | Int32 | Away team final score. |
+| `has_shootout` | Int32 | Flag for whether the game went to shootout. |
+| `game_report_url` | String | URL to the game report. |
+| `boxscore_url` | String | URL to the boxscore. |
 
 ```python
 load_pwhl_game_info(seasons=2024)
@@ -328,22 +328,22 @@ load_pwhl_game_info(seasons=2024)
 Release: [pwhl_game_rosters](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/pwhl_game_rosters) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/pwhl_game_rosters/game_rosters_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int32 |
-| `team_id` | Int32 |
-| `team` | String |
-| `team_abbr` | String |
-| `team_side` | String |
-| `player_type` | String |
-| `player_id` | Int32 |
-| `first_name` | String |
-| `last_name` | String |
-| `jersey_number` | Int32 |
-| `position` | String |
-| `birth_date` | String |
-| `starting` | Int32 |
-| `status` | String |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int32 | Unique game identifier. |
+| `team_id` | Int32 | Unique team identifier. |
+| `team` | String | Team name. |
+| `team_abbr` | String | Team abbreviation. |
+| `team_side` | String | Home or away indicator. |
+| `player_type` | String | Player type (skater or goalie). |
+| `player_id` | Int32 | Unique player identifier. |
+| `first_name` | String | Player first name. |
+| `last_name` | String | Player last name. |
+| `jersey_number` | Int32 | Jersey number. |
+| `position` | String | Player position. |
+| `birth_date` | String | Player birth date. |
+| `starting` | Int32 | Whether the player started the game. |
+| `status` | String | Status string (e.g. captain markers). |
 
 ```python
 load_pwhl_game_rosters(seasons=2024)
@@ -354,22 +354,22 @@ load_pwhl_game_rosters(seasons=2024)
 Release: [pwhl_shifts](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/pwhl_shifts) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/pwhl_shifts/shifts_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int32 |
-| `player_id` | Int32 |
-| `first_name` | String |
-| `last_name` | String |
-| `jersey_number` | Int32 |
-| `home` | Int32 |
-| `period` | Int32 |
-| `start_time` | String |
-| `end_time` | String |
-| `length` | String |
-| `start_s` | Int32 |
-| `end_s` | Int32 |
-| `goal_on_shift` | Int32 |
-| `penalty_on_shift` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int32 | Unique game identifier. |
+| `player_id` | Int32 | Unique player identifier. |
+| `first_name` | String | Player first name. |
+| `last_name` | String | Player last name. |
+| `jersey_number` | Int32 | Jersey number. |
+| `home` | Int32 | Whether the player's team was home. |
+| `period` | Int32 | Period number. |
+| `start_time` | String | Shift start time (MM:SS countdown clock). |
+| `end_time` | String | Shift end time (MM:SS countdown clock). |
+| `length` | String | Length of the streak in games. |
+| `start_s` | Int32 | Shift start in countdown seconds. |
+| `end_s` | Int32 | Shift end in countdown seconds. |
+| `goal_on_shift` | Int32 | 1 if a goal occurred during this shift, else 0. |
+| `penalty_on_shift` | Int32 | 1 if a penalty occurred during this shift, else 0. |
 
 ```python
 load_pwhl_shifts(seasons=2025)
@@ -380,29 +380,29 @@ load_pwhl_shifts(seasons=2025)
 Release: [pwhl_goalie_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/pwhl_goalie_boxscores) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/pwhl_goalie_boxscores/goalie_box_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `player_id` | String |
-| `first_name` | String |
-| `last_name` | String |
-| `position` | String |
-| `team_id` | Int32 |
-| `game_id` | Int32 |
-| `league` | String |
-| `toi` | String |
-| `time_on_ice` | Float64 |
-| `saves` | Int32 |
-| `goals_against` | Int32 |
-| `shots_against` | Int32 |
-| `goals` | Int32 |
-| `assists` | Int32 |
-| `points` | Int32 |
-| `penalty_minutes` | Int32 |
-| `faceoff_attempts` | Int32 |
-| `faceoff_wins` | Int32 |
-| `faceoff_losses` | Int32 |
-| `faceoff_pct` | Boolean |
-| `starting` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `player_id` | String | Unique player identifier. |
+| `first_name` | String | Player first name. |
+| `last_name` | String | Player last name. |
+| `position` | String | Player position. |
+| `team_id` | Int32 | Unique team identifier. |
+| `game_id` | Int32 | Unique game identifier. |
+| `league` | String | League code. |
+| `toi` | String | Time on ice. |
+| `time_on_ice` | Float64 | Time on ice in seconds. |
+| `saves` | Int32 | Saves made. |
+| `goals_against` | Int32 | Goals against. |
+| `shots_against` | Int32 | Shots faced. |
+| `goals` | Int32 | Goals scored. |
+| `assists` | Int32 | Assists. |
+| `points` | Int32 | Total points (goals + assists). |
+| `penalty_minutes` | Int32 | Penalty minutes. |
+| `faceoff_attempts` | Int32 | Faceoff attempts. |
+| `faceoff_wins` | Int32 | Faceoff wins. |
+| `faceoff_losses` | Int32 | Faceoff losses. |
+| `faceoff_pct` | Boolean | Faceoff win percentage. |
+| `starting` | Int32 | Whether the player started the game. |
 
 ```python
 load_pwhl_goalie_boxscores(seasons=2024)
@@ -413,14 +413,14 @@ load_pwhl_goalie_boxscores(seasons=2024)
 Release: [pwhl_officials](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/pwhl_officials) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/pwhl_officials/officials_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int32 |
-| `role` | String |
-| `first_name` | String |
-| `last_name` | String |
-| `jersey_number` | Int32 |
-| `official_role` | String |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int32 | Unique game identifier. |
+| `role` | String | Grouped official role (Referee/Linesperson). |
+| `first_name` | String | Player first name. |
+| `last_name` | String | Player last name. |
+| `jersey_number` | Int32 | Jersey number. |
+| `official_role` | String | Official's specific role. |
 
 ```python
 load_pwhl_officials(seasons=2024)
@@ -431,103 +431,103 @@ load_pwhl_officials(seasons=2024)
 Release: [pwhl_pbp](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/pwhl_pbp) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/pwhl_pbp/play_by_play_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int32 |
-| `event` | String |
-| `team_id` | Int32 |
-| `period_of_game` | String |
-| `time_of_period` | String |
-| `player_id` | Int32 |
-| `player_name_first` | String |
-| `player_name_last` | String |
-| `player_position` | String |
-| `player_two_id` | Int32 |
-| `player_two_name_first` | String |
-| `player_two_name_last` | String |
-| `player_two_position` | String |
-| `x_coord` | Float64 |
-| `y_coord` | Float64 |
-| `home_win` | Int32 |
-| `player_team_id` | Int32 |
-| `event_type` | String |
-| `shot_quality` | String |
-| `goal` | Boolean |
-| `goalie_id` | Int32 |
-| `goalie_first` | String |
-| `goalie_last` | String |
-| `player_three_id` | Int32 |
-| `player_three_name_first` | String |
-| `player_three_name_last` | String |
-| `player_three_position` | String |
-| `empty_net` | String |
-| `game_winner` | String |
-| `penalty_shot` | String |
-| `insurance` | String |
-| `power_play` | Int32 |
-| `short_handed` | String |
-| `plus_player_one_id` | Int32 |
-| `plus_player_one_first` | String |
-| `plus_player_one_last` | String |
-| `plus_player_one_position` | String |
-| `plus_player_two_id` | Int32 |
-| `plus_player_two_first` | String |
-| `plus_player_two_last` | String |
-| `plus_player_two_position` | String |
-| `plus_player_three_id` | Int32 |
-| `plus_player_three_first` | String |
-| `plus_player_three_last` | String |
-| `plus_player_three_position` | String |
-| `plus_player_four_id` | Int32 |
-| `plus_player_four_first` | String |
-| `plus_player_four_last` | String |
-| `plus_player_four_position` | String |
-| `plus_player_five_id` | Int32 |
-| `plus_player_five_first` | String |
-| `plus_player_five_last` | String |
-| `plus_player_five_position` | String |
-| `minus_player_one_id` | Int32 |
-| `minus_player_one_first` | String |
-| `minus_player_one_last` | String |
-| `minus_player_one_position` | String |
-| `minus_player_two_id` | Int32 |
-| `minus_player_two_first` | String |
-| `minus_player_two_last` | String |
-| `minus_player_two_position` | String |
-| `minus_player_three_id` | Int32 |
-| `minus_player_three_first` | String |
-| `minus_player_three_last` | String |
-| `minus_player_three_position` | String |
-| `minus_player_four_id` | Int32 |
-| `minus_player_four_first` | String |
-| `minus_player_four_last` | String |
-| `minus_player_four_position` | String |
-| `minus_player_five_id` | Int32 |
-| `minus_player_five_first` | String |
-| `minus_player_five_last` | String |
-| `minus_player_five_position` | String |
-| `penalty_length` | String |
-| `game_date` | String |
-| `game_season` | Int32 |
-| `game_season_id` | String |
-| `home_team_id` | Int32 |
-| `home_team` | String |
-| `away_team_id` | Int32 |
-| `away_team` | String |
-| `x_coord_original` | Int32 |
-| `y_coord_original` | Int32 |
-| `x_coord_neutral` | Int32 |
-| `y_coord_neutral` | Int32 |
-| `x_coord_fixed` | Float64 |
-| `y_coord_fixed` | Float64 |
-| `x_coord_right` | Float64 |
-| `y_coord_right` | Float64 |
-| `x_coord_vertical` | Float64 |
-| `y_coord_vertical` | Float64 |
-| `minute_start` | Int32 |
-| `second_start` | Int32 |
-| `clock` | String |
-| `sec_from_start` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int32 | Unique game identifier. |
+| `event` | String | Event description label. |
+| `team_id` | Int32 | Unique team identifier. |
+| `period_of_game` | String | Period in which the event occurred. |
+| `time_of_period` | String | Elapsed time within the period (MM:SS). |
+| `player_id` | Int32 | Unique player identifier. |
+| `player_name_first` | String | Primary player first name. |
+| `player_name_last` | String | Primary player last name. |
+| `player_position` | String | Primary player position. |
+| `player_two_id` | Int32 | Second player's unique identifier. |
+| `player_two_name_first` | String | Second player first name. |
+| `player_two_name_last` | String | Second player last name. |
+| `player_two_position` | String | Second player position. |
+| `x_coord` | Float64 | Transformed x-coordinate of the event (feet scale). |
+| `y_coord` | Float64 | Transformed y-coordinate of the event (feet scale). |
+| `home_win` | Int32 | Whether the home player won the faceoff. |
+| `player_team_id` | Int32 | Unique team identifier of the primary player. |
+| `event_type` | String | Standardized event type code. |
+| `shot_quality` | String | Shot quality descriptor. |
+| `goal` | Boolean | Flag for whether the event was a goal. |
+| `goalie_id` | Int32 | Goalie identifier on the play. |
+| `goalie_first` | String | Goalie first name. |
+| `goalie_last` | String | Goalie last name. |
+| `player_three_id` | Int32 | Third player's unique identifier. |
+| `player_three_name_first` | String | Third player first name. |
+| `player_three_name_last` | String | Third player last name. |
+| `player_three_position` | String | Third player position. |
+| `empty_net` | String | Whether the net was empty. |
+| `game_winner` | String | Whether the goal was the game-winning goal. |
+| `penalty_shot` | String | Whether the goal came on a penalty shot. |
+| `insurance` | String | Whether the goal was an insurance goal. |
+| `power_play` | Int32 | Whether the event occurred on a power play. |
+| `short_handed` | String | Whether the event occurred while short-handed. |
+| `plus_player_one_id` | Int32 | On-ice plus player one unique identifier. |
+| `plus_player_one_first` | String | On-ice plus player one first name. |
+| `plus_player_one_last` | String | On-ice plus player one last name. |
+| `plus_player_one_position` | String | On-ice plus player one position. |
+| `plus_player_two_id` | Int32 | On-ice plus player two unique identifier. |
+| `plus_player_two_first` | String | On-ice plus player two first name. |
+| `plus_player_two_last` | String | On-ice plus player two last name. |
+| `plus_player_two_position` | String | On-ice plus player two position. |
+| `plus_player_three_id` | Int32 | On-ice plus player three unique identifier. |
+| `plus_player_three_first` | String | On-ice plus player three first name. |
+| `plus_player_three_last` | String | On-ice plus player three last name. |
+| `plus_player_three_position` | String | On-ice plus player three position. |
+| `plus_player_four_id` | Int32 | On-ice plus player four unique identifier. |
+| `plus_player_four_first` | String | On-ice plus player four first name. |
+| `plus_player_four_last` | String | On-ice plus player four last name. |
+| `plus_player_four_position` | String | On-ice plus player four position. |
+| `plus_player_five_id` | Int32 | On-ice plus player five unique identifier. |
+| `plus_player_five_first` | String | On-ice plus player five first name. |
+| `plus_player_five_last` | String | On-ice plus player five last name. |
+| `plus_player_five_position` | String | On-ice plus player five position. |
+| `minus_player_one_id` | Int32 | On-ice minus player one unique identifier. |
+| `minus_player_one_first` | String | On-ice minus player one first name. |
+| `minus_player_one_last` | String | On-ice minus player one last name. |
+| `minus_player_one_position` | String | On-ice minus player one position. |
+| `minus_player_two_id` | Int32 | On-ice minus player two unique identifier. |
+| `minus_player_two_first` | String | On-ice minus player two first name. |
+| `minus_player_two_last` | String | On-ice minus player two last name. |
+| `minus_player_two_position` | String | On-ice minus player two position. |
+| `minus_player_three_id` | Int32 | On-ice minus player three unique identifier. |
+| `minus_player_three_first` | String | On-ice minus player three first name. |
+| `minus_player_three_last` | String | On-ice minus player three last name. |
+| `minus_player_three_position` | String | On-ice minus player three position. |
+| `minus_player_four_id` | Int32 | On-ice minus player four unique identifier. |
+| `minus_player_four_first` | String | On-ice minus player four first name. |
+| `minus_player_four_last` | String | On-ice minus player four last name. |
+| `minus_player_four_position` | String | On-ice minus player four position. |
+| `minus_player_five_id` | Int32 | On-ice minus player five unique identifier. |
+| `minus_player_five_first` | String | On-ice minus player five first name. |
+| `minus_player_five_last` | String | On-ice minus player five last name. |
+| `minus_player_five_position` | String | On-ice minus player five position. |
+| `penalty_length` | String | Penalty length in minutes. |
+| `game_date` | String | Game date. |
+| `game_season` | Int32 | Season (concluding year, YYYY). |
+| `game_season_id` | String | HockeyTech season identifier. |
+| `home_team_id` | Int32 | Home team identifier. |
+| `home_team` | String | Home team name. |
+| `away_team_id` | Int32 | Away team identifier. |
+| `away_team` | String | Away team name. |
+| `x_coord_original` | Int32 | Original raw x-coordinate from the feed. |
+| `y_coord_original` | Int32 | Original raw y-coordinate from the feed. |
+| `x_coord_neutral` | Int32 | Neutral-zone-centered x-coordinate. |
+| `y_coord_neutral` | Int32 | Neutral-zone-centered y-coordinate. |
+| `x_coord_fixed` | Float64 | Fixed-orientation x-coordinate. |
+| `y_coord_fixed` | Float64 | Fixed-orientation y-coordinate. |
+| `x_coord_right` | Float64 | Right-orientation x-coordinate. |
+| `y_coord_right` | Float64 | Right-orientation y-coordinate. |
+| `x_coord_vertical` | Float64 | Vertical-orientation x-coordinate. |
+| `y_coord_vertical` | Float64 | Vertical-orientation y-coordinate. |
+| `minute_start` | Int32 | Minute mark of the period when the event started. |
+| `second_start` | Int32 | Second mark of the period when the event started. |
+| `clock` | String | Game clock time remaining (MM:SS). |
+| `sec_from_start` | Int32 | Seconds elapsed since the start of the game. |
 
 ```python
 load_pwhl_pbp(seasons=2024)
@@ -538,29 +538,29 @@ load_pwhl_pbp(seasons=2024)
 Release: [pwhl_xg_pbp](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/pwhl_xg_pbp) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/pwhl_xg_pbp/pwhl_xg_pbp_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int32 |
-| `game_season` | Int32 |
-| `game_date` | String |
-| `team_id` | Int32 |
-| `player_id` | Int32 |
-| `goalie_id` | Int32 |
-| `period_of_game` | String |
-| `sec_from_start` | Int32 |
-| `clock` | String |
-| `x_coord` | Float64 |
-| `y_coord` | Float64 |
-| `shot_distance` | Float64 |
-| `shot_angle` | Float64 |
-| `event_type` | String |
-| `shot_quality` | String |
-| `power_play` | Int32 |
-| `short_handed` | String |
-| `empty_net` | String |
-| `penalty_shot` | String |
-| `goal` | Boolean |
-| `xg` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int32 | Unique game identifier. |
+| `game_season` | Int32 | Season (concluding year, YYYY). |
+| `game_date` | String | Game date. |
+| `team_id` | Int32 | Unique team identifier. |
+| `player_id` | Int32 | Unique player identifier. |
+| `goalie_id` | Int32 | Goalie identifier on the play. |
+| `period_of_game` | String | Period in which the event occurred. |
+| `sec_from_start` | Int32 | Seconds elapsed since the start of the game. |
+| `clock` | String | Game clock time remaining (MM:SS). |
+| `x_coord` | Float64 | Transformed x-coordinate of the event (feet scale). |
+| `y_coord` | Float64 | Transformed y-coordinate of the event (feet scale). |
+| `shot_distance` | Float64 | Distance of the shot from the net. |
+| `shot_angle` | Float64 | Angle of the shot relative to the net. |
+| `event_type` | String | Standardized event type code. |
+| `shot_quality` | String | Shot quality descriptor. |
+| `power_play` | Int32 | Whether the event occurred on a power play. |
+| `short_handed` | String | Whether the event occurred while short-handed. |
+| `empty_net` | String | Whether the net was empty. |
+| `penalty_shot` | String | Whether the goal came on a penalty shot. |
+| `goal` | Boolean | Flag for whether the event was a goal. |
+| `xg` | Float64 | Expected goals value for the shot event. |
 
 ```python
 load_pwhl_xg_pbp(seasons=2025)
@@ -571,28 +571,28 @@ load_pwhl_xg_pbp(seasons=2025)
 Release: [pwhl_penalty_summary](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/pwhl_penalty_summary) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/pwhl_penalty_summary/penalty_summary_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int32 |
-| `period_id` | Int32 |
-| `period` | String |
-| `time` | String |
-| `team_id` | Int32 |
-| `team` | String |
-| `team_abbr` | String |
-| `game_penalty_id` | Int32 |
-| `minutes` | Int32 |
-| `description` | String |
-| `rule_number` | String |
-| `is_power_play` | Int32 |
-| `is_bench` | Int32 |
-| `taken_by_id` | Int32 |
-| `taken_by_first` | String |
-| `taken_by_last` | String |
-| `taken_by_position` | String |
-| `served_by_id` | Int32 |
-| `served_by_first` | String |
-| `served_by_last` | String |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int32 | Unique game identifier. |
+| `period_id` | Int32 | Period identifier. |
+| `period` | String | Period number. |
+| `time` | String | Game clock at infraction (MM:SS). |
+| `team_id` | Int32 | Unique team identifier. |
+| `team` | String | Team name. |
+| `team_abbr` | String | Team abbreviation. |
+| `game_penalty_id` | Int32 | Penalty identifier within the game. |
+| `minutes` | Int32 | Penalty length in minutes. |
+| `description` | String | Full text description of the event. |
+| `rule_number` | String | Rulebook rule number. |
+| `is_power_play` | Int32 | Power-play flag. |
+| `is_bench` | Int32 | Bench-minor flag. |
+| `taken_by_id` | Int32 | Identifier of the player who took the penalty. |
+| `taken_by_first` | String | Offender first name. |
+| `taken_by_last` | String | Offender last name. |
+| `taken_by_position` | String | Offender position. |
+| `served_by_id` | Int32 | Identifier of the player serving the penalty. |
+| `served_by_first` | String | First name of the player serving. |
+| `served_by_last` | String | Last name of the player serving. |
 
 ```python
 load_pwhl_penalty_summary(seasons=2024)
@@ -603,34 +603,34 @@ load_pwhl_penalty_summary(seasons=2024)
 Release: [pwhl_player_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/pwhl_player_boxscores) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/pwhl_player_boxscores/player_box_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `player_id` | String |
-| `first_name` | String |
-| `last_name` | String |
-| `position` | String |
-| `team_id` | Int32 |
-| `game_id` | Int32 |
-| `league` | String |
-| `toi` | String |
-| `time_on_ice` | Float64 |
-| `goals` | Int32 |
-| `assists` | Int32 |
-| `points` | Int32 |
-| `shots` | Int32 |
-| `hits` | Int32 |
-| `blocked_shots` | Int32 |
-| `penalty_minutes` | Int32 |
-| `plus_minus` | Int32 |
-| `faceoff_attempts` | Int32 |
-| `faceoff_wins` | Int32 |
-| `faceoff_losses` | Int32 |
-| `faceoff_pct` | Float64 |
-| `starting` | Int32 |
-| `player_type` | String |
-| `saves` | Int32 |
-| `goals_against` | Int32 |
-| `shots_against` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `player_id` | String | Unique player identifier. |
+| `first_name` | String | Player first name. |
+| `last_name` | String | Player last name. |
+| `position` | String | Player position. |
+| `team_id` | Int32 | Unique team identifier. |
+| `game_id` | Int32 | Unique game identifier. |
+| `league` | String | League code. |
+| `toi` | String | Time on ice. |
+| `time_on_ice` | Float64 | Time on ice in seconds. |
+| `goals` | Int32 | Goals scored. |
+| `assists` | Int32 | Assists. |
+| `points` | Int32 | Total points (goals + assists). |
+| `shots` | Int32 | Shots on goal. |
+| `hits` | Int32 | Hits. |
+| `blocked_shots` | Int32 | Blocked shots. |
+| `penalty_minutes` | Int32 | Penalty minutes. |
+| `plus_minus` | Int32 | Plus/minus rating. |
+| `faceoff_attempts` | Int32 | Faceoff attempts. |
+| `faceoff_wins` | Int32 | Faceoff wins. |
+| `faceoff_losses` | Int32 | Faceoff losses. |
+| `faceoff_pct` | Float64 | Faceoff win percentage. |
+| `starting` | Int32 | Whether the player started the game. |
+| `player_type` | String | Player type (skater or goalie). |
+| `saves` | Int32 | Saves made. |
+| `goals_against` | Int32 | Goals against. |
+| `shots_against` | Int32 | Shots faced. |
 
 ```python
 load_pwhl_player_boxscores(seasons=2024)
@@ -641,20 +641,20 @@ load_pwhl_player_boxscores(seasons=2024)
 Release: [pwhl_rosters](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/pwhl_rosters) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/pwhl_rosters/rosters_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `team_id` | Int32 |
-| `team` | String |
-| `team_abbr` | String |
-| `team_side` | String |
-| `player_type` | String |
-| `player_id` | Int32 |
-| `first_name` | String |
-| `last_name` | String |
-| `jersey_number` | Int32 |
-| `position` | String |
-| `birth_date` | String |
-| `season` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `team_id` | Int32 | Unique team identifier. |
+| `team` | String | Team name. |
+| `team_abbr` | String | Team abbreviation. |
+| `team_side` | String | Home or away indicator. |
+| `player_type` | String | Player type (skater or goalie). |
+| `player_id` | Int32 | Unique player identifier. |
+| `first_name` | String | Player first name. |
+| `last_name` | String | Player last name. |
+| `jersey_number` | Int32 | Jersey number. |
+| `position` | String | Player position. |
+| `birth_date` | String | Player birth date. |
+| `season` | Int32 | Season year (echoed from arg). |
 
 ```python
 load_pwhl_rosters(seasons=2024)
@@ -665,37 +665,37 @@ load_pwhl_rosters(seasons=2024)
 Release: [pwhl_schedules](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/pwhl_schedules) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/pwhl_schedules/pwhl_schedule_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | String |
-| `season` | Int32 |
-| `game_date` | String |
-| `game_status` | String |
-| `home_team` | String |
-| `home_team_id` | String |
-| `away_team` | String |
-| `away_team_id` | String |
-| `home_score` | String |
-| `away_score` | String |
-| `winner` | String |
-| `venue` | String |
-| `venue_url` | String |
-| `game_type` | String |
-| `game_json` | Boolean |
-| `game_json_url` | String |
-| `PBP` | Boolean |
-| `player_box` | Boolean |
-| `skater_box` | Boolean |
-| `goalie_box` | Boolean |
-| `team_box` | Boolean |
-| `game_info` | Boolean |
-| `game_rosters` | Boolean |
-| `scoring_summary` | Boolean |
-| `penalty_summary` | Boolean |
-| `three_stars` | Boolean |
-| `officials` | Boolean |
-| `shots_by_period` | Boolean |
-| `shootout` | Boolean |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | String | Unique game identifier. |
+| `season` | Int32 | Season year (echoed from arg). |
+| `game_date` | String | Game date. |
+| `game_status` | String | Game status text. |
+| `home_team` | String | Home team name. |
+| `home_team_id` | String | Home team identifier. |
+| `away_team` | String | Away team name. |
+| `away_team_id` | String | Away team identifier. |
+| `home_score` | String | Home team final score. |
+| `away_score` | String | Away team final score. |
+| `winner` | String | Whether this competitor won the game. |
+| `venue` | String | Venue where the game was played. |
+| `venue_url` | String | URL for the venue. |
+| `game_type` | String | Game type the row belongs to. |
+| `game_json` | Boolean | Whether processed game JSON is available. |
+| `game_json_url` | String | URL to the processed game JSON. |
+| `PBP` | Boolean | Whether play-by-play data is available. |
+| `player_box` | Boolean | Whether player box score data is available. |
+| `skater_box` | Boolean | Whether skater box data is available. |
+| `goalie_box` | Boolean | Whether goalie box data is available. |
+| `team_box` | Boolean | Whether team box score data is available. |
+| `game_info` | Boolean | Whether game info data is available. |
+| `game_rosters` | Boolean | Whether game rosters data is available. |
+| `scoring_summary` | Boolean | Whether scoring summary data is available. |
+| `penalty_summary` | Boolean | Whether penalty summary data is available. |
+| `three_stars` | Boolean | Whether three stars data is available. |
+| `officials` | Boolean | Whether officials data is available. |
+| `shots_by_period` | Boolean | Whether shots-by-period data is available. |
+| `shootout` | Boolean | Whether shootout data is available. |
 
 ```python
 load_pwhl_schedules(seasons=2024)
@@ -706,35 +706,35 @@ load_pwhl_schedules(seasons=2024)
 Release: [pwhl_scoring_summary](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/pwhl_scoring_summary) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/pwhl_scoring_summary/scoring_summary_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int32 |
-| `period_id` | Int32 |
-| `period` | String |
-| `time` | String |
-| `team_id` | Int32 |
-| `team` | String |
-| `team_abbr` | String |
-| `game_goal_id` | Int32 |
-| `scorer_goal_number` | Int32 |
-| `scorer_id` | Int32 |
-| `scorer_first` | String |
-| `scorer_last` | String |
-| `scorer_position` | String |
-| `assist_1_id` | Int32 |
-| `assist_1_first` | String |
-| `assist_1_last` | String |
-| `assist_2_id` | Int32 |
-| `assist_2_first` | String |
-| `assist_2_last` | String |
-| `is_power_play` | Int32 |
-| `is_short_handed` | Int32 |
-| `is_empty_net` | Int32 |
-| `is_penalty_shot` | Int32 |
-| `is_insurance` | Int32 |
-| `is_game_winning` | Int32 |
-| `x_location` | Boolean |
-| `y_location` | Boolean |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int32 | Unique game identifier. |
+| `period_id` | Int32 | Period identifier. |
+| `period` | String | Period number. |
+| `time` | String | Game clock at infraction (MM:SS). |
+| `team_id` | Int32 | Unique team identifier. |
+| `team` | String | Team name. |
+| `team_abbr` | String | Team abbreviation. |
+| `game_goal_id` | Int32 | Goal identifier within the game. |
+| `scorer_goal_number` | Int32 | Scorer's season goal number. |
+| `scorer_id` | Int32 | Identifier of the goal scorer. |
+| `scorer_first` | String | Scorer first name. |
+| `scorer_last` | String | Scorer last name. |
+| `scorer_position` | String | Scorer position. |
+| `assist_1_id` | Int32 | Primary assist player identifier. |
+| `assist_1_first` | String | Primary assist first name. |
+| `assist_1_last` | String | Primary assist last name. |
+| `assist_2_id` | Int32 | Secondary assist player identifier. |
+| `assist_2_first` | String | Secondary assist first name. |
+| `assist_2_last` | String | Secondary assist last name. |
+| `is_power_play` | Int32 | Power-play flag. |
+| `is_short_handed` | Int32 | Short-handed flag. |
+| `is_empty_net` | Int32 | Empty-net flag. |
+| `is_penalty_shot` | Int32 | Penalty-shot flag. |
+| `is_insurance` | Int32 | Insurance-goal flag. |
+| `is_game_winning` | Int32 | Game-winning-goal flag. |
+| `x_location` | Boolean | Goal x-coordinate on the ice. |
+| `y_location` | Boolean | Goal y-coordinate on the ice. |
 
 ```python
 load_pwhl_scoring_summary(seasons=2024)
@@ -745,18 +745,18 @@ load_pwhl_scoring_summary(seasons=2024)
 Release: [pwhl_shootout](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/pwhl_shootout) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/pwhl_shootout/shootout_summary_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int32 |
-| `round` | Int32 |
-| `team_side` | String |
-| `shooter_id` | Int32 |
-| `shooter_first` | String |
-| `shooter_last` | String |
-| `goalie_id` | Int32 |
-| `goalie_first` | String |
-| `goalie_last` | String |
-| `is_goal` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int32 | Unique game identifier. |
+| `round` | Int32 | Shootout round number. |
+| `team_side` | String | Home or away indicator. |
+| `shooter_id` | Int32 | Shooter player identifier. |
+| `shooter_first` | String | Shooter first name. |
+| `shooter_last` | String | Shooter last name. |
+| `goalie_id` | Int32 | Goalie identifier on the play. |
+| `goalie_first` | String | Goalie first name. |
+| `goalie_last` | String | Goalie last name. |
+| `is_goal` | Int32 | Whether the attempt scored (1/0). |
 
 ```python
 load_pwhl_shootout(seasons=2026)
@@ -767,15 +767,15 @@ load_pwhl_shootout(seasons=2026)
 Release: [pwhl_shots_by_period](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/pwhl_shots_by_period) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/pwhl_shots_by_period/shots_by_period_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int32 |
-| `period_id` | Int32 |
-| `period` | String |
-| `home_goals` | Int32 |
-| `home_shots` | Int32 |
-| `away_goals` | Int32 |
-| `away_shots` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int32 | Unique game identifier. |
+| `period_id` | Int32 | Period identifier. |
+| `period` | String | Period number. |
+| `home_goals` | Int32 | Home goals in the period. |
+| `home_shots` | Int32 | Home team shots in the period. |
+| `away_goals` | Int32 | Away goals in the period. |
+| `away_shots` | Int32 | Away team shots in the period. |
 
 ```python
 load_pwhl_shots_by_period(seasons=2024)
@@ -786,30 +786,30 @@ load_pwhl_shots_by_period(seasons=2024)
 Release: [pwhl_skater_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/pwhl_skater_boxscores) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/pwhl_skater_boxscores/skater_box_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `player_id` | String |
-| `first_name` | String |
-| `last_name` | String |
-| `position` | String |
-| `team_id` | Int32 |
-| `game_id` | Int32 |
-| `league` | String |
-| `toi` | String |
-| `time_on_ice` | Float64 |
-| `goals` | Int32 |
-| `assists` | Int32 |
-| `points` | Int32 |
-| `shots` | Int32 |
-| `hits` | Int32 |
-| `blocked_shots` | Int32 |
-| `penalty_minutes` | Int32 |
-| `plus_minus` | Int32 |
-| `faceoff_attempts` | Int32 |
-| `faceoff_wins` | Int32 |
-| `faceoff_losses` | Int32 |
-| `faceoff_pct` | Float64 |
-| `starting` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `player_id` | String | Unique player identifier. |
+| `first_name` | String | Player first name. |
+| `last_name` | String | Player last name. |
+| `position` | String | Player position. |
+| `team_id` | Int32 | Unique team identifier. |
+| `game_id` | Int32 | Unique game identifier. |
+| `league` | String | League code. |
+| `toi` | String | Time on ice. |
+| `time_on_ice` | Float64 | Time on ice in seconds. |
+| `goals` | Int32 | Goals scored. |
+| `assists` | Int32 | Assists. |
+| `points` | Int32 | Total points (goals + assists). |
+| `shots` | Int32 | Shots on goal. |
+| `hits` | Int32 | Hits. |
+| `blocked_shots` | Int32 | Blocked shots. |
+| `penalty_minutes` | Int32 | Penalty minutes. |
+| `plus_minus` | Int32 | Plus/minus rating. |
+| `faceoff_attempts` | Int32 | Faceoff attempts. |
+| `faceoff_wins` | Int32 | Faceoff wins. |
+| `faceoff_losses` | Int32 | Faceoff losses. |
+| `faceoff_pct` | Float64 | Faceoff win percentage. |
+| `starting` | Int32 | Whether the player started the game. |
 
 ```python
 load_pwhl_skater_boxscores(seasons=2024)
@@ -820,31 +820,31 @@ load_pwhl_skater_boxscores(seasons=2024)
 Release: [pwhl_team_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/pwhl_team_boxscores) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/pwhl_team_boxscores/team_box_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int32 |
-| `team_id` | Int32 |
-| `team` | String |
-| `team_abbr` | String |
-| `team_side` | String |
-| `shots` | Int32 |
-| `goals` | Int32 |
-| `hits` | Int32 |
-| `pp_goals` | Int32 |
-| `pp_opportunities` | Int32 |
-| `goal_count` | Int32 |
-| `assist_count` | Int32 |
-| `penalty_minutes` | Int32 |
-| `infraction_count` | Int32 |
-| `faceoff_attempts` | Int32 |
-| `faceoff_wins` | Int32 |
-| `faceoff_win_pct` | Float64 |
-| `season_wins` | Int32 |
-| `season_losses` | Int32 |
-| `season_ot_wins` | Int32 |
-| `season_ot_losses` | Int32 |
-| `season_so_losses` | Int32 |
-| `season_record` | String |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int32 | Unique game identifier. |
+| `team_id` | Int32 | Unique team identifier. |
+| `team` | String | Team name. |
+| `team_abbr` | String | Team abbreviation. |
+| `team_side` | String | Home or away indicator. |
+| `shots` | Int32 | Shots on goal. |
+| `goals` | Int32 | Goals scored. |
+| `hits` | Int32 | Hits. |
+| `pp_goals` | Int32 | Power-play goals. |
+| `pp_opportunities` | Int32 | Power-play opportunities. |
+| `goal_count` | Int32 | Total goals recorded. |
+| `assist_count` | Int32 | Total assists recorded. |
+| `penalty_minutes` | Int32 | Penalty minutes. |
+| `infraction_count` | Int32 | Number of infractions. |
+| `faceoff_attempts` | Int32 | Faceoff attempts. |
+| `faceoff_wins` | Int32 | Faceoff wins. |
+| `faceoff_win_pct` | Float64 | Faceoff win percentage. |
+| `season_wins` | Int32 | Season wins entering/after the game. |
+| `season_losses` | Int32 | Season losses entering/after the game. |
+| `season_ot_wins` | Int32 | Season overtime wins. |
+| `season_ot_losses` | Int32 | Season overtime losses. |
+| `season_so_losses` | Int32 | Season shootout losses. |
+| `season_record` | String | Season record after this game. |
 
 ```python
 load_pwhl_team_boxscores(seasons=2024)
@@ -855,28 +855,28 @@ load_pwhl_team_boxscores(seasons=2024)
 Release: [pwhl_three_stars](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/pwhl_three_stars) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/pwhl_three_stars/three_stars_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int32 |
-| `star` | Int32 |
-| `team_id` | Int32 |
-| `team` | String |
-| `team_abbr` | String |
-| `player_id` | Int32 |
-| `first_name` | String |
-| `last_name` | String |
-| `jersey_number` | Int32 |
-| `position` | String |
-| `is_goalie` | Int32 |
-| `is_home` | Int32 |
-| `goals` | Int32 |
-| `assists` | Int32 |
-| `points` | Int32 |
-| `shots` | Int32 |
-| `saves` | Int32 |
-| `shots_against` | Int32 |
-| `goals_against` | Int32 |
-| `time_on_ice` | String |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int32 | Unique game identifier. |
+| `star` | Int32 | Star ranking (1, 2, or 3). |
+| `team_id` | Int32 | Unique team identifier. |
+| `team` | String | Team name. |
+| `team_abbr` | String | Team abbreviation. |
+| `player_id` | Int32 | Unique player identifier. |
+| `first_name` | String | Player first name. |
+| `last_name` | String | Player last name. |
+| `jersey_number` | Int32 | Jersey number. |
+| `position` | String | Player position. |
+| `is_goalie` | Int32 | Goalie flag. |
+| `is_home` | Int32 | Home-team flag. |
+| `goals` | Int32 | Goals scored. |
+| `assists` | Int32 | Assists. |
+| `points` | Int32 | Total points (goals + assists). |
+| `shots` | Int32 | Shots on goal. |
+| `saves` | Int32 | Saves made. |
+| `shots_against` | Int32 | Shots faced. |
+| `goals_against` | Int32 | Goals against. |
+| `time_on_ice` | String | Time on ice in seconds. |
 
 ```python
 load_pwhl_three_stars(seasons=2024)

--- a/docs/docs/wbb/reference/loaders.md
+++ b/docs/docs/wbb/reference/loaders.md
@@ -33,67 +33,67 @@ flowchart LR
 Release: [espn_womens_college_basketball_pbp](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_womens_college_basketball_pbp) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_womens_college_basketball_pbp/play_by_play_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `id` | Float64 |
-| `sequence_number` | String |
-| `type_id` | Int32 |
-| `type_text` | String |
-| `text` | String |
-| `away_score` | Int32 |
-| `home_score` | Int32 |
-| `period_number` | Int32 |
-| `period_display_value` | String |
-| `clock_display_value` | String |
-| `scoring_play` | Boolean |
-| `score_value` | Int32 |
-| `team_id` | Int32 |
-| `athlete_id_1` | Int32 |
-| `wallclock` | String |
-| `shooting_play` | Boolean |
-| `season` | Int32 |
-| `season_type` | Int32 |
-| `away_team_id` | Int32 |
-| `away_team_name` | String |
-| `away_team_mascot` | String |
-| `away_team_abbrev` | String |
-| `away_team_name_alt` | String |
-| `home_team_id` | Int32 |
-| `home_team_name` | String |
-| `home_team_mascot` | String |
-| `home_team_abbrev` | String |
-| `home_team_name_alt` | String |
-| `home_team_spread` | Float64 |
-| `game_spread` | Float64 |
-| `home_favorite` | Boolean |
-| `game_spread_available` | Boolean |
-| `game_id` | Int32 |
-| `qtr` | Int32 |
-| `time` | String |
-| `clock_minutes` | String |
-| `clock_seconds` | String |
-| `half` | String |
-| `game_half` | String |
-| `lead_qtr` | Int32 |
-| `lead_game_half` | String |
-| `start_quarter_seconds_remaining` | Int32 |
-| `start_half_seconds_remaining` | Int32 |
-| `start_game_seconds_remaining` | Int32 |
-| `game_play_number` | Int32 |
-| `end_quarter_seconds_remaining` | Int32 |
-| `end_half_seconds_remaining` | Int32 |
-| `end_game_seconds_remaining` | Int32 |
-| `period` | Int32 |
-| `lag_qtr` | Int32 |
-| `lag_game_half` | String |
-| `athlete_id_2` | Int32 |
-| `game_date` | Date |
-| `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') |
-| `coordinate_x_raw` | Float64 |
-| `coordinate_y_raw` | Float64 |
-| `coordinate_x` | Float64 |
-| `coordinate_y` | Float64 |
-| `media_id` | String |
+| col_name | type | description |
+|---|---|---|
+| `id` | Float64 | Unique play identifcation number |
+| `sequence_number` | String | Sequence number representing a shot-possession (V3 PBP). |
+| `type_id` | Int32 | Type identifier (numeric). |
+| `type_text` | String | Display text for the type field. |
+| `text` | String | Text description of the play / record. |
+| `away_score` | Int32 | Away team score at the time of the play. |
+| `home_score` | Int32 | Home team score at the time of the play. |
+| `period_number` | Int32 | Numeric period (1-4 for quarters; 5+ for OT). |
+| `period_display_value` | String | Period display label (e.g. '1st Quarter', 'OT'). |
+| `clock_display_value` | String | Game clock display string (e.g. '8:32'). |
+| `scoring_play` | Boolean | TRUE if the play resulted in points scored. |
+| `score_value` | Int32 | Point value of the play (2 / 3 / 1). |
+| `team_id` | Int32 | Unique team identifier. |
+| `athlete_id_1` | Int32 | Primary athlete identifier (e.g. shooter). |
+| `wallclock` | String | Wallclock. |
+| `shooting_play` | Boolean | TRUE if the play was a shooting attempt. |
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season_type` | Int32 | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
+| `away_team_id` | Int32 | Unique identifier for the away team. |
+| `away_team_name` | String | Away team name. |
+| `away_team_mascot` | String | Away team mascot. |
+| `away_team_abbrev` | String | Away team three-letter abbreviation. |
+| `away_team_name_alt` | String | Alternate versions of the away team abbreviation |
+| `home_team_id` | Int32 | Unique identifier for the home team. |
+| `home_team_name` | String | Home team name. |
+| `home_team_mascot` | String | Home team mascot. |
+| `home_team_abbrev` | String | Home team three-letter abbreviation. |
+| `home_team_name_alt` | String | Alternate versions of the home team abbreviation |
+| `home_team_spread` | Float64 | The game spread with respect to the home team |
+| `game_spread` | Float64 | Game spread in (-X Team) format. There are almost none, I would recommend not trusting any of these three columns |
+| `home_favorite` | Boolean | Logical (TRUE/FALSE) indicating whether the home team is favored |
+| `game_spread_available` | Boolean | Logical (TRUE/FALSE) indicating whether the spread was available from ESPN. Basically, I would just not recommend using any of the spread information, I think I defaulted a lot of them to -2.5 for the home team. Most games probably do not have spread information. This column should really be listed first |
+| `game_id` | Int32 | Unique game identifier. |
+| `qtr` | Int32 | Quarter of the game |
+| `time` | String | Time left within the period |
+| `clock_minutes` | String | Clock minutes split from seconds for developer convenience |
+| `clock_seconds` | String | Clock seconds split from minutes for developer convenience |
+| `half` | String | Half of the game |
+| `game_half` | String | Half of the game |
+| `lead_qtr` | Int32 | A lead column on the quarter |
+| `lead_game_half` | String | A lead column on the half |
+| `start_quarter_seconds_remaining` | Int32 | Quarter seconds remaining at the start of the play (these are more or less code artifacts from other sports, but may eventually be used more seriously) |
+| `start_half_seconds_remaining` | Int32 | Game half seconds remaining at the start of the play (these are more or less code artifacts from other sports, but may eventually be used more seriously) |
+| `start_game_seconds_remaining` | Int32 | Game seconds remaining at the start of the play (''') |
+| `game_play_number` | Int32 | Game play number |
+| `end_quarter_seconds_remaining` | Int32 | Quarter seconds remaining at the end of the play (''') |
+| `end_half_seconds_remaining` | Int32 | Game half seconds remaining at the end of the play (''') |
+| `end_game_seconds_remaining` | Int32 | Game seconds remaining at the end of the play (''') |
+| `period` | Int32 | Period of the game (1-4 quarters; 5+ for OT). |
+| `lag_qtr` | Int32 | A lag column on the quarter |
+| `lag_game_half` | String | A lag column on the half |
+| `athlete_id_2` | Int32 | Secondary athlete identifier (e.g. assister / fouler). |
+| `game_date` | Date | Game date (YYYY-MM-DD). |
+| `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') | Game start date/time (ISO 8601). |
+| `coordinate_x_raw` | Float64 | X coordinate as returned by the API before any adjustment. |
+| `coordinate_y_raw` | Float64 | Y coordinate as returned by the API before any adjustment. |
+| `coordinate_x` | Float64 | X coordinate on the court (half-court layout). |
+| `coordinate_y` | Float64 | Y coordinate on the court (half-court layout). |
+| `media_id` | String | Where did you come from |
 
 ```python
 load_wbb_pbp(seasons=2024)
@@ -104,63 +104,63 @@ load_wbb_pbp(seasons=2024)
 Release: [espn_womens_college_basketball_player_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_womens_college_basketball_player_boxscores) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_womens_college_basketball_player_boxscores/player_box_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int32 |
-| `season` | Int32 |
-| `season_type` | Int32 |
-| `game_date` | Date |
-| `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') |
-| `athlete_id` | Int32 |
-| `athlete_display_name` | String |
-| `team_id` | Int32 |
-| `team_name` | String |
-| `team_location` | String |
-| `team_short_display_name` | String |
-| `minutes` | Float64 |
-| `field_goals_made` | Int32 |
-| `field_goals_attempted` | Int32 |
-| `three_point_field_goals_made` | Int32 |
-| `three_point_field_goals_attempted` | Int32 |
-| `free_throws_made` | Int32 |
-| `free_throws_attempted` | Int32 |
-| `offensive_rebounds` | Int32 |
-| `defensive_rebounds` | Int32 |
-| `rebounds` | Int32 |
-| `assists` | Int32 |
-| `steals` | Int32 |
-| `blocks` | Int32 |
-| `turnovers` | Int32 |
-| `fouls` | Int32 |
-| `points` | Int32 |
-| `starter` | Boolean |
-| `ejected` | Boolean |
-| `did_not_play` | Boolean |
-| `active` | Boolean |
-| `athlete_jersey` | String |
-| `athlete_short_name` | String |
-| `athlete_headshot_href` | String |
-| `athlete_position_name` | String |
-| `athlete_position_abbreviation` | String |
-| `team_display_name` | String |
-| `team_uid` | String |
-| `team_slug` | String |
-| `team_logo` | String |
-| `team_abbreviation` | String |
-| `team_color` | String |
-| `team_alternate_color` | String |
-| `home_away` | String |
-| `team_winner` | Boolean |
-| `team_score` | Int32 |
-| `opponent_team_id` | Int32 |
-| `opponent_team_name` | String |
-| `opponent_team_location` | String |
-| `opponent_team_display_name` | String |
-| `opponent_team_abbreviation` | String |
-| `opponent_team_logo` | String |
-| `opponent_team_color` | String |
-| `opponent_team_alternate_color` | String |
-| `opponent_team_score` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int32 | Unique game identifier. |
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season_type` | Int32 | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
+| `game_date` | Date | Game date (YYYY-MM-DD). |
+| `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') | Game start date/time (ISO 8601). |
+| `athlete_id` | Int32 | Unique athlete identifier (ESPN). |
+| `athlete_display_name` | String | Athlete display name (full). |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_name` | String | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_location` | String | Team city or location string. |
+| `team_short_display_name` | String | Short team display name (e.g. 'Aces'). |
+| `minutes` | Float64 | Minutes played, formatted MM:SS (V3 PT-duration parsed) or decimal minutes (V2). |
+| `field_goals_made` | Int32 | Field goals made (2-pt + 3-pt). |
+| `field_goals_attempted` | Int32 | Field goal attempts (2-pt + 3-pt). |
+| `three_point_field_goals_made` | Int32 | Three-point field goals made. |
+| `three_point_field_goals_attempted` | Int32 | Three-point field goal attempts. |
+| `free_throws_made` | Int32 | Free throws made. |
+| `free_throws_attempted` | Int32 | Free throw attempts. |
+| `offensive_rebounds` | Int32 | Offensive rebounds. |
+| `defensive_rebounds` | Int32 | Defensive rebounds. |
+| `rebounds` | Int32 | Total rebounds. |
+| `assists` | Int32 | Total assists. |
+| `steals` | Int32 | Total steals. |
+| `blocks` | Int32 | Total blocks. |
+| `turnovers` | Int32 | Total turnovers. |
+| `fouls` | Int32 | Personal fouls. |
+| `points` | Int32 | Points scored. |
+| `starter` | Boolean | TRUE if the player was in the starting lineup; FALSE otherwise. |
+| `ejected` | Boolean | TRUE if the player was ejected from the game. |
+| `did_not_play` | Boolean | TRUE if the player did not appear in the game. |
+| `active` | Boolean | TRUE if the row represents an active record (player / team / season). |
+| `athlete_jersey` | String | Athlete jersey number. |
+| `athlete_short_name` | String | Athlete short display name. |
+| `athlete_headshot_href` | String | Athlete headshot image URL. |
+| `athlete_position_name` | String | Athlete position ('Guard', 'Forward', 'Center'). |
+| `athlete_position_abbreviation` | String | Athlete position abbreviation (G / F / C). |
+| `team_display_name` | String | Full team display name. |
+| `team_uid` | String | ESPN universal team identifier (UID format 's:40~l:...~t:...'). |
+| `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
+| `team_logo` | String | Team logo image URL. |
+| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
+| `team_color` | String | Team primary color (hex without leading '#'). |
+| `team_alternate_color` | String | Team alternate color (hex without leading '#'). |
+| `home_away` | String | Game venue label ('home' or 'away'). |
+| `team_winner` | Boolean | TRUE if the team won this game. |
+| `team_score` | Int32 | Team's score / final score. |
+| `opponent_team_id` | Int32 | Unique identifier for the opponent team. |
+| `opponent_team_name` | String | Opponent team display name. |
+| `opponent_team_location` | String | Opponent team city / location. |
+| `opponent_team_display_name` | String | Opponent team full display name. |
+| `opponent_team_abbreviation` | String | Opponent team abbreviation. |
+| `opponent_team_logo` | String | Opponent team logo URL. |
+| `opponent_team_color` | String | Opponent team primary color (hex). |
+| `opponent_team_alternate_color` | String | Opponent team alternate color (hex). |
+| `opponent_team_score` | Int32 | Opponent team's score. |
 
 ```python
 load_wbb_player_boxscore(seasons=2024)
@@ -171,79 +171,79 @@ load_wbb_player_boxscore(seasons=2024)
 Release: [espn_womens_college_basketball_schedules](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_womens_college_basketball_schedules) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_womens_college_basketball_schedules/wbb_schedule_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `id` | Int32 |
-| `uid` | String |
-| `date` | String |
-| `attendance` | Int32 |
-| `time_valid` | Boolean |
-| `neutral_site` | Boolean |
-| `conference_competition` | Boolean |
-| `recent` | Boolean |
-| `start_date` | String |
-| `notes_type` | String |
-| `notes_headline` | String |
-| `type_id` | Int32 |
-| `type_abbreviation` | String |
-| `status_clock` | Int32 |
-| `status_display_clock` | String |
-| `status_period` | Int32 |
-| `status_type_id` | Int32 |
-| `status_type_name` | String |
-| `status_type_state` | String |
-| `status_type_completed` | Boolean |
-| `status_type_description` | String |
-| `status_type_detail` | String |
-| `status_type_short_detail` | String |
-| `format_regulation_periods` | Int32 |
-| `home_id` | Int32 |
-| `home_uid` | String |
-| `home_location` | String |
-| `home_name` | String |
-| `home_abbreviation` | String |
-| `home_display_name` | String |
-| `home_short_display_name` | String |
-| `home_color` | String |
-| `home_alternate_color` | String |
-| `home_is_active` | Boolean |
-| `home_venue_id` | Int32 |
-| `home_logo` | String |
-| `home_conference_id` | Int32 |
-| `home_score` | Int32 |
-| `home_winner` | Boolean |
-| `away_id` | Int32 |
-| `away_uid` | String |
-| `away_location` | String |
-| `away_name` | String |
-| `away_abbreviation` | String |
-| `away_display_name` | String |
-| `away_short_display_name` | String |
-| `away_color` | String |
-| `away_alternate_color` | String |
-| `away_is_active` | Boolean |
-| `away_venue_id` | Int32 |
-| `away_logo` | String |
-| `away_conference_id` | Int32 |
-| `away_score` | Int32 |
-| `away_winner` | Boolean |
-| `game_id` | Int32 |
-| `season` | Int32 |
-| `season_type` | Int32 |
-| `groups_id` | Int32 |
-| `groups_name` | String |
-| `groups_short_name` | String |
-| `groups_is_conference` | Boolean |
-| `status_type_alt_detail` | String |
-| `venue_id` | Int32 |
-| `venue_full_name` | String |
-| `venue_address_city` | String |
-| `venue_address_state` | String |
-| `venue_capacity` | Int32 |
-| `venue_indoor` | Boolean |
-| `PBP` | Boolean |
-| `team_box` | Boolean |
-| `player_box` | Boolean |
+| col_name | type | description |
+|---|---|---|
+| `id` | Int32 | Unique play identifcation number |
+| `uid` | String | ESPN UID string. |
+| `date` | String | Date in YYYY-MM-DD format. |
+| `attendance` | Int32 | Reported attendance. |
+| `time_valid` | Boolean | Whether the start time is confirmed. |
+| `neutral_site` | Boolean | Neutral site. |
+| `conference_competition` | Boolean | Conference competition. |
+| `recent` | Boolean | Whether the game is recent. |
+| `start_date` | String | Start date (YYYY-MM-DD). |
+| `notes_type` | String | Notes type. |
+| `notes_headline` | String | Notes headline. |
+| `type_id` | Int32 | Type identifier (numeric). |
+| `type_abbreviation` | String | Play type abbreviation |
+| `status_clock` | Int32 | Game clock in seconds. |
+| `status_display_clock` | String | Status display clock. |
+| `status_period` | Int32 | Current period. |
+| `status_type_id` | Int32 | Unique identifier for status type. |
+| `status_type_name` | String | Status type name. |
+| `status_type_state` | String | Status state (pre/in/post). |
+| `status_type_completed` | Boolean | Whether the game is complete. |
+| `status_type_description` | String | Status type description. |
+| `status_type_detail` | String | Status type detail. |
+| `status_type_short_detail` | String | Status type short detail. |
+| `format_regulation_periods` | Int32 | Format regulation periods. |
+| `home_id` | Int32 | Unique identifier for home. |
+| `home_uid` | String | Home team's uid. |
+| `home_location` | String | Home team's location. |
+| `home_name` | String | Home team display name. |
+| `home_abbreviation` | String | Home team's abbreviation. |
+| `home_display_name` | String | Home team display name. |
+| `home_short_display_name` | String | Home short display name. |
+| `home_color` | String | Home team primary color hex. |
+| `home_alternate_color` | String | Color code (hex) for home alternate. |
+| `home_is_active` | Boolean | Home team's is active. |
+| `home_venue_id` | Int32 | Unique identifier for home venue. |
+| `home_logo` | String | Home team logo URL. |
+| `home_conference_id` | Int32 | Unique identifier for home conference. |
+| `home_score` | Int32 | Home team score at the time of the play. |
+| `home_winner` | Boolean | Whether the home team won. |
+| `away_id` | Int32 | Unique identifier for away. |
+| `away_uid` | String | Away team's uid. |
+| `away_location` | String | Away team's location. |
+| `away_name` | String | Away team display name. |
+| `away_abbreviation` | String | Away team's abbreviation. |
+| `away_display_name` | String | Away team display name. |
+| `away_short_display_name` | String | Away short display name. |
+| `away_color` | String | Away team primary color hex. |
+| `away_alternate_color` | String | Color code (hex) for away alternate. |
+| `away_is_active` | Boolean | Away team's is active. |
+| `away_venue_id` | Int32 | Unique identifier for away venue. |
+| `away_logo` | String | Away team logo URL. |
+| `away_conference_id` | Int32 | Unique identifier for away conference. |
+| `away_score` | Int32 | Away team score at the time of the play. |
+| `away_winner` | Boolean | Whether the away team won. |
+| `game_id` | Int32 | Unique game identifier. |
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season_type` | Int32 | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
+| `groups_id` | Int32 | Unique identifier for groups. |
+| `groups_name` | String | Groups name. |
+| `groups_short_name` | String | Groups short name. |
+| `groups_is_conference` | Boolean | Groups is conference. |
+| `status_type_alt_detail` | String | Status type alt detail. |
+| `venue_id` | Int32 | Unique venue identifier. |
+| `venue_full_name` | String | Venue full name. |
+| `venue_address_city` | String | Venue address city. |
+| `venue_address_state` | String | Venue address state / region. |
+| `venue_capacity` | Int32 | Venue seating capacity. |
+| `venue_indoor` | Boolean | Whether the home venue is indoors. |
+| `PBP` | Boolean | Whether play-by-play data is available. |
+| `team_box` | Boolean | Whether team box score data is available. |
+| `player_box` | Boolean | Whether player box score data is available. |
 
 ```python
 load_wbb_schedule(seasons=2024)
@@ -254,62 +254,62 @@ load_wbb_schedule(seasons=2024)
 Release: [espn_womens_college_basketball_team_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_womens_college_basketball_team_boxscores) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_womens_college_basketball_team_boxscores/team_box_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int32 |
-| `season` | Int32 |
-| `season_type` | Int32 |
-| `game_date` | Date |
-| `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') |
-| `team_id` | Int32 |
-| `team_uid` | String |
-| `team_slug` | String |
-| `team_location` | String |
-| `team_name` | String |
-| `team_abbreviation` | String |
-| `team_display_name` | String |
-| `team_short_display_name` | String |
-| `team_color` | String |
-| `team_alternate_color` | String |
-| `team_logo` | String |
-| `team_home_away` | String |
-| `team_score` | Int32 |
-| `team_winner` | Boolean |
-| `assists` | Int32 |
-| `blocks` | Int32 |
-| `defensive_rebounds` | Int32 |
-| `field_goal_pct` | Float64 |
-| `field_goals_made` | Int32 |
-| `field_goals_attempted` | Int32 |
-| `flagrant_fouls` | Int32 |
-| `fouls` | Int32 |
-| `free_throw_pct` | Float64 |
-| `free_throws_made` | Int32 |
-| `free_throws_attempted` | Int32 |
-| `largest_lead` | String |
-| `offensive_rebounds` | Int32 |
-| `steals` | Int32 |
-| `team_turnovers` | Int32 |
-| `technical_fouls` | Int32 |
-| `three_point_field_goal_pct` | Float64 |
-| `three_point_field_goals_made` | Int32 |
-| `three_point_field_goals_attempted` | Int32 |
-| `total_rebounds` | Int32 |
-| `total_technical_fouls` | Int32 |
-| `total_turnovers` | Int32 |
-| `turnovers` | Int32 |
-| `opponent_team_id` | Int32 |
-| `opponent_team_uid` | String |
-| `opponent_team_slug` | String |
-| `opponent_team_location` | String |
-| `opponent_team_name` | String |
-| `opponent_team_abbreviation` | String |
-| `opponent_team_display_name` | String |
-| `opponent_team_short_display_name` | String |
-| `opponent_team_color` | String |
-| `opponent_team_alternate_color` | String |
-| `opponent_team_logo` | String |
-| `opponent_team_score` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int32 | Unique game identifier. |
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season_type` | Int32 | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
+| `game_date` | Date | Game date (YYYY-MM-DD). |
+| `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') | Game start date/time (ISO 8601). |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_uid` | String | ESPN universal team identifier (UID format 's:40~l:...~t:...'). |
+| `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
+| `team_location` | String | Team city or location string. |
+| `team_name` | String | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
+| `team_display_name` | String | Full team display name. |
+| `team_short_display_name` | String | Short team display name (e.g. 'Aces'). |
+| `team_color` | String | Team primary color (hex without leading '#'). |
+| `team_alternate_color` | String | Team alternate color (hex without leading '#'). |
+| `team_logo` | String | Team logo image URL. |
+| `team_home_away` | String | Team home away. |
+| `team_score` | Int32 | Team's score / final score. |
+| `team_winner` | Boolean | TRUE if the team won this game. |
+| `assists` | Int32 | Total assists. |
+| `blocks` | Int32 | Total blocks. |
+| `defensive_rebounds` | Int32 | Defensive rebounds. |
+| `field_goal_pct` | Float64 | Field goal percentage (0-1). |
+| `field_goals_made` | Int32 | Field goals made (2-pt + 3-pt). |
+| `field_goals_attempted` | Int32 | Field goal attempts (2-pt + 3-pt). |
+| `flagrant_fouls` | Int32 | Total flagrant fouls. |
+| `fouls` | Int32 | Personal fouls. |
+| `free_throw_pct` | Float64 | Free throw percentage (0-1). |
+| `free_throws_made` | Int32 | Free throws made. |
+| `free_throws_attempted` | Int32 | Free throw attempts. |
+| `largest_lead` | String | Largest lead during the game. |
+| `offensive_rebounds` | Int32 | Offensive rebounds. |
+| `steals` | Int32 | Total steals. |
+| `team_turnovers` | Int32 | Team turnovers (turnovers credited to the team rather than a player). |
+| `technical_fouls` | Int32 | Total technical fouls. |
+| `three_point_field_goal_pct` | Float64 | Three-point field goal percentage (0-1). |
+| `three_point_field_goals_made` | Int32 | Three-point field goals made. |
+| `three_point_field_goals_attempted` | Int32 | Three-point field goal attempts. |
+| `total_rebounds` | Int32 | Total rebounds. |
+| `total_technical_fouls` | Int32 | Total technical fouls (player + team). |
+| `total_turnovers` | Int32 | Total turnovers (player + team). |
+| `turnovers` | Int32 | Total turnovers. |
+| `opponent_team_id` | Int32 | Unique identifier for the opponent team. |
+| `opponent_team_uid` | String | Opponent team uid. |
+| `opponent_team_slug` | String | Opponent team slug. |
+| `opponent_team_location` | String | Opponent team city / location. |
+| `opponent_team_name` | String | Opponent team display name. |
+| `opponent_team_abbreviation` | String | Opponent team abbreviation. |
+| `opponent_team_display_name` | String | Opponent team full display name. |
+| `opponent_team_short_display_name` | String | Opponent team short display name. |
+| `opponent_team_color` | String | Opponent team primary color (hex). |
+| `opponent_team_alternate_color` | String | Opponent team alternate color (hex). |
+| `opponent_team_logo` | String | Opponent team logo URL. |
+| `opponent_team_score` | Int32 | Opponent team's score. |
 
 ```python
 load_wbb_team_boxscore(seasons=2024)
@@ -320,19 +320,19 @@ load_wbb_team_boxscore(seasons=2024)
 Release: [wbb_ratings](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wbb_ratings) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/wbb_ratings/wbb_ratings_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int64 |
-| `team_id` | String |
-| `adj_o` | Float64 |
-| `adj_d` | Float64 |
-| `adj_em` | Float64 |
-| `adj_tempo` | Float64 |
-| `raw_o` | Float64 |
-| `raw_d` | Float64 |
-| `games` | Int64 |
-| `rank` | Int64 |
-| `adj_em_z` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `team_id` | String | Unique team identifier. |
+| `adj_o` | Float64 | Adj o. |
+| `adj_d` | Float64 | Adj d. |
+| `adj_em` | Float64 | Adj em. |
+| `adj_tempo` | Float64 |  |
+| `raw_o` | Float64 | Raw o. |
+| `raw_d` | Float64 | Raw d. |
+| `games` | Int64 | Games played. |
+| `rank` | Int64 | Whether to include statistical ranks in the returned table. |
+| `adj_em_z` | Float64 |  |
 
 ```python
 load_wbb_ratings(seasons=2025)
@@ -343,16 +343,16 @@ load_wbb_ratings(seasons=2025)
 Release: [wbb_player_value](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wbb_player_value) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/wbb_player_value/wbb_player_value_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `player_id` | String |
-| `player` | String |
-| `season` | Int64 |
-| `team_id` | String |
-| `min` | Float64 |
-| `box_obpm` | Float64 |
-| `box_dbpm` | Float64 |
-| `box_bpm` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `player_id` | String | Unique player identifier. |
+| `player` | String | Player name. |
+| `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `team_id` | String | Unique team identifier. |
+| `min` | Float64 | Minutes played. |
+| `box_obpm` | Float64 |  |
+| `box_dbpm` | Float64 |  |
+| `box_bpm` | Float64 |  |
 
 ```python
 load_wbb_player_value(seasons=2025)
@@ -363,30 +363,30 @@ load_wbb_player_value(seasons=2025)
 Release: [espn_womens_college_basketball_game_rosters](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_womens_college_basketball_game_rosters) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_womens_college_basketball_game_rosters/game_rosters_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int32 |
-| `game_id` | String |
-| `team_id` | Int32 |
-| `team_slug` | String |
-| `team_abbreviation` | String |
-| `team_display_name` | String |
-| `home_away` | String |
-| `athlete_id` | Int32 |
-| `athlete_uid` | String |
-| `athlete_guid` | String |
-| `athlete_display_name` | String |
-| `athlete_short_name` | String |
-| `athlete_first_name` | String |
-| `athlete_last_name` | String |
-| `athlete_jersey` | String |
-| `athlete_position` | String |
-| `athlete_headshot` | String |
-| `starter` | Boolean |
-| `did_not_play` | Boolean |
-| `active` | Boolean |
-| `ejected` | Boolean |
-| `reason` | String |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `game_id` | String | Unique game identifier. |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
+| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
+| `team_display_name` | String | Full team display name. |
+| `home_away` | String | Game venue label ('home' or 'away'). |
+| `athlete_id` | Int32 | Unique athlete identifier (ESPN). |
+| `athlete_uid` | String | ESPN athlete UID (universal identifier). |
+| `athlete_guid` | String | ESPN athlete GUID. |
+| `athlete_display_name` | String | Athlete display name (full). |
+| `athlete_short_name` | String | Athlete short display name. |
+| `athlete_first_name` | String | Player first name; `athlete_detail = TRUE` only. |
+| `athlete_last_name` | String | Athlete last name. |
+| `athlete_jersey` | String | Athlete jersey number. |
+| `athlete_position` | String | Athlete position. |
+| `athlete_headshot` | String |  |
+| `starter` | Boolean | TRUE if the player was in the starting lineup; FALSE otherwise. |
+| `did_not_play` | Boolean | TRUE if the player did not appear in the game. |
+| `active` | Boolean | TRUE if the row represents an active record (player / team / season). |
+| `ejected` | Boolean | TRUE if the player was ejected from the game. |
+| `reason` | String | Reason. |
 
 ```python
 load_wbb_game_rosters(seasons=2026)
@@ -397,19 +397,19 @@ load_wbb_game_rosters(seasons=2026)
 Release: [espn_womens_college_basketball_officials](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_womens_college_basketball_officials) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_womens_college_basketball_officials/officials_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int32 |
-| `game_id` | String |
-| `official_id` | Int32 |
-| `official_uid` | String |
-| `official_full_name` | String |
-| `official_display_name` | String |
-| `official_first_name` | String |
-| `official_last_name` | String |
-| `official_order` | Int32 |
-| `position_name` | String |
-| `position_display_name` | String |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `game_id` | String | Unique game identifier. |
+| `official_id` | Int32 | Unique official / referee identifier. |
+| `official_uid` | String |  |
+| `official_full_name` | String |  |
+| `official_display_name` | String |  |
+| `official_first_name` | String |  |
+| `official_last_name` | String |  |
+| `official_order` | Int32 |  |
+| `position_name` | String | Listed roster position ('Guard', 'Forward', 'Center'). |
+| `position_display_name` | String | Position display name. |
 
 ```python
 load_wbb_officials(seasons=2026)
@@ -420,24 +420,24 @@ load_wbb_officials(seasons=2026)
 Release: [espn_womens_college_basketball_player_season_stats](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_womens_college_basketball_player_season_stats) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_womens_college_basketball_player_season_stats/player_season_stats_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int32 |
-| `athlete_id` | Int32 |
-| `athlete_display_name` | String |
-| `athlete_first_name` | String |
-| `athlete_last_name` | String |
-| `athlete_position_abbreviation` | String |
-| `athlete_jersey` | String |
-| `team_id` | Int32 |
-| `team_display_name` | String |
-| `category` | String |
-| `stat_label` | String |
-| `stat_name` | String |
-| `stat_display_name` | String |
-| `stat_description` | String |
-| `display_value` | String |
-| `value` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `athlete_id` | Int32 | Unique athlete identifier (ESPN). |
+| `athlete_display_name` | String | Athlete display name (full). |
+| `athlete_first_name` | String | Player first name; `athlete_detail = TRUE` only. |
+| `athlete_last_name` | String | Athlete last name. |
+| `athlete_position_abbreviation` | String | Athlete position abbreviation (G / F / C). |
+| `athlete_jersey` | String | Athlete jersey number. |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_display_name` | String | Full team display name. |
+| `category` | String | Category label. |
+| `stat_label` | String | Human-readable label of the statistic (e.g. 'At bats'). |
+| `stat_name` | String | Internal stat key. |
+| `stat_display_name` | String | Stat display name. |
+| `stat_description` | String |  |
+| `display_value` | String | Display-formatted value. |
+| `value` | Float64 | Numeric or string value field. |
 
 ```python
 load_wbb_player_season_stats(seasons=2026)
@@ -448,44 +448,44 @@ load_wbb_player_season_stats(seasons=2026)
 Release: [espn_womens_college_basketball_rosters](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_womens_college_basketball_rosters) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_womens_college_basketball_rosters/rosters_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int32 |
-| `team_id` | Int32 |
-| `team_slug` | String |
-| `team_abbreviation` | String |
-| `team_display_name` | String |
-| `team_short_display_name` | String |
-| `team_color` | String |
-| `team_alternate_color` | String |
-| `team_logo` | String |
-| `athlete_id` | String |
-| `uid` | String |
-| `guid` | String |
-| `full_name` | String |
-| `display_name` | String |
-| `short_name` | String |
-| `first_name` | String |
-| `last_name` | String |
-| `jersey` | String |
-| `position_abbreviation` | String |
-| `position_name` | String |
-| `position_id` | String |
-| `height` | String |
-| `weight` | String |
-| `age` | String |
-| `date_of_birth` | String |
-| `birth_place_city` | String |
-| `birth_place_state` | String |
-| `birth_place_country` | String |
-| `experience_years` | String |
-| `experience_display_value` | String |
-| `headshot_href` | String |
-| `headshot_alt` | String |
-| `link_web` | String |
-| `status_id` | String |
-| `status_name` | String |
-| `status_type` | String |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
+| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
+| `team_display_name` | String | Full team display name. |
+| `team_short_display_name` | String | Short team display name (e.g. 'Aces'). |
+| `team_color` | String | Team primary color (hex without leading '#'). |
+| `team_alternate_color` | String | Team alternate color (hex without leading '#'). |
+| `team_logo` | String | Team logo image URL. |
+| `athlete_id` | String | Unique athlete identifier (ESPN). |
+| `uid` | String | ESPN UID string. |
+| `guid` | String | Stable cross-league team GUID. |
+| `full_name` | String | Player's full name. |
+| `display_name` | String | Display name. |
+| `short_name` | String | Short display name. |
+| `first_name` | String | Player's first name. |
+| `last_name` | String | Player's last name. |
+| `jersey` | String | Jersey number worn by the player. |
+| `position_abbreviation` | String | Position abbreviation ('G' / 'F' / 'C'). |
+| `position_name` | String | Listed roster position ('Guard', 'Forward', 'Center'). |
+| `position_id` | String | Unique position identifier. |
+| `height` | String | Player height (string e.g. '6-2' or inches). |
+| `weight` | String | Player weight in pounds. |
+| `age` | String | Player age (in years). |
+| `date_of_birth` | String | Date of birth (YYYY-MM-DD). |
+| `birth_place_city` | String | Birth place city. |
+| `birth_place_state` | String | Birth place state. |
+| `birth_place_country` | String | Birth place country. |
+| `experience_years` | String | Experience years. |
+| `experience_display_value` | String | Experience display value. |
+| `headshot_href` | String | Headshot image URL. |
+| `headshot_alt` | String | Alternative-text label for the headshot. |
+| `link_web` | String | Web link / URL. |
+| `status_id` | String | Status identifier. |
+| `status_name` | String | Status label. |
+| `status_type` | String | Status type. |
 
 ```python
 load_wbb_rosters(seasons=2026)
@@ -496,23 +496,23 @@ load_wbb_rosters(seasons=2026)
 Release: [espn_womens_college_basketball_shots](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_womens_college_basketball_shots) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_womens_college_basketball_shots/shots_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int32 |
-| `season` | Int32 |
-| `period_number` | Int32 |
-| `clock_display_value` | String |
-| `team_id` | Int32 |
-| `athlete_id_1` | Int32 |
-| `athlete_id_2` | Int32 |
-| `type_id` | Int32 |
-| `type_text` | String |
-| `scoring_play` | Boolean |
-| `score_value` | Int32 |
-| `coordinate_x` | Float64 |
-| `coordinate_y` | Float64 |
-| `coordinate_x_raw` | Float64 |
-| `coordinate_y_raw` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int32 | Unique game identifier. |
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `period_number` | Int32 | Numeric period (1-4 for quarters; 5+ for OT). |
+| `clock_display_value` | String | Game clock display string (e.g. '8:32'). |
+| `team_id` | Int32 | Unique team identifier. |
+| `athlete_id_1` | Int32 | Primary athlete identifier (e.g. shooter). |
+| `athlete_id_2` | Int32 | Secondary athlete identifier (e.g. assister / fouler). |
+| `type_id` | Int32 | Type identifier (numeric). |
+| `type_text` | String | Display text for the type field. |
+| `scoring_play` | Boolean | TRUE if the play resulted in points scored. |
+| `score_value` | Int32 | Point value of the play (2 / 3 / 1). |
+| `coordinate_x` | Float64 | X coordinate on the court (half-court layout). |
+| `coordinate_y` | Float64 | Y coordinate on the court (half-court layout). |
+| `coordinate_x_raw` | Float64 | X coordinate as returned by the API before any adjustment. |
+| `coordinate_y_raw` | Float64 | Y coordinate as returned by the API before any adjustment. |
 
 ```python
 load_wbb_shots(seasons=2026)
@@ -523,32 +523,32 @@ load_wbb_shots(seasons=2026)
 Release: [espn_womens_college_basketball_standings](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_womens_college_basketball_standings) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_womens_college_basketball_standings/standings_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int32 |
-| `group_id` | String |
-| `group_name` | String |
-| `group_abbreviation` | String |
-| `group_short_name` | String |
-| `team_id` | Int32 |
-| `team_uid` | String |
-| `team_slug` | String |
-| `team_location` | String |
-| `team_name` | String |
-| `team_abbreviation` | String |
-| `team_display_name` | String |
-| `team_short_display_name` | String |
-| `team_color` | String |
-| `team_alternate_color` | String |
-| `team_logo` | String |
-| `stat_name` | String |
-| `stat_display_name` | String |
-| `stat_short_display_name` | String |
-| `stat_description` | String |
-| `stat_abbreviation` | String |
-| `stat_type` | String |
-| `display_value` | String |
-| `value` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `group_id` | String | ESPN group id. |
+| `group_name` | String | Group name (conference / division). |
+| `group_abbreviation` | String | Group abbreviation. |
+| `group_short_name` | String |  |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_uid` | String | ESPN universal team identifier (UID format 's:40~l:...~t:...'). |
+| `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
+| `team_location` | String | Team city or location string. |
+| `team_name` | String | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
+| `team_display_name` | String | Full team display name. |
+| `team_short_display_name` | String | Short team display name (e.g. 'Aces'). |
+| `team_color` | String | Team primary color (hex without leading '#'). |
+| `team_alternate_color` | String | Team alternate color (hex without leading '#'). |
+| `team_logo` | String | Team logo image URL. |
+| `stat_name` | String | Internal stat key. |
+| `stat_display_name` | String | Stat display name. |
+| `stat_short_display_name` | String | Short human-readable stat name. |
+| `stat_description` | String |  |
+| `stat_abbreviation` | String |  |
+| `stat_type` | String | Stat type code (e.g. "win", "loss"). |
+| `display_value` | String | Display-formatted value. |
+| `value` | Float64 | Numeric or string value field. |
 
 ```python
 load_wbb_standings(seasons=2026)
@@ -559,24 +559,24 @@ load_wbb_standings(seasons=2026)
 Release: [espn_womens_college_basketball_team_season_stats](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_womens_college_basketball_team_season_stats) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_womens_college_basketball_team_season_stats/team_season_stats_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int32 |
-| `team_id` | Int32 |
-| `team_slug` | String |
-| `team_abbreviation` | String |
-| `team_display_name` | String |
-| `team_short_display_name` | String |
-| `team_color` | String |
-| `team_alternate_color` | String |
-| `team_logo` | String |
-| `category` | String |
-| `stat_label` | String |
-| `stat_name` | String |
-| `stat_display_name` | String |
-| `stat_description` | String |
-| `display_value` | String |
-| `value` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
+| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
+| `team_display_name` | String | Full team display name. |
+| `team_short_display_name` | String | Short team display name (e.g. 'Aces'). |
+| `team_color` | String | Team primary color (hex without leading '#'). |
+| `team_alternate_color` | String | Team alternate color (hex without leading '#'). |
+| `team_logo` | String | Team logo image URL. |
+| `category` | String | Category label. |
+| `stat_label` | String | Human-readable label of the statistic (e.g. 'At bats'). |
+| `stat_name` | String | Internal stat key. |
+| `stat_display_name` | String | Stat display name. |
+| `stat_description` | String |  |
+| `display_value` | String | Display-formatted value. |
+| `value` | Float64 | Numeric or string value field. |
 
 ```python
 load_wbb_team_season_stats(seasons=2026)

--- a/docs/docs/wnba/reference/loaders.md
+++ b/docs/docs/wnba/reference/loaders.md
@@ -41,67 +41,67 @@ flowchart LR
 Release: [espn_wnba_pbp](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_wnba_pbp) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_wnba_pbp/play_by_play_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `id` | Float64 |
-| `sequence_number` | String |
-| `type_id` | Int32 |
-| `type_text` | String |
-| `text` | String |
-| `away_score` | Int32 |
-| `home_score` | Int32 |
-| `period_number` | Int32 |
-| `period_display_value` | String |
-| `clock_display_value` | String |
-| `scoring_play` | Boolean |
-| `score_value` | Int32 |
-| `shooting_play` | Boolean |
-| `coordinate_x_raw` | Float64 |
-| `coordinate_y_raw` | Float64 |
-| `season` | Int32 |
-| `season_type` | Int32 |
-| `away_team_id` | Int32 |
-| `away_team_name` | String |
-| `away_team_mascot` | String |
-| `away_team_abbrev` | String |
-| `away_team_name_alt` | String |
-| `home_team_id` | Int32 |
-| `home_team_name` | String |
-| `home_team_mascot` | String |
-| `home_team_abbrev` | String |
-| `home_team_name_alt` | String |
-| `home_team_spread` | Float64 |
-| `game_spread` | Float64 |
-| `home_favorite` | Boolean |
-| `game_spread_available` | Boolean |
-| `game_id` | Int32 |
-| `qtr` | Int32 |
-| `time` | String |
-| `clock_minutes` | Int32 |
-| `clock_seconds` | Float64 |
-| `half` | String |
-| `game_half` | String |
-| `lead_qtr` | Int32 |
-| `lead_game_half` | String |
-| `start_quarter_seconds_remaining` | Int32 |
-| `start_half_seconds_remaining` | Int32 |
-| `start_game_seconds_remaining` | Int32 |
-| `game_play_number` | Int32 |
-| `end_quarter_seconds_remaining` | Int32 |
-| `end_half_seconds_remaining` | Int32 |
-| `end_game_seconds_remaining` | Int32 |
-| `period` | Int32 |
-| `team_id` | Int32 |
-| `athlete_id_1` | Int32 |
-| `athlete_id_2` | Int32 |
-| `athlete_id_3` | Int32 |
-| `lag_qtr` | Int32 |
-| `lag_game_half` | String |
-| `coordinate_x` | Float64 |
-| `coordinate_y` | Float64 |
-| `game_date` | Date |
-| `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') |
-| `type_abbreviation` | String |
+| col_name | type | description |
+|---|---|---|
+| `id` | Float64 | Unique play identifcation number |
+| `sequence_number` | String | Sequence number representing a shot-possession (V3 PBP). |
+| `type_id` | Int32 | Type identifier (numeric). |
+| `type_text` | String | Display text for the type field. |
+| `text` | String | Text description of the play / record. |
+| `away_score` | Int32 | Away team score at the time of the play. |
+| `home_score` | Int32 | Home team score at the time of the play. |
+| `period_number` | Int32 | Numeric period (1-4 for quarters; 5+ for OT). |
+| `period_display_value` | String | Period display label (e.g. '1st Quarter', 'OT'). |
+| `clock_display_value` | String | Game clock display string (e.g. '8:32'). |
+| `scoring_play` | Boolean | TRUE if the play resulted in points scored. |
+| `score_value` | Int32 | Point value of the play (2 / 3 / 1). |
+| `shooting_play` | Boolean | TRUE if the play was a shooting attempt. |
+| `coordinate_x_raw` | Float64 | X coordinate as returned by the API before any adjustment. |
+| `coordinate_y_raw` | Float64 | Y coordinate as returned by the API before any adjustment. |
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season_type` | Int32 | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
+| `away_team_id` | Int32 | Unique identifier for the away team. |
+| `away_team_name` | String | Away team name. |
+| `away_team_mascot` | String | Away team mascot. |
+| `away_team_abbrev` | String | Away team three-letter abbreviation. |
+| `away_team_name_alt` | String | Alternate versions of the away team abbreviation |
+| `home_team_id` | Int32 | Unique identifier for the home team. |
+| `home_team_name` | String | Home team name. |
+| `home_team_mascot` | String | Home team mascot. |
+| `home_team_abbrev` | String | Home team three-letter abbreviation. |
+| `home_team_name_alt` | String | Alternate versions of the home team abbreviation |
+| `home_team_spread` | Float64 | The game spread with respect to the home team |
+| `game_spread` | Float64 | Game spread in (-X Team) format. There are almost none, I would recommend not trusting any of these three columns |
+| `home_favorite` | Boolean | Logical (TRUE/FALSE) indicating whether the home team is favored |
+| `game_spread_available` | Boolean | Logical (TRUE/FALSE) indicating whether the spread was available from ESPN. Basically, I would just not recommend using any of the spread information, I think I defaulted a lot of them to -2.5 for the home team. Most games probably do not have spread information. This column should really be listed first |
+| `game_id` | Int32 | Unique game identifier. |
+| `qtr` | Int32 | Quarter of the game |
+| `time` | String | Time left within the period |
+| `clock_minutes` | Int32 | Clock minutes split from seconds for developer convenience |
+| `clock_seconds` | Float64 | Clock seconds split from minutes for developer convenience |
+| `half` | String | Half of the game |
+| `game_half` | String | Half of the game |
+| `lead_qtr` | Int32 | A lead column on the quarter |
+| `lead_game_half` | String | A lead column on the half |
+| `start_quarter_seconds_remaining` | Int32 | Quarter seconds remaining at the start of the play (these are more or less code artifacts from other sports, but may eventually be used more seriously) |
+| `start_half_seconds_remaining` | Int32 | Game half seconds remaining at the start of the play (these are more or less code artifacts from other sports, but may eventually be used more seriously) |
+| `start_game_seconds_remaining` | Int32 | Game seconds remaining at the start of the play (''') |
+| `game_play_number` | Int32 | Game play number |
+| `end_quarter_seconds_remaining` | Int32 | Quarter seconds remaining at the end of the play (''') |
+| `end_half_seconds_remaining` | Int32 | Game half seconds remaining at the end of the play (''') |
+| `end_game_seconds_remaining` | Int32 | Game seconds remaining at the end of the play (''') |
+| `period` | Int32 | Period of the game (1-4 quarters; 5+ for OT). |
+| `team_id` | Int32 | Unique team identifier. |
+| `athlete_id_1` | Int32 | Primary athlete identifier (e.g. shooter). |
+| `athlete_id_2` | Int32 | Secondary athlete identifier (e.g. assister / fouler). |
+| `athlete_id_3` | Int32 | Athlete id 3. |
+| `lag_qtr` | Int32 | A lag column on the quarter |
+| `lag_game_half` | String | A lag column on the half |
+| `coordinate_x` | Float64 | X coordinate on the court (half-court layout). |
+| `coordinate_y` | Float64 | Y coordinate on the court (half-court layout). |
+| `game_date` | Date | Game date (YYYY-MM-DD). |
+| `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') | Game start date/time (ISO 8601). |
+| `type_abbreviation` | String | Play type abbreviation |
 
 ```python
 load_wnba_pbp(seasons=2024)
@@ -112,43 +112,43 @@ load_wnba_pbp(seasons=2024)
 Release: [espn_wnba_player_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_wnba_player_boxscores) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_wnba_player_boxscores/player_box_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `athlete_display_name` | String |
-| `team_short_display_name` | String |
-| `min` | String |
-| `fg` | String |
-| `fg3` | String |
-| `ft` | String |
-| `oreb` | String |
-| `dreb` | String |
-| `reb` | String |
-| `ast` | String |
-| `stl` | String |
-| `blk` | String |
-| `to` | String |
-| `pf` | String |
-| `plus_minus` | String |
-| `pts` | String |
-| `starter` | Boolean |
-| `ejected` | Boolean |
-| `did_not_play` | Boolean |
-| `active` | Boolean |
-| `athlete_jersey` | String |
-| `athlete_id` | String |
-| `athlete_short_name` | String |
-| `athlete_position_name` | String |
-| `athlete_position_abbreviation` | String |
-| `team_name` | String |
-| `team_logo` | String |
-| `team_id` | String |
-| `team_abbreviation` | String |
-| `team_color` | String |
-| `game_id` | Int32 |
-| `season` | Int32 |
-| `season_type` | Int32 |
-| `game_date` | Date |
-| `athlete_headshot_href` | String |
+| col_name | type | description |
+|---|---|---|
+| `athlete_display_name` | String | Athlete display name (full). |
+| `team_short_display_name` | String | Short team display name (e.g. 'Aces'). |
+| `min` | String | Minutes played. |
+| `fg` | String |  |
+| `fg3` | String |  |
+| `ft` | String |  |
+| `oreb` | String | Offensive rebounds. |
+| `dreb` | String | Defensive rebounds. |
+| `reb` | String | Total rebounds. |
+| `ast` | String | Assists. |
+| `stl` | String | Steals. |
+| `blk` | String | Blocks. |
+| `to` | String | Final season played in NFL |
+| `pf` | String | Personal fouls. |
+| `plus_minus` | String | Plus/minus point differential while on court. |
+| `pts` | String | Points scored. |
+| `starter` | Boolean | TRUE if the player was in the starting lineup; FALSE otherwise. |
+| `ejected` | Boolean | TRUE if the player was ejected from the game. |
+| `did_not_play` | Boolean | TRUE if the player did not appear in the game. |
+| `active` | Boolean | TRUE if the row represents an active record (player / team / season). |
+| `athlete_jersey` | String | Athlete jersey number. |
+| `athlete_id` | String | Unique athlete identifier (ESPN). |
+| `athlete_short_name` | String | Athlete short display name. |
+| `athlete_position_name` | String | Athlete position ('Guard', 'Forward', 'Center'). |
+| `athlete_position_abbreviation` | String | Athlete position abbreviation (G / F / C). |
+| `team_name` | String | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_logo` | String | Team logo image URL. |
+| `team_id` | String | Unique team identifier. |
+| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
+| `team_color` | String | Team primary color (hex without leading '#'). |
+| `game_id` | Int32 | Unique game identifier. |
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season_type` | Int32 | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
+| `game_date` | Date | Game date (YYYY-MM-DD). |
+| `athlete_headshot_href` | String | Athlete headshot image URL. |
 
 ```python
 load_wnba_player_boxscore(seasons=2024)
@@ -159,77 +159,77 @@ load_wnba_player_boxscore(seasons=2024)
 Release: [espn_wnba_schedules](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_wnba_schedules) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_wnba_schedules/wnba_schedule_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `id` | Int32 |
-| `uid` | String |
-| `date` | String |
-| `attendance` | Float64 |
-| `time_valid` | Boolean |
-| `neutral_site` | Boolean |
-| `conference_competition` | Boolean |
-| `recent` | Boolean |
-| `start_date` | String |
-| `notes_type` | String |
-| `notes_headline` | String |
-| `type_id` | Int32 |
-| `type_abbreviation` | String |
-| `status_clock` | Float64 |
-| `status_display_clock` | String |
-| `status_period` | Float64 |
-| `status_type_id` | Int32 |
-| `status_type_name` | String |
-| `status_type_state` | String |
-| `status_type_completed` | Boolean |
-| `status_type_description` | String |
-| `status_type_detail` | String |
-| `status_type_short_detail` | String |
-| `format_regulation_periods` | Float64 |
-| `home_id` | Int32 |
-| `home_uid` | String |
-| `home_location` | String |
-| `home_name` | String |
-| `home_abbreviation` | String |
-| `home_display_name` | String |
-| `home_short_display_name` | String |
-| `home_color` | String |
-| `home_alternate_color` | String |
-| `home_is_active` | Boolean |
-| `home_venue_id` | Int32 |
-| `home_logo` | String |
-| `home_score` | Int32 |
-| `home_winner` | Boolean |
-| `away_id` | Int32 |
-| `away_uid` | String |
-| `away_location` | String |
-| `away_name` | String |
-| `away_abbreviation` | String |
-| `away_display_name` | String |
-| `away_short_display_name` | String |
-| `away_is_active` | Boolean |
-| `away_venue_id` | Int32 |
-| `away_score` | Int32 |
-| `away_winner` | Boolean |
-| `game_id` | Int32 |
-| `season` | Int32 |
-| `season_type` | Int32 |
-| `venue_id` | Int32 |
-| `venue_full_name` | String |
-| `venue_address_city` | String |
-| `venue_address_state` | String |
-| `venue_capacity` | Float64 |
-| `venue_indoor` | Boolean |
-| `away_color` | String |
-| `away_alternate_color` | String |
-| `away_logo` | String |
-| `status_type_alt_detail` | String |
-| `game_json` | Boolean |
-| `game_json_url` | String |
-| `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') |
-| `game_date` | Date |
-| `PBP` | Boolean |
-| `team_box` | Boolean |
-| `player_box` | Boolean |
+| col_name | type | description |
+|---|---|---|
+| `id` | Int32 | Unique play identifcation number |
+| `uid` | String | ESPN UID string. |
+| `date` | String | Date in YYYY-MM-DD format. |
+| `attendance` | Float64 | Reported attendance. |
+| `time_valid` | Boolean | Whether the start time is confirmed. |
+| `neutral_site` | Boolean | Neutral site. |
+| `conference_competition` | Boolean | Conference competition. |
+| `recent` | Boolean | Whether the game is recent. |
+| `start_date` | String | Start date (YYYY-MM-DD). |
+| `notes_type` | String | Notes type. |
+| `notes_headline` | String | Notes headline. |
+| `type_id` | Int32 | Type identifier (numeric). |
+| `type_abbreviation` | String | Play type abbreviation |
+| `status_clock` | Float64 | Game clock in seconds. |
+| `status_display_clock` | String | Status display clock. |
+| `status_period` | Float64 | Current period. |
+| `status_type_id` | Int32 | Unique identifier for status type. |
+| `status_type_name` | String | Status type name. |
+| `status_type_state` | String | Status state (pre/in/post). |
+| `status_type_completed` | Boolean | Whether the game is complete. |
+| `status_type_description` | String | Status type description. |
+| `status_type_detail` | String | Status type detail. |
+| `status_type_short_detail` | String | Status type short detail. |
+| `format_regulation_periods` | Float64 | Format regulation periods. |
+| `home_id` | Int32 | Unique identifier for home. |
+| `home_uid` | String | Home team's uid. |
+| `home_location` | String | Home team's location. |
+| `home_name` | String | Home team display name. |
+| `home_abbreviation` | String | Home team's abbreviation. |
+| `home_display_name` | String | Home team display name. |
+| `home_short_display_name` | String | Home short display name. |
+| `home_color` | String | Home team primary color hex. |
+| `home_alternate_color` | String | Color code (hex) for home alternate. |
+| `home_is_active` | Boolean | Home team's is active. |
+| `home_venue_id` | Int32 | Unique identifier for home venue. |
+| `home_logo` | String | Home team logo URL. |
+| `home_score` | Int32 | Home team score at the time of the play. |
+| `home_winner` | Boolean | Whether the home team won. |
+| `away_id` | Int32 | Unique identifier for away. |
+| `away_uid` | String | Away team's uid. |
+| `away_location` | String | Away team's location. |
+| `away_name` | String | Away team display name. |
+| `away_abbreviation` | String | Away team's abbreviation. |
+| `away_display_name` | String | Away team display name. |
+| `away_short_display_name` | String | Away short display name. |
+| `away_is_active` | Boolean | Away team's is active. |
+| `away_venue_id` | Int32 | Unique identifier for away venue. |
+| `away_score` | Int32 | Away team score at the time of the play. |
+| `away_winner` | Boolean | Whether the away team won. |
+| `game_id` | Int32 | Unique game identifier. |
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season_type` | Int32 | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
+| `venue_id` | Int32 | Unique venue identifier. |
+| `venue_full_name` | String | Venue full name. |
+| `venue_address_city` | String | Venue address city. |
+| `venue_address_state` | String | Venue address state / region. |
+| `venue_capacity` | Float64 | Venue seating capacity. |
+| `venue_indoor` | Boolean | Whether the home venue is indoors. |
+| `away_color` | String | Away team primary color hex. |
+| `away_alternate_color` | String | Color code (hex) for away alternate. |
+| `away_logo` | String | Away team logo URL. |
+| `status_type_alt_detail` | String | Status type alt detail. |
+| `game_json` | Boolean | Whether processed game JSON is available. |
+| `game_json_url` | String | URL to the processed game JSON. |
+| `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') | Game start date/time (ISO 8601). |
+| `game_date` | Date | Game date (YYYY-MM-DD). |
+| `PBP` | Boolean | Whether play-by-play data is available. |
+| `team_box` | Boolean | Whether team box score data is available. |
+| `player_box` | Boolean | Whether player box score data is available. |
 
 ```python
 load_wnba_schedule(seasons=2024)
@@ -240,65 +240,65 @@ load_wnba_schedule(seasons=2024)
 Release: [espn_wnba_team_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_wnba_team_boxscores) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_wnba_team_boxscores/team_box_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int32 |
-| `season` | Int32 |
-| `season_type` | Int32 |
-| `game_date` | Date |
-| `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') |
-| `team_id` | Int32 |
-| `team_uid` | String |
-| `team_slug` | String |
-| `team_location` | String |
-| `team_name` | String |
-| `team_abbreviation` | String |
-| `team_display_name` | String |
-| `team_short_display_name` | String |
-| `team_color` | String |
-| `team_alternate_color` | String |
-| `team_logo` | String |
-| `team_home_away` | String |
-| `team_score` | Int32 |
-| `team_winner` | Boolean |
-| `assists` | Int32 |
-| `blocks` | Int32 |
-| `defensive_rebounds` | Int32 |
-| `fast_break_points` | String |
-| `field_goal_pct` | Float64 |
-| `field_goals_made` | Int32 |
-| `field_goals_attempted` | Int32 |
-| `flagrant_fouls` | Int32 |
-| `fouls` | Int32 |
-| `free_throw_pct` | Float64 |
-| `free_throws_made` | Int32 |
-| `free_throws_attempted` | Int32 |
-| `largest_lead` | String |
-| `offensive_rebounds` | Int32 |
-| `points_in_paint` | String |
-| `steals` | Int32 |
-| `team_turnovers` | Int32 |
-| `technical_fouls` | Int32 |
-| `three_point_field_goal_pct` | Float64 |
-| `three_point_field_goals_made` | Int32 |
-| `three_point_field_goals_attempted` | Int32 |
-| `total_rebounds` | Int32 |
-| `total_technical_fouls` | Int32 |
-| `total_turnovers` | Int32 |
-| `turnover_points` | String |
-| `turnovers` | Int32 |
-| `opponent_team_id` | Int32 |
-| `opponent_team_uid` | String |
-| `opponent_team_slug` | String |
-| `opponent_team_location` | String |
-| `opponent_team_name` | String |
-| `opponent_team_abbreviation` | String |
-| `opponent_team_display_name` | String |
-| `opponent_team_short_display_name` | String |
-| `opponent_team_color` | String |
-| `opponent_team_alternate_color` | String |
-| `opponent_team_logo` | String |
-| `opponent_team_score` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int32 | Unique game identifier. |
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season_type` | Int32 | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
+| `game_date` | Date | Game date (YYYY-MM-DD). |
+| `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') | Game start date/time (ISO 8601). |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_uid` | String | ESPN universal team identifier (UID format 's:40~l:...~t:...'). |
+| `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
+| `team_location` | String | Team city or location string. |
+| `team_name` | String | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
+| `team_display_name` | String | Full team display name. |
+| `team_short_display_name` | String | Short team display name (e.g. 'Aces'). |
+| `team_color` | String | Team primary color (hex without leading '#'). |
+| `team_alternate_color` | String | Team alternate color (hex without leading '#'). |
+| `team_logo` | String | Team logo image URL. |
+| `team_home_away` | String | Team home away. |
+| `team_score` | Int32 | Team's score / final score. |
+| `team_winner` | Boolean | TRUE if the team won this game. |
+| `assists` | Int32 | Total assists. |
+| `blocks` | Int32 | Total blocks. |
+| `defensive_rebounds` | Int32 | Defensive rebounds. |
+| `fast_break_points` | String | Fast-break points scored. |
+| `field_goal_pct` | Float64 | Field goal percentage (0-1). |
+| `field_goals_made` | Int32 | Field goals made (2-pt + 3-pt). |
+| `field_goals_attempted` | Int32 | Field goal attempts (2-pt + 3-pt). |
+| `flagrant_fouls` | Int32 | Total flagrant fouls. |
+| `fouls` | Int32 | Personal fouls. |
+| `free_throw_pct` | Float64 | Free throw percentage (0-1). |
+| `free_throws_made` | Int32 | Free throws made. |
+| `free_throws_attempted` | Int32 | Free throw attempts. |
+| `largest_lead` | String | Largest lead during the game. |
+| `offensive_rebounds` | Int32 | Offensive rebounds. |
+| `points_in_paint` | String | Points scored in the paint. |
+| `steals` | Int32 | Total steals. |
+| `team_turnovers` | Int32 | Team turnovers (turnovers credited to the team rather than a player). |
+| `technical_fouls` | Int32 | Total technical fouls. |
+| `three_point_field_goal_pct` | Float64 | Three-point field goal percentage (0-1). |
+| `three_point_field_goals_made` | Int32 | Three-point field goals made. |
+| `three_point_field_goals_attempted` | Int32 | Three-point field goal attempts. |
+| `total_rebounds` | Int32 | Total rebounds. |
+| `total_technical_fouls` | Int32 | Total technical fouls (player + team). |
+| `total_turnovers` | Int32 | Total turnovers (player + team). |
+| `turnover_points` | String | Turnover points. |
+| `turnovers` | Int32 | Total turnovers. |
+| `opponent_team_id` | Int32 | Unique identifier for the opponent team. |
+| `opponent_team_uid` | String | Opponent team uid. |
+| `opponent_team_slug` | String | Opponent team slug. |
+| `opponent_team_location` | String | Opponent team city / location. |
+| `opponent_team_name` | String | Opponent team display name. |
+| `opponent_team_abbreviation` | String | Opponent team abbreviation. |
+| `opponent_team_display_name` | String | Opponent team full display name. |
+| `opponent_team_short_display_name` | String | Opponent team short display name. |
+| `opponent_team_color` | String | Opponent team primary color (hex). |
+| `opponent_team_alternate_color` | String | Opponent team alternate color (hex). |
+| `opponent_team_logo` | String | Opponent team logo URL. |
+| `opponent_team_score` | Int32 | Opponent team's score. |
 
 ```python
 load_wnba_team_boxscore(seasons=2024)
@@ -309,43 +309,43 @@ load_wnba_team_boxscore(seasons=2024)
 Release: [espn_wnba_draft](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_wnba_draft) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_wnba_draft/draft_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int32 |
-| `round` | Int32 |
-| `round_display_name` | String |
-| `pick` | Int32 |
-| `overall_pick` | Int32 |
-| `pick_traded` | String |
-| `pick_notes` | String |
-| `athlete_id` | Int32 |
-| `athlete_uid` | String |
-| `athlete_guid` | String |
-| `athlete_first_name` | String |
-| `athlete_last_name` | String |
-| `athlete_full_name` | String |
-| `athlete_display_name` | String |
-| `athlete_short_name` | String |
-| `athlete_height` | String |
-| `athlete_weight` | String |
-| `athlete_position_abbreviation` | String |
-| `athlete_position_name` | String |
-| `athlete_headshot_href` | String |
-| `college_id` | Int32 |
-| `college_name` | String |
-| `college_short_name` | String |
-| `college_abbreviation` | String |
-| `team_id` | Int32 |
-| `team_uid` | String |
-| `team_slug` | String |
-| `team_location` | String |
-| `team_name` | String |
-| `team_abbreviation` | String |
-| `team_display_name` | String |
-| `team_short_display_name` | String |
-| `team_color` | String |
-| `team_alternate_color` | String |
-| `team_logo` | String |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `round` | Int32 | Tournament / playoff round. |
+| `round_display_name` | String |  |
+| `pick` | Int32 | Pick. |
+| `overall_pick` | Int32 | Overall pick. |
+| `pick_traded` | String |  |
+| `pick_notes` | String |  |
+| `athlete_id` | Int32 | Unique athlete identifier (ESPN). |
+| `athlete_uid` | String | ESPN athlete UID (universal identifier). |
+| `athlete_guid` | String | ESPN athlete GUID. |
+| `athlete_first_name` | String | Player first name; `athlete_detail = TRUE` only. |
+| `athlete_last_name` | String | Athlete last name. |
+| `athlete_full_name` | String | Drafted player full name. |
+| `athlete_display_name` | String | Athlete display name (full). |
+| `athlete_short_name` | String | Athlete short display name. |
+| `athlete_height` | String | Athlete height. |
+| `athlete_weight` | String | Athlete weight. |
+| `athlete_position_abbreviation` | String | Athlete position abbreviation (G / F / C). |
+| `athlete_position_name` | String | Athlete position ('Guard', 'Forward', 'Center'). |
+| `athlete_headshot_href` | String | Athlete headshot image URL. |
+| `college_id` | Int32 | Unique identifier for college. |
+| `college_name` | String | College name. |
+| `college_short_name` | String | College short name. |
+| `college_abbreviation` | String |  |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_uid` | String | ESPN universal team identifier (UID format 's:40~l:...~t:...'). |
+| `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
+| `team_location` | String | Team city or location string. |
+| `team_name` | String | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
+| `team_display_name` | String | Full team display name. |
+| `team_short_display_name` | String | Short team display name (e.g. 'Aces'). |
+| `team_color` | String | Team primary color (hex without leading '#'). |
+| `team_alternate_color` | String | Team alternate color (hex without leading '#'). |
+| `team_logo` | String | Team logo image URL. |
 
 ```python
 load_wnba_draft(seasons=2026)
@@ -356,30 +356,30 @@ load_wnba_draft(seasons=2026)
 Release: [espn_wnba_game_rosters](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_wnba_game_rosters) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_wnba_game_rosters/game_rosters_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int32 |
-| `game_id` | String |
-| `team_id` | Int32 |
-| `team_slug` | String |
-| `team_abbreviation` | String |
-| `team_display_name` | String |
-| `home_away` | String |
-| `athlete_id` | Int32 |
-| `athlete_uid` | String |
-| `athlete_guid` | String |
-| `athlete_display_name` | String |
-| `athlete_short_name` | String |
-| `athlete_first_name` | String |
-| `athlete_last_name` | String |
-| `athlete_jersey` | String |
-| `athlete_position` | String |
-| `athlete_headshot` | String |
-| `starter` | Boolean |
-| `did_not_play` | Boolean |
-| `active` | Boolean |
-| `ejected` | Boolean |
-| `reason` | String |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `game_id` | String | Unique game identifier. |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
+| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
+| `team_display_name` | String | Full team display name. |
+| `home_away` | String | Game venue label ('home' or 'away'). |
+| `athlete_id` | Int32 | Unique athlete identifier (ESPN). |
+| `athlete_uid` | String | ESPN athlete UID (universal identifier). |
+| `athlete_guid` | String | ESPN athlete GUID. |
+| `athlete_display_name` | String | Athlete display name (full). |
+| `athlete_short_name` | String | Athlete short display name. |
+| `athlete_first_name` | String | Player first name; `athlete_detail = TRUE` only. |
+| `athlete_last_name` | String | Athlete last name. |
+| `athlete_jersey` | String | Athlete jersey number. |
+| `athlete_position` | String | Athlete position. |
+| `athlete_headshot` | String |  |
+| `starter` | Boolean | TRUE if the player was in the starting lineup; FALSE otherwise. |
+| `did_not_play` | Boolean | TRUE if the player did not appear in the game. |
+| `active` | Boolean | TRUE if the row represents an active record (player / team / season). |
+| `ejected` | Boolean | TRUE if the player was ejected from the game. |
+| `reason` | String | Reason. |
 
 ```python
 load_wnba_game_rosters(seasons=2024)
@@ -390,19 +390,19 @@ load_wnba_game_rosters(seasons=2024)
 Release: [espn_wnba_officials](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_wnba_officials) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_wnba_officials/officials_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int32 |
-| `game_id` | String |
-| `official_id` | Int32 |
-| `official_uid` | String |
-| `official_full_name` | String |
-| `official_display_name` | String |
-| `official_first_name` | String |
-| `official_last_name` | String |
-| `official_order` | Int32 |
-| `position_name` | String |
-| `position_display_name` | String |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `game_id` | String | Unique game identifier. |
+| `official_id` | Int32 | Unique official / referee identifier. |
+| `official_uid` | String |  |
+| `official_full_name` | String |  |
+| `official_display_name` | String |  |
+| `official_first_name` | String |  |
+| `official_last_name` | String |  |
+| `official_order` | Int32 |  |
+| `position_name` | String | Listed roster position ('Guard', 'Forward', 'Center'). |
+| `position_display_name` | String | Position display name. |
 
 ```python
 load_wnba_officials(seasons=2024)
@@ -413,24 +413,24 @@ load_wnba_officials(seasons=2024)
 Release: [espn_wnba_player_season_stats](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_wnba_player_season_stats) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_wnba_player_season_stats/player_season_stats_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int32 |
-| `athlete_id` | Int32 |
-| `athlete_display_name` | String |
-| `athlete_first_name` | String |
-| `athlete_last_name` | String |
-| `athlete_position_abbreviation` | String |
-| `athlete_jersey` | String |
-| `team_id` | Int32 |
-| `team_display_name` | String |
-| `category` | String |
-| `stat_label` | String |
-| `stat_name` | String |
-| `stat_display_name` | String |
-| `stat_description` | String |
-| `display_value` | String |
-| `value` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `athlete_id` | Int32 | Unique athlete identifier (ESPN). |
+| `athlete_display_name` | String | Athlete display name (full). |
+| `athlete_first_name` | String | Player first name; `athlete_detail = TRUE` only. |
+| `athlete_last_name` | String | Athlete last name. |
+| `athlete_position_abbreviation` | String | Athlete position abbreviation (G / F / C). |
+| `athlete_jersey` | String | Athlete jersey number. |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_display_name` | String | Full team display name. |
+| `category` | String | Category label. |
+| `stat_label` | String | Human-readable label of the statistic (e.g. 'At bats'). |
+| `stat_name` | String | Internal stat key. |
+| `stat_display_name` | String | Stat display name. |
+| `stat_description` | String |  |
+| `display_value` | String | Display-formatted value. |
+| `value` | Float64 | Numeric or string value field. |
 
 ```python
 load_wnba_player_season_stats(seasons=2024)
@@ -441,44 +441,44 @@ load_wnba_player_season_stats(seasons=2024)
 Release: [espn_wnba_rosters](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_wnba_rosters) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_wnba_rosters/rosters_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int32 |
-| `team_id` | Int32 |
-| `team_slug` | String |
-| `team_abbreviation` | String |
-| `team_display_name` | String |
-| `team_short_display_name` | String |
-| `team_color` | String |
-| `team_alternate_color` | String |
-| `team_logo` | String |
-| `athlete_id` | String |
-| `uid` | String |
-| `guid` | String |
-| `full_name` | String |
-| `display_name` | String |
-| `short_name` | String |
-| `first_name` | String |
-| `last_name` | String |
-| `jersey` | String |
-| `position_abbreviation` | String |
-| `position_name` | String |
-| `position_id` | String |
-| `height` | String |
-| `weight` | String |
-| `age` | String |
-| `date_of_birth` | String |
-| `birth_place_city` | String |
-| `birth_place_state` | String |
-| `birth_place_country` | String |
-| `experience_years` | String |
-| `experience_display_value` | String |
-| `headshot_href` | String |
-| `headshot_alt` | String |
-| `link_web` | String |
-| `status_id` | String |
-| `status_name` | String |
-| `status_type` | String |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
+| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
+| `team_display_name` | String | Full team display name. |
+| `team_short_display_name` | String | Short team display name (e.g. 'Aces'). |
+| `team_color` | String | Team primary color (hex without leading '#'). |
+| `team_alternate_color` | String | Team alternate color (hex without leading '#'). |
+| `team_logo` | String | Team logo image URL. |
+| `athlete_id` | String | Unique athlete identifier (ESPN). |
+| `uid` | String | ESPN UID string. |
+| `guid` | String | Stable cross-league team GUID. |
+| `full_name` | String | Player's full name. |
+| `display_name` | String | Display name. |
+| `short_name` | String | Short display name. |
+| `first_name` | String | Player's first name. |
+| `last_name` | String | Player's last name. |
+| `jersey` | String | Jersey number worn by the player. |
+| `position_abbreviation` | String | Position abbreviation ('G' / 'F' / 'C'). |
+| `position_name` | String | Listed roster position ('Guard', 'Forward', 'Center'). |
+| `position_id` | String | Unique position identifier. |
+| `height` | String | Player height (string e.g. '6-2' or inches). |
+| `weight` | String | Player weight in pounds. |
+| `age` | String | Player age (in years). |
+| `date_of_birth` | String | Date of birth (YYYY-MM-DD). |
+| `birth_place_city` | String | Birth place city. |
+| `birth_place_state` | String | Birth place state. |
+| `birth_place_country` | String | Birth place country. |
+| `experience_years` | String | Experience years. |
+| `experience_display_value` | String | Experience display value. |
+| `headshot_href` | String | Headshot image URL. |
+| `headshot_alt` | String | Alternative-text label for the headshot. |
+| `link_web` | String | Web link / URL. |
+| `status_id` | String | Status identifier. |
+| `status_name` | String | Status label. |
+| `status_type` | String | Status type. |
 
 ```python
 load_wnba_rosters(seasons=2024)
@@ -489,23 +489,23 @@ load_wnba_rosters(seasons=2024)
 Release: [espn_wnba_shots](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_wnba_shots) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_wnba_shots/shots_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | Int32 |
-| `season` | Int32 |
-| `period_number` | Int32 |
-| `clock_display_value` | String |
-| `team_id` | Int32 |
-| `athlete_id_1` | Int32 |
-| `athlete_id_2` | Int32 |
-| `type_id` | Int32 |
-| `type_text` | String |
-| `scoring_play` | Boolean |
-| `score_value` | Int32 |
-| `coordinate_x` | Float64 |
-| `coordinate_y` | Float64 |
-| `coordinate_x_raw` | Float64 |
-| `coordinate_y_raw` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | Int32 | Unique game identifier. |
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `period_number` | Int32 | Numeric period (1-4 for quarters; 5+ for OT). |
+| `clock_display_value` | String | Game clock display string (e.g. '8:32'). |
+| `team_id` | Int32 | Unique team identifier. |
+| `athlete_id_1` | Int32 | Primary athlete identifier (e.g. shooter). |
+| `athlete_id_2` | Int32 | Secondary athlete identifier (e.g. assister / fouler). |
+| `type_id` | Int32 | Type identifier (numeric). |
+| `type_text` | String | Display text for the type field. |
+| `scoring_play` | Boolean | TRUE if the play resulted in points scored. |
+| `score_value` | Int32 | Point value of the play (2 / 3 / 1). |
+| `coordinate_x` | Float64 | X coordinate on the court (half-court layout). |
+| `coordinate_y` | Float64 | Y coordinate on the court (half-court layout). |
+| `coordinate_x_raw` | Float64 | X coordinate as returned by the API before any adjustment. |
+| `coordinate_y_raw` | Float64 | Y coordinate as returned by the API before any adjustment. |
 
 ```python
 load_wnba_shots(seasons=2024)
@@ -516,32 +516,32 @@ load_wnba_shots(seasons=2024)
 Release: [espn_wnba_standings](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_wnba_standings) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_wnba_standings/standings_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int32 |
-| `group_id` | String |
-| `group_name` | String |
-| `group_abbreviation` | String |
-| `group_short_name` | String |
-| `team_id` | Int32 |
-| `team_uid` | String |
-| `team_slug` | String |
-| `team_location` | String |
-| `team_name` | String |
-| `team_abbreviation` | String |
-| `team_display_name` | String |
-| `team_short_display_name` | String |
-| `team_color` | String |
-| `team_alternate_color` | String |
-| `team_logo` | String |
-| `stat_name` | String |
-| `stat_display_name` | String |
-| `stat_short_display_name` | String |
-| `stat_description` | String |
-| `stat_abbreviation` | String |
-| `stat_type` | String |
-| `display_value` | String |
-| `value` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `group_id` | String | ESPN group id. |
+| `group_name` | String | Group name (conference / division). |
+| `group_abbreviation` | String | Group abbreviation. |
+| `group_short_name` | String |  |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_uid` | String | ESPN universal team identifier (UID format 's:40~l:...~t:...'). |
+| `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
+| `team_location` | String | Team city or location string. |
+| `team_name` | String | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
+| `team_display_name` | String | Full team display name. |
+| `team_short_display_name` | String | Short team display name (e.g. 'Aces'). |
+| `team_color` | String | Team primary color (hex without leading '#'). |
+| `team_alternate_color` | String | Team alternate color (hex without leading '#'). |
+| `team_logo` | String | Team logo image URL. |
+| `stat_name` | String | Internal stat key. |
+| `stat_display_name` | String | Stat display name. |
+| `stat_short_display_name` | String | Short human-readable stat name. |
+| `stat_description` | String |  |
+| `stat_abbreviation` | String |  |
+| `stat_type` | String | Stat type code (e.g. "win", "loss"). |
+| `display_value` | String | Display-formatted value. |
+| `value` | Float64 | Numeric or string value field. |
 
 ```python
 load_wnba_standings(seasons=2024)
@@ -552,24 +552,24 @@ load_wnba_standings(seasons=2024)
 Release: [espn_wnba_team_season_stats](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/espn_wnba_team_season_stats) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/espn_wnba_team_season_stats/team_season_stats_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season` | Int32 |
-| `team_id` | Int32 |
-| `team_slug` | String |
-| `team_abbreviation` | String |
-| `team_display_name` | String |
-| `team_short_display_name` | String |
-| `team_color` | String |
-| `team_alternate_color` | String |
-| `team_logo` | String |
-| `category` | String |
-| `stat_label` | String |
-| `stat_name` | String |
-| `stat_display_name` | String |
-| `stat_description` | String |
-| `display_value` | String |
-| `value` | Float64 |
+| col_name | type | description |
+|---|---|---|
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
+| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
+| `team_display_name` | String | Full team display name. |
+| `team_short_display_name` | String | Short team display name (e.g. 'Aces'). |
+| `team_color` | String | Team primary color (hex without leading '#'). |
+| `team_alternate_color` | String | Team alternate color (hex without leading '#'). |
+| `team_logo` | String | Team logo image URL. |
+| `category` | String | Category label. |
+| `stat_label` | String | Human-readable label of the statistic (e.g. 'At bats'). |
+| `stat_name` | String | Internal stat key. |
+| `stat_display_name` | String | Stat display name. |
+| `stat_description` | String |  |
+| `display_value` | String | Display-formatted value. |
+| `value` | Float64 | Numeric or string value field. |
 
 ```python
 load_wnba_team_season_stats(seasons=2024)
@@ -580,20 +580,20 @@ load_wnba_team_season_stats(seasons=2024)
 Release: [wnba_stats_coaches](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wnba_stats_coaches) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/wnba_stats_coaches/coaches_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `team_id` | String |
-| `season` | Int32 |
-| `coach_id` | String |
-| `first_name` | String |
-| `last_name` | String |
-| `coach_name` | String |
-| `is_assistant` | String |
-| `coach_type` | String |
-| `sort_sequence` | String |
-| `sub_sort_sequence` | String |
-| `season_2` | Int32 |
-| `team_id_lookup` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `team_id` | String | Unique team identifier. |
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `coach_id` | String | Unique identifier for coach. |
+| `first_name` | String | Player's first name. |
+| `last_name` | String | Player's last name. |
+| `coach_name` | String |  |
+| `is_assistant` | String |  |
+| `coach_type` | String |  |
+| `sort_sequence` | String |  |
+| `sub_sort_sequence` | String |  |
+| `season_2` | Int32 |  |
+| `team_id_lookup` | Int32 |  |
 
 ```python
 load_wnba_stats_coaches(seasons=2026)
@@ -604,23 +604,23 @@ load_wnba_stats_coaches(seasons=2026)
 Release: [wnba_stats_draft](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wnba_stats_draft) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/wnba_stats_draft/draft_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `person_id` | String |
-| `player_name` | String |
-| `season` | Int32 |
-| `round_number` | String |
-| `round_pick` | String |
-| `overall_pick` | String |
-| `draft_type` | String |
-| `team_id` | String |
-| `team_city` | String |
-| `team_name` | String |
-| `team_abbreviation` | String |
-| `organization` | String |
-| `organization_type` | String |
-| `player_profile_flag` | String |
-| `season_2` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `person_id` | String | Unique player identifier (V3 endpoints). |
+| `player_name` | String | Player name. |
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `round_number` | String | Numeric round. |
+| `round_pick` | String | Round pick. |
+| `overall_pick` | String | Overall pick. |
+| `draft_type` | String |  |
+| `team_id` | String | Unique team identifier. |
+| `team_city` | String | Team city or region (e.g. 'Las Vegas'). |
+| `team_name` | String | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
+| `organization` | String | Organization. |
+| `organization_type` | String | Organization type. |
+| `player_profile_flag` | String | Player profile flag. |
+| `season_2` | Int32 |  |
 
 ```python
 load_wnba_stats_draft(seasons=2025)
@@ -631,18 +631,18 @@ load_wnba_stats_draft(seasons=2025)
 Release: [wnba_stats_game_rosters](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wnba_stats_game_rosters) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/wnba_stats_game_rosters/game_rosters_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `player_id` | String |
-| `first_name` | String |
-| `last_name` | String |
-| `jersey_num` | String |
-| `team_id` | String |
-| `team_city` | String |
-| `team_name` | String |
-| `team_abbreviation` | String |
-| `game_id` | String |
-| `season` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `player_id` | String | Unique player identifier. |
+| `first_name` | String | Player's first name. |
+| `last_name` | String | Player's last name. |
+| `jersey_num` | String | Jersey number worn by the player. |
+| `team_id` | String | Unique team identifier. |
+| `team_city` | String | Team city or region (e.g. 'Las Vegas'). |
+| `team_name` | String | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
+| `game_id` | String | Unique game identifier. |
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
 
 ```python
 load_wnba_stats_game_rosters(seasons=2026)
@@ -653,14 +653,14 @@ load_wnba_stats_game_rosters(seasons=2026)
 Release: [wnba_stats_officials](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wnba_stats_officials) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/wnba_stats_officials/officials_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `official_id` | String |
-| `first_name` | String |
-| `last_name` | String |
-| `jersey_num` | String |
-| `game_id` | String |
-| `season` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `official_id` | String | Unique official / referee identifier. |
+| `first_name` | String | Player's first name. |
+| `last_name` | String | Player's last name. |
+| `jersey_num` | String | Jersey number worn by the player. |
+| `game_id` | String | Unique game identifier. |
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
 
 ```python
 load_wnba_stats_officials(seasons=2026)
@@ -671,93 +671,93 @@ load_wnba_stats_officials(seasons=2026)
 Release: [wnba_stats_pbp](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wnba_stats_pbp) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/wnba_stats_pbp/play_by_play_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | String |
-| `event_num` | String |
-| `event_type` | String |
-| `event_action_type` | String |
-| `period` | Int32 |
-| `clock` | String |
-| `minute_game` | Float64 |
-| `time_remaining` | Float64 |
-| `time_quarter` | String |
-| `minute_remaining_quarter` | Int32 |
-| `seconds_remaining_quarter` | Int32 |
-| `action_type` | String |
-| `sub_type` | String |
-| `neutral_description` | String |
-| `description` | String |
-| `location` | String |
-| `score` | String |
-| `away_score` | Int32 |
-| `home_score` | Int32 |
-| `score_margin` | String |
-| `person1type` | String |
-| `player1_id` | String |
-| `player1_name` | String |
-| `player1_team_id` | String |
-| `player1_team_abbreviation` | String |
-| `video_available_flag` | String |
-| `team_leading` | String |
-| `x_legacy` | Int32 |
-| `y_legacy` | Int32 |
-| `shot_distance` | Int32 |
-| `shot_result` | String |
-| `is_field_goal` | Int32 |
-| `points_total` | Int32 |
-| `shot_value` | Int32 |
-| `action_number` | Int32 |
-| `team_id` | Int32 |
-| `team_tricode` | String |
-| `person_id` | Int32 |
-| `player_name` | String |
-| `player_name_i` | String |
-| `score_home` | String |
-| `score_away` | String |
-| `video_available` | Int32 |
-| `action_id` | Int32 |
-| `away_player1` | Int32 |
-| `away_player2` | Int32 |
-| `away_player3` | Int32 |
-| `away_player4` | Int32 |
-| `away_player5` | Int32 |
-| `home_player1` | Int32 |
-| `home_player2` | Int32 |
-| `home_player3` | Int32 |
-| `home_player4` | Int32 |
-| `home_player5` | Int32 |
-| `home_description` | String |
-| `player1_team_city` | String |
-| `player1_team_nickname` | String |
-| `visitor_description` | String |
-| `player2_id` | String |
-| `player2_name` | String |
-| `player2_team_id` | String |
-| `player2_team_city` | String |
-| `player2_team_nickname` | String |
-| `player2_team_abbreviation` | String |
-| `player3_id` | String |
-| `player3_name` | String |
-| `player3_team_id` | String |
-| `player3_team_city` | String |
-| `player3_team_nickname` | String |
-| `player3_team_abbreviation` | String |
-| `score_value` | Int32 |
-| `msg_type` | Int32 |
-| `act_type` | Int32 |
-| `slug_team` | String |
-| `shot_pts` | Int32 |
-| `secs_passed_game` | Float64 |
-| `team_away` | String |
-| `team_home` | String |
-| `off_slug_team` | String |
-| `number_event` | Int32 |
-| `possession` | Int32 |
-| `total_starters_home` | Int32 |
-| `total_starters_away` | Int32 |
-| `garbage_time` | Int32 |
-| `season` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | String | Unique game identifier. |
+| `event_num` | String | Sequential event number within the game (V2 PBP). |
+| `event_type` | String | Event / play type code (V2 PBP). |
+| `event_action_type` | String | Numeric event-action-type code (V2 PBP). |
+| `period` | Int32 | Period of the game (1-4 quarters; 5+ for OT). |
+| `clock` | String | Game clock value. |
+| `minute_game` | Float64 | Minute game. |
+| `time_remaining` | Float64 | Time remaining. |
+| `time_quarter` | String | Time quarter. |
+| `minute_remaining_quarter` | Int32 | Minute remaining quarter. |
+| `seconds_remaining_quarter` | Int32 | Seconds remaining quarter. |
+| `action_type` | String | Action type label (e.g. 'Made Shot', 'Substitution'). |
+| `sub_type` | String | Action sub-type label. |
+| `neutral_description` | String | Neutral description. |
+| `description` | String | Long-form description text. |
+| `location` | String | Filter results by game location. |
+| `score` | String | Final score. |
+| `away_score` | Int32 | Away team score at the time of the play. |
+| `home_score` | Int32 | Home team score at the time of the play. |
+| `score_margin` | String | Score margin. |
+| `person1type` | String | Person1type. |
+| `player1_id` | String | V2 PBP primary player ID (e.g. shooter / fouler). |
+| `player1_name` | String | V2 PBP primary player name. |
+| `player1_team_id` | String | Team ID of player1. |
+| `player1_team_abbreviation` | String | Player1 team abbreviation. |
+| `video_available_flag` | String | Video available flag. |
+| `team_leading` | String | Team leading. |
+| `x_legacy` | Int32 | V2-format X coordinate (preserved for V3-to-V2 compatibility). |
+| `y_legacy` | Int32 | V2-format Y coordinate (preserved for V3-to-V2 compatibility). |
+| `shot_distance` | Int32 | Shot distance from the basket, in feet. |
+| `shot_result` | String | Shot result ('Made' / 'Missed'). |
+| `is_field_goal` | Int32 | 1 if the action was a field goal; 0 otherwise. |
+| `points_total` | Int32 | Running total of points scored. |
+| `shot_value` | Int32 | Point value of the shot (2 or 3). |
+| `action_number` | Int32 | Sequential action number within a game (V3 PBP). |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_tricode` | String | Three-letter team code (e.g. 'LAS' / 'NYL'). |
+| `person_id` | Int32 | Unique player identifier (V3 endpoints). |
+| `player_name` | String | Player name. |
+| `player_name_i` | String | Player name i. |
+| `score_home` | String | Score home. |
+| `score_away` | String | Score away. |
+| `video_available` | Int32 | Video available. |
+| `action_id` | Int32 | Unique action identifier within a game (V3 PBP). |
+| `away_player1` | Int32 | Away team's player1. |
+| `away_player2` | Int32 | Away team's player2. |
+| `away_player3` | Int32 | Away team's player3. |
+| `away_player4` | Int32 | Away team's player4. |
+| `away_player5` | Int32 | Away team's player5. |
+| `home_player1` | Int32 | Home team's player1. |
+| `home_player2` | Int32 | Home team's player2. |
+| `home_player3` | Int32 | Home team's player3. |
+| `home_player4` | Int32 | Home team's player4. |
+| `home_player5` | Int32 | Home team's player5. |
+| `home_description` | String | Home team's description. |
+| `player1_team_city` | String | Player1 team city. |
+| `player1_team_nickname` | String | Player1 team nickname. |
+| `visitor_description` | String | Visitor description. |
+| `player2_id` | String | V2 PBP secondary player ID (e.g. assister / fouled-by). |
+| `player2_name` | String | V2 PBP secondary player name. |
+| `player2_team_id` | String | Team ID of player2. |
+| `player2_team_city` | String | Player2 team city. |
+| `player2_team_nickname` | String | Player2 team nickname. |
+| `player2_team_abbreviation` | String | Player2 team abbreviation. |
+| `player3_id` | String | V2 PBP tertiary player ID (e.g. blocker). |
+| `player3_name` | String | V2 PBP tertiary player name. |
+| `player3_team_id` | String | Team ID of player3. |
+| `player3_team_city` | String | Player3 team city. |
+| `player3_team_nickname` | String | Player3 team nickname. |
+| `player3_team_abbreviation` | String | Player3 team abbreviation. |
+| `score_value` | Int32 | Point value of the play (2 / 3 / 1). |
+| `msg_type` | Int32 |  |
+| `act_type` | Int32 |  |
+| `slug_team` | String |  |
+| `shot_pts` | Int32 |  |
+| `secs_passed_game` | Float64 |  |
+| `team_away` | String |  |
+| `team_home` | String |  |
+| `off_slug_team` | String |  |
+| `number_event` | Int32 |  |
+| `possession` | Int32 | Abbreviation of the team currently in possession. |
+| `total_starters_home` | Int32 |  |
+| `total_starters_away` | Int32 |  |
+| `garbage_time` | Int32 | TRUE if the play occurred during garbage time. |
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
 
 ```python
 load_wnba_stats_pbp(seasons=2026)
@@ -768,42 +768,42 @@ load_wnba_stats_pbp(seasons=2026)
 Release: [wnba_stats_player_game_logs](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wnba_stats_player_game_logs) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/wnba_stats_player_game_logs/player_game_logs_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `season_id` | String |
-| `player_id` | Int32 |
-| `player_name` | String |
-| `team_id` | Int32 |
-| `team_abbreviation` | String |
-| `team_name` | String |
-| `game_id` | String |
-| `game_date` | String |
-| `matchup` | String |
-| `wl` | String |
-| `min` | String |
-| `fgm` | String |
-| `fga` | String |
-| `fg_pct` | String |
-| `fg3m` | String |
-| `fg3a` | String |
-| `fg3_pct` | String |
-| `ftm` | String |
-| `fta` | String |
-| `ft_pct` | String |
-| `oreb` | String |
-| `dreb` | String |
-| `reb` | String |
-| `ast` | String |
-| `stl` | String |
-| `blk` | String |
-| `tov` | String |
-| `pf` | String |
-| `pts` | String |
-| `plus_minus` | String |
-| `fantasy_pts` | String |
-| `video_available` | String |
-| `team_location` | String |
-| `season` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `season_id` | String | Unique season identifier. |
+| `player_id` | Int32 | Unique player identifier. |
+| `player_name` | String | Player name. |
+| `team_id` | Int32 | Unique team identifier. |
+| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
+| `team_name` | String | Full team display name (e.g. 'Las Vegas Aces'). |
+| `game_id` | String | Unique game identifier. |
+| `game_date` | String | Game date (YYYY-MM-DD). |
+| `matchup` | String | Matchup. |
+| `wl` | String | Wl. |
+| `min` | String | Minutes played. |
+| `fgm` | String | Field goals made. |
+| `fga` | String | Field goal attempts. |
+| `fg_pct` | String | Field goal percentage (0-1). |
+| `fg3m` | String | Three-point field goals made. |
+| `fg3a` | String | Three-point field goal attempts. |
+| `fg3_pct` | String | Three-point field goal percentage (0-1). |
+| `ftm` | String | Free throws made. |
+| `fta` | String | Free throw attempts. |
+| `ft_pct` | String | Free throw percentage (0-1). |
+| `oreb` | String | Offensive rebounds. |
+| `dreb` | String | Defensive rebounds. |
+| `reb` | String | Total rebounds. |
+| `ast` | String | Assists. |
+| `stl` | String | Steals. |
+| `blk` | String | Blocks. |
+| `tov` | String | Turnovers. |
+| `pf` | String | Personal fouls. |
+| `pts` | String | Points scored. |
+| `plus_minus` | String | Plus/minus point differential while on court. |
+| `fantasy_pts` | String |  |
+| `video_available` | String | Video available. |
+| `team_location` | String | Team city or location string. |
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
 
 ```python
 load_wnba_stats_player_game_logs(seasons=2025)
@@ -814,26 +814,26 @@ load_wnba_stats_player_game_logs(seasons=2025)
 Release: [wnba_stats_rosters](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wnba_stats_rosters) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/wnba_stats_rosters/rosters_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `team_id` | String |
-| `season` | Int32 |
-| `league_id` | String |
-| `player` | String |
-| `nickname` | String |
-| `player_slug` | String |
-| `num` | String |
-| `position` | String |
-| `height` | String |
-| `weight` | String |
-| `birth_date` | String |
-| `age` | String |
-| `exp` | String |
-| `school` | String |
-| `player_id` | String |
-| `how_acquired` | String |
-| `season_2` | Int32 |
-| `team_id_lookup` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `team_id` | String | Unique team identifier. |
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `league_id` | String | League identifier ('10' = WNBA). |
+| `player` | String | Player name. |
+| `nickname` | String | Team or athlete nickname. |
+| `player_slug` | String | URL-safe player identifier. |
+| `num` | String | Inning number. |
+| `position` | String | Listed roster position (G, F, C, etc.). |
+| `height` | String | Player height (string e.g. '6-2' or inches). |
+| `weight` | String | Player weight in pounds. |
+| `birth_date` | String | Date of birth (YYYY-MM-DD). |
+| `age` | String | Player age (in years). |
+| `exp` | String | Years of MLB service experience. |
+| `school` | String | Player's school / college (when distinct from 'college'). |
+| `player_id` | String | Unique player identifier. |
+| `how_acquired` | String |  |
+| `season_2` | Int32 |  |
+| `team_id_lookup` | Int32 |  |
 
 ```python
 load_wnba_stats_rosters(seasons=2026)
@@ -844,37 +844,37 @@ load_wnba_stats_rosters(seasons=2026)
 Release: [wnba_stats_schedules](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wnba_stats_schedules) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/wnba_stats_schedules/wnba_stats_schedule_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `SEASON_ID` | String |
-| `TEAM_ID` | String |
-| `TEAM_ABBREVIATION` | String |
-| `TEAM_NAME` | String |
-| `GAME_ID` | String |
-| `GAME_DATE` | String |
-| `MATCHUP` | String |
-| `WL` | String |
-| `MIN` | String |
-| `PTS` | String |
-| `FGM` | String |
-| `FGA` | String |
-| `FG_PCT` | String |
-| `FG3M` | String |
-| `FG3A` | String |
-| `FG3_PCT` | String |
-| `FTM` | String |
-| `FTA` | String |
-| `FT_PCT` | String |
-| `OREB` | String |
-| `DREB` | String |
-| `REB` | String |
-| `AST` | String |
-| `STL` | String |
-| `BLK` | String |
-| `TOV` | String |
-| `PF` | String |
-| `PLUS_MINUS` | String |
-| `season` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `SEASON_ID` | String | Unique season identifier. |
+| `TEAM_ID` | String | Unique team identifier. |
+| `TEAM_ABBREVIATION` | String | Short team abbreviation (e.g. 'LAS'). |
+| `TEAM_NAME` | String | Full team display name (e.g. 'Las Vegas Aces'). |
+| `GAME_ID` | String | Unique game identifier. |
+| `GAME_DATE` | String | Game date (YYYY-MM-DD). |
+| `MATCHUP` | String | Matchup. |
+| `WL` | String | Wl. |
+| `MIN` | String | Minutes played. |
+| `PTS` | String | Points scored. |
+| `FGM` | String | Field goals made. |
+| `FGA` | String | Field goal attempts. |
+| `FG_PCT` | String | Field goal percentage (0-1). |
+| `FG3M` | String | Three-point field goals made. |
+| `FG3A` | String | Three-point field goal attempts. |
+| `FG3_PCT` | String | Three-point field goal percentage (0-1). |
+| `FTM` | String | Free throws made. |
+| `FTA` | String | Free throw attempts. |
+| `FT_PCT` | String | Free throw percentage (0-1). |
+| `OREB` | String | Offensive rebounds. |
+| `DREB` | String | Defensive rebounds. |
+| `REB` | String | Total rebounds. |
+| `AST` | String | Assists. |
+| `STL` | String | Steals. |
+| `BLK` | String | Blocks. |
+| `TOV` | String | Turnovers. |
+| `PF` | String | Personal fouls. |
+| `PLUS_MINUS` | String | Plus/minus point differential while on court. |
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
 
 ```python
 load_wnba_stats_schedules(seasons=2025)
@@ -885,23 +885,23 @@ load_wnba_stats_schedules(seasons=2025)
 Release: [wnba_stats_shots](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wnba_stats_shots) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/wnba_stats_shots/shots_{season}.parquet`
 ### Returns
 
-| col_name | type |
-|---|---|
-| `game_id` | String |
-| `season` | Int32 |
-| `period` | Int32 |
-| `clock` | String |
-| `team_id` | Int32 |
-| `person_id` | Int32 |
-| `action_type` | String |
-| `sub_type` | String |
-| `description` | String |
-| `x_legacy` | Int32 |
-| `y_legacy` | Int32 |
-| `shot_distance` | Int32 |
-| `shot_value` | Int32 |
-| `shot_result` | String |
-| `points_total` | Int32 |
+| col_name | type | description |
+|---|---|---|
+| `game_id` | String | Unique game identifier. |
+| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `period` | Int32 | Period of the game (1-4 quarters; 5+ for OT). |
+| `clock` | String | Game clock value. |
+| `team_id` | Int32 | Unique team identifier. |
+| `person_id` | Int32 | Unique player identifier (V3 endpoints). |
+| `action_type` | String | Action type label (e.g. 'Made Shot', 'Substitution'). |
+| `sub_type` | String | Action sub-type label. |
+| `description` | String | Long-form description text. |
+| `x_legacy` | Int32 | V2-format X coordinate (preserved for V3-to-V2 compatibility). |
+| `y_legacy` | Int32 | V2-format Y coordinate (preserved for V3-to-V2 compatibility). |
+| `shot_distance` | Int32 | Shot distance from the basket, in feet. |
+| `shot_value` | Int32 | Point value of the shot (2 or 3). |
+| `shot_result` | String | Shot result ('Made' / 'Missed'). |
+| `points_total` | Int32 | Running total of points scored. |
 
 ```python
 load_wnba_stats_shots(seasons=2026)

--- a/docs/src/pages/CHANGELOG.md
+++ b/docs/src/pages/CHANGELOG.md
@@ -3,6 +3,8 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Unreleased](#unreleased)
+  - [CFB — `team_id` canonicalized to `Int64` at the loader boundary](#cfb--team_id-canonicalized-to-int64-at-the-loader-boundary)
+  - [Docs — loader returns tables now carry column descriptions](#docs--loader-returns-tables-now-carry-column-descriptions)
   - [CFB — `adv_*` `pos_team` now holds the team NAME, id moves to `pos_team_id` (BREAKING data change)](#cfb--adv_-pos_team-now-holds-the-team-name-id-moves-to-pos_team_id-breaking-data-change)
   - [CFB — `adv_*` declared schemas re-derived from the shipped data](#cfb--adv_-declared-schemas-re-derived-from-the-shipped-data)
 - [0.0.73 Release: August 1, 2026](#0073-release-august-1-2026)
@@ -208,6 +210,65 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Unreleased
+
+### CFB — `team_id` canonicalized to `Int64` at the loader boundary
+
+The same ESPN team id shipped with **three different dtypes** across the CFB
+release surface, which makes a cross-dataset join match **nothing** — silently,
+with no error and a structurally valid frame:
+
+| dtype | datasets |
+|---|---|
+| `Int64` | 13 — all `adv_*`, `drives`, `game_rosters`, `linescores`, `player_box`, `team_box`, `adv_team_gamelog` |
+| `String` | 8 — `passing`, `receiving`, `rushing`, `team_summaries`(+`_weekly`), `ratings`(+`_weekly`), `recruiting_proj` |
+| `Int32` | 1 — `team_info` |
+
+All nine non-`Int64` loaders now normalize on read, so
+`load_cfb_team_summaries(...)` joined to `load_cfb_adv_team(...)` on
+`team_id`/`pos_team_id` resolves **134/134** teams where it previously matched 0.
+
+- **Fixed at the boundary, not by republishing.** The published assets are
+  untouched; the loader pins the dtype on read, per the repo's "one dtype per id,
+  cast at the boundary" rule. No breaking change for anyone reading the parquet
+  directly.
+- **New `id_int64:` key in `releases.yaml`** declares which id columns a loader
+  canonicalizes; the generated loader emits a `_cast_ids_int64` call. Declaring it
+  is the whole change — no hand-edits to generated loaders.
+- **Lossless or refused, never silent.** `_cast_ids_int64` converts only when every
+  non-null value survives a round-trip. `"007"` casts cleanly to `7` and `1.5`
+  truncates to `1` — both change the id, so both leave the column untouched. A
+  "no new nulls" check alone would let both through. Float-origin ids go straight
+  to `Int64` rather than through a string (which would yield `"123.0"`).
+- Covered by `tests/codegen/test_id_casts.py`, including a manifest gate that fails
+  if a loader declares `id_int64` without emitting the call, or declares a
+  canonicalized column as anything other than `Int64`.
+- The two producer-schema contract tests now apply the declared `id_int64` overlay:
+  a returns table documents the **loader's** output, not the raw asset, so a
+  boundary cast is an expected divergence rather than a docs lie.
+
+### Docs — loader returns tables now carry column descriptions
+
+Generated loader returns tables rendered `col_name | type` only, while endpoint
+tables carried a third `description` column. Loader tables now match, resolving
+descriptions from `manual_column_descriptions.yaml` (keyed by the loader's own
+function name) and falling back to the R-package column dict — so shared columns
+like `game_id` / `season` / `week` fill in automatically.
+
+This exposed ~5,850 loader columns to the description coverage ratchet, which had
+never globbed `loader_schemas.yaml` — so those blanks were **invisible** to a gate
+whose stated intent is "every return-table column renders a description". The
+extractor now sees them (59% already covered) and the remainder is tracked via the
+existing `_DEFERRED_BUCKETS` mechanism, mirroring the `nba_stats` decision.
+
+The first documented use is `load_cfb_adv_defensive_players`, whose column
+availability is season-dependent and previously undiscoverable without loading
+several seasons and diffing them:
+
+| seasons | cols | shape |
+|---|---|---|
+| 2004 | 8 | fumble recoveries only |
+| 2005–2013 | 12 | `+ sacks, sacks_yards, pass_breakups, forced_fumbles` |
+| 2014–2025 | 14 | `+ interceptions, interceptions_yards` |
 
 ### CFB — `adv_*` `pos_team` now holds the team NAME, id moves to `pos_team_id` (BREAKING data change)
 

--- a/sportsdataverse/_codegen_runtime.py
+++ b/sportsdataverse/_codegen_runtime.py
@@ -18,6 +18,50 @@ _SDV_RELEASES = "https://github.com/sportsdataverse/sportsdataverse-data/release
 _RAW_DATA = "https://raw.githubusercontent.com/sportsdataverse/"
 
 
+def _cast_ids_int64(df: pl.DataFrame, cols: List[str]) -> pl.DataFrame:
+    """Canonicalize id columns to ``Int64`` at the loader boundary.
+
+    Producers have shipped the same ESPN id as ``String``, ``Int32`` and ``Int64``
+    across releases (CFB ``team_id`` was String on the summaries/ratings family and
+    Int64 on the box/pbp/adv family). Joining across two such datasets matches
+    **nothing** -- silently, with no error and a structurally valid frame -- so the
+    dtype is pinned once here rather than left to every caller.
+
+    Conservative by construction: a column is only converted when every non-null
+    value survives the cast. A String column holding a genuinely non-numeric id, or
+    one with leading zeros that would change meaning, is left exactly as-is rather
+    than corrupted or nulled. Float-origin ids go straight to Int64 rather than
+    through a string (which would yield ``"123.0"``).
+
+    Args:
+        df: frame to normalize (may be empty).
+        cols: id column names to canonicalize; missing ones are ignored.
+
+    Returns:
+        The frame with each named column cast to ``Int64`` where safe.
+    """
+    if df.height == 0:
+        return df
+    for col in cols:
+        if col not in df.columns or df.schema[col] == pl.Int64:
+            continue
+        src = df[col]
+        cast = src.cast(pl.Int64, strict=False)
+        # Refuse if the cast would invent nulls -- a value did not survive, so the
+        # column is not really an integer id.
+        if cast.null_count() != src.null_count():
+            continue
+        # Widening one integer type to another is always lossless. For every other
+        # source dtype require an exact round-trip, because "no new nulls" is
+        # necessary but NOT sufficient: "007" casts cleanly to 7 and 1.5 truncates
+        # to 1, both silently changing the id. Zero-padded and fractional values
+        # must keep their original column untouched.
+        if not src.dtype.is_integer() and not cast.cast(src.dtype).equals(src):
+            continue
+        df = df.with_columns(cast.alias(col))
+    return df
+
+
 def _get(url: str, params: Optional[dict] = None, **kwargs) -> Dict:
     """GET ``url`` as JSON. Returns ``{}`` on failure. Strips ``None`` params."""
     clean = {k: v for k, v in (params or {}).items() if v is not None}

--- a/sportsdataverse/cfb/cfb_loaders.py
+++ b/sportsdataverse/cfb/cfb_loaders.py
@@ -9,6 +9,7 @@ import polars as pl
 from sportsdataverse._codegen_runtime import (
     SeasonNotFoundError,  # noqa: F401
     _as_season_list,
+    _cast_ids_int64,  # noqa: F401  (used only by loaders declaring id_int64)
     _read_release_parquet,
     cli_warn,
 )
@@ -470,7 +471,7 @@ def load_cfb_ratings(seasons, return_as_pandas: bool = False):
         |col_name    |type    |
         |:-----------|:-------|
         |season      |Int64   |
-        |team_id     |String  |
+        |team_id     |Int64   |
         |adj_off_epa |Float64 |
         |adj_def_epa |Float64 |
         |adj_st_epa  |Float64 |
@@ -506,6 +507,9 @@ def load_cfb_ratings(seasons, return_as_pandas: bool = False):
     # diagonal: per-season release schemas can drift (columns added/dropped
     # over the years) -- union columns, null-fill gaps.
     out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    # Producers shipped this id with differing dtypes across releases; pin it here
+    # so a cross-dataset join cannot silently match nothing.
+    out = _cast_ids_int64(out, ["team_id"])
     return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
 
 
@@ -525,7 +529,7 @@ def load_cfb_recruiting_proj(seasons, return_as_pandas: bool = False):
         |col_name     |type    |
         |:------------|:-------|
         |season       |Int64   |
-        |team_id      |String  |
+        |team_id      |Int64   |
         |pred_wins    |Float64 |
         |pred_margin  |Float64 |
         |pred_net_epa |Float64 |
@@ -551,6 +555,9 @@ def load_cfb_recruiting_proj(seasons, return_as_pandas: bool = False):
     # diagonal: per-season release schemas can drift (columns added/dropped
     # over the years) -- union columns, null-fill gaps.
     out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    # Producers shipped this id with differing dtypes across releases; pin it here
+    # so a cross-dataset join cannot silently match nothing.
+    out = _cast_ids_int64(out, ["team_id"])
     return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
 
 
@@ -698,7 +705,7 @@ def load_cfb_team_info(seasons, return_as_pandas: bool = False):
 
         |col_name         |type    |
         |:----------------|:-------|
-        |team_id          |Int32   |
+        |team_id          |Int64   |
         |school           |String  |
         |mascot           |String  |
         |abbreviation     |String  |
@@ -748,6 +755,9 @@ def load_cfb_team_info(seasons, return_as_pandas: bool = False):
     # diagonal: per-season release schemas can drift (columns added/dropped
     # over the years) -- union columns, null-fill gaps.
     out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    # Producers shipped this id with differing dtypes across releases; pin it here
+    # so a cross-dataset join cannot silently match nothing.
+    out = _cast_ids_int64(out, ["team_id"])
     return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
 
 
@@ -2221,7 +2231,7 @@ def load_cfb_passing(seasons, return_as_pandas: bool = False):
 
         |col_name            |type    |
         |:-------------------|:-------|
-        |team_id             |String  |
+        |team_id             |Int64   |
         |pos_team            |String  |
         |division            |String  |
         |conference          |String  |
@@ -2286,6 +2296,9 @@ def load_cfb_passing(seasons, return_as_pandas: bool = False):
     # diagonal: per-season release schemas can drift (columns added/dropped
     # over the years) -- union columns, null-fill gaps.
     out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    # Producers shipped this id with differing dtypes across releases; pin it here
+    # so a cross-dataset join cannot silently match nothing.
+    out = _cast_ids_int64(out, ["team_id"])
     return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
 
 
@@ -2371,7 +2384,7 @@ def load_cfb_receiving(seasons, return_as_pandas: bool = False):
 
         |col_name             |type    |
         |:--------------------|:-------|
-        |team_id              |String  |
+        |team_id              |Int64   |
         |pos_team             |String  |
         |division             |String  |
         |conference           |String  |
@@ -2425,6 +2438,9 @@ def load_cfb_receiving(seasons, return_as_pandas: bool = False):
     # diagonal: per-season release schemas can drift (columns added/dropped
     # over the years) -- union columns, null-fill gaps.
     out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    # Producers shipped this id with differing dtypes across releases; pin it here
+    # so a cross-dataset join cannot silently match nothing.
+    out = _cast_ids_int64(out, ["team_id"])
     return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
 
 
@@ -2443,7 +2459,7 @@ def load_cfb_rushing(seasons, return_as_pandas: bool = False):
 
         |col_name           |type    |
         |:------------------|:-------|
-        |team_id            |String  |
+        |team_id            |Int64   |
         |pos_team           |String  |
         |division           |String  |
         |conference         |String  |
@@ -2493,6 +2509,9 @@ def load_cfb_rushing(seasons, return_as_pandas: bool = False):
     # diagonal: per-season release schemas can drift (columns added/dropped
     # over the years) -- union columns, null-fill gaps.
     out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    # Producers shipped this id with differing dtypes across releases; pin it here
+    # so a cross-dataset join cannot silently match nothing.
+    out = _cast_ids_int64(out, ["team_id"])
     return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
 
 
@@ -2511,7 +2530,7 @@ def load_cfb_team_summaries(seasons, return_as_pandas: bool = False):
 
         |col_name                             |type    |
         |:------------------------------------|:-------|
-        |team_id                              |String  |
+        |team_id                              |Int64   |
         |pos_team                             |String  |
         |division                             |String  |
         |conference                           |String  |
@@ -2916,6 +2935,9 @@ def load_cfb_team_summaries(seasons, return_as_pandas: bool = False):
     # diagonal: per-season release schemas can drift (columns added/dropped
     # over the years) -- union columns, null-fill gaps.
     out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    # Producers shipped this id with differing dtypes across releases; pin it here
+    # so a cross-dataset join cannot silently match nothing.
+    out = _cast_ids_int64(out, ["team_id"])
     return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
 
 
@@ -3065,7 +3087,7 @@ def load_cfb_ratings_weekly(seasons, return_as_pandas: bool = False):
         |col_name     |type    |
         |:------------|:-------|
         |season       |Int64   |
-        |team_id      |String  |
+        |team_id      |Int64   |
         |adj_off_epa  |Float64 |
         |adj_def_epa  |Float64 |
         |adj_st_epa   |Float64 |
@@ -3102,6 +3124,9 @@ def load_cfb_ratings_weekly(seasons, return_as_pandas: bool = False):
     # diagonal: per-season release schemas can drift (columns added/dropped
     # over the years) -- union columns, null-fill gaps.
     out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    # Producers shipped this id with differing dtypes across releases; pin it here
+    # so a cross-dataset join cannot silently match nothing.
+    out = _cast_ids_int64(out, ["team_id"])
     return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
 
 
@@ -3120,7 +3145,7 @@ def load_cfb_team_summaries_weekly(seasons, return_as_pandas: bool = False):
 
         |col_name                             |type    |
         |:------------------------------------|:-------|
-        |team_id                              |String  |
+        |team_id                              |Int64   |
         |pos_team                             |String  |
         |division                             |String  |
         |conference                           |String  |
@@ -3526,4 +3551,7 @@ def load_cfb_team_summaries_weekly(seasons, return_as_pandas: bool = False):
     # diagonal: per-season release schemas can drift (columns added/dropped
     # over the years) -- union columns, null-fill gaps.
     out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    # Producers shipped this id with differing dtypes across releases; pin it here
+    # so a cross-dataset join cannot silently match nothing.
+    out = _cast_ids_int64(out, ["team_id"])
     return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out

--- a/sportsdataverse/mbb/mbb_loaders.py
+++ b/sportsdataverse/mbb/mbb_loaders.py
@@ -9,6 +9,7 @@ import polars as pl
 from sportsdataverse._codegen_runtime import (
     SeasonNotFoundError,  # noqa: F401
     _as_season_list,
+    _cast_ids_int64,  # noqa: F401  (used only by loaders declaring id_int64)
     _read_release_parquet,
     cli_warn,
 )

--- a/sportsdataverse/mlb/mlb_loaders.py
+++ b/sportsdataverse/mlb/mlb_loaders.py
@@ -9,6 +9,7 @@ import polars as pl
 from sportsdataverse._codegen_runtime import (
     SeasonNotFoundError,  # noqa: F401
     _as_season_list,
+    _cast_ids_int64,  # noqa: F401  (used only by loaders declaring id_int64)
     _read_release_parquet,
     cli_warn,
 )

--- a/sportsdataverse/nba/nba_loaders.py
+++ b/sportsdataverse/nba/nba_loaders.py
@@ -9,6 +9,7 @@ import polars as pl
 from sportsdataverse._codegen_runtime import (
     SeasonNotFoundError,  # noqa: F401
     _as_season_list,
+    _cast_ids_int64,  # noqa: F401  (used only by loaders declaring id_int64)
     _read_release_parquet,
     cli_warn,
 )

--- a/sportsdataverse/nhl/nhl_loaders.py
+++ b/sportsdataverse/nhl/nhl_loaders.py
@@ -9,6 +9,7 @@ import polars as pl
 from sportsdataverse._codegen_runtime import (
     SeasonNotFoundError,  # noqa: F401
     _as_season_list,
+    _cast_ids_int64,  # noqa: F401  (used only by loaders declaring id_int64)
     _read_release_parquet,
     cli_warn,
 )

--- a/sportsdataverse/pwhl/pwhl_loaders.py
+++ b/sportsdataverse/pwhl/pwhl_loaders.py
@@ -9,6 +9,7 @@ import polars as pl
 from sportsdataverse._codegen_runtime import (
     SeasonNotFoundError,  # noqa: F401
     _as_season_list,
+    _cast_ids_int64,  # noqa: F401  (used only by loaders declaring id_int64)
     _read_release_parquet,
     cli_warn,
 )

--- a/sportsdataverse/wbb/wbb_loaders.py
+++ b/sportsdataverse/wbb/wbb_loaders.py
@@ -9,6 +9,7 @@ import polars as pl
 from sportsdataverse._codegen_runtime import (
     SeasonNotFoundError,  # noqa: F401
     _as_season_list,
+    _cast_ids_int64,  # noqa: F401  (used only by loaders declaring id_int64)
     _read_release_parquet,
     cli_warn,
 )

--- a/sportsdataverse/wnba/wnba_loaders.py
+++ b/sportsdataverse/wnba/wnba_loaders.py
@@ -9,6 +9,7 @@ import polars as pl
 from sportsdataverse._codegen_runtime import (
     SeasonNotFoundError,  # noqa: F401
     _as_season_list,
+    _cast_ids_int64,  # noqa: F401  (used only by loaders declaring id_int64)
     _read_release_parquet,
     cli_warn,
 )

--- a/tests/cfb/test_cfb_loaders_ratings.py
+++ b/tests/cfb/test_cfb_loaders_ratings.py
@@ -39,12 +39,22 @@ def _loader_entry() -> dict:
 
 
 def test_declared_schema_matches_the_producer_output_schema() -> None:
-    """The loader's returns-table must match `cfb_ratings()`'s real output.
+    """The loader's returns-table must match what the LOADER hands back.
 
     Both column ORDER and dtype: the published parquet is written straight from
-    that frame, so any divergence here is a docs lie, not a formatting nit.
+    ``cfb_ratings()``, so any divergence here is a docs lie, not a formatting nit.
+
+    One documented exception: columns listed under the loader's ``id_int64`` key
+    are canonicalized to Int64 at the loader boundary (the same ESPN team id ships
+    as String here and Int64 on the adv_*/box families, which makes a cross-dataset
+    join silently match nothing). For those the declared type must be Int64 even
+    though the producer still emits Utf8 -- the returns table documents the
+    loader's output, not the raw asset.
     """
-    produced = _ratings_mod._RATINGS_OUTPUT_SCHEMA
+    produced = dict(_ratings_mod._RATINGS_OUTPUT_SCHEMA)
+    for col in _loader_entry().get("id_int64", []):
+        if col in produced:
+            produced[col] = pl.Int64
     declared = _declared_schema()
 
     assert [c["name"] for c in declared] == list(produced.keys())

--- a/tests/cfb/test_cfb_loaders_recruiting.py
+++ b/tests/cfb/test_cfb_loaders_recruiting.py
@@ -38,12 +38,22 @@ def _loader_entry() -> dict:
 
 
 def test_declared_schema_matches_the_producer_output_schema() -> None:
-    """The loader's returns-table must match the projection's real output.
+    """The loader's returns-table must match what the LOADER hands back.
 
     Both column ORDER and dtype: the published parquet is written straight from
     that frame, so any divergence here is a docs lie, not a formatting nit.
+
+    One documented exception: columns listed under the loader's ``id_int64`` key
+    are canonicalized to Int64 at the loader boundary (the same ESPN team id ships
+    as String here and Int64 on the adv_*/box families, which makes a cross-dataset
+    join silently match nothing). For those the declared type must be Int64 even
+    though the producer still emits Utf8 -- the returns table documents the
+    loader's output, not the raw asset.
     """
-    produced = _proj_mod._PROJECTION_SCHEMA
+    produced = dict(_proj_mod._PROJECTION_SCHEMA)
+    for col in _loader_entry().get("id_int64", []):
+        if col in produced:
+            produced[col] = pl.Int64
     declared = _declared_schema()
 
     assert [c["name"] for c in declared] == list(produced.keys())

--- a/tests/codegen/test_id_casts.py
+++ b/tests/codegen/test_id_casts.py
@@ -1,0 +1,114 @@
+"""Loader-boundary id canonicalization (``_cast_ids_int64`` + the ``id_int64`` manifest).
+
+The same ESPN id shipped as String on one release family and Int64 on another, so a
+cross-dataset join matched **nothing** -- silently, with no error and a structurally
+valid frame. These tests pin both halves of the fix: the cast is lossless-or-refused,
+and every loader that declares ``id_int64`` actually emits the call.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from sportsdataverse._codegen_runtime import _cast_ids_int64
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+# --------------------------------------------------------------------------
+# _cast_ids_int64: converts what is safe, refuses what is not
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    ("label", "values", "dtype", "expected_dtype", "expected"),
+    [
+        ("string integral", ["103", "2649", None], pl.Utf8, pl.Int64, [103, 2649, None]),
+        ("int32 widens", [1, 2], pl.Int32, pl.Int64, [1, 2]),
+        ("float-origin id", [123.0, 456.0], pl.Float64, pl.Int64, [123, 456]),
+        ("already int64", [7, 8], pl.Int64, pl.Int64, [7, 8]),
+        ("all-null text", [None, None], pl.Utf8, pl.Int64, [None, None]),
+    ],
+)
+def test_cast_converts_integral_ids(label, values, dtype, expected_dtype, expected):
+    df = pl.DataFrame({"team_id": pl.Series(values, dtype=dtype)})
+    out = _cast_ids_int64(df, ["team_id"])
+    assert out.schema["team_id"] == expected_dtype, label
+    assert out["team_id"].to_list() == expected, label
+
+
+@pytest.mark.parametrize(
+    ("label", "values"),
+    [
+        # Not an integer id at all -- casting would null it out.
+        ("non-numeric", ["ABC", "103"]),
+        # Casts cleanly to 7 but SILENTLY changes the id. "no new nulls" is
+        # necessary but not sufficient; the round-trip check is what catches this.
+        ("zero-padded", ["007", "103"]),
+        ("float with a real fraction", None),
+    ],
+)
+def test_cast_refuses_when_it_would_change_the_id(label, values):
+    if values is None:  # float that does not round-trip to an integer
+        df = pl.DataFrame({"team_id": [1.5, 2.0]})
+        before = df.schema["team_id"]
+    else:
+        df = pl.DataFrame({"team_id": values})
+        before = pl.Utf8
+    out = _cast_ids_int64(df, ["team_id"])
+    assert out.schema["team_id"] == before, f"{label}: should have been left untouched"
+    assert out["team_id"].to_list() == df["team_id"].to_list(), label
+
+
+def test_cast_is_a_noop_for_missing_columns_and_empty_frames():
+    assert _cast_ids_int64(pl.DataFrame({"x": [1]}), ["team_id"]).columns == ["x"]
+    empty = pl.DataFrame({"team_id": []}, schema={"team_id": pl.Utf8})
+    assert _cast_ids_int64(empty, ["team_id"]).height == 0
+
+
+def test_cast_leaves_other_columns_alone():
+    df = pl.DataFrame({"team_id": ["1"], "other_id": ["2"], "name": ["x"]})
+    out = _cast_ids_int64(df, ["team_id"])
+    assert out.schema["team_id"] == pl.Int64
+    assert out.schema["other_id"] == pl.Utf8  # not declared -> untouched
+    assert out.schema["name"] == pl.Utf8
+
+
+# --------------------------------------------------------------------------
+# manifest -> generated code
+# --------------------------------------------------------------------------
+def _declared_id_int64() -> dict[str, list[str]]:
+    import yaml
+
+    raw = yaml.safe_load((ROOT / "tools" / "codegen" / "endpoints" / "releases.yaml").read_text(encoding="utf-8"))
+    return {ld["fn"]: ld["id_int64"] for ld in raw["loaders"] if ld.get("id_int64")}
+
+
+def test_every_declared_loader_emits_the_cast():
+    """A loader declaring ``id_int64`` must actually call it, or the manifest lies."""
+    declared = _declared_id_int64()
+    assert declared, "expected at least one loader to declare id_int64"
+    for fn, cols in declared.items():
+        league = fn.split("_")[1]
+        src = (ROOT / "sportsdataverse" / league / f"{league}_loaders.py").read_text(encoding="utf-8")
+        body = src.split(f"def {fn}(")[1].split("\ndef ")[0]
+        assert "_cast_ids_int64(" in body, f"{fn} declares id_int64={cols} but emits no cast"
+
+
+def test_declared_schema_agrees_with_the_cast():
+    """A column canonicalized to Int64 must be DECLARED Int64.
+
+    The declared schema drives the published returns table; if it still said String
+    the docs would contradict what the loader hands back.
+    """
+    import yaml
+
+    schemas = yaml.safe_load(
+        (ROOT / "tools" / "codegen" / "schemas" / "loader_schemas.yaml").read_text(encoding="utf-8")
+    )
+    for fn, cols in _declared_id_int64().items():
+        declared = {e["name"]: e["type"] for e in schemas.get(fn, [])}
+        for col in cols:
+            if col in declared:
+                assert declared[col] == "Int64", f"{fn}.{col} cast to Int64 but declared {declared[col]}"

--- a/tools/codegen/endpoints/releases.yaml
+++ b/tools/codegen/endpoints/releases.yaml
@@ -19,6 +19,8 @@ loaders:
   min_season: 2004
   example_args:
     seasons: 2024
+  id_int64:
+  - team_id
 - fn: load_cfb_recruiting_proj
   league: cfb
   base: sdv_releases
@@ -27,6 +29,8 @@ loaders:
   min_season: 2016
   example_args:
     seasons: 2024
+  id_int64:
+  - team_id
 - fn: load_cfb_rosters
   league: cfb
   base: raw_data
@@ -51,6 +55,8 @@ loaders:
   min_season: 2003
   example_args:
     seasons: 2024
+  id_int64:
+  - team_id
 - fn: load_cfb_teams_crosswalk
   league: cfb
   base: sdv_releases
@@ -229,6 +235,8 @@ loaders:
   min_season: 2004
   example_args:
     seasons: 2024
+  id_int64:
+  - team_id
 - fn: load_cfb_percentiles
   league: cfb
   base: sdv_releases
@@ -245,6 +253,8 @@ loaders:
   min_season: 2004
   example_args:
     seasons: 2024
+  id_int64:
+  - team_id
 - fn: load_cfb_rushing
   league: cfb
   base: sdv_releases
@@ -253,6 +263,8 @@ loaders:
   min_season: 2004
   example_args:
     seasons: 2024
+  id_int64:
+  - team_id
 - fn: load_cfb_team_summaries
   league: cfb
   base: sdv_releases
@@ -261,6 +273,8 @@ loaders:
   min_season: 2004
   example_args:
     seasons: 2024
+  id_int64:
+  - team_id
 - fn: load_cfb_adv_team_gamelog
   league: cfb
   base: sdv_releases
@@ -277,6 +291,8 @@ loaders:
   min_season: 2004
   example_args:
     seasons: 2024
+  id_int64:
+  - team_id
 - fn: load_cfb_team_summaries_weekly
   league: cfb
   base: sdv_releases
@@ -285,6 +301,8 @@ loaders:
   min_season: 2004
   example_args:
     seasons: 2024
+  id_int64:
+  - team_id
 - fn: load_mbb_pbp
   league: mbb
   base: sdv_releases

--- a/tools/codegen/extract_residual_columns.py
+++ b/tools/codegen/extract_residual_columns.py
@@ -58,13 +58,52 @@ def _bucket_of(path: str) -> str:
 # tracked follow-up, mirroring the nba_stats/wnba_stats decision above.
 # native/on3 + native/pff: the On3 RDB and PFF Premium column tails are likewise
 # authored as pilots with the remainder deferred (see those tracks' plans).
+# loader_schemas: generated dataset-loader return tables gained a `description`
+# column (previously they rendered name+type only), which exposed ~3k columns
+# across 8 leagues in one step. The shared//id columns fill from the R dict for
+# free; the per-dataset statistical tails are authored incrementally, mirroring
+# the nba_stats/wnba_stats decision above. `deferred_columns()` reports the count.
 _DEFERRED_BUCKETS = {
     "native/nba_stats",
     "native/wnba_stats",
     "native/sports247_site_pages",
     "native/on3",
     "native/pff",
+    "loader_schemas",
 }
+
+
+def _loader_schema_rows(d: dict) -> list[dict]:
+    """Rows for ``loader_schemas.yaml`` — ``{loader_fn: [{name, type}]}``.
+
+    The league is taken from the ``load_<league>_*`` function name (matching what
+    ``_loader_schema_table`` passes as ``league``), so the R-dict fallback resolves
+    the same way here as it does at render time. These entries carry no stored
+    description, so ``blank`` is always True and coverage is decided purely by the
+    manual dict + R dict.
+    """
+    rows: list[dict] = []
+    for fn, cols in (d or {}).items():
+        if not isinstance(cols, list):
+            continue
+        parts = fn.split("_")
+        league = parts[1] if len(parts) > 2 and parts[0] == "load" else None
+        names = [c.get("name", "") for c in cols if isinstance(c, dict)]
+        for c in cols:
+            if not isinstance(c, dict):
+                continue
+            rows.append(
+                {
+                    "schema": fn,
+                    "league": league,
+                    "bucket": "loader_schemas",
+                    "col": c.get("name", ""),
+                    "type": c.get("type", ""),
+                    "blank": True,
+                    "siblings": [n for n in names if n != c.get("name", "")],
+                }
+            )
+    return rows
 
 
 def iter_schema_columns() -> list[dict]:
@@ -78,6 +117,14 @@ def iter_schema_columns() -> list[dict]:
         except (yaml.YAMLError, OSError):
             continue
         if not isinstance(d, dict):
+            continue
+        # loader_schemas.yaml is a flat {loader_fn: [{name, type}]} map, not the
+        # `kind: dataframe` shape. It is globbed like any other schema file, so
+        # without this branch its columns silently contribute nothing -- and since
+        # loader return tables now render a description column, they would be blank
+        # cells invisible to the ratchet.
+        if os.path.basename(f) == "loader_schemas.yaml":
+            out.extend(_loader_schema_rows(d))
             continue
         schema = d.get("schema") or os.path.splitext(os.path.basename(f))[0]
         league = _league_of(f)

--- a/tools/codegen/generate.py
+++ b/tools/codegen/generate.py
@@ -973,6 +973,7 @@ class _LoaderView:
         self.stub_message = ld.stub_message
         self.abs_url = "" if ld.stub else f"{bases[ld.base]}{ld.url}"
         self.docstring = _build_loader_docstring(ld)
+        self.id_int64 = ld.id_int64
 
 
 def render_loader_module(league: str, loaders, bases: dict) -> str:
@@ -2006,13 +2007,22 @@ def _loader_base_label(prefix: str) -> str:
     return " / ".join(_LOADER_BASE_LABEL.get(b, b) for b in bases) or "sportsdataverse-data releases"
 
 
-def _loader_schema_table(fn: str) -> str:
-    """Markdown column table for a loader from the introspected footer schemas."""
+def _loader_schema_table(fn: str, league: str | None = None) -> str:
+    """Markdown column table for a loader from the introspected footer schemas.
+
+    Carries a ``description`` column so loader returns tables match the endpoint
+    ones. Descriptions resolve exactly like ``_return_table``'s: the hand-curated
+    ``manual_column_descriptions.yaml`` (keyed by the loader's ``fn``, so a loader
+    documents its columns under its own name), then the R-package column dict for
+    the league. Columns with neither are left blank rather than invented.
+    """
     cols = _loader_schemas().get(fn) or []
     if not cols:
         return ""
-    head = "| col_name | type |\n|---|---|\n"
-    return head + "".join(f"| `{c['name']}` | {c['type']} |\n" for c in cols)
+    head = "| col_name | type | description |\n|---|---|---|\n"
+    return head + "".join(
+        f"| `{c['name']}` | {c['type']} | {_table_cell_desc('', league, c['name'], fn)} |\n" for c in cols
+    )
 
 
 def _loader_doc_views(prefix: str) -> list[dict]:
@@ -2043,7 +2053,11 @@ def _loader_doc_views(prefix: str) -> list[dict]:
                 "tag_url": f"{tag_base}{ld.tag}",
                 "url": "" if ld.stub else f"{rel.bases[ld.base]}{ld.url}",
                 "automation": {"repo": auto.get("repo", ""), "workflow": auto.get("workflow", "")},
-                "return_table": _return_table(ld.returns_schema) if ld.returns_schema else _loader_schema_table(ld.fn),
+                "return_table": (
+                    _return_table(ld.returns_schema, prefix)
+                    if ld.returns_schema
+                    else _loader_schema_table(ld.fn, prefix)
+                ),
                 "example_seasons": (ld.example_args or {}).get("seasons", 2024),
             },
         )

--- a/tools/codegen/manual_column_descriptions.yaml
+++ b/tools/codegen/manual_column_descriptions.yaml
@@ -2585,6 +2585,21 @@ fit_field_position_ep:
 load_fp_curve:
   ep: Bundled expected points for a drive starting at this yard line (2018-2021 fit).
   yardline_own: Starting yard line from the offense's own goal (1-99).
+load_cfb_adv_defensive_players:
+  def_pos_team: Display name of the team on defense (e.g. 'Ohio State Buckeyes'). Held an ESPN team id until the
+    2026-08 republish; the id now lives in def_pos_team_id.
+  def_pos_team_id: ESPN team id of the team on defense. Present for every season 2004+.
+  forced_fumbles: Fumbles forced by the defender. Available from 2005 on; null for 2004, which ESPN ships with only
+    the fumble-recovery statistics.
+  fumble_recoveries: Fumbles recovered by the defender. Available for every season 2004+.
+  fumble_recoveries_yards: Yards returned on the defender's fumble recoveries. Available for every season 2004+.
+  interceptions: Passes intercepted by the defender. Available from 2014 on; null for 2004-2013, which ESPN ships
+    without interception statistics in this block.
+  interceptions_yards: Yards returned on the defender's interceptions. Available from 2014 on; null for 2004-2013.
+  pass_breakups: Passes broken up by the defender. Available from 2005 on; null for 2004.
+  player_name: Display name of the defender.
+  sacks: Sacks recorded by the defender. Available from 2005 on; null for 2004.
+  sacks_yards: Yards lost by the offense on the defender's sacks. Available from 2005 on; null for 2004.
 load_cfb_betting_lines:
   abbr: Selection/side this odds row applies to — a team abbreviation for spread and moneyline markets, or 'over'/'under'
     for total markets (the data is long-format, one row per book per selection per market_type).

--- a/tools/codegen/schemas/loader_schemas.yaml
+++ b/tools/codegen/schemas/loader_schemas.yaml
@@ -923,7 +923,7 @@ load_cfb_model_pbp:
   type: String
 load_cfb_passing:
 - name: team_id
-  type: String
+  type: Int64
 - name: pos_team
   type: String
 - name: division
@@ -2031,7 +2031,7 @@ load_cfb_ratings:
 - name: season
   type: Int64
 - name: team_id
-  type: String
+  type: Int64
 - name: adj_off_epa
   type: Float64
 - name: adj_def_epa
@@ -2060,7 +2060,7 @@ load_cfb_ratings:
   type: Float64
 load_cfb_receiving:
 - name: team_id
-  type: String
+  type: Int64
 - name: pos_team
   type: String
 - name: division
@@ -2127,7 +2127,7 @@ load_cfb_recruiting_proj:
 - name: season
   type: Int64
 - name: team_id
-  type: String
+  type: Int64
 - name: pred_wins
   type: Float64
 - name: pred_margin
@@ -2173,7 +2173,7 @@ load_cfb_rosters:
   type: Int32
 load_cfb_rushing:
 - name: team_id
-  type: String
+  type: Int64
 - name: pos_team
   type: String
 - name: division
@@ -2359,7 +2359,7 @@ load_cfb_team_box:
   type: Int64
 load_cfb_team_info:
 - name: team_id
-  type: Int32
+  type: Int64
 - name: school
   type: String
 - name: mascot
@@ -2416,7 +2416,7 @@ load_cfb_team_info:
   type: Boolean
 load_cfb_team_summaries:
 - name: team_id
-  type: String
+  type: Int64
 - name: pos_team
   type: String
 - name: division
@@ -11055,7 +11055,7 @@ load_cfb_ratings_weekly:
 - name: season
   type: Int64
 - name: team_id
-  type: String
+  type: Int64
 - name: adj_off_epa
   type: Float64
 - name: adj_def_epa
@@ -11086,7 +11086,7 @@ load_cfb_ratings_weekly:
   type: Int32
 load_cfb_team_summaries_weekly:
 - name: team_id
-  type: String
+  type: Int64
 - name: pos_team
   type: String
 - name: division

--- a/tools/codegen/spec.py
+++ b/tools/codegen/spec.py
@@ -102,6 +102,11 @@ class Loader:
     notebook: Optional[str] = None
     stub: bool = False
     stub_message: Optional[str] = None
+    # Id columns to canonicalize to Int64 at the loader boundary. Producers have
+    # shipped the same ESPN id as String, Int32 and Int64 across releases, which
+    # makes a cross-dataset join on that id silently match nothing. Declaring the
+    # column here normalizes it on read without touching the published asset.
+    id_int64: List[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -255,6 +260,7 @@ def load_releases(path: Path) -> ReleasesConfig:
             notebook=ld.get("notebook"),
             stub=ld.get("stub", False),
             stub_message=ld.get("stub_message"),
+            id_int64=list(ld.get("id_int64", []) or []),
         )
         for ld in raw["loaders"]
     ]

--- a/tools/codegen/templates/load_module.py.jinja
+++ b/tools/codegen/templates/load_module.py.jinja
@@ -8,6 +8,7 @@ import polars as pl
 from sportsdataverse._codegen_runtime import (
     SeasonNotFoundError,  # noqa: F401
     _as_season_list,
+    _cast_ids_int64,  # noqa: F401  (used only by loaders declaring id_int64)
     _read_release_parquet,
     cli_warn,
 )
@@ -41,6 +42,11 @@ def {{ ld.fn }}(seasons, return_as_pandas: bool = False):
     # diagonal: per-season release schemas can drift (columns added/dropped
     # over the years) -- union columns, null-fill gaps.
     out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+{% if ld.id_int64 %}
+    # Producers shipped this id with differing dtypes across releases; pin it here
+    # so a cross-dataset join cannot silently match nothing.
+    out = _cast_ids_int64(out, {{ ld.id_int64|py_repr }})
+{% endif %}
     return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
Two coupled codegen changes — the id cast alters declared dtypes, which the returns tables render, so they share one regeneration.

## 1. `team_id` canonicalized to `Int64`

The same ESPN team id shipped with **three different dtypes** across the CFB release surface. Joining across two of them matched **nothing** — silently, no error, structurally valid frame:

| dtype | datasets |
|---|---|
| `Int64` | 13 — all `adv_*`, `drives`, `game_rosters`, `linescores`, `player_box`, `team_box`, `adv_team_gamelog` |
| `String` | 8 — `passing`, `receiving`, `rushing`, `team_summaries`(+`_weekly`), `ratings`(+`_weekly`), `recruiting_proj` |
| `Int32` | 1 — `team_info` |

All nine non-`Int64` loaders normalize on read. `load_cfb_team_summaries` joined to `load_cfb_adv_team` on `team_id`/`pos_team_id` now resolves **134/134** teams; it previously matched **0**.

**Fixed at the boundary, not by republishing.** Published assets are untouched, so nobody reading the parquet directly is affected — this follows the repo's own "one dtype per id, cast at the boundary" rule and avoids a ~176-asset breaking republish.

**Lossless or refused, never silent.** `_cast_ids_int64` converts only when every non-null value survives a round-trip:

| input | result | why |
|---|---|---|
| `"103"`, `2649` | → `Int64` | integral, round-trips |
| `Int32`, `123.0` | → `Int64` | widening / float-origin id, no string detour (avoids `"123.0"`) |
| `"007"` | **left as String** | casts cleanly to `7` but changes the id |
| `1.5` | **left as Float64** | truncates to `1` |
| `"ABC"` | **left as String** | not an integer id |

A "no new nulls" check alone would let `"007"` and `1.5` through — both my own tests caught this while I was writing the guarantee down.

**New `id_int64:` key in `releases.yaml`** declares which columns a loader canonicalizes; the generated loader emits the call. Declaring it is the whole change — no generated file is ever hand-edited.

## 2. Loader returns tables carry descriptions

Generated loader tables rendered `col_name | type` while endpoint tables carried a third `description` column. They now match, resolving from `manual_column_descriptions.yaml` (keyed by the loader fn) with the R-package dict as fallback, so shared columns like `game_id`/`season`/`week` fill in automatically.

This exposed ~5,850 loader columns to the description coverage ratchet — which **had never globbed `loader_schemas.yaml`**, so those blanks were invisible to a gate whose stated intent is *"every return-table column renders a description"*. The extractor now sees them (**59% already covered**) and the remaining 2,407 are tracked via the existing `_DEFERRED_BUCKETS` mechanism, mirroring the `nba_stats` decision. Residual stays at **0**.

First documented use is `load_cfb_adv_defensive_players`, whose shape ramps in two steps and was previously undiscoverable without loading several seasons and diffing them:

| seasons | cols | shape |
|---|---|---|
| 2004 | 8 | fumble recoveries only |
| 2005–2013 | 12 | `+ sacks, sacks_yards, pass_breakups, forced_fumbles` |
| 2014–2025 | 14 | `+ interceptions, interceptions_yards` |

## Tests

- **`tests/codegen/test_id_casts.py`** (12) — conversion/refusal matrix plus two manifest gates: one fails if a loader declares `id_int64` without emitting the call, the other if a canonicalized column is declared as anything but `Int64`.
- The two producer-schema contract tests now apply the declared `id_int64` overlay. A returns table documents the **loader's** output, not the raw asset, so a boundary cast is an expected divergence rather than a docs lie.

## Gates

- `generate.py --check` → all generated files current
- `ruff format` + `ruff check` → clean
- targeted suites (id casts, manual descriptions, both producer contracts) → **24 passed**
- functional check against live releases: 134/134 join, all 9 loaders return `Int64`

## Summary by Sourcery

Canonicalize CFB loader team_id columns to Int64 at the loader boundary and extend generated loader documentation so return-table schemas include column descriptions across leagues.

New Features:
- Add declarative id_int64 support in loader specs to normalize identifier columns to Int64 on read.
- Expose loader return-table columns to the description coverage system by rendering a description field alongside name and type.

Enhancements:
- Introduce a shared _cast_ids_int64 helper and integrate it into generated loaders that declare id_int64.
- Update CFB loaders and schemas so team_id fields use a consistent Int64 type in both documentation and runtime output.
- Enhance schema extraction to treat loader_schemas.yaml as a tracked bucket with deferred documentation coverage.
- Document the identifier canonicalization and loader description changes in the changelog for both root and docs.

Tests:
- Add unit tests verifying _cast_ids_int64 only performs lossless identifier casts and leaves unsafe values untouched.
- Add manifest-level tests to ensure loaders declaring id_int64 emit the canonicalization call and declare those columns as Int64 in their schemas.
- Adjust existing CFB ratings and recruiting projection tests so producer-schema contract checks account for loader-side id_int64 overlays.