### PR TITLE
docs(cfb): describe 957 loader return-table columns (2407 deferred -> 1450)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Unreleased](#unreleased)
+  - [CFB — `opportunity_run` corrected, un-degenerating `opp_highlight_yards` (BREAKING)](#cfb--opportunity_run-corrected-un-degenerating-opp_highlight_yards-breaking)
+  - [CFB / PHF — 1,308 loader return-table columns described](#cfb--phf--1308-loader-return-table-columns-described)
   - [CFB — `team_id` canonicalized to `Int64` at the loader boundary](#cfb--team_id-canonicalized-to-int64-at-the-loader-boundary)
   - [Docs — loader returns tables now carry column descriptions](#docs--loader-returns-tables-now-carry-column-descriptions)
   - [CFB — `adv_*` `pos_team` now holds the team NAME, id moves to `pos_team_id` (BREAKING data change)](#cfb--adv_-pos_team-now-holds-the-team-name-id-moves-to-pos_team_id-breaking-data-change)
@@ -210,6 +212,70 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Unreleased
+
+### CFB — `opportunity_run` corrected, un-degenerating `opp_highlight_yards` (BREAKING)
+
+Found while **writing column descriptions**, not by a failing test — nothing
+pinned either invariant, which is why both survived.
+
+`opportunity_run` was `rush AND yds_rushed <= 4`. The cfbfastR oracle
+(`espn_cfb_15_team_summaries_creation.R:606`) is
+`((rush == 1) & (yds_rushed >= 4))`, and the sibling cfb-data producer agrees. An
+"opportunity" is a carry where the blocking **did** its job — one that reached 4
+yards. sdv-py had it as a stuff.
+
+That silently degenerated a second column. `opp_highlight_yards` gates on
+`opportunity_run`, but `highlight_yards` only accrues from 4 rushing yards up, so
+the two conditions could never co-occur: the column was **identically 0 in every
+published row**, verified across 162,950 plays in the 2024 release. It now ranges
+0–16 on the same games.
+
+The regression test then caught a **second divergence**: these gated on
+`type.text == "Rush"`, the literal ESPN play-type string, which excludes
+`"Rushing Touchdown"` and `"Fumble Recovery (Own)"` rushes — so a 4-yard rushing
+touchdown was not counted as an opportunity. The oracle gates on `rush`, and so
+does `line_yards` two statements below, which meant `adj_rush_yardage` was left
+null on exactly the plays `line_yards` tried to consume. `opportunity_run`,
+`highlight_run` and `adj_rush_yardage` now all gate on `rush`.
+
+**Still divergent, deliberately untouched:** the line-yards *scale*. The R oracle
+caps `adj_rush_yardage` at 10 and splits 0–4 / 5–10 / 11+; sdv-py caps at 8 with a
+`3 + 0.5(adj-3)` ramp and a 5.5 ceiling. Changing that shifts published
+`line_yards` / `second_level_yards` / `open_field_yards`, so it needs its own
+decision rather than riding along with a bug fix.
+
+**Breaking:** published `espn_cfb_pbp` assets carry the old values until
+republished; the column descriptions say so explicitly.
+
+### CFB / PHF — 1,308 loader return-table columns described
+
+Continues the work started in #312. Loader deferred columns **2,407 → 1,099**,
+residual ratchet unchanged at **0**.
+
+| batch | cols | grounding |
+|---|---|---|
+| `team_summaries` + `_weekly` | 757 | producer arithmetic (`_summarize_team`) |
+| `adv_team` + `_gamelog` | 131 | empirical profile of published assets |
+| `adv_situational` | 71 | empirical profile |
+| `cfb_pbp` | 247 | transcribed from `cfb_pbp.py`, thresholds quoted |
+| PHF (4 loaders) | 114 | provider fields, described at face value |
+
+Descriptions are **composed from verified vocabularies** rather than hand-written
+per column, and the generators are committed (`tools/codegen/gen_*_descriptions.py`)
+so each derivation stays reproducible. They enumerate `loader_schemas.yaml`, so
+re-running is idempotent.
+
+Profiling the ESPN blocks against real data contradicted their naming in ways that
+would otherwise have shipped as wrong documentation:
+
+- the bare `EPA_explosive*` and `EPA_success*` columns are integer play **counts**,
+  not EPA totals, despite the `EPA_` prefix (~40 columns)
+- `EPA_overall_off` and `EPA_overall_offense` are **exact duplicates**
+- `EPA_explosive_rate` is **not** `EPA_explosive / EPA_plays` — ESPN divides by a
+  smaller qualifying-play count, so deriving it will not reproduce their value
+
+Anything a generator could not ground is left **blank and reported**, never
+invented.
 
 ### CFB — `team_id` canonicalized to `Int64` at the loader boundary
 

--- a/docs/docs/cfb/reference/loaders.md
+++ b/docs/docs/cfb/reference/loaders.md
@@ -1638,384 +1638,384 @@ Release: [espn_cfb_team_summaries](https://github.com/sportsdataverse/sportsdata
 | `division` | String | Division in the conference for the team. |
 | `conference` | String | Conference of the team. |
 | `season` | Int64 | Season (4-digit year). |
-| `plays_off` | UInt32 |  |
-| `playsgame_off` | Float64 |  |
-| `passrate_off` | Float64 |  |
-| `rushrate_off` | Float64 |  |
-| `havoc_off` | Float64 |  |
-| `explosive_off` | Float64 |  |
-| `TEPA_off` | Float64 |  |
-| `EPAplay_off` | Float64 |  |
-| `EPAdrive_off` | Float64 |  |
-| `EPAgame_off` | Float64 |  |
-| `yards_off` | Int64 |  |
-| `yardsplay_off` | Float64 |  |
-| `yardsgame_off` | Float64 |  |
-| `play_stuffed_off` | Float64 |  |
-| `drives_off` | UInt32 |  |
-| `drivesgame_off` | Float64 |  |
-| `yardsdrive_off` | Float64 |  |
-| `playsdrive_off` | Float64 |  |
-| `success_off` | Float64 |  |
-| `red_zone_success_off` | Float64 |  |
-| `third_down_success_off` | Float64 |  |
-| `third_down_distance_off` | Float64 |  |
-| `late_down_success_off` | Float64 |  |
-| `early_down_EPA_off` | Float64 |  |
-| `start_position_off` | Float64 |  |
-| `nonExplosiveEpaPerPlay_off` | Float64 |  |
-| `line_yards_off` | Float64 |  |
-| `opportunity_rate_off` | Float64 |  |
-| `playsgame_off_rank` | Float64 |  |
-| `TEPA_off_rank` | Float64 |  |
-| `EPAgame_off_rank` | Float64 |  |
-| `EPAplay_off_rank` | Float64 |  |
-| `EPAdrive_off_rank` | Float64 |  |
-| `early_down_EPA_off_rank` | Float64 |  |
-| `success_off_rank` | Float64 |  |
-| `yards_off_rank` | Float64 |  |
-| `yardsplay_off_rank` | Float64 |  |
-| `yardsgame_off_rank` | Float64 |  |
-| `drivesgame_off_rank` | Float64 |  |
-| `yardsdrive_off_rank` | Float64 |  |
-| `playsdrive_off_rank` | Float64 |  |
-| `play_stuffed_off_rank` | Float64 |  |
-| `red_zone_success_off_rank` | Float64 |  |
-| `third_down_success_off_rank` | Float64 |  |
-| `late_down_success_off_rank` | Float64 |  |
-| `third_down_distance_off_rank` | Float64 |  |
-| `start_position_off_rank` | Float64 |  |
-| `havoc_off_rank` | Float64 |  |
-| `explosive_off_rank` | Float64 |  |
-| `passrate_off_rank` | Float64 |  |
-| `rushrate_off_rank` | Float64 |  |
-| `nonExplosiveEpaPerPlay_off_rank` | Float64 |  |
-| `line_yards_off_rank` | Float64 |  |
-| `opportunity_rate_off_rank` | Float64 |  |
-| `plays_def` | UInt32 |  |
-| `playsgame_def` | Float64 |  |
-| `passrate_def` | Float64 |  |
-| `rushrate_def` | Float64 |  |
-| `havoc_def` | Float64 |  |
-| `explosive_def` | Float64 |  |
-| `TEPA_def` | Float64 |  |
-| `EPAplay_def` | Float64 |  |
-| `EPAdrive_def` | Float64 |  |
-| `EPAgame_def` | Float64 |  |
-| `yards_def` | Int64 |  |
-| `yardsplay_def` | Float64 |  |
-| `yardsgame_def` | Float64 |  |
-| `play_stuffed_def` | Float64 |  |
-| `drives_def` | UInt32 |  |
-| `drivesgame_def` | Float64 |  |
-| `yardsdrive_def` | Float64 |  |
-| `playsdrive_def` | Float64 |  |
-| `success_def` | Float64 |  |
-| `red_zone_success_def` | Float64 |  |
-| `third_down_success_def` | Float64 |  |
-| `third_down_distance_def` | Float64 |  |
-| `late_down_success_def` | Float64 |  |
-| `early_down_EPA_def` | Float64 |  |
-| `start_position_def` | Float64 |  |
-| `nonExplosiveEpaPerPlay_def` | Float64 |  |
-| `line_yards_def` | Float64 |  |
-| `opportunity_rate_def` | Float64 |  |
-| `playsgame_def_rank` | Float64 |  |
-| `TEPA_def_rank` | Float64 |  |
-| `EPAgame_def_rank` | Float64 |  |
-| `EPAplay_def_rank` | Float64 |  |
-| `EPAdrive_def_rank` | Float64 |  |
-| `early_down_EPA_def_rank` | Float64 |  |
-| `success_def_rank` | Float64 |  |
-| `yards_def_rank` | Float64 |  |
-| `yardsplay_def_rank` | Float64 |  |
-| `yardsgame_def_rank` | Float64 |  |
-| `drivesgame_def_rank` | Float64 |  |
-| `yardsdrive_def_rank` | Float64 |  |
-| `playsdrive_def_rank` | Float64 |  |
-| `play_stuffed_def_rank` | Float64 |  |
-| `red_zone_success_def_rank` | Float64 |  |
-| `third_down_success_def_rank` | Float64 |  |
-| `late_down_success_def_rank` | Float64 |  |
-| `third_down_distance_def_rank` | Float64 |  |
-| `start_position_def_rank` | Float64 |  |
-| `havoc_def_rank` | Float64 |  |
-| `explosive_def_rank` | Float64 |  |
-| `passrate_def_rank` | Float64 |  |
-| `rushrate_def_rank` | Float64 |  |
-| `nonExplosiveEpaPerPlay_def_rank` | Float64 |  |
-| `line_yards_def_rank` | Float64 |  |
-| `opportunity_rate_def_rank` | Float64 |  |
-| `TEPA_margin` | Float64 |  |
-| `EPAplay_margin` | Float64 |  |
-| `EPAdrive_margin` | Float64 |  |
-| `EPAgame_margin` | Float64 |  |
-| `success_margin` | Float64 |  |
-| `yardsplay_margin` | Float64 |  |
-| `TEPA_margin_rank` | Float64 |  |
-| `EPAgame_margin_rank` | Float64 |  |
-| `EPAdrive_margin_rank` | Float64 |  |
-| `EPAplay_margin_rank` | Float64 |  |
-| `success_margin_rank` | Float64 |  |
-| `yardsplay_margin_rank` | Float64 |  |
-| `start_position_margin` | Float64 |  |
-| `start_position_margin_rank` | Float64 |  |
-| `total_available_yards_off` | Float64 |  |
-| `total_gained_yards_off` | Int64 |  |
-| `available_yards_pct_off` | Float64 |  |
-| `available_yards_pct_off_rank` | Float64 |  |
-| `total_available_yards_def` | Float64 |  |
-| `total_gained_yards_def` | Int64 |  |
-| `available_yards_pct_def` | Float64 |  |
-| `available_yards_pct_def_rank` | Float64 |  |
-| `total_available_yards_margin` | Float64 |  |
-| `total_gained_yards_margin` | Int64 |  |
-| `available_yards_pct_margin` | Float64 |  |
-| `total_available_yards_margin_rank` | Float64 |  |
-| `total_gained_yards_margin_rank` | Float64 |  |
-| `available_yards_pct_margin_rank` | Float64 |  |
-| `plays_off_pass` | UInt32 |  |
-| `playsgame_off_pass` | Float64 |  |
-| `passrate_off_pass` | Float64 |  |
-| `rushrate_off_pass` | Float64 |  |
-| `havoc_off_pass` | Float64 |  |
-| `explosive_off_pass` | Float64 |  |
-| `TEPA_off_pass` | Float64 |  |
-| `EPAplay_off_pass` | Float64 |  |
-| `EPAdrive_off_pass` | Float64 |  |
-| `EPAgame_off_pass` | Float64 |  |
-| `yards_off_pass` | Int64 |  |
-| `yardsplay_off_pass` | Float64 |  |
-| `yardsgame_off_pass` | Float64 |  |
-| `play_stuffed_off_pass` | Float64 |  |
-| `drives_off_pass` | UInt32 |  |
-| `drivesgame_off_pass` | Float64 |  |
-| `yardsdrive_off_pass` | Float64 |  |
-| `playsdrive_off_pass` | Float64 |  |
-| `success_off_pass` | Float64 |  |
-| `red_zone_success_off_pass` | Float64 |  |
-| `third_down_success_off_pass` | Float64 |  |
-| `third_down_distance_off_pass` | Float64 |  |
-| `late_down_success_off_pass` | Float64 |  |
-| `early_down_EPA_off_pass` | Float64 |  |
-| `nonExplosiveEpaPerPlay_off_pass` | Float64 |  |
-| `line_yards_off_pass` | Float64 |  |
-| `opportunity_rate_off_pass` | Float64 |  |
-| `playsgame_off_pass_rank` | Float64 |  |
-| `TEPA_off_pass_rank` | Float64 |  |
-| `EPAgame_off_pass_rank` | Float64 |  |
-| `EPAplay_off_pass_rank` | Float64 |  |
-| `EPAdrive_off_pass_rank` | Float64 |  |
-| `early_down_EPA_off_pass_rank` | Float64 |  |
-| `success_off_pass_rank` | Float64 |  |
-| `yards_off_pass_rank` | Float64 |  |
-| `yardsplay_off_pass_rank` | Float64 |  |
-| `yardsgame_off_pass_rank` | Float64 |  |
-| `drivesgame_off_pass_rank` | Float64 |  |
-| `yardsdrive_off_pass_rank` | Float64 |  |
-| `playsdrive_off_pass_rank` | Float64 |  |
-| `play_stuffed_off_pass_rank` | Float64 |  |
-| `red_zone_success_off_pass_rank` | Float64 |  |
-| `third_down_success_off_pass_rank` | Float64 |  |
-| `late_down_success_off_pass_rank` | Float64 |  |
-| `third_down_distance_off_pass_rank` | Float64 |  |
-| `havoc_off_pass_rank` | Float64 |  |
-| `explosive_off_pass_rank` | Float64 |  |
-| `passrate_off_pass_rank` | Float64 |  |
-| `rushrate_off_pass_rank` | Float64 |  |
-| `nonExplosiveEpaPerPlay_off_pass_rank` | Float64 |  |
-| `line_yards_off_pass_rank` | Float64 |  |
-| `opportunity_rate_off_pass_rank` | Float64 |  |
-| `plays_def_pass` | UInt32 |  |
-| `playsgame_def_pass` | Float64 |  |
-| `passrate_def_pass` | Float64 |  |
-| `rushrate_def_pass` | Float64 |  |
-| `havoc_def_pass` | Float64 |  |
-| `explosive_def_pass` | Float64 |  |
-| `TEPA_def_pass` | Float64 |  |
-| `EPAplay_def_pass` | Float64 |  |
-| `EPAdrive_def_pass` | Float64 |  |
-| `EPAgame_def_pass` | Float64 |  |
-| `yards_def_pass` | Int64 |  |
-| `yardsplay_def_pass` | Float64 |  |
-| `yardsgame_def_pass` | Float64 |  |
-| `play_stuffed_def_pass` | Float64 |  |
-| `drives_def_pass` | UInt32 |  |
-| `drivesgame_def_pass` | Float64 |  |
-| `yardsdrive_def_pass` | Float64 |  |
-| `playsdrive_def_pass` | Float64 |  |
-| `success_def_pass` | Float64 |  |
-| `red_zone_success_def_pass` | Float64 |  |
-| `third_down_success_def_pass` | Float64 |  |
-| `third_down_distance_def_pass` | Float64 |  |
-| `late_down_success_def_pass` | Float64 |  |
-| `early_down_EPA_def_pass` | Float64 |  |
-| `nonExplosiveEpaPerPlay_def_pass` | Float64 |  |
-| `line_yards_def_pass` | Float64 |  |
-| `opportunity_rate_def_pass` | Float64 |  |
-| `playsgame_def_pass_rank` | Float64 |  |
-| `TEPA_def_pass_rank` | Float64 |  |
-| `EPAgame_def_pass_rank` | Float64 |  |
-| `EPAplay_def_pass_rank` | Float64 |  |
-| `EPAdrive_def_pass_rank` | Float64 |  |
-| `early_down_EPA_def_pass_rank` | Float64 |  |
-| `success_def_pass_rank` | Float64 |  |
-| `yards_def_pass_rank` | Float64 |  |
-| `yardsplay_def_pass_rank` | Float64 |  |
-| `yardsgame_def_pass_rank` | Float64 |  |
-| `drivesgame_def_pass_rank` | Float64 |  |
-| `yardsdrive_def_pass_rank` | Float64 |  |
-| `playsdrive_def_pass_rank` | Float64 |  |
-| `play_stuffed_def_pass_rank` | Float64 |  |
-| `red_zone_success_def_pass_rank` | Float64 |  |
-| `third_down_success_def_pass_rank` | Float64 |  |
-| `late_down_success_def_pass_rank` | Float64 |  |
-| `third_down_distance_def_pass_rank` | Float64 |  |
-| `havoc_def_pass_rank` | Float64 |  |
-| `explosive_def_pass_rank` | Float64 |  |
-| `passrate_def_pass_rank` | Float64 |  |
-| `rushrate_def_pass_rank` | Float64 |  |
-| `nonExplosiveEpaPerPlay_def_pass_rank` | Float64 |  |
-| `line_yards_def_pass_rank` | Float64 |  |
-| `opportunity_rate_def_pass_rank` | Float64 |  |
-| `TEPA_margin_pass` | Float64 |  |
-| `EPAplay_margin_pass` | Float64 |  |
-| `EPAdrive_margin_pass` | Float64 |  |
-| `EPAgame_margin_pass` | Float64 |  |
-| `success_margin_pass` | Float64 |  |
-| `yardsplay_margin_pass` | Float64 |  |
-| `TEPA_margin_pass_rank` | Float64 |  |
-| `EPAgame_margin_pass_rank` | Float64 |  |
-| `EPAdrive_margin_pass_rank` | Float64 |  |
-| `EPAplay_margin_pass_rank` | Float64 |  |
-| `success_margin_pass_rank` | Float64 |  |
-| `yardsplay_margin_pass_rank` | Float64 |  |
-| `plays_off_rush` | UInt32 |  |
-| `playsgame_off_rush` | Float64 |  |
-| `passrate_off_rush` | Float64 |  |
-| `rushrate_off_rush` | Float64 |  |
-| `havoc_off_rush` | Float64 |  |
-| `explosive_off_rush` | Float64 |  |
-| `TEPA_off_rush` | Float64 |  |
-| `EPAplay_off_rush` | Float64 |  |
-| `EPAdrive_off_rush` | Float64 |  |
-| `EPAgame_off_rush` | Float64 |  |
-| `yards_off_rush` | Int64 |  |
-| `yardsplay_off_rush` | Float64 |  |
-| `yardsgame_off_rush` | Float64 |  |
-| `play_stuffed_off_rush` | Float64 |  |
-| `drives_off_rush` | UInt32 |  |
-| `drivesgame_off_rush` | Float64 |  |
-| `yardsdrive_off_rush` | Float64 |  |
-| `playsdrive_off_rush` | Float64 |  |
-| `success_off_rush` | Float64 |  |
-| `red_zone_success_off_rush` | Float64 |  |
-| `third_down_success_off_rush` | Float64 |  |
-| `third_down_distance_off_rush` | Float64 |  |
-| `late_down_success_off_rush` | Float64 |  |
-| `early_down_EPA_off_rush` | Float64 |  |
-| `nonExplosiveEpaPerPlay_off_rush` | Float64 |  |
-| `line_yards_off_rush` | Float64 |  |
-| `opportunity_rate_off_rush` | Float64 |  |
-| `playsgame_off_rush_rank` | Float64 |  |
-| `TEPA_off_rush_rank` | Float64 |  |
-| `EPAgame_off_rush_rank` | Float64 |  |
-| `EPAplay_off_rush_rank` | Float64 |  |
-| `EPAdrive_off_rush_rank` | Float64 |  |
-| `early_down_EPA_off_rush_rank` | Float64 |  |
-| `success_off_rush_rank` | Float64 |  |
-| `yards_off_rush_rank` | Float64 |  |
-| `yardsplay_off_rush_rank` | Float64 |  |
-| `yardsgame_off_rush_rank` | Float64 |  |
-| `drivesgame_off_rush_rank` | Float64 |  |
-| `yardsdrive_off_rush_rank` | Float64 |  |
-| `playsdrive_off_rush_rank` | Float64 |  |
-| `play_stuffed_off_rush_rank` | Float64 |  |
-| `red_zone_success_off_rush_rank` | Float64 |  |
-| `third_down_success_off_rush_rank` | Float64 |  |
-| `late_down_success_off_rush_rank` | Float64 |  |
-| `third_down_distance_off_rush_rank` | Float64 |  |
-| `havoc_off_rush_rank` | Float64 |  |
-| `explosive_off_rush_rank` | Float64 |  |
-| `passrate_off_rush_rank` | Float64 |  |
-| `rushrate_off_rush_rank` | Float64 |  |
-| `nonExplosiveEpaPerPlay_off_rush_rank` | Float64 |  |
-| `line_yards_off_rush_rank` | Float64 |  |
-| `opportunity_rate_off_rush_rank` | Float64 |  |
-| `plays_def_rush` | UInt32 |  |
-| `playsgame_def_rush` | Float64 |  |
-| `passrate_def_rush` | Float64 |  |
-| `rushrate_def_rush` | Float64 |  |
-| `havoc_def_rush` | Float64 |  |
-| `explosive_def_rush` | Float64 |  |
-| `TEPA_def_rush` | Float64 |  |
-| `EPAplay_def_rush` | Float64 |  |
-| `EPAdrive_def_rush` | Float64 |  |
-| `EPAgame_def_rush` | Float64 |  |
-| `yards_def_rush` | Int64 |  |
-| `yardsplay_def_rush` | Float64 |  |
-| `yardsgame_def_rush` | Float64 |  |
-| `play_stuffed_def_rush` | Float64 |  |
-| `drives_def_rush` | UInt32 |  |
-| `drivesgame_def_rush` | Float64 |  |
-| `yardsdrive_def_rush` | Float64 |  |
-| `playsdrive_def_rush` | Float64 |  |
-| `success_def_rush` | Float64 |  |
-| `red_zone_success_def_rush` | Float64 |  |
-| `third_down_success_def_rush` | Float64 |  |
-| `third_down_distance_def_rush` | Float64 |  |
-| `late_down_success_def_rush` | Float64 |  |
-| `early_down_EPA_def_rush` | Float64 |  |
-| `nonExplosiveEpaPerPlay_def_rush` | Float64 |  |
-| `line_yards_def_rush` | Float64 |  |
-| `opportunity_rate_def_rush` | Float64 |  |
-| `playsgame_def_rush_rank` | Float64 |  |
-| `TEPA_def_rush_rank` | Float64 |  |
-| `EPAgame_def_rush_rank` | Float64 |  |
-| `EPAplay_def_rush_rank` | Float64 |  |
-| `EPAdrive_def_rush_rank` | Float64 |  |
-| `early_down_EPA_def_rush_rank` | Float64 |  |
-| `success_def_rush_rank` | Float64 |  |
-| `yards_def_rush_rank` | Float64 |  |
-| `yardsplay_def_rush_rank` | Float64 |  |
-| `yardsgame_def_rush_rank` | Float64 |  |
-| `drivesgame_def_rush_rank` | Float64 |  |
-| `yardsdrive_def_rush_rank` | Float64 |  |
-| `playsdrive_def_rush_rank` | Float64 |  |
-| `play_stuffed_def_rush_rank` | Float64 |  |
-| `red_zone_success_def_rush_rank` | Float64 |  |
-| `third_down_success_def_rush_rank` | Float64 |  |
-| `late_down_success_def_rush_rank` | Float64 |  |
-| `third_down_distance_def_rush_rank` | Float64 |  |
-| `havoc_def_rush_rank` | Float64 |  |
-| `explosive_def_rush_rank` | Float64 |  |
-| `passrate_def_rush_rank` | Float64 |  |
-| `rushrate_def_rush_rank` | Float64 |  |
-| `nonExplosiveEpaPerPlay_def_rush_rank` | Float64 |  |
-| `line_yards_def_rush_rank` | Float64 |  |
-| `opportunity_rate_def_rush_rank` | Float64 |  |
-| `TEPA_margin_rush` | Float64 |  |
-| `EPAplay_margin_rush` | Float64 |  |
-| `EPAdrive_margin_rush` | Float64 |  |
-| `EPAgame_margin_rush` | Float64 |  |
-| `success_margin_rush` | Float64 |  |
-| `yardsplay_margin_rush` | Float64 |  |
-| `TEPA_margin_rush_rank` | Float64 |  |
-| `EPAgame_margin_rush_rank` | Float64 |  |
-| `EPAdrive_margin_rush_rank` | Float64 |  |
-| `EPAplay_margin_rush_rank` | Float64 |  |
-| `success_margin_rush_rank` | Float64 |  |
-| `yardsplay_margin_rush_rank` | Float64 |  |
-| `fbs_class` | String |  |
-| `valid_games` | UInt32 |  |
-| `adj_off_epa` | Float64 |  |
-| `adj_def_epa` | Float64 |  |
-| `def_strength_faced` | Float64 |  |
-| `off_strength_faced` | Float64 |  |
-| `net_adj_epa` | Float64 |  |
-| `adj_off_epa_rank` | Float64 |  |
-| `adj_def_epa_rank` | Float64 |  |
-| `net_adj_epa_rank` | Float64 |  |
+| `plays_off` | UInt32 | Plays run, with the team on offense. |
+| `playsgame_off` | Float64 | Plays run per game, with the team on offense. |
+| `passrate_off` | Float64 | Share of plays that were pass plays, with the team on offense. |
+| `rushrate_off` | Float64 | Share of plays that were rush plays, with the team on offense. |
+| `havoc_off` | Float64 | Havoc rate -- the share of plays carrying the defensive-disruption flag, with the team on offense. |
+| `explosive_off` | Float64 | Explosive-play rate -- the share of plays carrying the explosive flag, with the team on offense. |
+| `TEPA_off` | Float64 | Total EPA summed over every play, with the team on offense. |
+| `EPAplay_off` | Float64 | EPA per play, with the team on offense. |
+| `EPAdrive_off` | Float64 | EPA per drive (total EPA divided by drives), with the team on offense. |
+| `EPAgame_off` | Float64 | EPA per game (total EPA divided by games), with the team on offense. |
+| `yards_off` | Int64 | Total yards gained, with the team on offense. |
+| `yardsplay_off` | Float64 | Yards gained per play, with the team on offense. |
+| `yardsgame_off` | Float64 | Yards gained per game, with the team on offense. |
+| `play_stuffed_off` | Float64 | Stuffed-play rate -- the share of plays carrying the stuffed flag, with the team on offense. |
+| `drives_off` | UInt32 | Offensive drives, with the team on offense. |
+| `drivesgame_off` | Float64 | Drives per game, with the team on offense. |
+| `yardsdrive_off` | Float64 | Yards gained per drive, with the team on offense. |
+| `playsdrive_off` | Float64 | Plays run per drive, with the team on offense. |
+| `success_off` | Float64 | Success rate -- the share of plays flagged as successful by EPA, with the team on offense. |
+| `red_zone_success_off` | Float64 | Success rate on red-zone plays, with the team on offense. |
+| `third_down_success_off` | Float64 | Success rate on third-down plays, with the team on offense. |
+| `third_down_distance_off` | Float64 | Average yards to go on third down, with the team on offense. |
+| `late_down_success_off` | Float64 | Success rate on late-down plays, with the team on offense. |
+| `early_down_EPA_off` | Float64 | EPA per early-down play, with the team on offense. |
+| `start_position_off` | Float64 | Average drive start position, measured in yards from the opponent goal line, with the team on offense. |
+| `nonExplosiveEpaPerPlay_off` | Float64 | EPA per play with explosive plays excluded, with the team on offense. |
+| `line_yards_off` | Float64 | Average line yards credited to the offensive line on rushes, with the team on offense. |
+| `opportunity_rate_off` | Float64 | Opportunity rate -- the share of rushes carrying the opportunity flag, with the team on offense. |
+| `playsgame_off_rank` | Float64 | National rank of the team's plays run per game with the team on offense, where 1 is best. |
+| `TEPA_off_rank` | Float64 | National rank of the team's total EPA summed over every play with the team on offense, where 1 is best. |
+| `EPAgame_off_rank` | Float64 | National rank of the team's EPA per game (total EPA divided by games) with the team on offense, where 1 is best. |
+| `EPAplay_off_rank` | Float64 | National rank of the team's EPA per play with the team on offense, where 1 is best. |
+| `EPAdrive_off_rank` | Float64 | National rank of the team's EPA per drive (total EPA divided by drives) with the team on offense, where 1 is best. |
+| `early_down_EPA_off_rank` | Float64 | National rank of the team's EPA per early-down play with the team on offense, where 1 is best. |
+| `success_off_rank` | Float64 | National rank of the team's success rate -- the share of plays flagged as successful by EPA with the team on offense, where 1 is best. |
+| `yards_off_rank` | Float64 | National rank of the team's total yards gained with the team on offense, where 1 is best. |
+| `yardsplay_off_rank` | Float64 | National rank of the team's yards gained per play with the team on offense, where 1 is best. |
+| `yardsgame_off_rank` | Float64 | National rank of the team's yards gained per game with the team on offense, where 1 is best. |
+| `drivesgame_off_rank` | Float64 | National rank of the team's drives per game with the team on offense, where 1 is best. |
+| `yardsdrive_off_rank` | Float64 | National rank of the team's yards gained per drive with the team on offense, where 1 is best. |
+| `playsdrive_off_rank` | Float64 | National rank of the team's plays run per drive with the team on offense, where 1 is best. |
+| `play_stuffed_off_rank` | Float64 | National rank of the team's stuffed-play rate -- the share of plays carrying the stuffed flag with the team on offense, where 1 is best. |
+| `red_zone_success_off_rank` | Float64 | National rank of the team's success rate on red-zone plays with the team on offense, where 1 is best. |
+| `third_down_success_off_rank` | Float64 | National rank of the team's success rate on third-down plays with the team on offense, where 1 is best. |
+| `late_down_success_off_rank` | Float64 | National rank of the team's success rate on late-down plays with the team on offense, where 1 is best. |
+| `third_down_distance_off_rank` | Float64 | National rank of the team's average yards to go on third down with the team on offense, where 1 is best. |
+| `start_position_off_rank` | Float64 | National rank of the team's average drive start position, measured in yards from the opponent goal line with the team on offense, where 1 is best. |
+| `havoc_off_rank` | Float64 | National rank of the team's havoc rate -- the share of plays carrying the defensive-disruption flag with the team on offense, where 1 is best. |
+| `explosive_off_rank` | Float64 | National rank of the team's explosive-play rate -- the share of plays carrying the explosive flag with the team on offense, where 1 is best. |
+| `passrate_off_rank` | Float64 | National rank of the team's share of plays that were pass plays with the team on offense, where 1 is best. |
+| `rushrate_off_rank` | Float64 | National rank of the team's share of plays that were rush plays with the team on offense, where 1 is best. |
+| `nonExplosiveEpaPerPlay_off_rank` | Float64 | National rank of the team's EPA per play with explosive plays excluded with the team on offense, where 1 is best. |
+| `line_yards_off_rank` | Float64 | National rank of the team's average line yards credited to the offensive line on rushes with the team on offense, where 1 is best. |
+| `opportunity_rate_off_rank` | Float64 | National rank of the team's opportunity rate -- the share of rushes carrying the opportunity flag with the team on offense, where 1 is best. |
+| `plays_def` | UInt32 | Plays run, with the team on defense (i.e. allowed to opponents). |
+| `playsgame_def` | Float64 | Plays run per game, with the team on defense (i.e. allowed to opponents). |
+| `passrate_def` | Float64 | Share of plays that were pass plays, with the team on defense (i.e. allowed to opponents). |
+| `rushrate_def` | Float64 | Share of plays that were rush plays, with the team on defense (i.e. allowed to opponents). |
+| `havoc_def` | Float64 | Havoc rate -- the share of plays carrying the defensive-disruption flag, with the team on defense (i.e. allowed to opponents). |
+| `explosive_def` | Float64 | Explosive-play rate -- the share of plays carrying the explosive flag, with the team on defense (i.e. allowed to opponents). |
+| `TEPA_def` | Float64 | Total EPA summed over every play, with the team on defense (i.e. allowed to opponents). |
+| `EPAplay_def` | Float64 | EPA per play, with the team on defense (i.e. allowed to opponents). |
+| `EPAdrive_def` | Float64 | EPA per drive (total EPA divided by drives), with the team on defense (i.e. allowed to opponents). |
+| `EPAgame_def` | Float64 | EPA per game (total EPA divided by games), with the team on defense (i.e. allowed to opponents). |
+| `yards_def` | Int64 | Total yards gained, with the team on defense (i.e. allowed to opponents). |
+| `yardsplay_def` | Float64 | Yards gained per play, with the team on defense (i.e. allowed to opponents). |
+| `yardsgame_def` | Float64 | Yards gained per game, with the team on defense (i.e. allowed to opponents). |
+| `play_stuffed_def` | Float64 | Stuffed-play rate -- the share of plays carrying the stuffed flag, with the team on defense (i.e. allowed to opponents). |
+| `drives_def` | UInt32 | Offensive drives, with the team on defense (i.e. allowed to opponents). |
+| `drivesgame_def` | Float64 | Drives per game, with the team on defense (i.e. allowed to opponents). |
+| `yardsdrive_def` | Float64 | Yards gained per drive, with the team on defense (i.e. allowed to opponents). |
+| `playsdrive_def` | Float64 | Plays run per drive, with the team on defense (i.e. allowed to opponents). |
+| `success_def` | Float64 | Success rate -- the share of plays flagged as successful by EPA, with the team on defense (i.e. allowed to opponents). |
+| `red_zone_success_def` | Float64 | Success rate on red-zone plays, with the team on defense (i.e. allowed to opponents). |
+| `third_down_success_def` | Float64 | Success rate on third-down plays, with the team on defense (i.e. allowed to opponents). |
+| `third_down_distance_def` | Float64 | Average yards to go on third down, with the team on defense (i.e. allowed to opponents). |
+| `late_down_success_def` | Float64 | Success rate on late-down plays, with the team on defense (i.e. allowed to opponents). |
+| `early_down_EPA_def` | Float64 | EPA per early-down play, with the team on defense (i.e. allowed to opponents). |
+| `start_position_def` | Float64 | Average drive start position, measured in yards from the opponent goal line, with the team on defense (i.e. allowed to opponents). |
+| `nonExplosiveEpaPerPlay_def` | Float64 | EPA per play with explosive plays excluded, with the team on defense (i.e. allowed to opponents). |
+| `line_yards_def` | Float64 | Average line yards credited to the offensive line on rushes, with the team on defense (i.e. allowed to opponents). |
+| `opportunity_rate_def` | Float64 | Opportunity rate -- the share of rushes carrying the opportunity flag, with the team on defense (i.e. allowed to opponents). |
+| `playsgame_def_rank` | Float64 | National rank of the team's plays run per game with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `TEPA_def_rank` | Float64 | National rank of the team's total EPA summed over every play with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `EPAgame_def_rank` | Float64 | National rank of the team's EPA per game (total EPA divided by games) with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `EPAplay_def_rank` | Float64 | National rank of the team's EPA per play with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `EPAdrive_def_rank` | Float64 | National rank of the team's EPA per drive (total EPA divided by drives) with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `early_down_EPA_def_rank` | Float64 | National rank of the team's EPA per early-down play with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `success_def_rank` | Float64 | National rank of the team's success rate -- the share of plays flagged as successful by EPA with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `yards_def_rank` | Float64 | National rank of the team's total yards gained with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `yardsplay_def_rank` | Float64 | National rank of the team's yards gained per play with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `yardsgame_def_rank` | Float64 | National rank of the team's yards gained per game with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `drivesgame_def_rank` | Float64 | National rank of the team's drives per game with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `yardsdrive_def_rank` | Float64 | National rank of the team's yards gained per drive with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `playsdrive_def_rank` | Float64 | National rank of the team's plays run per drive with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `play_stuffed_def_rank` | Float64 | National rank of the team's stuffed-play rate -- the share of plays carrying the stuffed flag with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `red_zone_success_def_rank` | Float64 | National rank of the team's success rate on red-zone plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `third_down_success_def_rank` | Float64 | National rank of the team's success rate on third-down plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `late_down_success_def_rank` | Float64 | National rank of the team's success rate on late-down plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `third_down_distance_def_rank` | Float64 | National rank of the team's average yards to go on third down with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `start_position_def_rank` | Float64 | National rank of the team's average drive start position, measured in yards from the opponent goal line with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `havoc_def_rank` | Float64 | National rank of the team's havoc rate -- the share of plays carrying the defensive-disruption flag with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `explosive_def_rank` | Float64 | National rank of the team's explosive-play rate -- the share of plays carrying the explosive flag with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `passrate_def_rank` | Float64 | National rank of the team's share of plays that were pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `rushrate_def_rank` | Float64 | National rank of the team's share of plays that were rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `nonExplosiveEpaPerPlay_def_rank` | Float64 | National rank of the team's EPA per play with explosive plays excluded with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `line_yards_def_rank` | Float64 | National rank of the team's average line yards credited to the offensive line on rushes with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `opportunity_rate_def_rank` | Float64 | National rank of the team's opportunity rate -- the share of rushes carrying the opportunity flag with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `TEPA_margin` | Float64 | Margin in total EPA summed over every play: the team's offensive value minus the value it allowed on defense. |
+| `EPAplay_margin` | Float64 | Margin in EPA per play: the team's offensive value minus the value it allowed on defense. |
+| `EPAdrive_margin` | Float64 | Margin in EPA per drive (total EPA divided by drives): the team's offensive value minus the value it allowed on defense. |
+| `EPAgame_margin` | Float64 | Margin in EPA per game (total EPA divided by games): the team's offensive value minus the value it allowed on defense. |
+| `success_margin` | Float64 | Margin in success rate -- the share of plays flagged as successful by EPA: the team's offensive value minus the value it allowed on defense. |
+| `yardsplay_margin` | Float64 | Margin in yards gained per play: the team's offensive value minus the value it allowed on defense. |
+| `TEPA_margin_rank` | Float64 | Margin in total EPA summed over every play: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `EPAgame_margin_rank` | Float64 | Margin in EPA per game (total EPA divided by games): the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `EPAdrive_margin_rank` | Float64 | Margin in EPA per drive (total EPA divided by drives): the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `EPAplay_margin_rank` | Float64 | Margin in EPA per play: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `success_margin_rank` | Float64 | Margin in success rate -- the share of plays flagged as successful by EPA: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `yardsplay_margin_rank` | Float64 | Margin in yards gained per play: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `start_position_margin` | Float64 | Field-position margin: the team's own average starting field position minus the average starting field position it allowed, both measured as yards gained from their own goal line. Positive means the team started closer to scoring than its opponents. |
+| `start_position_margin_rank` | Float64 | Field-position margin: the team's own average starting field position minus the average starting field position it allowed, both measured as yards gained from their own goal line. Positive means the team started closer to scoring than its opponents. National rank of that margin, 1 = largest. |
+| `total_available_yards_off` | Float64 | Available yards are the yards a drive could theoretically gain, summed from each drive's starting distance to the opponent goal line. Total available yards on the team's own drives. |
+| `total_gained_yards_off` | Int64 | Total yards the team actually gained across its own drives. |
+| `available_yards_pct_off` | Float64 | Share of available yards the team's offense actually gained (total_gained_yards_off divided by total_available_yards_off). Higher is better. |
+| `available_yards_pct_off_rank` | Float64 | National rank of the team's offensive available-yards share, where 1 is best. |
+| `total_available_yards_def` | Float64 | Available yards are the yards a drive could theoretically gain, summed from each drive's starting distance to the opponent goal line. Total available yards on drives the team defended. |
+| `total_gained_yards_def` | Int64 | Total yards the team allowed across the drives it defended. |
+| `available_yards_pct_def` | Float64 | Share of available yards the team's defense allowed opponents to gain. Lower is better. |
+| `available_yards_pct_def_rank` | Float64 | National rank of the team's defensive available-yards share, where 1 is best. |
+| `total_available_yards_margin` | Float64 | Available yards on the team's own drives minus available yards on drives it defended. |
+| `total_gained_yards_margin` | Int64 | Yards the team gained minus yards it allowed. |
+| `available_yards_pct_margin` | Float64 | Available-yards share gained by the offense minus the share allowed by the defense. Higher is better. |
+| `total_available_yards_margin_rank` | Float64 | National rank of total_available_yards_margin, 1 = largest margin. |
+| `total_gained_yards_margin_rank` | Float64 | National rank of total_gained_yards_margin, 1 = largest margin. |
+| `available_yards_pct_margin_rank` | Float64 | National rank of available_yards_pct_margin, 1 = largest margin. |
+| `plays_off_pass` | UInt32 | Plays run on pass plays, with the team on offense. |
+| `playsgame_off_pass` | Float64 | Plays run per game on pass plays, with the team on offense. |
+| `passrate_off_pass` | Float64 | Share of plays that were pass plays on pass plays, with the team on offense. |
+| `rushrate_off_pass` | Float64 | Share of plays that were rush plays on pass plays, with the team on offense. |
+| `havoc_off_pass` | Float64 | Havoc rate -- the share of plays carrying the defensive-disruption flag on pass plays, with the team on offense. |
+| `explosive_off_pass` | Float64 | Explosive-play rate -- the share of plays carrying the explosive flag on pass plays, with the team on offense. |
+| `TEPA_off_pass` | Float64 | Total EPA summed over every play on pass plays, with the team on offense. |
+| `EPAplay_off_pass` | Float64 | EPA per play on pass plays, with the team on offense. |
+| `EPAdrive_off_pass` | Float64 | EPA per drive (total EPA divided by drives) on pass plays, with the team on offense. |
+| `EPAgame_off_pass` | Float64 | EPA per game (total EPA divided by games) on pass plays, with the team on offense. |
+| `yards_off_pass` | Int64 | Total yards gained on pass plays, with the team on offense. |
+| `yardsplay_off_pass` | Float64 | Yards gained per play on pass plays, with the team on offense. |
+| `yardsgame_off_pass` | Float64 | Yards gained per game on pass plays, with the team on offense. |
+| `play_stuffed_off_pass` | Float64 | Stuffed-play rate -- the share of plays carrying the stuffed flag on pass plays, with the team on offense. |
+| `drives_off_pass` | UInt32 | Offensive drives on pass plays, with the team on offense. |
+| `drivesgame_off_pass` | Float64 | Drives per game on pass plays, with the team on offense. |
+| `yardsdrive_off_pass` | Float64 | Yards gained per drive on pass plays, with the team on offense. |
+| `playsdrive_off_pass` | Float64 | Plays run per drive on pass plays, with the team on offense. |
+| `success_off_pass` | Float64 | Success rate -- the share of plays flagged as successful by EPA on pass plays, with the team on offense. |
+| `red_zone_success_off_pass` | Float64 | Success rate on red-zone plays on pass plays, with the team on offense. |
+| `third_down_success_off_pass` | Float64 | Success rate on third-down plays on pass plays, with the team on offense. |
+| `third_down_distance_off_pass` | Float64 | Average yards to go on third down on pass plays, with the team on offense. |
+| `late_down_success_off_pass` | Float64 | Success rate on late-down plays on pass plays, with the team on offense. |
+| `early_down_EPA_off_pass` | Float64 | EPA per early-down play on pass plays, with the team on offense. |
+| `nonExplosiveEpaPerPlay_off_pass` | Float64 | EPA per play with explosive plays excluded on pass plays, with the team on offense. |
+| `line_yards_off_pass` | Float64 | Average line yards credited to the offensive line on rushes on pass plays, with the team on offense. |
+| `opportunity_rate_off_pass` | Float64 | Opportunity rate -- the share of rushes carrying the opportunity flag on pass plays, with the team on offense. |
+| `playsgame_off_pass_rank` | Float64 | National rank of the team's plays run per game on pass plays with the team on offense, where 1 is best. |
+| `TEPA_off_pass_rank` | Float64 | National rank of the team's total EPA summed over every play on pass plays with the team on offense, where 1 is best. |
+| `EPAgame_off_pass_rank` | Float64 | National rank of the team's EPA per game (total EPA divided by games) on pass plays with the team on offense, where 1 is best. |
+| `EPAplay_off_pass_rank` | Float64 | National rank of the team's EPA per play on pass plays with the team on offense, where 1 is best. |
+| `EPAdrive_off_pass_rank` | Float64 | National rank of the team's EPA per drive (total EPA divided by drives) on pass plays with the team on offense, where 1 is best. |
+| `early_down_EPA_off_pass_rank` | Float64 | National rank of the team's EPA per early-down play on pass plays with the team on offense, where 1 is best. |
+| `success_off_pass_rank` | Float64 | National rank of the team's success rate -- the share of plays flagged as successful by EPA on pass plays with the team on offense, where 1 is best. |
+| `yards_off_pass_rank` | Float64 | National rank of the team's total yards gained on pass plays with the team on offense, where 1 is best. |
+| `yardsplay_off_pass_rank` | Float64 | National rank of the team's yards gained per play on pass plays with the team on offense, where 1 is best. |
+| `yardsgame_off_pass_rank` | Float64 | National rank of the team's yards gained per game on pass plays with the team on offense, where 1 is best. |
+| `drivesgame_off_pass_rank` | Float64 | National rank of the team's drives per game on pass plays with the team on offense, where 1 is best. |
+| `yardsdrive_off_pass_rank` | Float64 | National rank of the team's yards gained per drive on pass plays with the team on offense, where 1 is best. |
+| `playsdrive_off_pass_rank` | Float64 | National rank of the team's plays run per drive on pass plays with the team on offense, where 1 is best. |
+| `play_stuffed_off_pass_rank` | Float64 | National rank of the team's stuffed-play rate -- the share of plays carrying the stuffed flag on pass plays with the team on offense, where 1 is best. |
+| `red_zone_success_off_pass_rank` | Float64 | National rank of the team's success rate on red-zone plays on pass plays with the team on offense, where 1 is best. |
+| `third_down_success_off_pass_rank` | Float64 | National rank of the team's success rate on third-down plays on pass plays with the team on offense, where 1 is best. |
+| `late_down_success_off_pass_rank` | Float64 | National rank of the team's success rate on late-down plays on pass plays with the team on offense, where 1 is best. |
+| `third_down_distance_off_pass_rank` | Float64 | National rank of the team's average yards to go on third down on pass plays with the team on offense, where 1 is best. |
+| `havoc_off_pass_rank` | Float64 | National rank of the team's havoc rate -- the share of plays carrying the defensive-disruption flag on pass plays with the team on offense, where 1 is best. |
+| `explosive_off_pass_rank` | Float64 | National rank of the team's explosive-play rate -- the share of plays carrying the explosive flag on pass plays with the team on offense, where 1 is best. |
+| `passrate_off_pass_rank` | Float64 | National rank of the team's share of plays that were pass plays on pass plays with the team on offense, where 1 is best. |
+| `rushrate_off_pass_rank` | Float64 | National rank of the team's share of plays that were rush plays on pass plays with the team on offense, where 1 is best. |
+| `nonExplosiveEpaPerPlay_off_pass_rank` | Float64 | National rank of the team's EPA per play with explosive plays excluded on pass plays with the team on offense, where 1 is best. |
+| `line_yards_off_pass_rank` | Float64 | National rank of the team's average line yards credited to the offensive line on rushes on pass plays with the team on offense, where 1 is best. |
+| `opportunity_rate_off_pass_rank` | Float64 | National rank of the team's opportunity rate -- the share of rushes carrying the opportunity flag on pass plays with the team on offense, where 1 is best. |
+| `plays_def_pass` | UInt32 | Plays run on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `playsgame_def_pass` | Float64 | Plays run per game on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `passrate_def_pass` | Float64 | Share of plays that were pass plays on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `rushrate_def_pass` | Float64 | Share of plays that were rush plays on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `havoc_def_pass` | Float64 | Havoc rate -- the share of plays carrying the defensive-disruption flag on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `explosive_def_pass` | Float64 | Explosive-play rate -- the share of plays carrying the explosive flag on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `TEPA_def_pass` | Float64 | Total EPA summed over every play on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `EPAplay_def_pass` | Float64 | EPA per play on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `EPAdrive_def_pass` | Float64 | EPA per drive (total EPA divided by drives) on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `EPAgame_def_pass` | Float64 | EPA per game (total EPA divided by games) on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `yards_def_pass` | Int64 | Total yards gained on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `yardsplay_def_pass` | Float64 | Yards gained per play on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `yardsgame_def_pass` | Float64 | Yards gained per game on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `play_stuffed_def_pass` | Float64 | Stuffed-play rate -- the share of plays carrying the stuffed flag on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `drives_def_pass` | UInt32 | Offensive drives on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `drivesgame_def_pass` | Float64 | Drives per game on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `yardsdrive_def_pass` | Float64 | Yards gained per drive on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `playsdrive_def_pass` | Float64 | Plays run per drive on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `success_def_pass` | Float64 | Success rate -- the share of plays flagged as successful by EPA on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `red_zone_success_def_pass` | Float64 | Success rate on red-zone plays on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `third_down_success_def_pass` | Float64 | Success rate on third-down plays on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `third_down_distance_def_pass` | Float64 | Average yards to go on third down on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `late_down_success_def_pass` | Float64 | Success rate on late-down plays on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `early_down_EPA_def_pass` | Float64 | EPA per early-down play on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `nonExplosiveEpaPerPlay_def_pass` | Float64 | EPA per play with explosive plays excluded on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `line_yards_def_pass` | Float64 | Average line yards credited to the offensive line on rushes on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `opportunity_rate_def_pass` | Float64 | Opportunity rate -- the share of rushes carrying the opportunity flag on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `playsgame_def_pass_rank` | Float64 | National rank of the team's plays run per game on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `TEPA_def_pass_rank` | Float64 | National rank of the team's total EPA summed over every play on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `EPAgame_def_pass_rank` | Float64 | National rank of the team's EPA per game (total EPA divided by games) on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `EPAplay_def_pass_rank` | Float64 | National rank of the team's EPA per play on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `EPAdrive_def_pass_rank` | Float64 | National rank of the team's EPA per drive (total EPA divided by drives) on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `early_down_EPA_def_pass_rank` | Float64 | National rank of the team's EPA per early-down play on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `success_def_pass_rank` | Float64 | National rank of the team's success rate -- the share of plays flagged as successful by EPA on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `yards_def_pass_rank` | Float64 | National rank of the team's total yards gained on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `yardsplay_def_pass_rank` | Float64 | National rank of the team's yards gained per play on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `yardsgame_def_pass_rank` | Float64 | National rank of the team's yards gained per game on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `drivesgame_def_pass_rank` | Float64 | National rank of the team's drives per game on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `yardsdrive_def_pass_rank` | Float64 | National rank of the team's yards gained per drive on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `playsdrive_def_pass_rank` | Float64 | National rank of the team's plays run per drive on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `play_stuffed_def_pass_rank` | Float64 | National rank of the team's stuffed-play rate -- the share of plays carrying the stuffed flag on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `red_zone_success_def_pass_rank` | Float64 | National rank of the team's success rate on red-zone plays on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `third_down_success_def_pass_rank` | Float64 | National rank of the team's success rate on third-down plays on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `late_down_success_def_pass_rank` | Float64 | National rank of the team's success rate on late-down plays on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `third_down_distance_def_pass_rank` | Float64 | National rank of the team's average yards to go on third down on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `havoc_def_pass_rank` | Float64 | National rank of the team's havoc rate -- the share of plays carrying the defensive-disruption flag on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `explosive_def_pass_rank` | Float64 | National rank of the team's explosive-play rate -- the share of plays carrying the explosive flag on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `passrate_def_pass_rank` | Float64 | National rank of the team's share of plays that were pass plays on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `rushrate_def_pass_rank` | Float64 | National rank of the team's share of plays that were rush plays on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `nonExplosiveEpaPerPlay_def_pass_rank` | Float64 | National rank of the team's EPA per play with explosive plays excluded on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `line_yards_def_pass_rank` | Float64 | National rank of the team's average line yards credited to the offensive line on rushes on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `opportunity_rate_def_pass_rank` | Float64 | National rank of the team's opportunity rate -- the share of rushes carrying the opportunity flag on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `TEPA_margin_pass` | Float64 | Margin in total EPA summed over every play on pass plays: the team's offensive value minus the value it allowed on defense. |
+| `EPAplay_margin_pass` | Float64 | Margin in EPA per play on pass plays: the team's offensive value minus the value it allowed on defense. |
+| `EPAdrive_margin_pass` | Float64 | Margin in EPA per drive (total EPA divided by drives) on pass plays: the team's offensive value minus the value it allowed on defense. |
+| `EPAgame_margin_pass` | Float64 | Margin in EPA per game (total EPA divided by games) on pass plays: the team's offensive value minus the value it allowed on defense. |
+| `success_margin_pass` | Float64 | Margin in success rate -- the share of plays flagged as successful by EPA on pass plays: the team's offensive value minus the value it allowed on defense. |
+| `yardsplay_margin_pass` | Float64 | Margin in yards gained per play on pass plays: the team's offensive value minus the value it allowed on defense. |
+| `TEPA_margin_pass_rank` | Float64 | Margin in total EPA summed over every play on pass plays: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `EPAgame_margin_pass_rank` | Float64 | Margin in EPA per game (total EPA divided by games) on pass plays: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `EPAdrive_margin_pass_rank` | Float64 | Margin in EPA per drive (total EPA divided by drives) on pass plays: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `EPAplay_margin_pass_rank` | Float64 | Margin in EPA per play on pass plays: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `success_margin_pass_rank` | Float64 | Margin in success rate -- the share of plays flagged as successful by EPA on pass plays: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `yardsplay_margin_pass_rank` | Float64 | Margin in yards gained per play on pass plays: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `plays_off_rush` | UInt32 | Plays run on rush plays, with the team on offense. |
+| `playsgame_off_rush` | Float64 | Plays run per game on rush plays, with the team on offense. |
+| `passrate_off_rush` | Float64 | Share of plays that were pass plays on rush plays, with the team on offense. |
+| `rushrate_off_rush` | Float64 | Share of plays that were rush plays on rush plays, with the team on offense. |
+| `havoc_off_rush` | Float64 | Havoc rate -- the share of plays carrying the defensive-disruption flag on rush plays, with the team on offense. |
+| `explosive_off_rush` | Float64 | Explosive-play rate -- the share of plays carrying the explosive flag on rush plays, with the team on offense. |
+| `TEPA_off_rush` | Float64 | Total EPA summed over every play on rush plays, with the team on offense. |
+| `EPAplay_off_rush` | Float64 | EPA per play on rush plays, with the team on offense. |
+| `EPAdrive_off_rush` | Float64 | EPA per drive (total EPA divided by drives) on rush plays, with the team on offense. |
+| `EPAgame_off_rush` | Float64 | EPA per game (total EPA divided by games) on rush plays, with the team on offense. |
+| `yards_off_rush` | Int64 | Total yards gained on rush plays, with the team on offense. |
+| `yardsplay_off_rush` | Float64 | Yards gained per play on rush plays, with the team on offense. |
+| `yardsgame_off_rush` | Float64 | Yards gained per game on rush plays, with the team on offense. |
+| `play_stuffed_off_rush` | Float64 | Stuffed-play rate -- the share of plays carrying the stuffed flag on rush plays, with the team on offense. |
+| `drives_off_rush` | UInt32 | Offensive drives on rush plays, with the team on offense. |
+| `drivesgame_off_rush` | Float64 | Drives per game on rush plays, with the team on offense. |
+| `yardsdrive_off_rush` | Float64 | Yards gained per drive on rush plays, with the team on offense. |
+| `playsdrive_off_rush` | Float64 | Plays run per drive on rush plays, with the team on offense. |
+| `success_off_rush` | Float64 | Success rate -- the share of plays flagged as successful by EPA on rush plays, with the team on offense. |
+| `red_zone_success_off_rush` | Float64 | Success rate on red-zone plays on rush plays, with the team on offense. |
+| `third_down_success_off_rush` | Float64 | Success rate on third-down plays on rush plays, with the team on offense. |
+| `third_down_distance_off_rush` | Float64 | Average yards to go on third down on rush plays, with the team on offense. |
+| `late_down_success_off_rush` | Float64 | Success rate on late-down plays on rush plays, with the team on offense. |
+| `early_down_EPA_off_rush` | Float64 | EPA per early-down play on rush plays, with the team on offense. |
+| `nonExplosiveEpaPerPlay_off_rush` | Float64 | EPA per play with explosive plays excluded on rush plays, with the team on offense. |
+| `line_yards_off_rush` | Float64 | Average line yards credited to the offensive line on rushes on rush plays, with the team on offense. |
+| `opportunity_rate_off_rush` | Float64 | Opportunity rate -- the share of rushes carrying the opportunity flag on rush plays, with the team on offense. |
+| `playsgame_off_rush_rank` | Float64 | National rank of the team's plays run per game on rush plays with the team on offense, where 1 is best. |
+| `TEPA_off_rush_rank` | Float64 | National rank of the team's total EPA summed over every play on rush plays with the team on offense, where 1 is best. |
+| `EPAgame_off_rush_rank` | Float64 | National rank of the team's EPA per game (total EPA divided by games) on rush plays with the team on offense, where 1 is best. |
+| `EPAplay_off_rush_rank` | Float64 | National rank of the team's EPA per play on rush plays with the team on offense, where 1 is best. |
+| `EPAdrive_off_rush_rank` | Float64 | National rank of the team's EPA per drive (total EPA divided by drives) on rush plays with the team on offense, where 1 is best. |
+| `early_down_EPA_off_rush_rank` | Float64 | National rank of the team's EPA per early-down play on rush plays with the team on offense, where 1 is best. |
+| `success_off_rush_rank` | Float64 | National rank of the team's success rate -- the share of plays flagged as successful by EPA on rush plays with the team on offense, where 1 is best. |
+| `yards_off_rush_rank` | Float64 | National rank of the team's total yards gained on rush plays with the team on offense, where 1 is best. |
+| `yardsplay_off_rush_rank` | Float64 | National rank of the team's yards gained per play on rush plays with the team on offense, where 1 is best. |
+| `yardsgame_off_rush_rank` | Float64 | National rank of the team's yards gained per game on rush plays with the team on offense, where 1 is best. |
+| `drivesgame_off_rush_rank` | Float64 | National rank of the team's drives per game on rush plays with the team on offense, where 1 is best. |
+| `yardsdrive_off_rush_rank` | Float64 | National rank of the team's yards gained per drive on rush plays with the team on offense, where 1 is best. |
+| `playsdrive_off_rush_rank` | Float64 | National rank of the team's plays run per drive on rush plays with the team on offense, where 1 is best. |
+| `play_stuffed_off_rush_rank` | Float64 | National rank of the team's stuffed-play rate -- the share of plays carrying the stuffed flag on rush plays with the team on offense, where 1 is best. |
+| `red_zone_success_off_rush_rank` | Float64 | National rank of the team's success rate on red-zone plays on rush plays with the team on offense, where 1 is best. |
+| `third_down_success_off_rush_rank` | Float64 | National rank of the team's success rate on third-down plays on rush plays with the team on offense, where 1 is best. |
+| `late_down_success_off_rush_rank` | Float64 | National rank of the team's success rate on late-down plays on rush plays with the team on offense, where 1 is best. |
+| `third_down_distance_off_rush_rank` | Float64 | National rank of the team's average yards to go on third down on rush plays with the team on offense, where 1 is best. |
+| `havoc_off_rush_rank` | Float64 | National rank of the team's havoc rate -- the share of plays carrying the defensive-disruption flag on rush plays with the team on offense, where 1 is best. |
+| `explosive_off_rush_rank` | Float64 | National rank of the team's explosive-play rate -- the share of plays carrying the explosive flag on rush plays with the team on offense, where 1 is best. |
+| `passrate_off_rush_rank` | Float64 | National rank of the team's share of plays that were pass plays on rush plays with the team on offense, where 1 is best. |
+| `rushrate_off_rush_rank` | Float64 | National rank of the team's share of plays that were rush plays on rush plays with the team on offense, where 1 is best. |
+| `nonExplosiveEpaPerPlay_off_rush_rank` | Float64 | National rank of the team's EPA per play with explosive plays excluded on rush plays with the team on offense, where 1 is best. |
+| `line_yards_off_rush_rank` | Float64 | National rank of the team's average line yards credited to the offensive line on rushes on rush plays with the team on offense, where 1 is best. |
+| `opportunity_rate_off_rush_rank` | Float64 | National rank of the team's opportunity rate -- the share of rushes carrying the opportunity flag on rush plays with the team on offense, where 1 is best. |
+| `plays_def_rush` | UInt32 | Plays run on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `playsgame_def_rush` | Float64 | Plays run per game on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `passrate_def_rush` | Float64 | Share of plays that were pass plays on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `rushrate_def_rush` | Float64 | Share of plays that were rush plays on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `havoc_def_rush` | Float64 | Havoc rate -- the share of plays carrying the defensive-disruption flag on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `explosive_def_rush` | Float64 | Explosive-play rate -- the share of plays carrying the explosive flag on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `TEPA_def_rush` | Float64 | Total EPA summed over every play on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `EPAplay_def_rush` | Float64 | EPA per play on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `EPAdrive_def_rush` | Float64 | EPA per drive (total EPA divided by drives) on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `EPAgame_def_rush` | Float64 | EPA per game (total EPA divided by games) on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `yards_def_rush` | Int64 | Total yards gained on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `yardsplay_def_rush` | Float64 | Yards gained per play on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `yardsgame_def_rush` | Float64 | Yards gained per game on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `play_stuffed_def_rush` | Float64 | Stuffed-play rate -- the share of plays carrying the stuffed flag on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `drives_def_rush` | UInt32 | Offensive drives on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `drivesgame_def_rush` | Float64 | Drives per game on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `yardsdrive_def_rush` | Float64 | Yards gained per drive on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `playsdrive_def_rush` | Float64 | Plays run per drive on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `success_def_rush` | Float64 | Success rate -- the share of plays flagged as successful by EPA on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `red_zone_success_def_rush` | Float64 | Success rate on red-zone plays on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `third_down_success_def_rush` | Float64 | Success rate on third-down plays on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `third_down_distance_def_rush` | Float64 | Average yards to go on third down on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `late_down_success_def_rush` | Float64 | Success rate on late-down plays on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `early_down_EPA_def_rush` | Float64 | EPA per early-down play on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `nonExplosiveEpaPerPlay_def_rush` | Float64 | EPA per play with explosive plays excluded on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `line_yards_def_rush` | Float64 | Average line yards credited to the offensive line on rushes on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `opportunity_rate_def_rush` | Float64 | Opportunity rate -- the share of rushes carrying the opportunity flag on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `playsgame_def_rush_rank` | Float64 | National rank of the team's plays run per game on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `TEPA_def_rush_rank` | Float64 | National rank of the team's total EPA summed over every play on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `EPAgame_def_rush_rank` | Float64 | National rank of the team's EPA per game (total EPA divided by games) on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `EPAplay_def_rush_rank` | Float64 | National rank of the team's EPA per play on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `EPAdrive_def_rush_rank` | Float64 | National rank of the team's EPA per drive (total EPA divided by drives) on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `early_down_EPA_def_rush_rank` | Float64 | National rank of the team's EPA per early-down play on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `success_def_rush_rank` | Float64 | National rank of the team's success rate -- the share of plays flagged as successful by EPA on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `yards_def_rush_rank` | Float64 | National rank of the team's total yards gained on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `yardsplay_def_rush_rank` | Float64 | National rank of the team's yards gained per play on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `yardsgame_def_rush_rank` | Float64 | National rank of the team's yards gained per game on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `drivesgame_def_rush_rank` | Float64 | National rank of the team's drives per game on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `yardsdrive_def_rush_rank` | Float64 | National rank of the team's yards gained per drive on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `playsdrive_def_rush_rank` | Float64 | National rank of the team's plays run per drive on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `play_stuffed_def_rush_rank` | Float64 | National rank of the team's stuffed-play rate -- the share of plays carrying the stuffed flag on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `red_zone_success_def_rush_rank` | Float64 | National rank of the team's success rate on red-zone plays on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `third_down_success_def_rush_rank` | Float64 | National rank of the team's success rate on third-down plays on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `late_down_success_def_rush_rank` | Float64 | National rank of the team's success rate on late-down plays on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `third_down_distance_def_rush_rank` | Float64 | National rank of the team's average yards to go on third down on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `havoc_def_rush_rank` | Float64 | National rank of the team's havoc rate -- the share of plays carrying the defensive-disruption flag on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `explosive_def_rush_rank` | Float64 | National rank of the team's explosive-play rate -- the share of plays carrying the explosive flag on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `passrate_def_rush_rank` | Float64 | National rank of the team's share of plays that were pass plays on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `rushrate_def_rush_rank` | Float64 | National rank of the team's share of plays that were rush plays on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `nonExplosiveEpaPerPlay_def_rush_rank` | Float64 | National rank of the team's EPA per play with explosive plays excluded on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `line_yards_def_rush_rank` | Float64 | National rank of the team's average line yards credited to the offensive line on rushes on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `opportunity_rate_def_rush_rank` | Float64 | National rank of the team's opportunity rate -- the share of rushes carrying the opportunity flag on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `TEPA_margin_rush` | Float64 | Margin in total EPA summed over every play on rush plays: the team's offensive value minus the value it allowed on defense. |
+| `EPAplay_margin_rush` | Float64 | Margin in EPA per play on rush plays: the team's offensive value minus the value it allowed on defense. |
+| `EPAdrive_margin_rush` | Float64 | Margin in EPA per drive (total EPA divided by drives) on rush plays: the team's offensive value minus the value it allowed on defense. |
+| `EPAgame_margin_rush` | Float64 | Margin in EPA per game (total EPA divided by games) on rush plays: the team's offensive value minus the value it allowed on defense. |
+| `success_margin_rush` | Float64 | Margin in success rate -- the share of plays flagged as successful by EPA on rush plays: the team's offensive value minus the value it allowed on defense. |
+| `yardsplay_margin_rush` | Float64 | Margin in yards gained per play on rush plays: the team's offensive value minus the value it allowed on defense. |
+| `TEPA_margin_rush_rank` | Float64 | Margin in total EPA summed over every play on rush plays: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `EPAgame_margin_rush_rank` | Float64 | Margin in EPA per game (total EPA divided by games) on rush plays: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `EPAdrive_margin_rush_rank` | Float64 | Margin in EPA per drive (total EPA divided by drives) on rush plays: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `EPAplay_margin_rush_rank` | Float64 | Margin in EPA per play on rush plays: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `success_margin_rush_rank` | Float64 | Margin in success rate -- the share of plays flagged as successful by EPA on rush plays: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `yardsplay_margin_rush_rank` | Float64 | Margin in yards gained per play on rush plays: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `fbs_class` | String | Power/Group classification for the season: P4 or G6 from 2024 on, P5 or G5 through 2023, derived from conference membership (Notre Dame is classified with the power group). Null for teams outside FBS. |
+| `valid_games` | UInt32 | Number of the team's games that produced both an offensive and a defensive adjusted-EPA value; teams below two valid games are dropped from the adjusted ratings. |
+| `adj_off_epa` | Float64 | Offensive opponent-adjusted EPA per play from the ridge (RAPM-style) regression on offense/defense team indicators plus home field -- cfbfastR's adjust_epa adjustment, fit in-sample across the season, so the value is descriptive of that window rather than predictive. |
+| `adj_def_epa` | Float64 | Defensive opponent-adjusted EPA per play from the ridge (RAPM-style) regression on offense/defense team indicators plus home field -- cfbfastR's adjust_epa adjustment, fit in-sample across the season, so the value is descriptive of that window rather than predictive. Lower is better -- it is EPA allowed. |
+| `def_strength_faced` | Float64 | Average opponent-offense strength the team's defense faced, taken as the mean of the ridge's offensive coefficients across its opponents. Higher means a tougher slate. |
+| `off_strength_faced` | Float64 | Average opponent-defense strength the team's offense faced, taken as the mean of the ridge's defensive coefficients across its opponents. Higher means a tougher slate. |
+| `net_adj_epa` | Float64 | Net opponent-adjusted EPA per play: adj_off_epa minus adj_def_epa. Higher is better. |
+| `adj_off_epa_rank` | Float64 | National rank of the team's adj_off_epa, where 1 is best. |
+| `adj_def_epa_rank` | Float64 | National rank of the team's adj_def_epa, where 1 is best (fewest EPA allowed). |
+| `net_adj_epa_rank` | Float64 | National rank of the team's net_adj_epa, 1 = largest net adjusted EPA. |
 
 ```python
 load_cfb_team_summaries(seasons=2024)
@@ -2163,385 +2163,385 @@ Release: [cfb_team_summaries_weekly](https://github.com/sportsdataverse/sportsda
 | `division` | String | Division in the conference for the team. |
 | `conference` | String | Conference of the team. |
 | `season` | Int64 | Season (4-digit year). |
-| `plays_off` | UInt32 |  |
-| `passrate_off` | Float64 |  |
-| `rushrate_off` | Float64 |  |
-| `havoc_off` | Float64 |  |
-| `explosive_off` | Float64 |  |
-| `TEPA_off` | Float64 |  |
-| `EPAplay_off` | Float64 |  |
-| `yards_off` | Int64 |  |
-| `yardsplay_off` | Float64 |  |
-| `play_stuffed_off` | Float64 |  |
-| `success_off` | Float64 |  |
-| `red_zone_success_off` | Float64 |  |
-| `third_down_success_off` | Float64 |  |
-| `third_down_distance_off` | Float64 |  |
-| `late_down_success_off` | Float64 |  |
-| `early_down_EPA_off` | Float64 |  |
-| `start_position_off` | Float64 |  |
-| `nonExplosiveEpaPerPlay_off` | Float64 |  |
-| `line_yards_off` | Float64 |  |
-| `opportunity_rate_off` | Float64 |  |
-| `playsgame_off` | Float64 |  |
-| `EPAdrive_off` | Float64 |  |
-| `EPAgame_off` | Float64 |  |
-| `yardsgame_off` | Float64 |  |
-| `drives_off` | UInt32 |  |
-| `drivesgame_off` | Float64 |  |
-| `yardsdrive_off` | Float64 |  |
-| `playsdrive_off` | Float64 |  |
-| `playsgame_off_rank` | Float64 |  |
-| `TEPA_off_rank` | Float64 |  |
-| `EPAgame_off_rank` | Float64 |  |
-| `EPAplay_off_rank` | Float64 |  |
-| `EPAdrive_off_rank` | Float64 |  |
-| `early_down_EPA_off_rank` | Float64 |  |
-| `success_off_rank` | Float64 |  |
-| `yards_off_rank` | Float64 |  |
-| `yardsplay_off_rank` | Float64 |  |
-| `yardsgame_off_rank` | Float64 |  |
-| `drivesgame_off_rank` | Float64 |  |
-| `yardsdrive_off_rank` | Float64 |  |
-| `playsdrive_off_rank` | Float64 |  |
-| `play_stuffed_off_rank` | Float64 |  |
-| `red_zone_success_off_rank` | Float64 |  |
-| `third_down_success_off_rank` | Float64 |  |
-| `late_down_success_off_rank` | Float64 |  |
-| `third_down_distance_off_rank` | Float64 |  |
-| `start_position_off_rank` | Float64 |  |
-| `havoc_off_rank` | Float64 |  |
-| `explosive_off_rank` | Float64 |  |
-| `passrate_off_rank` | Float64 |  |
-| `rushrate_off_rank` | Float64 |  |
-| `nonExplosiveEpaPerPlay_off_rank` | Float64 |  |
-| `line_yards_off_rank` | Float64 |  |
-| `opportunity_rate_off_rank` | Float64 |  |
-| `plays_def` | UInt32 |  |
-| `passrate_def` | Float64 |  |
-| `rushrate_def` | Float64 |  |
-| `havoc_def` | Float64 |  |
-| `explosive_def` | Float64 |  |
-| `TEPA_def` | Float64 |  |
-| `EPAplay_def` | Float64 |  |
-| `yards_def` | Int64 |  |
-| `yardsplay_def` | Float64 |  |
-| `play_stuffed_def` | Float64 |  |
-| `success_def` | Float64 |  |
-| `red_zone_success_def` | Float64 |  |
-| `third_down_success_def` | Float64 |  |
-| `third_down_distance_def` | Float64 |  |
-| `late_down_success_def` | Float64 |  |
-| `early_down_EPA_def` | Float64 |  |
-| `start_position_def` | Float64 |  |
-| `nonExplosiveEpaPerPlay_def` | Float64 |  |
-| `line_yards_def` | Float64 |  |
-| `opportunity_rate_def` | Float64 |  |
-| `playsgame_def` | Float64 |  |
-| `EPAdrive_def` | Float64 |  |
-| `EPAgame_def` | Float64 |  |
-| `yardsgame_def` | Float64 |  |
-| `drives_def` | UInt32 |  |
-| `drivesgame_def` | Float64 |  |
-| `yardsdrive_def` | Float64 |  |
-| `playsdrive_def` | Float64 |  |
-| `playsgame_def_rank` | Float64 |  |
-| `TEPA_def_rank` | Float64 |  |
-| `EPAgame_def_rank` | Float64 |  |
-| `EPAplay_def_rank` | Float64 |  |
-| `EPAdrive_def_rank` | Float64 |  |
-| `early_down_EPA_def_rank` | Float64 |  |
-| `success_def_rank` | Float64 |  |
-| `yards_def_rank` | Float64 |  |
-| `yardsplay_def_rank` | Float64 |  |
-| `yardsgame_def_rank` | Float64 |  |
-| `drivesgame_def_rank` | Float64 |  |
-| `yardsdrive_def_rank` | Float64 |  |
-| `playsdrive_def_rank` | Float64 |  |
-| `play_stuffed_def_rank` | Float64 |  |
-| `red_zone_success_def_rank` | Float64 |  |
-| `third_down_success_def_rank` | Float64 |  |
-| `late_down_success_def_rank` | Float64 |  |
-| `third_down_distance_def_rank` | Float64 |  |
-| `start_position_def_rank` | Float64 |  |
-| `havoc_def_rank` | Float64 |  |
-| `explosive_def_rank` | Float64 |  |
-| `passrate_def_rank` | Float64 |  |
-| `rushrate_def_rank` | Float64 |  |
-| `nonExplosiveEpaPerPlay_def_rank` | Float64 |  |
-| `line_yards_def_rank` | Float64 |  |
-| `opportunity_rate_def_rank` | Float64 |  |
-| `TEPA_margin` | Float64 |  |
-| `EPAplay_margin` | Float64 |  |
-| `EPAdrive_margin` | Float64 |  |
-| `EPAgame_margin` | Float64 |  |
-| `success_margin` | Float64 |  |
-| `yardsplay_margin` | Float64 |  |
-| `TEPA_margin_rank` | Float64 |  |
-| `EPAplay_margin_rank` | Float64 |  |
-| `EPAdrive_margin_rank` | Float64 |  |
-| `EPAgame_margin_rank` | Float64 |  |
-| `success_margin_rank` | Float64 |  |
-| `yardsplay_margin_rank` | Float64 |  |
-| `start_position_margin` | Float64 |  |
-| `start_position_margin_rank` | Float64 |  |
-| `total_available_yards_off` | Float64 |  |
-| `total_gained_yards_off` | Int64 |  |
-| `available_yards_pct_off` | Float64 |  |
-| `available_yards_pct_off_rank` | Float64 |  |
-| `total_available_yards_def` | Float64 |  |
-| `total_gained_yards_def` | Int64 |  |
-| `available_yards_pct_def` | Float64 |  |
-| `available_yards_pct_def_rank` | Float64 |  |
-| `total_available_yards_margin` | Float64 |  |
-| `total_gained_yards_margin` | Int64 |  |
-| `available_yards_pct_margin` | Float64 |  |
-| `total_available_yards_margin_rank` | Float64 |  |
-| `total_gained_yards_margin_rank` | Float64 |  |
-| `available_yards_pct_margin_rank` | Float64 |  |
-| `plays_off_pass` | UInt32 |  |
-| `passrate_off_pass` | Float64 |  |
-| `rushrate_off_pass` | Float64 |  |
-| `havoc_off_pass` | Float64 |  |
-| `explosive_off_pass` | Float64 |  |
-| `TEPA_off_pass` | Float64 |  |
-| `EPAplay_off_pass` | Float64 |  |
-| `yards_off_pass` | Int64 |  |
-| `yardsplay_off_pass` | Float64 |  |
-| `play_stuffed_off_pass` | Float64 |  |
-| `success_off_pass` | Float64 |  |
-| `red_zone_success_off_pass` | Float64 |  |
-| `third_down_success_off_pass` | Float64 |  |
-| `third_down_distance_off_pass` | Float64 |  |
-| `late_down_success_off_pass` | Float64 |  |
-| `early_down_EPA_off_pass` | Float64 |  |
-| `nonExplosiveEpaPerPlay_off_pass` | Float64 |  |
-| `line_yards_off_pass` | Float64 |  |
-| `opportunity_rate_off_pass` | Float64 |  |
-| `playsgame_off_pass` | Float64 |  |
-| `EPAdrive_off_pass` | Float64 |  |
-| `EPAgame_off_pass` | Float64 |  |
-| `yardsgame_off_pass` | Float64 |  |
-| `drives_off_pass` | UInt32 |  |
-| `drivesgame_off_pass` | Float64 |  |
-| `yardsdrive_off_pass` | Float64 |  |
-| `playsdrive_off_pass` | Float64 |  |
-| `playsgame_off_pass_rank` | Float64 |  |
-| `TEPA_off_pass_rank` | Float64 |  |
-| `EPAgame_off_pass_rank` | Float64 |  |
-| `EPAplay_off_pass_rank` | Float64 |  |
-| `EPAdrive_off_pass_rank` | Float64 |  |
-| `early_down_EPA_off_pass_rank` | Float64 |  |
-| `success_off_pass_rank` | Float64 |  |
-| `yards_off_pass_rank` | Float64 |  |
-| `yardsplay_off_pass_rank` | Float64 |  |
-| `yardsgame_off_pass_rank` | Float64 |  |
-| `drivesgame_off_pass_rank` | Float64 |  |
-| `yardsdrive_off_pass_rank` | Float64 |  |
-| `playsdrive_off_pass_rank` | Float64 |  |
-| `play_stuffed_off_pass_rank` | Float64 |  |
-| `red_zone_success_off_pass_rank` | Float64 |  |
-| `third_down_success_off_pass_rank` | Float64 |  |
-| `late_down_success_off_pass_rank` | Float64 |  |
-| `third_down_distance_off_pass_rank` | Float64 |  |
-| `havoc_off_pass_rank` | Float64 |  |
-| `explosive_off_pass_rank` | Float64 |  |
-| `passrate_off_pass_rank` | Float64 |  |
-| `rushrate_off_pass_rank` | Float64 |  |
-| `nonExplosiveEpaPerPlay_off_pass_rank` | Float64 |  |
-| `line_yards_off_pass_rank` | Float64 |  |
-| `opportunity_rate_off_pass_rank` | Float64 |  |
-| `plays_def_pass` | UInt32 |  |
-| `passrate_def_pass` | Float64 |  |
-| `rushrate_def_pass` | Float64 |  |
-| `havoc_def_pass` | Float64 |  |
-| `explosive_def_pass` | Float64 |  |
-| `TEPA_def_pass` | Float64 |  |
-| `EPAplay_def_pass` | Float64 |  |
-| `yards_def_pass` | Int64 |  |
-| `yardsplay_def_pass` | Float64 |  |
-| `play_stuffed_def_pass` | Float64 |  |
-| `success_def_pass` | Float64 |  |
-| `red_zone_success_def_pass` | Float64 |  |
-| `third_down_success_def_pass` | Float64 |  |
-| `third_down_distance_def_pass` | Float64 |  |
-| `late_down_success_def_pass` | Float64 |  |
-| `early_down_EPA_def_pass` | Float64 |  |
-| `nonExplosiveEpaPerPlay_def_pass` | Float64 |  |
-| `line_yards_def_pass` | Float64 |  |
-| `opportunity_rate_def_pass` | Float64 |  |
-| `playsgame_def_pass` | Float64 |  |
-| `EPAdrive_def_pass` | Float64 |  |
-| `EPAgame_def_pass` | Float64 |  |
-| `yardsgame_def_pass` | Float64 |  |
-| `drives_def_pass` | UInt32 |  |
-| `drivesgame_def_pass` | Float64 |  |
-| `yardsdrive_def_pass` | Float64 |  |
-| `playsdrive_def_pass` | Float64 |  |
-| `playsgame_def_pass_rank` | Float64 |  |
-| `TEPA_def_pass_rank` | Float64 |  |
-| `EPAgame_def_pass_rank` | Float64 |  |
-| `EPAplay_def_pass_rank` | Float64 |  |
-| `EPAdrive_def_pass_rank` | Float64 |  |
-| `early_down_EPA_def_pass_rank` | Float64 |  |
-| `success_def_pass_rank` | Float64 |  |
-| `yards_def_pass_rank` | Float64 |  |
-| `yardsplay_def_pass_rank` | Float64 |  |
-| `yardsgame_def_pass_rank` | Float64 |  |
-| `drivesgame_def_pass_rank` | Float64 |  |
-| `yardsdrive_def_pass_rank` | Float64 |  |
-| `playsdrive_def_pass_rank` | Float64 |  |
-| `play_stuffed_def_pass_rank` | Float64 |  |
-| `red_zone_success_def_pass_rank` | Float64 |  |
-| `third_down_success_def_pass_rank` | Float64 |  |
-| `late_down_success_def_pass_rank` | Float64 |  |
-| `third_down_distance_def_pass_rank` | Float64 |  |
-| `havoc_def_pass_rank` | Float64 |  |
-| `explosive_def_pass_rank` | Float64 |  |
-| `passrate_def_pass_rank` | Float64 |  |
-| `rushrate_def_pass_rank` | Float64 |  |
-| `nonExplosiveEpaPerPlay_def_pass_rank` | Float64 |  |
-| `line_yards_def_pass_rank` | Float64 |  |
-| `opportunity_rate_def_pass_rank` | Float64 |  |
-| `TEPA_margin_pass` | Float64 |  |
-| `EPAplay_margin_pass` | Float64 |  |
-| `EPAdrive_margin_pass` | Float64 |  |
-| `EPAgame_margin_pass` | Float64 |  |
-| `success_margin_pass` | Float64 |  |
-| `yardsplay_margin_pass` | Float64 |  |
-| `TEPA_margin_pass_rank` | Float64 |  |
-| `EPAplay_margin_pass_rank` | Float64 |  |
-| `EPAdrive_margin_pass_rank` | Float64 |  |
-| `EPAgame_margin_pass_rank` | Float64 |  |
-| `success_margin_pass_rank` | Float64 |  |
-| `yardsplay_margin_pass_rank` | Float64 |  |
-| `plays_off_rush` | UInt32 |  |
-| `passrate_off_rush` | Float64 |  |
-| `rushrate_off_rush` | Float64 |  |
-| `havoc_off_rush` | Float64 |  |
-| `explosive_off_rush` | Float64 |  |
-| `TEPA_off_rush` | Float64 |  |
-| `EPAplay_off_rush` | Float64 |  |
-| `yards_off_rush` | Int64 |  |
-| `yardsplay_off_rush` | Float64 |  |
-| `play_stuffed_off_rush` | Float64 |  |
-| `success_off_rush` | Float64 |  |
-| `red_zone_success_off_rush` | Float64 |  |
-| `third_down_success_off_rush` | Float64 |  |
-| `third_down_distance_off_rush` | Float64 |  |
-| `late_down_success_off_rush` | Float64 |  |
-| `early_down_EPA_off_rush` | Float64 |  |
-| `nonExplosiveEpaPerPlay_off_rush` | Float64 |  |
-| `line_yards_off_rush` | Float64 |  |
-| `opportunity_rate_off_rush` | Float64 |  |
-| `playsgame_off_rush` | Float64 |  |
-| `EPAdrive_off_rush` | Float64 |  |
-| `EPAgame_off_rush` | Float64 |  |
-| `yardsgame_off_rush` | Float64 |  |
-| `drives_off_rush` | UInt32 |  |
-| `drivesgame_off_rush` | Float64 |  |
-| `yardsdrive_off_rush` | Float64 |  |
-| `playsdrive_off_rush` | Float64 |  |
-| `playsgame_off_rush_rank` | Float64 |  |
-| `TEPA_off_rush_rank` | Float64 |  |
-| `EPAgame_off_rush_rank` | Float64 |  |
-| `EPAplay_off_rush_rank` | Float64 |  |
-| `EPAdrive_off_rush_rank` | Float64 |  |
-| `early_down_EPA_off_rush_rank` | Float64 |  |
-| `success_off_rush_rank` | Float64 |  |
-| `yards_off_rush_rank` | Float64 |  |
-| `yardsplay_off_rush_rank` | Float64 |  |
-| `yardsgame_off_rush_rank` | Float64 |  |
-| `drivesgame_off_rush_rank` | Float64 |  |
-| `yardsdrive_off_rush_rank` | Float64 |  |
-| `playsdrive_off_rush_rank` | Float64 |  |
-| `play_stuffed_off_rush_rank` | Float64 |  |
-| `red_zone_success_off_rush_rank` | Float64 |  |
-| `third_down_success_off_rush_rank` | Float64 |  |
-| `late_down_success_off_rush_rank` | Float64 |  |
-| `third_down_distance_off_rush_rank` | Float64 |  |
-| `havoc_off_rush_rank` | Float64 |  |
-| `explosive_off_rush_rank` | Float64 |  |
-| `passrate_off_rush_rank` | Float64 |  |
-| `rushrate_off_rush_rank` | Float64 |  |
-| `nonExplosiveEpaPerPlay_off_rush_rank` | Float64 |  |
-| `line_yards_off_rush_rank` | Float64 |  |
-| `opportunity_rate_off_rush_rank` | Float64 |  |
-| `plays_def_rush` | UInt32 |  |
-| `passrate_def_rush` | Float64 |  |
-| `rushrate_def_rush` | Float64 |  |
-| `havoc_def_rush` | Float64 |  |
-| `explosive_def_rush` | Float64 |  |
-| `TEPA_def_rush` | Float64 |  |
-| `EPAplay_def_rush` | Float64 |  |
-| `yards_def_rush` | Int64 |  |
-| `yardsplay_def_rush` | Float64 |  |
-| `play_stuffed_def_rush` | Float64 |  |
-| `success_def_rush` | Float64 |  |
-| `red_zone_success_def_rush` | Float64 |  |
-| `third_down_success_def_rush` | Float64 |  |
-| `third_down_distance_def_rush` | Float64 |  |
-| `late_down_success_def_rush` | Float64 |  |
-| `early_down_EPA_def_rush` | Float64 |  |
-| `nonExplosiveEpaPerPlay_def_rush` | Float64 |  |
-| `line_yards_def_rush` | Float64 |  |
-| `opportunity_rate_def_rush` | Float64 |  |
-| `playsgame_def_rush` | Float64 |  |
-| `EPAdrive_def_rush` | Float64 |  |
-| `EPAgame_def_rush` | Float64 |  |
-| `yardsgame_def_rush` | Float64 |  |
-| `drives_def_rush` | UInt32 |  |
-| `drivesgame_def_rush` | Float64 |  |
-| `yardsdrive_def_rush` | Float64 |  |
-| `playsdrive_def_rush` | Float64 |  |
-| `playsgame_def_rush_rank` | Float64 |  |
-| `TEPA_def_rush_rank` | Float64 |  |
-| `EPAgame_def_rush_rank` | Float64 |  |
-| `EPAplay_def_rush_rank` | Float64 |  |
-| `EPAdrive_def_rush_rank` | Float64 |  |
-| `early_down_EPA_def_rush_rank` | Float64 |  |
-| `success_def_rush_rank` | Float64 |  |
-| `yards_def_rush_rank` | Float64 |  |
-| `yardsplay_def_rush_rank` | Float64 |  |
-| `yardsgame_def_rush_rank` | Float64 |  |
-| `drivesgame_def_rush_rank` | Float64 |  |
-| `yardsdrive_def_rush_rank` | Float64 |  |
-| `playsdrive_def_rush_rank` | Float64 |  |
-| `play_stuffed_def_rush_rank` | Float64 |  |
-| `red_zone_success_def_rush_rank` | Float64 |  |
-| `third_down_success_def_rush_rank` | Float64 |  |
-| `late_down_success_def_rush_rank` | Float64 |  |
-| `third_down_distance_def_rush_rank` | Float64 |  |
-| `havoc_def_rush_rank` | Float64 |  |
-| `explosive_def_rush_rank` | Float64 |  |
-| `passrate_def_rush_rank` | Float64 |  |
-| `rushrate_def_rush_rank` | Float64 |  |
-| `nonExplosiveEpaPerPlay_def_rush_rank` | Float64 |  |
-| `line_yards_def_rush_rank` | Float64 |  |
-| `opportunity_rate_def_rush_rank` | Float64 |  |
-| `TEPA_margin_rush` | Float64 |  |
-| `EPAplay_margin_rush` | Float64 |  |
-| `EPAdrive_margin_rush` | Float64 |  |
-| `EPAgame_margin_rush` | Float64 |  |
-| `success_margin_rush` | Float64 |  |
-| `yardsplay_margin_rush` | Float64 |  |
-| `TEPA_margin_rush_rank` | Float64 |  |
-| `EPAplay_margin_rush_rank` | Float64 |  |
-| `EPAdrive_margin_rush_rank` | Float64 |  |
-| `EPAgame_margin_rush_rank` | Float64 |  |
-| `success_margin_rush_rank` | Float64 |  |
-| `yardsplay_margin_rush_rank` | Float64 |  |
-| `fbs_class` | String |  |
-| `valid_games` | UInt32 |  |
-| `adj_off_epa` | Float64 |  |
-| `adj_def_epa` | Float64 |  |
-| `off_strength_faced` | Float64 |  |
-| `def_strength_faced` | Float64 |  |
-| `net_adj_epa` | Float64 |  |
-| `adj_off_epa_rank` | Float64 |  |
-| `adj_def_epa_rank` | Float64 |  |
-| `net_adj_epa_rank` | Float64 |  |
-| `through_week` | Int32 |  |
+| `plays_off` | UInt32 | Plays run, with the team on offense. |
+| `passrate_off` | Float64 | Share of plays that were pass plays, with the team on offense. |
+| `rushrate_off` | Float64 | Share of plays that were rush plays, with the team on offense. |
+| `havoc_off` | Float64 | Havoc rate -- the share of plays carrying the defensive-disruption flag, with the team on offense. |
+| `explosive_off` | Float64 | Explosive-play rate -- the share of plays carrying the explosive flag, with the team on offense. |
+| `TEPA_off` | Float64 | Total EPA summed over every play, with the team on offense. |
+| `EPAplay_off` | Float64 | EPA per play, with the team on offense. |
+| `yards_off` | Int64 | Total yards gained, with the team on offense. |
+| `yardsplay_off` | Float64 | Yards gained per play, with the team on offense. |
+| `play_stuffed_off` | Float64 | Stuffed-play rate -- the share of plays carrying the stuffed flag, with the team on offense. |
+| `success_off` | Float64 | Success rate -- the share of plays flagged as successful by EPA, with the team on offense. |
+| `red_zone_success_off` | Float64 | Success rate on red-zone plays, with the team on offense. |
+| `third_down_success_off` | Float64 | Success rate on third-down plays, with the team on offense. |
+| `third_down_distance_off` | Float64 | Average yards to go on third down, with the team on offense. |
+| `late_down_success_off` | Float64 | Success rate on late-down plays, with the team on offense. |
+| `early_down_EPA_off` | Float64 | EPA per early-down play, with the team on offense. |
+| `start_position_off` | Float64 | Average drive start position, measured in yards from the opponent goal line, with the team on offense. |
+| `nonExplosiveEpaPerPlay_off` | Float64 | EPA per play with explosive plays excluded, with the team on offense. |
+| `line_yards_off` | Float64 | Average line yards credited to the offensive line on rushes, with the team on offense. |
+| `opportunity_rate_off` | Float64 | Opportunity rate -- the share of rushes carrying the opportunity flag, with the team on offense. |
+| `playsgame_off` | Float64 | Plays run per game, with the team on offense. |
+| `EPAdrive_off` | Float64 | EPA per drive (total EPA divided by drives), with the team on offense. |
+| `EPAgame_off` | Float64 | EPA per game (total EPA divided by games), with the team on offense. |
+| `yardsgame_off` | Float64 | Yards gained per game, with the team on offense. |
+| `drives_off` | UInt32 | Offensive drives, with the team on offense. |
+| `drivesgame_off` | Float64 | Drives per game, with the team on offense. |
+| `yardsdrive_off` | Float64 | Yards gained per drive, with the team on offense. |
+| `playsdrive_off` | Float64 | Plays run per drive, with the team on offense. |
+| `playsgame_off_rank` | Float64 | National rank of the team's plays run per game with the team on offense, where 1 is best. |
+| `TEPA_off_rank` | Float64 | National rank of the team's total EPA summed over every play with the team on offense, where 1 is best. |
+| `EPAgame_off_rank` | Float64 | National rank of the team's EPA per game (total EPA divided by games) with the team on offense, where 1 is best. |
+| `EPAplay_off_rank` | Float64 | National rank of the team's EPA per play with the team on offense, where 1 is best. |
+| `EPAdrive_off_rank` | Float64 | National rank of the team's EPA per drive (total EPA divided by drives) with the team on offense, where 1 is best. |
+| `early_down_EPA_off_rank` | Float64 | National rank of the team's EPA per early-down play with the team on offense, where 1 is best. |
+| `success_off_rank` | Float64 | National rank of the team's success rate -- the share of plays flagged as successful by EPA with the team on offense, where 1 is best. |
+| `yards_off_rank` | Float64 | National rank of the team's total yards gained with the team on offense, where 1 is best. |
+| `yardsplay_off_rank` | Float64 | National rank of the team's yards gained per play with the team on offense, where 1 is best. |
+| `yardsgame_off_rank` | Float64 | National rank of the team's yards gained per game with the team on offense, where 1 is best. |
+| `drivesgame_off_rank` | Float64 | National rank of the team's drives per game with the team on offense, where 1 is best. |
+| `yardsdrive_off_rank` | Float64 | National rank of the team's yards gained per drive with the team on offense, where 1 is best. |
+| `playsdrive_off_rank` | Float64 | National rank of the team's plays run per drive with the team on offense, where 1 is best. |
+| `play_stuffed_off_rank` | Float64 | National rank of the team's stuffed-play rate -- the share of plays carrying the stuffed flag with the team on offense, where 1 is best. |
+| `red_zone_success_off_rank` | Float64 | National rank of the team's success rate on red-zone plays with the team on offense, where 1 is best. |
+| `third_down_success_off_rank` | Float64 | National rank of the team's success rate on third-down plays with the team on offense, where 1 is best. |
+| `late_down_success_off_rank` | Float64 | National rank of the team's success rate on late-down plays with the team on offense, where 1 is best. |
+| `third_down_distance_off_rank` | Float64 | National rank of the team's average yards to go on third down with the team on offense, where 1 is best. |
+| `start_position_off_rank` | Float64 | National rank of the team's average drive start position, measured in yards from the opponent goal line with the team on offense, where 1 is best. |
+| `havoc_off_rank` | Float64 | National rank of the team's havoc rate -- the share of plays carrying the defensive-disruption flag with the team on offense, where 1 is best. |
+| `explosive_off_rank` | Float64 | National rank of the team's explosive-play rate -- the share of plays carrying the explosive flag with the team on offense, where 1 is best. |
+| `passrate_off_rank` | Float64 | National rank of the team's share of plays that were pass plays with the team on offense, where 1 is best. |
+| `rushrate_off_rank` | Float64 | National rank of the team's share of plays that were rush plays with the team on offense, where 1 is best. |
+| `nonExplosiveEpaPerPlay_off_rank` | Float64 | National rank of the team's EPA per play with explosive plays excluded with the team on offense, where 1 is best. |
+| `line_yards_off_rank` | Float64 | National rank of the team's average line yards credited to the offensive line on rushes with the team on offense, where 1 is best. |
+| `opportunity_rate_off_rank` | Float64 | National rank of the team's opportunity rate -- the share of rushes carrying the opportunity flag with the team on offense, where 1 is best. |
+| `plays_def` | UInt32 | Plays run, with the team on defense (i.e. allowed to opponents). |
+| `passrate_def` | Float64 | Share of plays that were pass plays, with the team on defense (i.e. allowed to opponents). |
+| `rushrate_def` | Float64 | Share of plays that were rush plays, with the team on defense (i.e. allowed to opponents). |
+| `havoc_def` | Float64 | Havoc rate -- the share of plays carrying the defensive-disruption flag, with the team on defense (i.e. allowed to opponents). |
+| `explosive_def` | Float64 | Explosive-play rate -- the share of plays carrying the explosive flag, with the team on defense (i.e. allowed to opponents). |
+| `TEPA_def` | Float64 | Total EPA summed over every play, with the team on defense (i.e. allowed to opponents). |
+| `EPAplay_def` | Float64 | EPA per play, with the team on defense (i.e. allowed to opponents). |
+| `yards_def` | Int64 | Total yards gained, with the team on defense (i.e. allowed to opponents). |
+| `yardsplay_def` | Float64 | Yards gained per play, with the team on defense (i.e. allowed to opponents). |
+| `play_stuffed_def` | Float64 | Stuffed-play rate -- the share of plays carrying the stuffed flag, with the team on defense (i.e. allowed to opponents). |
+| `success_def` | Float64 | Success rate -- the share of plays flagged as successful by EPA, with the team on defense (i.e. allowed to opponents). |
+| `red_zone_success_def` | Float64 | Success rate on red-zone plays, with the team on defense (i.e. allowed to opponents). |
+| `third_down_success_def` | Float64 | Success rate on third-down plays, with the team on defense (i.e. allowed to opponents). |
+| `third_down_distance_def` | Float64 | Average yards to go on third down, with the team on defense (i.e. allowed to opponents). |
+| `late_down_success_def` | Float64 | Success rate on late-down plays, with the team on defense (i.e. allowed to opponents). |
+| `early_down_EPA_def` | Float64 | EPA per early-down play, with the team on defense (i.e. allowed to opponents). |
+| `start_position_def` | Float64 | Average drive start position, measured in yards from the opponent goal line, with the team on defense (i.e. allowed to opponents). |
+| `nonExplosiveEpaPerPlay_def` | Float64 | EPA per play with explosive plays excluded, with the team on defense (i.e. allowed to opponents). |
+| `line_yards_def` | Float64 | Average line yards credited to the offensive line on rushes, with the team on defense (i.e. allowed to opponents). |
+| `opportunity_rate_def` | Float64 | Opportunity rate -- the share of rushes carrying the opportunity flag, with the team on defense (i.e. allowed to opponents). |
+| `playsgame_def` | Float64 | Plays run per game, with the team on defense (i.e. allowed to opponents). |
+| `EPAdrive_def` | Float64 | EPA per drive (total EPA divided by drives), with the team on defense (i.e. allowed to opponents). |
+| `EPAgame_def` | Float64 | EPA per game (total EPA divided by games), with the team on defense (i.e. allowed to opponents). |
+| `yardsgame_def` | Float64 | Yards gained per game, with the team on defense (i.e. allowed to opponents). |
+| `drives_def` | UInt32 | Offensive drives, with the team on defense (i.e. allowed to opponents). |
+| `drivesgame_def` | Float64 | Drives per game, with the team on defense (i.e. allowed to opponents). |
+| `yardsdrive_def` | Float64 | Yards gained per drive, with the team on defense (i.e. allowed to opponents). |
+| `playsdrive_def` | Float64 | Plays run per drive, with the team on defense (i.e. allowed to opponents). |
+| `playsgame_def_rank` | Float64 | National rank of the team's plays run per game with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `TEPA_def_rank` | Float64 | National rank of the team's total EPA summed over every play with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `EPAgame_def_rank` | Float64 | National rank of the team's EPA per game (total EPA divided by games) with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `EPAplay_def_rank` | Float64 | National rank of the team's EPA per play with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `EPAdrive_def_rank` | Float64 | National rank of the team's EPA per drive (total EPA divided by drives) with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `early_down_EPA_def_rank` | Float64 | National rank of the team's EPA per early-down play with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `success_def_rank` | Float64 | National rank of the team's success rate -- the share of plays flagged as successful by EPA with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `yards_def_rank` | Float64 | National rank of the team's total yards gained with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `yardsplay_def_rank` | Float64 | National rank of the team's yards gained per play with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `yardsgame_def_rank` | Float64 | National rank of the team's yards gained per game with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `drivesgame_def_rank` | Float64 | National rank of the team's drives per game with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `yardsdrive_def_rank` | Float64 | National rank of the team's yards gained per drive with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `playsdrive_def_rank` | Float64 | National rank of the team's plays run per drive with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `play_stuffed_def_rank` | Float64 | National rank of the team's stuffed-play rate -- the share of plays carrying the stuffed flag with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `red_zone_success_def_rank` | Float64 | National rank of the team's success rate on red-zone plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `third_down_success_def_rank` | Float64 | National rank of the team's success rate on third-down plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `late_down_success_def_rank` | Float64 | National rank of the team's success rate on late-down plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `third_down_distance_def_rank` | Float64 | National rank of the team's average yards to go on third down with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `start_position_def_rank` | Float64 | National rank of the team's average drive start position, measured in yards from the opponent goal line with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `havoc_def_rank` | Float64 | National rank of the team's havoc rate -- the share of plays carrying the defensive-disruption flag with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `explosive_def_rank` | Float64 | National rank of the team's explosive-play rate -- the share of plays carrying the explosive flag with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `passrate_def_rank` | Float64 | National rank of the team's share of plays that were pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `rushrate_def_rank` | Float64 | National rank of the team's share of plays that were rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `nonExplosiveEpaPerPlay_def_rank` | Float64 | National rank of the team's EPA per play with explosive plays excluded with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `line_yards_def_rank` | Float64 | National rank of the team's average line yards credited to the offensive line on rushes with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `opportunity_rate_def_rank` | Float64 | National rank of the team's opportunity rate -- the share of rushes carrying the opportunity flag with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `TEPA_margin` | Float64 | Margin in total EPA summed over every play: the team's offensive value minus the value it allowed on defense. |
+| `EPAplay_margin` | Float64 | Margin in EPA per play: the team's offensive value minus the value it allowed on defense. |
+| `EPAdrive_margin` | Float64 | Margin in EPA per drive (total EPA divided by drives): the team's offensive value minus the value it allowed on defense. |
+| `EPAgame_margin` | Float64 | Margin in EPA per game (total EPA divided by games): the team's offensive value minus the value it allowed on defense. |
+| `success_margin` | Float64 | Margin in success rate -- the share of plays flagged as successful by EPA: the team's offensive value minus the value it allowed on defense. |
+| `yardsplay_margin` | Float64 | Margin in yards gained per play: the team's offensive value minus the value it allowed on defense. |
+| `TEPA_margin_rank` | Float64 | Margin in total EPA summed over every play: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `EPAplay_margin_rank` | Float64 | Margin in EPA per play: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `EPAdrive_margin_rank` | Float64 | Margin in EPA per drive (total EPA divided by drives): the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `EPAgame_margin_rank` | Float64 | Margin in EPA per game (total EPA divided by games): the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `success_margin_rank` | Float64 | Margin in success rate -- the share of plays flagged as successful by EPA: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `yardsplay_margin_rank` | Float64 | Margin in yards gained per play: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `start_position_margin` | Float64 | Field-position margin: the team's own average starting field position minus the average starting field position it allowed, both measured as yards gained from their own goal line. Positive means the team started closer to scoring than its opponents. |
+| `start_position_margin_rank` | Float64 | Field-position margin: the team's own average starting field position minus the average starting field position it allowed, both measured as yards gained from their own goal line. Positive means the team started closer to scoring than its opponents. National rank of that margin, 1 = largest. |
+| `total_available_yards_off` | Float64 | Available yards are the yards a drive could theoretically gain, summed from each drive's starting distance to the opponent goal line. Total available yards on the team's own drives. |
+| `total_gained_yards_off` | Int64 | Total yards the team actually gained across its own drives. |
+| `available_yards_pct_off` | Float64 | Share of available yards the team's offense actually gained (total_gained_yards_off divided by total_available_yards_off). Higher is better. |
+| `available_yards_pct_off_rank` | Float64 | National rank of the team's offensive available-yards share, where 1 is best. |
+| `total_available_yards_def` | Float64 | Available yards are the yards a drive could theoretically gain, summed from each drive's starting distance to the opponent goal line. Total available yards on drives the team defended. |
+| `total_gained_yards_def` | Int64 | Total yards the team allowed across the drives it defended. |
+| `available_yards_pct_def` | Float64 | Share of available yards the team's defense allowed opponents to gain. Lower is better. |
+| `available_yards_pct_def_rank` | Float64 | National rank of the team's defensive available-yards share, where 1 is best. |
+| `total_available_yards_margin` | Float64 | Available yards on the team's own drives minus available yards on drives it defended. |
+| `total_gained_yards_margin` | Int64 | Yards the team gained minus yards it allowed. |
+| `available_yards_pct_margin` | Float64 | Available-yards share gained by the offense minus the share allowed by the defense. Higher is better. |
+| `total_available_yards_margin_rank` | Float64 | National rank of total_available_yards_margin, 1 = largest margin. |
+| `total_gained_yards_margin_rank` | Float64 | National rank of total_gained_yards_margin, 1 = largest margin. |
+| `available_yards_pct_margin_rank` | Float64 | National rank of available_yards_pct_margin, 1 = largest margin. |
+| `plays_off_pass` | UInt32 | Plays run on pass plays, with the team on offense. |
+| `passrate_off_pass` | Float64 | Share of plays that were pass plays on pass plays, with the team on offense. |
+| `rushrate_off_pass` | Float64 | Share of plays that were rush plays on pass plays, with the team on offense. |
+| `havoc_off_pass` | Float64 | Havoc rate -- the share of plays carrying the defensive-disruption flag on pass plays, with the team on offense. |
+| `explosive_off_pass` | Float64 | Explosive-play rate -- the share of plays carrying the explosive flag on pass plays, with the team on offense. |
+| `TEPA_off_pass` | Float64 | Total EPA summed over every play on pass plays, with the team on offense. |
+| `EPAplay_off_pass` | Float64 | EPA per play on pass plays, with the team on offense. |
+| `yards_off_pass` | Int64 | Total yards gained on pass plays, with the team on offense. |
+| `yardsplay_off_pass` | Float64 | Yards gained per play on pass plays, with the team on offense. |
+| `play_stuffed_off_pass` | Float64 | Stuffed-play rate -- the share of plays carrying the stuffed flag on pass plays, with the team on offense. |
+| `success_off_pass` | Float64 | Success rate -- the share of plays flagged as successful by EPA on pass plays, with the team on offense. |
+| `red_zone_success_off_pass` | Float64 | Success rate on red-zone plays on pass plays, with the team on offense. |
+| `third_down_success_off_pass` | Float64 | Success rate on third-down plays on pass plays, with the team on offense. |
+| `third_down_distance_off_pass` | Float64 | Average yards to go on third down on pass plays, with the team on offense. |
+| `late_down_success_off_pass` | Float64 | Success rate on late-down plays on pass plays, with the team on offense. |
+| `early_down_EPA_off_pass` | Float64 | EPA per early-down play on pass plays, with the team on offense. |
+| `nonExplosiveEpaPerPlay_off_pass` | Float64 | EPA per play with explosive plays excluded on pass plays, with the team on offense. |
+| `line_yards_off_pass` | Float64 | Average line yards credited to the offensive line on rushes on pass plays, with the team on offense. |
+| `opportunity_rate_off_pass` | Float64 | Opportunity rate -- the share of rushes carrying the opportunity flag on pass plays, with the team on offense. |
+| `playsgame_off_pass` | Float64 | Plays run per game on pass plays, with the team on offense. |
+| `EPAdrive_off_pass` | Float64 | EPA per drive (total EPA divided by drives) on pass plays, with the team on offense. |
+| `EPAgame_off_pass` | Float64 | EPA per game (total EPA divided by games) on pass plays, with the team on offense. |
+| `yardsgame_off_pass` | Float64 | Yards gained per game on pass plays, with the team on offense. |
+| `drives_off_pass` | UInt32 | Offensive drives on pass plays, with the team on offense. |
+| `drivesgame_off_pass` | Float64 | Drives per game on pass plays, with the team on offense. |
+| `yardsdrive_off_pass` | Float64 | Yards gained per drive on pass plays, with the team on offense. |
+| `playsdrive_off_pass` | Float64 | Plays run per drive on pass plays, with the team on offense. |
+| `playsgame_off_pass_rank` | Float64 | National rank of the team's plays run per game on pass plays with the team on offense, where 1 is best. |
+| `TEPA_off_pass_rank` | Float64 | National rank of the team's total EPA summed over every play on pass plays with the team on offense, where 1 is best. |
+| `EPAgame_off_pass_rank` | Float64 | National rank of the team's EPA per game (total EPA divided by games) on pass plays with the team on offense, where 1 is best. |
+| `EPAplay_off_pass_rank` | Float64 | National rank of the team's EPA per play on pass plays with the team on offense, where 1 is best. |
+| `EPAdrive_off_pass_rank` | Float64 | National rank of the team's EPA per drive (total EPA divided by drives) on pass plays with the team on offense, where 1 is best. |
+| `early_down_EPA_off_pass_rank` | Float64 | National rank of the team's EPA per early-down play on pass plays with the team on offense, where 1 is best. |
+| `success_off_pass_rank` | Float64 | National rank of the team's success rate -- the share of plays flagged as successful by EPA on pass plays with the team on offense, where 1 is best. |
+| `yards_off_pass_rank` | Float64 | National rank of the team's total yards gained on pass plays with the team on offense, where 1 is best. |
+| `yardsplay_off_pass_rank` | Float64 | National rank of the team's yards gained per play on pass plays with the team on offense, where 1 is best. |
+| `yardsgame_off_pass_rank` | Float64 | National rank of the team's yards gained per game on pass plays with the team on offense, where 1 is best. |
+| `drivesgame_off_pass_rank` | Float64 | National rank of the team's drives per game on pass plays with the team on offense, where 1 is best. |
+| `yardsdrive_off_pass_rank` | Float64 | National rank of the team's yards gained per drive on pass plays with the team on offense, where 1 is best. |
+| `playsdrive_off_pass_rank` | Float64 | National rank of the team's plays run per drive on pass plays with the team on offense, where 1 is best. |
+| `play_stuffed_off_pass_rank` | Float64 | National rank of the team's stuffed-play rate -- the share of plays carrying the stuffed flag on pass plays with the team on offense, where 1 is best. |
+| `red_zone_success_off_pass_rank` | Float64 | National rank of the team's success rate on red-zone plays on pass plays with the team on offense, where 1 is best. |
+| `third_down_success_off_pass_rank` | Float64 | National rank of the team's success rate on third-down plays on pass plays with the team on offense, where 1 is best. |
+| `late_down_success_off_pass_rank` | Float64 | National rank of the team's success rate on late-down plays on pass plays with the team on offense, where 1 is best. |
+| `third_down_distance_off_pass_rank` | Float64 | National rank of the team's average yards to go on third down on pass plays with the team on offense, where 1 is best. |
+| `havoc_off_pass_rank` | Float64 | National rank of the team's havoc rate -- the share of plays carrying the defensive-disruption flag on pass plays with the team on offense, where 1 is best. |
+| `explosive_off_pass_rank` | Float64 | National rank of the team's explosive-play rate -- the share of plays carrying the explosive flag on pass plays with the team on offense, where 1 is best. |
+| `passrate_off_pass_rank` | Float64 | National rank of the team's share of plays that were pass plays on pass plays with the team on offense, where 1 is best. |
+| `rushrate_off_pass_rank` | Float64 | National rank of the team's share of plays that were rush plays on pass plays with the team on offense, where 1 is best. |
+| `nonExplosiveEpaPerPlay_off_pass_rank` | Float64 | National rank of the team's EPA per play with explosive plays excluded on pass plays with the team on offense, where 1 is best. |
+| `line_yards_off_pass_rank` | Float64 | National rank of the team's average line yards credited to the offensive line on rushes on pass plays with the team on offense, where 1 is best. |
+| `opportunity_rate_off_pass_rank` | Float64 | National rank of the team's opportunity rate -- the share of rushes carrying the opportunity flag on pass plays with the team on offense, where 1 is best. |
+| `plays_def_pass` | UInt32 | Plays run on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `passrate_def_pass` | Float64 | Share of plays that were pass plays on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `rushrate_def_pass` | Float64 | Share of plays that were rush plays on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `havoc_def_pass` | Float64 | Havoc rate -- the share of plays carrying the defensive-disruption flag on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `explosive_def_pass` | Float64 | Explosive-play rate -- the share of plays carrying the explosive flag on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `TEPA_def_pass` | Float64 | Total EPA summed over every play on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `EPAplay_def_pass` | Float64 | EPA per play on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `yards_def_pass` | Int64 | Total yards gained on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `yardsplay_def_pass` | Float64 | Yards gained per play on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `play_stuffed_def_pass` | Float64 | Stuffed-play rate -- the share of plays carrying the stuffed flag on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `success_def_pass` | Float64 | Success rate -- the share of plays flagged as successful by EPA on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `red_zone_success_def_pass` | Float64 | Success rate on red-zone plays on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `third_down_success_def_pass` | Float64 | Success rate on third-down plays on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `third_down_distance_def_pass` | Float64 | Average yards to go on third down on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `late_down_success_def_pass` | Float64 | Success rate on late-down plays on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `early_down_EPA_def_pass` | Float64 | EPA per early-down play on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `nonExplosiveEpaPerPlay_def_pass` | Float64 | EPA per play with explosive plays excluded on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `line_yards_def_pass` | Float64 | Average line yards credited to the offensive line on rushes on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `opportunity_rate_def_pass` | Float64 | Opportunity rate -- the share of rushes carrying the opportunity flag on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `playsgame_def_pass` | Float64 | Plays run per game on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `EPAdrive_def_pass` | Float64 | EPA per drive (total EPA divided by drives) on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `EPAgame_def_pass` | Float64 | EPA per game (total EPA divided by games) on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `yardsgame_def_pass` | Float64 | Yards gained per game on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `drives_def_pass` | UInt32 | Offensive drives on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `drivesgame_def_pass` | Float64 | Drives per game on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `yardsdrive_def_pass` | Float64 | Yards gained per drive on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `playsdrive_def_pass` | Float64 | Plays run per drive on pass plays, with the team on defense (i.e. allowed to opponents). |
+| `playsgame_def_pass_rank` | Float64 | National rank of the team's plays run per game on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `TEPA_def_pass_rank` | Float64 | National rank of the team's total EPA summed over every play on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `EPAgame_def_pass_rank` | Float64 | National rank of the team's EPA per game (total EPA divided by games) on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `EPAplay_def_pass_rank` | Float64 | National rank of the team's EPA per play on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `EPAdrive_def_pass_rank` | Float64 | National rank of the team's EPA per drive (total EPA divided by drives) on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `early_down_EPA_def_pass_rank` | Float64 | National rank of the team's EPA per early-down play on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `success_def_pass_rank` | Float64 | National rank of the team's success rate -- the share of plays flagged as successful by EPA on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `yards_def_pass_rank` | Float64 | National rank of the team's total yards gained on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `yardsplay_def_pass_rank` | Float64 | National rank of the team's yards gained per play on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `yardsgame_def_pass_rank` | Float64 | National rank of the team's yards gained per game on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `drivesgame_def_pass_rank` | Float64 | National rank of the team's drives per game on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `yardsdrive_def_pass_rank` | Float64 | National rank of the team's yards gained per drive on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `playsdrive_def_pass_rank` | Float64 | National rank of the team's plays run per drive on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `play_stuffed_def_pass_rank` | Float64 | National rank of the team's stuffed-play rate -- the share of plays carrying the stuffed flag on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `red_zone_success_def_pass_rank` | Float64 | National rank of the team's success rate on red-zone plays on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `third_down_success_def_pass_rank` | Float64 | National rank of the team's success rate on third-down plays on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `late_down_success_def_pass_rank` | Float64 | National rank of the team's success rate on late-down plays on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `third_down_distance_def_pass_rank` | Float64 | National rank of the team's average yards to go on third down on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `havoc_def_pass_rank` | Float64 | National rank of the team's havoc rate -- the share of plays carrying the defensive-disruption flag on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `explosive_def_pass_rank` | Float64 | National rank of the team's explosive-play rate -- the share of plays carrying the explosive flag on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `passrate_def_pass_rank` | Float64 | National rank of the team's share of plays that were pass plays on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `rushrate_def_pass_rank` | Float64 | National rank of the team's share of plays that were rush plays on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `nonExplosiveEpaPerPlay_def_pass_rank` | Float64 | National rank of the team's EPA per play with explosive plays excluded on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `line_yards_def_pass_rank` | Float64 | National rank of the team's average line yards credited to the offensive line on rushes on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `opportunity_rate_def_pass_rank` | Float64 | National rank of the team's opportunity rate -- the share of rushes carrying the opportunity flag on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `TEPA_margin_pass` | Float64 | Margin in total EPA summed over every play on pass plays: the team's offensive value minus the value it allowed on defense. |
+| `EPAplay_margin_pass` | Float64 | Margin in EPA per play on pass plays: the team's offensive value minus the value it allowed on defense. |
+| `EPAdrive_margin_pass` | Float64 | Margin in EPA per drive (total EPA divided by drives) on pass plays: the team's offensive value minus the value it allowed on defense. |
+| `EPAgame_margin_pass` | Float64 | Margin in EPA per game (total EPA divided by games) on pass plays: the team's offensive value minus the value it allowed on defense. |
+| `success_margin_pass` | Float64 | Margin in success rate -- the share of plays flagged as successful by EPA on pass plays: the team's offensive value minus the value it allowed on defense. |
+| `yardsplay_margin_pass` | Float64 | Margin in yards gained per play on pass plays: the team's offensive value minus the value it allowed on defense. |
+| `TEPA_margin_pass_rank` | Float64 | Margin in total EPA summed over every play on pass plays: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `EPAplay_margin_pass_rank` | Float64 | Margin in EPA per play on pass plays: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `EPAdrive_margin_pass_rank` | Float64 | Margin in EPA per drive (total EPA divided by drives) on pass plays: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `EPAgame_margin_pass_rank` | Float64 | Margin in EPA per game (total EPA divided by games) on pass plays: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `success_margin_pass_rank` | Float64 | Margin in success rate -- the share of plays flagged as successful by EPA on pass plays: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `yardsplay_margin_pass_rank` | Float64 | Margin in yards gained per play on pass plays: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `plays_off_rush` | UInt32 | Plays run on rush plays, with the team on offense. |
+| `passrate_off_rush` | Float64 | Share of plays that were pass plays on rush plays, with the team on offense. |
+| `rushrate_off_rush` | Float64 | Share of plays that were rush plays on rush plays, with the team on offense. |
+| `havoc_off_rush` | Float64 | Havoc rate -- the share of plays carrying the defensive-disruption flag on rush plays, with the team on offense. |
+| `explosive_off_rush` | Float64 | Explosive-play rate -- the share of plays carrying the explosive flag on rush plays, with the team on offense. |
+| `TEPA_off_rush` | Float64 | Total EPA summed over every play on rush plays, with the team on offense. |
+| `EPAplay_off_rush` | Float64 | EPA per play on rush plays, with the team on offense. |
+| `yards_off_rush` | Int64 | Total yards gained on rush plays, with the team on offense. |
+| `yardsplay_off_rush` | Float64 | Yards gained per play on rush plays, with the team on offense. |
+| `play_stuffed_off_rush` | Float64 | Stuffed-play rate -- the share of plays carrying the stuffed flag on rush plays, with the team on offense. |
+| `success_off_rush` | Float64 | Success rate -- the share of plays flagged as successful by EPA on rush plays, with the team on offense. |
+| `red_zone_success_off_rush` | Float64 | Success rate on red-zone plays on rush plays, with the team on offense. |
+| `third_down_success_off_rush` | Float64 | Success rate on third-down plays on rush plays, with the team on offense. |
+| `third_down_distance_off_rush` | Float64 | Average yards to go on third down on rush plays, with the team on offense. |
+| `late_down_success_off_rush` | Float64 | Success rate on late-down plays on rush plays, with the team on offense. |
+| `early_down_EPA_off_rush` | Float64 | EPA per early-down play on rush plays, with the team on offense. |
+| `nonExplosiveEpaPerPlay_off_rush` | Float64 | EPA per play with explosive plays excluded on rush plays, with the team on offense. |
+| `line_yards_off_rush` | Float64 | Average line yards credited to the offensive line on rushes on rush plays, with the team on offense. |
+| `opportunity_rate_off_rush` | Float64 | Opportunity rate -- the share of rushes carrying the opportunity flag on rush plays, with the team on offense. |
+| `playsgame_off_rush` | Float64 | Plays run per game on rush plays, with the team on offense. |
+| `EPAdrive_off_rush` | Float64 | EPA per drive (total EPA divided by drives) on rush plays, with the team on offense. |
+| `EPAgame_off_rush` | Float64 | EPA per game (total EPA divided by games) on rush plays, with the team on offense. |
+| `yardsgame_off_rush` | Float64 | Yards gained per game on rush plays, with the team on offense. |
+| `drives_off_rush` | UInt32 | Offensive drives on rush plays, with the team on offense. |
+| `drivesgame_off_rush` | Float64 | Drives per game on rush plays, with the team on offense. |
+| `yardsdrive_off_rush` | Float64 | Yards gained per drive on rush plays, with the team on offense. |
+| `playsdrive_off_rush` | Float64 | Plays run per drive on rush plays, with the team on offense. |
+| `playsgame_off_rush_rank` | Float64 | National rank of the team's plays run per game on rush plays with the team on offense, where 1 is best. |
+| `TEPA_off_rush_rank` | Float64 | National rank of the team's total EPA summed over every play on rush plays with the team on offense, where 1 is best. |
+| `EPAgame_off_rush_rank` | Float64 | National rank of the team's EPA per game (total EPA divided by games) on rush plays with the team on offense, where 1 is best. |
+| `EPAplay_off_rush_rank` | Float64 | National rank of the team's EPA per play on rush plays with the team on offense, where 1 is best. |
+| `EPAdrive_off_rush_rank` | Float64 | National rank of the team's EPA per drive (total EPA divided by drives) on rush plays with the team on offense, where 1 is best. |
+| `early_down_EPA_off_rush_rank` | Float64 | National rank of the team's EPA per early-down play on rush plays with the team on offense, where 1 is best. |
+| `success_off_rush_rank` | Float64 | National rank of the team's success rate -- the share of plays flagged as successful by EPA on rush plays with the team on offense, where 1 is best. |
+| `yards_off_rush_rank` | Float64 | National rank of the team's total yards gained on rush plays with the team on offense, where 1 is best. |
+| `yardsplay_off_rush_rank` | Float64 | National rank of the team's yards gained per play on rush plays with the team on offense, where 1 is best. |
+| `yardsgame_off_rush_rank` | Float64 | National rank of the team's yards gained per game on rush plays with the team on offense, where 1 is best. |
+| `drivesgame_off_rush_rank` | Float64 | National rank of the team's drives per game on rush plays with the team on offense, where 1 is best. |
+| `yardsdrive_off_rush_rank` | Float64 | National rank of the team's yards gained per drive on rush plays with the team on offense, where 1 is best. |
+| `playsdrive_off_rush_rank` | Float64 | National rank of the team's plays run per drive on rush plays with the team on offense, where 1 is best. |
+| `play_stuffed_off_rush_rank` | Float64 | National rank of the team's stuffed-play rate -- the share of plays carrying the stuffed flag on rush plays with the team on offense, where 1 is best. |
+| `red_zone_success_off_rush_rank` | Float64 | National rank of the team's success rate on red-zone plays on rush plays with the team on offense, where 1 is best. |
+| `third_down_success_off_rush_rank` | Float64 | National rank of the team's success rate on third-down plays on rush plays with the team on offense, where 1 is best. |
+| `late_down_success_off_rush_rank` | Float64 | National rank of the team's success rate on late-down plays on rush plays with the team on offense, where 1 is best. |
+| `third_down_distance_off_rush_rank` | Float64 | National rank of the team's average yards to go on third down on rush plays with the team on offense, where 1 is best. |
+| `havoc_off_rush_rank` | Float64 | National rank of the team's havoc rate -- the share of plays carrying the defensive-disruption flag on rush plays with the team on offense, where 1 is best. |
+| `explosive_off_rush_rank` | Float64 | National rank of the team's explosive-play rate -- the share of plays carrying the explosive flag on rush plays with the team on offense, where 1 is best. |
+| `passrate_off_rush_rank` | Float64 | National rank of the team's share of plays that were pass plays on rush plays with the team on offense, where 1 is best. |
+| `rushrate_off_rush_rank` | Float64 | National rank of the team's share of plays that were rush plays on rush plays with the team on offense, where 1 is best. |
+| `nonExplosiveEpaPerPlay_off_rush_rank` | Float64 | National rank of the team's EPA per play with explosive plays excluded on rush plays with the team on offense, where 1 is best. |
+| `line_yards_off_rush_rank` | Float64 | National rank of the team's average line yards credited to the offensive line on rushes on rush plays with the team on offense, where 1 is best. |
+| `opportunity_rate_off_rush_rank` | Float64 | National rank of the team's opportunity rate -- the share of rushes carrying the opportunity flag on rush plays with the team on offense, where 1 is best. |
+| `plays_def_rush` | UInt32 | Plays run on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `passrate_def_rush` | Float64 | Share of plays that were pass plays on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `rushrate_def_rush` | Float64 | Share of plays that were rush plays on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `havoc_def_rush` | Float64 | Havoc rate -- the share of plays carrying the defensive-disruption flag on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `explosive_def_rush` | Float64 | Explosive-play rate -- the share of plays carrying the explosive flag on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `TEPA_def_rush` | Float64 | Total EPA summed over every play on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `EPAplay_def_rush` | Float64 | EPA per play on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `yards_def_rush` | Int64 | Total yards gained on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `yardsplay_def_rush` | Float64 | Yards gained per play on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `play_stuffed_def_rush` | Float64 | Stuffed-play rate -- the share of plays carrying the stuffed flag on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `success_def_rush` | Float64 | Success rate -- the share of plays flagged as successful by EPA on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `red_zone_success_def_rush` | Float64 | Success rate on red-zone plays on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `third_down_success_def_rush` | Float64 | Success rate on third-down plays on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `third_down_distance_def_rush` | Float64 | Average yards to go on third down on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `late_down_success_def_rush` | Float64 | Success rate on late-down plays on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `early_down_EPA_def_rush` | Float64 | EPA per early-down play on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `nonExplosiveEpaPerPlay_def_rush` | Float64 | EPA per play with explosive plays excluded on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `line_yards_def_rush` | Float64 | Average line yards credited to the offensive line on rushes on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `opportunity_rate_def_rush` | Float64 | Opportunity rate -- the share of rushes carrying the opportunity flag on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `playsgame_def_rush` | Float64 | Plays run per game on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `EPAdrive_def_rush` | Float64 | EPA per drive (total EPA divided by drives) on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `EPAgame_def_rush` | Float64 | EPA per game (total EPA divided by games) on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `yardsgame_def_rush` | Float64 | Yards gained per game on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `drives_def_rush` | UInt32 | Offensive drives on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `drivesgame_def_rush` | Float64 | Drives per game on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `yardsdrive_def_rush` | Float64 | Yards gained per drive on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `playsdrive_def_rush` | Float64 | Plays run per drive on rush plays, with the team on defense (i.e. allowed to opponents). |
+| `playsgame_def_rush_rank` | Float64 | National rank of the team's plays run per game on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `TEPA_def_rush_rank` | Float64 | National rank of the team's total EPA summed over every play on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `EPAgame_def_rush_rank` | Float64 | National rank of the team's EPA per game (total EPA divided by games) on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `EPAplay_def_rush_rank` | Float64 | National rank of the team's EPA per play on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `EPAdrive_def_rush_rank` | Float64 | National rank of the team's EPA per drive (total EPA divided by drives) on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `early_down_EPA_def_rush_rank` | Float64 | National rank of the team's EPA per early-down play on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `success_def_rush_rank` | Float64 | National rank of the team's success rate -- the share of plays flagged as successful by EPA on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `yards_def_rush_rank` | Float64 | National rank of the team's total yards gained on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `yardsplay_def_rush_rank` | Float64 | National rank of the team's yards gained per play on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `yardsgame_def_rush_rank` | Float64 | National rank of the team's yards gained per game on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `drivesgame_def_rush_rank` | Float64 | National rank of the team's drives per game on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `yardsdrive_def_rush_rank` | Float64 | National rank of the team's yards gained per drive on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `playsdrive_def_rush_rank` | Float64 | National rank of the team's plays run per drive on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `play_stuffed_def_rush_rank` | Float64 | National rank of the team's stuffed-play rate -- the share of plays carrying the stuffed flag on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `red_zone_success_def_rush_rank` | Float64 | National rank of the team's success rate on red-zone plays on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `third_down_success_def_rush_rank` | Float64 | National rank of the team's success rate on third-down plays on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `late_down_success_def_rush_rank` | Float64 | National rank of the team's success rate on late-down plays on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `third_down_distance_def_rush_rank` | Float64 | National rank of the team's average yards to go on third down on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `havoc_def_rush_rank` | Float64 | National rank of the team's havoc rate -- the share of plays carrying the defensive-disruption flag on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `explosive_def_rush_rank` | Float64 | National rank of the team's explosive-play rate -- the share of plays carrying the explosive flag on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `passrate_def_rush_rank` | Float64 | National rank of the team's share of plays that were pass plays on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `rushrate_def_rush_rank` | Float64 | National rank of the team's share of plays that were rush plays on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `nonExplosiveEpaPerPlay_def_rush_rank` | Float64 | National rank of the team's EPA per play with explosive plays excluded on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `line_yards_def_rush_rank` | Float64 | National rank of the team's average line yards credited to the offensive line on rushes on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `opportunity_rate_def_rush_rank` | Float64 | National rank of the team's opportunity rate -- the share of rushes carrying the opportunity flag on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best. |
+| `TEPA_margin_rush` | Float64 | Margin in total EPA summed over every play on rush plays: the team's offensive value minus the value it allowed on defense. |
+| `EPAplay_margin_rush` | Float64 | Margin in EPA per play on rush plays: the team's offensive value minus the value it allowed on defense. |
+| `EPAdrive_margin_rush` | Float64 | Margin in EPA per drive (total EPA divided by drives) on rush plays: the team's offensive value minus the value it allowed on defense. |
+| `EPAgame_margin_rush` | Float64 | Margin in EPA per game (total EPA divided by games) on rush plays: the team's offensive value minus the value it allowed on defense. |
+| `success_margin_rush` | Float64 | Margin in success rate -- the share of plays flagged as successful by EPA on rush plays: the team's offensive value minus the value it allowed on defense. |
+| `yardsplay_margin_rush` | Float64 | Margin in yards gained per play on rush plays: the team's offensive value minus the value it allowed on defense. |
+| `TEPA_margin_rush_rank` | Float64 | Margin in total EPA summed over every play on rush plays: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `EPAplay_margin_rush_rank` | Float64 | Margin in EPA per play on rush plays: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `EPAdrive_margin_rush_rank` | Float64 | Margin in EPA per drive (total EPA divided by drives) on rush plays: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `EPAgame_margin_rush_rank` | Float64 | Margin in EPA per game (total EPA divided by games) on rush plays: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `success_margin_rush_rank` | Float64 | Margin in success rate -- the share of plays flagged as successful by EPA on rush plays: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `yardsplay_margin_rush_rank` | Float64 | Margin in yards gained per play on rush plays: the team's offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest. |
+| `fbs_class` | String | Power/Group classification for the season: P4 or G6 from 2024 on, P5 or G5 through 2023, derived from conference membership (Notre Dame is classified with the power group). Null for teams outside FBS. |
+| `valid_games` | UInt32 | Number of the team's games that produced both an offensive and a defensive adjusted-EPA value; teams below two valid games are dropped from the adjusted ratings. |
+| `adj_off_epa` | Float64 | Offensive opponent-adjusted EPA per play from the ridge (RAPM-style) regression on offense/defense team indicators plus home field -- cfbfastR's adjust_epa adjustment, fit in-sample across the season, so the value is descriptive of that window rather than predictive. |
+| `adj_def_epa` | Float64 | Defensive opponent-adjusted EPA per play from the ridge (RAPM-style) regression on offense/defense team indicators plus home field -- cfbfastR's adjust_epa adjustment, fit in-sample across the season, so the value is descriptive of that window rather than predictive. Lower is better -- it is EPA allowed. |
+| `off_strength_faced` | Float64 | Average opponent-defense strength the team's offense faced, taken as the mean of the ridge's defensive coefficients across its opponents. Higher means a tougher slate. |
+| `def_strength_faced` | Float64 | Average opponent-offense strength the team's defense faced, taken as the mean of the ridge's offensive coefficients across its opponents. Higher means a tougher slate. |
+| `net_adj_epa` | Float64 | Net opponent-adjusted EPA per play: adj_off_epa minus adj_def_epa. Higher is better. |
+| `adj_off_epa_rank` | Float64 | National rank of the team's adj_off_epa, where 1 is best. |
+| `adj_def_epa_rank` | Float64 | National rank of the team's adj_def_epa, where 1 is best (fewest EPA allowed). |
+| `net_adj_epa_rank` | Float64 | National rank of the team's net_adj_epa, 1 = largest net adjusted EPA. |
+| `through_week` | Int32 | Regular-season week this cumulative snapshot covers -- the row reflects the team's state through the end of that week. One asset holds every week, so filter on this column. |
 
 ```python
 load_cfb_team_summaries_weekly(seasons=2024)

--- a/docs/docs/cfb/reference/loaders.md
+++ b/docs/docs/cfb/reference/loaders.md
@@ -433,19 +433,19 @@ Release: [cfb_ratings](https://github.com/sportsdataverse/sportsdataverse-data/r
 |---|---|---|
 | `season` | Int64 | Season (4-digit year). |
 | `team_id` | Int64 | ESPN team id. |
-| `adj_off_epa` | Float64 |  |
-| `adj_def_epa` | Float64 |  |
-| `adj_st_epa` | Float64 |  |
-| `adj_net` | Float64 |  |
-| `fei_off` | Float64 |  |
-| `fei_def` | Float64 |  |
-| `fei_net` | Float64 |  |
+| `adj_off_epa` | Float64 | Opponent-adjusted offensive EPA per play: the team's raw per-game EPA on pass and rush plays net of each opponent's ridge-fitted defensive strength, averaged over its games. |
+| `adj_def_epa` | Float64 | Opponent-adjusted EPA per play allowed, netted the same way as the offensive rating, so lower is better because it measures EPA surrendered. |
+| `adj_st_epa` | Float64 | Special-teams composite in EPA units: per-play mean EPA on field goals, punts, and kick returns, each centered on that unit's league mean and summed across the three units. |
+| `adj_net` | Float64 | adj_off_epa minus adj_def_epa, the team's overall efficiency rating in EPA per play; special teams is deliberately excluded. |
+| `fei_off` | Float64 | Drive-level offensive rating from a ridge fit on per-drive EPA, the Fremeau-style drive-efficiency counterpart to adj_off_epa. |
+| `fei_def` | Float64 | Drive-level defensive rating from the same per-drive ridge fit, on the same scale as fei_off. |
+| `fei_net` | Float64 | fei_off minus fei_def, the team's overall drive-efficiency rating, with the ridge's dropped reference team pinned at zero. |
 | `games` | Int64 | Number of games included in the ATS summary. |
-| `off_pace` | Float64 |  |
-| `off_rank` | Int64 |  |
-| `def_rank` | Int64 |  |
-| `net_rank` | Int64 |  |
-| `net_z` | Float64 |  |
+| `off_pace` | Float64 | Tempo measure: scrimmage plays (pass plus rush) per game, centering near 65 and used as the pace input to the totals model. |
+| `off_rank` | Int64 | Dense rank of adj_off_epa in descending order, so rank 1 is the season's most efficient offense. |
+| `def_rank` | Int64 | Dense rank of adj_def_epa in ascending order, so rank 1 is the season's stingiest defense. |
+| `net_rank` | Int64 | Dense rank of adj_net in descending order, so rank 1 is the season's strongest overall team. |
+| `net_z` | Float64 | adj_net restated as a z-score against the mean and standard deviation of adj_net across the rated teams that season. |
 
 ```python
 load_cfb_ratings(seasons=2024)
@@ -460,9 +460,9 @@ Release: [cfb_recruiting_proj](https://github.com/sportsdataverse/sportsdatavers
 |---|---|---|
 | `season` | Int64 | Season (4-digit year). |
 | `team_id` | Int64 | ESPN team id. |
-| `pred_wins` | Float64 |  |
-| `pred_margin` | Float64 |  |
-| `pred_net_epa` | Float64 |  |
+| `pred_wins` | Float64 | Ridge projection of the team's season win total, fit strictly on prior seasons from talent composite, blue-chip ratio, offensive and defensive returning production, and prior wins. |
+| `pred_margin` | Float64 | Ridge projection of the team's average per-game scoring margin, from the same preseason-known feature set as pred_wins. |
+| `pred_net_epa` | Float64 | Reserved slot for a projected adjusted net EPA; it ships all-null because the adjusted-EPA training target is not currently loadable. |
 
 ```python
 load_cfb_recruiting_proj(seasons=2024)
@@ -490,7 +490,7 @@ Release: [cfbfastR-data](https://github.com/sportsdataverse/sportsdataverse-data
 | `home_latitude` | String | Hometown latitude. |
 | `home_longitude` | String | Hometown longitude. |
 | `home_county_fips` | String | Hometown FIPS code. |
-| `recruit_ids` | List(Int32) |  |
+| `recruit_ids` | List(Int32) | List of recruiting-database profile ids matched to the player; real ids run in the six-figure range and a lone 0 entry means no recruiting profile was matched. |
 | `headshot_url` | String | Player ESPN headshot url. |
 | `season` | Int32 | Season (4-digit year). |
 
@@ -560,8 +560,8 @@ Release: [cfbfastR-data](https://github.com/sportsdataverse/sportsdataverse-data
 | `color` | String | Primary team color (hex, no `#`). |
 | `alt_color` | String | Team color (alternate). |
 | `logo` | String | Team or league logo URL. |
-| `logo_2` | String |  |
-| `twitter` | String |  |
+| `logo_2` | String | URL of the team's alternate dark-background 500-pixel logo on ESPN's CDN, null for programs with no dark variant. |
+| `twitter` | String | The football program's Twitter/X handle including the leading at sign, populated for only a minority of listed teams. |
 | `venue_id` | Int32 | Referencing venue id. |
 | `venue_name` | String | Full name of the franchise's venue. |
 | `city` | String | Venue city. |
@@ -588,17 +588,17 @@ Release: [cfb_crosswalk](https://github.com/sportsdataverse/sportsdataverse-data
 
 | col_name | type | description |
 |---|---|---|
-| `norm_key` | String |  |
+| `norm_key` | String | Shared join key across providers: the team name lowercased, ASCII-folded, stripped of punctuation, whitespace-collapsed, and alias-mapped. |
 | `espn_team_id` | Int64 | ESPN team id for the crosswalk row. |
-| `espn_team` | String |  |
+| `espn_team` | String | ESPN's full team display name, school plus mascot, null when the row was anchored on a non-ESPN provider. |
 | `espn_abbreviation` | String | ESPN abbreviation. |
 | `fox_team_id` | String | Fox Sports team id for the same team. |
-| `fox_team` | String |  |
-| `fox_abbreviation` | String |  |
+| `fox_team` | String | Fox Sports' team name, which that feed ships in all capitals. |
+| `fox_abbreviation` | String | Fox Sports' short team code, which frequently differs from the ESPN abbreviation for the same school. |
 | `yahoo_team_id` | String | Yahoo Sports team id for the same team. |
-| `yahoo_team` | String |  |
-| `yahoo_abbreviation` | String |  |
-| `matched_sources` | String |  |
+| `yahoo_team` | String | Yahoo Sports' team display name, school plus mascot. |
+| `yahoo_abbreviation` | String | Yahoo Sports' short team code for the school. |
+| `matched_sources` | String | Plus-joined provenance tag naming which of espn, fox, and yahoo contributed a directory row for this team. |
 
 ```python
 load_cfb_teams_crosswalk(seasons=2024)
@@ -611,17 +611,17 @@ Release: [cfb_crosswalk](https://github.com/sportsdataverse/sportsdataverse-data
 
 | col_name | type | description |
 |---|---|---|
-| `matchup_key` | String |  |
+| `matchup_key` | String | Order-independent key for the game: the two normalized team names sorted alphabetically and joined with a pipe. |
 | `espn_game_id` | Int64 | ESPN game id for the crosswalk row. |
 | `fox_game_id` | String | Fox Sports game id for the same game. |
 | `yahoo_game_id` | String | Yahoo Sports game id for the same game. |
-| `yahoo_global_game_id` | String |  |
+| `yahoo_global_game_id` | String | Yahoo's cross-season global game key in ncaaf.g.<number> form, distinct from the date-encoded yahoo_game_id. |
 | `home_team` | String | Home team name. |
 | `away_team` | String | Away team name. |
-| `espn_date` | String |  |
-| `fox_date` | String |  |
-| `yahoo_date` | String |  |
-| `matched_sources` | String |  |
+| `espn_date` | String | Kickoff date as YYYY-MM-DD taken from ESPN's schedule, null on games that matched no ESPN row. |
+| `fox_date` | String | Kickoff date as YYYY-MM-DD taken from the Fox Sports schedule, null on games that matched no Fox row. |
+| `yahoo_date` | String | Kickoff date as YYYY-MM-DD, parsed from Yahoo's RFC-2822 start_time string. |
+| `matched_sources` | String | Plus-joined provenance tag naming which of espn, fox, and yahoo actually supplied a row for this game. |
 
 ```python
 load_cfb_schedule_crosswalk(seasons=2024)
@@ -634,21 +634,21 @@ Release: [espn_cfb_team_box](https://github.com/sportsdataverse/sportsdataverse-
 
 | col_name | type | description |
 |---|---|---|
-| `firstDowns` | String |  |
-| `thirdDownEff` | String |  |
-| `fourthDownEff` | String |  |
-| `totalYards` | String |  |
-| `netPassingYards` | String |  |
-| `completionAttempts` | String |  |
-| `yardsPerPass` | String |  |
+| `firstDowns` | String | Total first downs ESPN credits the team, carried verbatim from the box score as a string. |
+| `thirdDownEff` | String | Third-down efficiency as ESPN's conversions-attempts string, for example 5-15. |
+| `fourthDownEff` | String | Fourth-down efficiency as a conversions-attempts string, for example 3-4. |
+| `totalYards` | String | Total offensive yards for the team, matching rushingYards plus netPassingYards in about 99.8 percent of games. |
+| `netPassingYards` | String | Passing yards after yardage lost to sacks is deducted, the numerator behind yardsPerPass. |
+| `completionAttempts` | String | Completions and pass attempts as a slash-separated string, for example 23/41. |
+| `yardsPerPass` | String | Net passing yards per pass attempt, netPassingYards divided by the attempt count in completionAttempts and rounded to one decimal. |
 | `rushingYards` | String | Net rushing yards gained. |
 | `rushingAttempts` | String | Rushing attempts. |
 | `yardsPerRushAttempt` | String | Yards gained per rushing attempt. |
-| `totalPenaltiesYards` | String |  |
+| `totalPenaltiesYards` | String | Penalties and penalty yards as a hyphen-separated string, for example 7-64. |
 | `turnovers` | String | Turnovers total. |
-| `fumblesLost` | String |  |
+| `fumblesLost` | String | Number of fumbles the team lost to the opponent, carried as a string. |
 | `interceptions` | String | Passing interceptions. |
-| `possessionTime` | String |  |
+| `possessionTime` | String | Time of possession as mm:ss; the two teams' values add up to 60 minutes in a regulation game. |
 | `team_id` | Int64 | ESPN team id. |
 | `team_abbreviation` | String | Team abbreviation; `team_detail = TRUE` only. |
 | `team_name` | String | Team nickname; `team_detail = TRUE` only. |
@@ -708,11 +708,11 @@ Release: [espn_cfb_player_box](https://github.com/sportsdataverse/sportsdatavers
 | `longPunt` | String | Longest punt of the game, in yards. |
 | `game_id` | Int64 | ESPN game identifier. |
 | `season` | Int64 | Season (4-digit year). |
-| `stat_1` | String |  |
-| `stat_2` | String |  |
-| `stat_3` | String |  |
-| `stat_4` | String |  |
-| `stat_5` | String |  |
+| `stat_1` | String | First value of ESPN's raw athlete stats array, written only when the category's key list does not line up with the stats list; on those rows the named per-category columns are all null. |
+| `stat_2` | String | Second value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and the named columns could not be filled. |
+| `stat_3` | String | Third value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and the named columns could not be filled. |
+| `stat_4` | String | Fourth value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and the named columns could not be filled. |
+| `stat_5` | String | Fifth value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and the named columns could not be filled. |
 
 ```python
 load_cfb_player_box(seasons=2024)
@@ -742,7 +742,7 @@ Release: [espn_cfb_drives](https://github.com/sportsdataverse/sportsdataverse-da
 | `end_yard_line` | Int64 | Yard line at the end of the play. |
 | `end_clock` | String | Game clock display value at the end of the drive. |
 | `time_elapsed` | String | Elapsed game time for the drive (`MM:SS`). |
-| `n_plays` | Int64 |  |
+| `n_plays` | Int64 | Number of entries in ESPN's raw plays array for the drive, which is generally at least offensive_plays because it also counts penalties and other non-offensive snaps. |
 | `game_id` | Int64 | ESPN game identifier. |
 | `season` | Int64 | Season (4-digit year). |
 
@@ -867,17 +867,17 @@ Release: [espn_cfb_game_rosters](https://github.com/sportsdataverse/sportsdatave
 | `status_type` | String | Status type. |
 | `status_abbreviation` | String | Status abbreviation. |
 | `birth_place_country` | String | Birth place country. |
-| `birth_country_alternate_id` | String |  |
+| `birth_country_alternate_id` | String | ESPN's internal alternate identifier for the athlete's birth country, paired with birth_place_country and the flag fields. |
 | `birth_country_abbreviation` | String | Birth country abbreviation. |
-| `flag_href` | String |  |
-| `flag_alt` | String |  |
-| `flag_rel` | String |  |
+| `flag_href` | String | URL of the birth-country flag image hosted on ESPN's CDN under teamlogos/countries. |
+| `flag_alt` | String | Alt text ESPN attaches to the birth-country flag image, which is the country's name spelled out. |
+| `flag_rel` | String | Stringified relationship list ESPN ships with the flag image; the only non-null value observed is a single country-flag entry. |
 | `starter` | Boolean | `TRUE` if the athlete started the game. |
 | `valid` | Boolean | `TRUE` if the roster entry is flagged valid by ESPN. |
 | `did_not_play` | Boolean | `TRUE` if the athlete did not play. |
-| `athlete_href` | String |  |
-| `position_href` | String |  |
-| `statistics_href` | String |  |
+| `athlete_href` | String | ESPN Core v2 API reference URL for the athlete's season record, ending in the athlete id. |
+| `position_href` | String | ESPN Core v2 API reference URL for the position resource ESPN lists the athlete at. |
+| `statistics_href` | String | ESPN Core v2 API reference URL for this athlete's stat line in this game, null for the roughly 71 percent of listed players who recorded no stats. |
 | `team_id` | Int64 | ESPN team id. |
 | `order` | Int64 | Team order within the competition (0 = first). |
 | `home_away` | String | `home` or `away`. |
@@ -895,7 +895,7 @@ Release: [espn_cfb_game_rosters](https://github.com/sportsdataverse/sportsdatave
 | `team_alternate_color` | String | Alternate team color; `team_detail = TRUE` only. |
 | `is_active` | Boolean | Whether the team is currently active. |
 | `is_all_star` | Boolean | Whether the team is an all-star team. |
-| `team_alternate_ids_sdr` | String |  |
+| `team_alternate_ids_sdr` | String | The team's Sportradar alternate identifier, which maps one-to-one with team_id. |
 | `logo_href` | String | URL of the default team logo. |
 | `logo_dark_href` | String | URL of the dark-variant team logo. |
 | `game_id` | Int64 | ESPN game identifier. |
@@ -959,7 +959,7 @@ Release: [espn_cfb_power_index](https://github.com/sportsdataverse/sportsdataver
 
 | col_name | type | description |
 |---|---|---|
-| `$ref` | String |  |
+| `$ref` | String | ESPN Core v2 API URL for one team's FPI projection on this game; the published asset carries only these links, not the resolved projection numbers. |
 | `game_id` | Int64 | ESPN game identifier. |
 | `season` | Int64 | Season (4-digit year). |
 | `week` | Int64 | Game week of the season. |
@@ -1114,16 +1114,16 @@ Release: [espn_cfb_adv_rushing](https://github.com/sportsdataverse/sportsdataver
 | `pos_team_id` | Int64 | ESPN team id of the team on offense. Present for every season 2004+. |
 | `pos_team` | String | Team name in possession at the start of the play (offense, kickoff-aware). |
 | `rusher_player_name` | String | Display name of the ball carrier on a rush -- the FIRST participant in that role on the play. |
-| `Car` | Int64 |  |
+| `Car` | Int64 | Rushing attempts credited to this ball carrier in the game. |
 | `Yds` | Float64 | Passing yards from the advanced box score. |
-| `Rush_TD` | Int64 |  |
-| `YPC` | Float64 |  |
+| `Rush_TD` | Int64 | Rushing touchdowns scored by this ball carrier in the game. |
+| `YPC` | Float64 | Yards per carry, the mean rushing yardage across the player's attempts in the game. |
 | `EPA` | Float64 | Expected Points Added on the play (cfbfastR EPA model output). |
 | `EPA_per_Play` | Float64 | EPA per play on the passer's plays. |
 | `WPA` | Float64 | Win Probability Added. |
 | `SR` | Float64 | Success rate on the passer's plays. |
-| `Fum` | Int64 |  |
-| `Fum_Lost` | Int64 |  |
+| `Fum` | Int64 | Count of the carrier's rush attempts whose play text mentions a fumble; it is a play-level flag, not a fumble charged to this player. |
+| `Fum_Lost` | Int64 | Count of the carrier's rush attempts on which a fumble was lost to the opponent. |
 | `game_id` | Int64 | ESPN game identifier. |
 | `season` | Int64 | Season (4-digit year). |
 | `week` | Int64 | Game week of the season. |
@@ -1142,17 +1142,17 @@ Release: [espn_cfb_adv_receiving](https://github.com/sportsdataverse/sportsdatav
 | `pos_team_id` | Int64 | ESPN team id of the team on offense. Present for every season 2004+. |
 | `pos_team` | String | Team name in possession at the start of the play (offense, kickoff-aware). |
 | `receiver_player_name` | String | Display name of the targeted receiver -- the FIRST participant in that role on the play. |
-| `Rec` | Int64 |  |
-| `Tar` | Int64 |  |
+| `Rec` | Int64 | Receptions credited to the receiver, the number of completions on plays where this player was the targeted receiver. |
+| `Tar` | Int64 | Times the player was targeted on a pass attempt, the denominator behind YPT. |
 | `Yds` | Float64 | Passing yards from the advanced box score. |
-| `Rec_TD` | Int64 |  |
-| `YPT` | Float64 |  |
+| `Rec_TD` | Int64 | Receiving touchdowns, the count of the player's targeted plays that ended in a passing touchdown. |
+| `YPT` | Float64 | Receiving yards per target, the mean of receiving yardage over every target rather than over receptions only. |
 | `EPA` | Float64 | Expected Points Added on the play (cfbfastR EPA model output). |
 | `EPA_per_Play` | Float64 | EPA per play on the passer's plays. |
 | `WPA` | Float64 | Win Probability Added. |
 | `SR` | Float64 | Success rate on the passer's plays. |
-| `Fum` | Int64 |  |
-| `Fum_Lost` | Int64 |  |
+| `Fum` | Int64 | Count of the receiver's targeted pass plays whose text mentions a fumble; it is a play-level flag, not a fumble charged to this player. |
+| `Fum_Lost` | Int64 | Count of the receiver's targeted plays on which a fumble was lost to the opponent. |
 | `game_id` | Int64 | ESPN game identifier. |
 | `season` | Int64 | Season (4-digit year). |
 | `week` | Int64 | Game week of the season. |
@@ -1171,22 +1171,22 @@ Release: [espn_cfb_adv_defensive](https://github.com/sportsdataverse/sportsdatav
 | `def_pos_team_id` | Int64 |  |
 | `def_pos_team` | String | Team name on defense at the start of the play. |
 | `scrimmage_plays` | Int64 | Number of plays from scrimmage (rushes plus passes), excluding special teams. |
-| `TFL` | Int64 |  |
-| `TFL_pass` | Int64 |  |
-| `TFL_rush` | Int64 |  |
+| `TFL` | Int64 | Count of scrimmage plays the defense held to negative yardage (non-penalty, non-special-teams, ESPN statYardage below zero) plus every sack. |
+| `TFL_pass` | Int64 | The TFL count restricted to plays classified as passes, so it covers sacks together with completions and laterals stopped behind the line. |
+| `TFL_rush` | Int64 | The TFL count restricted to plays classified as rushes, that is rushing attempts the defense stopped for negative yardage. |
 | `havoc_total` | Int64 | Total havoc rate. |
-| `havoc_total_rate` | Float64 |  |
-| `fumbles` | Int64 |  |
-| `def_int` | Int64 |  |
-| `drive_stopped_rate` | Float64 |  |
-| `num_pass_plays` | Int64 |  |
-| `havoc_total_pass` | Int64 |  |
-| `havoc_total_pass_rate` | Float64 |  |
+| `havoc_total_rate` | Float64 | Share of the defense's scrimmage plays producing a havoc event, a 0-to-1 fraction equal to havoc_total divided by scrimmage_plays. |
+| `fumbles` | Int64 | Fumbles the defense forced, counted from plays whose narrative contains the phrase forced by, not the total number of fumbles on the play. |
+| `def_int` | Int64 | Interceptions the defense recorded, counted from plays ESPN types as Interception Return or Interception Return Touchdown. |
+| `drive_stopped_rate` | Float64 | Percentage from 0 to 100 of the defense's scrimmage plays that occurred on drives ending in a punt, fumble, interception, or turnover on downs; the denominator is plays, not drives. |
+| `num_pass_plays` | Int64 | Number of pass scrimmage plays the defense faced, the denominator behind havoc_total_pass_rate and sacks_rate. |
+| `havoc_total_pass` | Int64 | Havoc events (tackle for loss, sack, interception, forced fumble, or pass breakup) recorded on the pass plays the defense faced. |
+| `havoc_total_pass_rate` | Float64 | havoc_total_pass divided by num_pass_plays, the defense's havoc rate against the pass as a 0-to-1 fraction. |
 | `sacks` | Int64 | Team sacks. |
-| `sacks_rate` | Float64 |  |
-| `pass_breakups` | Int64 |  |
-| `havoc_total_rush` | Int64 |  |
-| `havoc_total_rush_rate` | Float64 |  |
+| `sacks_rate` | Float64 | Sacks divided by pass plays faced, the defense's per-pass-play sack rate as a 0-to-1 fraction. |
+| `pass_breakups` | Int64 | Passes the defense broke up, counted from plays whose narrative contains the phrase broken up by. |
+| `havoc_total_rush` | Int64 | Havoc events recorded on the rush plays the defense faced, in practice tackles for loss and forced fumbles. |
+| `havoc_total_rush_rate` | Float64 | Havoc events per rush play faced, the mean of the havoc flag over the defense's rush scrimmage plays. |
 | `game_id` | Int64 | ESPN game identifier. |
 | `season` | Int64 | Season (4-digit year). |
 | `week` | Int64 | Game week of the season. |
@@ -1230,13 +1230,13 @@ Release: [espn_cfb_adv_drives](https://github.com/sportsdataverse/sportsdatavers
 |---|---|---|
 | `pos_team_id` | Int64 | ESPN team id of the team on offense. Present for every season 2004+. |
 | `pos_team` | String | Team name in possession at the start of the play (offense, kickoff-aware). |
-| `drive_total_available_yards` | Float64 |  |
-| `drive_total_gained_yards` | Int64 |  |
-| `avg_field_position` | Float64 |  |
-| `plays_per_drive` | Float64 |  |
-| `yards_per_drive` | Float64 |  |
-| `drives` | Int64 |  |
-| `drive_total_gained_yards_rate` | Float64 |  |
+| `drive_total_available_yards` | Float64 | Sum of each drive's starting distance to the opponent end zone taken across every scrimmage play, so a drive contributes its available yards once per play rather than once per drive. |
+| `drive_total_gained_yards` | Int64 | Sum of ESPN's per-drive yardage repeated across every scrimmage play of that drive, so a drive contributes its yardage once per play. |
+| `avg_field_position` | Float64 | Mean distance to the opponent end zone at drive start averaged over the team's scrimmage plays, exactly drive_total_available_yards divided by that play count. |
+| `plays_per_drive` | Float64 | Mean of ESPN's per-drive offensivePlays taken over plays rather than over drives, which weights every drive by its own length. |
+| `yards_per_drive` | Float64 | Mean of ESPN's per-drive yardage taken over plays rather than over drives, exactly drive_total_gained_yards divided by the team's scrimmage-play count. |
+| `drives` | Int64 | Number of distinct ESPN drive ids on which the team ran at least one scrimmage play. |
+| `drive_total_gained_yards_rate` | Float64 | Available-yards conversion as a percentage, 100 times drive_total_gained_yards over drive_total_available_yards with both sums play-weighted. |
 | `game_id` | Int64 | ESPN game identifier. |
 | `season` | Int64 | Season (4-digit year). |
 | `week` | Int64 | Game week of the season. |
@@ -1342,16 +1342,16 @@ Release: [espn_cfb_adv_specialists](https://github.com/sportsdataverse/sportsdat
 | `pos_team` | String | Team name in possession at the start of the play (offense, kickoff-aware). |
 | `player_name` | String | Player name. |
 | `punts` | Int64 | Punts attempted. |
-| `punts_yards` | Int64 |  |
+| `punts_yards` | Int64 | Total gross punt yardage parsed from the play text for this punter, working out to roughly 42 yards per punt league-wide. |
 | `kick_returns` | Int64 | Number of kick returns. |
 | `kick_returns_yards` | Int64 |  |
 | `punt_returns` | Int64 | Number of punt returns. |
-| `punt_returns_yards` | Int64 |  |
+| `punt_returns_yards` | Int64 | Total punt-return yardage credited to this returner, with fair catches, downed punts, and out-of-bounds punts scored as zero. |
 | `game_id` | Int64 | ESPN game identifier. |
 | `season` | Int64 | Season (4-digit year). |
 | `week` | Int64 | Game week of the season. |
 | `field_goals` | Int64 | Number of field-goal attempts. |
-| `field_goals_yards` | Int64 |  |
+| `field_goals_yards` | Int64 | Sum of the field-goal attempt distances parsed out of the play text; it stays at zero when no distance could be parsed from the narrative. |
 
 ```python
 load_cfb_adv_specialists(seasons=2024)
@@ -1370,21 +1370,21 @@ Release: [espn_cfb_adv_turnover](https://github.com/sportsdataverse/sportsdatave
 | `st_turnovers_lost` | Int64 |  |
 | `Int` | Int64 | Interceptions thrown. |
 | `fumbles_lost` | Int64 | Fumbles lost. |
-| `pass_breakups` | Int64 |  |
+| `pass_breakups` | Int64 | Passes thrown by this offense that the opposing defense broke up; it equals the opponent's row in the advanced defensive table exactly. |
 | `total_fumbles` | Int64 | Team total fumbles. |
 | `fumbles_recovered` | Int64 | Team fumbles recovered. |
 | `team_id` | Int64 | ESPN team id. |
-| `turnovers_pbp` | Int64 |  |
-| `Int_pbp` | Int64 |  |
-| `fumbles_lost_pbp` | Int64 |  |
+| `turnovers_pbp` | Int64 | Turnover count derived from the play-by-play, retained unchanged so it can be reconciled against the ESPN-sourced turnovers total. |
+| `Int_pbp` | Int64 | Interception count derived from the play-by-play, kept alongside the ESPN-sourced Int for reconciliation. |
+| `fumbles_lost_pbp` | Int64 | Fumbles-lost count derived from the play-by-play, kept alongside the ESPN-sourced fumbles_lost for reconciliation. |
 | `espn_sourced` | Boolean |  |
-| `expected_turnovers` | Float64 |  |
-| `expected_turnover_margin` | Float64 |  |
-| `turnover_margin` | Int64 |  |
-| `turnover_luck` | Float64 |  |
+| `expected_turnovers` | Float64 | Turnover expectation for this team, computed as half its total fumbles plus 0.22 times the sum of its pass breakups and interceptions. |
+| `expected_turnover_margin` | Float64 | The opponent's expected_turnovers minus this team's, so positive means the team was expected to win the turnover battle. |
+| `turnover_margin` | Int64 | The opponent's turnovers minus this team's turnovers, positive when the team gained more possessions than it gave away. |
+| `turnover_luck` | Float64 | Points of scoring luck attributed to turnovers, five points per turnover times the gap between turnover_margin and expected_turnover_margin. |
 | `takeaways` | Int64 | Takeaways. |
-| `st_turnovers_gained` | Int64 |  |
-| `fumble_recoveries_gained` | Int64 |  |
+| `st_turnovers_gained` | Int64 | Special-teams turnovers this team recovered, taken as the opponent's st_turnovers_lost. |
+| `fumble_recoveries_gained` | Int64 | Opponent fumbles this team recovered, taken as the opponent's fumbles_lost. |
 | `game_id` | Int64 | ESPN game identifier. |
 | `season` | Int64 | Season (4-digit year). |
 | `week` | Int64 | Game week of the season. |
@@ -1404,31 +1404,31 @@ Release: [espn_cfb_model_pbp](https://github.com/sportsdataverse/sportsdataverse
 | `id` | String | 247Sports referencing id for the recruit. |
 | `sequenceNumber` | String | Broadcast sequence order number. |
 | `game_play_number` | Int64 | Sequential play number within the game (excludes timeouts/end markers). |
-| `drive.id` | String |  |
+| `drive.id` | String | ESPN's drive identifier, formed as the game id followed by the drive's sequence number within that game. |
 | `season` | Int64 | Season (4-digit year). |
 | `week` | Int64 | Game week of the season. |
 | `period` | Int64 | Period (quarter) number. |
 | `pos_team` | Int64 | Team name in possession at the start of the play (offense, kickoff-aware). |
 | `def_pos_team` | Int64 | Team name on defense at the start of the play. |
-| `start.pos_team.name` | String |  |
-| `homeTeamId` | Int64 |  |
-| `awayTeamId` | Int64 |  |
-| `homeTeamName` | String |  |
-| `awayTeamName` | String |  |
-| `type.text` | String |  |
+| `start.pos_team.name` | String | School name of the team with possession at the snap, taken from ESPN's team location field so it carries no mascot. |
+| `homeTeamId` | Int64 | ESPN team id of the home team, read off the game header and stamped on every play. |
+| `awayTeamId` | Int64 | ESPN team id of the away team, read off the game header and stamped on every play. |
+| `homeTeamName` | String | Home team's school name from ESPN's team location field, without the mascot. |
+| `awayTeamName` | String | Away team's school name from ESPN's team location field, without the mascot. |
+| `type.text` | String | ESPN's play-type label, for example Rush, Pass Reception, Sack, Punt, Penalty, or Timeout. |
 | `text` | String | Full play description. |
-| `start.down` | Int64 |  |
-| `start.distance` | Int64 |  |
-| `start.yardsToEndzone` | Int64 |  |
+| `start.down` | Int64 | Down at the snap as ESPN reports it; 0 marks the small share of rows ESPN leaves without a down, overwhelmingly timeouts and penalty administrations. |
+| `start.distance` | Int64 | Yards the offense needs for a first down at the snap, carried through from ESPN without correction. |
+| `start.yardsToEndzone` | Int64 | Distance in yards from the offense's spot at the snap to the opponent's end zone, ranging 0 to 100. |
 | `pos_score_diff_start` | Int64 | Score differential for the possession team at the start of the play. |
-| `start.TimeSecsRem` | Int64 |  |
-| `start.is_home` | Boolean |  |
-| `passing_down` | Boolean |  |
+| `start.TimeSecsRem` | Int64 | Seconds remaining in the half at the snap, so it tops out at 1800 rather than counting down from a full game. |
+| `start.is_home` | Boolean | True when the team holding possession at the snap is the home team. |
+| `passing_down` | Boolean | True on second and eight or longer, third and five or longer, or fourth and five or longer, the standard obvious-passing-situation flag. |
 | `pass` | Boolean | Binary flag for a passing play (includes sacks). |
 | `rush` | Boolean | Binary flag for a rushing play. |
 | `completion` | Boolean | Binary flag for a completed pass. |
 | `scoring_play` | Boolean | `TRUE` if the play resulted in a score. |
-| `statYardage` | Int64 |  |
+| `statYardage` | Int64 | Yards gained on the play as ESPN reports it, negative on plays that lost yardage. |
 | `passer_player_name` | String | Display name of the passer -- the FIRST participant in that role on the play. |
 | `ep_before` | Float64 | Expected points value before the play (cfbfastR EPA model). |
 | `ep_after` | Float64 | Expected points value after the play (cfbfastR EPA model). |
@@ -1569,14 +1569,14 @@ Release: [espn_cfb_receiving](https://github.com/sportsdataverse/sportsdataverse
 | `success` | Float64 | Success rate across the team plays. |
 | `comp` | UInt32 | Completed passes. |
 | `targets` | UInt32 | The number of pass plays where the player was the targeted receiver. |
-| `catchpct` | Float64 |  |
+| `catchpct` | Float64 | Catch rate on a 0-to-1 scale, receptions divided by targets for the season. |
 | `passing_td` | Float64 | Passing touchdowns thrown. |
-| `fumbles` | Float64 |  |
+| `fumbles` | Float64 | Count of the receiver's targeted pass plays across the season whose play text mentions a fumble by either team. |
 | `TEPA_rank` | Float64 | National rank of the team's total EPA summed over every play, where 1 is best. |
 | `EPAgame_rank` | Float64 | National rank of the team's EPA generated per game, where 1 is best. |
 | `EPAplay_rank` | Float64 | National rank of the team's EPA generated per play, where 1 is best. |
 | `success_rank` | Float64 | National rank of the team's success rate across the team plays, where 1 is best. |
-| `catchpct_rank` | Float64 |  |
+| `catchpct_rank` | Float64 | Season rank of catchpct with the best catch rate first, computed only for receivers clearing the leaderboard minimum of 1.875 targets per team game and using averaged ranks for ties. |
 | `yards_rank` | Float64 | National rank of the team's total yards, where 1 is best. |
 | `yardsplay_rank` | Float64 | National rank of the team's yards per play, where 1 is best. |
 | `yardsgame_rank` | Float64 | National rank of the team's yards per game, where 1 is best. |
@@ -1612,7 +1612,7 @@ Release: [espn_cfb_rushing](https://github.com/sportsdataverse/sportsdataverse-d
 | `yardsgame` | Float64 | Yards per game. |
 | `success` | Float64 | Success rate across the team plays. |
 | `rushing_td` | Float64 | Rushing touchdowns. |
-| `fumbles` | Float64 |  |
+| `fumbles` | Float64 | Count of the ball carrier's rush attempts across the season whose play text mentions a fumble by either team. |
 | `TEPA_rank` | Float64 | National rank of the team's total EPA summed over every play, where 1 is best. |
 | `EPAgame_rank` | Float64 | National rank of the team's EPA generated per game, where 1 is best. |
 | `EPAplay_rank` | Float64 | National rank of the team's EPA generated per play, where 1 is best. |
@@ -2041,7 +2041,7 @@ Release: [espn_cfb_adv_team_gamelog](https://github.com/sportsdataverse/sportsda
 | `neutral_site` | Boolean | TRUE/FALSE flag for if the game took place at a neutral site. |
 | `points_for` | Int64 | Goals/points scored. |
 | `points_against` | Int64 | Points allowed. |
-| `margin` | Int64 |  |
+| `margin` | Int64 | Final scoring margin from this team's perspective, exactly points_for minus points_against. |
 | `win` | Boolean | Whether the game was a win (goalie). |
 | `rushing_highlight_yards_per_opp` | Float64 | Highlight yards per rushing opportunity. |
 | `total_pen_yards` | Int64 | Total penalty yards assessed. |
@@ -2132,20 +2132,20 @@ Release: [cfb_ratings_weekly](https://github.com/sportsdataverse/sportsdataverse
 |---|---|---|
 | `season` | Int64 | Season (4-digit year). |
 | `team_id` | Int64 | ESPN team id. |
-| `adj_off_epa` | Float64 |  |
-| `adj_def_epa` | Float64 |  |
-| `adj_st_epa` | Float64 |  |
-| `adj_net` | Float64 |  |
-| `fei_off` | Float64 |  |
-| `fei_def` | Float64 |  |
-| `fei_net` | Float64 |  |
+| `adj_off_epa` | Float64 | Opponent-adjusted offensive EPA per play as of the snapshot week: raw per-game EPA on pass and rush plays net of each opponent's ridge-fitted defensive strength. |
+| `adj_def_epa` | Float64 | Opponent-adjusted EPA per play allowed as of the snapshot week, netted the same way as the offensive rating, so lower is better. |
+| `adj_st_epa` | Float64 | Special-teams composite in EPA units as of the snapshot week, summing the league-centered per-play EPA of the field goal, punt, and kick-return units. |
+| `adj_net` | Float64 | adj_off_epa minus adj_def_epa at the snapshot week, the team's overall efficiency rating in EPA per play with special teams excluded. |
+| `fei_off` | Float64 | Drive-level offensive rating at the snapshot week, from a ridge fit on per-drive EPA. |
+| `fei_def` | Float64 | Drive-level defensive rating at the snapshot week, from the same per-drive ridge fit and on the same scale as fei_off. |
+| `fei_net` | Float64 | fei_off minus fei_def at the snapshot week, the team's overall drive-efficiency rating. |
 | `games` | Int64 | Number of games included in the ATS summary. |
-| `off_pace` | Float64 |  |
-| `off_rank` | Int64 |  |
-| `def_rank` | Int64 |  |
-| `net_rank` | Int64 |  |
-| `net_z` | Float64 |  |
-| `through_week` | Int32 |  |
+| `off_pace` | Float64 | Scrimmage plays per game through the snapshot week, the tempo input consumed by the totals model. |
+| `off_rank` | Int64 | Dense rank of adj_off_epa in descending order within the snapshot week, so rank 1 is the most efficient offense at that point. |
+| `def_rank` | Int64 | Dense rank of adj_def_epa in ascending order within the snapshot week, so rank 1 is the stingiest defense at that point. |
+| `net_rank` | Int64 | Dense rank of adj_net in descending order within the snapshot week, so rank 1 is the strongest overall team at that point. |
+| `net_z` | Float64 | adj_net restated as a z-score against the mean and standard deviation of adj_net across the teams rated in that snapshot week. |
+| `through_week` | Int32 | Regular-season week the snapshot runs through; the ratings were refit using only games kicking off on or before that week's final kickoff date. |
 
 ```python
 load_cfb_ratings_weekly(seasons=2024)

--- a/docs/docs/cfb/reference/loaders.md
+++ b/docs/docs/cfb/reference/loaders.md
@@ -589,13 +589,13 @@ Release: [cfb_crosswalk](https://github.com/sportsdataverse/sportsdataverse-data
 | col_name | type | description |
 |---|---|---|
 | `norm_key` | String |  |
-| `espn_team_id` | Int64 | ESPN team id (canonical key). |
+| `espn_team_id` | Int64 | ESPN team id for the crosswalk row. |
 | `espn_team` | String |  |
 | `espn_abbreviation` | String | ESPN abbreviation. |
-| `fox_team_id` | String | Fox Bifrost team id (NA if unmatched). |
+| `fox_team_id` | String | Fox Sports team id for the same team. |
 | `fox_team` | String |  |
 | `fox_abbreviation` | String |  |
-| `yahoo_team_id` | String | Yahoo team id (NA placeholder). |
+| `yahoo_team_id` | String | Yahoo Sports team id for the same team. |
 | `yahoo_team` | String |  |
 | `yahoo_abbreviation` | String |  |
 | `matched_sources` | String |  |
@@ -612,9 +612,9 @@ Release: [cfb_crosswalk](https://github.com/sportsdataverse/sportsdataverse-data
 | col_name | type | description |
 |---|---|---|
 | `matchup_key` | String |  |
-| `espn_game_id` | Int64 | ESPN game id (NA for bart-only rows). |
-| `fox_game_id` | String | Fox game id (NA placeholder). |
-| `yahoo_game_id` | String | Yahoo game id (NA placeholder). |
+| `espn_game_id` | Int64 | ESPN game id for the crosswalk row. |
+| `fox_game_id` | String | Fox Sports game id for the same game. |
+| `yahoo_game_id` | String | Yahoo Sports game id for the same game. |
 | `yahoo_global_game_id` | String |  |
 | `home_team` | String | Home team name. |
 | `away_team` | String | Away team name. |
@@ -641,9 +641,9 @@ Release: [espn_cfb_team_box](https://github.com/sportsdataverse/sportsdataverse-
 | `netPassingYards` | String |  |
 | `completionAttempts` | String |  |
 | `yardsPerPass` | String |  |
-| `rushingYards` | String |  |
-| `rushingAttempts` | String |  |
-| `yardsPerRushAttempt` | String |  |
+| `rushingYards` | String | Net rushing yards gained. |
+| `rushingAttempts` | String | Rushing attempts. |
+| `yardsPerRushAttempt` | String | Yards gained per rushing attempt. |
 | `totalPenaltiesYards` | String |  |
 | `turnovers` | String | Turnovers total. |
 | `fumblesLost` | String |  |
@@ -667,45 +667,45 @@ Release: [espn_cfb_player_box](https://github.com/sportsdataverse/sportsdatavers
 
 | col_name | type | description |
 |---|---|---|
-| `completions/passingAttempts` | String |  |
-| `passingYards` | String |  |
-| `yardsPerPassAttempt` | String |  |
-| `passingTouchdowns` | String |  |
+| `completions/passingAttempts` | String | Completions and pass attempts, as ESPN's combined string. |
+| `passingYards` | String | Net passing yards gained. |
+| `yardsPerPassAttempt` | String | Yards gained per pass attempt. |
+| `passingTouchdowns` | String | Passing touchdowns. |
 | `interceptions` | String | Passing interceptions. |
-| `adjQBR` | String |  |
+| `adjQBR` | String | Adjusted Total QBR for the quarterback. |
 | `category` | String | CFBD stats category name (e.g. passing, rushing, defensive). |
 | `athlete_id` | Int64 | ESPN athlete id. |
 | `athlete_name` | String | Player full name. |
 | `jersey` | Null | Jersey number. |
 | `team_id` | Int64 | ESPN team id. |
-| `rushingAttempts` | String |  |
-| `rushingYards` | String |  |
-| `yardsPerRushAttempt` | String |  |
-| `rushingTouchdowns` | String |  |
-| `longRushing` | String |  |
+| `rushingAttempts` | String | Rushing attempts. |
+| `rushingYards` | String | Net rushing yards gained. |
+| `yardsPerRushAttempt` | String | Yards gained per rushing attempt. |
+| `rushingTouchdowns` | String | Rushing touchdowns. |
+| `longRushing` | String | Longest rush of the game, in yards. |
 | `receptions` | String | The number of pass receptions. Lateral receptions officially don't count as reception. |
-| `receivingYards` | String |  |
-| `yardsPerReception` | String |  |
-| `receivingTouchdowns` | String |  |
-| `longReception` | String |  |
-| `interceptionYards` | String |  |
-| `interceptionTouchdowns` | String |  |
-| `puntReturns` | String |  |
-| `puntReturnYards` | String |  |
-| `yardsPerPuntReturn` | String |  |
-| `longPuntReturn` | String |  |
-| `puntReturnTouchdowns` | String |  |
-| `fieldGoalsMade/fieldGoalAttempts` | String |  |
-| `fieldGoalPct` | String |  |
-| `longFieldGoalMade` | String |  |
-| `extraPointsMade/extraPointAttempts` | String |  |
-| `totalKickingPoints` | String |  |
-| `punts` | String |  |
-| `puntYards` | String |  |
-| `grossAvgPuntYards` | String |  |
-| `touchbacks` | String |  |
-| `puntsInside20` | String |  |
-| `longPunt` | String |  |
+| `receivingYards` | String | Receiving yards gained. |
+| `yardsPerReception` | String | Yards gained per reception. |
+| `receivingTouchdowns` | String | Receiving touchdowns. |
+| `longReception` | String | Longest reception of the game, in yards. |
+| `interceptionYards` | String | Yards returned on interceptions. |
+| `interceptionTouchdowns` | String | Touchdowns scored on interception returns. |
+| `puntReturns` | String | Punt returns attempted. |
+| `puntReturnYards` | String | Yards gained on punt returns. |
+| `yardsPerPuntReturn` | String | Yards gained per punt return. |
+| `longPuntReturn` | String | Longest punt return of the game, in yards. |
+| `puntReturnTouchdowns` | String | Touchdowns scored on punt returns. |
+| `fieldGoalsMade/fieldGoalAttempts` | String | Field goals made and attempted, as ESPN's combined string. |
+| `fieldGoalPct` | String | Field-goal percentage. |
+| `longFieldGoalMade` | String | Longest field goal made, in yards. |
+| `extraPointsMade/extraPointAttempts` | String | Extra points made and attempted, as ESPN's combined string. |
+| `totalKickingPoints` | String | Total points scored by kicking. |
+| `punts` | String | Punts attempted. |
+| `puntYards` | String | Total punt yards. |
+| `grossAvgPuntYards` | String | Gross average yards per punt, before return yardage. |
+| `touchbacks` | String | Punts or kickoffs that resulted in a touchback. |
+| `puntsInside20` | String | Punts downed inside the opponent 20-yard line. |
+| `longPunt` | String | Longest punt of the game, in yards. |
 | `game_id` | Int64 | ESPN game identifier. |
 | `season` | Int64 | Season (4-digit year). |
 | `stat_1` | String |  |
@@ -759,72 +759,72 @@ Release: [espn_cfb_play_participants](https://github.com/sportsdataverse/sportsd
 |---|---|---|
 | `game_id` | Int64 | ESPN game identifier. |
 | `play_id` | Int64 | ESPN play id. |
-| `kicker_player_name` | String | String name for the kicker on FG or kickoff. |
-| `returner_player_name` | String |  |
-| `passer_player_name` | String | Name of the passer on a passing play. |
-| `receiver_player_name` | String | Name of the receiver on a passing play. |
-| `rusher_player_name` | String | Name of the rusher on a rushing play. |
-| `penalized_player_name` | String |  |
-| `scorer_player_name` | String |  |
-| `pass_defender_player_name` | String |  |
-| `punter_player_name` | String | Name of the punter. |
-| `pat_scorer_player_name` | String |  |
-| `sacked_by_player_name` | String |  |
-| `kicker_player_id` | String | Unique identifier for the kicker on FG or kickoff. |
-| `returner_player_id` | String |  |
-| `passer_player_id` | String | Unique identifier for the player that attempted the pass. |
-| `receiver_player_id` | String | Unique identifier for the receiver that was targeted on the pass. |
-| `rusher_player_id` | String | Unique identifier for the player that attempted the run. |
-| `penalized_player_id` | String |  |
-| `scorer_player_id` | String |  |
-| `pass_defender_player_id` | String |  |
-| `punter_player_id` | String | Unique identifier for the punter. |
-| `pat_scorer_player_id` | String |  |
-| `sacked_by_player_id` | String |  |
-| `kicker_player_names` | String |  |
-| `returner_player_names` | String |  |
-| `passer_player_names` | String |  |
-| `receiver_player_names` | String |  |
-| `rusher_player_names` | String |  |
-| `penalized_player_names` | String |  |
-| `scorer_player_names` | String |  |
-| `pass_defender_player_names` | String |  |
-| `punter_player_names` | String |  |
-| `pat_scorer_player_names` | String |  |
-| `sacked_by_player_names` | String |  |
-| `kicker_player_ids` | String |  |
-| `returner_player_ids` | String |  |
-| `passer_player_ids` | String |  |
-| `receiver_player_ids` | String |  |
-| `rusher_player_ids` | String |  |
-| `penalized_player_ids` | String |  |
-| `scorer_player_ids` | String |  |
-| `pass_defender_player_ids` | String |  |
-| `punter_player_ids` | String |  |
-| `pat_scorer_player_ids` | String |  |
-| `sacked_by_player_ids` | String |  |
+| `kicker_player_name` | String | Display name of the kicker -- the FIRST participant in that role on the play. |
+| `returner_player_name` | String | Display name of the player returning the kick or punt -- the FIRST participant in that role on the play. |
+| `passer_player_name` | String | Display name of the passer -- the FIRST participant in that role on the play. |
+| `receiver_player_name` | String | Display name of the targeted receiver -- the FIRST participant in that role on the play. |
+| `rusher_player_name` | String | Display name of the ball carrier on a rush -- the FIRST participant in that role on the play. |
+| `penalized_player_name` | String | Display name of the penalized player -- the FIRST participant in that role on the play. |
+| `scorer_player_name` | String | Display name of the player credited with the score -- the FIRST participant in that role on the play. |
+| `pass_defender_player_name` | String | Display name of the defender credited with defending the pass -- the FIRST participant in that role on the play. |
+| `punter_player_name` | String | Display name of the punter -- the FIRST participant in that role on the play. |
+| `pat_scorer_player_name` | String | Display name of the player credited with the point-after score -- the FIRST participant in that role on the play. |
+| `sacked_by_player_name` | String | Display name of a defender credited with the sack -- the FIRST participant in that role on the play. |
+| `kicker_player_id` | String | ESPN athlete id of the kicker -- the FIRST participant in that role on the play. |
+| `returner_player_id` | String | ESPN athlete id of the player returning the kick or punt -- the FIRST participant in that role on the play. |
+| `passer_player_id` | String | ESPN athlete id of the passer -- the FIRST participant in that role on the play. |
+| `receiver_player_id` | String | ESPN athlete id of the targeted receiver -- the FIRST participant in that role on the play. |
+| `rusher_player_id` | String | ESPN athlete id of the ball carrier on a rush -- the FIRST participant in that role on the play. |
+| `penalized_player_id` | String | ESPN athlete id of the penalized player -- the FIRST participant in that role on the play. |
+| `scorer_player_id` | String | ESPN athlete id of the player credited with the score -- the FIRST participant in that role on the play. |
+| `pass_defender_player_id` | String | ESPN athlete id of the defender credited with defending the pass -- the FIRST participant in that role on the play. |
+| `punter_player_id` | String | ESPN athlete id of the punter -- the FIRST participant in that role on the play. |
+| `pat_scorer_player_id` | String | ESPN athlete id of the player credited with the point-after score -- the FIRST participant in that role on the play. |
+| `sacked_by_player_id` | String | ESPN athlete id of a defender credited with the sack -- the FIRST participant in that role on the play. |
+| `kicker_player_names` | String | List of the display names of EVERY participant credited as the kicker on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
+| `returner_player_names` | String | List of the display names of EVERY participant credited as the player returning the kick or punt on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
+| `passer_player_names` | String | List of the display names of EVERY participant credited as the passer on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
+| `receiver_player_names` | String | List of the display names of EVERY participant credited as the targeted receiver on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
+| `rusher_player_names` | String | List of the display names of EVERY participant credited as the ball carrier on a rush on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
+| `penalized_player_names` | String | List of the display names of EVERY participant credited as the penalized player on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
+| `scorer_player_names` | String | List of the display names of EVERY participant credited as the player credited with the score on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
+| `pass_defender_player_names` | String | List of the display names of EVERY participant credited as the defender credited with defending the pass on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
+| `punter_player_names` | String | List of the display names of EVERY participant credited as the punter on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
+| `pat_scorer_player_names` | String | List of the display names of EVERY participant credited as the player credited with the point-after score on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
+| `sacked_by_player_names` | String | List of the display names of EVERY participant credited as a defender credited with the sack on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
+| `kicker_player_ids` | String | List of the athlete ids of EVERY participant credited as the kicker on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
+| `returner_player_ids` | String | List of the athlete ids of EVERY participant credited as the player returning the kick or punt on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
+| `passer_player_ids` | String | List of the athlete ids of EVERY participant credited as the passer on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
+| `receiver_player_ids` | String | List of the athlete ids of EVERY participant credited as the targeted receiver on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
+| `rusher_player_ids` | String | List of the athlete ids of EVERY participant credited as the ball carrier on a rush on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
+| `penalized_player_ids` | String | List of the athlete ids of EVERY participant credited as the penalized player on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
+| `scorer_player_ids` | String | List of the athlete ids of EVERY participant credited as the player credited with the score on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
+| `pass_defender_player_ids` | String | List of the athlete ids of EVERY participant credited as the defender credited with defending the pass on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
+| `punter_player_ids` | String | List of the athlete ids of EVERY participant credited as the punter on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
+| `pat_scorer_player_ids` | String | List of the athlete ids of EVERY participant credited as the player credited with the point-after score on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
+| `sacked_by_player_ids` | String | List of the athlete ids of EVERY participant credited as a defender credited with the sack on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
 | `season` | Int64 | Season (4-digit year). |
 | `week` | Int64 | Game week of the season. |
-| `recoverer_player_name` | String |  |
-| `recoverer_player_id` | String |  |
-| `recoverer_player_names` | String |  |
-| `recoverer_player_ids` | String |  |
-| `tackler_player_name` | String |  |
-| `assisted_by_player_name` | String |  |
-| `forced_by_player_name` | String |  |
-| `tackler_player_id` | String |  |
-| `assisted_by_player_id` | String |  |
-| `forced_by_player_id` | String |  |
-| `tackler_player_names` | String |  |
-| `assisted_by_player_names` | String |  |
-| `forced_by_player_names` | String |  |
-| `tackler_player_ids` | String |  |
-| `assisted_by_player_ids` | String |  |
-| `forced_by_player_ids` | String |  |
-| `pat_passer_player_name` | String |  |
-| `pat_passer_player_id` | String |  |
-| `pat_passer_player_names` | String |  |
-| `pat_passer_player_ids` | String |  |
+| `recoverer_player_name` | String | Display name of the player who recovered the fumble -- the FIRST participant in that role on the play. |
+| `recoverer_player_id` | String | ESPN athlete id of the player who recovered the fumble -- the FIRST participant in that role on the play. |
+| `recoverer_player_names` | String | List of the display names of EVERY participant credited as the player who recovered the fumble on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
+| `recoverer_player_ids` | String | List of the athlete ids of EVERY participant credited as the player who recovered the fumble on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
+| `tackler_player_name` | String | Display name of a defender credited with the tackle -- the FIRST participant in that role on the play. |
+| `assisted_by_player_name` | String | Display name of a defender credited with an assisted tackle -- the FIRST participant in that role on the play. |
+| `forced_by_player_name` | String | Display name of the defender who forced the fumble -- the FIRST participant in that role on the play. |
+| `tackler_player_id` | String | ESPN athlete id of a defender credited with the tackle -- the FIRST participant in that role on the play. |
+| `assisted_by_player_id` | String | ESPN athlete id of a defender credited with an assisted tackle -- the FIRST participant in that role on the play. |
+| `forced_by_player_id` | String | ESPN athlete id of the defender who forced the fumble -- the FIRST participant in that role on the play. |
+| `tackler_player_names` | String | List of the display names of EVERY participant credited as a defender credited with the tackle on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
+| `assisted_by_player_names` | String | List of the display names of EVERY participant credited as a defender credited with an assisted tackle on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
+| `forced_by_player_names` | String | List of the display names of EVERY participant credited as the defender who forced the fumble on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
+| `tackler_player_ids` | String | List of the athlete ids of EVERY participant credited as a defender credited with the tackle on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
+| `assisted_by_player_ids` | String | List of the athlete ids of EVERY participant credited as a defender credited with an assisted tackle on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
+| `forced_by_player_ids` | String | List of the athlete ids of EVERY participant credited as the defender who forced the fumble on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
+| `pat_passer_player_name` | String | Display name of the passer on the point-after attempt -- the FIRST participant in that role on the play. |
+| `pat_passer_player_id` | String | ESPN athlete id of the passer on the point-after attempt -- the FIRST participant in that role on the play. |
+| `pat_passer_player_names` | String | List of the display names of EVERY participant credited as the passer on the point-after attempt on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
+| `pat_passer_player_ids` | String | List of the athlete ids of EVERY participant credited as the passer on the point-after attempt on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one. |
 
 ```python
 load_cfb_play_participants(seasons=2024)
@@ -1067,35 +1067,35 @@ Release: [espn_cfb_adv_passing](https://github.com/sportsdataverse/sportsdataver
 
 | col_name | type | description |
 |---|---|---|
-| `pos_team_id` | Int64 |  |
+| `pos_team_id` | Int64 | ESPN team id of the team on offense. Present for every season 2004+. |
 | `pos_team` | String | Team name in possession at the start of the play (offense, kickoff-aware). |
-| `passer_player_name` | String | Name of the passer on a passing play. |
-| `Comp` | Int64 |  |
-| `Att` | Int64 |  |
-| `xComp` | Float64 |  |
-| `Yds` | Float64 |  |
-| `Pass_TD` | Int64 |  |
-| `Int` | Int64 |  |
-| `YPA` | Float64 |  |
+| `passer_player_name` | String | Display name of the passer -- the FIRST participant in that role on the play. |
+| `Comp` | Int64 | Completed passes recorded in the advanced box score. |
+| `Att` | Int64 | Pass attempts recorded in the advanced box score. |
+| `xComp` | Float64 | Expected completions, summed from the per-play completion model. |
+| `Yds` | Float64 | Passing yards from the advanced box score. |
+| `Pass_TD` | Int64 | Passing touchdowns. |
+| `Int` | Int64 | Interceptions thrown. |
+| `YPA` | Float64 | Yards per pass attempt. |
 | `EPA` | Float64 | Expected Points Added on the play (cfbfastR EPA model output). |
-| `EPA_per_Play` | Float64 |  |
+| `EPA_per_Play` | Float64 | EPA per play on the passer's plays. |
 | `WPA` | Float64 | Win Probability Added. |
-| `SR` | Float64 |  |
-| `Sck` | Int64 |  |
-| `CompPct` | Float64 |  |
-| `xCompPct` | Float64 |  |
-| `CPOE` | Float64 |  |
-| `qbr_epa` | Float64 |  |
-| `sack_epa` | Float64 |  |
-| `pass_epa` | Float64 |  |
-| `rush_epa` | Float64 |  |
-| `pen_epa` | Float64 |  |
+| `SR` | Float64 | Success rate on the passer's plays. |
+| `Sck` | Int64 | Times the passer was sacked. |
+| `CompPct` | Float64 | Completion percentage from the advanced box score. |
+| `xCompPct` | Float64 | Expected completion percentage from the per-play completion model. |
+| `CPOE` | Float64 | Completion percentage over expected -- actual minus modelled completion rate. |
+| `qbr_epa` | Float64 | EPA variant used as an input to the QBR calculation. |
+| `sack_epa` | Float64 | EPA credited to the player's sacks taken. |
+| `pass_epa` | Float64 | EPA credited to the player's pass plays. |
+| `rush_epa` | Float64 | EPA credited to the player's rush plays. |
+| `pen_epa` | Float64 | EPA attributable to penalties on the player's plays. |
 | `spread` | Float64 | Pre-game point spread from the selected provider. |
-| `era0` | Int64 |  |
-| `era1` | Int64 |  |
-| `era2` | Int64 |  |
-| `era3` | Int64 |  |
-| `exp_qbr` | Float64 |  |
+| `era0` | Int64 | Rule-era indicator for the earliest modelled era. |
+| `era1` | Int64 | Rule-era indicator for the second modelled era. |
+| `era2` | Int64 | Rule-era indicator for the third modelled era. |
+| `era3` | Int64 | Rule-era indicator for the most recent modelled era. |
+| `exp_qbr` | Float64 | Expected QBR for the passer. |
 | `game_id` | Int64 | ESPN game identifier. |
 | `season` | Int64 | Season (4-digit year). |
 | `week` | Int64 | Game week of the season. |
@@ -1111,17 +1111,17 @@ Release: [espn_cfb_adv_rushing](https://github.com/sportsdataverse/sportsdataver
 
 | col_name | type | description |
 |---|---|---|
-| `pos_team_id` | Int64 |  |
+| `pos_team_id` | Int64 | ESPN team id of the team on offense. Present for every season 2004+. |
 | `pos_team` | String | Team name in possession at the start of the play (offense, kickoff-aware). |
-| `rusher_player_name` | String | Name of the rusher on a rushing play. |
+| `rusher_player_name` | String | Display name of the ball carrier on a rush -- the FIRST participant in that role on the play. |
 | `Car` | Int64 |  |
-| `Yds` | Float64 |  |
+| `Yds` | Float64 | Passing yards from the advanced box score. |
 | `Rush_TD` | Int64 |  |
 | `YPC` | Float64 |  |
 | `EPA` | Float64 | Expected Points Added on the play (cfbfastR EPA model output). |
-| `EPA_per_Play` | Float64 |  |
+| `EPA_per_Play` | Float64 | EPA per play on the passer's plays. |
 | `WPA` | Float64 | Win Probability Added. |
-| `SR` | Float64 |  |
+| `SR` | Float64 | Success rate on the passer's plays. |
 | `Fum` | Int64 |  |
 | `Fum_Lost` | Int64 |  |
 | `game_id` | Int64 | ESPN game identifier. |
@@ -1139,18 +1139,18 @@ Release: [espn_cfb_adv_receiving](https://github.com/sportsdataverse/sportsdatav
 
 | col_name | type | description |
 |---|---|---|
-| `pos_team_id` | Int64 |  |
+| `pos_team_id` | Int64 | ESPN team id of the team on offense. Present for every season 2004+. |
 | `pos_team` | String | Team name in possession at the start of the play (offense, kickoff-aware). |
-| `receiver_player_name` | String | Name of the receiver on a passing play. |
+| `receiver_player_name` | String | Display name of the targeted receiver -- the FIRST participant in that role on the play. |
 | `Rec` | Int64 |  |
 | `Tar` | Int64 |  |
-| `Yds` | Float64 |  |
+| `Yds` | Float64 | Passing yards from the advanced box score. |
 | `Rec_TD` | Int64 |  |
 | `YPT` | Float64 |  |
 | `EPA` | Float64 | Expected Points Added on the play (cfbfastR EPA model output). |
-| `EPA_per_Play` | Float64 |  |
+| `EPA_per_Play` | Float64 | EPA per play on the passer's plays. |
 | `WPA` | Float64 | Win Probability Added. |
-| `SR` | Float64 |  |
+| `SR` | Float64 | Success rate on the passer's plays. |
 | `Fum` | Int64 |  |
 | `Fum_Lost` | Int64 |  |
 | `game_id` | Int64 | ESPN game identifier. |
@@ -1170,7 +1170,7 @@ Release: [espn_cfb_adv_defensive](https://github.com/sportsdataverse/sportsdatav
 |---|---|---|
 | `def_pos_team_id` | Int64 |  |
 | `def_pos_team` | String | Team name on defense at the start of the play. |
-| `scrimmage_plays` | Int64 |  |
+| `scrimmage_plays` | Int64 | Number of plays from scrimmage (rushes plus passes), excluding special teams. |
 | `TFL` | Int64 |  |
 | `TFL_pass` | Int64 |  |
 | `TFL_rush` | Int64 |  |
@@ -1228,7 +1228,7 @@ Release: [espn_cfb_adv_drives](https://github.com/sportsdataverse/sportsdatavers
 
 | col_name | type | description |
 |---|---|---|
-| `pos_team_id` | Int64 |  |
+| `pos_team_id` | Int64 | ESPN team id of the team on offense. Present for every season 2004+. |
 | `pos_team` | String | Team name in possession at the start of the play (offense, kickoff-aware). |
 | `drive_total_available_yards` | Float64 |  |
 | `drive_total_gained_yards` | Int64 |  |
@@ -1338,10 +1338,10 @@ Release: [espn_cfb_adv_specialists](https://github.com/sportsdataverse/sportsdat
 
 | col_name | type | description |
 |---|---|---|
-| `pos_team_id` | Int64 |  |
+| `pos_team_id` | Int64 | ESPN team id of the team on offense. Present for every season 2004+. |
 | `pos_team` | String | Team name in possession at the start of the play (offense, kickoff-aware). |
 | `player_name` | String | Player name. |
-| `punts` | Int64 |  |
+| `punts` | Int64 | Punts attempted. |
 | `punts_yards` | Int64 |  |
 | `kick_returns` | Int64 | Number of kick returns. |
 | `kick_returns_yards` | Int64 |  |
@@ -1350,7 +1350,7 @@ Release: [espn_cfb_adv_specialists](https://github.com/sportsdataverse/sportsdat
 | `game_id` | Int64 | ESPN game identifier. |
 | `season` | Int64 | Season (4-digit year). |
 | `week` | Int64 | Game week of the season. |
-| `field_goals` | Int64 |  |
+| `field_goals` | Int64 | Number of field-goal attempts. |
 | `field_goals_yards` | Int64 |  |
 
 ```python
@@ -1364,11 +1364,11 @@ Release: [espn_cfb_adv_turnover](https://github.com/sportsdataverse/sportsdatave
 
 | col_name | type | description |
 |---|---|---|
-| `pos_team_id` | Int64 |  |
+| `pos_team_id` | Int64 | ESPN team id of the team on offense. Present for every season 2004+. |
 | `pos_team` | String | Team name in possession at the start of the play (offense, kickoff-aware). |
 | `turnovers` | Int64 | Turnovers total. |
 | `st_turnovers_lost` | Int64 |  |
-| `Int` | Int64 |  |
+| `Int` | Int64 | Interceptions thrown. |
 | `fumbles_lost` | Int64 | Fumbles lost. |
 | `pass_breakups` | Int64 |  |
 | `total_fumbles` | Int64 | Team total fumbles. |
@@ -1429,20 +1429,20 @@ Release: [espn_cfb_model_pbp](https://github.com/sportsdataverse/sportsdataverse
 | `completion` | Boolean | Binary flag for a completed pass. |
 | `scoring_play` | Boolean | `TRUE` if the play resulted in a score. |
 | `statYardage` | Int64 |  |
-| `passer_player_name` | String | Name of the passer on a passing play. |
+| `passer_player_name` | String | Display name of the passer -- the FIRST participant in that role on the play. |
 | `ep_before` | Float64 | Expected points value before the play (cfbfastR EPA model). |
 | `ep_after` | Float64 | Expected points value after the play (cfbfastR EPA model). |
 | `epa` | Float64 | Expected points added (EPA) by the posteam for the given play. |
 | `wp_before` | Float64 | Win probability for the possession team before the play (0-1). |
 | `wp_after` | Float64 | Win probability for the possession team after the play (0-1). |
 | `wpa` | Float64 | Win Probability Added on the play (cfbfastR WP model output). |
-| `completion_prob` | Float64 |  |
+| `completion_prob` | Float64 | Modelled probability the pass is completed. |
 | `cpoe` | Float64 | For a single pass play this is 1 - cp when the pass was completed or 0 - cp when the pass was incomplete. Analyzed for a whole game or season an indicator for the passer how much over or under expectation his completion percentage was. |
-| `model_pbp_version` | String |  |
-| `cp_model_version` | String |  |
-| `ep_model_version` | String |  |
-| `wp_model_version` | String |  |
-| `scored_date` | String |  |
+| `model_pbp_version` | String | Version of the model-scored play-by-play build. |
+| `cp_model_version` | String | Version of the completion-probability model that scored the play. |
+| `ep_model_version` | String | Version of the expected-points model that scored the play. |
+| `wp_model_version` | String | Version of the win-probability model that scored the play. |
+| `scored_date` | String | Date on which the play was scored by the models. |
 
 ```python
 load_cfb_model_pbp(seasons=2024)
@@ -1461,43 +1461,43 @@ Release: [espn_cfb_passing](https://github.com/sportsdataverse/sportsdataverse-d
 | `conference` | String | Conference of the team. |
 | `season` | Int64 | Season (4-digit year). |
 | `player_id` | Int64 | ESPN player id from the roster entry. |
-| `passer_player_name` | String | Name of the passer on a passing play. |
+| `passer_player_name` | String | Display name of the passer -- the FIRST participant in that role on the play. |
 | `plays` | UInt32 | Total qualifying passing plays included in the WEPA calculation. |
 | `games` | UInt32 | Number of games included in the ATS summary. |
-| `team_games` | UInt32 |  |
-| `playsgame` | Float64 |  |
-| `TEPA` | Float64 |  |
-| `EPAplay` | Float64 |  |
-| `EPAgame` | Float64 |  |
+| `team_games` | UInt32 | Games the team played, used as the per-game denominator. |
+| `playsgame` | Float64 | Plays per game. |
+| `TEPA` | Float64 | Total EPA summed over every play. |
+| `EPAplay` | Float64 | EPA generated per play. |
+| `EPAgame` | Float64 | EPA generated per game. |
 | `yards` | Int64 | Total yards gained on the drive. |
-| `yardsplay` | Float64 |  |
-| `yardsgame` | Float64 |  |
-| `success` | Float64 | Binary success-rate flag using the 50/70/100 percent down-state thresholds. |
-| `comp` | Float64 |  |
-| `att` | Float64 |  |
-| `comppct` | Float64 |  |
+| `yardsplay` | Float64 | Yards per play. |
+| `yardsgame` | Float64 | Yards per game. |
+| `success` | Float64 | Success rate across the team plays. |
+| `comp` | Float64 | Completed passes. |
+| `att` | Float64 | Pass attempts thrown. |
+| `comppct` | Float64 | Completion percentage. |
 | `passing_td` | Float64 | Passing touchdowns thrown. |
-| `sacked` | UInt32 |  |
-| `sack_yds` | Int64 |  |
-| `pass_int` | UInt32 |  |
-| `detmer` | Float64 |  |
-| `detmergame` | Float64 |  |
-| `dropbacks` | Float64 |  |
-| `sack_adj_yards` | Int64 |  |
-| `yardsdropback` | Float64 |  |
-| `TEPA_rank` | Float64 |  |
-| `EPAgame_rank` | Float64 |  |
-| `EPAplay_rank` | Float64 |  |
-| `success_rank` | Float64 |  |
-| `comppct_rank` | Float64 |  |
-| `yards_rank` | Float64 |  |
-| `yardsplay_rank` | Float64 |  |
-| `yardsgame_rank` | Float64 |  |
-| `sack_adj_yards_rank` | Float64 |  |
-| `yardsdropback_rank` | Float64 |  |
-| `detmer_rank` | Float64 |  |
-| `detmergame_rank` | Float64 |  |
-| `fbs_class` | String |  |
+| `sacked` | UInt32 | Times the passer was sacked. |
+| `sack_yds` | Int64 | Yards lost to sacks. |
+| `pass_int` | UInt32 | Interceptions thrown. |
+| `detmer` | Float64 | Detmer rating -- the composite passing-efficiency measure this pipeline publishes, named for the college passing-efficiency tradition. |
+| `detmergame` | Float64 | Detmer rating expressed per game. |
+| `dropbacks` | Float64 | Dropbacks taken by the passer. |
+| `sack_adj_yards` | Int64 | Passing yards adjusted for sack yardage lost. |
+| `yardsdropback` | Float64 | Yards per dropback. |
+| `TEPA_rank` | Float64 | National rank of the team's total EPA summed over every play, where 1 is best. |
+| `EPAgame_rank` | Float64 | National rank of the team's EPA generated per game, where 1 is best. |
+| `EPAplay_rank` | Float64 | National rank of the team's EPA generated per play, where 1 is best. |
+| `success_rank` | Float64 | National rank of the team's success rate across the team plays, where 1 is best. |
+| `comppct_rank` | Float64 | National rank of the team's completion percentage, where 1 is best. |
+| `yards_rank` | Float64 | National rank of the team's total yards, where 1 is best. |
+| `yardsplay_rank` | Float64 | National rank of the team's yards per play, where 1 is best. |
+| `yardsgame_rank` | Float64 | National rank of the team's yards per game, where 1 is best. |
+| `sack_adj_yards_rank` | Float64 | National rank of the team's passing yards adjusted for sack yardage lost, where 1 is best. |
+| `yardsdropback_rank` | Float64 | National rank of the team's yards per dropback, where 1 is best. |
+| `detmer_rank` | Float64 | National rank of the team's detmer rating -- the composite passing-efficiency measure this pipeline publishes, named for the college passing-efficiency tradition, where 1 is best. |
+| `detmergame_rank` | Float64 | National rank of the team's detmer rating expressed per game, where 1 is best. |
+| `fbs_class` | String | Power/Group classification for the season: P4 or G6 from 2024 on, P5 or G5 through 2023, derived from conference membership. Null for teams outside FBS. |
 
 ```python
 load_cfb_passing(seasons=2024)
@@ -1510,33 +1510,33 @@ Release: [espn_cfb_percentiles](https://github.com/sportsdataverse/sportsdataver
 
 | col_name | type | description |
 |---|---|---|
-| `pctile` | Float64 |  |
-| `GEI` | Float64 |  |
-| `EPAplay` | Float64 |  |
-| `pass_success` | Float64 |  |
-| `rush_success` | Float64 |  |
-| `early_down_success` | Float64 |  |
-| `early_down_EPA` | Float64 |  |
-| `late_down_success` | Float64 |  |
-| `success` | Float64 | Binary success-rate flag using the 50/70/100 percent down-state thresholds. |
-| `yardsplay` | Float64 |  |
-| `dropbacks` | Float64 |  |
-| `rushes` | Float64 |  |
-| `EPAdropback` | Float64 |  |
-| `EPArush` | Float64 |  |
-| `yardsdropback` | Float64 |  |
-| `pass_explosive` | Float64 |  |
-| `rush_explosive` | Float64 |  |
-| `explosive` | Float64 |  |
-| `third_down_success` | Float64 |  |
-| `red_zone_success` | Float64 |  |
-| `play_stuffed` | Float64 |  |
-| `nonExplosiveEpaPerPlay` | Float64 |  |
-| `havoc` | Float64 |  |
-| `yardsrush` | Float64 |  |
-| `lineyards` | Float64 |  |
-| `opportunity_run` | Float64 |  |
-| `third_down_distance` | Float64 |  |
+| `pctile` | Float64 | Percentile bucket the row reports, from 0 to 100. |
+| `GEI` | Float64 | Value of game excitement index at the percentile this row reports. |
+| `EPAplay` | Float64 | Value of EPA generated per play at the percentile this row reports. |
+| `pass_success` | Float64 | Value of success rate on pass plays at the percentile this row reports. |
+| `rush_success` | Float64 | Value of success rate on rush plays at the percentile this row reports. |
+| `early_down_success` | Float64 | Value of success rate on early downs at the percentile this row reports. |
+| `early_down_EPA` | Float64 | Value of EPA per early-down play at the percentile this row reports. |
+| `late_down_success` | Float64 | Value of success rate on late downs at the percentile this row reports. |
+| `success` | Float64 | Value of success rate across the team plays at the percentile this row reports. |
+| `yardsplay` | Float64 | Value of yards per play at the percentile this row reports. |
+| `dropbacks` | Float64 | Value of dropbacks taken by the passer at the percentile this row reports. |
+| `rushes` | Float64 | Value of rushing attempts at the percentile this row reports. |
+| `EPAdropback` | Float64 | Value of EPA generated per dropback at the percentile this row reports. |
+| `EPArush` | Float64 | Value of EPA generated per rushing attempt at the percentile this row reports. |
+| `yardsdropback` | Float64 | Value of yards per dropback at the percentile this row reports. |
+| `pass_explosive` | Float64 | Value of explosive-play rate on pass plays at the percentile this row reports. |
+| `rush_explosive` | Float64 | Value of explosive-play rate on rush plays at the percentile this row reports. |
+| `explosive` | Float64 | Value of explosive-play rate at the percentile this row reports. |
+| `third_down_success` | Float64 | Value of success rate on third down at the percentile this row reports. |
+| `red_zone_success` | Float64 | Value of success rate in the red zone at the percentile this row reports. |
+| `play_stuffed` | Float64 | Value of stuffed-play rate at the percentile this row reports. |
+| `nonExplosiveEpaPerPlay` | Float64 | Value of EPA per play excluding explosive plays at the percentile this row reports. |
+| `havoc` | Float64 | Value of havoc rate at the percentile this row reports. |
+| `yardsrush` | Float64 | Value of yards per rush at the percentile this row reports. |
+| `lineyards` | Float64 | Value of line yards per rush at the percentile this row reports. |
+| `opportunity_run` | Float64 | Value of opportunity-run rate at the percentile this row reports. |
+| `third_down_distance` | Float64 | Value of average yards to go on third down at the percentile this row reports. |
 
 ```python
 load_cfb_percentiles(seasons=2024)
@@ -1555,32 +1555,32 @@ Release: [espn_cfb_receiving](https://github.com/sportsdataverse/sportsdataverse
 | `conference` | String | Conference of the team. |
 | `season` | Int64 | Season (4-digit year). |
 | `player_id` | Int64 | ESPN player id from the roster entry. |
-| `receiver_player_name` | String | Name of the receiver on a passing play. |
+| `receiver_player_name` | String | Display name of the targeted receiver -- the FIRST participant in that role on the play. |
 | `plays` | UInt32 | Total qualifying passing plays included in the WEPA calculation. |
 | `games` | UInt32 | Number of games included in the ATS summary. |
-| `team_games` | UInt32 |  |
-| `playsgame` | Float64 |  |
-| `TEPA` | Float64 |  |
-| `EPAplay` | Float64 |  |
-| `EPAgame` | Float64 |  |
+| `team_games` | UInt32 | Games the team played, used as the per-game denominator. |
+| `playsgame` | Float64 | Plays per game. |
+| `TEPA` | Float64 | Total EPA summed over every play. |
+| `EPAplay` | Float64 | EPA generated per play. |
+| `EPAgame` | Float64 | EPA generated per game. |
 | `yards` | Int64 | Total yards gained on the drive. |
-| `yardsplay` | Float64 |  |
-| `yardsgame` | Float64 |  |
-| `success` | Float64 | Binary success-rate flag using the 50/70/100 percent down-state thresholds. |
-| `comp` | UInt32 |  |
+| `yardsplay` | Float64 | Yards per play. |
+| `yardsgame` | Float64 | Yards per game. |
+| `success` | Float64 | Success rate across the team plays. |
+| `comp` | UInt32 | Completed passes. |
 | `targets` | UInt32 | The number of pass plays where the player was the targeted receiver. |
 | `catchpct` | Float64 |  |
 | `passing_td` | Float64 | Passing touchdowns thrown. |
 | `fumbles` | Float64 |  |
-| `TEPA_rank` | Float64 |  |
-| `EPAgame_rank` | Float64 |  |
-| `EPAplay_rank` | Float64 |  |
-| `success_rank` | Float64 |  |
+| `TEPA_rank` | Float64 | National rank of the team's total EPA summed over every play, where 1 is best. |
+| `EPAgame_rank` | Float64 | National rank of the team's EPA generated per game, where 1 is best. |
+| `EPAplay_rank` | Float64 | National rank of the team's EPA generated per play, where 1 is best. |
+| `success_rank` | Float64 | National rank of the team's success rate across the team plays, where 1 is best. |
 | `catchpct_rank` | Float64 |  |
-| `yards_rank` | Float64 |  |
-| `yardsplay_rank` | Float64 |  |
-| `yardsgame_rank` | Float64 |  |
-| `fbs_class` | String |  |
+| `yards_rank` | Float64 | National rank of the team's total yards, where 1 is best. |
+| `yardsplay_rank` | Float64 | National rank of the team's yards per play, where 1 is best. |
+| `yardsgame_rank` | Float64 | National rank of the team's yards per game, where 1 is best. |
+| `fbs_class` | String | Power/Group classification for the season: P4 or G6 from 2024 on, P5 or G5 through 2023, derived from conference membership. Null for teams outside FBS. |
 
 ```python
 load_cfb_receiving(seasons=2024)
@@ -1599,28 +1599,28 @@ Release: [espn_cfb_rushing](https://github.com/sportsdataverse/sportsdataverse-d
 | `conference` | String | Conference of the team. |
 | `season` | Int64 | Season (4-digit year). |
 | `player_id` | Int64 | ESPN player id from the roster entry. |
-| `rusher_player_name` | String | Name of the rusher on a rushing play. |
+| `rusher_player_name` | String | Display name of the ball carrier on a rush -- the FIRST participant in that role on the play. |
 | `plays` | UInt32 | Total qualifying passing plays included in the WEPA calculation. |
 | `games` | UInt32 | Number of games included in the ATS summary. |
-| `team_games` | UInt32 |  |
-| `playsgame` | Float64 |  |
-| `TEPA` | Float64 |  |
-| `EPAplay` | Float64 |  |
-| `EPAgame` | Float64 |  |
+| `team_games` | UInt32 | Games the team played, used as the per-game denominator. |
+| `playsgame` | Float64 | Plays per game. |
+| `TEPA` | Float64 | Total EPA summed over every play. |
+| `EPAplay` | Float64 | EPA generated per play. |
+| `EPAgame` | Float64 | EPA generated per game. |
 | `yards` | Int64 | Total yards gained on the drive. |
-| `yardsplay` | Float64 |  |
-| `yardsgame` | Float64 |  |
-| `success` | Float64 | Binary success-rate flag using the 50/70/100 percent down-state thresholds. |
+| `yardsplay` | Float64 | Yards per play. |
+| `yardsgame` | Float64 | Yards per game. |
+| `success` | Float64 | Success rate across the team plays. |
 | `rushing_td` | Float64 | Rushing touchdowns. |
 | `fumbles` | Float64 |  |
-| `TEPA_rank` | Float64 |  |
-| `EPAgame_rank` | Float64 |  |
-| `EPAplay_rank` | Float64 |  |
-| `success_rank` | Float64 |  |
-| `yards_rank` | Float64 |  |
-| `yardsplay_rank` | Float64 |  |
-| `yardsgame_rank` | Float64 |  |
-| `fbs_class` | String |  |
+| `TEPA_rank` | Float64 | National rank of the team's total EPA summed over every play, where 1 is best. |
+| `EPAgame_rank` | Float64 | National rank of the team's EPA generated per game, where 1 is best. |
+| `EPAplay_rank` | Float64 | National rank of the team's EPA generated per play, where 1 is best. |
+| `success_rank` | Float64 | National rank of the team's success rate across the team plays, where 1 is best. |
+| `yards_rank` | Float64 | National rank of the team's total yards, where 1 is best. |
+| `yardsplay_rank` | Float64 | National rank of the team's yards per play, where 1 is best. |
+| `yardsgame_rank` | Float64 | National rank of the team's yards per game, where 1 is best. |
+| `fbs_class` | String | Power/Group classification for the season: P4 or G6 from 2024 on, P5 or G5 through 2023, derived from conference membership. Null for teams outside FBS. |
 
 ```python
 load_cfb_rushing(seasons=2024)

--- a/docs/docs/cfb/reference/loaders.md
+++ b/docs/docs/cfb/reference/loaders.md
@@ -273,7 +273,7 @@ Release: [espn_cfb_pbp](https://github.com/sportsdataverse/sportsdataverse-data/
 | `scoring_opp` | Boolean | Binary flag for a scoring opportunity (yards_to_goal <= 40). |
 | `stuffed_run` | Boolean | Binary flag for a stuffed run (zero or negative yards gained). |
 | `stopped_run` | Boolean | True when the rush was stopped at or behind the line of scrimmage. |
-| `opportunity_run` | Boolean | True when the play is a rush gaining 4 yards or fewer. Note this is the inverse of the conventional 'opportunity' definition (a carry gaining 4 or more). |
+| `opportunity_run` | Boolean | True when a rush reached 4 yards -- the carries on which the blocking did its job. Matches cfbfastR's espn_cfb_15 definition. Assets published before the 2026-08 fix carry the inverted (4 yards or fewer) flag. |
 | `highlight_run` | Boolean | True when the rush gained 8 or more yards. |
 | `short_rush_success` | Boolean | True when a short-yardage rush gained the yardage needed. |
 | `short_rush_attempt` | Boolean | True when the play is a rush in a short-yardage situation. |
@@ -374,7 +374,7 @@ Release: [espn_cfb_pbp](https://github.com/sportsdataverse/sportsdataverse-data/
 | `second_level_yards` | Float64 | Rushing yards earned from 4 to 8, split evenly between line and carrier under the line-yards decomposition. |
 | `open_field_yards` | Int32 | Rushing yards gained beyond 8, credited to the ball carrier rather than the line. |
 | `highlight_yards` | Float64 | Second-level plus open-field yards -- the yardage credited to the carrier. |
-| `opp_highlight_yards` | Float64 | Highlight yards on opportunity runs. DEGENERATE: this column is 0 in every published row, because its gate requires a rush of 4 yards or fewer while highlight yards only accrue at 4 or more. Do not use it as a signal. |
+| `opp_highlight_yards` | Float64 | Highlight yards earned on opportunity runs, isolating carrier production on carries where the blocking succeeded. Assets published before the 2026-08 fix are identically 0 here, because the inverted opportunity_run gate could never co-occur with non-zero highlight yards. |
 | `lag_EP_end` | Float64 | Value of EP_end on the previous play, used for sequence-aware derivations. |
 | `EP_between` | Float64 | Change in expected points across the play, before penalty adjustment. |
 | `EPA_rush` | Float64 | EPA credited to the play on rush plays. |

--- a/docs/docs/cfb/reference/loaders.md
+++ b/docs/docs/cfb/reference/loaders.md
@@ -225,7 +225,7 @@ Release: [espn_cfb_pbp](https://github.com/sportsdataverse/sportsdataverse-data/
 | `end.pos_score_diff` | Int32 | ESPN's `pos_score_diff` value for the play state at the end of the play. |
 | `lag_pos_team` | Int32 | Value of pos_team on the previous play, used for sequence-aware derivations. |
 | `lead_pos_team` | Int32 | Value of pos_team on the next play, used for sequence-aware derivations. |
-| `lead_pos_team2` | Int32 | Value of pos_team on the next 2 plays play, used for sequence-aware derivations. |
+| `lead_pos_team2` | Int32 | Value of pos_team 2 plays ahead, used for sequence-aware derivations. |
 | `pos_score_diff` | Int32 | Score differential from the possession team's perspective. |
 | `lag_pos_score_diff` | Int32 | Value of pos_score_diff on the previous play, used for sequence-aware derivations. |
 | `pos_score_pts` | Int32 | Points scored on the play attributed to the possession team. |
@@ -339,7 +339,7 @@ Release: [espn_cfb_pbp](https://github.com/sportsdataverse/sportsdataverse-data/
 | `home_wp_before` | Float64 | Home team win probability before the play (0-1). |
 | `away_wp_before` | Float64 | Away team win probability before the play (0-1). |
 | `lead_wp_before` | Float64 | Value of wp_before on the next play, used for sequence-aware derivations. |
-| `lead_wp_before2` | Float64 | Value of wp_before on the next 2 plays play, used for sequence-aware derivations. |
+| `lead_wp_before2` | Float64 | Value of wp_before 2 plays ahead, used for sequence-aware derivations. |
 | `wp_after` | Float64 | Win probability for the possession team after the play (0-1). |
 | `def_wp_after` | Float64 | Win probability for the defensive team after the play (0-1). |
 | `home_wp_after` | Float64 | Home team win probability after the play (0-1). |
@@ -982,8 +982,8 @@ Release: [espn_cfb_adv_team](https://github.com/sportsdataverse/sportsdataverse-
 | `EPA_penalty` | Float64 | Total EPA attributed to penalties. |
 | `penalty_first_downs_created` | Int64 | Number of first downs the team gained via opponent penalty. |
 | `penalty_first_downs_created_rate` | Float64 | Share of the team's first downs that came via opponent penalty. |
-| `penalties` | Int64 | Total number of penalties. |
-| `penalty_yards` | Int64 | Yards gained (or lost) by the posteam from the penalty. |
+| `penalties` | Int64 | Number of penalties assessed against the team. |
+| `penalty_yards` | Int64 | Net penalty yardage assessed against the team; can be negative when enforcement moved the team forward on balance. |
 | `special_teams_plays` | Int64 | Number of special-teams plays. |
 | `EPA_sp` | Float64 | Total special-teams EPA, ESPN's abbreviated field for the same phase. |
 | `EPA_special_teams` | Float64 | Total EPA generated on special-teams plays. |
@@ -994,7 +994,7 @@ Release: [espn_cfb_adv_team](https://github.com/sportsdataverse/sportsdataverse-
 | `kickoff_plays` | Int64 | Number of kickoff plays. |
 | `EPA_kickoff` | Float64 | Total EPA on kickoff plays. |
 | `rushes` | Int64 | Number of rushing attempts. |
-| `rush_yards` | Float64 | The number of rushing yards gained |
+| `rush_yards` | Float64 | Total yards the team gained on rush plays. |
 | `yards_per_rush` | Float64 | Yards gained per rushing attempt. |
 | `rushing_power_rate` | Float64 | Share of carries that were power rushing attempts. |
 | `rushing_first_downs_created` | Int64 | Number of first downs created on rush plays. |
@@ -1005,8 +1005,8 @@ Release: [espn_cfb_adv_team](https://github.com/sportsdataverse/sportsdataverse-
 | `EPA_explosive_rushing_rate` | Float64 | Explosive-play rate on rush plays, over ESPN's qualifying-play denominator. |
 | `EPA_non_explosive_rushing` | Float64 | Total EPA on rush plays with explosive plays excluded. |
 | `EPA_non_explosive_rushing_per_play` | Float64 | EPA per rush play with explosive plays excluded. |
-| `passes` | Int64 | Passes. |
-| `pass_yards` | Float64 | Number of yards gained on pass plays |
+| `passes` | Int64 | Number of pass plays the team ran. |
+| `pass_yards` | Float64 | Total yards the team gained on pass plays. |
 | `yards_per_pass` | Float64 | Team game yards per pass. |
 | `passing_first_downs_created` | Int64 | Number of first downs created on pass plays. |
 | `passing_first_downs_created_rate` | Float64 | Share of pass plays that created a first down. |
@@ -1029,25 +1029,25 @@ Release: [espn_cfb_adv_team](https://github.com/sportsdataverse/sportsdataverse-
 | `total_off_yards` | Int64 | Total offensive yards across all plays. |
 | `yards_per_play` | Float64 | Yards gained per play. |
 | `EPA_plays` | Int64 | Number of plays ESPN's advanced box score scored for the team. |
-| `total_yards` | Int64 | Team total yards. |
+| `total_yards` | Int64 | Total yards the team gained across all plays. |
 | `EPA_overall_total` | Float64 | Total EPA across all phases, which is why it differs from the offense-only EPA_overall_off. |
 | `rushes_rate` | Float64 | Share of the team's plays from scrimmage that were rush plays. |
 | `first_downs_created` | Int64 | Number of first downs the team created. |
 | `first_downs_created_rate` | Float64 | Share of the team's plays that created a first down. |
 | `EPA_rushing_power` | Float64 | Total EPA on power rushing situations, as classified by ESPN's advanced box score. |
 | `EPA_rushing_power_per_play` | Float64 | EPA per play on power rushing situations. |
-| `rushing_power_success` | Int64 | Rushing power success rate. |
+| `rushing_power_success` | Int64 | Count of power rushing attempts that gained the yardage needed. An integer count, not a rate -- the rate is published separately as rushing_power_success_rate. |
 | `rushing_power_success_rate` | Float64 | Share of power rushing attempts that succeeded. |
 | `rushing_power` | Int64 | Count of power rushing attempts, in short-yardage situations as classified by ESPN's advanced box score. |
 | `rushing_stuff` | Int64 | Count of stuffed rushing attempts. |
-| `rushing_stuff_rate` | Float64 | Rushing stuff rate. |
+| `rushing_stuff_rate` | Float64 | Share of the team's carries that were stuffed at or behind the line of scrimmage. |
 | `rushing_stopped` | Int64 | Count of rushing attempts stopped at or behind the line of scrimmage. |
 | `rushing_stopped_rate` | Float64 | Share of carries stopped at or behind the line of scrimmage. |
 | `rushing_opportunity` | Int64 | Count of rushing opportunities -- carries that reached ESPN's opportunity threshold. |
 | `rushing_opportunity_rate` | Float64 | Share of carries that qualified as rushing opportunities. |
 | `rushing_highlight` | Int64 | Highlight yards -- rushing yardage credited to the back rather than the offensive line. |
 | `rushing_highlight_rate` | Float64 | Share of rushing yardage that was highlight (back-credited) yardage. |
-| `rushing_highlight_yards` | Float64 | Opponent-adjusted offensive highlight yards per opportunity rush. |
+| `rushing_highlight_yards` | Float64 | Total highlight yards the team accumulated -- the yardage credited to ball carriers rather than the line. The per-carry figure is rushing_highlight_yards_per_opp. |
 | `line_yards` | Float64 | Line yards -- the portion of rushing yardage credited to the offensive line under the standard rushing decomposition. ESPN applies its own qualifying threshold for the yardage split. |
 | `line_yards_per_carry` | Float64 | Line yards per rushing attempt. |
 | `second_level_yards` | Float64 | Second-level yards -- rushing yardage earned just beyond the line of scrimmage. |
@@ -2048,8 +2048,8 @@ Release: [espn_cfb_adv_team_gamelog](https://github.com/sportsdataverse/sportsda
 | `EPA_penalty` | Float64 | Total EPA attributed to penalties. |
 | `penalty_first_downs_created` | Int64 | Number of first downs the team gained via opponent penalty. |
 | `penalty_first_downs_created_rate` | Float64 | Share of the team's first downs that came via opponent penalty. |
-| `penalties` | Int64 | Total number of penalties. |
-| `penalty_yards` | Int64 | Yards gained (or lost) by the posteam from the penalty. |
+| `penalties` | Int64 | Number of penalties assessed against the team. |
+| `penalty_yards` | Int64 | Net penalty yardage assessed against the team; can be negative when enforcement moved the team forward on balance. |
 | `special_teams_plays` | Int64 | Number of special-teams plays. |
 | `EPA_sp` | Float64 | Total special-teams EPA, ESPN's abbreviated field for the same phase. |
 | `EPA_special_teams` | Float64 | Total EPA generated on special-teams plays. |
@@ -2060,7 +2060,7 @@ Release: [espn_cfb_adv_team_gamelog](https://github.com/sportsdataverse/sportsda
 | `kickoff_plays` | Int64 | Number of kickoff plays. |
 | `EPA_kickoff` | Float64 | Total EPA on kickoff plays. |
 | `rushes` | Int64 | Number of rushing attempts. |
-| `rush_yards` | Float64 | The number of rushing yards gained |
+| `rush_yards` | Float64 | Total yards the team gained on rush plays. |
 | `yards_per_rush` | Float64 | Yards gained per rushing attempt. |
 | `rushing_power_rate` | Float64 | Share of carries that were power rushing attempts. |
 | `rushing_first_downs_created` | Int64 | Number of first downs created on rush plays. |
@@ -2071,8 +2071,8 @@ Release: [espn_cfb_adv_team_gamelog](https://github.com/sportsdataverse/sportsda
 | `EPA_explosive_rushing_rate` | Float64 | Explosive-play rate on rush plays, over ESPN's qualifying-play denominator. |
 | `EPA_non_explosive_rushing` | Float64 | Total EPA on rush plays with explosive plays excluded. |
 | `EPA_non_explosive_rushing_per_play` | Float64 | EPA per rush play with explosive plays excluded. |
-| `passes` | Int64 | Passes. |
-| `pass_yards` | Float64 | Number of yards gained on pass plays |
+| `passes` | Int64 | Number of pass plays the team ran. |
+| `pass_yards` | Float64 | Total yards the team gained on pass plays. |
 | `yards_per_pass` | Float64 | Team game yards per pass. |
 | `passing_first_downs_created` | Int64 | Number of first downs created on pass plays. |
 | `passing_first_downs_created_rate` | Float64 | Share of pass plays that created a first down. |
@@ -2095,25 +2095,25 @@ Release: [espn_cfb_adv_team_gamelog](https://github.com/sportsdataverse/sportsda
 | `total_off_yards` | Int64 | Total offensive yards across all plays. |
 | `yards_per_play` | Float64 | Yards gained per play. |
 | `EPA_plays` | Int64 | Number of plays ESPN's advanced box score scored for the team. |
-| `total_yards` | Int64 | Team total yards. |
+| `total_yards` | Int64 | Total yards the team gained across all plays. |
 | `EPA_overall_total` | Float64 | Total EPA across all phases, which is why it differs from the offense-only EPA_overall_off. |
 | `rushes_rate` | Float64 | Share of the team's plays from scrimmage that were rush plays. |
 | `first_downs_created` | Int64 | Number of first downs the team created. |
 | `first_downs_created_rate` | Float64 | Share of the team's plays that created a first down. |
 | `EPA_rushing_power` | Float64 | Total EPA on power rushing situations, as classified by ESPN's advanced box score. |
 | `EPA_rushing_power_per_play` | Float64 | EPA per play on power rushing situations. |
-| `rushing_power_success` | Int64 | Rushing power success rate. |
+| `rushing_power_success` | Int64 | Count of power rushing attempts that gained the yardage needed. An integer count, not a rate -- the rate is published separately as rushing_power_success_rate. |
 | `rushing_power_success_rate` | Float64 | Share of power rushing attempts that succeeded. |
 | `rushing_power` | Int64 | Count of power rushing attempts, in short-yardage situations as classified by ESPN's advanced box score. |
 | `rushing_stuff` | Int64 | Count of stuffed rushing attempts. |
-| `rushing_stuff_rate` | Float64 | Rushing stuff rate. |
+| `rushing_stuff_rate` | Float64 | Share of the team's carries that were stuffed at or behind the line of scrimmage. |
 | `rushing_stopped` | Int64 | Count of rushing attempts stopped at or behind the line of scrimmage. |
 | `rushing_stopped_rate` | Float64 | Share of carries stopped at or behind the line of scrimmage. |
 | `rushing_opportunity` | Int64 | Count of rushing opportunities -- carries that reached ESPN's opportunity threshold. |
 | `rushing_opportunity_rate` | Float64 | Share of carries that qualified as rushing opportunities. |
 | `rushing_highlight` | Int64 | Highlight yards -- rushing yardage credited to the back rather than the offensive line. |
 | `rushing_highlight_rate` | Float64 | Share of rushing yardage that was highlight (back-credited) yardage. |
-| `rushing_highlight_yards` | Float64 | Opponent-adjusted offensive highlight yards per opportunity rush. |
+| `rushing_highlight_yards` | Float64 | Total highlight yards the team accumulated -- the yardage credited to ball carriers rather than the line. The per-carry figure is rushing_highlight_yards_per_opp. |
 | `line_yards` | Float64 | Line yards -- the portion of rushing yardage credited to the offensive line under the standard rushing decomposition. ESPN applies its own qualifying threshold for the yardage split. |
 | `line_yards_per_carry` | Float64 | Line yards per rushing attempt. |
 | `second_level_yards` | Float64 | Second-level yards -- rushing yardage earned just beyond the line of scrimmage. |

--- a/docs/docs/cfb/reference/loaders.md
+++ b/docs/docs/cfb/reference/loaders.md
@@ -1252,77 +1252,77 @@ Release: [espn_cfb_adv_situational](https://github.com/sportsdataverse/sportsdat
 
 | col_name | type | description |
 |---|---|---|
-| `pos_team_id` | Int64 |  |
-| `pos_team` | String | Team name in possession at the start of the play (offense, kickoff-aware). |
-| `EPA_success` | Int64 |  |
-| `EPA_success_rate` | Float64 |  |
-| `EPA_success_pass` | Int64 |  |
-| `EPA_success_pass_rate` | Float64 |  |
-| `EPA_success_rush` | Int64 |  |
-| `EPA_success_rush_rate` | Float64 |  |
-| `EPA_success_rz` | Int64 |  |
-| `EPA_success_rate_rz` | Float64 |  |
-| `EPA_success_third` | Int64 |  |
-| `EPA_success_rate_third` | Float64 |  |
-| `EPA_success_early_down` | Int64 |  |
-| `EPA_success_early_down_rate` | Float64 |  |
-| `early_downs` | Int64 |  |
-| `early_down_pass_rate` | Float64 |  |
-| `early_down_rush_rate` | Float64 |  |
-| `EPA_early_down` | Float64 |  |
-| `EPA_early_down_per_play` | Float64 |  |
-| `early_down_first_down` | Int64 |  |
-| `early_down_first_down_rate` | Float64 |  |
-| `early_down_pass` | Int64 |  |
-| `EPA_early_down_pass` | Float64 |  |
-| `EPA_early_down_pass_per_play` | Float64 |  |
-| `EPA_success_early_down_pass` | Int64 |  |
-| `EPA_success_early_down_pass_rate` | Float64 |  |
-| `early_down_rush` | Int64 |  |
-| `EPA_early_down_rush` | Float64 |  |
-| `EPA_early_down_rush_per_play` | Float64 |  |
-| `EPA_success_early_down_rush` | Int64 |  |
-| `EPA_success_early_down_rush_rate` | Float64 |  |
-| `middle_8` | Int64 | TRUE for plays in the middle-8 window (final 4 min of 1H, first 4 min of 2H). |
-| `middle_8_pass_rate` | Float64 |  |
-| `middle_8_rush_rate` | Float64 |  |
-| `EPA_middle_8` | Float64 |  |
-| `EPA_middle_8_per_play` | Float64 |  |
-| `EPA_middle_8_success` | Int64 |  |
-| `EPA_middle_8_success_rate` | Float64 |  |
-| `middle_8_pass` | Int64 |  |
-| `EPA_middle_8_pass` | Float64 |  |
-| `EPA_middle_8_pass_per_play` | Float64 |  |
-| `EPA_middle_8_success_pass` | Int64 |  |
-| `EPA_middle_8_success_pass_rate` | Float64 |  |
-| `middle_8_rush` | Int64 |  |
-| `EPA_middle_8_rush` | Float64 |  |
-| `EPA_middle_8_rush_per_play` | Float64 |  |
-| `EPA_middle_8_success_rush` | Int64 |  |
-| `EPA_middle_8_success_rush_rate` | Float64 |  |
-| `EPA_success_late_down` | Int64 |  |
-| `EPA_success_late_down_pass` | Int64 |  |
-| `EPA_success_late_down_rush` | Int64 |  |
-| `late_downs` | Int64 |  |
-| `late_down_pass` | Int64 |  |
-| `late_down_rush` | Int64 |  |
-| `EPA_late_down` | Float64 |  |
-| `EPA_late_down_per_play` | Float64 |  |
-| `EPA_success_late_down_rate` | Float64 |  |
-| `EPA_success_late_down_pass_rate` | Float64 |  |
-| `EPA_success_late_down_rush_rate` | Float64 |  |
-| `late_down_pass_rate` | Float64 |  |
-| `late_down_rush_rate` | Float64 |  |
-| `EPA_success_standard_down` | Int64 |  |
-| `EPA_success_standard_down_rate` | Float64 |  |
-| `EPA_standard_down` | Float64 |  |
-| `EPA_standard_down_per_play` | Float64 |  |
-| `standard_downs` | Int64 |  |
-| `EPA_success_passing_down` | Int64 |  |
-| `EPA_success_passing_down_rate` | Float64 |  |
-| `EPA_passing_down` | Float64 |  |
-| `EPA_passing_down_per_play` | Float64 |  |
-| `passing_downs` | Int64 |  |
+| `pos_team_id` | Int64 | ESPN team id of the team on offense. Present for every season 2004+. |
+| `pos_team` | String | Display name of the team on offense (e.g. 'Ohio State Buckeyes'). |
+| `EPA_success` | Int64 | Count of successful plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total. |
+| `EPA_success_rate` | Float64 | Success rate -- the share of those plays ESPN scored as successful. |
+| `EPA_success_pass` | Int64 | Count of successful plays on pass plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total. |
+| `EPA_success_pass_rate` | Float64 | Success rate on pass plays -- the share of those plays ESPN scored as successful. |
+| `EPA_success_rush` | Int64 | Count of successful plays on rush plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total. |
+| `EPA_success_rush_rate` | Float64 | Success rate on rush plays -- the share of those plays ESPN scored as successful. |
+| `EPA_success_rz` | Int64 | Count of successful plays on the red zone. Despite the EPA_ prefix this is a play COUNT, not an EPA total. |
+| `EPA_success_rate_rz` | Float64 | Success rate on the red zone -- the share of those plays ESPN scored as successful. |
+| `EPA_success_third` | Int64 | Count of successful plays on third down. Despite the EPA_ prefix this is a play COUNT, not an EPA total. |
+| `EPA_success_rate_third` | Float64 | Success rate on third down -- the share of those plays ESPN scored as successful. |
+| `EPA_success_early_down` | Int64 | Count of successful plays on early downs. Despite the EPA_ prefix this is a play COUNT, not an EPA total. |
+| `EPA_success_early_down_rate` | Float64 | Success rate on early downs -- the share of those plays ESPN scored as successful. |
+| `early_downs` | Int64 | Number of plays the team ran on early downs. |
+| `early_down_pass_rate` | Float64 | Share of the team's plays on early downs that were pass plays. |
+| `early_down_rush_rate` | Float64 | Share of the team's plays on early downs that were rush plays. |
+| `EPA_early_down` | Float64 | Total EPA the team generated on early downs. |
+| `EPA_early_down_per_play` | Float64 | EPA per play on early downs. |
+| `early_down_first_down` | Int64 | Number of early-down plays that produced a first down. |
+| `early_down_first_down_rate` | Float64 | Share of early-down plays that produced a first down. |
+| `early_down_pass` | Int64 | Number of pass plays the team ran on early downs. |
+| `EPA_early_down_pass` | Float64 | Total EPA the team generated on early downs on pass plays. |
+| `EPA_early_down_pass_per_play` | Float64 | EPA per play on early downs on pass plays. |
+| `EPA_success_early_down_pass` | Int64 | Count of successful plays on early downs on pass plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total. |
+| `EPA_success_early_down_pass_rate` | Float64 | Success rate on early downs on pass plays -- the share of those plays ESPN scored as successful. |
+| `early_down_rush` | Int64 | Number of rush plays the team ran on early downs. |
+| `EPA_early_down_rush` | Float64 | Total EPA the team generated on early downs on rush plays. |
+| `EPA_early_down_rush_per_play` | Float64 | EPA per play on early downs on rush plays. |
+| `EPA_success_early_down_rush` | Int64 | Count of successful plays on early downs on rush plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total. |
+| `EPA_success_early_down_rush_rate` | Float64 | Success rate on early downs on rush plays -- the share of those plays ESPN scored as successful. |
+| `middle_8` | Int64 | Number of plays the team ran in the middle eight -- the closing minutes of the first half and opening minutes of the second. |
+| `middle_8_pass_rate` | Float64 | Share of the team's plays on the middle eight -- the closing minutes of the first half and opening minutes of the second that were pass plays. |
+| `middle_8_rush_rate` | Float64 | Share of the team's plays on the middle eight -- the closing minutes of the first half and opening minutes of the second that were rush plays. |
+| `EPA_middle_8` | Float64 | Total EPA the team generated on the middle eight -- the closing minutes of the first half and opening minutes of the second. |
+| `EPA_middle_8_per_play` | Float64 | EPA per play on the middle eight -- the closing minutes of the first half and opening minutes of the second. |
+| `EPA_middle_8_success` | Int64 | Count of successful plays on the middle eight -- the closing minutes of the first half and opening minutes of the second. Despite the EPA_ prefix this is a play COUNT, not an EPA total. |
+| `EPA_middle_8_success_rate` | Float64 | Success rate on the middle eight -- the closing minutes of the first half and opening minutes of the second -- the share of those plays ESPN scored as successful. |
+| `middle_8_pass` | Int64 | Number of pass plays the team ran on the middle eight -- the closing minutes of the first half and opening minutes of the second. |
+| `EPA_middle_8_pass` | Float64 | Total EPA the team generated on the middle eight -- the closing minutes of the first half and opening minutes of the second on pass plays. |
+| `EPA_middle_8_pass_per_play` | Float64 | EPA per play on the middle eight -- the closing minutes of the first half and opening minutes of the second on pass plays. |
+| `EPA_middle_8_success_pass` | Int64 | Count of successful plays on the middle eight -- the closing minutes of the first half and opening minutes of the second on pass plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total. |
+| `EPA_middle_8_success_pass_rate` | Float64 | Success rate on the middle eight -- the closing minutes of the first half and opening minutes of the second on pass plays -- the share of those plays ESPN scored as successful. |
+| `middle_8_rush` | Int64 | Number of rush plays the team ran on the middle eight -- the closing minutes of the first half and opening minutes of the second. |
+| `EPA_middle_8_rush` | Float64 | Total EPA the team generated on the middle eight -- the closing minutes of the first half and opening minutes of the second on rush plays. |
+| `EPA_middle_8_rush_per_play` | Float64 | EPA per play on the middle eight -- the closing minutes of the first half and opening minutes of the second on rush plays. |
+| `EPA_middle_8_success_rush` | Int64 | Count of successful plays on the middle eight -- the closing minutes of the first half and opening minutes of the second on rush plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total. |
+| `EPA_middle_8_success_rush_rate` | Float64 | Success rate on the middle eight -- the closing minutes of the first half and opening minutes of the second on rush plays -- the share of those plays ESPN scored as successful. |
+| `EPA_success_late_down` | Int64 | Count of successful plays on late downs. Despite the EPA_ prefix this is a play COUNT, not an EPA total. |
+| `EPA_success_late_down_pass` | Int64 | Count of successful plays on late downs on pass plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total. |
+| `EPA_success_late_down_rush` | Int64 | Count of successful plays on late downs on rush plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total. |
+| `late_downs` | Int64 | Number of plays the team ran on late downs. |
+| `late_down_pass` | Int64 | Number of pass plays the team ran on late downs. |
+| `late_down_rush` | Int64 | Number of rush plays the team ran on late downs. |
+| `EPA_late_down` | Float64 | Total EPA the team generated on late downs. |
+| `EPA_late_down_per_play` | Float64 | EPA per play on late downs. |
+| `EPA_success_late_down_rate` | Float64 | Success rate on late downs -- the share of those plays ESPN scored as successful. |
+| `EPA_success_late_down_pass_rate` | Float64 | Success rate on late downs on pass plays -- the share of those plays ESPN scored as successful. |
+| `EPA_success_late_down_rush_rate` | Float64 | Success rate on late downs on rush plays -- the share of those plays ESPN scored as successful. |
+| `late_down_pass_rate` | Float64 | Share of the team's plays on late downs that were pass plays. |
+| `late_down_rush_rate` | Float64 | Share of the team's plays on late downs that were rush plays. |
+| `EPA_success_standard_down` | Int64 | Count of successful plays on standard downs (the team ahead of schedule for the series). Despite the EPA_ prefix this is a play COUNT, not an EPA total. |
+| `EPA_success_standard_down_rate` | Float64 | Success rate on standard downs (the team ahead of schedule for the series) -- the share of those plays ESPN scored as successful. |
+| `EPA_standard_down` | Float64 | Total EPA the team generated on standard downs (the team ahead of schedule for the series). |
+| `EPA_standard_down_per_play` | Float64 | EPA per play on standard downs (the team ahead of schedule for the series). |
+| `standard_downs` | Int64 | Number of plays the team ran on standard downs (the team ahead of schedule for the series). |
+| `EPA_success_passing_down` | Int64 | Count of successful plays on passing downs (the team behind schedule for the series). Despite the EPA_ prefix this is a play COUNT, not an EPA total. |
+| `EPA_success_passing_down_rate` | Float64 | Success rate on passing downs (the team behind schedule for the series) -- the share of those plays ESPN scored as successful. |
+| `EPA_passing_down` | Float64 | Total EPA the team generated on passing downs (the team behind schedule for the series). |
+| `EPA_passing_down_per_play` | Float64 | EPA per play on passing downs (the team behind schedule for the series). |
+| `passing_downs` | Int64 | Number of plays the team ran on passing downs (the team behind schedule for the series). |
 | `game_id` | Int64 | ESPN game identifier. |
 | `season` | Int64 | Season (4-digit year). |
 | `week` | Int64 | Game week of the season. |

--- a/docs/docs/cfb/reference/loaders.md
+++ b/docs/docs/cfb/reference/loaders.md
@@ -975,83 +975,83 @@ Release: [espn_cfb_adv_team](https://github.com/sportsdataverse/sportsdataverse-
 
 | col_name | type | description |
 |---|---|---|
-| `pos_team_id` | Int64 |  |
+| `pos_team_id` | Int64 | ESPN team id of the team on offense. Present for every season 2004+. |
 | `pos_team` | String | Team name in possession at the start of the play (offense, kickoff-aware). |
-| `rushing_highlight_yards_per_opp` | Float64 |  |
-| `total_pen_yards` | Int64 |  |
-| `EPA_penalty` | Float64 |  |
-| `penalty_first_downs_created` | Int64 |  |
-| `penalty_first_downs_created_rate` | Float64 |  |
+| `rushing_highlight_yards_per_opp` | Float64 | Highlight yards per rushing opportunity. |
+| `total_pen_yards` | Int64 | Total penalty yards assessed. |
+| `EPA_penalty` | Float64 | Total EPA attributed to penalties. |
+| `penalty_first_downs_created` | Int64 | Number of first downs the team gained via opponent penalty. |
+| `penalty_first_downs_created_rate` | Float64 | Share of the team's first downs that came via opponent penalty. |
 | `penalties` | Int64 | Total number of penalties. |
 | `penalty_yards` | Int64 | Yards gained (or lost) by the posteam from the penalty. |
-| `special_teams_plays` | Int64 |  |
-| `EPA_sp` | Float64 |  |
-| `EPA_special_teams` | Float64 |  |
-| `field_goals` | Int64 |  |
-| `EPA_fg` | Float64 |  |
-| `punt_plays` | Int64 |  |
-| `EPA_punt` | Float64 |  |
-| `kickoff_plays` | Int64 |  |
-| `EPA_kickoff` | Float64 |  |
-| `rushes` | Int64 |  |
+| `special_teams_plays` | Int64 | Number of special-teams plays. |
+| `EPA_sp` | Float64 | Total special-teams EPA, ESPN's abbreviated field for the same phase. |
+| `EPA_special_teams` | Float64 | Total EPA generated on special-teams plays. |
+| `field_goals` | Int64 | Number of field-goal attempts. |
+| `EPA_fg` | Float64 | Total EPA on field-goal attempts. |
+| `punt_plays` | Int64 | Number of punt plays. |
+| `EPA_punt` | Float64 | Total EPA on punt plays. |
+| `kickoff_plays` | Int64 | Number of kickoff plays. |
+| `EPA_kickoff` | Float64 | Total EPA on kickoff plays. |
+| `rushes` | Int64 | Number of rushing attempts. |
 | `rush_yards` | Float64 | The number of rushing yards gained |
-| `yards_per_rush` | Float64 |  |
-| `rushing_power_rate` | Float64 |  |
-| `rushing_first_downs_created` | Int64 |  |
-| `rushing_first_downs_created_rate` | Float64 |  |
-| `EPA_rushing_overall` | Float64 |  |
-| `EPA_rushing_per_play` | Float64 |  |
-| `EPA_explosive_rushing` | Int64 |  |
-| `EPA_explosive_rushing_rate` | Float64 |  |
-| `EPA_non_explosive_rushing` | Float64 |  |
-| `EPA_non_explosive_rushing_per_play` | Float64 |  |
+| `yards_per_rush` | Float64 | Yards gained per rushing attempt. |
+| `rushing_power_rate` | Float64 | Share of carries that were power rushing attempts. |
+| `rushing_first_downs_created` | Int64 | Number of first downs created on rush plays. |
+| `rushing_first_downs_created_rate` | Float64 | Share of rush plays that created a first down. |
+| `EPA_rushing_overall` | Float64 | Total EPA on rush plays. |
+| `EPA_rushing_per_play` | Float64 | EPA per rush play. |
+| `EPA_explosive_rushing` | Int64 | Count of explosive rush plays. A play count, not an EPA total. |
+| `EPA_explosive_rushing_rate` | Float64 | Explosive-play rate on rush plays, over ESPN's qualifying-play denominator. |
+| `EPA_non_explosive_rushing` | Float64 | Total EPA on rush plays with explosive plays excluded. |
+| `EPA_non_explosive_rushing_per_play` | Float64 | EPA per rush play with explosive plays excluded. |
 | `passes` | Int64 | Passes. |
 | `pass_yards` | Float64 | Number of yards gained on pass plays |
 | `yards_per_pass` | Float64 | Team game yards per pass. |
-| `passing_first_downs_created` | Int64 |  |
-| `passing_first_downs_created_rate` | Float64 |  |
-| `EPA_passing_overall` | Float64 |  |
-| `EPA_passing_per_play` | Float64 |  |
-| `EPA_explosive_passing` | Int64 |  |
-| `EPA_explosive_passing_rate` | Float64 |  |
-| `EPA_non_explosive_passing` | Float64 |  |
-| `EPA_non_explosive_passing_per_play` | Float64 |  |
-| `scrimmage_plays` | Int64 |  |
-| `EPA_overall_off` | Float64 |  |
-| `EPA_overall_offense` | Float64 |  |
-| `EPA_per_play` | Float64 |  |
-| `EPA_non_explosive` | Float64 |  |
-| `EPA_non_explosive_per_play` | Float64 |  |
-| `EPA_explosive` | Int64 |  |
-| `EPA_explosive_rate` | Float64 |  |
-| `passes_rate` | Float64 |  |
-| `off_yards` | Int64 |  |
-| `total_off_yards` | Int64 |  |
-| `yards_per_play` | Float64 |  |
-| `EPA_plays` | Int64 |  |
+| `passing_first_downs_created` | Int64 | Number of first downs created on pass plays. |
+| `passing_first_downs_created_rate` | Float64 | Share of pass plays that created a first down. |
+| `EPA_passing_overall` | Float64 | Total EPA on pass plays. |
+| `EPA_passing_per_play` | Float64 | EPA per pass play. |
+| `EPA_explosive_passing` | Int64 | Count of explosive pass plays. A play count, not an EPA total. |
+| `EPA_explosive_passing_rate` | Float64 | Explosive-play rate on pass plays, over ESPN's qualifying-play denominator. |
+| `EPA_non_explosive_passing` | Float64 | Total EPA on pass plays with explosive plays excluded. |
+| `EPA_non_explosive_passing_per_play` | Float64 | EPA per pass play with explosive plays excluded. |
+| `scrimmage_plays` | Int64 | Number of plays from scrimmage (rushes plus passes), excluding special teams. |
+| `EPA_overall_off` | Float64 | Total offensive EPA for the team. Duplicated exactly by EPA_overall_offense in every published season checked -- prefer one and ignore the other. |
+| `EPA_overall_offense` | Float64 | Total offensive EPA. An exact duplicate of EPA_overall_off. |
+| `EPA_per_play` | Float64 | Offensive EPA per play. |
+| `EPA_non_explosive` | Float64 | Total EPA with explosive plays excluded, isolating the team's routine-down production. |
+| `EPA_non_explosive_per_play` | Float64 | EPA per play with explosive plays excluded. |
+| `EPA_explosive` | Int64 | Count of explosive plays, per ESPN's advanced box score. Despite the EPA_ prefix this is a play COUNT, not an EPA total. |
+| `EPA_explosive_rate` | Float64 | Explosive-play rate. Note this is NOT EPA_explosive divided by EPA_plays -- ESPN divides by its own smaller qualifying-play count, so deriving it yourself will not reproduce this value. |
+| `passes_rate` | Float64 | Share of the team's plays from scrimmage that were pass plays. |
+| `off_yards` | Int64 | Offensive yards gained from scrimmage. |
+| `total_off_yards` | Int64 | Total offensive yards across all plays. |
+| `yards_per_play` | Float64 | Yards gained per play. |
+| `EPA_plays` | Int64 | Number of plays ESPN's advanced box score scored for the team. |
 | `total_yards` | Int64 | Team total yards. |
-| `EPA_overall_total` | Float64 |  |
-| `rushes_rate` | Float64 |  |
-| `first_downs_created` | Int64 |  |
-| `first_downs_created_rate` | Float64 |  |
-| `EPA_rushing_power` | Float64 |  |
-| `EPA_rushing_power_per_play` | Float64 |  |
+| `EPA_overall_total` | Float64 | Total EPA across all phases, which is why it differs from the offense-only EPA_overall_off. |
+| `rushes_rate` | Float64 | Share of the team's plays from scrimmage that were rush plays. |
+| `first_downs_created` | Int64 | Number of first downs the team created. |
+| `first_downs_created_rate` | Float64 | Share of the team's plays that created a first down. |
+| `EPA_rushing_power` | Float64 | Total EPA on power rushing situations, as classified by ESPN's advanced box score. |
+| `EPA_rushing_power_per_play` | Float64 | EPA per play on power rushing situations. |
 | `rushing_power_success` | Int64 | Rushing power success rate. |
-| `rushing_power_success_rate` | Float64 |  |
-| `rushing_power` | Int64 |  |
-| `rushing_stuff` | Int64 |  |
+| `rushing_power_success_rate` | Float64 | Share of power rushing attempts that succeeded. |
+| `rushing_power` | Int64 | Count of power rushing attempts, in short-yardage situations as classified by ESPN's advanced box score. |
+| `rushing_stuff` | Int64 | Count of stuffed rushing attempts. |
 | `rushing_stuff_rate` | Float64 | Rushing stuff rate. |
-| `rushing_stopped` | Int64 |  |
-| `rushing_stopped_rate` | Float64 |  |
-| `rushing_opportunity` | Int64 |  |
-| `rushing_opportunity_rate` | Float64 |  |
-| `rushing_highlight` | Int64 |  |
-| `rushing_highlight_rate` | Float64 |  |
+| `rushing_stopped` | Int64 | Count of rushing attempts stopped at or behind the line of scrimmage. |
+| `rushing_stopped_rate` | Float64 | Share of carries stopped at or behind the line of scrimmage. |
+| `rushing_opportunity` | Int64 | Count of rushing opportunities -- carries that reached ESPN's opportunity threshold. |
+| `rushing_opportunity_rate` | Float64 | Share of carries that qualified as rushing opportunities. |
+| `rushing_highlight` | Int64 | Highlight yards -- rushing yardage credited to the back rather than the offensive line. |
+| `rushing_highlight_rate` | Float64 | Share of rushing yardage that was highlight (back-credited) yardage. |
 | `rushing_highlight_yards` | Float64 | Opponent-adjusted offensive highlight yards per opportunity rush. |
-| `line_yards` | Float64 |  |
-| `line_yards_per_carry` | Float64 |  |
-| `second_level_yards` | Float64 |  |
-| `open_field_yards` | Float64 |  |
+| `line_yards` | Float64 | Line yards -- the portion of rushing yardage credited to the offensive line under the standard rushing decomposition. ESPN applies its own qualifying threshold for the yardage split. |
+| `line_yards_per_carry` | Float64 | Line yards per rushing attempt. |
+| `second_level_yards` | Float64 | Second-level yards -- rushing yardage earned just beyond the line of scrimmage. |
+| `open_field_yards` | Float64 | Open-field yards -- rushing yardage earned well downfield, past the second level. |
 | `game_id` | Int64 | ESPN game identifier. |
 | `season` | Int64 | Season (4-digit year). |
 | `week` | Int64 | Game week of the season. |
@@ -2043,81 +2043,81 @@ Release: [espn_cfb_adv_team_gamelog](https://github.com/sportsdataverse/sportsda
 | `points_against` | Int64 | Points allowed. |
 | `margin` | Int64 |  |
 | `win` | Boolean | Whether the game was a win (goalie). |
-| `rushing_highlight_yards_per_opp` | Float64 |  |
-| `total_pen_yards` | Int64 |  |
-| `EPA_penalty` | Float64 |  |
-| `penalty_first_downs_created` | Int64 |  |
-| `penalty_first_downs_created_rate` | Float64 |  |
+| `rushing_highlight_yards_per_opp` | Float64 | Highlight yards per rushing opportunity. |
+| `total_pen_yards` | Int64 | Total penalty yards assessed. |
+| `EPA_penalty` | Float64 | Total EPA attributed to penalties. |
+| `penalty_first_downs_created` | Int64 | Number of first downs the team gained via opponent penalty. |
+| `penalty_first_downs_created_rate` | Float64 | Share of the team's first downs that came via opponent penalty. |
 | `penalties` | Int64 | Total number of penalties. |
 | `penalty_yards` | Int64 | Yards gained (or lost) by the posteam from the penalty. |
-| `special_teams_plays` | Int64 |  |
-| `EPA_sp` | Float64 |  |
-| `EPA_special_teams` | Float64 |  |
-| `field_goals` | Int64 |  |
-| `EPA_fg` | Float64 |  |
-| `punt_plays` | Int64 |  |
-| `EPA_punt` | Float64 |  |
-| `kickoff_plays` | Int64 |  |
-| `EPA_kickoff` | Float64 |  |
-| `rushes` | Int64 |  |
+| `special_teams_plays` | Int64 | Number of special-teams plays. |
+| `EPA_sp` | Float64 | Total special-teams EPA, ESPN's abbreviated field for the same phase. |
+| `EPA_special_teams` | Float64 | Total EPA generated on special-teams plays. |
+| `field_goals` | Int64 | Number of field-goal attempts. |
+| `EPA_fg` | Float64 | Total EPA on field-goal attempts. |
+| `punt_plays` | Int64 | Number of punt plays. |
+| `EPA_punt` | Float64 | Total EPA on punt plays. |
+| `kickoff_plays` | Int64 | Number of kickoff plays. |
+| `EPA_kickoff` | Float64 | Total EPA on kickoff plays. |
+| `rushes` | Int64 | Number of rushing attempts. |
 | `rush_yards` | Float64 | The number of rushing yards gained |
-| `yards_per_rush` | Float64 |  |
-| `rushing_power_rate` | Float64 |  |
-| `rushing_first_downs_created` | Int64 |  |
-| `rushing_first_downs_created_rate` | Float64 |  |
-| `EPA_rushing_overall` | Float64 |  |
-| `EPA_rushing_per_play` | Float64 |  |
-| `EPA_explosive_rushing` | Int64 |  |
-| `EPA_explosive_rushing_rate` | Float64 |  |
-| `EPA_non_explosive_rushing` | Float64 |  |
-| `EPA_non_explosive_rushing_per_play` | Float64 |  |
+| `yards_per_rush` | Float64 | Yards gained per rushing attempt. |
+| `rushing_power_rate` | Float64 | Share of carries that were power rushing attempts. |
+| `rushing_first_downs_created` | Int64 | Number of first downs created on rush plays. |
+| `rushing_first_downs_created_rate` | Float64 | Share of rush plays that created a first down. |
+| `EPA_rushing_overall` | Float64 | Total EPA on rush plays. |
+| `EPA_rushing_per_play` | Float64 | EPA per rush play. |
+| `EPA_explosive_rushing` | Int64 | Count of explosive rush plays. A play count, not an EPA total. |
+| `EPA_explosive_rushing_rate` | Float64 | Explosive-play rate on rush plays, over ESPN's qualifying-play denominator. |
+| `EPA_non_explosive_rushing` | Float64 | Total EPA on rush plays with explosive plays excluded. |
+| `EPA_non_explosive_rushing_per_play` | Float64 | EPA per rush play with explosive plays excluded. |
 | `passes` | Int64 | Passes. |
 | `pass_yards` | Float64 | Number of yards gained on pass plays |
 | `yards_per_pass` | Float64 | Team game yards per pass. |
-| `passing_first_downs_created` | Int64 |  |
-| `passing_first_downs_created_rate` | Float64 |  |
-| `EPA_passing_overall` | Float64 |  |
-| `EPA_passing_per_play` | Float64 |  |
-| `EPA_explosive_passing` | Int64 |  |
-| `EPA_explosive_passing_rate` | Float64 |  |
-| `EPA_non_explosive_passing` | Float64 |  |
-| `EPA_non_explosive_passing_per_play` | Float64 |  |
-| `scrimmage_plays` | Int64 |  |
-| `EPA_overall_off` | Float64 |  |
-| `EPA_overall_offense` | Float64 |  |
-| `EPA_per_play` | Float64 |  |
-| `EPA_non_explosive` | Float64 |  |
-| `EPA_non_explosive_per_play` | Float64 |  |
-| `EPA_explosive` | Int64 |  |
-| `EPA_explosive_rate` | Float64 |  |
-| `passes_rate` | Float64 |  |
-| `off_yards` | Int64 |  |
-| `total_off_yards` | Int64 |  |
-| `yards_per_play` | Float64 |  |
-| `EPA_plays` | Int64 |  |
+| `passing_first_downs_created` | Int64 | Number of first downs created on pass plays. |
+| `passing_first_downs_created_rate` | Float64 | Share of pass plays that created a first down. |
+| `EPA_passing_overall` | Float64 | Total EPA on pass plays. |
+| `EPA_passing_per_play` | Float64 | EPA per pass play. |
+| `EPA_explosive_passing` | Int64 | Count of explosive pass plays. A play count, not an EPA total. |
+| `EPA_explosive_passing_rate` | Float64 | Explosive-play rate on pass plays, over ESPN's qualifying-play denominator. |
+| `EPA_non_explosive_passing` | Float64 | Total EPA on pass plays with explosive plays excluded. |
+| `EPA_non_explosive_passing_per_play` | Float64 | EPA per pass play with explosive plays excluded. |
+| `scrimmage_plays` | Int64 | Number of plays from scrimmage (rushes plus passes), excluding special teams. |
+| `EPA_overall_off` | Float64 | Total offensive EPA for the team. Duplicated exactly by EPA_overall_offense in every published season checked -- prefer one and ignore the other. |
+| `EPA_overall_offense` | Float64 | Total offensive EPA. An exact duplicate of EPA_overall_off. |
+| `EPA_per_play` | Float64 | Offensive EPA per play. |
+| `EPA_non_explosive` | Float64 | Total EPA with explosive plays excluded, isolating the team's routine-down production. |
+| `EPA_non_explosive_per_play` | Float64 | EPA per play with explosive plays excluded. |
+| `EPA_explosive` | Int64 | Count of explosive plays, per ESPN's advanced box score. Despite the EPA_ prefix this is a play COUNT, not an EPA total. |
+| `EPA_explosive_rate` | Float64 | Explosive-play rate. Note this is NOT EPA_explosive divided by EPA_plays -- ESPN divides by its own smaller qualifying-play count, so deriving it yourself will not reproduce this value. |
+| `passes_rate` | Float64 | Share of the team's plays from scrimmage that were pass plays. |
+| `off_yards` | Int64 | Offensive yards gained from scrimmage. |
+| `total_off_yards` | Int64 | Total offensive yards across all plays. |
+| `yards_per_play` | Float64 | Yards gained per play. |
+| `EPA_plays` | Int64 | Number of plays ESPN's advanced box score scored for the team. |
 | `total_yards` | Int64 | Team total yards. |
-| `EPA_overall_total` | Float64 |  |
-| `rushes_rate` | Float64 |  |
-| `first_downs_created` | Int64 |  |
-| `first_downs_created_rate` | Float64 |  |
-| `EPA_rushing_power` | Float64 |  |
-| `EPA_rushing_power_per_play` | Float64 |  |
+| `EPA_overall_total` | Float64 | Total EPA across all phases, which is why it differs from the offense-only EPA_overall_off. |
+| `rushes_rate` | Float64 | Share of the team's plays from scrimmage that were rush plays. |
+| `first_downs_created` | Int64 | Number of first downs the team created. |
+| `first_downs_created_rate` | Float64 | Share of the team's plays that created a first down. |
+| `EPA_rushing_power` | Float64 | Total EPA on power rushing situations, as classified by ESPN's advanced box score. |
+| `EPA_rushing_power_per_play` | Float64 | EPA per play on power rushing situations. |
 | `rushing_power_success` | Int64 | Rushing power success rate. |
-| `rushing_power_success_rate` | Float64 |  |
-| `rushing_power` | Int64 |  |
-| `rushing_stuff` | Int64 |  |
+| `rushing_power_success_rate` | Float64 | Share of power rushing attempts that succeeded. |
+| `rushing_power` | Int64 | Count of power rushing attempts, in short-yardage situations as classified by ESPN's advanced box score. |
+| `rushing_stuff` | Int64 | Count of stuffed rushing attempts. |
 | `rushing_stuff_rate` | Float64 | Rushing stuff rate. |
-| `rushing_stopped` | Int64 |  |
-| `rushing_stopped_rate` | Float64 |  |
-| `rushing_opportunity` | Int64 |  |
-| `rushing_opportunity_rate` | Float64 |  |
-| `rushing_highlight` | Int64 |  |
-| `rushing_highlight_rate` | Float64 |  |
+| `rushing_stopped` | Int64 | Count of rushing attempts stopped at or behind the line of scrimmage. |
+| `rushing_stopped_rate` | Float64 | Share of carries stopped at or behind the line of scrimmage. |
+| `rushing_opportunity` | Int64 | Count of rushing opportunities -- carries that reached ESPN's opportunity threshold. |
+| `rushing_opportunity_rate` | Float64 | Share of carries that qualified as rushing opportunities. |
+| `rushing_highlight` | Int64 | Highlight yards -- rushing yardage credited to the back rather than the offensive line. |
+| `rushing_highlight_rate` | Float64 | Share of rushing yardage that was highlight (back-credited) yardage. |
 | `rushing_highlight_yards` | Float64 | Opponent-adjusted offensive highlight yards per opportunity rush. |
-| `line_yards` | Float64 |  |
-| `line_yards_per_carry` | Float64 |  |
-| `second_level_yards` | Float64 |  |
-| `open_field_yards` | Float64 |  |
+| `line_yards` | Float64 | Line yards -- the portion of rushing yardage credited to the offensive line under the standard rushing decomposition. ESPN applies its own qualifying threshold for the yardage split. |
+| `line_yards_per_carry` | Float64 | Line yards per rushing attempt. |
+| `second_level_yards` | Float64 | Second-level yards -- rushing yardage earned just beyond the line of scrimmage. |
+| `open_field_yards` | Float64 | Open-field yards -- rushing yardage earned well downfield, past the second level. |
 
 ```python
 load_cfb_adv_team_gamelog(seasons=2024)

--- a/docs/docs/cfb/reference/loaders.md
+++ b/docs/docs/cfb/reference/loaders.md
@@ -62,129 +62,129 @@ Release: [espn_cfb_pbp](https://github.com/sportsdataverse/sportsdataverse-data/
 | `text` | String | Full play description. |
 | `awayScore` | Int32 | Away team score after the goal. |
 | `homeScore` | Int32 | Home team score after the goal. |
-| `scoringPlay` | Boolean |  |
+| `scoringPlay` | Boolean | ESPN flag marking the play as a scoring play. |
 | `priority` | Boolean | `TRUE` if ESPN flags the play as a priority highlight. |
 | `modified` | String | ISO timestamp the play record was last modified. |
-| `statYardage` | Int32 |  |
-| `type.id` | String |  |
-| `type.text` | String |  |
-| `period.number` | Int32 |  |
-| `clock.displayValue` | String |  |
-| `start.down` | Int32 |  |
-| `start.distance` | Int32 |  |
-| `start.yardLine` | Int32 |  |
-| `start.yardsToEndzone` | Int32 |  |
-| `start.downDistanceText` | String |  |
-| `start.shortDownDistanceText` | String |  |
-| `start.possessionText` | String |  |
-| `start.team.id` | Int32 |  |
-| `end.down` | Int32 |  |
-| `end.distance` | Int32 |  |
-| `end.yardLine` | Int32 |  |
-| `end.yardsToEndzone` | Int32 |  |
-| `end.downDistanceText` | String |  |
-| `end.shortDownDistanceText` | String |  |
-| `end.possessionText` | String |  |
-| `end.team.id` | Int32 |  |
-| `drive.id` | String |  |
-| `drive.displayResult` | String |  |
-| `drive.isScore` | Boolean |  |
-| `drive.team.shortDisplayName` | String |  |
-| `drive.team.displayName` | String |  |
-| `drive.team.name` | String |  |
-| `drive.team.abbreviation` | String |  |
-| `drive.yards` | Int32 |  |
-| `drive.offensivePlays` | Int32 |  |
-| `drive.result` | String |  |
-| `drive.description` | String |  |
-| `drive.shortDisplayResult` | String |  |
-| `drive.timeElapsed.displayValue` | String |  |
-| `drive.start.period.number` | Int32 |  |
-| `drive.start.period.type` | String |  |
-| `drive.start.yardLine` | Int32 |  |
-| `drive.start.clock.displayValue` | String |  |
-| `drive.start.text` | String |  |
-| `drive.end.period.number` | Int32 |  |
-| `drive.end.period.type` | String |  |
-| `drive.end.yardLine` | Int32 |  |
-| `drive.end.clock.displayValue` | String |  |
+| `statYardage` | Int32 | Yardage ESPN credits to the play for statistical purposes. |
+| `type.id` | String | ESPN's numeric identifier for the play type. |
+| `type.text` | String | ESPN's text label for the play type. |
+| `period.number` | Int32 | Period (quarter) number in which the play occurred. |
+| `clock.displayValue` | String | Game clock at the play, as the displayed mm:ss string. |
+| `start.down` | Int32 | ESPN's `down` value for the play state at the start of the play. |
+| `start.distance` | Int32 | ESPN's `distance` value for the play state at the start of the play. |
+| `start.yardLine` | Int32 | ESPN's `yardLine` value for the play state at the start of the play. |
+| `start.yardsToEndzone` | Int32 | ESPN's `yardsToEndzone` value for the play state at the start of the play. |
+| `start.downDistanceText` | String | ESPN's `downDistanceText` value for the play state at the start of the play. |
+| `start.shortDownDistanceText` | String | ESPN's `shortDownDistanceText` value for the play state at the start of the play. |
+| `start.possessionText` | String | ESPN's `possessionText` value for the play state at the start of the play. |
+| `start.team.id` | Int32 | ESPN's `team.id` value for the play state at the start of the play. |
+| `end.down` | Int32 | ESPN's `down` value for the play state at the end of the play. |
+| `end.distance` | Int32 | ESPN's `distance` value for the play state at the end of the play. |
+| `end.yardLine` | Int32 | ESPN's `yardLine` value for the play state at the end of the play. |
+| `end.yardsToEndzone` | Int32 | ESPN's `yardsToEndzone` value for the play state at the end of the play. |
+| `end.downDistanceText` | String | ESPN's `downDistanceText` value for the play state at the end of the play. |
+| `end.shortDownDistanceText` | String | ESPN's `shortDownDistanceText` value for the play state at the end of the play. |
+| `end.possessionText` | String | ESPN's `possessionText` value for the play state at the end of the play. |
+| `end.team.id` | Int32 | ESPN's `team.id` value for the play state at the end of the play. |
+| `drive.id` | String | ESPN's `id` field for the drive containing this play. |
+| `drive.displayResult` | String | ESPN's `displayResult` field for the drive containing this play. |
+| `drive.isScore` | Boolean | ESPN's `isScore` field for the drive containing this play. |
+| `drive.team.shortDisplayName` | String | ESPN's `team.shortDisplayName` field for the drive containing this play. |
+| `drive.team.displayName` | String | ESPN's `team.displayName` field for the drive containing this play. |
+| `drive.team.name` | String | ESPN's `team.name` field for the drive containing this play. |
+| `drive.team.abbreviation` | String | ESPN's `team.abbreviation` field for the drive containing this play. |
+| `drive.yards` | Int32 | ESPN's `yards` field for the drive containing this play. |
+| `drive.offensivePlays` | Int32 | ESPN's `offensivePlays` field for the drive containing this play. |
+| `drive.result` | String | ESPN's `result` field for the drive containing this play. |
+| `drive.description` | String | ESPN's `description` field for the drive containing this play. |
+| `drive.shortDisplayResult` | String | ESPN's `shortDisplayResult` field for the drive containing this play. |
+| `drive.timeElapsed.displayValue` | String | ESPN's `timeElapsed.displayValue` field for the drive containing this play. |
+| `drive.start.period.number` | Int32 | ESPN's `start.period.number` field for the drive containing this play. |
+| `drive.start.period.type` | String | ESPN's `start.period.type` field for the drive containing this play. |
+| `drive.start.yardLine` | Int32 | ESPN's `start.yardLine` field for the drive containing this play. |
+| `drive.start.clock.displayValue` | String | ESPN's `start.clock.displayValue` field for the drive containing this play. |
+| `drive.start.text` | String | ESPN's `start.text` field for the drive containing this play. |
+| `drive.end.period.number` | Int32 | ESPN's `end.period.number` field for the drive containing this play. |
+| `drive.end.period.type` | String | ESPN's `end.period.type` field for the drive containing this play. |
+| `drive.end.yardLine` | Int32 | ESPN's `end.yardLine` field for the drive containing this play. |
+| `drive.end.clock.displayValue` | String | ESPN's `end.clock.displayValue` field for the drive containing this play. |
 | `game_id` | Int32 | ESPN game identifier. |
 | `season` | Int32 | Season (4-digit year). |
-| `seasonType` | Int32 |  |
-| `homeTeamId` | Int32 |  |
-| `awayTeamId` | Int32 |  |
-| `homeTeamName` | String |  |
-| `awayTeamName` | String |  |
-| `homeTeamMascot` | String |  |
-| `awayTeamMascot` | String |  |
-| `homeTeamAbbrev` | String |  |
-| `awayTeamAbbrev` | String |  |
-| `homeTeamNameAlt` | String |  |
-| `awayTeamNameAlt` | String |  |
-| `homeTeamSpread` | Float64 |  |
-| `gameSpread` | Float64 |  |
-| `gameSpreadAvailable` | Boolean |  |
-| `overUnder` | Float64 |  |
-| `homeFavorite` | Boolean |  |
-| `clock.minutes` | String |  |
-| `clock.seconds` | String |  |
+| `seasonType` | Int32 | ESPN season type for the game (2 = regular season, 3 = postseason). |
+| `homeTeamId` | Int32 | ESPN's home-team Id for the game, stamped on every play. |
+| `awayTeamId` | Int32 | ESPN's away-team Id for the game, stamped on every play. |
+| `homeTeamName` | String | ESPN's home-team Name for the game, stamped on every play. |
+| `awayTeamName` | String | ESPN's away-team Name for the game, stamped on every play. |
+| `homeTeamMascot` | String | ESPN's home-team Mascot for the game, stamped on every play. |
+| `awayTeamMascot` | String | ESPN's away-team Mascot for the game, stamped on every play. |
+| `homeTeamAbbrev` | String | ESPN's home-team Abbrev for the game, stamped on every play. |
+| `awayTeamAbbrev` | String | ESPN's away-team Abbrev for the game, stamped on every play. |
+| `homeTeamNameAlt` | String | ESPN's home-team NameAlt for the game, stamped on every play. |
+| `awayTeamNameAlt` | String | ESPN's away-team NameAlt for the game, stamped on every play. |
+| `homeTeamSpread` | Float64 | ESPN's home-team Spread for the game, stamped on every play. |
+| `gameSpread` | Float64 | Point spread used as an input to the win-probability model. |
+| `gameSpreadAvailable` | Boolean | True when a spread was available for the game. |
+| `overUnder` | Float64 | Over/under total used as a model input. |
+| `homeFavorite` | Boolean | True when the home team was favoured by the spread. |
+| `clock.minutes` | String | Minutes remaining on the game clock at the play. |
+| `clock.seconds` | String | Seconds component of the game clock at the play. |
 | `half` | Int32 | Half indicator (1 or 2). |
-| `lead_half` | Int32 | A lead column on the half |
-| `start.TimeSecsRem` | Int32 |  |
-| `start.adj_TimeSecsRem` | Int32 |  |
-| `lead_text` | String |  |
-| `lead_start_team` | String |  |
-| `lead_start_yardsToEndzone` | Int32 |  |
-| `lead_start_down` | Int32 |  |
-| `lead_start_distance` | Int32 |  |
-| `lead_scoringPlay` | Boolean |  |
-| `text_dupe` | Boolean |  |
+| `lead_half` | Int32 | Value of half on the next play, used for sequence-aware derivations. |
+| `start.TimeSecsRem` | Int32 | ESPN's `TimeSecsRem` value for the play state at the start of the play. |
+| `start.adj_TimeSecsRem` | Int32 | ESPN's `adj_TimeSecsRem` value for the play state at the start of the play. |
+| `lead_text` | String | Value of text on the next play, used for sequence-aware derivations. |
+| `lead_start_team` | String | Value of start_team on the next play, used for sequence-aware derivations. |
+| `lead_start_yardsToEndzone` | Int32 | Value of start_yardsToEndzone on the next play, used for sequence-aware derivations. |
+| `lead_start_down` | Int32 | Value of start_down on the next play, used for sequence-aware derivations. |
+| `lead_start_distance` | Int32 | Value of start_distance on the next play, used for sequence-aware derivations. |
+| `lead_scoringPlay` | Boolean | Value of scoringPlay on the next play, used for sequence-aware derivations. |
+| `text_dupe` | Boolean | True when the play description duplicates the previous row's text. |
 | `game_play_number` | Int32 | Sequential play number within the game (excludes timeouts/end markers). |
-| `start.pos_team.id` | Int32 |  |
-| `start.def_pos_team.id` | Int32 |  |
-| `end.def_team.id` | Int32 |  |
-| `end.pos_team.id` | Int32 |  |
-| `end.def_pos_team.id` | Int32 |  |
-| `start.pos_team.name` | String |  |
-| `start.def_pos_team.name` | String |  |
-| `end.pos_team.name` | String |  |
-| `end.def_pos_team.name` | String |  |
-| `start.is_home` | Boolean |  |
-| `end.is_home` | Boolean |  |
-| `homeTimeoutCalled` | Boolean |  |
-| `awayTimeoutCalled` | Boolean |  |
-| `end.homeTeamTimeouts` | Int32 |  |
-| `end.awayTeamTimeouts` | Int32 |  |
-| `start.homeTeamTimeouts` | Int32 |  |
-| `start.awayTeamTimeouts` | Int32 |  |
-| `end.TimeSecsRem` | Int32 |  |
-| `end.adj_TimeSecsRem` | Int32 |  |
-| `start.posTeamTimeouts` | Int32 |  |
-| `start.defPosTeamTimeouts` | Int32 |  |
-| `end.posTeamTimeouts` | Int32 |  |
-| `end.defPosTeamTimeouts` | Int32 |  |
-| `firstHalfKickoffTeamId` | Int32 |  |
+| `start.pos_team.id` | Int32 | ESPN's `pos_team.id` value for the play state at the start of the play. |
+| `start.def_pos_team.id` | Int32 | ESPN's `def_pos_team.id` value for the play state at the start of the play. |
+| `end.def_team.id` | Int32 | ESPN's `def_team.id` value for the play state at the end of the play. |
+| `end.pos_team.id` | Int32 | ESPN's `pos_team.id` value for the play state at the end of the play. |
+| `end.def_pos_team.id` | Int32 | ESPN's `def_pos_team.id` value for the play state at the end of the play. |
+| `start.pos_team.name` | String | ESPN's `pos_team.name` value for the play state at the start of the play. |
+| `start.def_pos_team.name` | String | ESPN's `def_pos_team.name` value for the play state at the start of the play. |
+| `end.pos_team.name` | String | ESPN's `pos_team.name` value for the play state at the end of the play. |
+| `end.def_pos_team.name` | String | ESPN's `def_pos_team.name` value for the play state at the end of the play. |
+| `start.is_home` | Boolean | ESPN's `is_home` value for the play state at the start of the play. |
+| `end.is_home` | Boolean | ESPN's `is_home` value for the play state at the end of the play. |
+| `homeTimeoutCalled` | Boolean | True when the home team called a timeout on the play. |
+| `awayTimeoutCalled` | Boolean | True when the away team called a timeout on the play. |
+| `end.homeTeamTimeouts` | Int32 | ESPN's `homeTeamTimeouts` value for the play state at the end of the play. |
+| `end.awayTeamTimeouts` | Int32 | ESPN's `awayTeamTimeouts` value for the play state at the end of the play. |
+| `start.homeTeamTimeouts` | Int32 | ESPN's `homeTeamTimeouts` value for the play state at the start of the play. |
+| `start.awayTeamTimeouts` | Int32 | ESPN's `awayTeamTimeouts` value for the play state at the start of the play. |
+| `end.TimeSecsRem` | Int32 | ESPN's `TimeSecsRem` value for the play state at the end of the play. |
+| `end.adj_TimeSecsRem` | Int32 | ESPN's `adj_TimeSecsRem` value for the play state at the end of the play. |
+| `start.posTeamTimeouts` | Int32 | ESPN's `posTeamTimeouts` value for the play state at the start of the play. |
+| `start.defPosTeamTimeouts` | Int32 | ESPN's `defPosTeamTimeouts` value for the play state at the start of the play. |
+| `end.posTeamTimeouts` | Int32 | ESPN's `posTeamTimeouts` value for the play state at the end of the play. |
+| `end.defPosTeamTimeouts` | Int32 | ESPN's `defPosTeamTimeouts` value for the play state at the end of the play. |
+| `firstHalfKickoffTeamId` | Int32 | ESPN id of the team that received the opening kickoff. |
 | `period` | Int32 | Period (quarter) number. |
-| `start.yard` | Int32 |  |
-| `end.yard` | Int32 |  |
-| `playType` | String |  |
+| `start.yard` | Int32 | ESPN's `yard` value for the play state at the start of the play. |
+| `end.yard` | Int32 | ESPN's `yard` value for the play state at the end of the play. |
+| `playType` | String | ESPN's play-type label for the play. |
 | `week` | Int32 | Game week of the season. |
 | `end_of_half` | Boolean | Binary flag for the last play of a half. |
-| `down_1` | Boolean |  |
-| `down_2` | Boolean |  |
-| `down_3` | Boolean |  |
-| `down_4` | Boolean |  |
-| `down_1_end` | Boolean |  |
-| `down_2_end` | Boolean |  |
-| `down_3_end` | Boolean |  |
-| `down_4_end` | Boolean |  |
+| `down_1` | Boolean | True when it is 1st down at the start of the play. |
+| `down_2` | Boolean | True when it is 2nd down at the start of the play. |
+| `down_3` | Boolean | True when it is 3rd down at the start of the play. |
+| `down_4` | Boolean | True when it is 4th down at the start of the play. |
+| `down_1_end` | Boolean | True when it is 1st down at the end of the play. |
+| `down_2_end` | Boolean | True when it is 2nd down at the end of the play. |
+| `down_3_end` | Boolean | True when it is 3rd down at the end of the play. |
+| `down_4_end` | Boolean | True when it is 4th down at the end of the play. |
 | `scoring_play` | Boolean | `TRUE` if the play resulted in a score. |
 | `td_play` | Boolean | Binary flag for a touchdown play. |
 | `touchdown` | Boolean | Binary flag for a touchdown (duplicate of td_play for downstream use). |
-| `td_check` | Boolean |  |
+| `td_check` | Boolean | Internal flag used while reconciling whether the play produced a touchdown. |
 | `safety` | Boolean | Binary flag for a safety. |
 | `fumble_vec` | Boolean | Binary flag for a play involving a fumble. |
-| `forced_fumble` | Boolean |  |
+| `forced_fumble` | Boolean | True when the defense forced a fumble on the play. |
 | `kickoff_play` | Boolean | Binary flag for a kickoff play. |
 | `kickoff_tb` | Boolean | Binary flag for a kickoff touchback. |
 | `kickoff_onside` | Boolean | Binary flag for an onside kickoff attempt. |
@@ -208,211 +208,211 @@ Release: [espn_cfb_pbp](https://github.com/sportsdataverse/sportsdataverse-data/
 | `pos_team` | Int32 | Team name in possession at the start of the play (offense, kickoff-aware). |
 | `def_pos_team` | Int32 | Team name on defense at the start of the play. |
 | `is_home` | Boolean | Whether the subject team was the home team. |
-| `HA_score_diff` | Int32 |  |
-| `lag_homeScore` | Int32 |  |
-| `lag_awayScore` | Int32 |  |
-| `start.homeScore` | Int32 |  |
-| `start.awayScore` | Int32 |  |
-| `end.homeScore` | Int32 |  |
-| `end.awayScore` | Int32 |  |
+| `HA_score_diff` | Int32 | Home score minus away score for the play. |
+| `lag_homeScore` | Int32 | Value of homeScore on the previous play, used for sequence-aware derivations. |
+| `lag_awayScore` | Int32 | Value of awayScore on the previous play, used for sequence-aware derivations. |
+| `start.homeScore` | Int32 | ESPN's `homeScore` value for the play state at the start of the play. |
+| `start.awayScore` | Int32 | ESPN's `awayScore` value for the play state at the start of the play. |
+| `end.homeScore` | Int32 | ESPN's `homeScore` value for the play state at the end of the play. |
+| `end.awayScore` | Int32 | ESPN's `awayScore` value for the play state at the end of the play. |
 | `pos_team_score` | Int32 | Score for the team in possession at the start of the play. |
 | `def_pos_team_score` | Int32 | Score for the defensive team at the start of the play. |
-| `start.pos_team_score` | Int32 |  |
-| `start.def_pos_team_score` | Int32 |  |
-| `start.pos_score_diff` | Int32 |  |
-| `end.pos_team_score` | Int32 |  |
-| `end.def_pos_team_score` | Int32 |  |
-| `end.pos_score_diff` | Int32 |  |
-| `lag_pos_team` | Int32 | Possession team on the previous play (lag value). |
-| `lead_pos_team` | Int32 | Possession team on the next play (lead value). |
-| `lead_pos_team2` | Int32 | Possession team two plays ahead (lead 2 of pos_team). |
+| `start.pos_team_score` | Int32 | ESPN's `pos_team_score` value for the play state at the start of the play. |
+| `start.def_pos_team_score` | Int32 | ESPN's `def_pos_team_score` value for the play state at the start of the play. |
+| `start.pos_score_diff` | Int32 | ESPN's `pos_score_diff` value for the play state at the start of the play. |
+| `end.pos_team_score` | Int32 | ESPN's `pos_team_score` value for the play state at the end of the play. |
+| `end.def_pos_team_score` | Int32 | ESPN's `def_pos_team_score` value for the play state at the end of the play. |
+| `end.pos_score_diff` | Int32 | ESPN's `pos_score_diff` value for the play state at the end of the play. |
+| `lag_pos_team` | Int32 | Value of pos_team on the previous play, used for sequence-aware derivations. |
+| `lead_pos_team` | Int32 | Value of pos_team on the next play, used for sequence-aware derivations. |
+| `lead_pos_team2` | Int32 | Value of pos_team on the next 2 plays play, used for sequence-aware derivations. |
 | `pos_score_diff` | Int32 | Score differential from the possession team's perspective. |
-| `lag_pos_score_diff` | Int32 | pos_score_diff from the previous play (lag value). |
+| `lag_pos_score_diff` | Int32 | Value of pos_score_diff on the previous play, used for sequence-aware derivations. |
 | `pos_score_pts` | Int32 | Points scored on the play attributed to the possession team. |
 | `pos_score_diff_start` | Int32 | Score differential for the possession team at the start of the play. |
-| `start.pos_team_receives_2H_kickoff` | Boolean |  |
-| `end.pos_team_receives_2H_kickoff` | Boolean |  |
+| `start.pos_team_receives_2H_kickoff` | Boolean | ESPN's `pos_team_receives_2H_kickoff` value for the play state at the start of the play. |
+| `end.pos_team_receives_2H_kickoff` | Boolean | ESPN's `pos_team_receives_2H_kickoff` value for the play state at the end of the play. |
 | `change_of_poss` | Int32 | Binary flag for change of possession on the play (CFBD offense field). |
 | `penalty_flag` | Boolean | TRUE when a penalty was flagged on the play. |
 | `penalty_declined` | Boolean | TRUE when the penalty was declined. |
 | `penalty_no_play` | Boolean | TRUE when the penalty nullified the play (no play counted). |
 | `penalty_offset` | Boolean | TRUE when offsetting penalties were called. |
 | `penalty_1st_conv` | Boolean | TRUE when the penalty resulted in a first down conversion. |
-| `penalty_in_text` | Boolean |  |
+| `penalty_in_text` | Boolean | True when the play description mentions a penalty. |
 | `sack` | Boolean | Binary flag for a sack (duplicate of sack_vec for downstream use). |
 | `int` | Boolean | Binary flag for an interception. |
 | `int_td` | Boolean | Binary flag for an interception returned for a touchdown. |
 | `completion` | Boolean | Binary flag for a completed pass. |
 | `pass_attempt` | Boolean | Binary flag for a pass attempt. |
 | `target` | Boolean | Binary flag for a targeted receiver on the play. |
-| `pass_breakup` | Boolean |  |
+| `pass_breakup` | Boolean | True when a defender broke up the pass. |
 | `pass_td` | Boolean | Binary flag for a passing touchdown. |
 | `rush_td` | Boolean | Binary flag for a rushing touchdown. |
 | `turnover_vec` | Boolean | Binary flag for any play classified as a turnover. |
 | `offense_score_play` | Boolean | Binary flag for an offensive scoring play. |
 | `defense_score_play` | Boolean | Binary flag for a defensive scoring play. |
 | `downs_turnover` | Boolean | Binary flag for a turnover on downs. |
-| `fg_attempt` | Boolean |  |
+| `fg_attempt` | Boolean | True when the play was a field-goal attempt. |
 | `fg_made` | Boolean | TRUE when the field goal attempt was successful. |
 | `pos_unit` | String | Possession-team unit label (offense or special teams). |
 | `def_pos_unit` | String | Defensive possession-team unit label (defense or special teams). |
-| `lead_play_type` | String | Play type on the next play (lead value). |
+| `lead_play_type` | String | Value of play_type on the next play, used for sequence-aware derivations. |
 | `sp` | Boolean | Binary indicator for whether or not a score occurred on the play. |
 | `play` | Boolean | Binary flag indicating the row is a counted play (excludes end markers/timeouts/penalties). |
-| `scrimmage_play` | Boolean |  |
+| `scrimmage_play` | Boolean | True when the play is a play from scrimmage rather than a special-teams or administrative row. |
 | `change_of_pos_team` | Boolean | Binary flag for change of possession-team on the play. |
-| `pos_score_diff_end` | Int32 |  |
+| `pos_score_diff_end` | Int32 | Score differential from the possessing team's perspective at the end of the play. |
 | `fumble_lost` | Boolean | Binary indicator for if the fumble was lost. |
-| `fumble_recovered` | Boolean |  |
+| `fumble_recovered` | Boolean | True when a fumble on the play was recovered. |
 | `receiver_player_name` | String | Name of the receiver on a passing play. |
 | `passer_player_name` | String | Name of the passer on a passing play. |
-| `new_down` | Int32 |  |
-| `new_distance` | Int32 |  |
+| `new_down` | Int32 | Down after the play, including any penalty enforcement. |
+| `new_distance` | Int32 | Distance to go after the play, including any penalty enforcement. |
 | `middle_8` | Boolean | TRUE for plays in the middle-8 window (final 4 min of 1H, first 4 min of 2H). |
 | `rz_play` | Boolean | Binary flag for a red-zone play (yards_to_goal <= 20). |
 | `scoring_opp` | Boolean | Binary flag for a scoring opportunity (yards_to_goal <= 40). |
 | `stuffed_run` | Boolean | Binary flag for a stuffed run (zero or negative yards gained). |
-| `stopped_run` | Boolean |  |
-| `opportunity_run` | Boolean |  |
-| `highlight_run` | Boolean |  |
-| `short_rush_success` | Boolean |  |
-| `short_rush_attempt` | Boolean |  |
-| `power_rush_success` | Boolean |  |
-| `power_rush_attempt` | Boolean |  |
-| `early_down` | Boolean |  |
-| `late_down` | Boolean |  |
-| `early_down_pass` | Boolean |  |
-| `early_down_rush` | Boolean |  |
-| `late_down_pass` | Boolean |  |
-| `late_down_rush` | Boolean |  |
-| `standard_down` | Boolean |  |
-| `passing_down` | Boolean |  |
-| `TFL` | Boolean |  |
-| `TFL_pass` | Boolean |  |
-| `TFL_rush` | Boolean |  |
-| `havoc` | Boolean |  |
-| `start.pos_team_spread` | Float64 |  |
-| `start.elapsed_share` | Float64 |  |
-| `start.spread_time` | Float64 |  |
-| `end.pos_team_spread` | Float64 |  |
-| `end.elapsed_share` | Float64 |  |
-| `end.spread_time` | Float64 |  |
-| `start.yardsToEndzone.touchback` | Int32 |  |
-| `EP_start_touchback` | Float64 |  |
-| `EP_start` | Float64 |  |
-| `EP_end` | Float64 |  |
-| `lag_change_of_pos_team` | Boolean | change_of_pos_team from the previous play (lag value). |
+| `stopped_run` | Boolean | True when the rush was stopped at or behind the line of scrimmage. |
+| `opportunity_run` | Boolean | True when the play is a rush gaining 4 yards or fewer. Note this is the inverse of the conventional 'opportunity' definition (a carry gaining 4 or more). |
+| `highlight_run` | Boolean | True when the rush gained 8 or more yards. |
+| `short_rush_success` | Boolean | True when a short-yardage rush gained the yardage needed. |
+| `short_rush_attempt` | Boolean | True when the play is a rush in a short-yardage situation. |
+| `power_rush_success` | Boolean | True when a power rushing attempt gained the yardage needed. |
+| `power_rush_attempt` | Boolean | True when the play is a short-yardage power rushing attempt. |
+| `early_down` | Boolean | True when the play is a scrimmage play on first or second down. |
+| `late_down` | Boolean | True when the play is a scrimmage play on third or fourth down. |
+| `early_down_pass` | Boolean | True when the play is a pass on an early down. |
+| `early_down_rush` | Boolean | True when the play is a rush on an early down. |
+| `late_down_pass` | Boolean | True when the play is a pass on a late down. |
+| `late_down_rush` | Boolean | True when the play is a rush on a late down. |
+| `standard_down` | Boolean | True when the offense is on schedule for the series -- first down, second down needing fewer than 8, or third/fourth down needing fewer than 5. |
+| `passing_down` | Boolean | True when the offense is behind schedule for the series -- second down needing 8 or more, or third/fourth down needing 5 or more. |
+| `TFL` | Boolean | True when the play was a tackle for loss. |
+| `TFL_pass` | Boolean | True when the play was a tackle for loss on a pass play (a sack). |
+| `TFL_rush` | Boolean | True when the play was a tackle for loss on a rush play. |
+| `havoc` | Boolean | True when the defense disrupted the play: a pass breakup, tackle for loss, interception or forced fumble. |
+| `start.pos_team_spread` | Float64 | ESPN's `pos_team_spread` value for the play state at the start of the play. |
+| `start.elapsed_share` | Float64 | ESPN's `elapsed_share` value for the play state at the start of the play. |
+| `start.spread_time` | Float64 | ESPN's `spread_time` value for the play state at the start of the play. |
+| `end.pos_team_spread` | Float64 | ESPN's `pos_team_spread` value for the play state at the end of the play. |
+| `end.elapsed_share` | Float64 | ESPN's `elapsed_share` value for the play state at the end of the play. |
+| `end.spread_time` | Float64 | ESPN's `spread_time` value for the play state at the end of the play. |
+| `start.yardsToEndzone.touchback` | Int32 | ESPN's `yardsToEndzone.touchback` value for the play state at the start of the play. |
+| `EP_start_touchback` | Float64 | Expected points the offense would have had from a touchback on this play. |
+| `EP_start` | Float64 | Expected points for the offense at the start of the play. |
+| `EP_end` | Float64 | Expected points for the offense at the end of the play. |
+| `lag_change_of_pos_team` | Boolean | Value of change_of_pos_team on the previous play, used for sequence-aware derivations. |
 | `EPA` | Float64 | Expected Points Added on the play (cfbfastR EPA model output). |
 | `def_EPA` | Float64 | EPA for the defensive team on the play (sign-flipped offense EPA). |
-| `EPA_scrimmage` | Float64 |  |
-| `EPA_pass` | Float64 |  |
-| `EPA_explosive` | Boolean |  |
-| `EPA_non_explosive` | Float64 |  |
-| `EPA_explosive_pass` | Boolean |  |
-| `EPA_explosive_rush` | Boolean |  |
-| `first_down_created` | Boolean |  |
-| `EPA_success` | Boolean |  |
-| `EPA_success_early_down` | Boolean |  |
-| `EPA_success_early_down_pass` | Boolean |  |
-| `EPA_success_early_down_rush` | Boolean |  |
-| `EPA_success_late_down` | Boolean |  |
-| `EPA_success_late_down_pass` | Boolean |  |
-| `EPA_success_late_down_rush` | Boolean |  |
-| `EPA_success_standard_down` | Boolean |  |
-| `EPA_success_passing_down` | Boolean |  |
-| `EPA_success_pass` | Boolean |  |
-| `EPA_success_rush` | Boolean |  |
-| `EPA_success_rush_EPA` | Boolean |  |
-| `EPA_middle_8_success` | Boolean |  |
-| `EPA_middle_8_success_pass` | Boolean |  |
-| `EPA_middle_8_success_rush` | Boolean |  |
-| `EPA_sp` | Float64 |  |
-| `start.ExpScoreDiff_touchback` | Float64 |  |
-| `start.ExpScoreDiff` | Float64 |  |
-| `start.ExpScoreDiff_Time_Ratio_touchback` | Float64 |  |
-| `start.ExpScoreDiff_Time_Ratio` | Float64 |  |
-| `end.ExpScoreDiff` | Float64 |  |
-| `end.ExpScoreDiff_Time_Ratio` | Float64 |  |
+| `EPA_scrimmage` | Float64 | EPA credited to the play on plays from scrimmage. |
+| `EPA_pass` | Float64 | EPA credited to the play on pass plays. |
+| `EPA_explosive` | Boolean | True when the play was explosive. |
+| `EPA_non_explosive` | Float64 | EPA credited to the play on non-explosive plays. |
+| `EPA_explosive_pass` | Boolean | True when the pass play was explosive. |
+| `EPA_explosive_rush` | Boolean | True when the rush play was explosive. |
+| `first_down_created` | Boolean | True when the play produced a first down for the offense. |
+| `EPA_success` | Boolean | True when the play was successful by EPA. |
+| `EPA_success_early_down` | Boolean | True when the play on an early down was successful by EPA. |
+| `EPA_success_early_down_pass` | Boolean | True when the pass play on an early down was successful by EPA. |
+| `EPA_success_early_down_rush` | Boolean | True when the rush play on an early down was successful by EPA. |
+| `EPA_success_late_down` | Boolean | True when the play on a late down was successful by EPA. |
+| `EPA_success_late_down_pass` | Boolean | True when the pass play on a late down was successful by EPA. |
+| `EPA_success_late_down_rush` | Boolean | True when the rush play on a late down was successful by EPA. |
+| `EPA_success_standard_down` | Boolean | True when the play on a standard down was successful by EPA. |
+| `EPA_success_passing_down` | Boolean | True when the play on a passing down was successful by EPA. |
+| `EPA_success_pass` | Boolean | True when the pass play was successful by EPA. |
+| `EPA_success_rush` | Boolean | True when the rush play was successful by EPA. |
+| `EPA_success_rush_EPA` | Boolean | EPA on successful rush plays. |
+| `EPA_middle_8_success` | Boolean | True when the play in the middle eight was successful by EPA. |
+| `EPA_middle_8_success_pass` | Boolean | True when the pass play in the middle eight was successful by EPA. |
+| `EPA_middle_8_success_rush` | Boolean | True when the rush play in the middle eight was successful by EPA. |
+| `EPA_sp` | Float64 | EPA credited to the play on special-teams plays. |
+| `start.ExpScoreDiff_touchback` | Float64 | ESPN's `ExpScoreDiff_touchback` value for the play state at the start of the play. |
+| `start.ExpScoreDiff` | Float64 | ESPN's `ExpScoreDiff` value for the play state at the start of the play. |
+| `start.ExpScoreDiff_Time_Ratio_touchback` | Float64 | ESPN's `ExpScoreDiff_Time_Ratio_touchback` value for the play state at the start of the play. |
+| `start.ExpScoreDiff_Time_Ratio` | Float64 | ESPN's `ExpScoreDiff_Time_Ratio` value for the play state at the start of the play. |
+| `end.ExpScoreDiff` | Float64 | ESPN's `ExpScoreDiff` value for the play state at the end of the play. |
+| `end.ExpScoreDiff_Time_Ratio` | Float64 | ESPN's `ExpScoreDiff_Time_Ratio` value for the play state at the end of the play. |
 | `wp_before` | Float64 | Win probability for the possession team before the play (0-1). |
-| `wp_touchback` | Float64 |  |
+| `wp_touchback` | Float64 | Win probability the offense would have had starting from a touchback. |
 | `def_wp_before` | Float64 | Win probability for the defensive team before the play (0-1). |
 | `home_wp_before` | Float64 | Home team win probability before the play (0-1). |
 | `away_wp_before` | Float64 | Away team win probability before the play (0-1). |
-| `lead_wp_before` | Float64 | Win probability on the next play (lead of wp_before). |
-| `lead_wp_before2` | Float64 | Win probability two plays ahead (lead 2 of wp_before). |
+| `lead_wp_before` | Float64 | Value of wp_before on the next play, used for sequence-aware derivations. |
+| `lead_wp_before2` | Float64 | Value of wp_before on the next 2 plays play, used for sequence-aware derivations. |
 | `wp_after` | Float64 | Win probability for the possession team after the play (0-1). |
 | `def_wp_after` | Float64 | Win probability for the defensive team after the play (0-1). |
 | `home_wp_after` | Float64 | Home team win probability after the play (0-1). |
 | `away_wp_after` | Float64 | Away team win probability after the play (0-1). |
 | `wpa` | Float64 | Win Probability Added on the play (cfbfastR WP model output). |
-| `drive_start` | Int32 |  |
-| `drive_stopped` | Boolean |  |
-| `drive_play_index` | Int32 |  |
-| `drive_offense_plays` | Int32 |  |
-| `prog_drive_EPA` | Float64 |  |
-| `prog_drive_WPA` | Float64 |  |
-| `drive_offense_yards` | Int32 |  |
-| `drive_total_yards` | Int32 |  |
-| `qbr_epa` | Float64 |  |
+| `drive_start` | Int32 | Yard line at which the drive began. |
+| `drive_stopped` | Boolean | True when the play ended the drive. |
+| `drive_play_index` | Int32 | Sequence number of the play within its drive. |
+| `drive_offense_plays` | Int32 | Offensive plays run on the drive. |
+| `prog_drive_EPA` | Float64 | Cumulative EPA accrued by the drive up to and including this play. |
+| `prog_drive_WPA` | Float64 | Cumulative win-probability added by the drive up to and including this play. |
+| `drive_offense_yards` | Int32 | Offensive yards gained on the drive. |
+| `drive_total_yards` | Int32 | Total yards gained on the drive. |
+| `qbr_epa` | Float64 | EPA variant used as an input to the QBR calculation. |
 | `weight` | Float64 | Listed weight (lbs). |
-| `non_fumble_sack` | Boolean |  |
-| `pass_epa` | Float64 |  |
-| `pass_weight` | Float64 |  |
-| `action_play` | Boolean |  |
+| `non_fumble_sack` | Boolean | True when the play was a sack that did not produce a fumble. |
+| `pass_epa` | Float64 | EPA credited to the play when it is a pass. |
+| `pass_weight` | Float64 | Weighting applied to the pass component of the play. |
+| `action_play` | Boolean | True when the play advanced the game state -- excludes timeouts, end-of-period markers and other non-action rows. |
 | `athlete_name` | String | Player full name. |
-| `type.abbreviation` | String |  |
-| `lag_half` | String | A lag column on the half |
-| `lag_scoringPlay` | Boolean |  |
-| `lag_HA_score_diff` | Int32 |  |
-| `net_HA_score_pts` | Int32 |  |
-| `H_score_diff` | Int32 |  |
-| `A_score_diff` | Int32 |  |
+| `type.abbreviation` | String | ESPN's abbreviation for the play type. |
+| `lag_half` | String | Value of half on the previous play, used for sequence-aware derivations. |
+| `lag_scoringPlay` | Boolean | Value of scoringPlay on the previous play, used for sequence-aware derivations. |
+| `lag_HA_score_diff` | Int32 | Value of HA_score_diff on the previous play, used for sequence-aware derivations. |
+| `net_HA_score_pts` | Int32 | Net points the play added to the home-minus-away score margin. |
+| `H_score_diff` | Int32 | Home team's score minus the away team's, from the home perspective. |
+| `A_score_diff` | Int32 | Away team's score minus the home team's, from the away perspective. |
 | `yds_rushed` | Int32 | Rushing yards gained on the play. |
 | `rusher_player_name` | String | Name of the rusher on a rushing play. |
-| `adj_rush_yardage` | Int32 |  |
-| `line_yards` | Float64 |  |
-| `second_level_yards` | Float64 |  |
-| `open_field_yards` | Int32 |  |
-| `highlight_yards` | Float64 |  |
-| `opp_highlight_yards` | Float64 |  |
-| `lag_EP_end` | Float64 |  |
-| `EP_between` | Float64 |  |
-| `EPA_rush` | Float64 |  |
-| `EPA_success_EPA` | Float64 |  |
-| `EPA_success_passing_down_EPA` | Float64 |  |
-| `rush_epa` | Float64 |  |
-| `rush_weight` | Float64 |  |
+| `adj_rush_yardage` | Int32 | Rushing yards capped at 8, the input to the line-yards decomposition. |
+| `line_yards` | Float64 | Yards credited to the offensive line on a rush, using the standard sliding scale: 1.2x the capped yardage on a loss, all of it through 3 yards, half of each yard from 4 to 8, and a 5.5-yard ceiling beyond that. |
+| `second_level_yards` | Float64 | Rushing yards earned from 4 to 8, split evenly between line and carrier under the line-yards decomposition. |
+| `open_field_yards` | Int32 | Rushing yards gained beyond 8, credited to the ball carrier rather than the line. |
+| `highlight_yards` | Float64 | Second-level plus open-field yards -- the yardage credited to the carrier. |
+| `opp_highlight_yards` | Float64 | Highlight yards on opportunity runs. DEGENERATE: this column is 0 in every published row, because its gate requires a rush of 4 yards or fewer while highlight yards only accrue at 4 or more. Do not use it as a signal. |
+| `lag_EP_end` | Float64 | Value of EP_end on the previous play, used for sequence-aware derivations. |
+| `EP_between` | Float64 | Change in expected points across the play, before penalty adjustment. |
+| `EPA_rush` | Float64 | EPA credited to the play on rush plays. |
+| `EPA_success_EPA` | Float64 | EPA on successful plays. |
+| `EPA_success_passing_down_EPA` | Float64 | EPA on successful plays on a passing down. |
+| `rush_epa` | Float64 | EPA credited to the play when it is a rush. |
+| `rush_weight` | Float64 | Weighting applied to the rush component of the play. |
 | `penalty_detail` | String | Parsed penalty description extracted from play text. |
 | `penalty_text` | String | TRUE when penalty information is detectable in the play text. |
 | `yds_penalty` | Int32 | Yardage assessed on the penalty. |
-| `EPA_penalty` | Float64 |  |
-| `pen_epa` | Float64 |  |
-| `pen_weight` | Float64 |  |
+| `EPA_penalty` | Float64 | EPA credited to the play attributable to penalties. |
+| `pen_epa` | Float64 | EPA attributable to a penalty on the play. |
+| `pen_weight` | Float64 | Weighting applied to the penalty component of the play. |
 | `yds_punt_gained` | Int32 | Net yards gained on the punt (punt distance minus return). |
 | `yds_punt_return` | Int32 | Yards gained on the punt return. |
 | `punter_player_name` | String | Name of the punter. |
-| `punt_return_player_name` | String |  |
-| `EPA_punt` | Float64 |  |
-| `EPA_success_standard_down_EPA` | Float64 |  |
+| `punt_return_player_name` | String | Name of the player returning the punt. |
+| `EPA_punt` | Float64 | EPA credited to the play on punt plays. |
+| `EPA_success_standard_down_EPA` | Float64 | EPA on successful plays on a standard down. |
 | `yds_receiving` | Int32 | Receiving yards gained on the play. |
-| `EPA_success_pass_EPA` | Float64 |  |
+| `EPA_success_pass_EPA` | Float64 | EPA on successful pass plays. |
 | `interception_player_name` | String | Name of the defender credited with the interception. |
-| `scoringType.name` | String |  |
-| `scoringType.displayName` | String |  |
-| `scoringType.abbreviation` | String |  |
+| `scoringType.name` | String | ESPN's name for the scoring type (e.g. touchdown, field goal). |
+| `scoringType.displayName` | String | ESPN's display label for the scoring type. |
+| `scoringType.abbreviation` | String | ESPN's abbreviation for the scoring type. |
 | `yds_kickoff_return` | Int32 | Yards gained on the kickoff return. |
 | `kickoff_player_name` | String | Name of the kickoff specialist. |
-| `kickoff_return_player_name` | String |  |
+| `kickoff_return_player_name` | String | Name of the player returning the kickoff. |
 | `down` | Int32 | Down of the play (1-4). |
 | `distance` | Int32 | Yards to gain for a first down (or to the goal line in goal-to-go situations). |
-| `EPA_kickoff` | Float64 |  |
+| `EPA_kickoff` | Float64 | EPA credited to the play on kickoff plays. |
 | `yds_fg` | Int32 | Distance of the field goal attempt in yards. |
-| `EPA_fg` | Float64 |  |
+| `EPA_fg` | Float64 | EPA credited to the play on field-goal attempts. |
 | `fumble_player_name` | String | Name of the player who fumbled. |
 | `fumble_recovered_player_name` | String | Name of the player who recovered the fumble. |
 | `yds_sacked` | Int32 | Yards lost on the sack. |
-| `sack_epa` | Float64 |  |
-| `sack_weight` | Float64 |  |
+| `sack_epa` | Float64 | EPA credited to the play when it is a sack. |
+| `sack_weight` | Float64 | Weighting applied to the sack component of the play. |
 | `date` | String | Date of the poll release. |
 | `fg_kicker_player_name` | String | Name of the field goal kicker. |
 | `yds_int_return` | Int32 | Yards gained on an interception return. |

--- a/docs/docs/mbb/reference/loaders.md
+++ b/docs/docs/mbb/reference/loaders.md
@@ -75,13 +75,13 @@ Release: [espn_mens_college_basketball_pbp](https://github.com/sportsdataverse/s
 | `clock_seconds` | Int32 | Clock seconds split out for convenience. |
 | `home_timeout_called` | Boolean |  |
 | `away_timeout_called` | Boolean |  |
-| `lead_period` | Int32 |  |
+| `lead_period` | Int32 | Period number of the next play in the same game (period_number shifted back one row within game_id), and null on each game's final play. |
 | `lead_half` | Int32 | A lead column on the half |
-| `start_period_seconds_remaining` | Int32 |  |
+| `start_period_seconds_remaining` | Int32 | Seconds left in the current period when the play started, computed as 60 times the game clock minutes plus the seconds, so 1200 at the tip of each 20-minute half and 300 at the start of an overtime. |
 | `start_game_seconds_remaining` | Int32 | Seconds remaining in the game at the start of the play. |
 | `end_period_seconds_remaining` | Int32 |  |
 | `end_game_seconds_remaining` | Int32 | Seconds remaining in the game at the end of the play. |
-| `lag_period` | Int32 |  |
+| `lag_period` | Int32 | Period number of the previous play in the same game (period_number shifted forward one row within game_id), and null on each game's first play. |
 | `lag_half` | Int32 | A lag column on the half |
 | `athlete_id_2` | Int32 | Secondary athlete identifier (e.g. assister / fouler). |
 | `game_date` | Date | Game date (YYYY-MM-DD). |
@@ -329,12 +329,12 @@ Release: [mbb_ratings](https://github.com/sportsdataverse/sportsdataverse-data/r
 | `adj_o` | Float64 | Adj o. |
 | `adj_d` | Float64 | Adj d. |
 | `adj_em` | Float64 | Adj em. |
-| `adj_tempo` | Float64 |  |
+| `adj_tempo` | Float64 | Opponent-adjusted possessions per 40 minutes, solved by the same fixed point as the efficiency ratings under the additive model that a game's pace is the two teams' tempos less the league baseline; it averages about 71 in 2025. |
 | `raw_o` | Float64 | Raw o. |
 | `raw_d` | Float64 | Raw d. |
 | `games` | Int64 | Games played. |
 | `rank` | Int64 | Rank. |
-| `adj_em_z` | Float64 |  |
+| `adj_em_z` | Float64 | Within-season z-score of adj_em, computed as adj_em minus the season mean divided by the season standard deviation, so each season is centered at zero with unit spread. |
 
 ```python
 load_mbb_ratings(seasons=2025)
@@ -354,7 +354,7 @@ Release: [mbb_player_value](https://github.com/sportsdataverse/sportsdataverse-d
 | `min` | Float64 | Minutes played. |
 | `box_obpm` | Float64 |  |
 | `box_dbpm` | Float64 |  |
-| `box_bpm` | Float64 |  |
+| `box_bpm` | Float64 | Total box plus/minus in points per 100 possessions above an average player, exactly box_obpm plus box_dbpm (verified to zero residual across all 9,805 rows of 2025). |
 
 ```python
 load_mbb_player_value(seasons=2025)
@@ -398,7 +398,7 @@ Release: [espn_mens_college_basketball_standings](https://github.com/sportsdatav
 | `group_id` | String | ESPN group id. |
 | `group_name` | String | Group name (conference / division). |
 | `group_abbreviation` | String | Group abbreviation. |
-| `group_short_name` | String |  |
+| `group_short_name` | String | Abbreviated conference label ESPN prints in standings tables, such as ACC, Big Ten or Am. East, one value per group_id. |
 | `team_id` | Int32 | Unique team identifier. |
 | `team_uid` | String | ESPN universal team identifier (UID format 's:40~l:...~t:...'). |
 | `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
@@ -413,8 +413,8 @@ Release: [espn_mens_college_basketball_standings](https://github.com/sportsdatav
 | `stat_name` | String | Stat key. |
 | `stat_display_name` | String | Stat display name (from `displayNames`). |
 | `stat_short_display_name` | String | Short human-readable stat name. |
-| `stat_description` | String |  |
-| `stat_abbreviation` | String |  |
+| `stat_description` | String | ESPN's longer-form label for the standings statistic, which can differ from stat_display_name (streak is described as Current Streak and playoffSeed as Playoff Seed). |
+| `stat_abbreviation` | String | Short code ESPN prints for the standings statistic in a table header, such as W, L, PCT, GB or STRK; it diverges from stat_short_display_name for playoff seed and the home and conference record rows. |
 | `stat_type` | String | Stat type code (e.g. "win", "loss"). |
 | `display_value` | String | Display-formatted value. |
 | `value` | Float64 | Numeric or string value field. |
@@ -442,7 +442,7 @@ Release: [espn_mens_college_basketball_player_season_stats](https://github.com/s
 | `stat_label` | String | Human-readable label of the statistic (e.g. 'At bats'). |
 | `stat_name` | String | Stat key. |
 | `stat_display_name` | String | Stat display name (from `displayNames`). |
-| `stat_description` | String |  |
+| `stat_description` | String | ESPN's prose glossary definition of the statistic named in stat_name, for example defining assists as a pass to a teammate that leads directly to a field goal. |
 | `display_value` | String | Display-formatted value. |
 | `value` | Float64 | Numeric or string value field. |
 
@@ -507,10 +507,10 @@ Release: [espn_mens_college_basketball_officials](https://github.com/sportsdatav
 |---|---|---|
 | `season` | Int32 | Season year. |
 | `game_id` | Int32 | Unique game identifier. |
-| `official_full_name` | String |  |
-| `official_display_name` | String |  |
-| `official_position` | String |  |
-| `official_position_id` | Int32 |  |
+| `official_full_name` | String | Full name of the game official as published in ESPN's gameInfo officials list; in this release it is byte-identical to official_display_name on every row. |
+| `official_display_name` | String | Display form of the official's name used by ESPN's game feed, which duplicates official_full_name for all 18,284 rows of the 2025 release. |
+| `official_position` | String | ESPN's role label for the crew member, which is the constant Referee for every men's college basketball official in this release rather than a distinct crew chief or umpire designation. |
+| `official_position_id` | Int32 | ESPN's numeric code for the official's role, constant at 40 (Referee) across the entire men's college basketball officials release. |
 | `official_order` | Int32 |  |
 
 ```python
@@ -540,7 +540,7 @@ Release: [espn_mens_college_basketball_game_rosters](https://github.com/sportsda
 | `athlete_last_name` | String | Athlete last name. |
 | `athlete_jersey` | String | Athlete jersey number. |
 | `athlete_position` | String | Player position name; `athlete_detail = TRUE` only. |
-| `athlete_headshot` | String |  |
+| `athlete_headshot` | String | URL of the player's ESPN headshot image, whose filename is the athlete_id (verified equal for all 190,365 non-null rows in 2025); null when ESPN publishes no photo for that player. |
 | `starter` | Boolean | TRUE if the player was in the starting lineup; FALSE otherwise. |
 | `did_not_play` | Boolean | TRUE if the player did not appear in the game. |
 | `active` | Boolean | TRUE if the row represents an active record (player / team / season). |
@@ -571,7 +571,7 @@ Release: [espn_mens_college_basketball_team_season_stats](https://github.com/spo
 | `stat_label` | String | Human-readable label of the statistic (e.g. 'At bats'). |
 | `stat_name` | String | Stat key. |
 | `stat_display_name` | String | Stat display name (from `displayNames`). |
-| `stat_description` | String |  |
+| `stat_description` | String | ESPN's prose glossary definition of the statistic named in stat_name, for example defining field goal percentage as the ratio of field goals made to field goals attempted. |
 | `display_value` | String | Display-formatted value. |
 | `value` | Float64 | Numeric or string value field. |
 

--- a/docs/docs/mlb/reference/loaders.md
+++ b/docs/docs/mlb/reference/loaders.md
@@ -33,10 +33,10 @@ Release: [mlb_game_state](https://github.com/sportsdataverse/sportsdataverse-dat
 
 | col_name | type | description |
 |---|---|---|
-| `base_state` | String |  |
+| `base_state` | String | Three-character pre-play base occupancy where each slot carries its base number when occupied and an underscore when empty, so ___ is bases empty and 123 is bases loaded. |
 | `outs` | Int64 | Outs in the inning after the play. |
-| `re` | Float64 |  |
-| `n` | UInt32 |  |
+| `re` | Float64 | Mean runs the batting team went on to score from this base-out state through the end of the half-inning, with bottom-of-the-9th-and-later halves excluded to avoid walk-off selection bias. |
+| `n` | UInt32 | Plate appearances observed starting in this base-out state, the sample size behind re. |
 | `season` | Int64 | Season year. |
 
 ```python
@@ -50,13 +50,13 @@ Release: [mlb_game_state](https://github.com/sportsdataverse/sportsdataverse-dat
 
 | col_name | type | description |
 |---|---|---|
-| `inning_capped` | Int64 |  |
+| `inning_capped` | Int64 | Inning number with the ninth and every extra inning collapsed into 9, so extras share the ninth-inning win-expectancy cells. |
 | `half` | String | Half of the game (1 or 2). |
-| `base_state` | String |  |
-| `outs_start` | Int64 |  |
-| `score_diff_bucket` | Int64 |  |
+| `base_state` | String | Three-character pre-play base occupancy where each slot carries its base number when occupied and an underscore when empty, so ___ is bases empty and 123 is bases loaded. |
+| `outs_start` | Int64 | Outs already recorded when the plate appearance began, normally 0 through 2, though a handful of published rows carry a stale 3 that the RE24 matrix filters out but this table does not. |
+| `score_diff_bucket` | Int64 | Home score minus away score before the play, clipped to the range -6 through +6 so blowouts collapse into the end buckets. |
 | `home_win_exp` | Float64 | Home team win expectancy before the play. |
-| `n` | UInt32 |  |
+| `n` | UInt32 | Plate appearances observed in this state bucket, the sample size behind the Laplace-smoothed home_win_exp. |
 | `season` | Int64 | Season year. |
 
 ```python
@@ -88,11 +88,11 @@ Release: [mlb_hitting_models](https://github.com/sportsdataverse/sportsdataverse
 |---|---|---|
 | `batter` | Int64 | Full name of the batter for this swing record. |
 | `season` | Int64 | Season year. |
-| `pa` | Int64 |  |
+| `pa` | Int64 | Statcast rows charged to the batter for the season, counting balls in play carrying launch data plus every other pitch, so it is a pitch-row total rather than a true plate-appearance count. |
 | `ab` | Int64 | At-bats. |
-| `xwoba` | Float64 |  |
-| `xba` | Float64 |  |
-| `xslg` | Float64 |  |
+| `xwoba` | Float64 | Expected wOBA blending the exit-velocity by launch-angle grid's predicted contact value on balls in play with realized wOBA value on walks, hit-by-pitches and strikeouts, over the wOBA denominator; low-sample batters can exceed 1. |
+| `xba` | Float64 | Sum of grid-predicted hit probability over the batter's balls in play divided by ab, which lands far below conventional batting-average scale because ab counts pitch rows rather than at-bats. |
+| `xslg` | Float64 | Sum of grid-predicted total bases over the batter's balls in play divided by ab, which lands far below conventional slugging scale because ab counts pitch rows rather than at-bats. |
 
 ```python
 load_mlb_expected_stats(seasons=2024)
@@ -108,9 +108,9 @@ Release: [mlb_hitting_models](https://github.com/sportsdataverse/sportsdataverse
 | `batter` | Int64 | Full name of the batter for this swing record. |
 | `season` | Int64 | Season year. |
 | `hr` | Int64 | Park factor for home runs. |
-| `xhr_neutral` | Float64 |  |
-| `xhr_park_adj` | Float64 |  |
-| `hr_above_expected` | Float64 |  |
+| `xhr_neutral` | Float64 | Park-neutral expected home runs, summing over the batter's balls in play the home-run probability read off the exit-velocity by launch-angle by spray-angle grid. |
+| `xhr_park_adj` | Float64 | The same expected-home-run sum after scaling each ball by its ballpark's Savant home-run park factor over 100; published values run between 0.77 and 1.26 times xhr_neutral. |
+| `hr_above_expected` | Float64 | Home runs actually hit minus xhr_neutral, so it grades over- and under-performance against the park-neutral expectation rather than the park-adjusted one. |
 
 ```python
 load_mlb_expected_hr(seasons=2024)
@@ -126,7 +126,7 @@ Release: [mlb_hitting_models](https://github.com/sportsdataverse/sportsdataverse
 | `batter` | Int64 | Full name of the batter for this swing record. |
 | `age` | Int64 | Player age (in years). |
 | `proj_xwoba` | Float64 |  |
-| `proj_pa` | Float64 |  |
+| `proj_pa` | Float64 | Combined prior-three-season pa behind the projection, its effective sample size; it inherits the pitch-row counting of load_mlb_expected_stats pa rather than true plate appearances. |
 
 ```python
 load_mlb_batter_projection(seasons=2024)
@@ -139,10 +139,10 @@ Release: [mlb_fielding_models](https://github.com/sportsdataverse/sportsdatavers
 
 | col_name | type | description |
 |---|---|---|
-| `fielder_id` | String |  |
+| `fielder_id` | String | MLBAM identifier of the fielder charged with the ball in play, resolved from whichever fielder_N column matches the responsible position and published as a string rather than an integer. |
 | `position` | Int64 | Listed roster position (G, F, C, etc.). |
-| `opportunities` | UInt32 |  |
-| `oaa` | Float64 |  |
+| `opportunities` | UInt32 | Balls in play charged to this fielder at this position, the sample the oaa sum runs over. |
+| `oaa` | Float64 | Outs above average: outs the fielder actually recorded minus what a per-position catch-probability logistic expected from the same batted-ball trajectories, summed across their opportunities. |
 | `season` | Int64 | Season year. |
 
 ```python
@@ -156,10 +156,10 @@ Release: [mlb_fielding_models](https://github.com/sportsdataverse/sportsdatavers
 
 | col_name | type | description |
 |---|---|---|
-| `catcher_id` | String |  |
-| `takes` | UInt32 |  |
-| `framing_runs` | Float64 |  |
-| `strikes_gained` | Float64 |  |
+| `catcher_id` | String | MLBAM identifier of the receiving catcher, taken from Savant's fielder_2 and published as a string rather than an integer. |
+| `takes` | UInt32 | Called strikes plus balls the catcher received across the season, a pure workload count; the framing figures themselves sum only over the shadow-zone subset of these. |
+| `framing_runs` | Float64 | Runs saved by receiving, summing actual called strike minus modeled strike probability times that count's strike run value over shadow-zone takes only. |
+| `strikes_gained` | Float64 | The same shadow-zone sum of actual called strike minus modeled strike probability left unweighted by run value, so it measures stolen strikes rather than runs. |
 | `season` | Int64 | Season year. |
 
 ```python
@@ -176,7 +176,7 @@ Release: [mlb_pitching_models](https://github.com/sportsdataverse/sportsdatavers
 | `pitcher` | Int64 | Whether the position is a pitcher. |
 | `season` | Int64 | Season year. |
 | `x_woba` | Float64 |  |
-| `x_era` | Float64 |  |
+| `x_era` | Float64 | ERA-scale conversion of x_woba as league_era plus (x_woba minus league_woba) over woba_scale times pa_per_9, an exact linear function of x_woba that can go negative for extreme pitchers. |
 
 ```python
 load_mlb_xera(seasons=2024)
@@ -191,8 +191,8 @@ Release: [mlb_pitching_models](https://github.com/sportsdataverse/sportsdatavers
 |---|---|---|
 | `pitcher` | Int64 | Whether the position is a pitcher. |
 | `pitch_type` | String | Abbreviation of the pitch type thrown (e.g. FF, SL, CH). |
-| `stuff_rv_hat` | Float64 |  |
-| `stuff_plus` | Float64 |  |
+| `stuff_rv_hat` | Float64 | Mean predicted per-pitch run value from the bundled xgboost stuff model over this pitcher's pitches of this type, on Savant's batter-perspective delta_run_exp scale so lower is better for the pitcher. |
+| `stuff_plus` | Float64 | Stuff+ on the 100-is-average scale, exactly 100 minus 10 times (stuff_rv_hat minus the league mean) over the league SD, so higher is better and outlier run-value predictions can push it well below zero. |
 | `season` | Int64 | Season year. |
 
 ```python
@@ -207,8 +207,8 @@ Release: [mlb_pitching_models](https://github.com/sportsdataverse/sportsdatavers
 | col_name | type | description |
 |---|---|---|
 | `pitcher` | Int64 | Whether the position is a pitcher. |
-| `location_rv_hat` | Float64 |  |
-| `command_plus` | Float64 |  |
+| `location_rv_hat` | Float64 | Mean predicted per-pitch run value from the bundled location model, which sees plate location, count, handedness and pitch type but no raw pitch physics; lower is better for the pitcher. |
+| `command_plus` | Float64 | Command+/Location+ on the 100-is-average scale, exactly 100 minus 10 times (location_rv_hat minus the league mean) over the league SD; it grades where the pitch finished, not intent, since Statcast ships no catcher target. |
 | `season` | Int64 | Season year. |
 
 ```python

--- a/docs/docs/nba/reference/loaders.md
+++ b/docs/docs/nba/reference/loaders.md
@@ -359,11 +359,11 @@ Release: [espn_nba_officials](https://github.com/sportsdataverse/sportsdataverse
 |---|---|---|
 | `season` | Int32 | Season year. |
 | `game_id` | Int32 | Unique game identifier. |
-| `official_full_name` | String |  |
-| `official_display_name` | String |  |
-| `official_position` | String |  |
-| `official_position_id` | Int32 |  |
-| `official_order` | Int32 |  |
+| `official_full_name` | String | Full name of an on-court game official as ESPN publishes it in the summary gameInfo.officials array; it is identical to official_display_name in every released NBA row. |
+| `official_display_name` | String | ESPN's display-form name for the official, falling back to the full name when ESPN omits it; it never diverges from official_full_name in the released NBA data. |
+| `official_position` | String | ESPN's label for the official's assignment slot; the NBA summary feed only ever ships Referee, so this reads the same on every released row. |
+| `official_position_id` | Int32 | ESPN's numeric identifier for the official's assignment slot, constant at 40 (Referee) across every released NBA season. |
+| `official_order` | Int32 | The official's listing index within the game's crew as ESPN orders them, normally 1 through 3 for a three-person crew; a fourth entry appears in a small share of recent-season games and the sequence is not guaranteed to be gap-free. |
 
 ```python
 load_nba_officials(seasons=2002)
@@ -407,7 +407,7 @@ Release: [espn_nba_standings](https://github.com/sportsdataverse/sportsdataverse
 | `group_id` | String | ESPN group id. |
 | `group_name` | String | Group name (conference / division). |
 | `group_abbreviation` | String | Group abbreviation. |
-| `group_short_name` | String |  |
+| `group_short_name` | String | ESPN's short name for the standings grouping the team sits in, read from the group node's shortName; the NBA standings payload supplies only the group name and abbreviation, so this is null throughout. |
 | `team_id` | Int32 | Unique team identifier. |
 | `team_uid` | String | ESPN universal team identifier (UID format 's:40~l:...~t:...'). |
 | `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
@@ -422,8 +422,8 @@ Release: [espn_nba_standings](https://github.com/sportsdataverse/sportsdataverse
 | `stat_name` | String | Stat key. |
 | `stat_display_name` | String | Stat display name (from `displayNames`). |
 | `stat_short_display_name` | String | Short human-readable stat name. |
-| `stat_description` | String |  |
-| `stat_abbreviation` | String |  |
+| `stat_description` | String | ESPN's prose gloss for the standings statistic on this row; for the clincher stat it is not a fixed label but the team's actual status text, such as Clinched Playoff Berth or Eliminated From Playoff. |
+| `stat_abbreviation` | String | ESPN's short code for the standings statistic, such as PCT, GB or OPP PPG; it is null for the four record-style splits (Home, Road, vs. Conf., vs. Div.), which ship no abbreviation. |
 | `stat_type` | String | Stat type code (e.g. "win", "loss"). |
 | `display_value` | String | Display-formatted value. |
 | `value` | Float64 | Numeric or string value field. |
@@ -451,7 +451,7 @@ Release: [espn_nba_player_season_stats](https://github.com/sportsdataverse/sport
 | `stat_label` | String | Human-readable label of the statistic (e.g. 'At bats'). |
 | `stat_name` | String | Stat key. |
 | `stat_display_name` | String | Stat display name (from `displayNames`). |
-| `stat_description` | String |  |
+| `stat_description` | String | ESPN's prose definition of the statistic on this row, for example the ratio of field goals made to field goals attempted; for the paired Made-Attempted stats it is the two definitions joined with a hyphen. |
 | `display_value` | String | Display-formatted value. |
 | `value` | Float64 | Numeric or string value field. |
 
@@ -479,7 +479,7 @@ Release: [espn_nba_team_season_stats](https://github.com/sportsdataverse/sportsd
 | `stat_label` | String | Human-readable label of the statistic (e.g. 'At bats'). |
 | `stat_name` | String | Stat key. |
 | `stat_display_name` | String | Stat display name (from `displayNames`). |
-| `stat_description` | String |  |
+| `stat_description` | String | ESPN's prose definition of the team statistic on this row, for example the average number of assists a team records per turnover. |
 | `display_value` | String | Display-formatted value. |
 | `value` | Float64 | Numeric or string value field. |
 
@@ -496,11 +496,11 @@ Release: [espn_nba_draft](https://github.com/sportsdataverse/sportsdataverse-dat
 |---|---|---|
 | `season` | Int32 | Season year. |
 | `round` | Int32 | Tournament / playoff round. |
-| `round_display_name` | String |  |
+| `round_display_name` | String | ESPN's display label for the draft round a pick belongs to, read from the round object's displayName; the NBA payload supplies no round metadata, so this is null for every released season 2003 through 2025. |
 | `pick` | Int32 | Pick number within the round. |
 | `overall_pick` | Int32 | Overall pick number in the draft. |
-| `pick_traded` | String |  |
-| `pick_notes` | String |  |
+| `pick_traded` | String | ESPN's traded flag for the pick, carried through as a string rather than a boolean; every released NBA row reads FALSE, so it does not currently identify traded picks. |
+| `pick_notes` | String | Free-text note ESPN can attach to a pick, read from the pick's notes or note field; the NBA draft payload never populates it, so it is null across all released seasons. |
 | `athlete_id` | Int32 | Unique athlete identifier (ESPN). |
 | `athlete_uid` | String | ESPN athlete UID (universal identifier). |
 | `athlete_guid` | String | ESPN athlete GUID. |
@@ -517,7 +517,7 @@ Release: [espn_nba_draft](https://github.com/sportsdataverse/sportsdataverse-dat
 | `college_id` | Int32 | Unique identifier for college. |
 | `college_name` | String | College / pre-draft team. |
 | `college_short_name` | String | College short name. |
-| `college_abbreviation` | String |  |
+| `college_abbreviation` | String | Abbreviation of the drafted player's college taken from the pick's nested college block; the ESPN NBA draft feed omits that block entirely, so this and the other college columns are null throughout. |
 | `team_id` | Int32 | Unique team identifier. |
 | `team_uid` | String | ESPN universal team identifier (UID format 's:40~l:...~t:...'). |
 | `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
@@ -609,7 +609,7 @@ Release: [nba_stats_schedules](https://github.com/sportsdataverse/sportsdatavers
 | `week_name` | String | Week name. |
 | `if_necessary` | String | If necessary. |
 | `series_game_number` | String | Series game number. |
-| `game_label` | String |  |
+| `game_label` | String | The stats.nba.com event label naming the round or special event a game belongs to, such as NBA Finals, East First Round, Emirates NBA Cup or NBA Mexico City Game; an empty string for an ordinary regular-season game. |
 | `game_sub_label` | String |  |
 | `series_text` | String | Series text. |
 | `arena_name` | String | Arena name. |
@@ -659,26 +659,26 @@ Release: [nba_player_impact](https://github.com/sportsdataverse/sportsdataverse-
 | `team_abbreviation` | Utf8 | Short team abbreviation (e.g. 'LAS'). |
 | `team_name` | Utf8 | Full team display name (e.g. 'Las Vegas Aces'). |
 | `teams` | Utf8 | Nested list of member-team membership spans. |
-| `o_rapm` | Float64 |  |
-| `d_rapm` | Float64 |  |
-| `rapm` | Float64 |  |
-| `off_poss` | Int64 |  |
-| `def_poss` | Int64 |  |
+| `o_rapm` | Float64 | Offensive regularized adjusted plus-minus per 100 possessions from the single-season ridge fit over possession-level lineup indicators; positive means the player raised his team's scoring rate while on offense. |
+| `d_rapm` | Float64 | Defensive regularized adjusted plus-minus per 100 possessions, negated from the raw points-allowed coefficient so a positive value marks a defender who suppresses opponent scoring. |
+| `rapm` | Float64 | Total regularized adjusted plus-minus per 100 possessions, exactly the sum of o_rapm and d_rapm. |
+| `off_poss` | Int64 | Number of possessions the player was on the floor on offense, the count of design-matrix rows carrying his offensive indicator and therefore the offensive-side sample size behind o_rapm. |
+| `def_poss` | Int64 | Number of possessions the player was on the floor on defense, the sample size behind d_rapm; it tracks off_poss almost exactly because substitutions rarely split an offense-defense pair. |
 | `o_adj_rapm` | Float64 |  |
 | `d_adj_rapm` | Float64 |  |
-| `adj_rapm` | Float64 |  |
-| `ospm` | Float64 |  |
-| `dspm` | Float64 |  |
-| `spm` | Float64 |  |
+| `adj_rapm` | Float64 | Total prior-informed RAPM per 100 possessions, exactly the sum of o_adj_rapm and d_adj_rapm. |
+| `ospm` | Float64 | Offensive statistical plus-minus per 100 possessions: the player's per-100 box-score feature vector scored through ridge coefficients trained on that season's o_rapm target. |
+| `dspm` | Float64 | Defensive statistical plus-minus per 100 possessions from the same box-score feature vector scored through coefficients trained on the d_rapm target. |
+| `spm` | Float64 | Total statistical plus-minus per 100 possessions, exactly the sum of ospm and dspm. |
 | `min` | Float64 | Minutes played. |
 | `gp` | Int64 | Games played. |
 | `obpm` | Float64 | Offensive box plus/minus. |
 | `dbpm` | Float64 | Defensive box plus/minus. |
 | `bpm` | Float64 | Career box plus/minus. |
-| `war` | Float64 |  |
-| `darko_filtered_skill` | Float64 |  |
-| `darko_projected_rating` | Float64 |  |
-| `darko_projected_sd` | Float64 |  |
+| `war` | Float64 | Wins above replacement, computed as (rapm minus a replacement level of -2.0 per 100) times total possessions divided by 100, divided by a points-per-win constant calibrated each season by regressing team wins on full-season point margin. |
+| `darko_filtered_skill` | Float64 | DARKO-style Kalman-filtered skill estimate at the end of the player's observed multi-season RAPM panel, i.e. his current-form rating after aging drift and possession-weighted observation noise. |
+| `darko_projected_rating` | Float64 | One-season-ahead DARKO forecast, the filtered skill plus the empirical aging-curve drift at the player's last observed age; both season_type rows of a player-season carry the same value because the projection is not playoff-specific. |
+| `darko_projected_sd` | Float64 | Standard deviation of the one-season-ahead DARKO forecast, the square root of the filtered state variance plus the Kalman process variance; it sits at roughly 10.19 for a player with only one season in the panel, whose diffuse prior variance was never updated. |
 | `season` | Int64 | Season year. |
 
 ```python

--- a/docs/docs/nhl/reference/loaders.md
+++ b/docs/docs/nhl/reference/loaders.md
@@ -559,16 +559,16 @@ Release: [nhl_penalties](https://github.com/sportsdataverse/sportsdataverse-data
 | `committedByPlayer.firstName.sv` | String |  |
 | `committedByPlayer.firstName.fr` | String |  |
 | `committedByPlayer.lastName.default` | String |  |
-| `committedByPlayer.lastName.cs` | String |  |
-| `committedByPlayer.lastName.fi` | String |  |
-| `committedByPlayer.lastName.sk` | String |  |
-| `committedByPlayer.lastName.sv` | String |  |
+| `committedByPlayer.lastName.cs` | String | Alternate rendering of the family name published under the NHL feed's Czech key. It differs from the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead -- so treat it as an alternate spelling, not a canonical one. |
+| `committedByPlayer.lastName.fi` | String | Alternate rendering of the family name published under the NHL feed's Finnish key. It differs from the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead -- so treat it as an alternate spelling, not a canonical one. |
+| `committedByPlayer.lastName.sk` | String | Alternate rendering of the family name published under the NHL feed's Slovak key. It differs from the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead -- so treat it as an alternate spelling, not a canonical one. |
+| `committedByPlayer.lastName.sv` | String | Alternate rendering of the family name published under the NHL feed's Swedish key. It differs from the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead -- so treat it as an alternate spelling, not a canonical one. |
 | `committedByPlayer.lastName.de` | String |  |
 | `committedByPlayer.lastName.es` | String |  |
 | `committedByPlayer.lastName.fr` | String |  |
-| `teamAbbrev.default` | String |  |
-| `drawnBy.sweaterNumber` | Int32 |  |
-| `drawnBy.firstName.default` | String |  |
+| `teamAbbrev.default` | String | Three-letter code of the team charged with the penalty, matching the committing player's boxscore team rather than the team that drew it. |
+| `drawnBy.sweaterNumber` | Int32 | Jersey number of the opposing player credited with drawing the infraction; null whenever no victim is credited, as on all bench and game-misconduct penalties. |
+| `drawnBy.firstName.default` | String | Given name, in the feed's default English locale, of the opposing player credited with drawing the penalty. |
 | `drawnBy.firstName.cs` | String |  |
 | `drawnBy.firstName.fi` | String |  |
 | `drawnBy.firstName.sk` | String |  |
@@ -576,21 +576,21 @@ Release: [nhl_penalties](https://github.com/sportsdataverse/sportsdataverse-data
 | `drawnBy.firstName.es` | String |  |
 | `drawnBy.firstName.sv` | String |  |
 | `drawnBy.firstName.fr` | String |  |
-| `drawnBy.lastName.default` | String |  |
-| `drawnBy.lastName.cs` | String |  |
-| `drawnBy.lastName.fi` | String |  |
-| `drawnBy.lastName.sk` | String |  |
-| `drawnBy.lastName.sv` | String |  |
+| `drawnBy.lastName.default` | String | Family name, in the feed's default English locale, of the opposing player credited with drawing the penalty. |
+| `drawnBy.lastName.cs` | String | Alternate rendering of the family name published under the NHL feed's Czech key. It differs from the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead -- so treat it as an alternate spelling, not a canonical one. |
+| `drawnBy.lastName.fi` | String | Alternate rendering of the family name published under the NHL feed's Finnish key. It differs from the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead -- so treat it as an alternate spelling, not a canonical one. |
+| `drawnBy.lastName.sk` | String | Alternate rendering of the family name published under the NHL feed's Slovak key. It differs from the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead -- so treat it as an alternate spelling, not a canonical one. |
+| `drawnBy.lastName.sv` | String | Alternate rendering of the family name published under the NHL feed's Swedish key. It differs from the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead -- so treat it as an alternate spelling, not a canonical one. |
 | `drawnBy.lastName.de` | String |  |
 | `drawnBy.lastName.es` | String |  |
 | `drawnBy.lastName.fr` | String |  |
 | `servedBy.default` | String |  |
-| `servedBy.cs` | String |  |
-| `servedBy.fi` | String |  |
-| `servedBy.sk` | String |  |
-| `servedBy.de` | String |  |
-| `servedBy.es` | String |  |
-| `servedBy.sv` | String |  |
+| `servedBy.cs` | String | Alternate abbreviated name (first initial plus family name) published under the NHL feed's Czech key, differing from the default by diacritics or by an alternate given-name form. |
+| `servedBy.fi` | String | Alternate abbreviated name (first initial plus family name) published under the NHL feed's Finnish key, differing from the default by diacritics or by an alternate given-name form. |
+| `servedBy.sk` | String | Alternate abbreviated name (first initial plus family name) published under the NHL feed's Slovak key, differing from the default by diacritics or by an alternate given-name form. |
+| `servedBy.de` | String | Alternate abbreviated name (first initial plus family name) published under the NHL feed's German key, differing from the default by diacritics or by an alternate given-name form. |
+| `servedBy.es` | String | Alternate abbreviated name (first initial plus family name) published under the NHL feed's Spanish key, differing from the default by diacritics or by an alternate given-name form. |
+| `servedBy.sv` | String | Alternate abbreviated name (first initial plus family name) published under the NHL feed's Swedish key, differing from the default by diacritics or by an alternate given-name form. |
 
 ```python
 load_nhl_penalties(seasons=2024)
@@ -724,8 +724,8 @@ Release: [nhl_scoring](https://github.com/sportsdataverse/sportsdataverse-data/r
 | `highlightClipSharingUrlFr` | String |  |
 | `highlightClipFr` | Float64 |  |
 | `discreteClip` | Float64 | Discrete clip identifier. |
-| `discreteClipFr` | Float64 |  |
-| `firstName.default` | String |  |
+| `discreteClipFr` | Float64 | Numeric NHL video identifier of the French-language standalone clip of the goal, always a different asset id from discreteClip. |
+| `firstName.default` | String | Given name of the goal scorer as rendered in the NHL feed's default English locale. |
 | `firstName.cs` | String |  |
 | `firstName.de` | String |  |
 | `firstName.es` | String |  |
@@ -733,24 +733,24 @@ Release: [nhl_scoring](https://github.com/sportsdataverse/sportsdataverse-data/r
 | `firstName.sk` | String |  |
 | `firstName.sv` | String |  |
 | `firstName.fr` | String |  |
-| `lastName.default` | String |  |
-| `lastName.cs` | String |  |
-| `lastName.fi` | String |  |
-| `lastName.sk` | String |  |
-| `lastName.sv` | String |  |
+| `lastName.default` | String | Family name of the goal scorer as rendered in the NHL feed's default English locale. |
+| `lastName.cs` | String | Alternate rendering of the family name published under the NHL feed's Czech key. It differs from the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead -- so treat it as an alternate spelling, not a canonical one. |
+| `lastName.fi` | String | Alternate rendering of the family name published under the NHL feed's Finnish key. It differs from the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead -- so treat it as an alternate spelling, not a canonical one. |
+| `lastName.sk` | String | Alternate rendering of the family name published under the NHL feed's Slovak key. It differs from the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead -- so treat it as an alternate spelling, not a canonical one. |
+| `lastName.sv` | String | Alternate rendering of the family name published under the NHL feed's Swedish key. It differs from the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead -- so treat it as an alternate spelling, not a canonical one. |
 | `lastName.de` | String |  |
 | `lastName.es` | String |  |
-| `lastName.fr` | String |  |
+| `lastName.fr` | String | Alternate rendering of the family name published under the NHL feed's French key. It differs from the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead -- so treat it as an alternate spelling, not a canonical one. |
 | `name.default` | String | Team name (default language). |
-| `name.cs` | String |  |
-| `name.fi` | String |  |
-| `name.sk` | String |  |
-| `name.sv` | String |  |
-| `name.de` | String |  |
-| `name.es` | String |  |
+| `name.cs` | String | Alternate abbreviated name (first initial plus family name) published under the NHL feed's Czech key, differing from the default by diacritics or by an alternate given-name form. |
+| `name.fi` | String | Alternate abbreviated name (first initial plus family name) published under the NHL feed's Finnish key, differing from the default by diacritics or by an alternate given-name form. |
+| `name.sk` | String | Alternate abbreviated name (first initial plus family name) published under the NHL feed's Slovak key, differing from the default by diacritics or by an alternate given-name form. |
+| `name.sv` | String | Alternate abbreviated name (first initial plus family name) published under the NHL feed's Swedish key, differing from the default by diacritics or by an alternate given-name form. |
+| `name.de` | String | Alternate abbreviated name (first initial plus family name) published under the NHL feed's German key, differing from the default by diacritics or by an alternate given-name form. |
+| `name.es` | String | Alternate abbreviated name (first initial plus family name) published under the NHL feed's Spanish key, differing from the default by diacritics or by an alternate given-name form. |
 | `name.fr` | String | Team name (French). |
-| `teamAbbrev.default` | String |  |
-| `leadingTeamAbbrev.default` | String |  |
+| `teamAbbrev.default` | String | Three-letter code of the team that scored the goal, resolving to the home club exactly when isHome is true and to the visitor otherwise. |
+| `leadingTeamAbbrev.default` | String | Three-letter code of the team ahead on the scoreboard immediately after this goal, null exactly when the goal tied the game and not always the scoring team. |
 
 ```python
 load_nhl_scoring(seasons=2024)
@@ -815,27 +815,27 @@ Release: [nhl_shootout](https://github.com/sportsdataverse/sportsdataverse-data/
 | `shotType` | String | Type of shot on the goal. |
 | `result` | String | Attempt result (goal/save/miss). |
 | `headshot` | String | URL to the player headshot image. |
-| `gameWinner` | Boolean |  |
+| `gameWinner` | Boolean | True on the single attempt per shootout credited as the game-deciding goal, false on every other attempt and null on the per-game summary row. |
 | `homeScore` | Int32 | Home team score after the goal. |
 | `awayScore` | Int32 | Away team score after the goal. |
 | `game_id` | Int32 | Unique game identifier. |
 | `season` | Int32 | Season year (echoed from arg). |
 | `game_date` | String | Game date. |
 | `discreteClip` | Float64 | Discrete clip identifier. |
-| `discreteClipFr` | Float64 |  |
-| `teamAbbrev.default` | String |  |
-| `firstName.default` | String |  |
-| `firstName.cs` | String |  |
-| `firstName.sk` | String |  |
-| `firstName.fi` | String |  |
-| `firstName.de` | String |  |
-| `firstName.es` | String |  |
-| `firstName.sv` | String |  |
-| `lastName.default` | String |  |
-| `lastName.cs` | String |  |
-| `lastName.fi` | String |  |
-| `lastName.sk` | String |  |
-| `lastName.sv` | String |  |
+| `discreteClipFr` | Float64 | Numeric NHL video identifier of the French-language clip of the shootout attempt, distinct from the id in discreteClip. |
+| `teamAbbrev.default` | String | Three-letter code of the shooting player's team; null on the per-game summary row that instead carries the home and away shootout goal totals. |
+| `firstName.default` | String | Given name of the shooter in the feed's default English locale; null on the per-game summary row. |
+| `firstName.cs` | String | Alternate given name published under the NHL feed's Czech key. Verified against the data it is frequently a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable transliteration of the default. |
+| `firstName.sk` | String | Alternate given name published under the NHL feed's Slovak key. Verified against the data it is frequently a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable transliteration of the default. |
+| `firstName.fi` | String | Alternate given name published under the NHL feed's Finnish key. Verified against the data it is frequently a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable transliteration of the default. |
+| `firstName.de` | String | Alternate given name published under the NHL feed's German key. Verified against the data it is frequently a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable transliteration of the default. |
+| `firstName.es` | String | Alternate given name published under the NHL feed's Spanish key. Verified against the data it is frequently a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable transliteration of the default. |
+| `firstName.sv` | String | Alternate given name published under the NHL feed's Swedish key. Verified against the data it is frequently a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable transliteration of the default. |
+| `lastName.default` | String | Family name of the shooter in the feed's default English locale; null on the per-game summary row. |
+| `lastName.cs` | String | Alternate rendering of the family name published under the NHL feed's Czech key. It differs from the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead -- so treat it as an alternate spelling, not a canonical one. |
+| `lastName.fi` | String | Alternate rendering of the family name published under the NHL feed's Finnish key. It differs from the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead -- so treat it as an alternate spelling, not a canonical one. |
+| `lastName.sk` | String | Alternate rendering of the family name published under the NHL feed's Slovak key. It differs from the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead -- so treat it as an alternate spelling, not a canonical one. |
+| `lastName.sv` | String | Alternate rendering of the family name published under the NHL feed's Swedish key. It differs from the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead -- so treat it as an alternate spelling, not a canonical one. |
 
 ```python
 load_nhl_shootout(seasons=2025)
@@ -855,8 +855,8 @@ Release: [nhl_shots_by_period](https://github.com/sportsdataverse/sportsdatavers
 | `game_date` | String | Game date. |
 | `period` | Int32 | Period number. |
 | `period_type` | String | Period type (REG/OT/SO). |
-| `max_regulation_periods` | Int32 |  |
-| `ot_periods` | Int32 |  |
+| `max_regulation_periods` | Int32 | Number of regulation periods the game format defines before overtime, constant at 3 for every row in the published seasons. |
+| `ot_periods` | Int32 | Overtime period ordinal taken from the NHL period descriptor, populated only from the second overtime onward so period 5 rows carry 2 and all other rows are null. |
 
 ```python
 load_nhl_shots_by_period(seasons=2025)
@@ -950,12 +950,12 @@ Release: [nhl_three_stars](https://github.com/sportsdataverse/sportsdataverse-da
 | `goalsAgainstAverage` | Float64 | Goals-against average (goalies). |
 | `savePctg` | Float64 | Save percentage (goalies). |
 | `name.default` | String | Team name (default language). |
-| `name.cs` | String |  |
-| `name.sk` | String |  |
-| `name.fi` | String |  |
-| `name.sv` | String |  |
-| `name.de` | String |  |
-| `name.es` | String |  |
+| `name.cs` | String | Alternate abbreviated name (first initial plus family name) published under the NHL feed's Czech key, differing from the default by diacritics or by an alternate given-name form. |
+| `name.sk` | String | Alternate abbreviated name (first initial plus family name) published under the NHL feed's Slovak key, differing from the default by diacritics or by an alternate given-name form. |
+| `name.fi` | String | Alternate abbreviated name (first initial plus family name) published under the NHL feed's Finnish key, differing from the default by diacritics or by an alternate given-name form. |
+| `name.sv` | String | Alternate abbreviated name (first initial plus family name) published under the NHL feed's Swedish key, differing from the default by diacritics or by an alternate given-name form. |
+| `name.de` | String | Alternate abbreviated name (first initial plus family name) published under the NHL feed's German key, differing from the default by diacritics or by an alternate given-name form. |
+| `name.es` | String | Alternate abbreviated name (first initial plus family name) published under the NHL feed's Spanish key, differing from the default by diacritics or by an alternate given-name form. |
 | `name.fr` | String | Team name (French). |
 
 ```python

--- a/docs/docs/pwhl/reference/loaders.md
+++ b/docs/docs/pwhl/reference/loaders.md
@@ -46,81 +46,81 @@ Release: [phf_pbp](https://github.com/sportsdataverse/sportsdataverse-data/relea
 | `play_type` | String | String indicating the type of play: pass (includes sacks), run (includes scrambles), punt, field_goal, kickoff, extra_point, qb_kneel, qb_spike, no_play (timeouts and penalties), and missing for rows indicating end of play. |
 | `team` | String | Team name. |
 | `time` | String | Game clock at infraction (MM:SS). |
-| `play_description` | String |  |
+| `play_description` | String | Free-text description of the play as published by the league. |
 | `period_id` | Int32 | Period identifier. |
 | `game_id` | Int32 | Unique game identifier. |
 | `game_date` | String | Game date. |
 | `home_team` | String | Home team name. |
 | `home_location` | String | Home team city. |
-| `home_nickname` | String |  |
+| `home_nickname` | String | Nickname of the home team. |
 | `home_abbreviation` | String | Home team abbreviation. |
-| `home_score_total` | Int32 |  |
+| `home_score_total` | Int32 | Home team's cumulative score after the play. |
 | `away_team` | String | Away team name. |
 | `away_location` | String | Away team city. |
-| `away_nickname` | String |  |
+| `away_nickname` | String | Nickname of the away team. |
 | `away_abbreviation` | String | Away team abbreviation. |
-| `away_score_total` | Int32 |  |
+| `away_score_total` | Int32 | Away team's cumulative score after the play. |
 | `away_goalie` | String | Name of the away goalie on the ice. |
-| `away_goalie_jersey` | String |  |
-| `goalie_change` | String |  |
+| `away_goalie_jersey` | String | Jersey number of the away goaltender on the ice. |
+| `goalie_change` | String | True when the play records a goaltender change. |
 | `penalty` | Int32 | Binary indicator for whether or not a penalty occurred. |
-| `on_ice_situation` | String |  |
+| `on_ice_situation` | String | Strength situation on the ice for the play (e.g. even strength, power play). |
 | `score` | String | Final score string. |
 | `minute_start` | Int32 | Minute mark of the period when the event started. |
 | `second_start` | Int32 | Second mark of the period when the event started. |
 | `clock` | String | Game clock time remaining (MM:SS). |
-| `leader` | String |  |
+| `leader` | String | Team leading the game at this point in the play sequence. |
 | `away_goals` | String | Away goals in the period. |
 | `home_goals` | String | Home goals in the period. |
 | `sec_from_start` | Int32 | Seconds elapsed since the start of the game. |
-| `power_play_seconds` | Int32 |  |
+| `power_play_seconds` | Int32 | Elapsed seconds of the power play at this play. |
 | `time_elapsed` | String | Elapsed game time for the drive (`MM:SS`). |
 | `time_remaining` | String | Time remaining. |
-| `player_name_1` | String |  |
-| `player_jersey_1` | String |  |
+| `player_name_1` | String | Name of the player in slot 1 of the play's participant list. |
+| `player_jersey_1` | String | Jersey number of the player in slot 1 of the play's participant list. |
 | `home_skaters` | Int32 | Number of home skaters on the ice. |
 | `away_skaters` | Int32 | Number of away skaters on the ice. |
 | `home_goalie` | String | Name of the home goalie on the ice. |
-| `home_goalie_jersey` | String |  |
-| `player_name_2` | String |  |
-| `player_jersey_2` | String |  |
+| `home_goalie_jersey` | String | Jersey number of the home goaltender on the ice. |
+| `player_name_2` | String | Name of the player in slot 2 of the play's participant list. |
+| `player_jersey_2` | String | Jersey number of the player in slot 2 of the play's participant list. |
 | `shot_result` | String | Shot result ('Made' / 'Missed'). |
-| `goalie_involved` | String |  |
+| `goalie_involved` | String | Name of the goaltender involved in the play. |
 | `penalty_type` | String | String indicating the penalty type of the first penalty in the given play. Will be `NA` if `desc` is missing the type. |
-| `penalty_level` | String |  |
+| `penalty_level` | String | Severity classification of the penalty (e.g. minor, major). |
 | `penalty_length` | String | Penalty length in minutes. |
-| `start_power_play` | Int32 |  |
-| `end_power_play` | Int32 |  |
-| `player_name_3` | String |  |
-| `player_jersey_3` | String |  |
-| `scoring_team_abbrev` | String |  |
-| `scoring_team_on_ice` | String |  |
-| `offensive_player_name_1` | String |  |
-| `offensive_player_name_2` | String |  |
-| `offensive_player_name_3` | String |  |
-| `offensive_player_name_4` | String |  |
-| `offensive_player_name_5` | String |  |
-| `defending_team_abbrev` | String |  |
-| `offensive_player_jersey_1` | String |  |
-| `offensive_player_jersey_2` | String |  |
-| `offensive_player_jersey_3` | String |  |
-| `offensive_player_jersey_4` | String |  |
-| `offensive_player_jersey_5` | String |  |
-| `defending_team_on_ice` | String |  |
-| `defensive_player_name_1` | String |  |
-| `defensive_player_name_2` | String |  |
-| `defensive_player_name_3` | String |  |
-| `defensive_player_name_4` | String |  |
-| `defensive_player_name_5` | String |  |
-| `defensive_player_jersey_1` | String |  |
-| `defensive_player_jersey_2` | String |  |
-| `defensive_player_jersey_3` | String |  |
-| `defensive_player_jersey_4` | String |  |
-| `defensive_player_jersey_5` | String |  |
-| `defensive_player_name_6` | String |  |
-| `defensive_player_jersey_6` | String |  |
-| `offensive_player_name_6` | String |  |
-| `offensive_player_jersey_6` | String |  |
+| `start_power_play` | Int32 | True on the play where a power play begins. |
+| `end_power_play` | Int32 | True on the play where a power play ends. |
+| `player_name_3` | String | Name of the player in slot 3 of the play's participant list. |
+| `player_jersey_3` | String | Jersey number of the player in slot 3 of the play's participant list. |
+| `scoring_team_abbrev` | String | Abbreviation of the team credited with the goal. |
+| `scoring_team_on_ice` | String | Skaters the scoring team had on the ice for the goal. |
+| `offensive_player_name_1` | String | Name of the attacking team's skater in on-ice slot 1 for the play. |
+| `offensive_player_name_2` | String | Name of the attacking team's skater in on-ice slot 2 for the play. |
+| `offensive_player_name_3` | String | Name of the attacking team's skater in on-ice slot 3 for the play. |
+| `offensive_player_name_4` | String | Name of the attacking team's skater in on-ice slot 4 for the play. |
+| `offensive_player_name_5` | String | Name of the attacking team's skater in on-ice slot 5 for the play. |
+| `defending_team_abbrev` | String | Abbreviation of the team defending on the play. |
+| `offensive_player_jersey_1` | String | Jersey number of the attacking team's skater in on-ice slot 1 for the play. |
+| `offensive_player_jersey_2` | String | Jersey number of the attacking team's skater in on-ice slot 2 for the play. |
+| `offensive_player_jersey_3` | String | Jersey number of the attacking team's skater in on-ice slot 3 for the play. |
+| `offensive_player_jersey_4` | String | Jersey number of the attacking team's skater in on-ice slot 4 for the play. |
+| `offensive_player_jersey_5` | String | Jersey number of the attacking team's skater in on-ice slot 5 for the play. |
+| `defending_team_on_ice` | String | Skaters the defending team had on the ice for the play. |
+| `defensive_player_name_1` | String | Name of the defending team's skater in on-ice slot 1 for the play. |
+| `defensive_player_name_2` | String | Name of the defending team's skater in on-ice slot 2 for the play. |
+| `defensive_player_name_3` | String | Name of the defending team's skater in on-ice slot 3 for the play. |
+| `defensive_player_name_4` | String | Name of the defending team's skater in on-ice slot 4 for the play. |
+| `defensive_player_name_5` | String | Name of the defending team's skater in on-ice slot 5 for the play. |
+| `defensive_player_jersey_1` | String | Jersey number of the defending team's skater in on-ice slot 1 for the play. |
+| `defensive_player_jersey_2` | String | Jersey number of the defending team's skater in on-ice slot 2 for the play. |
+| `defensive_player_jersey_3` | String | Jersey number of the defending team's skater in on-ice slot 3 for the play. |
+| `defensive_player_jersey_4` | String | Jersey number of the defending team's skater in on-ice slot 4 for the play. |
+| `defensive_player_jersey_5` | String | Jersey number of the defending team's skater in on-ice slot 5 for the play. |
+| `defensive_player_name_6` | String | Name of the defending team's skater in on-ice slot 6 for the play. |
+| `defensive_player_jersey_6` | String | Jersey number of the defending team's skater in on-ice slot 6 for the play. |
+| `offensive_player_name_6` | String | Name of the attacking team's skater in on-ice slot 6 for the play. |
+| `offensive_player_jersey_6` | String | Jersey number of the attacking team's skater in on-ice slot 6 for the play. |
 | `season` | Int32 | Season year (echoed from arg). |
 
 ```python
@@ -134,7 +134,7 @@ Release: [phf_player_boxscores](https://github.com/sportsdataverse/sportsdataver
 
 | col_name | type | description |
 |---|---|---|
-| `player_jersey` | Int32 |  |
+| `player_jersey` | Int32 | Player's jersey number. |
 | `player_name` | String | Player name. |
 | `position` | String | Player position. |
 | `goals` | Int32 | Goals scored. |
@@ -145,24 +145,24 @@ Release: [phf_player_boxscores](https://github.com/sportsdataverse/sportsdataver
 | `blocks` | Int32 | Total blocks. |
 | `giveaways` | Int32 | Giveaways. |
 | `takeaways` | Int32 | Takeaways. |
-| `faceoffs_won_lost` | String |  |
-| `faceoffs_win_pct` | Float64 |  |
-| `powerplay_goals` | Int32 |  |
+| `faceoffs_won_lost` | String | Faceoffs won and lost, as the league's combined won-lost string. |
+| `faceoffs_win_pct` | Float64 | Share of the player's faceoffs won. |
+| `powerplay_goals` | Int32 | Goals the player scored on the power play. |
 | `shorthanded_goals` | Int32 | Shorthanded goals. |
 | `shots` | Int32 | Shots on goal. |
-| `shots_blocked` | Int32 |  |
+| `shots_blocked` | Int32 | Shots the player blocked. |
 | `faceoffs_won` | Int32 | Faceoffs won in the season. |
 | `faceoffs_lost` | Int32 | Faceoffs lost in the season. |
 | `team` | String | Team name. |
-| `skaters_href` | String |  |
+| `skaters_href` | String | Relative link to the league's skater table for this game. |
 | `player_id` | String | Unique player identifier. |
 | `game_id` | Int32 | Unique game identifier. |
 | `minutes_played` | String | Minutes played. |
 | `shots_against` | Int32 | Shots faced. |
 | `goals_against` | Int32 | Goals against. |
 | `saves` | Int32 | Saves made. |
-| `save_percent` | Float64 |  |
-| `goalies_href` | String |  |
+| `save_percent` | Float64 | Share of shots faced that the goaltender saved. |
+| `goalies_href` | String | Relative link to the league's goaltender table for this game. |
 | `season` | Int32 | Season year (echoed from arg). |
 
 ```python
@@ -183,62 +183,62 @@ Release: [phf_schedules](https://github.com/sportsdataverse/sportsdataverse-data
 | `tournament_id` | Boolean | ESPN tournament id parsed from the `$ref` URL. |
 | `game_id` | Int32 | Unique game identifier. |
 | `number` | Int32 | Week number as returned by the API. |
-| `datetime` | Datetime(time_unit='us', time_zone='UTC') |  |
-| `datetime_tz` | Datetime(time_unit='us', time_zone='UTC') |  |
-| `time_zone` | String |  |
-| `time_zone_abbr` | String |  |
-| `updated_at` | Datetime(time_unit='us', time_zone='UTC') |  |
-| `created_at` | Datetime(time_unit='us', time_zone='UTC') |  |
+| `datetime` | Datetime(time_unit='us', time_zone='UTC') | Scheduled start of the game as a timestamp. |
+| `datetime_tz` | Datetime(time_unit='us', time_zone='UTC') | Scheduled start of the game including its time-zone offset. |
+| `time_zone` | String | Time zone in which the game is played. |
+| `time_zone_abbr` | String | Abbreviated form of the game's time zone. |
+| `updated_at` | Datetime(time_unit='us', time_zone='UTC') | Timestamp at which the league last updated the game record. |
+| `created_at` | Datetime(time_unit='us', time_zone='UTC') | Timestamp at which the league created the game record. |
 | `home_team_id` | Int32 | Home team identifier. |
 | `home_team` | String | Home team name. |
-| `home_team_short` | String |  |
-| `home_team_logo_url_full` | String |  |
-| `home_team_logo_url_small` | String |  |
-| `home_team_logo_url_medium` | String |  |
-| `home_team_logo_url_large` | String |  |
-| `home_team_logo_url_50` | String |  |
-| `home_team_logo_url_100` | String |  |
-| `home_team_logo_url_200` | String |  |
+| `home_team_short` | String | Short display name of the home team. |
+| `home_team_logo_url_full` | String | URL of the home team's logo at the full rendition. |
+| `home_team_logo_url_small` | String | URL of the home team's logo at the small rendition. |
+| `home_team_logo_url_medium` | String | URL of the home team's logo at the medium rendition. |
+| `home_team_logo_url_large` | String | URL of the home team's logo at the large rendition. |
+| `home_team_logo_url_50` | String | URL of the home team's logo at the 50px rendition. |
+| `home_team_logo_url_100` | String | URL of the home team's logo at the 100px rendition. |
+| `home_team_logo_url_200` | String | URL of the home team's logo at the 200px rendition. |
 | `away_team_id` | Int32 | Away team identifier. |
 | `away_team` | String | Away team name. |
-| `away_team_short` | String |  |
-| `away_team_logo_url_full` | String |  |
-| `away_team_logo_url_small` | String |  |
-| `away_team_logo_url_medium` | String |  |
-| `away_team_logo_url_large` | String |  |
-| `away_team_logo_url_50` | String |  |
-| `away_team_logo_url_100` | String |  |
-| `away_team_logo_url_200` | String |  |
-| `home_division_id` | Int32 |  |
+| `away_team_short` | String | Short display name of the away team. |
+| `away_team_logo_url_full` | String | URL of the away team's logo at the full rendition. |
+| `away_team_logo_url_small` | String | URL of the away team's logo at the small rendition. |
+| `away_team_logo_url_medium` | String | URL of the away team's logo at the medium rendition. |
+| `away_team_logo_url_large` | String | URL of the away team's logo at the large rendition. |
+| `away_team_logo_url_50` | String | URL of the away team's logo at the 50px rendition. |
+| `away_team_logo_url_100` | String | URL of the away team's logo at the 100px rendition. |
+| `away_team_logo_url_200` | String | URL of the away team's logo at the 200px rendition. |
+| `home_division_id` | Int32 | League identifier for the home team's division. |
 | `home_division` | String | Home team division. |
-| `away_division_id` | Int32 |  |
+| `away_division_id` | Int32 | League identifier for the away team's division. |
 | `away_division` | String | Away team division. |
 | `home_score` | Int32 | Home team final score. |
 | `away_score` | Int32 | Away team final score. |
 | `home_shots` | Int32 | Home team shots in the period. |
 | `away_shots` | Int32 | Away team shots in the period. |
-| `home_penalty_minutes` | Int32 |  |
-| `away_penalty_minutes` | Int32 |  |
-| `home_roster_count` | Int32 |  |
-| `away_roster_count` | Int32 |  |
-| `facility_id` | Int32 |  |
-| `facility` | String |  |
-| `facility_address` | String |  |
-| `rink_id` | Boolean |  |
-| `rink` | Boolean |  |
+| `home_penalty_minutes` | Int32 | Penalty minutes assessed to the home team. |
+| `away_penalty_minutes` | Int32 | Penalty minutes assessed to the away team. |
+| `home_roster_count` | Int32 | Number of players dressed for the home team. |
+| `away_roster_count` | Int32 | Number of players dressed for the away team. |
+| `facility_id` | Int32 | League identifier for the hosting facility. |
+| `facility` | String | Name of the facility hosting the game. |
+| `facility_address` | String | Street address of the hosting facility. |
+| `rink_id` | Boolean | League identifier for the rink. |
+| `rink` | Boolean | Name of the rink within the facility. |
 | `game_type` | String | Game type the row belongs to. |
 | `notes` | String | Notes flag for the pick. |
 | `status` | String | Status string (e.g. captain markers). |
 | `overtime` | Boolean | Binary indicator of whether or not game went to overtime. |
 | `shootout` | Boolean | Whether shootout data is available. |
-| `allow_players` | Boolean |  |
-| `tickets_url` | String |  |
-| `watch_live_url` | String |  |
-| `external_url` | Boolean |  |
-| `has_play_by_play` | Boolean |  |
-| `highlight_color` | Boolean |  |
+| `allow_players` | Boolean | League flag for whether player-level detail is published for the game. |
+| `tickets_url` | String | Link to purchase tickets for the game. |
+| `watch_live_url` | String | Link to the live broadcast of the game. |
+| `external_url` | Boolean | League-published external link for the game. |
+| `has_play_by_play` | Boolean | True when a play-by-play feed exists for the game. |
+| `highlight_color` | Boolean | Display colour the league uses for the game in its schedule UI. |
 | `attendance` | Int32 | Game attendance. |
-| `date_group` | Date |  |
+| `date_group` | Date | League grouping key for the game's date, used to bucket a slate. |
 | `winner` | String | Whether this competitor won the game. |
 | `season` | Int32 | Season year (echoed from arg). |
 | `PBP` | Boolean | Whether play-by-play data is available. |
@@ -259,28 +259,28 @@ Release: [phf_team_boxscores](https://github.com/sportsdataverse/sportsdataverse
 | `team` | String | Team name. |
 | `game_id` | Int32 | Unique game identifier. |
 | `winner` | Boolean | Whether this competitor won the game. |
-| `total_scoring` | Int32 |  |
-| `successful_power_play` | Float64 |  |
+| `total_scoring` | Int32 | Goals the team scored in the game. |
+| `successful_power_play` | Float64 | Number of power plays on which the team scored. |
 | `power_play_opportunities` | Float64 | Power play opportunities. |
-| `power_play_percent` | Float64 |  |
+| `power_play_percent` | Float64 | Share of the team's power plays that produced a goal. |
 | `penalty_minutes` | Float64 | Penalty minutes. |
 | `faceoff_percent` | Float64 | Faceoff win percentage. |
-| `blocked_opponent_shots` | Float64 |  |
+| `blocked_opponent_shots` | Float64 | Opponent shots the team blocked. |
 | `takeaways` | Float64 | Takeaways. |
 | `giveaways` | Float64 | Giveaways. |
-| `period_1_shots` | Int32 |  |
-| `period_2_shots` | Int32 |  |
-| `period_3_shots` | Int32 |  |
-| `overtime_shots` | Int32 |  |
-| `shootout_made_shots` | Int32 |  |
-| `shootout_missed_shots` | Int32 |  |
-| `total_shots` | Int32 |  |
-| `period_1_scoring` | Int32 |  |
-| `period_2_scoring` | Int32 |  |
-| `period_3_scoring` | Int32 |  |
-| `overtime_scoring` | Int32 |  |
-| `shootout_made_scoring` | Float64 |  |
-| `shootout_missed_scoring` | Float64 |  |
+| `period_1_shots` | Int32 | Shots the team took in period 1. |
+| `period_2_shots` | Int32 | Shots the team took in period 2. |
+| `period_3_shots` | Int32 | Shots the team took in period 3. |
+| `overtime_shots` | Int32 | Shots the team took in overtime. |
+| `shootout_made_shots` | Int32 | Shootout shots the team took that scored. |
+| `shootout_missed_shots` | Int32 | Shootout shots the team took that did not score. |
+| `total_shots` | Int32 | Shots the team took in the game. |
+| `period_1_scoring` | Int32 | Goals the team scored in period 1. |
+| `period_2_scoring` | Int32 | Goals the team scored in period 2. |
+| `period_3_scoring` | Int32 | Goals the team scored in period 3. |
+| `overtime_scoring` | Int32 | Goals the team scored in overtime. |
+| `shootout_made_scoring` | Float64 | Shootout attempts the team converted. |
+| `shootout_missed_scoring` | Float64 | Shootout attempts the team failed to convert. |
 | `season` | Int32 | Season year (echoed from arg). |
 
 ```python

--- a/docs/docs/wbb/reference/loaders.md
+++ b/docs/docs/wbb/reference/loaders.md
@@ -327,12 +327,12 @@ Release: [wbb_ratings](https://github.com/sportsdataverse/sportsdataverse-data/r
 | `adj_o` | Float64 | Adj o. |
 | `adj_d` | Float64 | Adj d. |
 | `adj_em` | Float64 | Adj em. |
-| `adj_tempo` | Float64 |  |
+| `adj_tempo` | Float64 | Opponent-adjusted tempo in possessions per 40 minutes, produced by the same fixed-point adjustment as the efficiencies applied to game possessions under the additive model poss = tempo_i + tempo_j minus the league baseline. |
 | `raw_o` | Float64 | Raw o. |
 | `raw_d` | Float64 | Raw d. |
 | `games` | Int64 | Games played. |
 | `rank` | Int64 | Whether to include statistical ranks in the returned table. |
-| `adj_em_z` | Float64 |  |
+| `adj_em_z` | Float64 | Within-season z-score of adj_em, computed as adj_em minus the season mean divided by the season standard deviation over every team in the frame, so it is mean 0 and standard deviation 1 per season. |
 
 ```python
 load_wbb_ratings(seasons=2025)
@@ -352,7 +352,7 @@ Release: [wbb_player_value](https://github.com/sportsdataverse/sportsdataverse-d
 | `min` | Float64 | Minutes played. |
 | `box_obpm` | Float64 |  |
 | `box_dbpm` | Float64 |  |
-| `box_bpm` | Float64 |  |
+| `box_bpm` | Float64 | Total box plus/minus in points per 100 possessions above average, exactly box_obpm plus box_dbpm in every published row. |
 
 ```python
 load_wbb_player_value(seasons=2025)
@@ -381,7 +381,7 @@ Release: [espn_womens_college_basketball_game_rosters](https://github.com/sports
 | `athlete_last_name` | String | Athlete last name. |
 | `athlete_jersey` | String | Athlete jersey number. |
 | `athlete_position` | String | Athlete position. |
-| `athlete_headshot` | String |  |
+| `athlete_headshot` | String | URL of the player's ESPN headshot image on a.espncdn.com, whose filename is the athlete_id; null when ESPN publishes no headshot for that player. |
 | `starter` | Boolean | TRUE if the player was in the starting lineup; FALSE otherwise. |
 | `did_not_play` | Boolean | TRUE if the player did not appear in the game. |
 | `active` | Boolean | TRUE if the row represents an active record (player / team / season). |
@@ -402,12 +402,12 @@ Release: [espn_womens_college_basketball_officials](https://github.com/sportsdat
 | `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
 | `game_id` | String | Unique game identifier. |
 | `official_id` | Int32 | Unique official / referee identifier. |
-| `official_uid` | String |  |
-| `official_full_name` | String |  |
-| `official_display_name` | String |  |
-| `official_first_name` | String |  |
-| `official_last_name` | String |  |
-| `official_order` | Int32 |  |
+| `official_uid` | String | ESPN's globally unique resource identifier for the official, read from the core-api items[] uid key; that payload never ships it, so the column is null for every published row. |
+| `official_full_name` | String | ESPN's fullName for the official, falling back to displayName when fullName is absent; ESPN sometimes ships it with a middle initial or a doubled internal space, so it is not simply first plus last name. |
+| `official_display_name` | String | ESPN's displayName for the official, which is identical to official_full_name in every published row of the released data. |
+| `official_first_name` | String | The official's given name as ESPN splits it out separately from the full name, excluding any middle initial that appears in official_full_name. |
+| `official_last_name` | String | The official's surname as ESPN splits it out; joined to official_first_name it reconstructs roughly 98 percent of official_full_name values, the rest differing by middle initials or spacing. |
+| `official_order` | Int32 | ESPN's 1-based sequence of the official within that game's crew listing, unique within a game and running 1 to 3 for the standard three-person crew. |
 | `position_name` | String | Listed roster position ('Guard', 'Forward', 'Center'). |
 | `position_display_name` | String | Position display name. |
 
@@ -435,7 +435,7 @@ Release: [espn_womens_college_basketball_player_season_stats](https://github.com
 | `stat_label` | String | Human-readable label of the statistic (e.g. 'At bats'). |
 | `stat_name` | String | Internal stat key. |
 | `stat_display_name` | String | Stat display name. |
-| `stat_description` | String |  |
+| `stat_description` | String | ESPN's prose definition of the statistic named in stat_name, for example The average assists per game for avgAssists; combined made-attempted stats carry both definitions joined by a hyphen. |
 | `display_value` | String | Display-formatted value. |
 | `value` | Float64 | Numeric or string value field. |
 
@@ -544,8 +544,8 @@ Release: [espn_womens_college_basketball_standings](https://github.com/sportsdat
 | `stat_name` | String | Internal stat key. |
 | `stat_display_name` | String | Stat display name. |
 | `stat_short_display_name` | String | Short human-readable stat name. |
-| `stat_description` | String |  |
-| `stat_abbreviation` | String |  |
+| `stat_description` | String | ESPN's longer wording for the standings stat, for example Overall Record for the Team Season Record entry and Current Streak for Streak; null for stats ESPN ships without one, such as vs AP Top 25. |
+| `stat_abbreviation` | String | ESPN's abbreviation for the standings stat, such as GB, OPP PPG or VS CONF; always populated and matching stat_short_display_name for about 90 percent of rows. |
 | `stat_type` | String | Stat type code (e.g. "win", "loss"). |
 | `display_value` | String | Display-formatted value. |
 | `value` | Float64 | Numeric or string value field. |
@@ -574,7 +574,7 @@ Release: [espn_womens_college_basketball_team_season_stats](https://github.com/s
 | `stat_label` | String | Human-readable label of the statistic (e.g. 'At bats'). |
 | `stat_name` | String | Internal stat key. |
 | `stat_display_name` | String | Stat display name. |
-| `stat_description` | String |  |
+| `stat_description` | String | ESPN's prose definition of the team statistic named in stat_name, for example The average blocks per game for avgBlocks or the full sentence defining a blocked shot for blocks. |
 | `display_value` | String | Display-formatted value. |
 | `value` | Float64 | Numeric or string value field. |
 

--- a/docs/docs/wnba/reference/loaders.md
+++ b/docs/docs/wnba/reference/loaders.md
@@ -313,11 +313,11 @@ Release: [espn_wnba_draft](https://github.com/sportsdataverse/sportsdataverse-da
 |---|---|---|
 | `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
 | `round` | Int32 | Tournament / playoff round. |
-| `round_display_name` | String |  |
+| `round_display_name` | String | Human-readable label for the draft round, read from the ESPN round object's displayName falling back to its name; null whenever ESPN ships the modern flat picks array with no round objects, which is the case for every published season. |
 | `pick` | Int32 | Pick. |
 | `overall_pick` | Int32 | Overall pick. |
-| `pick_traded` | String |  |
-| `pick_notes` | String |  |
+| `pick_traded` | String | ESPN's pick-level traded flag stringified as TRUE or FALSE, marking selections made with a pick that had changed hands (17 of the 45 published 2026 picks are TRUE). |
+| `pick_notes` | String | Free-text annotation ESPN attaches to a pick, taken from notes and falling back to note; empty for every pick published so far. |
 | `athlete_id` | Int32 | Unique athlete identifier (ESPN). |
 | `athlete_uid` | String | ESPN athlete UID (universal identifier). |
 | `athlete_guid` | String | ESPN athlete GUID. |
@@ -334,7 +334,7 @@ Release: [espn_wnba_draft](https://github.com/sportsdataverse/sportsdataverse-da
 | `college_id` | Int32 | Unique identifier for college. |
 | `college_name` | String | College name. |
 | `college_short_name` | String | College short name. |
-| `college_abbreviation` | String |  |
+| `college_abbreviation` | String | Short code for the drafted player's school, read from the athlete's ESPN college block; null throughout the published data because ESPN ships no college block on these picks. |
 | `team_id` | Int32 | Unique team identifier. |
 | `team_uid` | String | ESPN universal team identifier (UID format 's:40~l:...~t:...'). |
 | `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
@@ -374,7 +374,7 @@ Release: [espn_wnba_game_rosters](https://github.com/sportsdataverse/sportsdatav
 | `athlete_last_name` | String | Athlete last name. |
 | `athlete_jersey` | String | Athlete jersey number. |
 | `athlete_position` | String | Athlete position. |
-| `athlete_headshot` | String |  |
+| `athlete_headshot` | String | Direct link to the player's ESPN headshot image, always of the form https://a.espncdn.com/i/headshots/wnba/players/full/{athlete_id}.png, and null for the few players ESPN has no photo for. |
 | `starter` | Boolean | TRUE if the player was in the starting lineup; FALSE otherwise. |
 | `did_not_play` | Boolean | TRUE if the player did not appear in the game. |
 | `active` | Boolean | TRUE if the row represents an active record (player / team / season). |
@@ -395,12 +395,12 @@ Release: [espn_wnba_officials](https://github.com/sportsdataverse/sportsdatavers
 | `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
 | `game_id` | String | Unique game identifier. |
 | `official_id` | Int32 | Unique official / referee identifier. |
-| `official_uid` | String |  |
-| `official_full_name` | String |  |
-| `official_display_name` | String |  |
-| `official_first_name` | String |  |
-| `official_last_name` | String |  |
-| `official_order` | Int32 |  |
+| `official_uid` | String | ESPN's global uid string for the official, carried straight through from the officials payload; the Core v2 items ESPN serves omit it, so it is null in every published season. |
+| `official_full_name` | String | The official's full name, taken from ESPN fullName and falling back to displayName; it equals first plus last name on every published row. |
+| `official_display_name` | String | ESPN's display rendering of the official's name, which is byte-identical to official_full_name on every published row and therefore adds nothing. |
+| `official_first_name` | String | Given name of the official as ESPN splits it out, the leading token of official_full_name. |
+| `official_last_name` | String | Family name of the official as ESPN splits it out, the trailing token of official_full_name, with hyphenated surnames kept intact. |
+| `official_order` | Int32 | ESPN's 1-based position of the official within that game's crew; most games run 1 through 3 for a three-person crew and 40 of 573 games in 2024-2025 add a fourth. |
 | `position_name` | String | Listed roster position ('Guard', 'Forward', 'Center'). |
 | `position_display_name` | String | Position display name. |
 
@@ -428,7 +428,7 @@ Release: [espn_wnba_player_season_stats](https://github.com/sportsdataverse/spor
 | `stat_label` | String | Human-readable label of the statistic (e.g. 'At bats'). |
 | `stat_name` | String | Internal stat key. |
 | `stat_display_name` | String | Stat display name. |
-| `stat_description` | String |  |
+| `stat_description` | String | ESPN's prose definition of the statistic on this row, for example The average number of points scored per game for avgPoints; combined made-attempted stats carry both halves joined by a hyphen. |
 | `display_value` | String | Display-formatted value. |
 | `value` | Float64 | Numeric or string value field. |
 
@@ -522,7 +522,7 @@ Release: [espn_wnba_standings](https://github.com/sportsdataverse/sportsdatavers
 | `group_id` | String | ESPN group id. |
 | `group_name` | String | Group name (conference / division). |
 | `group_abbreviation` | String | Group abbreviation. |
-| `group_short_name` | String |  |
+| `group_short_name` | String | Short label of the standings group node the team sits under, read from ESPN shortName; the WNBA conference nodes ship only name and abbreviation, so it is null on every published row. |
 | `team_id` | Int32 | Unique team identifier. |
 | `team_uid` | String | ESPN universal team identifier (UID format 's:40~l:...~t:...'). |
 | `team_slug` | String | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
@@ -537,8 +537,8 @@ Release: [espn_wnba_standings](https://github.com/sportsdataverse/sportsdatavers
 | `stat_name` | String | Internal stat key. |
 | `stat_display_name` | String | Stat display name. |
 | `stat_short_display_name` | String | Short human-readable stat name. |
-| `stat_description` | String |  |
-| `stat_abbreviation` | String |  |
+| `stat_description` | String | ESPN's long-form explanation of the standings stat, such as Clinched Best League Record for clincher or Record last 10 games for lasttengames. |
+| `stat_abbreviation` | String | ESPN's abbreviation for the standings stat, which can differ from stat_short_display_name (playoffSeed is SEED here but POS there) and is null on the record-split rows such as Home and vs. Conf. |
 | `stat_type` | String | Stat type code (e.g. "win", "loss"). |
 | `display_value` | String | Display-formatted value. |
 | `value` | Float64 | Numeric or string value field. |
@@ -587,11 +587,11 @@ Release: [wnba_stats_coaches](https://github.com/sportsdataverse/sportsdataverse
 | `coach_id` | String | Unique identifier for coach. |
 | `first_name` | String | Player's first name. |
 | `last_name` | String | Player's last name. |
-| `coach_name` | String |  |
-| `is_assistant` | String |  |
-| `coach_type` | String |  |
-| `sort_sequence` | String |  |
-| `sub_sort_sequence` | String |  |
+| `coach_name` | String | Full name of the staff member as the feed renders it, exactly first_name plus a space plus last_name on every published row. |
+| `is_assistant` | String | Numeric staff-role code rather than a boolean flag: 1 head coach, 2 assistant coach, 3 trainer, 9 associate head coach, mapping one-to-one onto coach_type. |
+| `coach_type` | String | Job title of the staff member, one of Head Coach, Associate Head Coach, Assistant Coach or Trainer in the published data. |
+| `sort_sequence` | String | Ordering field passed through unchanged from the stats.wnba.com coaches result set; it arrives empty, so every published row is null. |
+| `sub_sort_sequence` | String | Secondary display-ordering rank that tracks coach_type exactly: 1 head coach, 2 associate head coach, 5 assistant coach, 7 trainer. |
 | `season_2` | Int32 |  |
 | `team_id_lookup` | Int32 |  |
 

--- a/docs/docs/wnba/reference/loaders.md
+++ b/docs/docs/wnba/reference/loaders.md
@@ -567,7 +567,7 @@ Release: [espn_wnba_team_season_stats](https://github.com/sportsdataverse/sports
 | `stat_label` | String | Human-readable label of the statistic (e.g. 'At bats'). |
 | `stat_name` | String | Internal stat key. |
 | `stat_display_name` | String | Stat display name. |
-| `stat_description` | String |  |
+| `stat_description` | String | Human-readable description of the statistic the row reports. |
 | `display_value` | String | Display-formatted value. |
 | `value` | Float64 | Numeric or string value field. |
 
@@ -744,18 +744,18 @@ Release: [wnba_stats_pbp](https://github.com/sportsdataverse/sportsdataverse-dat
 | `player3_team_nickname` | String | Player3 team nickname. |
 | `player3_team_abbreviation` | String | Player3 team abbreviation. |
 | `score_value` | Int32 | Point value of the play (2 / 3 / 1). |
-| `msg_type` | Int32 |  |
-| `act_type` | Int32 |  |
-| `slug_team` | String |  |
-| `shot_pts` | Int32 |  |
-| `secs_passed_game` | Float64 |  |
-| `team_away` | String |  |
-| `team_home` | String |  |
-| `off_slug_team` | String |  |
-| `number_event` | Int32 |  |
+| `msg_type` | Int32 | Message-type code for the play-by-play event. |
+| `act_type` | Int32 | Action-type code for the play-by-play event. |
+| `slug_team` | String | Slug of the team credited with the event. |
+| `shot_pts` | Int32 | Points scored on the shot, if the event was a made field goal. |
+| `secs_passed_game` | Float64 | Seconds elapsed in the game at the event. |
+| `team_away` | String | Slug of the away team. |
+| `team_home` | String | Slug of the home team. |
+| `off_slug_team` | String | Slug of the team on offense for the event. |
+| `number_event` | Int32 | Sequence number of the event within the game. |
 | `possession` | Int32 | Abbreviation of the team currently in possession. |
-| `total_starters_home` | Int32 |  |
-| `total_starters_away` | Int32 |  |
+| `total_starters_home` | Int32 | Number of the home team's starters on the floor for the event. |
+| `total_starters_away` | Int32 | Number of the away team's starters on the floor for the event. |
 | `garbage_time` | Int32 | TRUE if the play occurred during garbage time. |
 | `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
 
@@ -782,25 +782,25 @@ Release: [wnba_stats_player_game_logs](https://github.com/sportsdataverse/sports
 | `wl` | String | Wl. |
 | `min` | String | Minutes played. |
 | `fgm` | String | Field goals made. |
-| `fga` | String | Field goal attempts. |
-| `fg_pct` | String | Field goal percentage (0-1). |
+| `fga` | String | Field goals attempted. |
+| `fg_pct` | String | Field-goal percentage. |
 | `fg3m` | String | Three-point field goals made. |
-| `fg3a` | String | Three-point field goal attempts. |
-| `fg3_pct` | String | Three-point field goal percentage (0-1). |
+| `fg3a` | String | Three-point field goals attempted. |
+| `fg3_pct` | String | Three-point percentage. |
 | `ftm` | String | Free throws made. |
-| `fta` | String | Free throw attempts. |
-| `ft_pct` | String | Free throw percentage (0-1). |
-| `oreb` | String | Offensive rebounds. |
-| `dreb` | String | Defensive rebounds. |
-| `reb` | String | Total rebounds. |
-| `ast` | String | Assists. |
-| `stl` | String | Steals. |
-| `blk` | String | Blocks. |
-| `tov` | String | Turnovers. |
-| `pf` | String | Personal fouls. |
-| `pts` | String | Points scored. |
-| `plus_minus` | String | Plus/minus point differential while on court. |
-| `fantasy_pts` | String |  |
+| `fta` | String | Free throws attempted. |
+| `ft_pct` | String | Free-throw percentage. |
+| `oreb` | String | Offensive rebounds collected. |
+| `dreb` | String | Defensive rebounds collected. |
+| `reb` | String | Total rebounds collected. |
+| `ast` | String | Assists credited. |
+| `stl` | String | Steals recorded. |
+| `blk` | String | Total shots blocked. |
+| `tov` | String | Turnovers committed. |
+| `pf` | String | Personal fouls committed. |
+| `pts` | String | Total points scored. |
+| `plus_minus` | String | Plus-minus point differential. |
+| `fantasy_pts` | String | Fantasy points. |
 | `video_available` | String | Video available. |
 | `team_location` | String | Team city or location string. |
 | `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
@@ -831,9 +831,9 @@ Release: [wnba_stats_rosters](https://github.com/sportsdataverse/sportsdataverse
 | `exp` | String | Years of MLB service experience. |
 | `school` | String | Player's school / college (when distinct from 'college'). |
 | `player_id` | String | Unique player identifier. |
-| `how_acquired` | String |  |
-| `season_2` | Int32 |  |
-| `team_id_lookup` | Int32 |  |
+| `how_acquired` | String | How the team acquired the player (draft, trade, free agency). |
+| `season_2` | Int32 | Season label in the league's second display form. |
+| `team_id_lookup` | Int32 | Team id used to join the row back to the team tables. |
 
 ```python
 load_wnba_stats_rosters(seasons=2026)

--- a/docs/src/pages/CHANGELOG.md
+++ b/docs/src/pages/CHANGELOG.md
@@ -3,6 +3,8 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Unreleased](#unreleased)
+  - [CFB — `opportunity_run` corrected, un-degenerating `opp_highlight_yards` (BREAKING)](#cfb--opportunity_run-corrected-un-degenerating-opp_highlight_yards-breaking)
+  - [CFB / PHF — 1,308 loader return-table columns described](#cfb--phf--1308-loader-return-table-columns-described)
   - [CFB — `team_id` canonicalized to `Int64` at the loader boundary](#cfb--team_id-canonicalized-to-int64-at-the-loader-boundary)
   - [Docs — loader returns tables now carry column descriptions](#docs--loader-returns-tables-now-carry-column-descriptions)
   - [CFB — `adv_*` `pos_team` now holds the team NAME, id moves to `pos_team_id` (BREAKING data change)](#cfb--adv_-pos_team-now-holds-the-team-name-id-moves-to-pos_team_id-breaking-data-change)
@@ -210,6 +212,70 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Unreleased
+
+### CFB — `opportunity_run` corrected, un-degenerating `opp_highlight_yards` (BREAKING)
+
+Found while **writing column descriptions**, not by a failing test — nothing
+pinned either invariant, which is why both survived.
+
+`opportunity_run` was `rush AND yds_rushed <= 4`. The cfbfastR oracle
+(`espn_cfb_15_team_summaries_creation.R:606`) is
+`((rush == 1) & (yds_rushed >= 4))`, and the sibling cfb-data producer agrees. An
+"opportunity" is a carry where the blocking **did** its job — one that reached 4
+yards. sdv-py had it as a stuff.
+
+That silently degenerated a second column. `opp_highlight_yards` gates on
+`opportunity_run`, but `highlight_yards` only accrues from 4 rushing yards up, so
+the two conditions could never co-occur: the column was **identically 0 in every
+published row**, verified across 162,950 plays in the 2024 release. It now ranges
+0–16 on the same games.
+
+The regression test then caught a **second divergence**: these gated on
+`type.text == "Rush"`, the literal ESPN play-type string, which excludes
+`"Rushing Touchdown"` and `"Fumble Recovery (Own)"` rushes — so a 4-yard rushing
+touchdown was not counted as an opportunity. The oracle gates on `rush`, and so
+does `line_yards` two statements below, which meant `adj_rush_yardage` was left
+null on exactly the plays `line_yards` tried to consume. `opportunity_run`,
+`highlight_run` and `adj_rush_yardage` now all gate on `rush`.
+
+**Still divergent, deliberately untouched:** the line-yards *scale*. The R oracle
+caps `adj_rush_yardage` at 10 and splits 0–4 / 5–10 / 11+; sdv-py caps at 8 with a
+`3 + 0.5(adj-3)` ramp and a 5.5 ceiling. Changing that shifts published
+`line_yards` / `second_level_yards` / `open_field_yards`, so it needs its own
+decision rather than riding along with a bug fix.
+
+**Breaking:** published `espn_cfb_pbp` assets carry the old values until
+republished; the column descriptions say so explicitly.
+
+### CFB / PHF — 1,308 loader return-table columns described
+
+Continues the work started in #312. Loader deferred columns **2,407 → 1,099**,
+residual ratchet unchanged at **0**.
+
+| batch | cols | grounding |
+|---|---|---|
+| `team_summaries` + `_weekly` | 757 | producer arithmetic (`_summarize_team`) |
+| `adv_team` + `_gamelog` | 131 | empirical profile of published assets |
+| `adv_situational` | 71 | empirical profile |
+| `cfb_pbp` | 247 | transcribed from `cfb_pbp.py`, thresholds quoted |
+| PHF (4 loaders) | 114 | provider fields, described at face value |
+
+Descriptions are **composed from verified vocabularies** rather than hand-written
+per column, and the generators are committed (`tools/codegen/gen_*_descriptions.py`)
+so each derivation stays reproducible. They enumerate `loader_schemas.yaml`, so
+re-running is idempotent.
+
+Profiling the ESPN blocks against real data contradicted their naming in ways that
+would otherwise have shipped as wrong documentation:
+
+- the bare `EPA_explosive*` and `EPA_success*` columns are integer play **counts**,
+  not EPA totals, despite the `EPA_` prefix (~40 columns)
+- `EPA_overall_off` and `EPA_overall_offense` are **exact duplicates**
+- `EPA_explosive_rate` is **not** `EPA_explosive / EPA_plays` — ESPN divides by a
+  smaller qualifying-play count, so deriving it will not reproduce their value
+
+Anything a generator could not ground is left **blank and reported**, never
+invented.
 
 ### CFB — `team_id` canonicalized to `Int64` at the loader boundary
 

--- a/sportsdataverse/cfb/cfb_pbp.py
+++ b/sportsdataverse/cfb/cfb_pbp.py
@@ -4500,15 +4500,28 @@ class CFBPlayProcess(object):
                 stopped_run=pl.when((pl.col("type.text") == "Rush").and_(pl.col("yds_rushed") <= 2))
                 .then(True)
                 .otherwise(False),
-                opportunity_run=pl.when((pl.col("type.text") == "Rush").and_(pl.col("yds_rushed") <= 4))
+                # An "opportunity" is a carry where the blocking did its job, i.e. the run
+                # REACHED 4 yards -- cfbfastR's espn_cfb_15 oracle is
+                # `opportunity_run = ((rush == 1) & (yds_rushed >= 4))`, and the sibling
+                # cfb-data producer agrees. This was inverted to `<= 4`, which also made
+                # opp_highlight_yards identically 0 (its gate demanded <= 4 rushing yards
+                # while highlight yards only accrue from 4 up, so the two could never
+                # co-occur).
+                # Gate on `rush`, not `type.text == "Rush"`. The literal play-type
+                # string excludes "Rushing Touchdown" and "Fumble Recovery (Own)"
+                # rushes, so a 4-yard rushing TD was not counted as an opportunity;
+                # cfbfastR's oracle gates on `rush == 1`. It also left
+                # adj_rush_yardage null on those plays while line_yards below gates
+                # on `rush`, so the decomposition disagreed with itself.
+                opportunity_run=pl.when((pl.col("rush") == True).and_(pl.col("yds_rushed") >= 4))
                 .then(True)
                 .otherwise(False),
-                highlight_run=pl.when((pl.col("type.text") == "Rush").and_(pl.col("yds_rushed") >= 8))
+                highlight_run=pl.when((pl.col("rush") == True).and_(pl.col("yds_rushed") >= 8))
                 .then(True)
                 .otherwise(False),
-                adj_rush_yardage=pl.when((pl.col("type.text") == "Rush").and_(pl.col("yds_rushed") > 8))
+                adj_rush_yardage=pl.when((pl.col("rush") == True).and_(pl.col("yds_rushed") > 8))
                 .then(8)
-                .when((pl.col("type.text") == "Rush").and_(pl.col("yds_rushed") <= 8))
+                .when((pl.col("rush") == True).and_(pl.col("yds_rushed") <= 8))
                 .then(pl.col("yds_rushed"))
                 .otherwise(None),
             )

--- a/tests/cfb/test_cfb_opportunity_run.py
+++ b/tests/cfb/test_cfb_opportunity_run.py
@@ -42,7 +42,12 @@ def plays(request) -> pl.DataFrame:
     request.addfinalizer(mp.undo)
     mp.setattr("sportsdataverse.cfb.cfb_pbp.download", lambda *a, **k: _Resp())
 
-    proc = CFBPlayProcess(gameId=401628455)
+    # join_participants=False keeps this offline. The monkeypatch above only
+    # replaces cfb_pbp.download; the participants path makes its OWN cdn sidecar
+    # and $ref fetches, so leaving the default True would let this "offline"
+    # regression test reach the network. None of the rushing decomposition under
+    # test depends on participant joins.
+    proc = CFBPlayProcess(gameId=401628455, join_participants=False)
     proc.espn_cfb_pbp()
     out = proc.run_processing_pipeline()
     df = out["plays"] if isinstance(out, dict) else out

--- a/tests/cfb/test_cfb_opportunity_run.py
+++ b/tests/cfb/test_cfb_opportunity_run.py
@@ -1,0 +1,98 @@
+"""Regression tests for the rushing opportunity / highlight-yards decomposition.
+
+``opportunity_run`` was implemented as ``rush AND yds_rushed <= 4`` -- the INVERSE
+of the cfbfastR oracle (``espn_cfb_15_team_summaries_creation.R``):
+
+    opportunity_run = ((rush == 1) & (yds_rushed >= 4))
+
+and of the sibling cfb-data producer, which agrees with the R. The inversion had a
+second, silent consequence: ``opp_highlight_yards`` gates on ``opportunity_run``
+while ``highlight_yards`` only accrues from 4 rushing yards up, so the two
+conditions could never co-occur and the column was **identically 0 in every
+published row** (verified across 162,950 plays in the 2024 release).
+
+Nothing failed when the flag was inverted -- no test pinned either invariant,
+which is exactly why it survived. These run the real pipeline over a committed
+summary fixture and pin both.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from sportsdataverse.cfb.cfb_pbp import CFBPlayProcess
+
+FIX = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture(scope="module")
+def plays(request) -> pl.DataFrame:
+    """Processed play frame for a committed game, via the offline fixture path."""
+    summary = json.loads((FIX / "summary_401628455.json").read_text())
+
+    class _Resp:
+        def json(self):
+            return summary
+
+    mp = pytest.MonkeyPatch()
+    request.addfinalizer(mp.undo)
+    mp.setattr("sportsdataverse.cfb.cfb_pbp.download", lambda *a, **k: _Resp())
+
+    proc = CFBPlayProcess(gameId=401628455)
+    proc.espn_cfb_pbp()
+    out = proc.run_processing_pipeline()
+    df = out["plays"] if isinstance(out, dict) else out
+    if isinstance(df, pl.DataFrame):
+        return df
+    # the pipeline hands back a list of dicts; scan every row when inferring so a
+    # column that is null for the first N plays does not get the wrong dtype
+    return pl.from_dicts(df, infer_schema_length=None)
+
+
+def _rushes(plays: pl.DataFrame) -> pl.DataFrame:
+    return plays.filter(pl.col("rush") == True).drop_nulls("yds_rushed")  # noqa: E712
+
+
+def test_opportunity_run_marks_carries_that_reached_four_yards(plays):
+    """The oracle is ``yds_rushed >= 4`` -- a gain, not a stuff.
+
+    Asserted as an implication over every rush in the game rather than a fixed
+    count, so the test does not re-encode this fixture's box score.
+    """
+    r = _rushes(plays)
+    bad = r.filter(pl.col("opportunity_run") != (pl.col("yds_rushed") >= 4))
+    assert bad.height == 0, (
+        f"{bad.height} rushes disagree with `yds_rushed >= 4`; "
+        f"sample={bad.select(['yds_rushed', 'opportunity_run']).head(5).to_dicts()}"
+    )
+
+
+def test_short_rush_is_not_an_opportunity(plays):
+    """Guards the exact regression: sub-4-yard carries must not be flagged."""
+    short = _rushes(plays).filter(pl.col("yds_rushed") < 4)
+    assert short.height > 0, "fixture has no short rushes to test"
+    assert not short["opportunity_run"].any()
+
+
+def test_opp_highlight_yards_is_not_degenerate(plays):
+    """Some carry must carry non-zero opportunity highlight yards.
+
+    With the inverted flag this column could only ever be 0, so a single non-zero
+    value anywhere is what distinguishes fixed from broken.
+    """
+    vals = _rushes(plays)["opp_highlight_yards"].drop_nulls()
+    assert vals.len() > 0, "no opp_highlight_yards values in the fixture"
+    assert (vals > 0).any(), "opp_highlight_yards is identically 0 -- opportunity_run is inverted"
+
+
+def test_opp_highlight_yards_passes_through_on_opportunity_runs(plays):
+    """On an opportunity run the column is exactly highlight_yards; else 0."""
+    r = _rushes(plays).drop_nulls(["highlight_yards", "opp_highlight_yards"])
+    on = r.filter(pl.col("opportunity_run") == True)  # noqa: E712
+    off = r.filter(pl.col("opportunity_run") == False)  # noqa: E712
+    assert (on["opp_highlight_yards"] == on["highlight_yards"]).all()
+    assert (off["opp_highlight_yards"] == 0).all()

--- a/tools/codegen/extract_residual_columns.py
+++ b/tools/codegen/extract_residual_columns.py
@@ -73,6 +73,27 @@ _DEFERRED_BUCKETS = {
 }
 
 
+def _rendering_loaders() -> set[str]:
+    """Loaders whose return table actually RENDERS a column/description table.
+
+    Only loaders declared in ``releases.yaml`` reach ``loaders_page.md.jinja`` via
+    ``_loader_schema_table``. Hand-written loaders are documented on the league's
+    ``additional`` page, whose Returns section is prose -- they have no column table
+    for a description to appear in. Counting their columns would let an authored
+    description register as "covered" while rendering nowhere, so they are excluded
+    from the accounting entirely rather than reported as blank.
+    """
+    import yaml
+
+    path = os.path.join(ROOT, "tools", "codegen", "endpoints", "releases.yaml")
+    try:
+        with open(path, encoding="utf-8") as fh:
+            raw = yaml.safe_load(fh) or {}
+    except (yaml.YAMLError, OSError):
+        return set()
+    return {ld["fn"] for ld in raw.get("loaders", []) if "fn" in ld}
+
+
 def _loader_schema_rows(d: dict) -> list[dict]:
     """Rows for ``loader_schemas.yaml`` — ``{loader_fn: [{name, type}]}``.
 
@@ -82,9 +103,10 @@ def _loader_schema_rows(d: dict) -> list[dict]:
     description, so ``blank`` is always True and coverage is decided purely by the
     manual dict + R dict.
     """
+    rendering = _rendering_loaders()
     rows: list[dict] = []
     for fn, cols in (d or {}).items():
-        if not isinstance(cols, list):
+        if not isinstance(cols, list) or fn not in rendering:
             continue
         parts = fn.split("_")
         league = parts[1] if len(parts) > 2 and parts[0] == "load" else None

--- a/tools/codegen/gen_cfb_adv_descriptions.py
+++ b/tools/codegen/gen_cfb_adv_descriptions.py
@@ -108,6 +108,29 @@ DESCS: dict[str, str] = {
     "rushing_power_rate": "Share of carries that were power rushing attempts.",
     "rushing_power_success_rate": "Share of power rushing attempts that succeeded.",
     "rushing_stopped": "Count of rushing attempts stopped at or behind the line of scrimmage.",
+    # These nine were falling through to the R-package dict, which mislabels two of
+    # them: rushing_power_success is Int64 0-7 (a COUNT) but was rendered "success
+    # rate", and rushing_highlight_yards was given the per-opportunity wording that
+    # belongs to rushing_highlight_yards_per_opp. Manual entries take precedence,
+    # so these override the fallback. Ranges verified on the published 2024 asset.
+    "rushing_power_success": (
+        "Count of power rushing attempts that gained the yardage needed. An integer count, not a "
+        "rate -- the rate is published separately as rushing_power_success_rate."
+    ),
+    "rushing_highlight_yards": (
+        "Total highlight yards the team accumulated -- the yardage credited to ball carriers rather "
+        "than the line. The per-carry figure is rushing_highlight_yards_per_opp."
+    ),
+    "rushing_stuff_rate": "Share of the team's carries that were stuffed at or behind the line of scrimmage.",
+    "rush_yards": "Total yards the team gained on rush plays.",
+    "pass_yards": "Total yards the team gained on pass plays.",
+    "passes": "Number of pass plays the team ran.",
+    "total_yards": "Total yards the team gained across all plays.",
+    "penalties": "Number of penalties assessed against the team.",
+    "penalty_yards": (
+        "Net penalty yardage assessed against the team; can be negative when enforcement moved the "
+        "team forward on balance."
+    ),
     "rushing_stopped_rate": "Share of carries stopped at or behind the line of scrimmage.",
     "rushing_stuff": "Count of stuffed rushing attempts.",
     # --- yardage totals -----------------------------------------------------

--- a/tools/codegen/gen_cfb_adv_descriptions.py
+++ b/tools/codegen/gen_cfb_adv_descriptions.py
@@ -122,7 +122,13 @@ DESCS: dict[str, str] = {
 def main() -> None:
     import yaml
 
-    targets = ("load_cfb_adv_team", "load_cfb_adv_team_gamelog")
+    # Every adv_* loader flattens the same ESPN advBoxScore vocabulary, so the
+    # descriptions apply across the family, not just the team block.
+    targets = tuple(
+        f
+        for f in yaml.safe_load(pathlib.Path("tools/codegen/schemas/loader_schemas.yaml").read_text(encoding="utf-8"))
+        if f.startswith("load_cfb_adv")
+    )
     schemas = yaml.safe_load(pathlib.Path("tools/codegen/schemas/loader_schemas.yaml").read_text(encoding="utf-8"))
     out: dict[str, dict[str, str]] = {}
     missing: set[str] = set()
@@ -134,7 +140,7 @@ def main() -> None:
                 got[col] = DESCS[col]
         out[t] = got
         declared = {c["name"] for c in schemas[t]}
-        missing |= {c for c in DESCS if c not in declared and t == targets[0]}
+        del declared  # per-target set unused; staleness is checked against the union below
     print("composed: " + ", ".join(f"{t}={len(v)}" for t, v in out.items()))
     if missing:
         print(f"WARNING description written for column not in adv_team schema: {sorted(missing)}")

--- a/tools/codegen/gen_cfb_adv_descriptions.py
+++ b/tools/codegen/gen_cfb_adv_descriptions.py
@@ -1,0 +1,147 @@
+"""Descriptions for the ESPN advBoxScore team columns (adv_team + adv_team_gamelog).
+
+Unlike team_summaries, these are NOT computed in this ecosystem -- they are raw
+fields from ESPN's `advBoxScore.team` block, flattened verbatim. There is no
+producer arithmetic to read, so every claim below is either (a) verified
+empirically against the published 2024 asset, or (b) stated at a level that does
+not assert ESPN's internal thresholds.
+
+Verified empirically before writing:
+  * EPA_overall_off and EPA_overall_offense are EXACT duplicates (max abs diff 0).
+  * The bare EPA_explosive* columns are integer COUNTS (0-13), not EPA, despite
+    the EPA_ prefix. The *_rate siblings are true rates in [0,1].
+  * EPA_explosive_rate is NOT EPA_explosive / EPA_plays -- the implied denominator
+    runs 1-27 plays smaller. The denominator is ESPN's own qualifying-play count,
+    so the text says so rather than inventing a formula.
+
+Anything not listed is left BLANK rather than invented.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+sys.path.insert(0, ".")
+
+_ESPN = "ESPN's advanced box score"
+_THRESH = "ESPN applies its own qualifying threshold"
+
+DESCS: dict[str, str] = {
+    # --- identity -----------------------------------------------------------
+    "pos_team_id": "ESPN team id of the team on offense. Present for every season 2004+.",
+    # --- play counts --------------------------------------------------------
+    "EPA_plays": f"Number of plays {_ESPN} scored for the team.",
+    "scrimmage_plays": "Number of plays from scrimmage (rushes plus passes), excluding special teams.",
+    "special_teams_plays": "Number of special-teams plays.",
+    "kickoff_plays": "Number of kickoff plays.",
+    "punt_plays": "Number of punt plays.",
+    "rushes": "Number of rushing attempts.",
+    "field_goals": "Number of field-goal attempts.",
+    # --- explosive counts + rates ------------------------------------------
+    "EPA_explosive": (
+        f"Count of explosive plays, per {_ESPN}. Despite the EPA_ prefix this is a play COUNT, not an EPA total."
+    ),
+    "EPA_explosive_passing": "Count of explosive pass plays. A play count, not an EPA total.",
+    "EPA_explosive_rushing": "Count of explosive rush plays. A play count, not an EPA total.",
+    "EPA_explosive_rate": (
+        "Explosive-play rate. Note this is NOT EPA_explosive divided by EPA_plays -- ESPN divides "
+        "by its own smaller qualifying-play count, so deriving it yourself will not reproduce this value."
+    ),
+    "EPA_explosive_passing_rate": "Explosive-play rate on pass plays, over ESPN's qualifying-play denominator.",
+    "EPA_explosive_rushing_rate": "Explosive-play rate on rush plays, over ESPN's qualifying-play denominator.",
+    # --- EPA totals + per-play ---------------------------------------------
+    "EPA_overall_off": (
+        "Total offensive EPA for the team. Duplicated exactly by EPA_overall_offense in every "
+        "published season checked -- prefer one and ignore the other."
+    ),
+    "EPA_overall_offense": "Total offensive EPA. An exact duplicate of EPA_overall_off.",
+    "EPA_overall_total": (
+        "Total EPA across all phases, which is why it differs from the offense-only EPA_overall_off."
+    ),
+    "EPA_per_play": "Offensive EPA per play.",
+    "EPA_passing_overall": "Total EPA on pass plays.",
+    "EPA_passing_per_play": "EPA per pass play.",
+    "EPA_rushing_overall": "Total EPA on rush plays.",
+    "EPA_rushing_per_play": "EPA per rush play.",
+    "EPA_rushing_power": f"Total EPA on power rushing situations, as classified by {_ESPN}.",
+    "EPA_rushing_power_per_play": "EPA per play on power rushing situations.",
+    "EPA_non_explosive": "Total EPA with explosive plays excluded, isolating the team's routine-down production.",
+    "EPA_non_explosive_per_play": "EPA per play with explosive plays excluded.",
+    "EPA_non_explosive_passing": "Total EPA on pass plays with explosive plays excluded.",
+    "EPA_non_explosive_passing_per_play": "EPA per pass play with explosive plays excluded.",
+    "EPA_non_explosive_rushing": "Total EPA on rush plays with explosive plays excluded.",
+    "EPA_non_explosive_rushing_per_play": "EPA per rush play with explosive plays excluded.",
+    # --- special teams / penalty EPA ---------------------------------------
+    "EPA_special_teams": "Total EPA generated on special-teams plays.",
+    "EPA_sp": "Total special-teams EPA, ESPN's abbreviated field for the same phase.",
+    "EPA_fg": "Total EPA on field-goal attempts.",
+    "EPA_punt": "Total EPA on punt plays.",
+    "EPA_kickoff": "Total EPA on kickoff plays.",
+    "EPA_penalty": "Total EPA attributed to penalties.",
+    # --- first downs created ------------------------------------------------
+    "first_downs_created": "Number of first downs the team created.",
+    "first_downs_created_rate": "Share of the team's plays that created a first down.",
+    "passing_first_downs_created": "Number of first downs created on pass plays.",
+    "passing_first_downs_created_rate": "Share of pass plays that created a first down.",
+    "rushing_first_downs_created": "Number of first downs created on rush plays.",
+    "rushing_first_downs_created_rate": "Share of rush plays that created a first down.",
+    "penalty_first_downs_created": "Number of first downs the team gained via opponent penalty.",
+    "penalty_first_downs_created_rate": "Share of the team's first downs that came via opponent penalty.",
+    # --- play mix -----------------------------------------------------------
+    "passes_rate": "Share of the team's plays from scrimmage that were pass plays.",
+    "rushes_rate": "Share of the team's plays from scrimmage that were rush plays.",
+    # --- rushing decomposition ---------------------------------------------
+    "line_yards": (
+        "Line yards -- the portion of rushing yardage credited to the offensive line under the "
+        f"standard rushing decomposition. {_THRESH} for the yardage split."
+    ),
+    "line_yards_per_carry": "Line yards per rushing attempt.",
+    "second_level_yards": "Second-level yards -- rushing yardage earned just beyond the line of scrimmage.",
+    "open_field_yards": "Open-field yards -- rushing yardage earned well downfield, past the second level.",
+    "rushing_highlight": ("Highlight yards -- rushing yardage credited to the back rather than the offensive line."),
+    "rushing_highlight_rate": "Share of rushing yardage that was highlight (back-credited) yardage.",
+    "rushing_highlight_yards_per_opp": "Highlight yards per rushing opportunity.",
+    "rushing_opportunity": "Count of rushing opportunities -- carries that reached ESPN's opportunity threshold.",
+    "rushing_opportunity_rate": "Share of carries that qualified as rushing opportunities.",
+    "rushing_power": f"Count of power rushing attempts, in short-yardage situations as classified by {_ESPN}.",
+    "rushing_power_rate": "Share of carries that were power rushing attempts.",
+    "rushing_power_success_rate": "Share of power rushing attempts that succeeded.",
+    "rushing_stopped": "Count of rushing attempts stopped at or behind the line of scrimmage.",
+    "rushing_stopped_rate": "Share of carries stopped at or behind the line of scrimmage.",
+    "rushing_stuff": "Count of stuffed rushing attempts.",
+    # --- yardage totals -----------------------------------------------------
+    "off_yards": "Offensive yards gained from scrimmage.",
+    "total_off_yards": "Total offensive yards across all plays.",
+    "total_pen_yards": "Total penalty yards assessed.",
+    "yards_per_play": "Yards gained per play.",
+    "yards_per_rush": "Yards gained per rushing attempt.",
+}
+
+
+def main() -> None:
+    import yaml
+
+    targets = ("load_cfb_adv_team", "load_cfb_adv_team_gamelog")
+    schemas = yaml.safe_load(pathlib.Path("tools/codegen/schemas/loader_schemas.yaml").read_text(encoding="utf-8"))
+    out: dict[str, dict[str, str]] = {}
+    missing: set[str] = set()
+    for t in targets:
+        got = {}
+        for c in schemas[t]:
+            col = c["name"]
+            if col in DESCS:
+                got[col] = DESCS[col]
+        out[t] = got
+        declared = {c["name"] for c in schemas[t]}
+        missing |= {c for c in DESCS if c not in declared and t == targets[0]}
+    print("composed: " + ", ".join(f"{t}={len(v)}" for t, v in out.items()))
+    if missing:
+        print(f"WARNING description written for column not in adv_team schema: {sorted(missing)}")
+    with open("_adv_descs.yaml", "w", encoding="utf-8") as fh:
+        yaml.safe_dump(out, fh, sort_keys=True, allow_unicode=True, width=120)
+    print("wrote _adv_descs.yaml")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/codegen/gen_cfb_pbp_descriptions.py
+++ b/tools/codegen/gen_cfb_pbp_descriptions.py
@@ -1,0 +1,263 @@
+"""Descriptions for the cfb_pbp return table (CFBPlayProcess output).
+
+Unlike the ESPN advBoxScore blocks, these columns ARE computed in this repo, so
+the derived flags are transcribed from sportsdataverse/cfb/cfb_pbp.py rather than
+described generically. Exact thresholds are quoted where the producer sets them.
+
+Verified while writing (see the module for line refs):
+  * early_down  = (1st or 2nd down) and a scrimmage play
+  * late_down   = (3rd or 4th down) and a scrimmage play
+  * standard/passing_down split on down-and-distance thresholds
+  * havoc       = pass_breakup OR TFL OR interception OR forced_fumble
+  * the line-yards decomposition uses adj_rush_yardage = min(rush yards, 8):
+      line_yards        <0 -> 1.2*adj; 0-3 -> adj; 4-8 -> 3+0.5*(adj-3); >=8 -> 5.5
+      second_level      >=4 -> 0.5*(adj-4) else 0
+      open_field        >8  -> yards-adj  else 0
+      highlight_yards   = second_level + open_field
+  * opportunity_run is `rush AND yards <= 4` -- the INVERSE of the conventional
+    "carry gained 4+", so it is documented as what the code computes.
+  * opp_highlight_yards is identically 0 in every published row (verified across
+    162,950 plays in 2024): its gate requires <=4 rushing yards while
+    highlight_yards is non-zero only at >=4, so the two can never co-occur.
+    Documented as a known-degenerate column rather than silently described.
+
+Anything unparsed is reported and left blank, never invented.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+sys.path.insert(0, ".")
+
+STATIC: dict[str, str] = {
+    # --- expected points ---------------------------------------------------
+    "EP_start": "Expected points for the offense at the start of the play.",
+    "EP_end": "Expected points for the offense at the end of the play.",
+    "EP_between": "Change in expected points across the play, before penalty adjustment.",
+    "EP_start_touchback": "Expected points the offense would have had from a touchback on this play.",
+    # --- derived flags, transcribed from cfb_pbp.py ------------------------
+    "early_down": "True when the play is a scrimmage play on first or second down.",
+    "late_down": "True when the play is a scrimmage play on third or fourth down.",
+    "early_down_pass": "True when the play is a pass on an early down.",
+    "early_down_rush": "True when the play is a rush on an early down.",
+    "late_down_pass": "True when the play is a pass on a late down.",
+    "late_down_rush": "True when the play is a rush on a late down.",
+    "passing_down": (
+        "True when the offense is behind schedule for the series -- second down needing 8 or more, "
+        "or third/fourth down needing 5 or more."
+    ),
+    "havoc": (
+        "True when the defense disrupted the play: a pass breakup, tackle for loss, interception or forced fumble."
+    ),
+    "TFL": "True when the play was a tackle for loss.",
+    "TFL_pass": "True when the play was a tackle for loss on a pass play (a sack).",
+    "TFL_rush": "True when the play was a tackle for loss on a rush play.",
+    "pass_breakup": "True when a defender broke up the pass.",
+    "forced_fumble": "True when the defense forced a fumble on the play.",
+    "fumble_recovered": "True when a fumble on the play was recovered.",
+    "non_fumble_sack": "True when the play was a sack that did not produce a fumble.",
+    "first_down_created": "True when the play produced a first down for the offense.",
+    "fg_attempt": "True when the play was a field-goal attempt.",
+    "penalty_in_text": "True when the play description mentions a penalty.",
+    "action_play": (
+        "True when the play advanced the game state -- excludes timeouts, end-of-period markers and "
+        "other non-action rows."
+    ),
+    # --- rushing decomposition, exact formulas from cfb_pbp.py -------------
+    "adj_rush_yardage": "Rushing yards capped at 8, the input to the line-yards decomposition.",
+    "line_yards": (
+        "Yards credited to the offensive line on a rush, using the standard sliding scale: 1.2x the "
+        "capped yardage on a loss, all of it through 3 yards, half of each yard from 4 to 8, and a "
+        "5.5-yard ceiling beyond that."
+    ),
+    "open_field_yards": "Rushing yards gained beyond 8, credited to the ball carrier rather than the line.",
+    "highlight_yards": "Second-level plus open-field yards -- the yardage credited to the carrier.",
+    "highlight_run": "True when the rush gained 8 or more yards.",
+    "opportunity_run": (
+        "True when the play is a rush gaining 4 yards or fewer. Note this is the inverse of the "
+        "conventional 'opportunity' definition (a carry gaining 4 or more)."
+    ),
+    "opp_highlight_yards": (
+        "Highlight yards on opportunity runs. DEGENERATE: this column is 0 in every published row, "
+        "because its gate requires a rush of 4 yards or fewer while highlight yards only accrue at "
+        "4 or more. Do not use it as a signal."
+    ),
+    "power_rush_attempt": "True when the play is a short-yardage power rushing attempt.",
+    "power_rush_success": "True when a power rushing attempt gained the yardage needed.",
+    # --- EPA / weights -----------------------------------------------------
+    "pass_epa": "EPA credited to the play when it is a pass.",
+    "rush_epa": "EPA credited to the play when it is a rush.",
+    "pen_epa": "EPA attributable to a penalty on the play.",
+    "qbr_epa": "EPA variant used as an input to the QBR calculation.",
+    "pass_weight": "Weighting applied to the pass component of the play.",
+    "rush_weight": "Weighting applied to the rush component of the play.",
+    "pen_weight": "Weighting applied to the penalty component of the play.",
+    "prog_drive_EPA": "Cumulative EPA accrued by the drive up to and including this play.",
+    "prog_drive_WPA": "Cumulative win-probability added by the drive up to and including this play.",
+    # --- score state -------------------------------------------------------
+    "H_score_diff": "Home team's score minus the away team's, from the home perspective.",
+    "A_score_diff": "Away team's score minus the home team's, from the away perspective.",
+    "HA_score_diff": "Home score minus away score for the play.",
+    "net_HA_score_pts": "Net points the play added to the home-minus-away score margin.",
+    "pos_score_diff_end": "Score differential from the possessing team's perspective at the end of the play.",
+    # --- betting inputs ----------------------------------------------------
+    "gameSpread": "Point spread used as an input to the win-probability model.",
+    "gameSpreadAvailable": "True when a spread was available for the game.",
+    "overUnder": "Over/under total used as a model input.",
+    "homeFavorite": "True when the home team was favoured by the spread.",
+    # --- game / clock metadata --------------------------------------------
+    "playType": "ESPN's play-type label for the play.",
+    "period.number": "Period (quarter) number in which the play occurred.",
+    "firstHalfKickoffTeamId": "ESPN id of the team that received the opening kickoff.",
+    "homeTimeoutCalled": "True when the home team called a timeout on the play.",
+    "awayTimeoutCalled": "True when the away team called a timeout on the play.",
+    "new_down": "Down after the play, including any penalty enforcement.",
+    "new_distance": "Distance to go after the play, including any penalty enforcement.",
+    "drive_start": "Yard line at which the drive began.",
+    "drive_stopped": "True when the play ended the drive.",
+    "drive_play_index": "Sequence number of the play within its drive.",
+    "drive_offense_plays": "Offensive plays run on the drive.",
+    "drive_offense_yards": "Offensive yards gained on the drive.",
+    "drive_total_yards": "Total yards gained on the drive.",
+    "kickoff_return_player_name": "Name of the player returning the kickoff.",
+    "punt_return_player_name": "Name of the player returning the punt.",
+    # --- remainder ---------------------------------------------------------
+    "scrimmage_play": "True when the play is a play from scrimmage rather than a special-teams or administrative row.",
+    "standard_down": (
+        "True when the offense is on schedule for the series -- first down, second down needing "
+        "fewer than 8, or third/fourth down needing fewer than 5."
+    ),
+    "second_level_yards": (
+        "Rushing yards earned from 4 to 8, split evenly between line and carrier under the line-yards decomposition."
+    ),
+    "short_rush_attempt": "True when the play is a rush in a short-yardage situation.",
+    "short_rush_success": "True when a short-yardage rush gained the yardage needed.",
+    "stopped_run": "True when the rush was stopped at or behind the line of scrimmage.",
+    "sack_epa": "EPA credited to the play when it is a sack.",
+    "sack_weight": "Weighting applied to the sack component of the play.",
+    "wp_touchback": "Win probability the offense would have had starting from a touchback.",
+    "td_check": "Internal flag used while reconciling whether the play produced a touchdown.",
+    "text_dupe": "True when the play description duplicates the previous row's text.",
+    "scoringPlay": "ESPN flag marking the play as a scoring play.",
+    "scoringType.name": "ESPN's name for the scoring type (e.g. touchdown, field goal).",
+    "scoringType.displayName": "ESPN's display label for the scoring type.",
+    "scoringType.abbreviation": "ESPN's abbreviation for the scoring type.",
+    "type.id": "ESPN's numeric identifier for the play type.",
+    "type.text": "ESPN's text label for the play type.",
+    "type.abbreviation": "ESPN's abbreviation for the play type.",
+    "statYardage": "Yardage ESPN credits to the play for statistical purposes.",
+    "seasonType": "ESPN season type for the game (2 = regular season, 3 = postseason).",
+}
+
+CLOCK = {
+    "clock.displayValue": "Game clock at the play, as the displayed mm:ss string.",
+    "clock.minutes": "Minutes remaining on the game clock at the play.",
+    "clock.seconds": "Seconds component of the game clock at the play.",
+}
+
+
+def describe(col: str) -> str | None:
+    if col in STATIC:
+        return STATIC[col]
+    if col in CLOCK:
+        return CLOCK[col]
+
+    # --- down indicator flags: down_N / down_N_end
+    m = re.fullmatch(r"down_([1-4])(_end)?", col)
+    if m:
+        n, end = m.groups()
+        when = "at the end of" if end else "at the start of"
+        return f"True when it is {n}{'st' if n == '1' else 'nd' if n == '2' else 'rd' if n == '3' else 'th'} down {when} the play."
+
+    # --- EPA success COUNTS/flags and EPA splits
+    m = re.fullmatch(
+        r"EPA_success(?:_(early_down|late_down|standard_down|passing_down))?(?:_(pass|rush))?(_EPA)?",
+        col,
+    )
+    if m:
+        sit, play, epa = m.groups()
+        where = {
+            "early_down": " on an early down",
+            "late_down": " on a late down",
+            "standard_down": " on a standard down",
+            "passing_down": " on a passing down",
+        }.get(sit or "", "")
+        pl_ = {"pass": " pass", "rush": " rush"}.get(play or "", "")
+        if epa:
+            return f"EPA on successful{pl_} plays{where}."
+        return f"True when the{pl_} play{where} was successful by EPA."
+    m = re.fullmatch(r"EPA_middle_8_success(?:_(pass|rush))?", col)
+    if m:
+        pl_ = {"pass": " pass", "rush": " rush"}.get(m.group(1) or "", "")
+        return f"True when the{pl_} play in the middle eight was successful by EPA."
+    m = re.fullmatch(r"EPA_explosive(?:_(pass|rush))?", col)
+    if m:
+        pl_ = {"pass": " pass", "rush": " rush"}.get(m.group(1) or "", "")
+        return f"True when the{pl_} play was explosive."
+    m = re.fullmatch(r"EPA_(pass|rush|scrimmage|penalty|punt|kickoff|fg|sp|non_explosive|success)", col)
+    if m:
+        k = m.group(1)
+        label = {
+            "pass": "on pass plays",
+            "rush": "on rush plays",
+            "scrimmage": "on plays from scrimmage",
+            "penalty": "attributable to penalties",
+            "punt": "on punt plays",
+            "kickoff": "on kickoff plays",
+            "fg": "on field-goal attempts",
+            "sp": "on special-teams plays",
+            "non_explosive": "on non-explosive plays",
+            "success": "on successful plays",
+        }[k]
+        if k == "success":
+            return "True when the play was successful by EPA."
+        return f"EPA credited to the play {label}."
+
+    # --- lag/lead shifted columns
+    m = re.fullmatch(r"(lag|lead)_(.+?)(\d?)$", col)
+    if m:
+        d, base, n = m.groups()
+        direction = "previous" if d == "lag" else "next"
+        step = f" {n} plays" if n and n not in ("1", "") else ""
+        return f"Value of {base} on the {direction}{step or ''} play, used for sequence-aware derivations."
+
+    # --- ESPN nested passthrough: start.* / end.* / drive.* / homeTeam* / awayTeam*
+    m = re.fullmatch(r"(start|end)\.(.+)", col)
+    if m:
+        side, field = m.groups()
+        when = "start" if side == "start" else "end"
+        return f"ESPN's `{field}` value for the play state at the {when} of the play."
+    if col.startswith("drive."):
+        return f"ESPN's `{col[len('drive.') :]}` field for the drive containing this play."
+    m = re.fullmatch(r"(home|away)Team(.*)", col)
+    if m:
+        side, field = m.groups()
+        return f"ESPN's {side}-team {field or 'identifier'} for the game, stamped on every play."
+    return None
+
+
+def main() -> None:
+    import yaml
+
+    target = "load_cfb_pbp"
+    schemas = yaml.safe_load(pathlib.Path("tools/codegen/schemas/loader_schemas.yaml").read_text(encoding="utf-8"))
+    got, unparsed = {}, []
+    for c in schemas[target]:
+        d = describe(c["name"])
+        if d:
+            got[c["name"]] = d
+        else:
+            unparsed.append(c["name"])
+    print(f"composed {len(got)}; unparsed (left blank, never invented) {len(unparsed)}")
+    for u in unparsed[:60]:
+        print(f"   {u}")
+    with open("_pbp_descs.yaml", "w", encoding="utf-8") as fh:
+        yaml.safe_dump({target: dict(sorted(got.items()))}, fh, sort_keys=False, allow_unicode=True, width=120)
+    print("wrote _pbp_descs.yaml")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/codegen/gen_cfb_pbp_descriptions.py
+++ b/tools/codegen/gen_cfb_pbp_descriptions.py
@@ -14,12 +14,13 @@ Verified while writing (see the module for line refs):
       second_level      >=4 -> 0.5*(adj-4) else 0
       open_field        >8  -> yards-adj  else 0
       highlight_yards   = second_level + open_field
-  * opportunity_run is `rush AND yards <= 4` -- the INVERSE of the conventional
-    "carry gained 4+", so it is documented as what the code computes.
-  * opp_highlight_yards is identically 0 in every published row (verified across
-    162,950 plays in 2024): its gate requires <=4 rushing yards while
-    highlight_yards is non-zero only at >=4, so the two can never co-occur.
-    Documented as a known-degenerate column rather than silently described.
+  * opportunity_run WAS `rush AND yards <= 4` -- the inverse of the cfbfastR
+    oracle. FIXED (2026-08) to `rush AND yards >= 4`; the column descriptions
+    scope the old behaviour to assets published before that fix.
+  * opp_highlight_yards was consequently identically 0 in every published row
+    (verified across 162,950 plays in 2024): the inverted gate required <=4
+    rushing yards while highlight_yards only accrues at >=4, so the two could
+    never co-occur. Non-degenerate since the fix.
 
 Anything unparsed is reported and left blank, never invented.
 """
@@ -221,9 +222,13 @@ def describe(col: str) -> str | None:
     m = re.fullmatch(r"(lag|lead)_(.+?)(\d?)$", col)
     if m:
         d, base, n = m.groups()
-        direction = "previous" if d == "lag" else "next"
-        step = f" {n} plays" if n and n not in ("1", "") else ""
-        return f"Value of {base} on the {direction}{step or ''} play, used for sequence-aware derivations."
+        # A multi-step column names the OFFSET, so "the next 2 plays" must not also
+        # take the singular "play" suffix -- that rendered "on the next 2 plays play".
+        if n and n not in ("1", ""):
+            where = f"{n} plays {'back' if d == 'lag' else 'ahead'}"
+        else:
+            where = f"the {'previous' if d == 'lag' else 'next'} play"
+        return f"Value of {base} {where}, used for sequence-aware derivations."
 
     # --- ESPN nested passthrough: start.* / end.* / drive.* / homeTeam* / awayTeam*
     m = re.fullmatch(r"(start|end)\.(.+)", col)

--- a/tools/codegen/gen_cfb_pbp_descriptions.py
+++ b/tools/codegen/gen_cfb_pbp_descriptions.py
@@ -77,13 +77,14 @@ STATIC: dict[str, str] = {
     "highlight_yards": "Second-level plus open-field yards -- the yardage credited to the carrier.",
     "highlight_run": "True when the rush gained 8 or more yards.",
     "opportunity_run": (
-        "True when the play is a rush gaining 4 yards or fewer. Note this is the inverse of the "
-        "conventional 'opportunity' definition (a carry gaining 4 or more)."
+        "True when a rush reached 4 yards -- the carries on which the blocking did its job. Matches "
+        "cfbfastR's espn_cfb_15 definition. Assets published before the 2026-08 fix carry the "
+        "inverted (4 yards or fewer) flag."
     ),
     "opp_highlight_yards": (
-        "Highlight yards on opportunity runs. DEGENERATE: this column is 0 in every published row, "
-        "because its gate requires a rush of 4 yards or fewer while highlight yards only accrue at "
-        "4 or more. Do not use it as a signal."
+        "Highlight yards earned on opportunity runs, isolating carrier production on carries where "
+        "the blocking succeeded. Assets published before the 2026-08 fix are identically 0 here, "
+        "because the inverted opportunity_run gate could never co-occur with non-zero highlight yards."
     ),
     "power_rush_attempt": "True when the play is a short-yardage power rushing attempt.",
     "power_rush_success": "True when a power rushing attempt gained the yardage needed.",

--- a/tools/codegen/gen_cfb_rest_descriptions.py
+++ b/tools/codegen/gen_cfb_rest_descriptions.py
@@ -1,0 +1,261 @@
+"""Descriptions for the remaining CFB loader return tables.
+
+Covers the tail after team_summaries / adv_* / cfb_pbp: play_participants,
+player_box, passing/rushing/receiving, percentiles, adv_passing, model_pbp,
+ratings, crosswalks and the small leftovers.
+
+play_participants is a pure grid -- ``{role}_player_{id|ids|name|names}`` -- and
+the scalar/plural contract is the one this repo documents: the SCALAR column is
+the first/primary participant of that role, the PLURAL column lists every
+participant, so multi-entry roles (split sacks, gang tackles) are not silently
+collapsed.
+
+Percentile columns are the summaries metrics expressed as a percentile, so they
+reuse that vocabulary rather than redefining it.
+
+Anything unmatched is reported and left blank, never invented.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+sys.path.insert(0, ".")
+
+ROLE = {
+    "passer": "the passer",
+    "rusher": "the ball carrier on a rush",
+    "receiver": "the targeted receiver",
+    "sacked_by": "a defender credited with the sack",
+    "tackler": "a defender credited with the tackle",
+    "assisted_by": "a defender credited with an assisted tackle",
+    "forced_by": "the defender who forced the fumble",
+    "recoverer": "the player who recovered the fumble",
+    "pass_defender": "the defender credited with defending the pass",
+    "penalized": "the penalized player",
+    "returner": "the player returning the kick or punt",
+    "kicker": "the kicker",
+    "punter": "the punter",
+    "scorer": "the player credited with the score",
+    "pat_passer": "the passer on the point-after attempt",
+    "pat_scorer": "the player credited with the point-after score",
+}
+
+# summaries/percentile shared vocabulary (see gen_cfb_summary_descriptions.py)
+METRIC = {
+    "EPAplay": "EPA generated per play",
+    "EPAgame": "EPA generated per game",
+    "EPAdrive": "EPA generated per drive",
+    "EPAdropback": "EPA generated per dropback",
+    "EPArush": "EPA generated per rushing attempt",
+    "TEPA": "total EPA summed over every play",
+    "early_down_EPA": "EPA per early-down play",
+    "nonExplosiveEpaPerPlay": "EPA per play excluding explosive plays",
+    "success": "success rate across the team plays",
+    "pass_success": "success rate on pass plays",
+    "rush_success": "success rate on rush plays",
+    "early_down_success": "success rate on early downs",
+    "late_down_success": "success rate on late downs",
+    "third_down_success": "success rate on third down",
+    "red_zone_success": "success rate in the red zone",
+    "third_down_distance": "average yards to go on third down",
+    "explosive": "explosive-play rate",
+    "pass_explosive": "explosive-play rate on pass plays",
+    "rush_explosive": "explosive-play rate on rush plays",
+    "havoc": "havoc rate",
+    "play_stuffed": "stuffed-play rate",
+    "lineyards": "line yards per rush",
+    "opportunity_run": "opportunity-run rate",
+    "yardsplay": "yards per play",
+    "yardsgame": "yards per game",
+    "yardsrush": "yards per rush",
+    "yardsdropback": "yards per dropback",
+    "dropbacks": "dropbacks taken by the passer",
+    "rushes": "rushing attempts",
+    "playsgame": "plays per game",
+    "GEI": "game excitement index",
+}
+
+STATIC: dict[str, str] = {
+    # --- passing / rushing / receiving season tables ---------------------
+    "att": "Pass attempts thrown.",
+    "comp": "Completed passes.",
+    "comppct": "Completion percentage.",
+    "pass_int": "Interceptions thrown.",
+    "sacked": "Times the passer was sacked.",
+    "sack_yds": "Yards lost to sacks.",
+    "sack_adj_yards": "Passing yards adjusted for sack yardage lost.",
+    "team_games": "Games the team played, used as the per-game denominator.",
+    "fbs_class": (
+        "Power/Group classification for the season: P4 or G6 from 2024 on, P5 or G5 through 2023, "
+        "derived from conference membership. Null for teams outside FBS."
+    ),
+    "detmer": (
+        "Detmer rating -- the composite passing-efficiency measure this pipeline publishes, named "
+        "for the college passing-efficiency tradition."
+    ),
+    "detmergame": "Detmer rating expressed per game.",
+    "pctile": "Percentile bucket the row reports, from 0 to 100.",
+    # --- adv_passing (ESPN block + model outputs) ------------------------
+    "Att": "Pass attempts recorded in the advanced box score.",
+    "Comp": "Completed passes recorded in the advanced box score.",
+    "CompPct": "Completion percentage from the advanced box score.",
+    "Yds": "Passing yards from the advanced box score.",
+    "YPA": "Yards per pass attempt.",
+    "Int": "Interceptions thrown.",
+    "Pass_TD": "Passing touchdowns.",
+    "Sck": "Times the passer was sacked.",
+    "SR": "Success rate on the passer's plays.",
+    "EPA_per_Play": "EPA per play on the passer's plays.",
+    "CPOE": "Completion percentage over expected -- actual minus modelled completion rate.",
+    "xComp": "Expected completions, summed from the per-play completion model.",
+    "xCompPct": "Expected completion percentage from the per-play completion model.",
+    "exp_qbr": "Expected QBR for the passer.",
+    "era0": "Rule-era indicator for the earliest modelled era.",
+    "era1": "Rule-era indicator for the second modelled era.",
+    "era2": "Rule-era indicator for the third modelled era.",
+    "era3": "Rule-era indicator for the most recent modelled era.",
+    "pass_epa": "EPA credited to the player's pass plays.",
+    "rush_epa": "EPA credited to the player's rush plays.",
+    "sack_epa": "EPA credited to the player's sacks taken.",
+    "pen_epa": "EPA attributable to penalties on the player's plays.",
+    "qbr_epa": "EPA variant used as an input to the QBR calculation.",
+    "pos_team_id": "ESPN team id of the team on offense. Present for every season 2004+.",
+    # --- model_pbp -------------------------------------------------------
+    "completion_prob": "Modelled probability the pass is completed.",
+    "cp_model_version": "Version of the completion-probability model that scored the play.",
+    "ep_model_version": "Version of the expected-points model that scored the play.",
+    "wp_model_version": "Version of the win-probability model that scored the play.",
+    "model_pbp_version": "Version of the model-scored play-by-play build.",
+    "scored_date": "Date on which the play was scored by the models.",
+    # --- player_box (ESPN camelCase stat names) --------------------------
+    "adjQBR": "Adjusted Total QBR for the quarterback.",
+    "completions/passingAttempts": "Completions and pass attempts, as ESPN's combined string.",
+    "fieldGoalsMade/fieldGoalAttempts": "Field goals made and attempted, as ESPN's combined string.",
+    "extraPointsMade/extraPointAttempts": "Extra points made and attempted, as ESPN's combined string.",
+    "fieldGoalPct": "Field-goal percentage.",
+    "longFieldGoalMade": "Longest field goal made, in yards.",
+    "totalKickingPoints": "Total points scored by kicking.",
+    "passingYards": "Net passing yards gained.",
+    "passingTouchdowns": "Passing touchdowns.",
+    "yardsPerPassAttempt": "Yards gained per pass attempt.",
+    "rushingYards": "Net rushing yards gained.",
+    "rushingAttempts": "Rushing attempts.",
+    "rushingTouchdowns": "Rushing touchdowns.",
+    "yardsPerRushAttempt": "Yards gained per rushing attempt.",
+    "longRushing": "Longest rush of the game, in yards.",
+    "receivingYards": "Receiving yards gained.",
+    "receivingTouchdowns": "Receiving touchdowns.",
+    "yardsPerReception": "Yards gained per reception.",
+    "longReception": "Longest reception of the game, in yards.",
+    "interceptionYards": "Yards returned on interceptions.",
+    "interceptionTouchdowns": "Touchdowns scored on interception returns.",
+    "punts": "Punts attempted.",
+    "puntYards": "Total punt yards.",
+    "longPunt": "Longest punt of the game, in yards.",
+    "grossAvgPuntYards": "Gross average yards per punt, before return yardage.",
+    "puntsInside20": "Punts downed inside the opponent 20-yard line.",
+    "touchbacks": "Punts or kickoffs that resulted in a touchback.",
+    "puntReturns": "Punt returns attempted.",
+    "puntReturnYards": "Yards gained on punt returns.",
+    "puntReturnTouchdowns": "Touchdowns scored on punt returns.",
+    "yardsPerPuntReturn": "Yards gained per punt return.",
+    "longPuntReturn": "Longest punt return of the game, in yards.",
+}
+
+CROSSWALK = {
+    "espn_team_id": "ESPN team id for the crosswalk row.",
+    "fox_team_id": "Fox Sports team id for the same team.",
+    "yahoo_team_id": "Yahoo Sports team id for the same team.",
+    "cfbd_team_id": "collegefootballdata.com team id for the same team.",
+    "espn_game_id": "ESPN game id for the crosswalk row.",
+    "fox_game_id": "Fox Sports game id for the same game.",
+    "yahoo_game_id": "Yahoo Sports game id for the same game.",
+    "cfbd_game_id": "collegefootballdata.com game id for the same game.",
+}
+
+
+def describe(col: str) -> str | None:
+    if col in STATIC:
+        return STATIC[col]
+    if col in CROSSWALK:
+        return CROSSWALK[col]
+
+    # play_participants grid: {role}_player_{id|ids|name|names}
+    m = re.fullmatch(r"(.+)_player_(id|ids|name|names)", col)
+    if m and m.group(1) in ROLE:
+        role, kind = ROLE[m.group(1)], m.group(2)
+        if kind == "id":
+            return f"ESPN athlete id of {role} -- the FIRST participant in that role on the play."
+        if kind == "name":
+            return f"Display name of {role} -- the FIRST participant in that role on the play."
+        what = "athlete ids" if kind == "ids" else "display names"
+        return (
+            f"List of the {what} of EVERY participant credited as {role} on the play, so multi-entry "
+            "roles such as split sacks or gang tackles are not collapsed to one."
+        )
+
+    # percentile/summary metrics, optionally _rank suffixed
+    m = re.fullmatch(r"(.+?)(_rank)?", col)
+    if m and m.group(1) in METRIC:
+        p = METRIC[m.group(1)]
+        if m.group(2):
+            return f"National rank of the team's {p}, where 1 is best."
+        return f"{p[0].upper()}{p[1:]}."
+    # bare *_rank over a static stat (yards_rank, success_rank, ...)
+    m = re.fullmatch(r"(.+)_rank", col)
+    if m:
+        base = m.group(1)
+        if base in METRIC:
+            return f"National rank of the team's {METRIC[base]}, where 1 is best."
+        alias = {
+            "yards": "total yards",
+            "success": "success rate across the team plays",
+            "comppct": "completion percentage",
+        }
+        if base in alias:
+            return f"National rank of the team's {alias[base]}, where 1 is best."
+        if base in STATIC:
+            return f"National rank of the team's {STATIC[base].rstrip('.').lower()}, where 1 is best."
+    return None
+
+
+def main() -> None:
+    import yaml
+
+    from tools.codegen import extract_residual_columns as x
+
+    rows = [r for r in x.deferred_columns() if r["league"] == "cfb"]
+    schemas = yaml.safe_load(pathlib.Path("tools/codegen/schemas/loader_schemas.yaml").read_text(encoding="utf-8"))
+    targets = sorted({r["schema"] for r in rows})
+    out, unparsed = {}, []
+    for t in targets:
+        got = {}
+        pct = t == "load_cfb_percentiles"
+        for c in schemas.get(t, []):
+            d = describe(c["name"])
+            if d and pct and c["name"] in METRIC:
+                # this table reports DISTRIBUTION cut-points, not a team value
+                d = f"Value of {METRIC[c['name']]} at the percentile this row reports."
+            if d:
+                got[c["name"]] = d
+        if got:
+            out[t] = got
+    covered = {(t, c) for t, v in out.items() for c in v}
+    for r in rows:
+        if (r["schema"], r["col"]) not in covered:
+            unparsed.append(f"{r['schema']}.{r['col']}")
+    print(f"composed {sum(len(v) for v in out.values())}; still-uncovered {len(unparsed)}")
+    for u in sorted(unparsed)[:40]:
+        print(f"   {u}")
+    with open("_cfbrest_descs.yaml", "w", encoding="utf-8") as fh:
+        yaml.safe_dump(
+            {k: dict(sorted(v.items())) for k, v in out.items()}, fh, sort_keys=True, allow_unicode=True, width=120
+        )
+    print("wrote _cfbrest_descs.yaml")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/codegen/gen_cfb_situational_descriptions.py
+++ b/tools/codegen/gen_cfb_situational_descriptions.py
@@ -1,0 +1,132 @@
+"""Descriptions for the ESPN advBoxScore situational block (adv_situational).
+
+Another raw-ESPN block, so the same discipline as gen_cfb_adv_descriptions.py:
+the SHAPE of each column (count vs rate vs EPA) is verified empirically against
+the published 2024 asset, and situation definitions are described without
+asserting ESPN's internal down/distance thresholds.
+
+Verified empirically before writing:
+  * EPA_success* WITHOUT a _rate suffix are integer play COUNTS (e.g. 7..56),
+    not EPA totals, despite the EPA_ prefix.
+  * *_rate columns are true rates in [0,1].
+  * EPA_{situation} and *_per_play are signed EPA floats.
+Naming alone would have mislabelled every EPA_success* column.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+sys.path.insert(0, ".")
+
+# situation -> phrase. Thresholds are ESPN's; the text does not invent them.
+SIT = {
+    "early_down": "early downs",
+    "late_down": "late downs",
+    "standard_down": "standard downs (the team ahead of schedule for the series)",
+    "passing_down": "passing downs (the team behind schedule for the series)",
+    "middle_8": "the middle eight -- the closing minutes of the first half and opening minutes of the second",
+    "rz": "the red zone",
+    "third": "third down",
+}
+PLAY = {"pass": " on pass plays", "rush": " on rush plays"}
+
+
+def _sit_phrase(key: str) -> str | None:
+    return SIT.get(key)
+
+
+def describe(col: str) -> str | None:
+    # --- play-mix counts / rates: {situation}_{pass|rush}[_rate], {situation}s
+    m = re.fullmatch(r"(early_down|late_down|middle_8)_(pass|rush)(_rate)?", col)
+    if m:
+        sit, play, rate = m.groups()
+        if rate:
+            return f"Share of the team's plays on {SIT[sit]} that were {play} plays."
+        return f"Number of {play} plays the team ran on {SIT[sit]}."
+    if col in ("early_downs", "late_downs", "standard_downs", "passing_downs"):
+        return f"Number of plays the team ran on {SIT[col[:-1]]}."
+    if col == "middle_8":
+        # verified Int64 1..27 on the published 2024 asset -- a play count, not an EPA figure
+        return f"Number of plays the team ran in {SIT['middle_8']}."
+    if col == "pos_team":
+        return "Display name of the team on offense (e.g. 'Ohio State Buckeyes')."
+    if col == "early_down_first_down":
+        return "Number of early-down plays that produced a first down."
+    if col == "early_down_first_down_rate":
+        return "Share of early-down plays that produced a first down."
+
+    # --- success COUNTS and RATES: EPA_success[_{sit}][_{pass|rush}][_rate]
+    m = re.fullmatch(
+        r"EPA_success(?:_(early_down|late_down|standard_down|passing_down|middle_8|rz|third))?"
+        r"(?:_(pass|rush))?(_rate)?",
+        col,
+    )
+    if m:
+        sit, play, rate = m.groups()
+        where = f" on {SIT[sit]}" if sit else ""
+        pl_ = PLAY.get(play or "", "")
+        if rate:
+            return f"Success rate{where}{pl_} -- the share of those plays ESPN scored as successful."
+        return f"Count of successful plays{where}{pl_}. Despite the EPA_ prefix this is a play COUNT, not an EPA total."
+    # ESPN also emits the SITUATION-FIRST order for middle-eight success:
+    # EPA_middle_8_success[_{pass|rush}][_rate], not EPA_success_middle_8_*.
+    m = re.fullmatch(r"EPA_(middle_8)_success(?:_(pass|rush))?(_rate)?", col)
+    if m:
+        sit, play, rate = m.groups()
+        pl_ = PLAY.get(play or "", "")
+        if rate:
+            return f"Success rate on {SIT[sit]}{pl_} -- the share of those plays ESPN scored as successful."
+        return (
+            f"Count of successful plays on {SIT[sit]}{pl_}. Despite the EPA_ prefix this is a play "
+            "COUNT, not an EPA total."
+        )
+
+    # EPA_success_rate_rz / EPA_success_rate_third (suffix order flipped by ESPN)
+    m = re.fullmatch(r"EPA_success_rate_(rz|third)", col)
+    if m:
+        return f"Success rate on {SIT[m.group(1)]} -- the share of those plays ESPN scored as successful."
+
+    # --- EPA totals / per-play: EPA_{sit}[_{pass|rush}][_per_play]
+    m = re.fullmatch(
+        r"EPA_(early_down|late_down|standard_down|passing_down|middle_8)"
+        r"(?:_(pass|rush))?(_per_play)?",
+        col,
+    )
+    if m:
+        sit, play, per = m.groups()
+        pl_ = PLAY.get(play or "", "")
+        if per:
+            return f"EPA per play on {SIT[sit]}{pl_}."
+        return f"Total EPA the team generated on {SIT[sit]}{pl_}."
+
+    if col == "pos_team_id":
+        return "ESPN team id of the team on offense. Present for every season 2004+."
+    return None
+
+
+def main() -> None:
+    import yaml
+
+    target = "load_cfb_adv_situational"
+    schemas = yaml.safe_load(pathlib.Path("tools/codegen/schemas/loader_schemas.yaml").read_text(encoding="utf-8"))
+    got, unparsed = {}, []
+    for c in schemas[target]:
+        col = c["name"]
+        d = describe(col)
+        if d is None:
+            unparsed.append(col)
+        else:
+            got[col] = d
+    print(f"composed {len(got)}; unparsed (left blank, never invented) {len(unparsed)}")
+    for u in unparsed:
+        print(f"   {u}")
+    with open("_sit_descs.yaml", "w", encoding="utf-8") as fh:
+        yaml.safe_dump({target: dict(sorted(got.items()))}, fh, sort_keys=False, allow_unicode=True, width=120)
+    print("wrote _sit_descs.yaml")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/codegen/gen_cfb_summary_descriptions.py
+++ b/tools/codegen/gen_cfb_summary_descriptions.py
@@ -1,0 +1,208 @@
+"""Compose descriptions for the cfb team_summaries column grid.
+
+The schema is a combinatorial grid, not 378 independent concepts:
+
+    {base}_{off|def|margin}[_{pass|rush}][_rank]
+
+Every base metric below is transcribed from the PRODUCER
+(cfbfastR-cfb-data/python/cfb_data_build/team_summaries.py::_summarize_team), so
+the text states what is actually computed. Where a base is the mean of an
+upstream pbp/ESPN flag, the description says so rather than asserting a
+threshold this script cannot verify.
+
+Rank direction is verified from the producer: offense is ranked with
+ascending=False and defense with ascending=True (and the "lower is better"
+metrics flip again), so rank 1 is BEST for that side of the ball in every case.
+Margins rank descending, so 1 = largest margin.
+
+Anything that does not parse is reported and left BLANK -- never invented.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+sys.path.insert(0, ".")
+
+# base -> (noun phrase, "higher"|"lower"|None for better-direction commentary)
+BASES: dict[str, str] = {
+    "plays": "plays run",
+    "playsgame": "plays run per game",
+    "playsdrive": "plays run per drive",
+    "drives": "offensive drives",
+    "drivesgame": "drives per game",
+    "passrate": "share of plays that were pass plays",
+    "rushrate": "share of plays that were rush plays",
+    "TEPA": "total EPA summed over every play",
+    "EPAplay": "EPA per play",
+    "EPAdrive": "EPA per drive (total EPA divided by drives)",
+    "EPAgame": "EPA per game (total EPA divided by games)",
+    "early_down_EPA": "EPA per early-down play",
+    "nonExplosiveEpaPerPlay": "EPA per play with explosive plays excluded",
+    "yards": "total yards gained",
+    "yardsplay": "yards gained per play",
+    "yardsgame": "yards gained per game",
+    "yardsdrive": "yards gained per drive",
+    "success": "success rate -- the share of plays flagged as successful by EPA",
+    "red_zone_success": "success rate on red-zone plays",
+    "third_down_success": "success rate on third-down plays",
+    "late_down_success": "success rate on late-down plays",
+    "third_down_distance": "average yards to go on third down",
+    "havoc": "havoc rate -- the share of plays carrying the defensive-disruption flag",
+    "explosive": "explosive-play rate -- the share of plays carrying the explosive flag",
+    "play_stuffed": "stuffed-play rate -- the share of plays carrying the stuffed flag",
+    "line_yards": "average line yards credited to the offensive line on rushes",
+    "opportunity_rate": "opportunity rate -- the share of rushes carrying the opportunity flag",
+    "start_position": "average drive start position, measured in yards from the opponent goal line",
+}
+
+SIDE = {
+    "off": "with the team on offense",
+    "def": "with the team on defense (i.e. allowed to opponents)",
+}
+PHASE = {"pass": " on pass plays", "rush": " on rush plays"}
+
+_RE = re.compile(r"^(?P<base>.+?)_(?P<side>off|def|margin)(?:_(?P<phase>pass|rush))?(?P<rank>_rank)?$")
+
+# Columns outside the {base}_{side} grid. Each is transcribed from its producer:
+#   adj_*/net/strength/valid_games -> sportsdataverse/cfb/cfb_adjusted_epa.py
+#   available/total_*_yards        -> team_summaries.py (drive aggregation)
+#   fbs_class                      -> team_summaries.py::prepare_for_write
+_ADJ = (
+    "opponent-adjusted EPA per play from the ridge (RAPM-style) regression on offense/defense "
+    "team indicators plus home field -- cfbfastR's adjust_epa adjustment, fit in-sample across "
+    "the season, so the value is descriptive of that window rather than predictive"
+)
+_AVAIL = (
+    "Available yards are the yards a drive could theoretically gain, summed from each drive's "
+    "starting distance to the opponent goal line"
+)
+EXTRA: dict[str, str] = {
+    "adj_off_epa": f"Offensive {_ADJ}.",
+    "adj_def_epa": f"Defensive {_ADJ}. Lower is better -- it is EPA allowed.",
+    "net_adj_epa": "Net opponent-adjusted EPA per play: adj_off_epa minus adj_def_epa. Higher is better.",
+    "adj_off_epa_rank": "National rank of the team's adj_off_epa, where 1 is best.",
+    "adj_def_epa_rank": "National rank of the team's adj_def_epa, where 1 is best (fewest EPA allowed).",
+    "net_adj_epa_rank": "National rank of the team's net_adj_epa, 1 = largest net adjusted EPA.",
+    "off_strength_faced": (
+        "Average opponent-defense strength the team's offense faced, taken as the mean of the "
+        "ridge's defensive coefficients across its opponents. Higher means a tougher slate."
+    ),
+    "def_strength_faced": (
+        "Average opponent-offense strength the team's defense faced, taken as the mean of the "
+        "ridge's offensive coefficients across its opponents. Higher means a tougher slate."
+    ),
+    "valid_games": (
+        "Number of the team's games that produced both an offensive and a defensive adjusted-EPA "
+        "value; teams below two valid games are dropped from the adjusted ratings."
+    ),
+    "fbs_class": (
+        "Power/Group classification for the season: P4 or G6 from 2024 on, P5 or G5 through 2023, "
+        "derived from conference membership (Notre Dame is classified with the power group). Null "
+        "for teams outside FBS."
+    ),
+    "through_week": (
+        "Regular-season week this cumulative snapshot covers -- the row reflects the team's state "
+        "through the end of that week. One asset holds every week, so filter on this column."
+    ),
+    "total_available_yards_off": f"{_AVAIL}. Total available yards on the team's own drives.",
+    "total_available_yards_def": f"{_AVAIL}. Total available yards on drives the team defended.",
+    "total_gained_yards_off": "Total yards the team actually gained across its own drives.",
+    "total_gained_yards_def": "Total yards the team allowed across the drives it defended.",
+    "available_yards_pct_off": (
+        "Share of available yards the team's offense actually gained (total_gained_yards_off "
+        "divided by total_available_yards_off). Higher is better."
+    ),
+    "available_yards_pct_def": (
+        "Share of available yards the team's defense allowed opponents to gain. Lower is better."
+    ),
+    "available_yards_pct_off_rank": "National rank of the team's offensive available-yards share, where 1 is best.",
+    "available_yards_pct_def_rank": "National rank of the team's defensive available-yards share, where 1 is best.",
+    "total_available_yards_margin": "Available yards on the team's own drives minus available yards on drives it defended.",
+    "total_gained_yards_margin": "Yards the team gained minus yards it allowed.",
+    "available_yards_pct_margin": (
+        "Available-yards share gained by the offense minus the share allowed by the defense. Higher is better."
+    ),
+    "total_available_yards_margin_rank": "National rank of total_available_yards_margin, 1 = largest margin.",
+    "total_gained_yards_margin_rank": "National rank of total_gained_yards_margin, 1 = largest margin.",
+    "available_yards_pct_margin_rank": "National rank of available_yards_pct_margin, 1 = largest margin.",
+}
+
+
+def _sentence_case(s: str) -> str:
+    """Upper-case the first letter WITHOUT touching the rest.
+
+    str.capitalize() lower-cases the tail, which turns the "EPA per play" nouns
+    into "Epa per play" -- it destroys every acronym in the vocabulary.
+    """
+    return s[:1].upper() + s[1:] if s else s
+
+
+def describe(col: str) -> str | None:
+    if col in EXTRA:
+        return EXTRA[col]
+    m = _RE.match(col)
+    if not m:
+        return None
+    base, side, phase, rank = m["base"], m["side"], m["phase"], m["rank"]
+    if base not in BASES:
+        return None
+    noun, ph = BASES[base], PHASE.get(phase or "", "")
+
+    if side == "margin":
+        if base == "start_position":
+            body = (
+                "Field-position margin: the team's own average starting field position minus the "
+                "average starting field position it allowed, both measured as yards gained from "
+                "their own goal line. Positive means the team started closer to scoring than its "
+                "opponents"
+            )
+        else:
+            body = f"Margin in {noun}{ph}: the team's offensive value minus the value it allowed on defense"
+        return f"{body}. National rank of that margin, 1 = largest." if rank else f"{body}."
+
+    if rank:
+        return f"National rank of the team's {noun}{ph} {SIDE[side]}, where 1 is best."
+    return f"{_sentence_case(noun)}{ph}, {SIDE[side]}."
+
+
+def main() -> None:
+    """Enumerate from loader_schemas.yaml, NOT from deferred_columns().
+
+    deferred_columns() shrinks as descriptions land, so driving off it makes the
+    generator non-idempotent -- a second run sees zero work and a re-merge would
+    wipe the block it just wrote. The declared schema is the stable source.
+    """
+    import pathlib
+
+    import yaml
+
+    targets = ("load_cfb_team_summaries", "load_cfb_team_summaries_weekly")
+    schemas = yaml.safe_load(pathlib.Path("tools/codegen/schemas/loader_schemas.yaml").read_text(encoding="utf-8"))
+    out: dict[str, dict[str, str]] = {t: {} for t in targets}
+    unparsed: list[str] = []
+    for t in targets:
+        for c in schemas[t]:
+            col = c["name"]
+            d = describe(col)
+            if d is None:
+                unparsed.append(f"{t}.{col}")
+                continue
+            out[t][col] = d
+
+    total = sum(len(v) for v in out.values())
+    print(f"composed {total} descriptions across {len(targets)} schemas")
+    print(f"UNPARSED (left blank, never invented): {len(unparsed)}")
+    for u in sorted(set(c.split(".", 1)[1] for c in unparsed))[:40]:
+        print(f"   {u}")
+
+    import yaml
+
+    with open("_summary_descs.yaml", "w", encoding="utf-8") as fh:
+        yaml.safe_dump(out, fh, sort_keys=True, allow_unicode=True, width=120)
+    print("wrote _summary_descs.yaml")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/codegen/gen_phf_descriptions.py
+++ b/tools/codegen/gen_phf_descriptions.py
@@ -74,12 +74,12 @@ STATIC: dict[str, str] = {
     "facility": "Name of the facility hosting the game.",
     "facility_address": "Street address of the hosting facility.",
     "facility_id": "League identifier for the hosting facility.",
-    "rink": "Name of the rink within the facility.",
-    "rink_id": "League identifier for the rink.",
-    "external_url": "League-published external link for the game.",
+    "rink": "Name of the rink within the facility.  NEVER POPULATED: the column is all-null in every published season, which is why it is typed Boolean -- that dtype is polars' inference for an entirely empty column, not a flag.",
+    "rink_id": "League identifier for the rink.  NEVER POPULATED: the column is all-null in every published season, which is why it is typed Boolean -- that dtype is polars' inference for an entirely empty column, not a flag.",
+    "external_url": "League-published external link for the game.  NEVER POPULATED: the column is all-null in every published season, which is why it is typed Boolean -- that dtype is polars' inference for an entirely empty column, not a flag.",
     "tickets_url": "Link to purchase tickets for the game.",
     "watch_live_url": "Link to the live broadcast of the game.",
-    "highlight_color": "Display colour the league uses for the game in its schedule UI.",
+    "highlight_color": "Display colour the league uses for the game in its schedule UI.  NEVER POPULATED: the column is all-null in every published season, which is why it is typed Boolean -- that dtype is polars' inference for an entirely empty column, not a flag.",
     "home_team_short": "Short display name of the home team.",
     "away_team_short": "Short display name of the away team.",
     "home_division_id": "League identifier for the home team's division.",
@@ -138,11 +138,18 @@ def main() -> None:
             d = describe(c["name"])
             if d:
                 got[c["name"]] = d
+            else:
+                # report, never silently omit -- a column this generator cannot
+                # resolve must surface so it is authored rather than lost
+                unparsed.append(f"{t}.{c['name']}")
         out[t] = got
     # report anything declared in STATIC but absent from every schema
     declared = {c["name"] for t in targets for c in schemas.get(t, [])}
     stale = sorted(k for k in STATIC if k not in declared)
     print("composed: " + ", ".join(f"{t.split('_', 2)[-1]}={len(v)}" for t, v in out.items()))
+    print(f"unresolved (left blank, never invented): {len(unparsed)}")
+    for u in unparsed[:40]:
+        print(f"   {u}")
     if stale:
         print(f"WARNING described but not in any PHF schema: {stale}")
     with open("_phf_descs.yaml", "w", encoding="utf-8") as fh:

--- a/tools/codegen/gen_phf_descriptions.py
+++ b/tools/codegen/gen_phf_descriptions.py
@@ -1,0 +1,160 @@
+"""Descriptions for the PHF (Premier Hockey Federation) loader return tables.
+
+PHF assets come from the fastRhockey-lineage scrape of the league's own site, so
+these are provider fields rather than computed metrics. They are described at
+face value; nothing asserts a derivation this repo does not perform.
+
+Compositional families (slot/period/size indexes) are generated rather than
+repeated by hand:
+  * on-ice skater slots 1-6 (offensive/defensive/neutral naming all appear)
+  * team logo URLs by rendition size
+  * per-period and shootout scoring/shots
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+sys.path.insert(0, ".")
+
+STATIC: dict[str, str] = {
+    # --- pbp -------------------------------------------------------------
+    "play_description": "Free-text description of the play as published by the league.",
+    "on_ice_situation": "Strength situation on the ice for the play (e.g. even strength, power play).",
+    "penalty_level": "Severity classification of the penalty (e.g. minor, major).",
+    "start_power_play": "True on the play where a power play begins.",
+    "end_power_play": "True on the play where a power play ends.",
+    "power_play_seconds": "Elapsed seconds of the power play at this play.",
+    "goalie_change": "True when the play records a goaltender change.",
+    "goalie_involved": "Name of the goaltender involved in the play.",
+    "home_goalie_jersey": "Jersey number of the home goaltender on the ice.",
+    "away_goalie_jersey": "Jersey number of the away goaltender on the ice.",
+    "home_nickname": "Nickname of the home team.",
+    "away_nickname": "Nickname of the away team.",
+    "home_score_total": "Home team's cumulative score after the play.",
+    "away_score_total": "Away team's cumulative score after the play.",
+    "scoring_team_abbrev": "Abbreviation of the team credited with the goal.",
+    "scoring_team_on_ice": "Skaters the scoring team had on the ice for the goal.",
+    "defending_team_abbrev": "Abbreviation of the team defending on the play.",
+    "defending_team_on_ice": "Skaters the defending team had on the ice for the play.",
+    "leader": "Team leading the game at this point in the play sequence.",
+    # --- player boxscores -------------------------------------------------
+    "player_jersey": "Player's jersey number.",
+    "faceoffs_win_pct": "Share of the player's faceoffs won.",
+    "faceoffs_won_lost": "Faceoffs won and lost, as the league's combined won-lost string.",
+    "powerplay_goals": "Goals the player scored on the power play.",
+    "save_percent": "Share of shots faced that the goaltender saved.",
+    "shots_blocked": "Shots the player blocked.",
+    "goalies_href": "Relative link to the league's goaltender table for this game.",
+    "skaters_href": "Relative link to the league's skater table for this game.",
+    # --- team boxscores ---------------------------------------------------
+    "total_scoring": "Goals the team scored in the game.",
+    "total_shots": "Shots the team took in the game.",
+    "overtime_scoring": "Goals the team scored in overtime.",
+    "overtime_shots": "Shots the team took in overtime.",
+    "power_play_percent": "Share of the team's power plays that produced a goal.",
+    "successful_power_play": "Number of power plays on which the team scored.",
+    "blocked_opponent_shots": "Opponent shots the team blocked.",
+    "shootout_made_scoring": "Shootout attempts the team converted.",
+    "shootout_made_shots": "Shootout shots the team took that scored.",
+    "shootout_missed_scoring": "Shootout attempts the team failed to convert.",
+    "shootout_missed_shots": "Shootout shots the team took that did not score.",
+    # --- schedules --------------------------------------------------------
+    "allow_players": "League flag for whether player-level detail is published for the game.",
+    "has_play_by_play": "True when a play-by-play feed exists for the game.",
+    "created_at": "Timestamp at which the league created the game record.",
+    "updated_at": "Timestamp at which the league last updated the game record.",
+    "datetime": "Scheduled start of the game as a timestamp.",
+    "datetime_tz": "Scheduled start of the game including its time-zone offset.",
+    "date_group": "League grouping key for the game's date, used to bucket a slate.",
+    "time_zone": "Time zone in which the game is played.",
+    "time_zone_abbr": "Abbreviated form of the game's time zone.",
+    "facility": "Name of the facility hosting the game.",
+    "facility_address": "Street address of the hosting facility.",
+    "facility_id": "League identifier for the hosting facility.",
+    "rink": "Name of the rink within the facility.",
+    "rink_id": "League identifier for the rink.",
+    "external_url": "League-published external link for the game.",
+    "tickets_url": "Link to purchase tickets for the game.",
+    "watch_live_url": "Link to the live broadcast of the game.",
+    "highlight_color": "Display colour the league uses for the game in its schedule UI.",
+    "home_team_short": "Short display name of the home team.",
+    "away_team_short": "Short display name of the away team.",
+    "home_division_id": "League identifier for the home team's division.",
+    "away_division_id": "League identifier for the away team's division.",
+    "home_roster_count": "Number of players dressed for the home team.",
+    "away_roster_count": "Number of players dressed for the away team.",
+    "home_penalty_minutes": "Penalty minutes assessed to the home team.",
+    "away_penalty_minutes": "Penalty minutes assessed to the away team.",
+}
+
+
+def describe(col: str) -> str | None:
+    if col in STATIC:
+        return STATIC[col]
+    # on-ice skater slots: {offensive|defensive}_player_{name|jersey}_{1..6}
+    m = re.fullmatch(r"(offensive|defensive)_player_(name|jersey)_([1-6])", col)
+    if m:
+        side, kind, n = m.groups()
+        what = "Name" if kind == "name" else "Jersey number"
+        role = "attacking" if side == "offensive" else "defending"
+        return f"{what} of the {role} team's skater in on-ice slot {n} for the play."
+    # neutral slots: player_{name|jersey}_{1..3}
+    m = re.fullmatch(r"player_(name|jersey)_([1-3])", col)
+    if m:
+        kind, n = m.groups()
+        what = "Name" if kind == "name" else "Jersey number"
+        return f"{what} of the player in slot {n} of the play's participant list."
+    # team logo renditions
+    m = re.fullmatch(r"(home|away)_team_logo_url_(\d+|full|large|medium|small)", col)
+    if m:
+        side, size = m.groups()
+        rend = f"{size}px" if size.isdigit() else size
+        return f"URL of the {side} team's logo at the {rend} rendition."
+    # per-period scoring / shots
+    m = re.fullmatch(r"period_([123])_(scoring|shots)", col)
+    if m:
+        n, kind = m.groups()
+        return f"{'Goals the team scored' if kind == 'scoring' else 'Shots the team took'} in period {n}."
+    return None
+
+
+def main() -> None:
+    import yaml
+
+    targets = (
+        "load_phf_pbp",
+        "load_phf_player_boxscores",
+        "load_phf_schedules",
+        "load_phf_team_boxscores",
+    )
+    schemas = yaml.safe_load(pathlib.Path("tools/codegen/schemas/loader_schemas.yaml").read_text(encoding="utf-8"))
+    out, unparsed = {}, []
+    for t in targets:
+        got = {}
+        for c in schemas.get(t, []):
+            d = describe(c["name"])
+            if d:
+                got[c["name"]] = d
+        out[t] = got
+    # report anything declared in STATIC but absent from every schema
+    declared = {c["name"] for t in targets for c in schemas.get(t, [])}
+    stale = sorted(k for k in STATIC if k not in declared)
+    print("composed: " + ", ".join(f"{t.split('_', 2)[-1]}={len(v)}" for t, v in out.items()))
+    if stale:
+        print(f"WARNING described but not in any PHF schema: {stale}")
+    with open("_phf_descs.yaml", "w", encoding="utf-8") as fh:
+        yaml.safe_dump(
+            {k: dict(sorted(v.items())) for k, v in out.items() if v},
+            fh,
+            sort_keys=True,
+            allow_unicode=True,
+            width=120,
+        )
+    print("wrote _phf_descs.yaml")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/codegen/gen_wnba_stats_descriptions.py
+++ b/tools/codegen/gen_wnba_stats_descriptions.py
@@ -1,0 +1,273 @@
+"""Descriptions for the stats.wnba.com loader return tables.
+
+These are the league's own result-set columns, so the vocabulary is the standard
+stats API one. Two things are NOT assumed and are derived from published data:
+
+  * column SHAPE (count vs rate vs rank), profiled from the 2024 asset;
+  * RANK DIRECTION, which is *not* uniform. Verified empirically: pts_rank 1 is
+    the highest points total, but tov_rank 1 is the MOST turnovers (i.e. worst),
+    while def_rating_rank 1 and pf_rank 1 are the lowest values. Writing
+    "1 = best" everywhere would have been wrong for the negative stats, so each
+    rank column states the direction measured for that specific column.
+
+Anything unmatched is reported and left blank rather than invented.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+sys.path.insert(0, ".")
+
+BASE: dict[str, str] = {
+    "gp": "games played",
+    "w": "games won",
+    "l": "games lost",
+    "w_pct": "win percentage",
+    "min": "minutes played",
+    "pts": "total points scored",
+    "ast": "assists credited",
+    "reb": "total rebounds collected",
+    "oreb": "offensive rebounds collected",
+    "dreb": "defensive rebounds collected",
+    "stl": "steals recorded",
+    "blk": "total shots blocked",
+    "blka": "blocked attempts -- the player's own shots that were blocked",
+    "tov": "turnovers committed",
+    "pf": "personal fouls committed",
+    "pfd": "personal fouls drawn",
+    "fgm": "field goals made",
+    "fga": "field goals attempted",
+    "fg_pct": "field-goal percentage",
+    "fg3m": "three-point field goals made",
+    "fg3a": "three-point field goals attempted",
+    "fg3_pct": "three-point percentage",
+    "ftm": "free throws made",
+    "fta": "free throws attempted",
+    "ft_pct": "free-throw percentage",
+    "plus_minus": "plus-minus point differential",
+    "dd2": "double-doubles",
+    "td3": "triple-doubles",
+    "nba_fantasy_pts": "fantasy points",
+    "fantasy_pts": "fantasy points",
+    # --- advanced ---
+    "off_rating": "offensive rating -- points produced per 100 possessions",
+    "def_rating": "defensive rating -- points allowed per 100 possessions",
+    "net_rating": "net rating -- offensive minus defensive rating",
+    "ast_pct": "assist percentage -- share of teammate field goals assisted while on court",
+    "ast_to": "assist-to-turnover ratio",
+    "ast_ratio": "assist ratio -- assists per 100 possessions used",
+    "oreb_pct": "offensive rebound percentage",
+    "dreb_pct": "defensive rebound percentage",
+    "reb_pct": "total rebound percentage",
+    "tm_tov_pct": "team turnover percentage -- turnovers per 100 possessions",
+    "efg_pct": "effective field-goal percentage, weighting three-pointers 1.5x",
+    "ts_pct": "true shooting percentage, accounting for threes and free throws",
+    "usg_pct": "usage percentage -- share of team possessions used while on court",
+    "pace": "pace -- possessions per 48 minutes",
+    "pie": "player impact estimate -- share of game events contributed",
+    "poss": "possessions used",
+    "def_ws": "defensive win shares",
+    "def_ws_raw": "defensive win shares before rounding",
+}
+
+STANDINGS: dict[str, str] = {
+    "conference_games_back": "Games behind the conference leader.",
+    "division_games_back": "Games behind the division leader.",
+    "league_games_back": "Games behind the league leader.",
+    "division_rank": "Rank within the division.",
+    "league_rank": "Rank within the league.",
+    "division_record": "Record against divisional opponents.",
+    "current_streak": "Current winning or losing streak, signed.",
+    "current_home_streak": "Current streak in home games.",
+    "current_road_streak": "Current streak in road games.",
+    "long_win_streak": "Longest winning streak of the season.",
+    "long_loss_streak": "Longest losing streak of the season.",
+    "long_home_streak": "Longest home winning streak of the season.",
+    "long_road_streak": "Longest road winning streak of the season.",
+    "last10home": "Record over the team's last 10 home games.",
+    "last10road": "Record over the team's last 10 road games.",
+    "diff_total_points": "Season point differential -- points scored minus points allowed.",
+    "ahead_at_half": "Record in games the team led at halftime.",
+    "behind_at_half": "Record in games the team trailed at halftime.",
+    "ahead_at_third": "Record in games the team led after the third period.",
+    "behind_at_third": "Record in games the team trailed after the third period.",
+    "fewer_turnovers": "Record in games the team committed fewer turnovers than its opponent.",
+    "lead_in_fgpct": "Record in games the team shot a higher field-goal percentage than its opponent.",
+    "lead_in_reb": "Record in games the team out-rebounded its opponent.",
+    "opp_over500": "Record against opponents with a winning record.",
+    "opp_score100pts": "Record in games the opponent reached 100 points.",
+    "opp_score_80_plus": "Record in games the opponent scored 80 or more.",
+    "opp_score_below_80": "Record in games the opponent scored fewer than 80.",
+    "score_100pts": "Record in games the team reached 100 points.",
+    "score_80_plus": "Record in games the team scored 80 or more.",
+    "score_below_80": "Record in games the team scored fewer than 80.",
+    "clinched_conference_title": "Flag for having clinched the conference title.",
+    "clinched_division_title": "Flag for having clinched the division title.",
+    "clinched_playoff_birth": "Flag for having clinched a playoff berth.",
+    "clinched_play_in": "Flag for having clinched a play-in berth.",
+    "clinched_post_season": "Flag for having clinched a postseason berth.",
+    "eliminated_conference": "Flag for elimination from conference contention.",
+    "eliminated_division": "Flag for elimination from division contention.",
+}
+MONTHS = {
+    "jan": "January",
+    "feb": "February",
+    "mar": "March",
+    "apr": "April",
+    "may": "May",
+    "jun": "June",
+    "jul": "July",
+    "aug": "August",
+    "sep": "September",
+    "oct": "October",
+    "nov": "November",
+    "dec": "December",
+}
+
+MISC: dict[str, str] = {
+    "measure_type": "Which stats.wnba.com measure set the row came from (e.g. Base, Advanced).",
+    "how_acquired": "How the team acquired the player (draft, trade, free agency).",
+    "season_2": "Season label in the league's second display form.",
+    "team_id_lookup": "Team id used to join the row back to the team tables.",
+    "stat_description": "Human-readable description of the statistic the row reports.",
+    "act_type": "Action-type code for the play-by-play event.",
+    "msg_type": "Message-type code for the play-by-play event.",
+    "number_event": "Sequence number of the event within the game.",
+    "off_slug_team": "Slug of the team on offense for the event.",
+    "slug_team": "Slug of the team credited with the event.",
+    "team_home": "Slug of the home team.",
+    "team_away": "Slug of the away team.",
+    "secs_passed_game": "Seconds elapsed in the game at the event.",
+    "shot_pts": "Points scored on the shot, if the event was a made field goal.",
+    "total_starters_away": "Number of the away team's starters on the floor for the event.",
+    "total_starters_home": "Number of the home team's starters on the floor for the event.",
+}
+
+
+def _phrase(stat: str) -> str | None:
+    """Resolve a (possibly modified) stat token to a noun phrase."""
+    opp = stat.startswith("opp_")
+    if opp:
+        stat = stat[4:]
+    est = stat.startswith("e_")
+    if est:
+        stat = stat[2:]
+    pg = stat.endswith("_pg")
+    if pg:
+        stat = stat[:-3]
+    base = BASE.get(stat)
+    if base is None:
+        return None
+    out = base
+    if pg:
+        out += " per game"
+    if est:
+        out = f"estimated {out}"
+    if opp:
+        out = f"opponent {out}"
+    return out
+
+
+def build(direction: dict[str, str]):
+    def describe(col: str) -> str | None:
+        if col in MISC:
+            return MISC[col]
+        if col in STANDINGS:
+            return STANDINGS[col]
+        if col in MONTHS:
+            return f"Team's win-loss record in {MONTHS[col]}."
+        m = re.fullmatch(r"(.+)_rank", col)
+        if m:
+            p = _phrase(m.group(1))
+            if p:
+                d = direction.get(col)
+                tail = f" Rank 1 is the {d} value." if d else ""
+                return f"League rank for {p}.{tail}"
+            return None
+        p = _phrase(col)
+        return f"{p[0].upper()}{p[1:]}." if p else None
+
+    return describe
+
+
+def _measure_directions(frames) -> dict[str, str]:
+    """Per-rank-column direction, measured rather than assumed.
+
+    stats.wnba.com does not rank every statistic the same way -- pts_rank 1 is the
+    highest total while pf_rank 1 is the lowest -- so the direction is read off the
+    data by correlating each value column with its rank.
+    """
+    import polars as pl
+
+    out: dict[str, str] = {}
+    for d in frames:
+        for rk in [c for c in d.columns if c.endswith("_rank")]:
+            val = rk[: -len("_rank")]
+            if val not in d.columns:
+                continue
+            s = d.select([val, rk]).drop_nulls()
+            if s.height < 20:
+                continue
+            try:
+                corr = pl.DataFrame(s).select(pl.corr(val, rk)).item()
+            except Exception:
+                continue
+            if corr is None:
+                continue
+            out[rk] = "highest" if corr < 0 else "lowest"
+    return out
+
+
+def main() -> None:
+    import yaml
+
+    import sportsdataverse.wnba as w
+
+    # ONLY loaders declared in releases.yaml render a column/description table.
+    # The four big wnba_stats season/standings/lineups loaders are hand-written and
+    # document a PROSE Returns paragraph on the league additional page, so authoring
+    # descriptions for them would be dead config -- excluded deliberately.
+    targets = [
+        "load_wnba_stats_pbp",
+        "load_wnba_stats_rosters",
+        "load_wnba_stats_player_game_logs",
+        "load_wnba_team_season_stats",
+    ]
+    frames = []
+    for fn in ("load_wnba_stats_player_season_stats", "load_wnba_stats_team_season_stats"):
+        try:
+            frames.append(getattr(w, fn)([2024]))
+        except Exception as exc:  # noqa: BLE001
+            print(f"   (direction probe skipped for {fn}: {type(exc).__name__})")
+    direction = _measure_directions(frames)
+    print(f"measured rank direction for {len(direction)} columns")
+    describe = build(direction)
+
+    schemas = yaml.safe_load(pathlib.Path("tools/codegen/schemas/loader_schemas.yaml").read_text(encoding="utf-8"))
+    out, unparsed = {}, []
+    for t in targets:
+        got = {}
+        for c in schemas.get(t, []):
+            d = describe(c["name"])
+            if d:
+                got[c["name"]] = d
+            else:
+                unparsed.append(f"{t}.{c['name']}")
+        if got:
+            out[t] = got
+    print(f"composed {sum(len(v) for v in out.values())}; unparsed {len(unparsed)}")
+    seen = sorted({u.split(".", 1)[1] for u in unparsed})
+    for u in seen[:45]:
+        print(f"   {u}")
+    with open("_wnba_descs.yaml", "w", encoding="utf-8") as fh:
+        yaml.safe_dump(
+            {k: dict(sorted(v.items())) for k, v in out.items()}, fh, sort_keys=True, allow_unicode=True, width=120
+        )
+    print("wrote _wnba_descs.yaml")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/codegen/manual_column_descriptions.yaml
+++ b/tools/codegen/manual_column_descriptions.yaml
@@ -2599,6 +2599,1447 @@ load_cfb_betting_lines:
     null for moneyline rows.
   opening_odds: Opening American-odds price for this selection before line movement (vig on spread/total rows, moneyline price
     on moneyline rows).
+load_cfb_passing:
+  EPAgame: EPA generated per game.
+  EPAgame_rank: National rank of the team's EPA generated per game, where 1 is best.
+  EPAplay: EPA generated per play.
+  EPAplay_rank: National rank of the team's EPA generated per play, where 1 is best.
+  TEPA: Total EPA summed over every play.
+  TEPA_rank: National rank of the team's total EPA summed over every play, where 1 is best.
+  att: Pass attempts thrown.
+  comp: Completed passes.
+  comppct: Completion percentage.
+  comppct_rank: National rank of the team's completion percentage, where 1 is best.
+  detmer: Detmer rating -- the composite passing-efficiency measure this pipeline publishes, named for the college passing-efficiency
+    tradition.
+  detmer_rank: National rank of the team's detmer rating -- the composite passing-efficiency measure this pipeline publishes,
+    named for the college passing-efficiency tradition, where 1 is best.
+  detmergame: Detmer rating expressed per game.
+  detmergame_rank: National rank of the team's detmer rating expressed per game, where 1 is best.
+  dropbacks: Dropbacks taken by the passer.
+  fbs_class: 'Power/Group classification for the season: P4 or G6 from 2024 on, P5 or G5 through 2023, derived from conference
+    membership. Null for teams outside FBS.'
+  pass_int: Interceptions thrown.
+  passer_player_name: Display name of the passer -- the FIRST participant in that role on the play.
+  playsgame: Plays per game.
+  sack_adj_yards: Passing yards adjusted for sack yardage lost.
+  sack_adj_yards_rank: National rank of the team's passing yards adjusted for sack yardage lost, where 1 is best.
+  sack_yds: Yards lost to sacks.
+  sacked: Times the passer was sacked.
+  success: Success rate across the team plays.
+  success_rank: National rank of the team's success rate across the team plays, where 1 is best.
+  team_games: Games the team played, used as the per-game denominator.
+  yards_rank: National rank of the team's total yards, where 1 is best.
+  yardsdropback: Yards per dropback.
+  yardsdropback_rank: National rank of the team's yards per dropback, where 1 is best.
+  yardsgame: Yards per game.
+  yardsgame_rank: National rank of the team's yards per game, where 1 is best.
+  yardsplay: Yards per play.
+  yardsplay_rank: National rank of the team's yards per play, where 1 is best.
+load_cfb_percentiles:
+  EPAdropback: Value of EPA generated per dropback at the percentile this row reports.
+  EPAplay: Value of EPA generated per play at the percentile this row reports.
+  EPArush: Value of EPA generated per rushing attempt at the percentile this row reports.
+  GEI: Value of game excitement index at the percentile this row reports.
+  dropbacks: Value of dropbacks taken by the passer at the percentile this row reports.
+  early_down_EPA: Value of EPA per early-down play at the percentile this row reports.
+  early_down_success: Value of success rate on early downs at the percentile this row reports.
+  explosive: Value of explosive-play rate at the percentile this row reports.
+  havoc: Value of havoc rate at the percentile this row reports.
+  late_down_success: Value of success rate on late downs at the percentile this row reports.
+  lineyards: Value of line yards per rush at the percentile this row reports.
+  nonExplosiveEpaPerPlay: Value of EPA per play excluding explosive plays at the percentile this row reports.
+  opportunity_run: Value of opportunity-run rate at the percentile this row reports.
+  pass_explosive: Value of explosive-play rate on pass plays at the percentile this row reports.
+  pass_success: Value of success rate on pass plays at the percentile this row reports.
+  pctile: Percentile bucket the row reports, from 0 to 100.
+  play_stuffed: Value of stuffed-play rate at the percentile this row reports.
+  red_zone_success: Value of success rate in the red zone at the percentile this row reports.
+  rush_explosive: Value of explosive-play rate on rush plays at the percentile this row reports.
+  rush_success: Value of success rate on rush plays at the percentile this row reports.
+  rushes: Value of rushing attempts at the percentile this row reports.
+  success: Value of success rate across the team plays at the percentile this row reports.
+  third_down_distance: Value of average yards to go on third down at the percentile this row reports.
+  third_down_success: Value of success rate on third down at the percentile this row reports.
+  yardsdropback: Value of yards per dropback at the percentile this row reports.
+  yardsplay: Value of yards per play at the percentile this row reports.
+  yardsrush: Value of yards per rush at the percentile this row reports.
+load_cfb_play_participants:
+  assisted_by_player_id: ESPN athlete id of a defender credited with an assisted tackle -- the FIRST participant in that role
+    on the play.
+  assisted_by_player_ids: List of the athlete ids of EVERY participant credited as a defender credited with an assisted tackle
+    on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  assisted_by_player_name: Display name of a defender credited with an assisted tackle -- the FIRST participant in that role
+    on the play.
+  assisted_by_player_names: List of the display names of EVERY participant credited as a defender credited with an assisted
+    tackle on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  forced_by_player_id: ESPN athlete id of the defender who forced the fumble -- the FIRST participant in that role on the
+    play.
+  forced_by_player_ids: List of the athlete ids of EVERY participant credited as the defender who forced the fumble on the
+    play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  forced_by_player_name: Display name of the defender who forced the fumble -- the FIRST participant in that role on the play.
+  forced_by_player_names: List of the display names of EVERY participant credited as the defender who forced the fumble on
+    the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  kicker_player_id: ESPN athlete id of the kicker -- the FIRST participant in that role on the play.
+  kicker_player_ids: List of the athlete ids of EVERY participant credited as the kicker on the play, so multi-entry roles
+    such as split sacks or gang tackles are not collapsed to one.
+  kicker_player_name: Display name of the kicker -- the FIRST participant in that role on the play.
+  kicker_player_names: List of the display names of EVERY participant credited as the kicker on the play, so multi-entry roles
+    such as split sacks or gang tackles are not collapsed to one.
+  pass_defender_player_id: ESPN athlete id of the defender credited with defending the pass -- the FIRST participant in that
+    role on the play.
+  pass_defender_player_ids: List of the athlete ids of EVERY participant credited as the defender credited with defending
+    the pass on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  pass_defender_player_name: Display name of the defender credited with defending the pass -- the FIRST participant in that
+    role on the play.
+  pass_defender_player_names: List of the display names of EVERY participant credited as the defender credited with defending
+    the pass on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  passer_player_id: ESPN athlete id of the passer -- the FIRST participant in that role on the play.
+  passer_player_ids: List of the athlete ids of EVERY participant credited as the passer on the play, so multi-entry roles
+    such as split sacks or gang tackles are not collapsed to one.
+  passer_player_name: Display name of the passer -- the FIRST participant in that role on the play.
+  passer_player_names: List of the display names of EVERY participant credited as the passer on the play, so multi-entry roles
+    such as split sacks or gang tackles are not collapsed to one.
+  pat_passer_player_id: ESPN athlete id of the passer on the point-after attempt -- the FIRST participant in that role on
+    the play.
+  pat_passer_player_ids: List of the athlete ids of EVERY participant credited as the passer on the point-after attempt on
+    the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  pat_passer_player_name: Display name of the passer on the point-after attempt -- the FIRST participant in that role on the
+    play.
+  pat_passer_player_names: List of the display names of EVERY participant credited as the passer on the point-after attempt
+    on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  pat_scorer_player_id: ESPN athlete id of the player credited with the point-after score -- the FIRST participant in that
+    role on the play.
+  pat_scorer_player_ids: List of the athlete ids of EVERY participant credited as the player credited with the point-after
+    score on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  pat_scorer_player_name: Display name of the player credited with the point-after score -- the FIRST participant in that
+    role on the play.
+  pat_scorer_player_names: List of the display names of EVERY participant credited as the player credited with the point-after
+    score on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  penalized_player_id: ESPN athlete id of the penalized player -- the FIRST participant in that role on the play.
+  penalized_player_ids: List of the athlete ids of EVERY participant credited as the penalized player on the play, so multi-entry
+    roles such as split sacks or gang tackles are not collapsed to one.
+  penalized_player_name: Display name of the penalized player -- the FIRST participant in that role on the play.
+  penalized_player_names: List of the display names of EVERY participant credited as the penalized player on the play, so
+    multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  punter_player_id: ESPN athlete id of the punter -- the FIRST participant in that role on the play.
+  punter_player_ids: List of the athlete ids of EVERY participant credited as the punter on the play, so multi-entry roles
+    such as split sacks or gang tackles are not collapsed to one.
+  punter_player_name: Display name of the punter -- the FIRST participant in that role on the play.
+  punter_player_names: List of the display names of EVERY participant credited as the punter on the play, so multi-entry roles
+    such as split sacks or gang tackles are not collapsed to one.
+  receiver_player_id: ESPN athlete id of the targeted receiver -- the FIRST participant in that role on the play.
+  receiver_player_ids: List of the athlete ids of EVERY participant credited as the targeted receiver on the play, so multi-entry
+    roles such as split sacks or gang tackles are not collapsed to one.
+  receiver_player_name: Display name of the targeted receiver -- the FIRST participant in that role on the play.
+  receiver_player_names: List of the display names of EVERY participant credited as the targeted receiver on the play, so
+    multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  recoverer_player_id: ESPN athlete id of the player who recovered the fumble -- the FIRST participant in that role on the
+    play.
+  recoverer_player_ids: List of the athlete ids of EVERY participant credited as the player who recovered the fumble on the
+    play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  recoverer_player_name: Display name of the player who recovered the fumble -- the FIRST participant in that role on the
+    play.
+  recoverer_player_names: List of the display names of EVERY participant credited as the player who recovered the fumble on
+    the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  returner_player_id: ESPN athlete id of the player returning the kick or punt -- the FIRST participant in that role on the
+    play.
+  returner_player_ids: List of the athlete ids of EVERY participant credited as the player returning the kick or punt on the
+    play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  returner_player_name: Display name of the player returning the kick or punt -- the FIRST participant in that role on the
+    play.
+  returner_player_names: List of the display names of EVERY participant credited as the player returning the kick or punt
+    on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  rusher_player_id: ESPN athlete id of the ball carrier on a rush -- the FIRST participant in that role on the play.
+  rusher_player_ids: List of the athlete ids of EVERY participant credited as the ball carrier on a rush on the play, so multi-entry
+    roles such as split sacks or gang tackles are not collapsed to one.
+  rusher_player_name: Display name of the ball carrier on a rush -- the FIRST participant in that role on the play.
+  rusher_player_names: List of the display names of EVERY participant credited as the ball carrier on a rush on the play,
+    so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  sacked_by_player_id: ESPN athlete id of a defender credited with the sack -- the FIRST participant in that role on the play.
+  sacked_by_player_ids: List of the athlete ids of EVERY participant credited as a defender credited with the sack on the
+    play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  sacked_by_player_name: Display name of a defender credited with the sack -- the FIRST participant in that role on the play.
+  sacked_by_player_names: List of the display names of EVERY participant credited as a defender credited with the sack on
+    the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  scorer_player_id: ESPN athlete id of the player credited with the score -- the FIRST participant in that role on the play.
+  scorer_player_ids: List of the athlete ids of EVERY participant credited as the player credited with the score on the play,
+    so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  scorer_player_name: Display name of the player credited with the score -- the FIRST participant in that role on the play.
+  scorer_player_names: List of the display names of EVERY participant credited as the player credited with the score on the
+    play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  tackler_player_id: ESPN athlete id of a defender credited with the tackle -- the FIRST participant in that role on the play.
+  tackler_player_ids: List of the athlete ids of EVERY participant credited as a defender credited with the tackle on the
+    play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  tackler_player_name: Display name of a defender credited with the tackle -- the FIRST participant in that role on the play.
+  tackler_player_names: List of the display names of EVERY participant credited as a defender credited with the tackle on
+    the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+load_cfb_drives:
+  n_plays: Number of entries in ESPN's raw plays array for the drive, which is generally at least offensive_plays because
+    it also counts penalties and other non-offensive snaps.
+load_cfb_game_rosters:
+  athlete_href: ESPN Core v2 API reference URL for the athlete's season record, ending in the athlete id.
+  birth_country_alternate_id: ESPN's internal alternate identifier for the athlete's birth country, paired with birth_place_country
+    and the flag fields.
+  flag_alt: Alt text ESPN attaches to the birth-country flag image, which is the country's name spelled out.
+  flag_href: URL of the birth-country flag image hosted on ESPN's CDN under teamlogos/countries.
+  flag_rel: Stringified relationship list ESPN ships with the flag image; the only non-null value observed is a single country-flag
+    entry.
+  position_href: ESPN Core v2 API reference URL for the position resource ESPN lists the athlete at.
+  statistics_href: ESPN Core v2 API reference URL for this athlete's stat line in this game, null for the roughly 71 percent
+    of listed players who recorded no stats.
+  team_alternate_ids_sdr: The team's Sportradar alternate identifier, which maps one-to-one with team_id.
+load_cfb_model_pbp:
+  awayTeamId: ESPN team id of the away team, read off the game header and stamped on every play.
+  awayTeamName: Away team's school name from ESPN's team location field, without the mascot.
+  completion_prob: Modelled probability the pass is completed.
+  cp_model_version: Version of the completion-probability model that scored the play.
+  drive.id: ESPN's drive identifier, formed as the game id followed by the drive's sequence number within that game.
+  ep_model_version: Version of the expected-points model that scored the play.
+  homeTeamId: ESPN team id of the home team, read off the game header and stamped on every play.
+  homeTeamName: Home team's school name from ESPN's team location field, without the mascot.
+  model_pbp_version: Version of the model-scored play-by-play build.
+  passer_player_name: Display name of the passer -- the FIRST participant in that role on the play.
+  passing_down: True on second and eight or longer, third and five or longer, or fourth and five or longer, the standard obvious-passing-situation
+    flag.
+  scored_date: Date on which the play was scored by the models.
+  start.TimeSecsRem: Seconds remaining in the half at the snap, so it tops out at 1800 rather than counting down from a full
+    game.
+  start.distance: Yards the offense needs for a first down at the snap, carried through from ESPN without correction.
+  start.down: Down at the snap as ESPN reports it; 0 marks the small share of rows ESPN leaves without a down, overwhelmingly
+    timeouts and penalty administrations.
+  start.is_home: True when the team holding possession at the snap is the home team.
+  start.pos_team.name: School name of the team with possession at the snap, taken from ESPN's team location field so it carries
+    no mascot.
+  start.yardsToEndzone: Distance in yards from the offense's spot at the snap to the opponent's end zone, ranging 0 to 100.
+  statYardage: Yards gained on the play as ESPN reports it, negative on plays that lost yardage.
+  type.text: ESPN's play-type label, for example Rush, Pass Reception, Sack, Punt, Penalty, or Timeout.
+  wp_model_version: Version of the win-probability model that scored the play.
+load_cfb_player_box:
+  adjQBR: Adjusted Total QBR for the quarterback.
+  completions/passingAttempts: Completions and pass attempts, as ESPN's combined string.
+  extraPointsMade/extraPointAttempts: Extra points made and attempted, as ESPN's combined string.
+  fieldGoalPct: Field-goal percentage.
+  fieldGoalsMade/fieldGoalAttempts: Field goals made and attempted, as ESPN's combined string.
+  grossAvgPuntYards: Gross average yards per punt, before return yardage.
+  interceptionTouchdowns: Touchdowns scored on interception returns.
+  interceptionYards: Yards returned on interceptions.
+  longFieldGoalMade: Longest field goal made, in yards.
+  longPunt: Longest punt of the game, in yards.
+  longPuntReturn: Longest punt return of the game, in yards.
+  longReception: Longest reception of the game, in yards.
+  longRushing: Longest rush of the game, in yards.
+  passingTouchdowns: Passing touchdowns.
+  passingYards: Net passing yards gained.
+  puntReturnTouchdowns: Touchdowns scored on punt returns.
+  puntReturnYards: Yards gained on punt returns.
+  puntReturns: Punt returns attempted.
+  puntYards: Total punt yards.
+  punts: Punts attempted.
+  puntsInside20: Punts downed inside the opponent 20-yard line.
+  receivingTouchdowns: Receiving touchdowns.
+  receivingYards: Receiving yards gained.
+  rushingAttempts: Rushing attempts.
+  rushingTouchdowns: Rushing touchdowns.
+  rushingYards: Net rushing yards gained.
+  stat_1: First value of ESPN's raw athlete stats array, written only when the category's key list does not line up with the
+    stats list; on those rows the named per-category columns are all null.
+  stat_2: Second value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and
+    the named columns could not be filled.
+  stat_3: Third value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and
+    the named columns could not be filled.
+  stat_4: Fourth value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and
+    the named columns could not be filled.
+  stat_5: Fifth value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and
+    the named columns could not be filled.
+  totalKickingPoints: Total points scored by kicking.
+  touchbacks: Punts or kickoffs that resulted in a touchback.
+  yardsPerPassAttempt: Yards gained per pass attempt.
+  yardsPerPuntReturn: Yards gained per punt return.
+  yardsPerReception: Yards gained per reception.
+  yardsPerRushAttempt: Yards gained per rushing attempt.
+load_cfb_power_index:
+  $ref: ESPN Core v2 API URL for one team's FPI projection on this game; the published asset carries only these links, not
+    the resolved projection numbers.
+load_cfb_ratings:
+  adj_def_epa: Opponent-adjusted EPA per play allowed, netted the same way as the offensive rating, so lower is better because
+    it measures EPA surrendered.
+  adj_net: adj_off_epa minus adj_def_epa, the team's overall efficiency rating in EPA per play; special teams is deliberately
+    excluded.
+  adj_off_epa: 'Opponent-adjusted offensive EPA per play: the team''s raw per-game EPA on pass and rush plays net of each
+    opponent''s ridge-fitted defensive strength, averaged over its games.'
+  adj_st_epa: 'Special-teams composite in EPA units: per-play mean EPA on field goals, punts, and kick returns, each centered
+    on that unit''s league mean and summed across the three units.'
+  def_rank: Dense rank of adj_def_epa in ascending order, so rank 1 is the season's stingiest defense.
+  fei_def: Drive-level defensive rating from the same per-drive ridge fit, on the same scale as fei_off.
+  fei_net: fei_off minus fei_def, the team's overall drive-efficiency rating, with the ridge's dropped reference team pinned
+    at zero.
+  fei_off: Drive-level offensive rating from a ridge fit on per-drive EPA, the Fremeau-style drive-efficiency counterpart
+    to adj_off_epa.
+  net_rank: Dense rank of adj_net in descending order, so rank 1 is the season's strongest overall team.
+  net_z: adj_net restated as a z-score against the mean and standard deviation of adj_net across the rated teams that season.
+  off_pace: 'Tempo measure: scrimmage plays (pass plus rush) per game, centering near 65 and used as the pace input to the
+    totals model.'
+  off_rank: Dense rank of adj_off_epa in descending order, so rank 1 is the season's most efficient offense.
+load_cfb_ratings_weekly:
+  adj_def_epa: Opponent-adjusted EPA per play allowed as of the snapshot week, netted the same way as the offensive rating,
+    so lower is better.
+  adj_net: adj_off_epa minus adj_def_epa at the snapshot week, the team's overall efficiency rating in EPA per play with special
+    teams excluded.
+  adj_off_epa: 'Opponent-adjusted offensive EPA per play as of the snapshot week: raw per-game EPA on pass and rush plays
+    net of each opponent''s ridge-fitted defensive strength.'
+  adj_st_epa: Special-teams composite in EPA units as of the snapshot week, summing the league-centered per-play EPA of the
+    field goal, punt, and kick-return units.
+  def_rank: Dense rank of adj_def_epa in ascending order within the snapshot week, so rank 1 is the stingiest defense at that
+    point.
+  fei_def: Drive-level defensive rating at the snapshot week, from the same per-drive ridge fit and on the same scale as fei_off.
+  fei_net: fei_off minus fei_def at the snapshot week, the team's overall drive-efficiency rating.
+  fei_off: Drive-level offensive rating at the snapshot week, from a ridge fit on per-drive EPA.
+  net_rank: Dense rank of adj_net in descending order within the snapshot week, so rank 1 is the strongest overall team at
+    that point.
+  net_z: adj_net restated as a z-score against the mean and standard deviation of adj_net across the teams rated in that snapshot
+    week.
+  off_pace: Scrimmage plays per game through the snapshot week, the tempo input consumed by the totals model.
+  off_rank: Dense rank of adj_off_epa in descending order within the snapshot week, so rank 1 is the most efficient offense
+    at that point.
+  through_week: Regular-season week the snapshot runs through; the ratings were refit using only games kicking off on or before
+    that week's final kickoff date.
+load_cfb_receiving:
+  EPAgame: EPA generated per game.
+  EPAgame_rank: National rank of the team's EPA generated per game, where 1 is best.
+  EPAplay: EPA generated per play.
+  EPAplay_rank: National rank of the team's EPA generated per play, where 1 is best.
+  TEPA: Total EPA summed over every play.
+  TEPA_rank: National rank of the team's total EPA summed over every play, where 1 is best.
+  catchpct: Catch rate on a 0-to-1 scale, receptions divided by targets for the season.
+  catchpct_rank: Season rank of catchpct with the best catch rate first, computed only for receivers clearing the leaderboard
+    minimum of 1.875 targets per team game and using averaged ranks for ties.
+  comp: Completed passes.
+  fbs_class: 'Power/Group classification for the season: P4 or G6 from 2024 on, P5 or G5 through 2023, derived from conference
+    membership. Null for teams outside FBS.'
+  fumbles: Count of the receiver's targeted pass plays across the season whose play text mentions a fumble by either team.
+  playsgame: Plays per game.
+  receiver_player_name: Display name of the targeted receiver -- the FIRST participant in that role on the play.
+  success: Success rate across the team plays.
+  success_rank: National rank of the team's success rate across the team plays, where 1 is best.
+  team_games: Games the team played, used as the per-game denominator.
+  yards_rank: National rank of the team's total yards, where 1 is best.
+  yardsgame: Yards per game.
+  yardsgame_rank: National rank of the team's yards per game, where 1 is best.
+  yardsplay: Yards per play.
+  yardsplay_rank: National rank of the team's yards per play, where 1 is best.
+load_cfb_recruiting_proj:
+  pred_margin: Ridge projection of the team's average per-game scoring margin, from the same preseason-known feature set as
+    pred_wins.
+  pred_net_epa: Reserved slot for a projected adjusted net EPA; it ships all-null because the adjusted-EPA training target
+    is not currently loadable.
+  pred_wins: Ridge projection of the team's season win total, fit strictly on prior seasons from talent composite, blue-chip
+    ratio, offensive and defensive returning production, and prior wins.
+load_cfb_rosters:
+  recruit_ids: List of recruiting-database profile ids matched to the player; real ids run in the six-figure range and a lone
+    0 entry means no recruiting profile was matched.
+load_cfb_rushing:
+  EPAgame: EPA generated per game.
+  EPAgame_rank: National rank of the team's EPA generated per game, where 1 is best.
+  EPAplay: EPA generated per play.
+  EPAplay_rank: National rank of the team's EPA generated per play, where 1 is best.
+  TEPA: Total EPA summed over every play.
+  TEPA_rank: National rank of the team's total EPA summed over every play, where 1 is best.
+  fbs_class: 'Power/Group classification for the season: P4 or G6 from 2024 on, P5 or G5 through 2023, derived from conference
+    membership. Null for teams outside FBS.'
+  fumbles: Count of the ball carrier's rush attempts across the season whose play text mentions a fumble by either team.
+  playsgame: Plays per game.
+  rusher_player_name: Display name of the ball carrier on a rush -- the FIRST participant in that role on the play.
+  success: Success rate across the team plays.
+  success_rank: National rank of the team's success rate across the team plays, where 1 is best.
+  team_games: Games the team played, used as the per-game denominator.
+  yards_rank: National rank of the team's total yards, where 1 is best.
+  yardsgame: Yards per game.
+  yardsgame_rank: National rank of the team's yards per game, where 1 is best.
+  yardsplay: Yards per play.
+  yardsplay_rank: National rank of the team's yards per play, where 1 is best.
+load_cfb_schedule_crosswalk:
+  espn_date: Kickoff date as YYYY-MM-DD taken from ESPN's schedule, null on games that matched no ESPN row.
+  espn_game_id: ESPN game id for the crosswalk row.
+  fox_date: Kickoff date as YYYY-MM-DD taken from the Fox Sports schedule, null on games that matched no Fox row.
+  fox_game_id: Fox Sports game id for the same game.
+  matched_sources: Plus-joined provenance tag naming which of espn, fox, and yahoo actually supplied a row for this game.
+  matchup_key: 'Order-independent key for the game: the two normalized team names sorted alphabetically and joined with a
+    pipe.'
+  yahoo_date: Kickoff date as YYYY-MM-DD, parsed from Yahoo's RFC-2822 start_time string.
+  yahoo_game_id: Yahoo Sports game id for the same game.
+  yahoo_global_game_id: Yahoo's cross-season global game key in ncaaf.g.<number> form, distinct from the date-encoded yahoo_game_id.
+load_cfb_team_box:
+  completionAttempts: Completions and pass attempts as a slash-separated string, for example 23/41.
+  firstDowns: Total first downs ESPN credits the team, carried verbatim from the box score as a string.
+  fourthDownEff: Fourth-down efficiency as a conversions-attempts string, for example 3-4.
+  fumblesLost: Number of fumbles the team lost to the opponent, carried as a string.
+  netPassingYards: Passing yards after yardage lost to sacks is deducted, the numerator behind yardsPerPass.
+  possessionTime: Time of possession as mm:ss; the two teams' values add up to 60 minutes in a regulation game.
+  rushingAttempts: Rushing attempts.
+  rushingYards: Net rushing yards gained.
+  thirdDownEff: Third-down efficiency as ESPN's conversions-attempts string, for example 5-15.
+  totalPenaltiesYards: Penalties and penalty yards as a hyphen-separated string, for example 7-64.
+  totalYards: Total offensive yards for the team, matching rushingYards plus netPassingYards in about 99.8 percent of games.
+  yardsPerPass: Net passing yards per pass attempt, netPassingYards divided by the attempt count in completionAttempts and
+    rounded to one decimal.
+  yardsPerRushAttempt: Yards gained per rushing attempt.
+load_cfb_team_info:
+  logo_2: URL of the team's alternate dark-background 500-pixel logo on ESPN's CDN, null for programs with no dark variant.
+  twitter: The football program's Twitter/X handle including the leading at sign, populated for only a minority of listed
+    teams.
+load_cfb_teams_crosswalk:
+  espn_team: ESPN's full team display name, school plus mascot, null when the row was anchored on a non-ESPN provider.
+  espn_team_id: ESPN team id for the crosswalk row.
+  fox_abbreviation: Fox Sports' short team code, which frequently differs from the ESPN abbreviation for the same school.
+  fox_team: Fox Sports' team name, which that feed ships in all capitals.
+  fox_team_id: Fox Sports team id for the same team.
+  matched_sources: Plus-joined provenance tag naming which of espn, fox, and yahoo contributed a directory row for this team.
+  norm_key: 'Shared join key across providers: the team name lowercased, ASCII-folded, stripped of punctuation, whitespace-collapsed,
+    and alias-mapped.'
+  yahoo_abbreviation: Yahoo Sports' short team code for the school.
+  yahoo_team: Yahoo Sports' team display name, school plus mascot.
+  yahoo_team_id: Yahoo Sports team id for the same team.
+load_mbb_game_rosters:
+  athlete_headshot: URL of the player's ESPN headshot image, whose filename is the athlete_id (verified equal for all 190,365
+    non-null rows in 2025); null when ESPN publishes no photo for that player.
+load_mbb_officials:
+  official_display_name: Display form of the official's name used by ESPN's game feed, which duplicates official_full_name
+    for all 18,284 rows of the 2025 release.
+  official_full_name: Full name of the game official as published in ESPN's gameInfo officials list; in this release it is
+    byte-identical to official_display_name on every row.
+  official_position: ESPN's role label for the crew member, which is the constant Referee for every men's college basketball
+    official in this release rather than a distinct crew chief or umpire designation.
+  official_position_id: ESPN's numeric code for the official's role, constant at 40 (Referee) across the entire men's college
+    basketball officials release.
+load_mbb_pbp:
+  lag_period: Period number of the previous play in the same game (period_number shifted forward one row within game_id),
+    and null on each game's first play.
+  lead_period: Period number of the next play in the same game (period_number shifted back one row within game_id), and null
+    on each game's final play.
+  start_period_seconds_remaining: Seconds left in the current period when the play started, computed as 60 times the game
+    clock minutes plus the seconds, so 1200 at the tip of each 20-minute half and 300 at the start of an overtime.
+load_mbb_player_season_stats:
+  stat_description: ESPN's prose glossary definition of the statistic named in stat_name, for example defining assists as
+    a pass to a teammate that leads directly to a field goal.
+load_mbb_player_value:
+  box_bpm: Total box plus/minus in points per 100 possessions above an average player, exactly box_obpm plus box_dbpm (verified
+    to zero residual across all 9,805 rows of 2025).
+load_mbb_ratings:
+  adj_em_z: Within-season z-score of adj_em, computed as adj_em minus the season mean divided by the season standard deviation,
+    so each season is centered at zero with unit spread.
+  adj_tempo: Opponent-adjusted possessions per 40 minutes, solved by the same fixed point as the efficiency ratings under
+    the additive model that a game's pace is the two teams' tempos less the league baseline; it averages about 71 in 2025.
+load_mbb_standings:
+  group_short_name: Abbreviated conference label ESPN prints in standings tables, such as ACC, Big Ten or Am. East, one value
+    per group_id.
+  stat_abbreviation: Short code ESPN prints for the standings statistic in a table header, such as W, L, PCT, GB or STRK;
+    it diverges from stat_short_display_name for playoff seed and the home and conference record rows.
+  stat_description: ESPN's longer-form label for the standings statistic, which can differ from stat_display_name (streak
+    is described as Current Streak and playoffSeed as Playoff Seed).
+load_mbb_team_season_stats:
+  stat_description: ESPN's prose glossary definition of the statistic named in stat_name, for example defining field goal
+    percentage as the ratio of field goals made to field goals attempted.
+load_mlb_batter_projection:
+  proj_pa: Combined prior-three-season pa behind the projection, its effective sample size; it inherits the pitch-row counting
+    of load_mlb_expected_stats pa rather than true plate appearances.
+load_mlb_catcher_framing:
+  catcher_id: MLBAM identifier of the receiving catcher, taken from Savant's fielder_2 and published as a string rather than
+    an integer.
+  framing_runs: Runs saved by receiving, summing actual called strike minus modeled strike probability times that count's
+    strike run value over shadow-zone takes only.
+  strikes_gained: The same shadow-zone sum of actual called strike minus modeled strike probability left unweighted by run
+    value, so it measures stolen strikes rather than runs.
+  takes: Called strikes plus balls the catcher received across the season, a pure workload count; the framing figures themselves
+    sum only over the shadow-zone subset of these.
+load_mlb_command_plus:
+  command_plus: Command+/Location+ on the 100-is-average scale, exactly 100 minus 10 times (location_rv_hat minus the league
+    mean) over the league SD; it grades where the pitch finished, not intent, since Statcast ships no catcher target.
+  location_rv_hat: Mean predicted per-pitch run value from the bundled location model, which sees plate location, count, handedness
+    and pitch type but no raw pitch physics; lower is better for the pitcher.
+load_mlb_expected_hr:
+  hr_above_expected: Home runs actually hit minus xhr_neutral, so it grades over- and under-performance against the park-neutral
+    expectation rather than the park-adjusted one.
+  xhr_neutral: Park-neutral expected home runs, summing over the batter's balls in play the home-run probability read off
+    the exit-velocity by launch-angle by spray-angle grid.
+  xhr_park_adj: The same expected-home-run sum after scaling each ball by its ballpark's Savant home-run park factor over
+    100; published values run between 0.77 and 1.26 times xhr_neutral.
+load_mlb_expected_stats:
+  pa: Statcast rows charged to the batter for the season, counting balls in play carrying launch data plus every other pitch,
+    so it is a pitch-row total rather than a true plate-appearance count.
+  xba: Sum of grid-predicted hit probability over the batter's balls in play divided by ab, which lands far below conventional
+    batting-average scale because ab counts pitch rows rather than at-bats.
+  xslg: Sum of grid-predicted total bases over the batter's balls in play divided by ab, which lands far below conventional
+    slugging scale because ab counts pitch rows rather than at-bats.
+  xwoba: Expected wOBA blending the exit-velocity by launch-angle grid's predicted contact value on balls in play with realized
+    wOBA value on walks, hit-by-pitches and strikeouts, over the wOBA denominator; low-sample batters can exceed 1.
+load_mlb_oaa:
+  fielder_id: MLBAM identifier of the fielder charged with the ball in play, resolved from whichever fielder_N column matches
+    the responsible position and published as a string rather than an integer.
+  oaa: 'Outs above average: outs the fielder actually recorded minus what a per-position catch-probability logistic expected
+    from the same batted-ball trajectories, summed across their opportunities.'
+  opportunities: Balls in play charged to this fielder at this position, the sample the oaa sum runs over.
+load_mlb_re24_matrix:
+  base_state: Three-character pre-play base occupancy where each slot carries its base number when occupied and an underscore
+    when empty, so ___ is bases empty and 123 is bases loaded.
+  n: Plate appearances observed starting in this base-out state, the sample size behind re.
+  re: Mean runs the batting team went on to score from this base-out state through the end of the half-inning, with bottom-of-the-9th-and-later
+    halves excluded to avoid walk-off selection bias.
+load_mlb_stuff_plus:
+  stuff_plus: Stuff+ on the 100-is-average scale, exactly 100 minus 10 times (stuff_rv_hat minus the league mean) over the
+    league SD, so higher is better and outlier run-value predictions can push it well below zero.
+  stuff_rv_hat: Mean predicted per-pitch run value from the bundled xgboost stuff model over this pitcher's pitches of this
+    type, on Savant's batter-perspective delta_run_exp scale so lower is better for the pitcher.
+load_mlb_we_table:
+  base_state: Three-character pre-play base occupancy where each slot carries its base number when occupied and an underscore
+    when empty, so ___ is bases empty and 123 is bases loaded.
+  inning_capped: Inning number with the ninth and every extra inning collapsed into 9, so extras share the ninth-inning win-expectancy
+    cells.
+  n: Plate appearances observed in this state bucket, the sample size behind the Laplace-smoothed home_win_exp.
+  outs_start: Outs already recorded when the plate appearance began, normally 0 through 2, though a handful of published rows
+    carry a stale 3 that the RE24 matrix filters out but this table does not.
+  score_diff_bucket: Home score minus away score before the play, clipped to the range -6 through +6 so blowouts collapse
+    into the end buckets.
+load_mlb_xera:
+  x_era: ERA-scale conversion of x_woba as league_era plus (x_woba minus league_woba) over woba_scale times pa_per_9, an exact
+    linear function of x_woba that can go negative for extreme pitchers.
+load_nba_draft:
+  college_abbreviation: Abbreviation of the drafted player's college taken from the pick's nested college block; the ESPN
+    NBA draft feed omits that block entirely, so this and the other college columns are null throughout.
+  pick_notes: Free-text note ESPN can attach to a pick, read from the pick's notes or note field; the NBA draft payload never
+    populates it, so it is null across all released seasons.
+  pick_traded: ESPN's traded flag for the pick, carried through as a string rather than a boolean; every released NBA row
+    reads FALSE, so it does not currently identify traded picks.
+  round_display_name: ESPN's display label for the draft round a pick belongs to, read from the round object's displayName;
+    the NBA payload supplies no round metadata, so this is null for every released season 2003 through 2025.
+load_nba_officials:
+  official_display_name: ESPN's display-form name for the official, falling back to the full name when ESPN omits it; it never
+    diverges from official_full_name in the released NBA data.
+  official_full_name: Full name of an on-court game official as ESPN publishes it in the summary gameInfo.officials array;
+    it is identical to official_display_name in every released NBA row.
+  official_order: The official's listing index within the game's crew as ESPN orders them, normally 1 through 3 for a three-person
+    crew; a fourth entry appears in a small share of recent-season games and the sequence is not guaranteed to be gap-free.
+  official_position: ESPN's label for the official's assignment slot; the NBA summary feed only ever ships Referee, so this
+    reads the same on every released row.
+  official_position_id: ESPN's numeric identifier for the official's assignment slot, constant at 40 (Referee) across every
+    released NBA season.
+load_nba_player_impact:
+  adj_rapm: Total prior-informed RAPM per 100 possessions, exactly the sum of o_adj_rapm and d_adj_rapm.
+  d_rapm: Defensive regularized adjusted plus-minus per 100 possessions, negated from the raw points-allowed coefficient so
+    a positive value marks a defender who suppresses opponent scoring.
+  darko_filtered_skill: DARKO-style Kalman-filtered skill estimate at the end of the player's observed multi-season RAPM panel,
+    i.e. his current-form rating after aging drift and possession-weighted observation noise.
+  darko_projected_rating: One-season-ahead DARKO forecast, the filtered skill plus the empirical aging-curve drift at the
+    player's last observed age; both season_type rows of a player-season carry the same value because the projection is not
+    playoff-specific.
+  darko_projected_sd: Standard deviation of the one-season-ahead DARKO forecast, the square root of the filtered state variance
+    plus the Kalman process variance; it sits at roughly 10.19 for a player with only one season in the panel, whose diffuse
+    prior variance was never updated.
+  def_poss: Number of possessions the player was on the floor on defense, the sample size behind d_rapm; it tracks off_poss
+    almost exactly because substitutions rarely split an offense-defense pair.
+  dspm: Defensive statistical plus-minus per 100 possessions from the same box-score feature vector scored through coefficients
+    trained on the d_rapm target.
+  o_rapm: Offensive regularized adjusted plus-minus per 100 possessions from the single-season ridge fit over possession-level
+    lineup indicators; positive means the player raised his team's scoring rate while on offense.
+  off_poss: Number of possessions the player was on the floor on offense, the count of design-matrix rows carrying his offensive
+    indicator and therefore the offensive-side sample size behind o_rapm.
+  ospm: 'Offensive statistical plus-minus per 100 possessions: the player''s per-100 box-score feature vector scored through
+    ridge coefficients trained on that season''s o_rapm target.'
+  rapm: Total regularized adjusted plus-minus per 100 possessions, exactly the sum of o_rapm and d_rapm.
+  spm: Total statistical plus-minus per 100 possessions, exactly the sum of ospm and dspm.
+  war: Wins above replacement, computed as (rapm minus a replacement level of -2.0 per 100) times total possessions divided
+    by 100, divided by a points-per-win constant calibrated each season by regressing team wins on full-season point margin.
+load_nba_player_season_stats:
+  stat_description: ESPN's prose definition of the statistic on this row, for example the ratio of field goals made to field
+    goals attempted; for the paired Made-Attempted stats it is the two definitions joined with a hyphen.
+load_nba_standings:
+  group_short_name: ESPN's short name for the standings grouping the team sits in, read from the group node's shortName; the
+    NBA standings payload supplies only the group name and abbreviation, so this is null throughout.
+  stat_abbreviation: ESPN's short code for the standings statistic, such as PCT, GB or OPP PPG; it is null for the four record-style
+    splits (Home, Road, vs. Conf., vs. Div.), which ship no abbreviation.
+  stat_description: ESPN's prose gloss for the standings statistic on this row; for the clincher stat it is not a fixed label
+    but the team's actual status text, such as Clinched Playoff Berth or Eliminated From Playoff.
+load_nba_stats_schedules:
+  game_label: The stats.nba.com event label naming the round or special event a game belongs to, such as NBA Finals, East
+    First Round, Emirates NBA Cup or NBA Mexico City Game; an empty string for an ordinary regular-season game.
+load_nba_team_season_stats:
+  stat_description: ESPN's prose definition of the team statistic on this row, for example the average number of assists a
+    team records per turnover.
+load_nhl_penalties:
+  committedByPlayer.lastName.cs: Alternate rendering of the family name published under the NHL feed's Czech key. It differs
+    from the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips
+    them instead -- so treat it as an alternate spelling, not a canonical one.
+  committedByPlayer.lastName.fi: Alternate rendering of the family name published under the NHL feed's Finnish key. It differs
+    from the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips
+    them instead -- so treat it as an alternate spelling, not a canonical one.
+  committedByPlayer.lastName.sk: Alternate rendering of the family name published under the NHL feed's Slovak key. It differs
+    from the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips
+    them instead -- so treat it as an alternate spelling, not a canonical one.
+  committedByPlayer.lastName.sv: Alternate rendering of the family name published under the NHL feed's Swedish key. It differs
+    from the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips
+    them instead -- so treat it as an alternate spelling, not a canonical one.
+  drawnBy.firstName.default: Given name, in the feed's default English locale, of the opposing player credited with drawing
+    the penalty.
+  drawnBy.lastName.cs: Alternate rendering of the family name published under the NHL feed's Czech key. It differs from the
+    default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them
+    instead -- so treat it as an alternate spelling, not a canonical one.
+  drawnBy.lastName.default: Family name, in the feed's default English locale, of the opposing player credited with drawing
+    the penalty.
+  drawnBy.lastName.fi: Alternate rendering of the family name published under the NHL feed's Finnish key. It differs from
+    the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips
+    them instead -- so treat it as an alternate spelling, not a canonical one.
+  drawnBy.lastName.sk: Alternate rendering of the family name published under the NHL feed's Slovak key. It differs from the
+    default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them
+    instead -- so treat it as an alternate spelling, not a canonical one.
+  drawnBy.lastName.sv: Alternate rendering of the family name published under the NHL feed's Swedish key. It differs from
+    the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips
+    them instead -- so treat it as an alternate spelling, not a canonical one.
+  drawnBy.sweaterNumber: Jersey number of the opposing player credited with drawing the infraction; null whenever no victim
+    is credited, as on all bench and game-misconduct penalties.
+  servedBy.cs: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Czech key, differing
+    from the default by diacritics or by an alternate given-name form.
+  servedBy.de: Alternate abbreviated name (first initial plus family name) published under the NHL feed's German key, differing
+    from the default by diacritics or by an alternate given-name form.
+  servedBy.es: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Spanish key, differing
+    from the default by diacritics or by an alternate given-name form.
+  servedBy.fi: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Finnish key, differing
+    from the default by diacritics or by an alternate given-name form.
+  servedBy.sk: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Slovak key, differing
+    from the default by diacritics or by an alternate given-name form.
+  servedBy.sv: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Swedish key, differing
+    from the default by diacritics or by an alternate given-name form.
+  teamAbbrev.default: Three-letter code of the team charged with the penalty, matching the committing player's boxscore team
+    rather than the team that drew it.
+load_nhl_scoring:
+  discreteClipFr: Numeric NHL video identifier of the French-language standalone clip of the goal, always a different asset
+    id from discreteClip.
+  firstName.default: Given name of the goal scorer as rendered in the NHL feed's default English locale.
+  lastName.cs: Alternate rendering of the family name published under the NHL feed's Czech key. It differs from the default
+    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
+    -- so treat it as an alternate spelling, not a canonical one.
+  lastName.default: Family name of the goal scorer as rendered in the NHL feed's default English locale.
+  lastName.fi: Alternate rendering of the family name published under the NHL feed's Finnish key. It differs from the default
+    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
+    -- so treat it as an alternate spelling, not a canonical one.
+  lastName.fr: Alternate rendering of the family name published under the NHL feed's French key. It differs from the default
+    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
+    -- so treat it as an alternate spelling, not a canonical one.
+  lastName.sk: Alternate rendering of the family name published under the NHL feed's Slovak key. It differs from the default
+    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
+    -- so treat it as an alternate spelling, not a canonical one.
+  lastName.sv: Alternate rendering of the family name published under the NHL feed's Swedish key. It differs from the default
+    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
+    -- so treat it as an alternate spelling, not a canonical one.
+  leadingTeamAbbrev.default: Three-letter code of the team ahead on the scoreboard immediately after this goal, null exactly
+    when the goal tied the game and not always the scoring team.
+  name.cs: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Czech key, differing
+    from the default by diacritics or by an alternate given-name form.
+  name.de: Alternate abbreviated name (first initial plus family name) published under the NHL feed's German key, differing
+    from the default by diacritics or by an alternate given-name form.
+  name.es: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Spanish key, differing
+    from the default by diacritics or by an alternate given-name form.
+  name.fi: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Finnish key, differing
+    from the default by diacritics or by an alternate given-name form.
+  name.sk: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Slovak key, differing
+    from the default by diacritics or by an alternate given-name form.
+  name.sv: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Swedish key, differing
+    from the default by diacritics or by an alternate given-name form.
+  teamAbbrev.default: Three-letter code of the team that scored the goal, resolving to the home club exactly when isHome is
+    true and to the visitor otherwise.
+load_nhl_shootout:
+  discreteClipFr: Numeric NHL video identifier of the French-language clip of the shootout attempt, distinct from the id in
+    discreteClip.
+  firstName.cs: Alternate given name published under the NHL feed's Czech key. Verified against the data it is frequently
+    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
+    transliteration of the default.
+  firstName.de: Alternate given name published under the NHL feed's German key. Verified against the data it is frequently
+    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
+    transliteration of the default.
+  firstName.default: Given name of the shooter in the feed's default English locale; null on the per-game summary row.
+  firstName.es: Alternate given name published under the NHL feed's Spanish key. Verified against the data it is frequently
+    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
+    transliteration of the default.
+  firstName.fi: Alternate given name published under the NHL feed's Finnish key. Verified against the data it is frequently
+    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
+    transliteration of the default.
+  firstName.sk: Alternate given name published under the NHL feed's Slovak key. Verified against the data it is frequently
+    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
+    transliteration of the default.
+  firstName.sv: Alternate given name published under the NHL feed's Swedish key. Verified against the data it is frequently
+    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
+    transliteration of the default.
+  gameWinner: True on the single attempt per shootout credited as the game-deciding goal, false on every other attempt and
+    null on the per-game summary row.
+  lastName.cs: Alternate rendering of the family name published under the NHL feed's Czech key. It differs from the default
+    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
+    -- so treat it as an alternate spelling, not a canonical one.
+  lastName.default: Family name of the shooter in the feed's default English locale; null on the per-game summary row.
+  lastName.fi: Alternate rendering of the family name published under the NHL feed's Finnish key. It differs from the default
+    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
+    -- so treat it as an alternate spelling, not a canonical one.
+  lastName.sk: Alternate rendering of the family name published under the NHL feed's Slovak key. It differs from the default
+    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
+    -- so treat it as an alternate spelling, not a canonical one.
+  lastName.sv: Alternate rendering of the family name published under the NHL feed's Swedish key. It differs from the default
+    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
+    -- so treat it as an alternate spelling, not a canonical one.
+  teamAbbrev.default: Three-letter code of the shooting player's team; null on the per-game summary row that instead carries
+    the home and away shootout goal totals.
+load_nhl_shots_by_period:
+  max_regulation_periods: Number of regulation periods the game format defines before overtime, constant at 3 for every row
+    in the published seasons.
+  ot_periods: Overtime period ordinal taken from the NHL period descriptor, populated only from the second overtime onward
+    so period 5 rows carry 2 and all other rows are null.
+load_nhl_three_stars:
+  name.cs: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Czech key, differing
+    from the default by diacritics or by an alternate given-name form.
+  name.de: Alternate abbreviated name (first initial plus family name) published under the NHL feed's German key, differing
+    from the default by diacritics or by an alternate given-name form.
+  name.es: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Spanish key, differing
+    from the default by diacritics or by an alternate given-name form.
+  name.fi: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Finnish key, differing
+    from the default by diacritics or by an alternate given-name form.
+  name.sk: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Slovak key, differing
+    from the default by diacritics or by an alternate given-name form.
+  name.sv: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Swedish key, differing
+    from the default by diacritics or by an alternate given-name form.
+load_wbb_game_rosters:
+  athlete_headshot: URL of the player's ESPN headshot image on a.espncdn.com, whose filename is the athlete_id; null when
+    ESPN publishes no headshot for that player.
+load_wbb_officials:
+  official_display_name: ESPN's displayName for the official, which is identical to official_full_name in every published
+    row of the released data.
+  official_first_name: The official's given name as ESPN splits it out separately from the full name, excluding any middle
+    initial that appears in official_full_name.
+  official_full_name: ESPN's fullName for the official, falling back to displayName when fullName is absent; ESPN sometimes
+    ships it with a middle initial or a doubled internal space, so it is not simply first plus last name.
+  official_last_name: The official's surname as ESPN splits it out; joined to official_first_name it reconstructs roughly
+    98 percent of official_full_name values, the rest differing by middle initials or spacing.
+  official_order: ESPN's 1-based sequence of the official within that game's crew listing, unique within a game and running
+    1 to 3 for the standard three-person crew.
+  official_uid: ESPN's globally unique resource identifier for the official, read from the core-api items[] uid key; that
+    payload never ships it, so the column is null for every published row.
+load_wbb_player_season_stats:
+  stat_description: ESPN's prose definition of the statistic named in stat_name, for example The average assists per game
+    for avgAssists; combined made-attempted stats carry both definitions joined by a hyphen.
+load_wbb_player_value:
+  box_bpm: Total box plus/minus in points per 100 possessions above average, exactly box_obpm plus box_dbpm in every published
+    row.
+load_wbb_ratings:
+  adj_em_z: Within-season z-score of adj_em, computed as adj_em minus the season mean divided by the season standard deviation
+    over every team in the frame, so it is mean 0 and standard deviation 1 per season.
+  adj_tempo: Opponent-adjusted tempo in possessions per 40 minutes, produced by the same fixed-point adjustment as the efficiencies
+    applied to game possessions under the additive model poss = tempo_i + tempo_j minus the league baseline.
+load_wbb_standings:
+  stat_abbreviation: ESPN's abbreviation for the standings stat, such as GB, OPP PPG or VS CONF; always populated and matching
+    stat_short_display_name for about 90 percent of rows.
+  stat_description: ESPN's longer wording for the standings stat, for example Overall Record for the Team Season Record entry
+    and Current Streak for Streak; null for stats ESPN ships without one, such as vs AP Top 25.
+load_wbb_team_season_stats:
+  stat_description: ESPN's prose definition of the team statistic named in stat_name, for example The average blocks per game
+    for avgBlocks or the full sentence defining a blocked shot for blocks.
+load_wnba_draft:
+  college_abbreviation: Short code for the drafted player's school, read from the athlete's ESPN college block; null throughout
+    the published data because ESPN ships no college block on these picks.
+  pick_notes: Free-text annotation ESPN attaches to a pick, taken from notes and falling back to note; empty for every pick
+    published so far.
+  pick_traded: ESPN's pick-level traded flag stringified as TRUE or FALSE, marking selections made with a pick that had changed
+    hands (17 of the 45 published 2026 picks are TRUE).
+  round_display_name: Human-readable label for the draft round, read from the ESPN round object's displayName falling back
+    to its name; null whenever ESPN ships the modern flat picks array with no round objects, which is the case for every published
+    season.
+load_wnba_game_rosters:
+  athlete_headshot: Direct link to the player's ESPN headshot image, always of the form https://a.espncdn.com/i/headshots/wnba/players/full/{athlete_id}.png,
+    and null for the few players ESPN has no photo for.
+load_wnba_officials:
+  official_display_name: ESPN's display rendering of the official's name, which is byte-identical to official_full_name on
+    every published row and therefore adds nothing.
+  official_first_name: Given name of the official as ESPN splits it out, the leading token of official_full_name.
+  official_full_name: The official's full name, taken from ESPN fullName and falling back to displayName; it equals first
+    plus last name on every published row.
+  official_last_name: Family name of the official as ESPN splits it out, the trailing token of official_full_name, with hyphenated
+    surnames kept intact.
+  official_order: ESPN's 1-based position of the official within that game's crew; most games run 1 through 3 for a three-person
+    crew and 40 of 573 games in 2024-2025 add a fourth.
+  official_uid: ESPN's global uid string for the official, carried straight through from the officials payload; the Core v2
+    items ESPN serves omit it, so it is null in every published season.
+load_wnba_player_season_stats:
+  stat_description: ESPN's prose definition of the statistic on this row, for example The average number of points scored
+    per game for avgPoints; combined made-attempted stats carry both halves joined by a hyphen.
+load_wnba_standings:
+  group_short_name: Short label of the standings group node the team sits under, read from ESPN shortName; the WNBA conference
+    nodes ship only name and abbreviation, so it is null on every published row.
+  stat_abbreviation: ESPN's abbreviation for the standings stat, which can differ from stat_short_display_name (playoffSeed
+    is SEED here but POS there) and is null on the record-split rows such as Home and vs. Conf.
+  stat_description: ESPN's long-form explanation of the standings stat, such as Clinched Best League Record for clincher or
+    Record last 10 games for lasttengames.
+load_wnba_stats_coaches:
+  coach_name: Full name of the staff member as the feed renders it, exactly first_name plus a space plus last_name on every
+    published row.
+  coach_type: Job title of the staff member, one of Head Coach, Associate Head Coach, Assistant Coach or Trainer in the published
+    data.
+  is_assistant: 'Numeric staff-role code rather than a boolean flag: 1 head coach, 2 assistant coach, 3 trainer, 9 associate
+    head coach, mapping one-to-one onto coach_type.'
+  sort_sequence: Ordering field passed through unchanged from the stats.wnba.com coaches result set; it arrives empty, so
+    every published row is null.
+  sub_sort_sequence: 'Secondary display-ordering rank that tracks coach_type exactly: 1 head coach, 2 associate head coach,
+    5 assistant coach, 7 trainer.'
+load_cfb_adv_defensive:
+  TFL: Count of scrimmage plays the defense held to negative yardage (non-penalty, non-special-teams, ESPN statYardage below
+    zero) plus every sack.
+  TFL_pass: The TFL count restricted to plays classified as passes, so it covers sacks together with completions and laterals
+    stopped behind the line.
+  TFL_rush: The TFL count restricted to plays classified as rushes, that is rushing attempts the defense stopped for negative
+    yardage.
+  def_int: Interceptions the defense recorded, counted from plays ESPN types as Interception Return or Interception Return
+    Touchdown.
+  drive_stopped_rate: Percentage from 0 to 100 of the defense's scrimmage plays that occurred on drives ending in a punt,
+    fumble, interception, or turnover on downs; the denominator is plays, not drives.
+  fumbles: Fumbles the defense forced, counted from plays whose narrative contains the phrase forced by, not the total number
+    of fumbles on the play.
+  havoc_total_pass: Havoc events (tackle for loss, sack, interception, forced fumble, or pass breakup) recorded on the pass
+    plays the defense faced.
+  havoc_total_pass_rate: havoc_total_pass divided by num_pass_plays, the defense's havoc rate against the pass as a 0-to-1
+    fraction.
+  havoc_total_rate: Share of the defense's scrimmage plays producing a havoc event, a 0-to-1 fraction equal to havoc_total
+    divided by scrimmage_plays.
+  havoc_total_rush: Havoc events recorded on the rush plays the defense faced, in practice tackles for loss and forced fumbles.
+  havoc_total_rush_rate: Havoc events per rush play faced, the mean of the havoc flag over the defense's rush scrimmage plays.
+  num_pass_plays: Number of pass scrimmage plays the defense faced, the denominator behind havoc_total_pass_rate and sacks_rate.
+  pass_breakups: Passes the defense broke up, counted from plays whose narrative contains the phrase broken up by.
+  sacks_rate: Sacks divided by pass plays faced, the defense's per-pass-play sack rate as a 0-to-1 fraction.
+  scrimmage_plays: Number of plays from scrimmage (rushes plus passes), excluding special teams.
+load_cfb_adv_defensive_players:
+  def_pos_team: Display name of the team on defense (e.g. 'Ohio State Buckeyes'). Held an ESPN team id until the 2026-08 republish;
+    the id now lives in def_pos_team_id.
+  def_pos_team_id: ESPN team id of the team on defense. Present for every season 2004+.
+  forced_fumbles: Fumbles forced by the defender. Available from 2005 on; null for 2004, which ESPN ships with only the fumble-recovery
+    statistics.
+  fumble_recoveries: Fumbles recovered by the defender. Available for every season 2004+.
+  fumble_recoveries_yards: Yards returned on the defender's fumble recoveries. Available for every season 2004+.
+  interceptions: Passes intercepted by the defender. Available from 2014 on; null for 2004-2013, which ESPN ships without
+    interception statistics in this block.
+  interceptions_yards: Yards returned on the defender's interceptions. Available from 2014 on; null for 2004-2013.
+  pass_breakups: Passes broken up by the defender. Available from 2005 on; null for 2004.
+  player_name: Display name of the defender.
+  sacks: Sacks recorded by the defender. Available from 2005 on; null for 2004.
+  sacks_yards: Yards lost by the offense on the defender's sacks. Available from 2005 on; null for 2004.
+load_cfb_adv_drives:
+  avg_field_position: Mean distance to the opponent end zone at drive start averaged over the team's scrimmage plays, exactly
+    drive_total_available_yards divided by that play count.
+  drive_total_available_yards: Sum of each drive's starting distance to the opponent end zone taken across every scrimmage
+    play, so a drive contributes its available yards once per play rather than once per drive.
+  drive_total_gained_yards: Sum of ESPN's per-drive yardage repeated across every scrimmage play of that drive, so a drive
+    contributes its yardage once per play.
+  drive_total_gained_yards_rate: Available-yards conversion as a percentage, 100 times drive_total_gained_yards over drive_total_available_yards
+    with both sums play-weighted.
+  drives: Number of distinct ESPN drive ids on which the team ran at least one scrimmage play.
+  plays_per_drive: Mean of ESPN's per-drive offensivePlays taken over plays rather than over drives, which weights every drive
+    by its own length.
+  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
+  yards_per_drive: Mean of ESPN's per-drive yardage taken over plays rather than over drives, exactly drive_total_gained_yards
+    divided by the team's scrimmage-play count.
+load_cfb_adv_passing:
+  Att: Pass attempts recorded in the advanced box score.
+  CPOE: Completion percentage over expected -- actual minus modelled completion rate.
+  Comp: Completed passes recorded in the advanced box score.
+  CompPct: Completion percentage from the advanced box score.
+  EPA_per_Play: EPA per play on the passer's plays.
+  Int: Interceptions thrown.
+  Pass_TD: Passing touchdowns.
+  SR: Success rate on the passer's plays.
+  Sck: Times the passer was sacked.
+  YPA: Yards per pass attempt.
+  Yds: Passing yards from the advanced box score.
+  era0: Rule-era indicator for the earliest modelled era.
+  era1: Rule-era indicator for the second modelled era.
+  era2: Rule-era indicator for the third modelled era.
+  era3: Rule-era indicator for the most recent modelled era.
+  exp_qbr: Expected QBR for the passer.
+  pass_epa: EPA credited to the player's pass plays.
+  passer_player_name: Display name of the passer -- the FIRST participant in that role on the play.
+  pen_epa: EPA attributable to penalties on the player's plays.
+  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
+  qbr_epa: EPA variant used as an input to the QBR calculation.
+  rush_epa: EPA credited to the player's rush plays.
+  sack_epa: EPA credited to the player's sacks taken.
+  xComp: Expected completions, summed from the per-play completion model.
+  xCompPct: Expected completion percentage from the per-play completion model.
+load_cfb_adv_receiving:
+  EPA_per_Play: EPA per play on the passer's plays.
+  Fum: Count of the receiver's targeted pass plays whose text mentions a fumble; it is a play-level flag, not a fumble charged
+    to this player.
+  Fum_Lost: Count of the receiver's targeted plays on which a fumble was lost to the opponent.
+  Rec: Receptions credited to the receiver, the number of completions on plays where this player was the targeted receiver.
+  Rec_TD: Receiving touchdowns, the count of the player's targeted plays that ended in a passing touchdown.
+  SR: Success rate on the passer's plays.
+  Tar: Times the player was targeted on a pass attempt, the denominator behind YPT.
+  YPT: Receiving yards per target, the mean of receiving yardage over every target rather than over receptions only.
+  Yds: Passing yards from the advanced box score.
+  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
+  receiver_player_name: Display name of the targeted receiver -- the FIRST participant in that role on the play.
+load_cfb_adv_rushing:
+  Car: Rushing attempts credited to this ball carrier in the game.
+  EPA_per_Play: EPA per play on the passer's plays.
+  Fum: Count of the carrier's rush attempts whose play text mentions a fumble; it is a play-level flag, not a fumble charged
+    to this player.
+  Fum_Lost: Count of the carrier's rush attempts on which a fumble was lost to the opponent.
+  Rush_TD: Rushing touchdowns scored by this ball carrier in the game.
+  SR: Success rate on the passer's plays.
+  YPC: Yards per carry, the mean rushing yardage across the player's attempts in the game.
+  Yds: Passing yards from the advanced box score.
+  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
+  rusher_player_name: Display name of the ball carrier on a rush -- the FIRST participant in that role on the play.
+load_cfb_adv_situational:
+  EPA_early_down: Total EPA the team generated on early downs.
+  EPA_early_down_pass: Total EPA the team generated on early downs on pass plays.
+  EPA_early_down_pass_per_play: EPA per play on early downs on pass plays.
+  EPA_early_down_per_play: EPA per play on early downs.
+  EPA_early_down_rush: Total EPA the team generated on early downs on rush plays.
+  EPA_early_down_rush_per_play: EPA per play on early downs on rush plays.
+  EPA_late_down: Total EPA the team generated on late downs.
+  EPA_late_down_per_play: EPA per play on late downs.
+  EPA_middle_8: Total EPA the team generated on the middle eight -- the closing minutes of the first half and opening minutes
+    of the second.
+  EPA_middle_8_pass: Total EPA the team generated on the middle eight -- the closing minutes of the first half and opening
+    minutes of the second on pass plays.
+  EPA_middle_8_pass_per_play: EPA per play on the middle eight -- the closing minutes of the first half and opening minutes
+    of the second on pass plays.
+  EPA_middle_8_per_play: EPA per play on the middle eight -- the closing minutes of the first half and opening minutes of
+    the second.
+  EPA_middle_8_rush: Total EPA the team generated on the middle eight -- the closing minutes of the first half and opening
+    minutes of the second on rush plays.
+  EPA_middle_8_rush_per_play: EPA per play on the middle eight -- the closing minutes of the first half and opening minutes
+    of the second on rush plays.
+  EPA_middle_8_success: Count of successful plays on the middle eight -- the closing minutes of the first half and opening
+    minutes of the second. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
+  EPA_middle_8_success_pass: Count of successful plays on the middle eight -- the closing minutes of the first half and opening
+    minutes of the second on pass plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
+  EPA_middle_8_success_pass_rate: Success rate on the middle eight -- the closing minutes of the first half and opening minutes
+    of the second on pass plays -- the share of those plays ESPN scored as successful.
+  EPA_middle_8_success_rate: Success rate on the middle eight -- the closing minutes of the first half and opening minutes
+    of the second -- the share of those plays ESPN scored as successful.
+  EPA_middle_8_success_rush: Count of successful plays on the middle eight -- the closing minutes of the first half and opening
+    minutes of the second on rush plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
+  EPA_middle_8_success_rush_rate: Success rate on the middle eight -- the closing minutes of the first half and opening minutes
+    of the second on rush plays -- the share of those plays ESPN scored as successful.
+  EPA_passing_down: Total EPA the team generated on passing downs (the team behind schedule for the series).
+  EPA_passing_down_per_play: EPA per play on passing downs (the team behind schedule for the series).
+  EPA_standard_down: Total EPA the team generated on standard downs (the team ahead of schedule for the series).
+  EPA_standard_down_per_play: EPA per play on standard downs (the team ahead of schedule for the series).
+  EPA_success: Count of successful plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
+  EPA_success_early_down: Count of successful plays on early downs. Despite the EPA_ prefix this is a play COUNT, not an EPA
+    total.
+  EPA_success_early_down_pass: Count of successful plays on early downs on pass plays. Despite the EPA_ prefix this is a play
+    COUNT, not an EPA total.
+  EPA_success_early_down_pass_rate: Success rate on early downs on pass plays -- the share of those plays ESPN scored as successful.
+  EPA_success_early_down_rate: Success rate on early downs -- the share of those plays ESPN scored as successful.
+  EPA_success_early_down_rush: Count of successful plays on early downs on rush plays. Despite the EPA_ prefix this is a play
+    COUNT, not an EPA total.
+  EPA_success_early_down_rush_rate: Success rate on early downs on rush plays -- the share of those plays ESPN scored as successful.
+  EPA_success_late_down: Count of successful plays on late downs. Despite the EPA_ prefix this is a play COUNT, not an EPA
+    total.
+  EPA_success_late_down_pass: Count of successful plays on late downs on pass plays. Despite the EPA_ prefix this is a play
+    COUNT, not an EPA total.
+  EPA_success_late_down_pass_rate: Success rate on late downs on pass plays -- the share of those plays ESPN scored as successful.
+  EPA_success_late_down_rate: Success rate on late downs -- the share of those plays ESPN scored as successful.
+  EPA_success_late_down_rush: Count of successful plays on late downs on rush plays. Despite the EPA_ prefix this is a play
+    COUNT, not an EPA total.
+  EPA_success_late_down_rush_rate: Success rate on late downs on rush plays -- the share of those plays ESPN scored as successful.
+  EPA_success_pass: Count of successful plays on pass plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
+  EPA_success_pass_rate: Success rate on pass plays -- the share of those plays ESPN scored as successful.
+  EPA_success_passing_down: Count of successful plays on passing downs (the team behind schedule for the series). Despite
+    the EPA_ prefix this is a play COUNT, not an EPA total.
+  EPA_success_passing_down_rate: Success rate on passing downs (the team behind schedule for the series) -- the share of those
+    plays ESPN scored as successful.
+  EPA_success_rate: Success rate -- the share of those plays ESPN scored as successful.
+  EPA_success_rate_rz: Success rate on the red zone -- the share of those plays ESPN scored as successful.
+  EPA_success_rate_third: Success rate on third down -- the share of those plays ESPN scored as successful.
+  EPA_success_rush: Count of successful plays on rush plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
+  EPA_success_rush_rate: Success rate on rush plays -- the share of those plays ESPN scored as successful.
+  EPA_success_rz: Count of successful plays on the red zone. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
+  EPA_success_standard_down: Count of successful plays on standard downs (the team ahead of schedule for the series). Despite
+    the EPA_ prefix this is a play COUNT, not an EPA total.
+  EPA_success_standard_down_rate: Success rate on standard downs (the team ahead of schedule for the series) -- the share
+    of those plays ESPN scored as successful.
+  EPA_success_third: Count of successful plays on third down. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
+  early_down_first_down: Number of early-down plays that produced a first down.
+  early_down_first_down_rate: Share of early-down plays that produced a first down.
+  early_down_pass: Number of pass plays the team ran on early downs.
+  early_down_pass_rate: Share of the team's plays on early downs that were pass plays.
+  early_down_rush: Number of rush plays the team ran on early downs.
+  early_down_rush_rate: Share of the team's plays on early downs that were rush plays.
+  early_downs: Number of plays the team ran on early downs.
+  late_down_pass: Number of pass plays the team ran on late downs.
+  late_down_pass_rate: Share of the team's plays on late downs that were pass plays.
+  late_down_rush: Number of rush plays the team ran on late downs.
+  late_down_rush_rate: Share of the team's plays on late downs that were rush plays.
+  late_downs: Number of plays the team ran on late downs.
+  middle_8: Number of plays the team ran in the middle eight -- the closing minutes of the first half and opening minutes
+    of the second.
+  middle_8_pass: Number of pass plays the team ran on the middle eight -- the closing minutes of the first half and opening
+    minutes of the second.
+  middle_8_pass_rate: Share of the team's plays on the middle eight -- the closing minutes of the first half and opening minutes
+    of the second that were pass plays.
+  middle_8_rush: Number of rush plays the team ran on the middle eight -- the closing minutes of the first half and opening
+    minutes of the second.
+  middle_8_rush_rate: Share of the team's plays on the middle eight -- the closing minutes of the first half and opening minutes
+    of the second that were rush plays.
+  passing_downs: Number of plays the team ran on passing downs (the team behind schedule for the series).
+  pos_team: Display name of the team on offense (e.g. 'Ohio State Buckeyes').
+  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
+  standard_downs: Number of plays the team ran on standard downs (the team ahead of schedule for the series).
+load_cfb_adv_specialists:
+  field_goals: Number of field-goal attempts.
+  field_goals_yards: Sum of the field-goal attempt distances parsed out of the play text; it stays at zero when no distance
+    could be parsed from the narrative.
+  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
+  punt_returns_yards: Total punt-return yardage credited to this returner, with fair catches, downed punts, and out-of-bounds
+    punts scored as zero.
+  punts: Punts attempted.
+  punts_yards: Total gross punt yardage parsed from the play text for this punter, working out to roughly 42 yards per punt
+    league-wide.
+load_cfb_adv_team:
+  EPA_explosive: Count of explosive plays, per ESPN's advanced box score. Despite the EPA_ prefix this is a play COUNT, not
+    an EPA total.
+  EPA_explosive_passing: Count of explosive pass plays. A play count, not an EPA total.
+  EPA_explosive_passing_rate: Explosive-play rate on pass plays, over ESPN's qualifying-play denominator.
+  EPA_explosive_rate: Explosive-play rate. Note this is NOT EPA_explosive divided by EPA_plays -- ESPN divides by its own
+    smaller qualifying-play count, so deriving it yourself will not reproduce this value.
+  EPA_explosive_rushing: Count of explosive rush plays. A play count, not an EPA total.
+  EPA_explosive_rushing_rate: Explosive-play rate on rush plays, over ESPN's qualifying-play denominator.
+  EPA_fg: Total EPA on field-goal attempts.
+  EPA_kickoff: Total EPA on kickoff plays.
+  EPA_non_explosive: Total EPA with explosive plays excluded, isolating the team's routine-down production.
+  EPA_non_explosive_passing: Total EPA on pass plays with explosive plays excluded.
+  EPA_non_explosive_passing_per_play: EPA per pass play with explosive plays excluded.
+  EPA_non_explosive_per_play: EPA per play with explosive plays excluded.
+  EPA_non_explosive_rushing: Total EPA on rush plays with explosive plays excluded.
+  EPA_non_explosive_rushing_per_play: EPA per rush play with explosive plays excluded.
+  EPA_overall_off: Total offensive EPA for the team. Duplicated exactly by EPA_overall_offense in every published season checked
+    -- prefer one and ignore the other.
+  EPA_overall_offense: Total offensive EPA. An exact duplicate of EPA_overall_off.
+  EPA_overall_total: Total EPA across all phases, which is why it differs from the offense-only EPA_overall_off.
+  EPA_passing_overall: Total EPA on pass plays.
+  EPA_passing_per_play: EPA per pass play.
+  EPA_penalty: Total EPA attributed to penalties.
+  EPA_per_play: Offensive EPA per play.
+  EPA_plays: Number of plays ESPN's advanced box score scored for the team.
+  EPA_punt: Total EPA on punt plays.
+  EPA_rushing_overall: Total EPA on rush plays.
+  EPA_rushing_per_play: EPA per rush play.
+  EPA_rushing_power: Total EPA on power rushing situations, as classified by ESPN's advanced box score.
+  EPA_rushing_power_per_play: EPA per play on power rushing situations.
+  EPA_sp: Total special-teams EPA, ESPN's abbreviated field for the same phase.
+  EPA_special_teams: Total EPA generated on special-teams plays.
+  field_goals: Number of field-goal attempts.
+  first_downs_created: Number of first downs the team created.
+  first_downs_created_rate: Share of the team's plays that created a first down.
+  kickoff_plays: Number of kickoff plays.
+  line_yards: Line yards -- the portion of rushing yardage credited to the offensive line under the standard rushing decomposition.
+    ESPN applies its own qualifying threshold for the yardage split.
+  line_yards_per_carry: Line yards per rushing attempt.
+  off_yards: Offensive yards gained from scrimmage.
+  open_field_yards: Open-field yards -- rushing yardage earned well downfield, past the second level.
+  pass_yards: Total yards the team gained on pass plays.
+  passes: Number of pass plays the team ran.
+  passes_rate: Share of the team's plays from scrimmage that were pass plays.
+  passing_first_downs_created: Number of first downs created on pass plays.
+  passing_first_downs_created_rate: Share of pass plays that created a first down.
+  penalties: Number of penalties assessed against the team.
+  penalty_first_downs_created: Number of first downs the team gained via opponent penalty.
+  penalty_first_downs_created_rate: Share of the team's first downs that came via opponent penalty.
+  penalty_yards: Net penalty yardage assessed against the team; can be negative when enforcement moved the team forward on
+    balance.
+  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
+  punt_plays: Number of punt plays.
+  rush_yards: Total yards the team gained on rush plays.
+  rushes: Number of rushing attempts.
+  rushes_rate: Share of the team's plays from scrimmage that were rush plays.
+  rushing_first_downs_created: Number of first downs created on rush plays.
+  rushing_first_downs_created_rate: Share of rush plays that created a first down.
+  rushing_highlight: Highlight yards -- rushing yardage credited to the back rather than the offensive line.
+  rushing_highlight_rate: Share of rushing yardage that was highlight (back-credited) yardage.
+  rushing_highlight_yards: Total highlight yards the team accumulated -- the yardage credited to ball carriers rather than
+    the line. The per-carry figure is rushing_highlight_yards_per_opp.
+  rushing_highlight_yards_per_opp: Highlight yards per rushing opportunity.
+  rushing_opportunity: Count of rushing opportunities -- carries that reached ESPN's opportunity threshold.
+  rushing_opportunity_rate: Share of carries that qualified as rushing opportunities.
+  rushing_power: Count of power rushing attempts, in short-yardage situations as classified by ESPN's advanced box score.
+  rushing_power_rate: Share of carries that were power rushing attempts.
+  rushing_power_success: Count of power rushing attempts that gained the yardage needed. An integer count, not a rate -- the
+    rate is published separately as rushing_power_success_rate.
+  rushing_power_success_rate: Share of power rushing attempts that succeeded.
+  rushing_stopped: Count of rushing attempts stopped at or behind the line of scrimmage.
+  rushing_stopped_rate: Share of carries stopped at or behind the line of scrimmage.
+  rushing_stuff: Count of stuffed rushing attempts.
+  rushing_stuff_rate: Share of the team's carries that were stuffed at or behind the line of scrimmage.
+  scrimmage_plays: Number of plays from scrimmage (rushes plus passes), excluding special teams.
+  second_level_yards: Second-level yards -- rushing yardage earned just beyond the line of scrimmage.
+  special_teams_plays: Number of special-teams plays.
+  total_off_yards: Total offensive yards across all plays.
+  total_pen_yards: Total penalty yards assessed.
+  total_yards: Total yards the team gained across all plays.
+  yards_per_play: Yards gained per play.
+  yards_per_rush: Yards gained per rushing attempt.
+load_cfb_adv_team_gamelog:
+  EPA_explosive: Count of explosive plays, per ESPN's advanced box score. Despite the EPA_ prefix this is a play COUNT, not
+    an EPA total.
+  EPA_explosive_passing: Count of explosive pass plays. A play count, not an EPA total.
+  EPA_explosive_passing_rate: Explosive-play rate on pass plays, over ESPN's qualifying-play denominator.
+  EPA_explosive_rate: Explosive-play rate. Note this is NOT EPA_explosive divided by EPA_plays -- ESPN divides by its own
+    smaller qualifying-play count, so deriving it yourself will not reproduce this value.
+  EPA_explosive_rushing: Count of explosive rush plays. A play count, not an EPA total.
+  EPA_explosive_rushing_rate: Explosive-play rate on rush plays, over ESPN's qualifying-play denominator.
+  EPA_fg: Total EPA on field-goal attempts.
+  EPA_kickoff: Total EPA on kickoff plays.
+  EPA_non_explosive: Total EPA with explosive plays excluded, isolating the team's routine-down production.
+  EPA_non_explosive_passing: Total EPA on pass plays with explosive plays excluded.
+  EPA_non_explosive_passing_per_play: EPA per pass play with explosive plays excluded.
+  EPA_non_explosive_per_play: EPA per play with explosive plays excluded.
+  EPA_non_explosive_rushing: Total EPA on rush plays with explosive plays excluded.
+  EPA_non_explosive_rushing_per_play: EPA per rush play with explosive plays excluded.
+  EPA_overall_off: Total offensive EPA for the team. Duplicated exactly by EPA_overall_offense in every published season checked
+    -- prefer one and ignore the other.
+  EPA_overall_offense: Total offensive EPA. An exact duplicate of EPA_overall_off.
+  EPA_overall_total: Total EPA across all phases, which is why it differs from the offense-only EPA_overall_off.
+  EPA_passing_overall: Total EPA on pass plays.
+  EPA_passing_per_play: EPA per pass play.
+  EPA_penalty: Total EPA attributed to penalties.
+  EPA_per_play: Offensive EPA per play.
+  EPA_plays: Number of plays ESPN's advanced box score scored for the team.
+  EPA_punt: Total EPA on punt plays.
+  EPA_rushing_overall: Total EPA on rush plays.
+  EPA_rushing_per_play: EPA per rush play.
+  EPA_rushing_power: Total EPA on power rushing situations, as classified by ESPN's advanced box score.
+  EPA_rushing_power_per_play: EPA per play on power rushing situations.
+  EPA_sp: Total special-teams EPA, ESPN's abbreviated field for the same phase.
+  EPA_special_teams: Total EPA generated on special-teams plays.
+  field_goals: Number of field-goal attempts.
+  first_downs_created: Number of first downs the team created.
+  first_downs_created_rate: Share of the team's plays that created a first down.
+  kickoff_plays: Number of kickoff plays.
+  line_yards: Line yards -- the portion of rushing yardage credited to the offensive line under the standard rushing decomposition.
+    ESPN applies its own qualifying threshold for the yardage split.
+  line_yards_per_carry: Line yards per rushing attempt.
+  margin: Final scoring margin from this team's perspective, exactly points_for minus points_against.
+  off_yards: Offensive yards gained from scrimmage.
+  open_field_yards: Open-field yards -- rushing yardage earned well downfield, past the second level.
+  pass_yards: Total yards the team gained on pass plays.
+  passes: Number of pass plays the team ran.
+  passes_rate: Share of the team's plays from scrimmage that were pass plays.
+  passing_first_downs_created: Number of first downs created on pass plays.
+  passing_first_downs_created_rate: Share of pass plays that created a first down.
+  penalties: Number of penalties assessed against the team.
+  penalty_first_downs_created: Number of first downs the team gained via opponent penalty.
+  penalty_first_downs_created_rate: Share of the team's first downs that came via opponent penalty.
+  penalty_yards: Net penalty yardage assessed against the team; can be negative when enforcement moved the team forward on
+    balance.
+  punt_plays: Number of punt plays.
+  rush_yards: Total yards the team gained on rush plays.
+  rushes: Number of rushing attempts.
+  rushes_rate: Share of the team's plays from scrimmage that were rush plays.
+  rushing_first_downs_created: Number of first downs created on rush plays.
+  rushing_first_downs_created_rate: Share of rush plays that created a first down.
+  rushing_highlight: Highlight yards -- rushing yardage credited to the back rather than the offensive line.
+  rushing_highlight_rate: Share of rushing yardage that was highlight (back-credited) yardage.
+  rushing_highlight_yards: Total highlight yards the team accumulated -- the yardage credited to ball carriers rather than
+    the line. The per-carry figure is rushing_highlight_yards_per_opp.
+  rushing_highlight_yards_per_opp: Highlight yards per rushing opportunity.
+  rushing_opportunity: Count of rushing opportunities -- carries that reached ESPN's opportunity threshold.
+  rushing_opportunity_rate: Share of carries that qualified as rushing opportunities.
+  rushing_power: Count of power rushing attempts, in short-yardage situations as classified by ESPN's advanced box score.
+  rushing_power_rate: Share of carries that were power rushing attempts.
+  rushing_power_success: Count of power rushing attempts that gained the yardage needed. An integer count, not a rate -- the
+    rate is published separately as rushing_power_success_rate.
+  rushing_power_success_rate: Share of power rushing attempts that succeeded.
+  rushing_stopped: Count of rushing attempts stopped at or behind the line of scrimmage.
+  rushing_stopped_rate: Share of carries stopped at or behind the line of scrimmage.
+  rushing_stuff: Count of stuffed rushing attempts.
+  rushing_stuff_rate: Share of the team's carries that were stuffed at or behind the line of scrimmage.
+  scrimmage_plays: Number of plays from scrimmage (rushes plus passes), excluding special teams.
+  second_level_yards: Second-level yards -- rushing yardage earned just beyond the line of scrimmage.
+  special_teams_plays: Number of special-teams plays.
+  total_off_yards: Total offensive yards across all plays.
+  total_pen_yards: Total penalty yards assessed.
+  total_yards: Total yards the team gained across all plays.
+  yards_per_play: Yards gained per play.
+  yards_per_rush: Yards gained per rushing attempt.
+load_cfb_adv_turnover:
+  Int: Interceptions thrown.
+  Int_pbp: Interception count derived from the play-by-play, kept alongside the ESPN-sourced Int for reconciliation.
+  expected_turnover_margin: The opponent's expected_turnovers minus this team's, so positive means the team was expected to
+    win the turnover battle.
+  expected_turnovers: Turnover expectation for this team, computed as half its total fumbles plus 0.22 times the sum of its
+    pass breakups and interceptions.
+  fumble_recoveries_gained: Opponent fumbles this team recovered, taken as the opponent's fumbles_lost.
+  fumbles_lost_pbp: Fumbles-lost count derived from the play-by-play, kept alongside the ESPN-sourced fumbles_lost for reconciliation.
+  pass_breakups: Passes thrown by this offense that the opposing defense broke up; it equals the opponent's row in the advanced
+    defensive table exactly.
+  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
+  st_turnovers_gained: Special-teams turnovers this team recovered, taken as the opponent's st_turnovers_lost.
+  turnover_luck: Points of scoring luck attributed to turnovers, five points per turnover times the gap between turnover_margin
+    and expected_turnover_margin.
+  turnover_margin: The opponent's turnovers minus this team's turnovers, positive when the team gained more possessions than
+    it gave away.
+  turnovers_pbp: Turnover count derived from the play-by-play, retained unchanged so it can be reconciled against the ESPN-sourced
+    turnovers total.
+load_cfb_pbp:
+  A_score_diff: Away team's score minus the home team's, from the away perspective.
+  EPA_explosive: True when the play was explosive.
+  EPA_explosive_pass: True when the pass play was explosive.
+  EPA_explosive_rush: True when the rush play was explosive.
+  EPA_fg: EPA credited to the play on field-goal attempts.
+  EPA_kickoff: EPA credited to the play on kickoff plays.
+  EPA_middle_8_success: True when the play in the middle eight was successful by EPA.
+  EPA_middle_8_success_pass: True when the pass play in the middle eight was successful by EPA.
+  EPA_middle_8_success_rush: True when the rush play in the middle eight was successful by EPA.
+  EPA_non_explosive: EPA credited to the play on non-explosive plays.
+  EPA_pass: EPA credited to the play on pass plays.
+  EPA_penalty: EPA credited to the play attributable to penalties.
+  EPA_punt: EPA credited to the play on punt plays.
+  EPA_rush: EPA credited to the play on rush plays.
+  EPA_scrimmage: EPA credited to the play on plays from scrimmage.
+  EPA_sp: EPA credited to the play on special-teams plays.
+  EPA_success: True when the play was successful by EPA.
+  EPA_success_EPA: EPA on successful plays.
+  EPA_success_early_down: True when the play on an early down was successful by EPA.
+  EPA_success_early_down_pass: True when the pass play on an early down was successful by EPA.
+  EPA_success_early_down_rush: True when the rush play on an early down was successful by EPA.
+  EPA_success_late_down: True when the play on a late down was successful by EPA.
+  EPA_success_late_down_pass: True when the pass play on a late down was successful by EPA.
+  EPA_success_late_down_rush: True when the rush play on a late down was successful by EPA.
+  EPA_success_pass: True when the pass play was successful by EPA.
+  EPA_success_pass_EPA: EPA on successful pass plays.
+  EPA_success_passing_down: True when the play on a passing down was successful by EPA.
+  EPA_success_passing_down_EPA: EPA on successful plays on a passing down.
+  EPA_success_rush: True when the rush play was successful by EPA.
+  EPA_success_rush_EPA: EPA on successful rush plays.
+  EPA_success_standard_down: True when the play on a standard down was successful by EPA.
+  EPA_success_standard_down_EPA: EPA on successful plays on a standard down.
+  EP_between: Change in expected points across the play, before penalty adjustment.
+  EP_end: Expected points for the offense at the end of the play.
+  EP_start: Expected points for the offense at the start of the play.
+  EP_start_touchback: Expected points the offense would have had from a touchback on this play.
+  HA_score_diff: Home score minus away score for the play.
+  H_score_diff: Home team's score minus the away team's, from the home perspective.
+  TFL: True when the play was a tackle for loss.
+  TFL_pass: True when the play was a tackle for loss on a pass play (a sack).
+  TFL_rush: True when the play was a tackle for loss on a rush play.
+  action_play: True when the play advanced the game state -- excludes timeouts, end-of-period markers and other non-action
+    rows.
+  adj_rush_yardage: Rushing yards capped at 8, the input to the line-yards decomposition.
+  awayTeamAbbrev: ESPN's away-team Abbrev for the game, stamped on every play.
+  awayTeamId: ESPN's away-team Id for the game, stamped on every play.
+  awayTeamMascot: ESPN's away-team Mascot for the game, stamped on every play.
+  awayTeamName: ESPN's away-team Name for the game, stamped on every play.
+  awayTeamNameAlt: ESPN's away-team NameAlt for the game, stamped on every play.
+  awayTimeoutCalled: True when the away team called a timeout on the play.
+  clock.displayValue: Game clock at the play, as the displayed mm:ss string.
+  clock.minutes: Minutes remaining on the game clock at the play.
+  clock.seconds: Seconds component of the game clock at the play.
+  down_1: True when it is 1st down at the start of the play.
+  down_1_end: True when it is 1st down at the end of the play.
+  down_2: True when it is 2nd down at the start of the play.
+  down_2_end: True when it is 2nd down at the end of the play.
+  down_3: True when it is 3rd down at the start of the play.
+  down_3_end: True when it is 3rd down at the end of the play.
+  down_4: True when it is 4th down at the start of the play.
+  down_4_end: True when it is 4th down at the end of the play.
+  drive.description: ESPN's `description` field for the drive containing this play.
+  drive.displayResult: ESPN's `displayResult` field for the drive containing this play.
+  drive.end.clock.displayValue: ESPN's `end.clock.displayValue` field for the drive containing this play.
+  drive.end.period.number: ESPN's `end.period.number` field for the drive containing this play.
+  drive.end.period.type: ESPN's `end.period.type` field for the drive containing this play.
+  drive.end.yardLine: ESPN's `end.yardLine` field for the drive containing this play.
+  drive.id: ESPN's `id` field for the drive containing this play.
+  drive.isScore: ESPN's `isScore` field for the drive containing this play.
+  drive.offensivePlays: ESPN's `offensivePlays` field for the drive containing this play.
+  drive.result: ESPN's `result` field for the drive containing this play.
+  drive.shortDisplayResult: ESPN's `shortDisplayResult` field for the drive containing this play.
+  drive.start.clock.displayValue: ESPN's `start.clock.displayValue` field for the drive containing this play.
+  drive.start.period.number: ESPN's `start.period.number` field for the drive containing this play.
+  drive.start.period.type: ESPN's `start.period.type` field for the drive containing this play.
+  drive.start.text: ESPN's `start.text` field for the drive containing this play.
+  drive.start.yardLine: ESPN's `start.yardLine` field for the drive containing this play.
+  drive.team.abbreviation: ESPN's `team.abbreviation` field for the drive containing this play.
+  drive.team.displayName: ESPN's `team.displayName` field for the drive containing this play.
+  drive.team.name: ESPN's `team.name` field for the drive containing this play.
+  drive.team.shortDisplayName: ESPN's `team.shortDisplayName` field for the drive containing this play.
+  drive.timeElapsed.displayValue: ESPN's `timeElapsed.displayValue` field for the drive containing this play.
+  drive.yards: ESPN's `yards` field for the drive containing this play.
+  drive_offense_plays: Offensive plays run on the drive.
+  drive_offense_yards: Offensive yards gained on the drive.
+  drive_play_index: Sequence number of the play within its drive.
+  drive_start: Yard line at which the drive began.
+  drive_stopped: True when the play ended the drive.
+  drive_total_yards: Total yards gained on the drive.
+  early_down: True when the play is a scrimmage play on first or second down.
+  early_down_pass: True when the play is a pass on an early down.
+  early_down_rush: True when the play is a rush on an early down.
+  end.ExpScoreDiff: ESPN's `ExpScoreDiff` value for the play state at the end of the play.
+  end.ExpScoreDiff_Time_Ratio: ESPN's `ExpScoreDiff_Time_Ratio` value for the play state at the end of the play.
+  end.TimeSecsRem: ESPN's `TimeSecsRem` value for the play state at the end of the play.
+  end.adj_TimeSecsRem: ESPN's `adj_TimeSecsRem` value for the play state at the end of the play.
+  end.awayScore: ESPN's `awayScore` value for the play state at the end of the play.
+  end.awayTeamTimeouts: ESPN's `awayTeamTimeouts` value for the play state at the end of the play.
+  end.defPosTeamTimeouts: ESPN's `defPosTeamTimeouts` value for the play state at the end of the play.
+  end.def_pos_team.id: ESPN's `def_pos_team.id` value for the play state at the end of the play.
+  end.def_pos_team.name: ESPN's `def_pos_team.name` value for the play state at the end of the play.
+  end.def_pos_team_score: ESPN's `def_pos_team_score` value for the play state at the end of the play.
+  end.def_team.id: ESPN's `def_team.id` value for the play state at the end of the play.
+  end.distance: ESPN's `distance` value for the play state at the end of the play.
+  end.down: ESPN's `down` value for the play state at the end of the play.
+  end.downDistanceText: ESPN's `downDistanceText` value for the play state at the end of the play.
+  end.elapsed_share: ESPN's `elapsed_share` value for the play state at the end of the play.
+  end.homeScore: ESPN's `homeScore` value for the play state at the end of the play.
+  end.homeTeamTimeouts: ESPN's `homeTeamTimeouts` value for the play state at the end of the play.
+  end.is_home: ESPN's `is_home` value for the play state at the end of the play.
+  end.posTeamTimeouts: ESPN's `posTeamTimeouts` value for the play state at the end of the play.
+  end.pos_score_diff: ESPN's `pos_score_diff` value for the play state at the end of the play.
+  end.pos_team.id: ESPN's `pos_team.id` value for the play state at the end of the play.
+  end.pos_team.name: ESPN's `pos_team.name` value for the play state at the end of the play.
+  end.pos_team_receives_2H_kickoff: ESPN's `pos_team_receives_2H_kickoff` value for the play state at the end of the play.
+  end.pos_team_score: ESPN's `pos_team_score` value for the play state at the end of the play.
+  end.pos_team_spread: ESPN's `pos_team_spread` value for the play state at the end of the play.
+  end.possessionText: ESPN's `possessionText` value for the play state at the end of the play.
+  end.shortDownDistanceText: ESPN's `shortDownDistanceText` value for the play state at the end of the play.
+  end.spread_time: ESPN's `spread_time` value for the play state at the end of the play.
+  end.team.id: ESPN's `team.id` value for the play state at the end of the play.
+  end.yard: ESPN's `yard` value for the play state at the end of the play.
+  end.yardLine: ESPN's `yardLine` value for the play state at the end of the play.
+  end.yardsToEndzone: ESPN's `yardsToEndzone` value for the play state at the end of the play.
+  fg_attempt: True when the play was a field-goal attempt.
+  firstHalfKickoffTeamId: ESPN id of the team that received the opening kickoff.
+  first_down_created: True when the play produced a first down for the offense.
+  forced_fumble: True when the defense forced a fumble on the play.
+  fumble_recovered: True when a fumble on the play was recovered.
+  gameSpread: Point spread used as an input to the win-probability model.
+  gameSpreadAvailable: True when a spread was available for the game.
+  havoc: 'True when the defense disrupted the play: a pass breakup, tackle for loss, interception or forced fumble.'
+  highlight_run: True when the rush gained 8 or more yards.
+  highlight_yards: Second-level plus open-field yards -- the yardage credited to the carrier.
+  homeFavorite: True when the home team was favoured by the spread.
+  homeTeamAbbrev: ESPN's home-team Abbrev for the game, stamped on every play.
+  homeTeamId: ESPN's home-team Id for the game, stamped on every play.
+  homeTeamMascot: ESPN's home-team Mascot for the game, stamped on every play.
+  homeTeamName: ESPN's home-team Name for the game, stamped on every play.
+  homeTeamNameAlt: ESPN's home-team NameAlt for the game, stamped on every play.
+  homeTeamSpread: ESPN's home-team Spread for the game, stamped on every play.
+  homeTimeoutCalled: True when the home team called a timeout on the play.
+  kickoff_return_player_name: Name of the player returning the kickoff.
+  lag_EP_end: Value of EP_end on the previous play, used for sequence-aware derivations.
+  lag_HA_score_diff: Value of HA_score_diff on the previous play, used for sequence-aware derivations.
+  lag_awayScore: Value of awayScore on the previous play, used for sequence-aware derivations.
+  lag_change_of_pos_team: Value of change_of_pos_team on the previous play, used for sequence-aware derivations.
+  lag_half: Value of half on the previous play, used for sequence-aware derivations.
+  lag_homeScore: Value of homeScore on the previous play, used for sequence-aware derivations.
+  lag_pos_score_diff: Value of pos_score_diff on the previous play, used for sequence-aware derivations.
+  lag_pos_team: Value of pos_team on the previous play, used for sequence-aware derivations.
+  lag_scoringPlay: Value of scoringPlay on the previous play, used for sequence-aware derivations.
+  late_down: True when the play is a scrimmage play on third or fourth down.
+  late_down_pass: True when the play is a pass on a late down.
+  late_down_rush: True when the play is a rush on a late down.
+  lead_half: Value of half on the next play, used for sequence-aware derivations.
+  lead_play_type: Value of play_type on the next play, used for sequence-aware derivations.
+  lead_pos_team: Value of pos_team on the next play, used for sequence-aware derivations.
+  lead_pos_team2: Value of pos_team 2 plays ahead, used for sequence-aware derivations.
+  lead_scoringPlay: Value of scoringPlay on the next play, used for sequence-aware derivations.
+  lead_start_distance: Value of start_distance on the next play, used for sequence-aware derivations.
+  lead_start_down: Value of start_down on the next play, used for sequence-aware derivations.
+  lead_start_team: Value of start_team on the next play, used for sequence-aware derivations.
+  lead_start_yardsToEndzone: Value of start_yardsToEndzone on the next play, used for sequence-aware derivations.
+  lead_text: Value of text on the next play, used for sequence-aware derivations.
+  lead_wp_before: Value of wp_before on the next play, used for sequence-aware derivations.
+  lead_wp_before2: Value of wp_before 2 plays ahead, used for sequence-aware derivations.
+  line_yards: 'Yards credited to the offensive line on a rush, using the standard sliding scale: 1.2x the capped yardage on
+    a loss, all of it through 3 yards, half of each yard from 4 to 8, and a 5.5-yard ceiling beyond that.'
+  net_HA_score_pts: Net points the play added to the home-minus-away score margin.
+  new_distance: Distance to go after the play, including any penalty enforcement.
+  new_down: Down after the play, including any penalty enforcement.
+  non_fumble_sack: True when the play was a sack that did not produce a fumble.
+  open_field_yards: Rushing yards gained beyond 8, credited to the ball carrier rather than the line.
+  opp_highlight_yards: Highlight yards earned on opportunity runs, isolating carrier production on carries where the blocking
+    succeeded. Assets published before the 2026-08 fix are identically 0 here, because the inverted opportunity_run gate could
+    never co-occur with non-zero highlight yards.
+  opportunity_run: True when a rush reached 4 yards -- the carries on which the blocking did its job. Matches cfbfastR's espn_cfb_15
+    definition. Assets published before the 2026-08 fix carry the inverted (4 yards or fewer) flag.
+  overUnder: Over/under total used as a model input.
+  pass_breakup: True when a defender broke up the pass.
+  pass_epa: EPA credited to the play when it is a pass.
+  pass_weight: Weighting applied to the pass component of the play.
+  passing_down: True when the offense is behind schedule for the series -- second down needing 8 or more, or third/fourth
+    down needing 5 or more.
+  pen_epa: EPA attributable to a penalty on the play.
+  pen_weight: Weighting applied to the penalty component of the play.
+  penalty_in_text: True when the play description mentions a penalty.
+  period.number: Period (quarter) number in which the play occurred.
+  playType: ESPN's play-type label for the play.
+  pos_score_diff_end: Score differential from the possessing team's perspective at the end of the play.
+  power_rush_attempt: True when the play is a short-yardage power rushing attempt.
+  power_rush_success: True when a power rushing attempt gained the yardage needed.
+  prog_drive_EPA: Cumulative EPA accrued by the drive up to and including this play.
+  prog_drive_WPA: Cumulative win-probability added by the drive up to and including this play.
+  punt_return_player_name: Name of the player returning the punt.
+  qbr_epa: EPA variant used as an input to the QBR calculation.
+  rush_epa: EPA credited to the play when it is a rush.
+  rush_weight: Weighting applied to the rush component of the play.
+  sack_epa: EPA credited to the play when it is a sack.
+  sack_weight: Weighting applied to the sack component of the play.
+  scoringPlay: ESPN flag marking the play as a scoring play.
+  scoringType.abbreviation: ESPN's abbreviation for the scoring type.
+  scoringType.displayName: ESPN's display label for the scoring type.
+  scoringType.name: ESPN's name for the scoring type (e.g. touchdown, field goal).
+  scrimmage_play: True when the play is a play from scrimmage rather than a special-teams or administrative row.
+  seasonType: ESPN season type for the game (2 = regular season, 3 = postseason).
+  second_level_yards: Rushing yards earned from 4 to 8, split evenly between line and carrier under the line-yards decomposition.
+  short_rush_attempt: True when the play is a rush in a short-yardage situation.
+  short_rush_success: True when a short-yardage rush gained the yardage needed.
+  standard_down: True when the offense is on schedule for the series -- first down, second down needing fewer than 8, or third/fourth
+    down needing fewer than 5.
+  start.ExpScoreDiff: ESPN's `ExpScoreDiff` value for the play state at the start of the play.
+  start.ExpScoreDiff_Time_Ratio: ESPN's `ExpScoreDiff_Time_Ratio` value for the play state at the start of the play.
+  start.ExpScoreDiff_Time_Ratio_touchback: ESPN's `ExpScoreDiff_Time_Ratio_touchback` value for the play state at the start
+    of the play.
+  start.ExpScoreDiff_touchback: ESPN's `ExpScoreDiff_touchback` value for the play state at the start of the play.
+  start.TimeSecsRem: ESPN's `TimeSecsRem` value for the play state at the start of the play.
+  start.adj_TimeSecsRem: ESPN's `adj_TimeSecsRem` value for the play state at the start of the play.
+  start.awayScore: ESPN's `awayScore` value for the play state at the start of the play.
+  start.awayTeamTimeouts: ESPN's `awayTeamTimeouts` value for the play state at the start of the play.
+  start.defPosTeamTimeouts: ESPN's `defPosTeamTimeouts` value for the play state at the start of the play.
+  start.def_pos_team.id: ESPN's `def_pos_team.id` value for the play state at the start of the play.
+  start.def_pos_team.name: ESPN's `def_pos_team.name` value for the play state at the start of the play.
+  start.def_pos_team_score: ESPN's `def_pos_team_score` value for the play state at the start of the play.
+  start.distance: ESPN's `distance` value for the play state at the start of the play.
+  start.down: ESPN's `down` value for the play state at the start of the play.
+  start.downDistanceText: ESPN's `downDistanceText` value for the play state at the start of the play.
+  start.elapsed_share: ESPN's `elapsed_share` value for the play state at the start of the play.
+  start.homeScore: ESPN's `homeScore` value for the play state at the start of the play.
+  start.homeTeamTimeouts: ESPN's `homeTeamTimeouts` value for the play state at the start of the play.
+  start.is_home: ESPN's `is_home` value for the play state at the start of the play.
+  start.posTeamTimeouts: ESPN's `posTeamTimeouts` value for the play state at the start of the play.
+  start.pos_score_diff: ESPN's `pos_score_diff` value for the play state at the start of the play.
+  start.pos_team.id: ESPN's `pos_team.id` value for the play state at the start of the play.
+  start.pos_team.name: ESPN's `pos_team.name` value for the play state at the start of the play.
+  start.pos_team_receives_2H_kickoff: ESPN's `pos_team_receives_2H_kickoff` value for the play state at the start of the play.
+  start.pos_team_score: ESPN's `pos_team_score` value for the play state at the start of the play.
+  start.pos_team_spread: ESPN's `pos_team_spread` value for the play state at the start of the play.
+  start.possessionText: ESPN's `possessionText` value for the play state at the start of the play.
+  start.shortDownDistanceText: ESPN's `shortDownDistanceText` value for the play state at the start of the play.
+  start.spread_time: ESPN's `spread_time` value for the play state at the start of the play.
+  start.team.id: ESPN's `team.id` value for the play state at the start of the play.
+  start.yard: ESPN's `yard` value for the play state at the start of the play.
+  start.yardLine: ESPN's `yardLine` value for the play state at the start of the play.
+  start.yardsToEndzone: ESPN's `yardsToEndzone` value for the play state at the start of the play.
+  start.yardsToEndzone.touchback: ESPN's `yardsToEndzone.touchback` value for the play state at the start of the play.
+  statYardage: Yardage ESPN credits to the play for statistical purposes.
+  stopped_run: True when the rush was stopped at or behind the line of scrimmage.
+  td_check: Internal flag used while reconciling whether the play produced a touchdown.
+  text_dupe: True when the play description duplicates the previous row's text.
+  type.abbreviation: ESPN's abbreviation for the play type.
+  type.id: ESPN's numeric identifier for the play type.
+  type.text: ESPN's text label for the play type.
+  wp_touchback: Win probability the offense would have had starting from a touchback.
 load_cfb_team_summaries:
   EPAdrive_def: EPA per drive (total EPA divided by drives), with the team on defense (i.e. allowed to opponents).
   EPAdrive_def_pass: EPA per drive (total EPA divided by drives) on pass plays, with the team on defense (i.e. allowed to
@@ -3911,262 +5352,6 @@ load_phf_team_boxscores:
   successful_power_play: Number of power plays on which the team scored.
   total_scoring: Goals the team scored in the game.
   total_shots: Shots the team took in the game.
-load_cfb_pbp:
-  A_score_diff: Away team's score minus the home team's, from the away perspective.
-  EPA_explosive: True when the play was explosive.
-  EPA_explosive_pass: True when the pass play was explosive.
-  EPA_explosive_rush: True when the rush play was explosive.
-  EPA_fg: EPA credited to the play on field-goal attempts.
-  EPA_kickoff: EPA credited to the play on kickoff plays.
-  EPA_middle_8_success: True when the play in the middle eight was successful by EPA.
-  EPA_middle_8_success_pass: True when the pass play in the middle eight was successful by EPA.
-  EPA_middle_8_success_rush: True when the rush play in the middle eight was successful by EPA.
-  EPA_non_explosive: EPA credited to the play on non-explosive plays.
-  EPA_pass: EPA credited to the play on pass plays.
-  EPA_penalty: EPA credited to the play attributable to penalties.
-  EPA_punt: EPA credited to the play on punt plays.
-  EPA_rush: EPA credited to the play on rush plays.
-  EPA_scrimmage: EPA credited to the play on plays from scrimmage.
-  EPA_sp: EPA credited to the play on special-teams plays.
-  EPA_success: True when the play was successful by EPA.
-  EPA_success_EPA: EPA on successful plays.
-  EPA_success_early_down: True when the play on an early down was successful by EPA.
-  EPA_success_early_down_pass: True when the pass play on an early down was successful by EPA.
-  EPA_success_early_down_rush: True when the rush play on an early down was successful by EPA.
-  EPA_success_late_down: True when the play on a late down was successful by EPA.
-  EPA_success_late_down_pass: True when the pass play on a late down was successful by EPA.
-  EPA_success_late_down_rush: True when the rush play on a late down was successful by EPA.
-  EPA_success_pass: True when the pass play was successful by EPA.
-  EPA_success_pass_EPA: EPA on successful pass plays.
-  EPA_success_passing_down: True when the play on a passing down was successful by EPA.
-  EPA_success_passing_down_EPA: EPA on successful plays on a passing down.
-  EPA_success_rush: True when the rush play was successful by EPA.
-  EPA_success_rush_EPA: EPA on successful rush plays.
-  EPA_success_standard_down: True when the play on a standard down was successful by EPA.
-  EPA_success_standard_down_EPA: EPA on successful plays on a standard down.
-  EP_between: Change in expected points across the play, before penalty adjustment.
-  EP_end: Expected points for the offense at the end of the play.
-  EP_start: Expected points for the offense at the start of the play.
-  EP_start_touchback: Expected points the offense would have had from a touchback on this play.
-  HA_score_diff: Home score minus away score for the play.
-  H_score_diff: Home team's score minus the away team's, from the home perspective.
-  TFL: True when the play was a tackle for loss.
-  TFL_pass: True when the play was a tackle for loss on a pass play (a sack).
-  TFL_rush: True when the play was a tackle for loss on a rush play.
-  action_play: True when the play advanced the game state -- excludes timeouts, end-of-period markers and other non-action
-    rows.
-  adj_rush_yardage: Rushing yards capped at 8, the input to the line-yards decomposition.
-  awayTeamAbbrev: ESPN's away-team Abbrev for the game, stamped on every play.
-  awayTeamId: ESPN's away-team Id for the game, stamped on every play.
-  awayTeamMascot: ESPN's away-team Mascot for the game, stamped on every play.
-  awayTeamName: ESPN's away-team Name for the game, stamped on every play.
-  awayTeamNameAlt: ESPN's away-team NameAlt for the game, stamped on every play.
-  awayTimeoutCalled: True when the away team called a timeout on the play.
-  clock.displayValue: Game clock at the play, as the displayed mm:ss string.
-  clock.minutes: Minutes remaining on the game clock at the play.
-  clock.seconds: Seconds component of the game clock at the play.
-  down_1: True when it is 1st down at the start of the play.
-  down_1_end: True when it is 1st down at the end of the play.
-  down_2: True when it is 2nd down at the start of the play.
-  down_2_end: True when it is 2nd down at the end of the play.
-  down_3: True when it is 3rd down at the start of the play.
-  down_3_end: True when it is 3rd down at the end of the play.
-  down_4: True when it is 4th down at the start of the play.
-  down_4_end: True when it is 4th down at the end of the play.
-  drive.description: ESPN's `description` field for the drive containing this play.
-  drive.displayResult: ESPN's `displayResult` field for the drive containing this play.
-  drive.end.clock.displayValue: ESPN's `end.clock.displayValue` field for the drive containing this play.
-  drive.end.period.number: ESPN's `end.period.number` field for the drive containing this play.
-  drive.end.period.type: ESPN's `end.period.type` field for the drive containing this play.
-  drive.end.yardLine: ESPN's `end.yardLine` field for the drive containing this play.
-  drive.id: ESPN's `id` field for the drive containing this play.
-  drive.isScore: ESPN's `isScore` field for the drive containing this play.
-  drive.offensivePlays: ESPN's `offensivePlays` field for the drive containing this play.
-  drive.result: ESPN's `result` field for the drive containing this play.
-  drive.shortDisplayResult: ESPN's `shortDisplayResult` field for the drive containing this play.
-  drive.start.clock.displayValue: ESPN's `start.clock.displayValue` field for the drive containing this play.
-  drive.start.period.number: ESPN's `start.period.number` field for the drive containing this play.
-  drive.start.period.type: ESPN's `start.period.type` field for the drive containing this play.
-  drive.start.text: ESPN's `start.text` field for the drive containing this play.
-  drive.start.yardLine: ESPN's `start.yardLine` field for the drive containing this play.
-  drive.team.abbreviation: ESPN's `team.abbreviation` field for the drive containing this play.
-  drive.team.displayName: ESPN's `team.displayName` field for the drive containing this play.
-  drive.team.name: ESPN's `team.name` field for the drive containing this play.
-  drive.team.shortDisplayName: ESPN's `team.shortDisplayName` field for the drive containing this play.
-  drive.timeElapsed.displayValue: ESPN's `timeElapsed.displayValue` field for the drive containing this play.
-  drive.yards: ESPN's `yards` field for the drive containing this play.
-  drive_offense_plays: Offensive plays run on the drive.
-  drive_offense_yards: Offensive yards gained on the drive.
-  drive_play_index: Sequence number of the play within its drive.
-  drive_start: Yard line at which the drive began.
-  drive_stopped: True when the play ended the drive.
-  drive_total_yards: Total yards gained on the drive.
-  early_down: True when the play is a scrimmage play on first or second down.
-  early_down_pass: True when the play is a pass on an early down.
-  early_down_rush: True when the play is a rush on an early down.
-  end.ExpScoreDiff: ESPN's `ExpScoreDiff` value for the play state at the end of the play.
-  end.ExpScoreDiff_Time_Ratio: ESPN's `ExpScoreDiff_Time_Ratio` value for the play state at the end of the play.
-  end.TimeSecsRem: ESPN's `TimeSecsRem` value for the play state at the end of the play.
-  end.adj_TimeSecsRem: ESPN's `adj_TimeSecsRem` value for the play state at the end of the play.
-  end.awayScore: ESPN's `awayScore` value for the play state at the end of the play.
-  end.awayTeamTimeouts: ESPN's `awayTeamTimeouts` value for the play state at the end of the play.
-  end.defPosTeamTimeouts: ESPN's `defPosTeamTimeouts` value for the play state at the end of the play.
-  end.def_pos_team.id: ESPN's `def_pos_team.id` value for the play state at the end of the play.
-  end.def_pos_team.name: ESPN's `def_pos_team.name` value for the play state at the end of the play.
-  end.def_pos_team_score: ESPN's `def_pos_team_score` value for the play state at the end of the play.
-  end.def_team.id: ESPN's `def_team.id` value for the play state at the end of the play.
-  end.distance: ESPN's `distance` value for the play state at the end of the play.
-  end.down: ESPN's `down` value for the play state at the end of the play.
-  end.downDistanceText: ESPN's `downDistanceText` value for the play state at the end of the play.
-  end.elapsed_share: ESPN's `elapsed_share` value for the play state at the end of the play.
-  end.homeScore: ESPN's `homeScore` value for the play state at the end of the play.
-  end.homeTeamTimeouts: ESPN's `homeTeamTimeouts` value for the play state at the end of the play.
-  end.is_home: ESPN's `is_home` value for the play state at the end of the play.
-  end.posTeamTimeouts: ESPN's `posTeamTimeouts` value for the play state at the end of the play.
-  end.pos_score_diff: ESPN's `pos_score_diff` value for the play state at the end of the play.
-  end.pos_team.id: ESPN's `pos_team.id` value for the play state at the end of the play.
-  end.pos_team.name: ESPN's `pos_team.name` value for the play state at the end of the play.
-  end.pos_team_receives_2H_kickoff: ESPN's `pos_team_receives_2H_kickoff` value for the play state at the end of the play.
-  end.pos_team_score: ESPN's `pos_team_score` value for the play state at the end of the play.
-  end.pos_team_spread: ESPN's `pos_team_spread` value for the play state at the end of the play.
-  end.possessionText: ESPN's `possessionText` value for the play state at the end of the play.
-  end.shortDownDistanceText: ESPN's `shortDownDistanceText` value for the play state at the end of the play.
-  end.spread_time: ESPN's `spread_time` value for the play state at the end of the play.
-  end.team.id: ESPN's `team.id` value for the play state at the end of the play.
-  end.yard: ESPN's `yard` value for the play state at the end of the play.
-  end.yardLine: ESPN's `yardLine` value for the play state at the end of the play.
-  end.yardsToEndzone: ESPN's `yardsToEndzone` value for the play state at the end of the play.
-  fg_attempt: True when the play was a field-goal attempt.
-  firstHalfKickoffTeamId: ESPN id of the team that received the opening kickoff.
-  first_down_created: True when the play produced a first down for the offense.
-  forced_fumble: True when the defense forced a fumble on the play.
-  fumble_recovered: True when a fumble on the play was recovered.
-  gameSpread: Point spread used as an input to the win-probability model.
-  gameSpreadAvailable: True when a spread was available for the game.
-  havoc: 'True when the defense disrupted the play: a pass breakup, tackle for loss, interception or forced fumble.'
-  highlight_run: True when the rush gained 8 or more yards.
-  highlight_yards: Second-level plus open-field yards -- the yardage credited to the carrier.
-  homeFavorite: True when the home team was favoured by the spread.
-  homeTeamAbbrev: ESPN's home-team Abbrev for the game, stamped on every play.
-  homeTeamId: ESPN's home-team Id for the game, stamped on every play.
-  homeTeamMascot: ESPN's home-team Mascot for the game, stamped on every play.
-  homeTeamName: ESPN's home-team Name for the game, stamped on every play.
-  homeTeamNameAlt: ESPN's home-team NameAlt for the game, stamped on every play.
-  homeTeamSpread: ESPN's home-team Spread for the game, stamped on every play.
-  homeTimeoutCalled: True when the home team called a timeout on the play.
-  kickoff_return_player_name: Name of the player returning the kickoff.
-  lag_EP_end: Value of EP_end on the previous play, used for sequence-aware derivations.
-  lag_HA_score_diff: Value of HA_score_diff on the previous play, used for sequence-aware derivations.
-  lag_awayScore: Value of awayScore on the previous play, used for sequence-aware derivations.
-  lag_change_of_pos_team: Value of change_of_pos_team on the previous play, used for sequence-aware derivations.
-  lag_half: Value of half on the previous play, used for sequence-aware derivations.
-  lag_homeScore: Value of homeScore on the previous play, used for sequence-aware derivations.
-  lag_pos_score_diff: Value of pos_score_diff on the previous play, used for sequence-aware derivations.
-  lag_pos_team: Value of pos_team on the previous play, used for sequence-aware derivations.
-  lag_scoringPlay: Value of scoringPlay on the previous play, used for sequence-aware derivations.
-  late_down: True when the play is a scrimmage play on third or fourth down.
-  late_down_pass: True when the play is a pass on a late down.
-  late_down_rush: True when the play is a rush on a late down.
-  lead_half: Value of half on the next play, used for sequence-aware derivations.
-  lead_play_type: Value of play_type on the next play, used for sequence-aware derivations.
-  lead_pos_team: Value of pos_team on the next play, used for sequence-aware derivations.
-  lead_pos_team2: Value of pos_team on the next 2 plays play, used for sequence-aware derivations.
-  lead_scoringPlay: Value of scoringPlay on the next play, used for sequence-aware derivations.
-  lead_start_distance: Value of start_distance on the next play, used for sequence-aware derivations.
-  lead_start_down: Value of start_down on the next play, used for sequence-aware derivations.
-  lead_start_team: Value of start_team on the next play, used for sequence-aware derivations.
-  lead_start_yardsToEndzone: Value of start_yardsToEndzone on the next play, used for sequence-aware derivations.
-  lead_text: Value of text on the next play, used for sequence-aware derivations.
-  lead_wp_before: Value of wp_before on the next play, used for sequence-aware derivations.
-  lead_wp_before2: Value of wp_before on the next 2 plays play, used for sequence-aware derivations.
-  line_yards: 'Yards credited to the offensive line on a rush, using the standard sliding scale: 1.2x the capped yardage on
-    a loss, all of it through 3 yards, half of each yard from 4 to 8, and a 5.5-yard ceiling beyond that.'
-  net_HA_score_pts: Net points the play added to the home-minus-away score margin.
-  new_distance: Distance to go after the play, including any penalty enforcement.
-  new_down: Down after the play, including any penalty enforcement.
-  non_fumble_sack: True when the play was a sack that did not produce a fumble.
-  open_field_yards: Rushing yards gained beyond 8, credited to the ball carrier rather than the line.
-  opp_highlight_yards: Highlight yards earned on opportunity runs, isolating carrier production on carries where the blocking
-    succeeded. Assets published before the 2026-08 fix are identically 0 here, because the inverted opportunity_run gate could
-    never co-occur with non-zero highlight yards.
-  opportunity_run: True when a rush reached 4 yards -- the carries on which the blocking did its job. Matches cfbfastR's espn_cfb_15
-    definition. Assets published before the 2026-08 fix carry the inverted (4 yards or fewer) flag.
-  overUnder: Over/under total used as a model input.
-  pass_breakup: True when a defender broke up the pass.
-  pass_epa: EPA credited to the play when it is a pass.
-  pass_weight: Weighting applied to the pass component of the play.
-  passing_down: True when the offense is behind schedule for the series -- second down needing 8 or more, or third/fourth
-    down needing 5 or more.
-  pen_epa: EPA attributable to a penalty on the play.
-  pen_weight: Weighting applied to the penalty component of the play.
-  penalty_in_text: True when the play description mentions a penalty.
-  period.number: Period (quarter) number in which the play occurred.
-  playType: ESPN's play-type label for the play.
-  pos_score_diff_end: Score differential from the possessing team's perspective at the end of the play.
-  power_rush_attempt: True when the play is a short-yardage power rushing attempt.
-  power_rush_success: True when a power rushing attempt gained the yardage needed.
-  prog_drive_EPA: Cumulative EPA accrued by the drive up to and including this play.
-  prog_drive_WPA: Cumulative win-probability added by the drive up to and including this play.
-  punt_return_player_name: Name of the player returning the punt.
-  qbr_epa: EPA variant used as an input to the QBR calculation.
-  rush_epa: EPA credited to the play when it is a rush.
-  rush_weight: Weighting applied to the rush component of the play.
-  sack_epa: EPA credited to the play when it is a sack.
-  sack_weight: Weighting applied to the sack component of the play.
-  scoringPlay: ESPN flag marking the play as a scoring play.
-  scoringType.abbreviation: ESPN's abbreviation for the scoring type.
-  scoringType.displayName: ESPN's display label for the scoring type.
-  scoringType.name: ESPN's name for the scoring type (e.g. touchdown, field goal).
-  scrimmage_play: True when the play is a play from scrimmage rather than a special-teams or administrative row.
-  seasonType: ESPN season type for the game (2 = regular season, 3 = postseason).
-  second_level_yards: Rushing yards earned from 4 to 8, split evenly between line and carrier under the line-yards decomposition.
-  short_rush_attempt: True when the play is a rush in a short-yardage situation.
-  short_rush_success: True when a short-yardage rush gained the yardage needed.
-  standard_down: True when the offense is on schedule for the series -- first down, second down needing fewer than 8, or third/fourth
-    down needing fewer than 5.
-  start.ExpScoreDiff: ESPN's `ExpScoreDiff` value for the play state at the start of the play.
-  start.ExpScoreDiff_Time_Ratio: ESPN's `ExpScoreDiff_Time_Ratio` value for the play state at the start of the play.
-  start.ExpScoreDiff_Time_Ratio_touchback: ESPN's `ExpScoreDiff_Time_Ratio_touchback` value for the play state at the start
-    of the play.
-  start.ExpScoreDiff_touchback: ESPN's `ExpScoreDiff_touchback` value for the play state at the start of the play.
-  start.TimeSecsRem: ESPN's `TimeSecsRem` value for the play state at the start of the play.
-  start.adj_TimeSecsRem: ESPN's `adj_TimeSecsRem` value for the play state at the start of the play.
-  start.awayScore: ESPN's `awayScore` value for the play state at the start of the play.
-  start.awayTeamTimeouts: ESPN's `awayTeamTimeouts` value for the play state at the start of the play.
-  start.defPosTeamTimeouts: ESPN's `defPosTeamTimeouts` value for the play state at the start of the play.
-  start.def_pos_team.id: ESPN's `def_pos_team.id` value for the play state at the start of the play.
-  start.def_pos_team.name: ESPN's `def_pos_team.name` value for the play state at the start of the play.
-  start.def_pos_team_score: ESPN's `def_pos_team_score` value for the play state at the start of the play.
-  start.distance: ESPN's `distance` value for the play state at the start of the play.
-  start.down: ESPN's `down` value for the play state at the start of the play.
-  start.downDistanceText: ESPN's `downDistanceText` value for the play state at the start of the play.
-  start.elapsed_share: ESPN's `elapsed_share` value for the play state at the start of the play.
-  start.homeScore: ESPN's `homeScore` value for the play state at the start of the play.
-  start.homeTeamTimeouts: ESPN's `homeTeamTimeouts` value for the play state at the start of the play.
-  start.is_home: ESPN's `is_home` value for the play state at the start of the play.
-  start.posTeamTimeouts: ESPN's `posTeamTimeouts` value for the play state at the start of the play.
-  start.pos_score_diff: ESPN's `pos_score_diff` value for the play state at the start of the play.
-  start.pos_team.id: ESPN's `pos_team.id` value for the play state at the start of the play.
-  start.pos_team.name: ESPN's `pos_team.name` value for the play state at the start of the play.
-  start.pos_team_receives_2H_kickoff: ESPN's `pos_team_receives_2H_kickoff` value for the play state at the start of the play.
-  start.pos_team_score: ESPN's `pos_team_score` value for the play state at the start of the play.
-  start.pos_team_spread: ESPN's `pos_team_spread` value for the play state at the start of the play.
-  start.possessionText: ESPN's `possessionText` value for the play state at the start of the play.
-  start.shortDownDistanceText: ESPN's `shortDownDistanceText` value for the play state at the start of the play.
-  start.spread_time: ESPN's `spread_time` value for the play state at the start of the play.
-  start.team.id: ESPN's `team.id` value for the play state at the start of the play.
-  start.yard: ESPN's `yard` value for the play state at the start of the play.
-  start.yardLine: ESPN's `yardLine` value for the play state at the start of the play.
-  start.yardsToEndzone: ESPN's `yardsToEndzone` value for the play state at the start of the play.
-  start.yardsToEndzone.touchback: ESPN's `yardsToEndzone.touchback` value for the play state at the start of the play.
-  statYardage: Yardage ESPN credits to the play for statistical purposes.
-  stopped_run: True when the rush was stopped at or behind the line of scrimmage.
-  td_check: Internal flag used while reconciling whether the play produced a touchdown.
-  text_dupe: True when the play description duplicates the previous row's text.
-  type.abbreviation: ESPN's abbreviation for the play type.
-  type.id: ESPN's numeric identifier for the play type.
-  type.text: ESPN's text label for the play type.
-  wp_touchback: Win probability the offense would have had starting from a touchback.
 load_wnba_stats_pbp:
   act_type: Action-type code for the play-by-play event.
   msg_type: Message-type code for the play-by-play event.
@@ -4207,1167 +5392,6 @@ load_wnba_stats_rosters:
   team_id_lookup: Team id used to join the row back to the team tables.
 load_wnba_team_season_stats:
   stat_description: Human-readable description of the statistic the row reports.
-load_cfb_adv_defensive_players:
-  def_pos_team: Display name of the team on defense (e.g. 'Ohio State Buckeyes'). Held an ESPN team id until the 2026-08 republish;
-    the id now lives in def_pos_team_id.
-  def_pos_team_id: ESPN team id of the team on defense. Present for every season 2004+.
-  forced_fumbles: Fumbles forced by the defender. Available from 2005 on; null for 2004, which ESPN ships with only the fumble-recovery
-    statistics.
-  fumble_recoveries: Fumbles recovered by the defender. Available for every season 2004+.
-  fumble_recoveries_yards: Yards returned on the defender's fumble recoveries. Available for every season 2004+.
-  interceptions: Passes intercepted by the defender. Available from 2014 on; null for 2004-2013, which ESPN ships without
-    interception statistics in this block.
-  interceptions_yards: Yards returned on the defender's interceptions. Available from 2014 on; null for 2004-2013.
-  pass_breakups: Passes broken up by the defender. Available from 2005 on; null for 2004.
-  player_name: Display name of the defender.
-  sacks: Sacks recorded by the defender. Available from 2005 on; null for 2004.
-  sacks_yards: Yards lost by the offense on the defender's sacks. Available from 2005 on; null for 2004.
-load_cfb_adv_passing:
-  Att: Pass attempts recorded in the advanced box score.
-  CPOE: Completion percentage over expected -- actual minus modelled completion rate.
-  Comp: Completed passes recorded in the advanced box score.
-  CompPct: Completion percentage from the advanced box score.
-  EPA_per_Play: EPA per play on the passer's plays.
-  Int: Interceptions thrown.
-  Pass_TD: Passing touchdowns.
-  SR: Success rate on the passer's plays.
-  Sck: Times the passer was sacked.
-  YPA: Yards per pass attempt.
-  Yds: Passing yards from the advanced box score.
-  era0: Rule-era indicator for the earliest modelled era.
-  era1: Rule-era indicator for the second modelled era.
-  era2: Rule-era indicator for the third modelled era.
-  era3: Rule-era indicator for the most recent modelled era.
-  exp_qbr: Expected QBR for the passer.
-  pass_epa: EPA credited to the player's pass plays.
-  passer_player_name: Display name of the passer -- the FIRST participant in that role on the play.
-  pen_epa: EPA attributable to penalties on the player's plays.
-  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
-  qbr_epa: EPA variant used as an input to the QBR calculation.
-  rush_epa: EPA credited to the player's rush plays.
-  sack_epa: EPA credited to the player's sacks taken.
-  xComp: Expected completions, summed from the per-play completion model.
-  xCompPct: Expected completion percentage from the per-play completion model.
-load_cfb_adv_situational:
-  EPA_early_down: Total EPA the team generated on early downs.
-  EPA_early_down_pass: Total EPA the team generated on early downs on pass plays.
-  EPA_early_down_pass_per_play: EPA per play on early downs on pass plays.
-  EPA_early_down_per_play: EPA per play on early downs.
-  EPA_early_down_rush: Total EPA the team generated on early downs on rush plays.
-  EPA_early_down_rush_per_play: EPA per play on early downs on rush plays.
-  EPA_late_down: Total EPA the team generated on late downs.
-  EPA_late_down_per_play: EPA per play on late downs.
-  EPA_middle_8: Total EPA the team generated on the middle eight -- the closing minutes of the first half and opening minutes
-    of the second.
-  EPA_middle_8_pass: Total EPA the team generated on the middle eight -- the closing minutes of the first half and opening
-    minutes of the second on pass plays.
-  EPA_middle_8_pass_per_play: EPA per play on the middle eight -- the closing minutes of the first half and opening minutes
-    of the second on pass plays.
-  EPA_middle_8_per_play: EPA per play on the middle eight -- the closing minutes of the first half and opening minutes of
-    the second.
-  EPA_middle_8_rush: Total EPA the team generated on the middle eight -- the closing minutes of the first half and opening
-    minutes of the second on rush plays.
-  EPA_middle_8_rush_per_play: EPA per play on the middle eight -- the closing minutes of the first half and opening minutes
-    of the second on rush plays.
-  EPA_middle_8_success: Count of successful plays on the middle eight -- the closing minutes of the first half and opening
-    minutes of the second. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
-  EPA_middle_8_success_pass: Count of successful plays on the middle eight -- the closing minutes of the first half and opening
-    minutes of the second on pass plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
-  EPA_middle_8_success_pass_rate: Success rate on the middle eight -- the closing minutes of the first half and opening minutes
-    of the second on pass plays -- the share of those plays ESPN scored as successful.
-  EPA_middle_8_success_rate: Success rate on the middle eight -- the closing minutes of the first half and opening minutes
-    of the second -- the share of those plays ESPN scored as successful.
-  EPA_middle_8_success_rush: Count of successful plays on the middle eight -- the closing minutes of the first half and opening
-    minutes of the second on rush plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
-  EPA_middle_8_success_rush_rate: Success rate on the middle eight -- the closing minutes of the first half and opening minutes
-    of the second on rush plays -- the share of those plays ESPN scored as successful.
-  EPA_passing_down: Total EPA the team generated on passing downs (the team behind schedule for the series).
-  EPA_passing_down_per_play: EPA per play on passing downs (the team behind schedule for the series).
-  EPA_standard_down: Total EPA the team generated on standard downs (the team ahead of schedule for the series).
-  EPA_standard_down_per_play: EPA per play on standard downs (the team ahead of schedule for the series).
-  EPA_success: Count of successful plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
-  EPA_success_early_down: Count of successful plays on early downs. Despite the EPA_ prefix this is a play COUNT, not an EPA
-    total.
-  EPA_success_early_down_pass: Count of successful plays on early downs on pass plays. Despite the EPA_ prefix this is a play
-    COUNT, not an EPA total.
-  EPA_success_early_down_pass_rate: Success rate on early downs on pass plays -- the share of those plays ESPN scored as successful.
-  EPA_success_early_down_rate: Success rate on early downs -- the share of those plays ESPN scored as successful.
-  EPA_success_early_down_rush: Count of successful plays on early downs on rush plays. Despite the EPA_ prefix this is a play
-    COUNT, not an EPA total.
-  EPA_success_early_down_rush_rate: Success rate on early downs on rush plays -- the share of those plays ESPN scored as successful.
-  EPA_success_late_down: Count of successful plays on late downs. Despite the EPA_ prefix this is a play COUNT, not an EPA
-    total.
-  EPA_success_late_down_pass: Count of successful plays on late downs on pass plays. Despite the EPA_ prefix this is a play
-    COUNT, not an EPA total.
-  EPA_success_late_down_pass_rate: Success rate on late downs on pass plays -- the share of those plays ESPN scored as successful.
-  EPA_success_late_down_rate: Success rate on late downs -- the share of those plays ESPN scored as successful.
-  EPA_success_late_down_rush: Count of successful plays on late downs on rush plays. Despite the EPA_ prefix this is a play
-    COUNT, not an EPA total.
-  EPA_success_late_down_rush_rate: Success rate on late downs on rush plays -- the share of those plays ESPN scored as successful.
-  EPA_success_pass: Count of successful plays on pass plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
-  EPA_success_pass_rate: Success rate on pass plays -- the share of those plays ESPN scored as successful.
-  EPA_success_passing_down: Count of successful plays on passing downs (the team behind schedule for the series). Despite
-    the EPA_ prefix this is a play COUNT, not an EPA total.
-  EPA_success_passing_down_rate: Success rate on passing downs (the team behind schedule for the series) -- the share of those
-    plays ESPN scored as successful.
-  EPA_success_rate: Success rate -- the share of those plays ESPN scored as successful.
-  EPA_success_rate_rz: Success rate on the red zone -- the share of those plays ESPN scored as successful.
-  EPA_success_rate_third: Success rate on third down -- the share of those plays ESPN scored as successful.
-  EPA_success_rush: Count of successful plays on rush plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
-  EPA_success_rush_rate: Success rate on rush plays -- the share of those plays ESPN scored as successful.
-  EPA_success_rz: Count of successful plays on the red zone. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
-  EPA_success_standard_down: Count of successful plays on standard downs (the team ahead of schedule for the series). Despite
-    the EPA_ prefix this is a play COUNT, not an EPA total.
-  EPA_success_standard_down_rate: Success rate on standard downs (the team ahead of schedule for the series) -- the share
-    of those plays ESPN scored as successful.
-  EPA_success_third: Count of successful plays on third down. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
-  early_down_first_down: Number of early-down plays that produced a first down.
-  early_down_first_down_rate: Share of early-down plays that produced a first down.
-  early_down_pass: Number of pass plays the team ran on early downs.
-  early_down_pass_rate: Share of the team's plays on early downs that were pass plays.
-  early_down_rush: Number of rush plays the team ran on early downs.
-  early_down_rush_rate: Share of the team's plays on early downs that were rush plays.
-  early_downs: Number of plays the team ran on early downs.
-  late_down_pass: Number of pass plays the team ran on late downs.
-  late_down_pass_rate: Share of the team's plays on late downs that were pass plays.
-  late_down_rush: Number of rush plays the team ran on late downs.
-  late_down_rush_rate: Share of the team's plays on late downs that were rush plays.
-  late_downs: Number of plays the team ran on late downs.
-  middle_8: Number of plays the team ran in the middle eight -- the closing minutes of the first half and opening minutes
-    of the second.
-  middle_8_pass: Number of pass plays the team ran on the middle eight -- the closing minutes of the first half and opening
-    minutes of the second.
-  middle_8_pass_rate: Share of the team's plays on the middle eight -- the closing minutes of the first half and opening minutes
-    of the second that were pass plays.
-  middle_8_rush: Number of rush plays the team ran on the middle eight -- the closing minutes of the first half and opening
-    minutes of the second.
-  middle_8_rush_rate: Share of the team's plays on the middle eight -- the closing minutes of the first half and opening minutes
-    of the second that were rush plays.
-  passing_downs: Number of plays the team ran on passing downs (the team behind schedule for the series).
-  pos_team: Display name of the team on offense (e.g. 'Ohio State Buckeyes').
-  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
-  standard_downs: Number of plays the team ran on standard downs (the team ahead of schedule for the series).
-load_cfb_adv_team:
-  EPA_explosive: Count of explosive plays, per ESPN's advanced box score. Despite the EPA_ prefix this is a play COUNT, not
-    an EPA total.
-  EPA_explosive_passing: Count of explosive pass plays. A play count, not an EPA total.
-  EPA_explosive_passing_rate: Explosive-play rate on pass plays, over ESPN's qualifying-play denominator.
-  EPA_explosive_rate: Explosive-play rate. Note this is NOT EPA_explosive divided by EPA_plays -- ESPN divides by its own
-    smaller qualifying-play count, so deriving it yourself will not reproduce this value.
-  EPA_explosive_rushing: Count of explosive rush plays. A play count, not an EPA total.
-  EPA_explosive_rushing_rate: Explosive-play rate on rush plays, over ESPN's qualifying-play denominator.
-  EPA_fg: Total EPA on field-goal attempts.
-  EPA_kickoff: Total EPA on kickoff plays.
-  EPA_non_explosive: Total EPA with explosive plays excluded, isolating the team's routine-down production.
-  EPA_non_explosive_passing: Total EPA on pass plays with explosive plays excluded.
-  EPA_non_explosive_passing_per_play: EPA per pass play with explosive plays excluded.
-  EPA_non_explosive_per_play: EPA per play with explosive plays excluded.
-  EPA_non_explosive_rushing: Total EPA on rush plays with explosive plays excluded.
-  EPA_non_explosive_rushing_per_play: EPA per rush play with explosive plays excluded.
-  EPA_overall_off: Total offensive EPA for the team. Duplicated exactly by EPA_overall_offense in every published season checked
-    -- prefer one and ignore the other.
-  EPA_overall_offense: Total offensive EPA. An exact duplicate of EPA_overall_off.
-  EPA_overall_total: Total EPA across all phases, which is why it differs from the offense-only EPA_overall_off.
-  EPA_passing_overall: Total EPA on pass plays.
-  EPA_passing_per_play: EPA per pass play.
-  EPA_penalty: Total EPA attributed to penalties.
-  EPA_per_play: Offensive EPA per play.
-  EPA_plays: Number of plays ESPN's advanced box score scored for the team.
-  EPA_punt: Total EPA on punt plays.
-  EPA_rushing_overall: Total EPA on rush plays.
-  EPA_rushing_per_play: EPA per rush play.
-  EPA_rushing_power: Total EPA on power rushing situations, as classified by ESPN's advanced box score.
-  EPA_rushing_power_per_play: EPA per play on power rushing situations.
-  EPA_sp: Total special-teams EPA, ESPN's abbreviated field for the same phase.
-  EPA_special_teams: Total EPA generated on special-teams plays.
-  field_goals: Number of field-goal attempts.
-  first_downs_created: Number of first downs the team created.
-  first_downs_created_rate: Share of the team's plays that created a first down.
-  kickoff_plays: Number of kickoff plays.
-  line_yards: Line yards -- the portion of rushing yardage credited to the offensive line under the standard rushing decomposition.
-    ESPN applies its own qualifying threshold for the yardage split.
-  line_yards_per_carry: Line yards per rushing attempt.
-  off_yards: Offensive yards gained from scrimmage.
-  open_field_yards: Open-field yards -- rushing yardage earned well downfield, past the second level.
-  passes_rate: Share of the team's plays from scrimmage that were pass plays.
-  passing_first_downs_created: Number of first downs created on pass plays.
-  passing_first_downs_created_rate: Share of pass plays that created a first down.
-  penalty_first_downs_created: Number of first downs the team gained via opponent penalty.
-  penalty_first_downs_created_rate: Share of the team's first downs that came via opponent penalty.
-  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
-  punt_plays: Number of punt plays.
-  rushes: Number of rushing attempts.
-  rushes_rate: Share of the team's plays from scrimmage that were rush plays.
-  rushing_first_downs_created: Number of first downs created on rush plays.
-  rushing_first_downs_created_rate: Share of rush plays that created a first down.
-  rushing_highlight: Highlight yards -- rushing yardage credited to the back rather than the offensive line.
-  rushing_highlight_rate: Share of rushing yardage that was highlight (back-credited) yardage.
-  rushing_highlight_yards_per_opp: Highlight yards per rushing opportunity.
-  rushing_opportunity: Count of rushing opportunities -- carries that reached ESPN's opportunity threshold.
-  rushing_opportunity_rate: Share of carries that qualified as rushing opportunities.
-  rushing_power: Count of power rushing attempts, in short-yardage situations as classified by ESPN's advanced box score.
-  rushing_power_rate: Share of carries that were power rushing attempts.
-  rushing_power_success_rate: Share of power rushing attempts that succeeded.
-  rushing_stopped: Count of rushing attempts stopped at or behind the line of scrimmage.
-  rushing_stopped_rate: Share of carries stopped at or behind the line of scrimmage.
-  rushing_stuff: Count of stuffed rushing attempts.
-  scrimmage_plays: Number of plays from scrimmage (rushes plus passes), excluding special teams.
-  second_level_yards: Second-level yards -- rushing yardage earned just beyond the line of scrimmage.
-  special_teams_plays: Number of special-teams plays.
-  total_off_yards: Total offensive yards across all plays.
-  total_pen_yards: Total penalty yards assessed.
-  yards_per_play: Yards gained per play.
-  yards_per_rush: Yards gained per rushing attempt.
-load_cfb_passing:
-  EPAgame: EPA generated per game.
-  EPAgame_rank: National rank of the team's EPA generated per game, where 1 is best.
-  EPAplay: EPA generated per play.
-  EPAplay_rank: National rank of the team's EPA generated per play, where 1 is best.
-  TEPA: Total EPA summed over every play.
-  TEPA_rank: National rank of the team's total EPA summed over every play, where 1 is best.
-  att: Pass attempts thrown.
-  comp: Completed passes.
-  comppct: Completion percentage.
-  comppct_rank: National rank of the team's completion percentage, where 1 is best.
-  detmer: Detmer rating -- the composite passing-efficiency measure this pipeline publishes, named for the college passing-efficiency
-    tradition.
-  detmer_rank: National rank of the team's detmer rating -- the composite passing-efficiency measure this pipeline publishes,
-    named for the college passing-efficiency tradition, where 1 is best.
-  detmergame: Detmer rating expressed per game.
-  detmergame_rank: National rank of the team's detmer rating expressed per game, where 1 is best.
-  dropbacks: Dropbacks taken by the passer.
-  fbs_class: 'Power/Group classification for the season: P4 or G6 from 2024 on, P5 or G5 through 2023, derived from conference
-    membership. Null for teams outside FBS.'
-  pass_int: Interceptions thrown.
-  passer_player_name: Display name of the passer -- the FIRST participant in that role on the play.
-  playsgame: Plays per game.
-  sack_adj_yards: Passing yards adjusted for sack yardage lost.
-  sack_adj_yards_rank: National rank of the team's passing yards adjusted for sack yardage lost, where 1 is best.
-  sack_yds: Yards lost to sacks.
-  sacked: Times the passer was sacked.
-  success: Success rate across the team plays.
-  success_rank: National rank of the team's success rate across the team plays, where 1 is best.
-  team_games: Games the team played, used as the per-game denominator.
-  yards_rank: National rank of the team's total yards, where 1 is best.
-  yardsdropback: Yards per dropback.
-  yardsdropback_rank: National rank of the team's yards per dropback, where 1 is best.
-  yardsgame: Yards per game.
-  yardsgame_rank: National rank of the team's yards per game, where 1 is best.
-  yardsplay: Yards per play.
-  yardsplay_rank: National rank of the team's yards per play, where 1 is best.
-load_cfb_percentiles:
-  EPAdropback: Value of EPA generated per dropback at the percentile this row reports.
-  EPAplay: Value of EPA generated per play at the percentile this row reports.
-  EPArush: Value of EPA generated per rushing attempt at the percentile this row reports.
-  GEI: Value of game excitement index at the percentile this row reports.
-  dropbacks: Value of dropbacks taken by the passer at the percentile this row reports.
-  early_down_EPA: Value of EPA per early-down play at the percentile this row reports.
-  early_down_success: Value of success rate on early downs at the percentile this row reports.
-  explosive: Value of explosive-play rate at the percentile this row reports.
-  havoc: Value of havoc rate at the percentile this row reports.
-  late_down_success: Value of success rate on late downs at the percentile this row reports.
-  lineyards: Value of line yards per rush at the percentile this row reports.
-  nonExplosiveEpaPerPlay: Value of EPA per play excluding explosive plays at the percentile this row reports.
-  opportunity_run: Value of opportunity-run rate at the percentile this row reports.
-  pass_explosive: Value of explosive-play rate on pass plays at the percentile this row reports.
-  pass_success: Value of success rate on pass plays at the percentile this row reports.
-  pctile: Percentile bucket the row reports, from 0 to 100.
-  play_stuffed: Value of stuffed-play rate at the percentile this row reports.
-  red_zone_success: Value of success rate in the red zone at the percentile this row reports.
-  rush_explosive: Value of explosive-play rate on rush plays at the percentile this row reports.
-  rush_success: Value of success rate on rush plays at the percentile this row reports.
-  rushes: Value of rushing attempts at the percentile this row reports.
-  success: Value of success rate across the team plays at the percentile this row reports.
-  third_down_distance: Value of average yards to go on third down at the percentile this row reports.
-  third_down_success: Value of success rate on third down at the percentile this row reports.
-  yardsdropback: Value of yards per dropback at the percentile this row reports.
-  yardsplay: Value of yards per play at the percentile this row reports.
-  yardsrush: Value of yards per rush at the percentile this row reports.
-load_cfb_play_participants:
-  assisted_by_player_id: ESPN athlete id of a defender credited with an assisted tackle -- the FIRST participant in that role
-    on the play.
-  assisted_by_player_ids: List of the athlete ids of EVERY participant credited as a defender credited with an assisted tackle
-    on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  assisted_by_player_name: Display name of a defender credited with an assisted tackle -- the FIRST participant in that role
-    on the play.
-  assisted_by_player_names: List of the display names of EVERY participant credited as a defender credited with an assisted
-    tackle on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  forced_by_player_id: ESPN athlete id of the defender who forced the fumble -- the FIRST participant in that role on the
-    play.
-  forced_by_player_ids: List of the athlete ids of EVERY participant credited as the defender who forced the fumble on the
-    play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  forced_by_player_name: Display name of the defender who forced the fumble -- the FIRST participant in that role on the play.
-  forced_by_player_names: List of the display names of EVERY participant credited as the defender who forced the fumble on
-    the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  kicker_player_id: ESPN athlete id of the kicker -- the FIRST participant in that role on the play.
-  kicker_player_ids: List of the athlete ids of EVERY participant credited as the kicker on the play, so multi-entry roles
-    such as split sacks or gang tackles are not collapsed to one.
-  kicker_player_name: Display name of the kicker -- the FIRST participant in that role on the play.
-  kicker_player_names: List of the display names of EVERY participant credited as the kicker on the play, so multi-entry roles
-    such as split sacks or gang tackles are not collapsed to one.
-  pass_defender_player_id: ESPN athlete id of the defender credited with defending the pass -- the FIRST participant in that
-    role on the play.
-  pass_defender_player_ids: List of the athlete ids of EVERY participant credited as the defender credited with defending
-    the pass on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  pass_defender_player_name: Display name of the defender credited with defending the pass -- the FIRST participant in that
-    role on the play.
-  pass_defender_player_names: List of the display names of EVERY participant credited as the defender credited with defending
-    the pass on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  passer_player_id: ESPN athlete id of the passer -- the FIRST participant in that role on the play.
-  passer_player_ids: List of the athlete ids of EVERY participant credited as the passer on the play, so multi-entry roles
-    such as split sacks or gang tackles are not collapsed to one.
-  passer_player_name: Display name of the passer -- the FIRST participant in that role on the play.
-  passer_player_names: List of the display names of EVERY participant credited as the passer on the play, so multi-entry roles
-    such as split sacks or gang tackles are not collapsed to one.
-  pat_passer_player_id: ESPN athlete id of the passer on the point-after attempt -- the FIRST participant in that role on
-    the play.
-  pat_passer_player_ids: List of the athlete ids of EVERY participant credited as the passer on the point-after attempt on
-    the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  pat_passer_player_name: Display name of the passer on the point-after attempt -- the FIRST participant in that role on the
-    play.
-  pat_passer_player_names: List of the display names of EVERY participant credited as the passer on the point-after attempt
-    on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  pat_scorer_player_id: ESPN athlete id of the player credited with the point-after score -- the FIRST participant in that
-    role on the play.
-  pat_scorer_player_ids: List of the athlete ids of EVERY participant credited as the player credited with the point-after
-    score on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  pat_scorer_player_name: Display name of the player credited with the point-after score -- the FIRST participant in that
-    role on the play.
-  pat_scorer_player_names: List of the display names of EVERY participant credited as the player credited with the point-after
-    score on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  penalized_player_id: ESPN athlete id of the penalized player -- the FIRST participant in that role on the play.
-  penalized_player_ids: List of the athlete ids of EVERY participant credited as the penalized player on the play, so multi-entry
-    roles such as split sacks or gang tackles are not collapsed to one.
-  penalized_player_name: Display name of the penalized player -- the FIRST participant in that role on the play.
-  penalized_player_names: List of the display names of EVERY participant credited as the penalized player on the play, so
-    multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  punter_player_id: ESPN athlete id of the punter -- the FIRST participant in that role on the play.
-  punter_player_ids: List of the athlete ids of EVERY participant credited as the punter on the play, so multi-entry roles
-    such as split sacks or gang tackles are not collapsed to one.
-  punter_player_name: Display name of the punter -- the FIRST participant in that role on the play.
-  punter_player_names: List of the display names of EVERY participant credited as the punter on the play, so multi-entry roles
-    such as split sacks or gang tackles are not collapsed to one.
-  receiver_player_id: ESPN athlete id of the targeted receiver -- the FIRST participant in that role on the play.
-  receiver_player_ids: List of the athlete ids of EVERY participant credited as the targeted receiver on the play, so multi-entry
-    roles such as split sacks or gang tackles are not collapsed to one.
-  receiver_player_name: Display name of the targeted receiver -- the FIRST participant in that role on the play.
-  receiver_player_names: List of the display names of EVERY participant credited as the targeted receiver on the play, so
-    multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  recoverer_player_id: ESPN athlete id of the player who recovered the fumble -- the FIRST participant in that role on the
-    play.
-  recoverer_player_ids: List of the athlete ids of EVERY participant credited as the player who recovered the fumble on the
-    play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  recoverer_player_name: Display name of the player who recovered the fumble -- the FIRST participant in that role on the
-    play.
-  recoverer_player_names: List of the display names of EVERY participant credited as the player who recovered the fumble on
-    the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  returner_player_id: ESPN athlete id of the player returning the kick or punt -- the FIRST participant in that role on the
-    play.
-  returner_player_ids: List of the athlete ids of EVERY participant credited as the player returning the kick or punt on the
-    play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  returner_player_name: Display name of the player returning the kick or punt -- the FIRST participant in that role on the
-    play.
-  returner_player_names: List of the display names of EVERY participant credited as the player returning the kick or punt
-    on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  rusher_player_id: ESPN athlete id of the ball carrier on a rush -- the FIRST participant in that role on the play.
-  rusher_player_ids: List of the athlete ids of EVERY participant credited as the ball carrier on a rush on the play, so multi-entry
-    roles such as split sacks or gang tackles are not collapsed to one.
-  rusher_player_name: Display name of the ball carrier on a rush -- the FIRST participant in that role on the play.
-  rusher_player_names: List of the display names of EVERY participant credited as the ball carrier on a rush on the play,
-    so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  sacked_by_player_id: ESPN athlete id of a defender credited with the sack -- the FIRST participant in that role on the play.
-  sacked_by_player_ids: List of the athlete ids of EVERY participant credited as a defender credited with the sack on the
-    play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  sacked_by_player_name: Display name of a defender credited with the sack -- the FIRST participant in that role on the play.
-  sacked_by_player_names: List of the display names of EVERY participant credited as a defender credited with the sack on
-    the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  scorer_player_id: ESPN athlete id of the player credited with the score -- the FIRST participant in that role on the play.
-  scorer_player_ids: List of the athlete ids of EVERY participant credited as the player credited with the score on the play,
-    so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  scorer_player_name: Display name of the player credited with the score -- the FIRST participant in that role on the play.
-  scorer_player_names: List of the display names of EVERY participant credited as the player credited with the score on the
-    play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  tackler_player_id: ESPN athlete id of a defender credited with the tackle -- the FIRST participant in that role on the play.
-  tackler_player_ids: List of the athlete ids of EVERY participant credited as a defender credited with the tackle on the
-    play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-  tackler_player_name: Display name of a defender credited with the tackle -- the FIRST participant in that role on the play.
-  tackler_player_names: List of the display names of EVERY participant credited as a defender credited with the tackle on
-    the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
-load_cfb_adv_defensive:
-  TFL: Count of scrimmage plays the defense held to negative yardage (non-penalty, non-special-teams, ESPN statYardage below
-    zero) plus every sack.
-  TFL_pass: The TFL count restricted to plays classified as passes, so it covers sacks together with completions and laterals
-    stopped behind the line.
-  TFL_rush: The TFL count restricted to plays classified as rushes, that is rushing attempts the defense stopped for negative
-    yardage.
-  def_int: Interceptions the defense recorded, counted from plays ESPN types as Interception Return or Interception Return
-    Touchdown.
-  drive_stopped_rate: Percentage from 0 to 100 of the defense's scrimmage plays that occurred on drives ending in a punt,
-    fumble, interception, or turnover on downs; the denominator is plays, not drives.
-  fumbles: Fumbles the defense forced, counted from plays whose narrative contains the phrase forced by, not the total number
-    of fumbles on the play.
-  havoc_total_pass: Havoc events (tackle for loss, sack, interception, forced fumble, or pass breakup) recorded on the pass
-    plays the defense faced.
-  havoc_total_pass_rate: havoc_total_pass divided by num_pass_plays, the defense's havoc rate against the pass as a 0-to-1
-    fraction.
-  havoc_total_rate: Share of the defense's scrimmage plays producing a havoc event, a 0-to-1 fraction equal to havoc_total
-    divided by scrimmage_plays.
-  havoc_total_rush: Havoc events recorded on the rush plays the defense faced, in practice tackles for loss and forced fumbles.
-  havoc_total_rush_rate: Havoc events per rush play faced, the mean of the havoc flag over the defense's rush scrimmage plays.
-  num_pass_plays: Number of pass scrimmage plays the defense faced, the denominator behind havoc_total_pass_rate and sacks_rate.
-  pass_breakups: Passes the defense broke up, counted from plays whose narrative contains the phrase broken up by.
-  sacks_rate: Sacks divided by pass plays faced, the defense's per-pass-play sack rate as a 0-to-1 fraction.
-  scrimmage_plays: Number of plays from scrimmage (rushes plus passes), excluding special teams.
-load_cfb_adv_drives:
-  avg_field_position: Mean distance to the opponent end zone at drive start averaged over the team's scrimmage plays, exactly
-    drive_total_available_yards divided by that play count.
-  drive_total_available_yards: Sum of each drive's starting distance to the opponent end zone taken across every scrimmage
-    play, so a drive contributes its available yards once per play rather than once per drive.
-  drive_total_gained_yards: Sum of ESPN's per-drive yardage repeated across every scrimmage play of that drive, so a drive
-    contributes its yardage once per play.
-  drive_total_gained_yards_rate: Available-yards conversion as a percentage, 100 times drive_total_gained_yards over drive_total_available_yards
-    with both sums play-weighted.
-  drives: Number of distinct ESPN drive ids on which the team ran at least one scrimmage play.
-  plays_per_drive: Mean of ESPN's per-drive offensivePlays taken over plays rather than over drives, which weights every drive
-    by its own length.
-  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
-  yards_per_drive: Mean of ESPN's per-drive yardage taken over plays rather than over drives, exactly drive_total_gained_yards
-    divided by the team's scrimmage-play count.
-load_cfb_adv_receiving:
-  EPA_per_Play: EPA per play on the passer's plays.
-  Fum: Count of the receiver's targeted pass plays whose text mentions a fumble; it is a play-level flag, not a fumble charged
-    to this player.
-  Fum_Lost: Count of the receiver's targeted plays on which a fumble was lost to the opponent.
-  Rec: Receptions credited to the receiver, the number of completions on plays where this player was the targeted receiver.
-  Rec_TD: Receiving touchdowns, the count of the player's targeted plays that ended in a passing touchdown.
-  SR: Success rate on the passer's plays.
-  Tar: Times the player was targeted on a pass attempt, the denominator behind YPT.
-  YPT: Receiving yards per target, the mean of receiving yardage over every target rather than over receptions only.
-  Yds: Passing yards from the advanced box score.
-  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
-  receiver_player_name: Display name of the targeted receiver -- the FIRST participant in that role on the play.
-load_cfb_adv_rushing:
-  Car: Rushing attempts credited to this ball carrier in the game.
-  EPA_per_Play: EPA per play on the passer's plays.
-  Fum: Count of the carrier's rush attempts whose play text mentions a fumble; it is a play-level flag, not a fumble charged
-    to this player.
-  Fum_Lost: Count of the carrier's rush attempts on which a fumble was lost to the opponent.
-  Rush_TD: Rushing touchdowns scored by this ball carrier in the game.
-  SR: Success rate on the passer's plays.
-  YPC: Yards per carry, the mean rushing yardage across the player's attempts in the game.
-  Yds: Passing yards from the advanced box score.
-  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
-  rusher_player_name: Display name of the ball carrier on a rush -- the FIRST participant in that role on the play.
-load_cfb_adv_specialists:
-  field_goals: Number of field-goal attempts.
-  field_goals_yards: Sum of the field-goal attempt distances parsed out of the play text; it stays at zero when no distance
-    could be parsed from the narrative.
-  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
-  punt_returns_yards: Total punt-return yardage credited to this returner, with fair catches, downed punts, and out-of-bounds
-    punts scored as zero.
-  punts: Punts attempted.
-  punts_yards: Total gross punt yardage parsed from the play text for this punter, working out to roughly 42 yards per punt
-    league-wide.
-load_cfb_adv_team_gamelog:
-  EPA_explosive: Count of explosive plays, per ESPN's advanced box score. Despite the EPA_ prefix this is a play COUNT, not
-    an EPA total.
-  EPA_explosive_passing: Count of explosive pass plays. A play count, not an EPA total.
-  EPA_explosive_passing_rate: Explosive-play rate on pass plays, over ESPN's qualifying-play denominator.
-  EPA_explosive_rate: Explosive-play rate. Note this is NOT EPA_explosive divided by EPA_plays -- ESPN divides by its own
-    smaller qualifying-play count, so deriving it yourself will not reproduce this value.
-  EPA_explosive_rushing: Count of explosive rush plays. A play count, not an EPA total.
-  EPA_explosive_rushing_rate: Explosive-play rate on rush plays, over ESPN's qualifying-play denominator.
-  EPA_fg: Total EPA on field-goal attempts.
-  EPA_kickoff: Total EPA on kickoff plays.
-  EPA_non_explosive: Total EPA with explosive plays excluded, isolating the team's routine-down production.
-  EPA_non_explosive_passing: Total EPA on pass plays with explosive plays excluded.
-  EPA_non_explosive_passing_per_play: EPA per pass play with explosive plays excluded.
-  EPA_non_explosive_per_play: EPA per play with explosive plays excluded.
-  EPA_non_explosive_rushing: Total EPA on rush plays with explosive plays excluded.
-  EPA_non_explosive_rushing_per_play: EPA per rush play with explosive plays excluded.
-  EPA_overall_off: Total offensive EPA for the team. Duplicated exactly by EPA_overall_offense in every published season checked
-    -- prefer one and ignore the other.
-  EPA_overall_offense: Total offensive EPA. An exact duplicate of EPA_overall_off.
-  EPA_overall_total: Total EPA across all phases, which is why it differs from the offense-only EPA_overall_off.
-  EPA_passing_overall: Total EPA on pass plays.
-  EPA_passing_per_play: EPA per pass play.
-  EPA_penalty: Total EPA attributed to penalties.
-  EPA_per_play: Offensive EPA per play.
-  EPA_plays: Number of plays ESPN's advanced box score scored for the team.
-  EPA_punt: Total EPA on punt plays.
-  EPA_rushing_overall: Total EPA on rush plays.
-  EPA_rushing_per_play: EPA per rush play.
-  EPA_rushing_power: Total EPA on power rushing situations, as classified by ESPN's advanced box score.
-  EPA_rushing_power_per_play: EPA per play on power rushing situations.
-  EPA_sp: Total special-teams EPA, ESPN's abbreviated field for the same phase.
-  EPA_special_teams: Total EPA generated on special-teams plays.
-  field_goals: Number of field-goal attempts.
-  first_downs_created: Number of first downs the team created.
-  first_downs_created_rate: Share of the team's plays that created a first down.
-  kickoff_plays: Number of kickoff plays.
-  line_yards: Line yards -- the portion of rushing yardage credited to the offensive line under the standard rushing decomposition.
-    ESPN applies its own qualifying threshold for the yardage split.
-  line_yards_per_carry: Line yards per rushing attempt.
-  margin: Final scoring margin from this team's perspective, exactly points_for minus points_against.
-  off_yards: Offensive yards gained from scrimmage.
-  open_field_yards: Open-field yards -- rushing yardage earned well downfield, past the second level.
-  passes_rate: Share of the team's plays from scrimmage that were pass plays.
-  passing_first_downs_created: Number of first downs created on pass plays.
-  passing_first_downs_created_rate: Share of pass plays that created a first down.
-  penalty_first_downs_created: Number of first downs the team gained via opponent penalty.
-  penalty_first_downs_created_rate: Share of the team's first downs that came via opponent penalty.
-  punt_plays: Number of punt plays.
-  rushes: Number of rushing attempts.
-  rushes_rate: Share of the team's plays from scrimmage that were rush plays.
-  rushing_first_downs_created: Number of first downs created on rush plays.
-  rushing_first_downs_created_rate: Share of rush plays that created a first down.
-  rushing_highlight: Highlight yards -- rushing yardage credited to the back rather than the offensive line.
-  rushing_highlight_rate: Share of rushing yardage that was highlight (back-credited) yardage.
-  rushing_highlight_yards_per_opp: Highlight yards per rushing opportunity.
-  rushing_opportunity: Count of rushing opportunities -- carries that reached ESPN's opportunity threshold.
-  rushing_opportunity_rate: Share of carries that qualified as rushing opportunities.
-  rushing_power: Count of power rushing attempts, in short-yardage situations as classified by ESPN's advanced box score.
-  rushing_power_rate: Share of carries that were power rushing attempts.
-  rushing_power_success_rate: Share of power rushing attempts that succeeded.
-  rushing_stopped: Count of rushing attempts stopped at or behind the line of scrimmage.
-  rushing_stopped_rate: Share of carries stopped at or behind the line of scrimmage.
-  rushing_stuff: Count of stuffed rushing attempts.
-  scrimmage_plays: Number of plays from scrimmage (rushes plus passes), excluding special teams.
-  second_level_yards: Second-level yards -- rushing yardage earned just beyond the line of scrimmage.
-  special_teams_plays: Number of special-teams plays.
-  total_off_yards: Total offensive yards across all plays.
-  total_pen_yards: Total penalty yards assessed.
-  yards_per_play: Yards gained per play.
-  yards_per_rush: Yards gained per rushing attempt.
-load_cfb_adv_turnover:
-  Int: Interceptions thrown.
-  Int_pbp: Interception count derived from the play-by-play, kept alongside the ESPN-sourced Int for reconciliation.
-  expected_turnover_margin: The opponent's expected_turnovers minus this team's, so positive means the team was expected to
-    win the turnover battle.
-  expected_turnovers: Turnover expectation for this team, computed as half its total fumbles plus 0.22 times the sum of its
-    pass breakups and interceptions.
-  fumble_recoveries_gained: Opponent fumbles this team recovered, taken as the opponent's fumbles_lost.
-  fumbles_lost_pbp: Fumbles-lost count derived from the play-by-play, kept alongside the ESPN-sourced fumbles_lost for reconciliation.
-  pass_breakups: Passes thrown by this offense that the opposing defense broke up; it equals the opponent's row in the advanced
-    defensive table exactly.
-  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
-  st_turnovers_gained: Special-teams turnovers this team recovered, taken as the opponent's st_turnovers_lost.
-  turnover_luck: Points of scoring luck attributed to turnovers, five points per turnover times the gap between turnover_margin
-    and expected_turnover_margin.
-  turnover_margin: The opponent's turnovers minus this team's turnovers, positive when the team gained more possessions than
-    it gave away.
-  turnovers_pbp: Turnover count derived from the play-by-play, retained unchanged so it can be reconciled against the ESPN-sourced
-    turnovers total.
-load_cfb_drives:
-  n_plays: Number of entries in ESPN's raw plays array for the drive, which is generally at least offensive_plays because
-    it also counts penalties and other non-offensive snaps.
-load_cfb_game_rosters:
-  athlete_href: ESPN Core v2 API reference URL for the athlete's season record, ending in the athlete id.
-  birth_country_alternate_id: ESPN's internal alternate identifier for the athlete's birth country, paired with birth_place_country
-    and the flag fields.
-  flag_alt: Alt text ESPN attaches to the birth-country flag image, which is the country's name spelled out.
-  flag_href: URL of the birth-country flag image hosted on ESPN's CDN under teamlogos/countries.
-  flag_rel: Stringified relationship list ESPN ships with the flag image; the only non-null value observed is a single country-flag
-    entry.
-  position_href: ESPN Core v2 API reference URL for the position resource ESPN lists the athlete at.
-  statistics_href: ESPN Core v2 API reference URL for this athlete's stat line in this game, null for the roughly 71 percent
-    of listed players who recorded no stats.
-  team_alternate_ids_sdr: The team's Sportradar alternate identifier, which maps one-to-one with team_id.
-load_cfb_model_pbp:
-  awayTeamId: ESPN team id of the away team, read off the game header and stamped on every play.
-  awayTeamName: Away team's school name from ESPN's team location field, without the mascot.
-  completion_prob: Modelled probability the pass is completed.
-  cp_model_version: Version of the completion-probability model that scored the play.
-  drive.id: ESPN's drive identifier, formed as the game id followed by the drive's sequence number within that game.
-  ep_model_version: Version of the expected-points model that scored the play.
-  homeTeamId: ESPN team id of the home team, read off the game header and stamped on every play.
-  homeTeamName: Home team's school name from ESPN's team location field, without the mascot.
-  model_pbp_version: Version of the model-scored play-by-play build.
-  passer_player_name: Display name of the passer -- the FIRST participant in that role on the play.
-  passing_down: True on second and eight or longer, third and five or longer, or fourth and five or longer, the standard obvious-passing-situation
-    flag.
-  scored_date: Date on which the play was scored by the models.
-  start.TimeSecsRem: Seconds remaining in the half at the snap, so it tops out at 1800 rather than counting down from a full
-    game.
-  start.distance: Yards the offense needs for a first down at the snap, carried through from ESPN without correction.
-  start.down: Down at the snap as ESPN reports it; 0 marks the small share of rows ESPN leaves without a down, overwhelmingly
-    timeouts and penalty administrations.
-  start.is_home: True when the team holding possession at the snap is the home team.
-  start.pos_team.name: School name of the team with possession at the snap, taken from ESPN's team location field so it carries
-    no mascot.
-  start.yardsToEndzone: Distance in yards from the offense's spot at the snap to the opponent's end zone, ranging 0 to 100.
-  statYardage: Yards gained on the play as ESPN reports it, negative on plays that lost yardage.
-  type.text: ESPN's play-type label, for example Rush, Pass Reception, Sack, Punt, Penalty, or Timeout.
-  wp_model_version: Version of the win-probability model that scored the play.
-load_cfb_player_box:
-  adjQBR: Adjusted Total QBR for the quarterback.
-  completions/passingAttempts: Completions and pass attempts, as ESPN's combined string.
-  extraPointsMade/extraPointAttempts: Extra points made and attempted, as ESPN's combined string.
-  fieldGoalPct: Field-goal percentage.
-  fieldGoalsMade/fieldGoalAttempts: Field goals made and attempted, as ESPN's combined string.
-  grossAvgPuntYards: Gross average yards per punt, before return yardage.
-  interceptionTouchdowns: Touchdowns scored on interception returns.
-  interceptionYards: Yards returned on interceptions.
-  longFieldGoalMade: Longest field goal made, in yards.
-  longPunt: Longest punt of the game, in yards.
-  longPuntReturn: Longest punt return of the game, in yards.
-  longReception: Longest reception of the game, in yards.
-  longRushing: Longest rush of the game, in yards.
-  passingTouchdowns: Passing touchdowns.
-  passingYards: Net passing yards gained.
-  puntReturnTouchdowns: Touchdowns scored on punt returns.
-  puntReturnYards: Yards gained on punt returns.
-  puntReturns: Punt returns attempted.
-  puntYards: Total punt yards.
-  punts: Punts attempted.
-  puntsInside20: Punts downed inside the opponent 20-yard line.
-  receivingTouchdowns: Receiving touchdowns.
-  receivingYards: Receiving yards gained.
-  rushingAttempts: Rushing attempts.
-  rushingTouchdowns: Rushing touchdowns.
-  rushingYards: Net rushing yards gained.
-  stat_1: First value of ESPN's raw athlete stats array, written only when the category's key list does not line up with the
-    stats list; on those rows the named per-category columns are all null.
-  stat_2: Second value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and
-    the named columns could not be filled.
-  stat_3: Third value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and
-    the named columns could not be filled.
-  stat_4: Fourth value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and
-    the named columns could not be filled.
-  stat_5: Fifth value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and
-    the named columns could not be filled.
-  totalKickingPoints: Total points scored by kicking.
-  touchbacks: Punts or kickoffs that resulted in a touchback.
-  yardsPerPassAttempt: Yards gained per pass attempt.
-  yardsPerPuntReturn: Yards gained per punt return.
-  yardsPerReception: Yards gained per reception.
-  yardsPerRushAttempt: Yards gained per rushing attempt.
-load_cfb_power_index:
-  $ref: ESPN Core v2 API URL for one team's FPI projection on this game; the published asset carries only these links, not
-    the resolved projection numbers.
-load_cfb_ratings:
-  adj_def_epa: Opponent-adjusted EPA per play allowed, netted the same way as the offensive rating, so lower is better because
-    it measures EPA surrendered.
-  adj_net: adj_off_epa minus adj_def_epa, the team's overall efficiency rating in EPA per play; special teams is deliberately
-    excluded.
-  adj_off_epa: 'Opponent-adjusted offensive EPA per play: the team''s raw per-game EPA on pass and rush plays net of each
-    opponent''s ridge-fitted defensive strength, averaged over its games.'
-  adj_st_epa: 'Special-teams composite in EPA units: per-play mean EPA on field goals, punts, and kick returns, each centered
-    on that unit''s league mean and summed across the three units.'
-  def_rank: Dense rank of adj_def_epa in ascending order, so rank 1 is the season's stingiest defense.
-  fei_def: Drive-level defensive rating from the same per-drive ridge fit, on the same scale as fei_off.
-  fei_net: fei_off minus fei_def, the team's overall drive-efficiency rating, with the ridge's dropped reference team pinned
-    at zero.
-  fei_off: Drive-level offensive rating from a ridge fit on per-drive EPA, the Fremeau-style drive-efficiency counterpart
-    to adj_off_epa.
-  net_rank: Dense rank of adj_net in descending order, so rank 1 is the season's strongest overall team.
-  net_z: adj_net restated as a z-score against the mean and standard deviation of adj_net across the rated teams that season.
-  off_pace: 'Tempo measure: scrimmage plays (pass plus rush) per game, centering near 65 and used as the pace input to the
-    totals model.'
-  off_rank: Dense rank of adj_off_epa in descending order, so rank 1 is the season's most efficient offense.
-load_cfb_ratings_weekly:
-  adj_def_epa: Opponent-adjusted EPA per play allowed as of the snapshot week, netted the same way as the offensive rating,
-    so lower is better.
-  adj_net: adj_off_epa minus adj_def_epa at the snapshot week, the team's overall efficiency rating in EPA per play with special
-    teams excluded.
-  adj_off_epa: 'Opponent-adjusted offensive EPA per play as of the snapshot week: raw per-game EPA on pass and rush plays
-    net of each opponent''s ridge-fitted defensive strength.'
-  adj_st_epa: Special-teams composite in EPA units as of the snapshot week, summing the league-centered per-play EPA of the
-    field goal, punt, and kick-return units.
-  def_rank: Dense rank of adj_def_epa in ascending order within the snapshot week, so rank 1 is the stingiest defense at that
-    point.
-  fei_def: Drive-level defensive rating at the snapshot week, from the same per-drive ridge fit and on the same scale as fei_off.
-  fei_net: fei_off minus fei_def at the snapshot week, the team's overall drive-efficiency rating.
-  fei_off: Drive-level offensive rating at the snapshot week, from a ridge fit on per-drive EPA.
-  net_rank: Dense rank of adj_net in descending order within the snapshot week, so rank 1 is the strongest overall team at
-    that point.
-  net_z: adj_net restated as a z-score against the mean and standard deviation of adj_net across the teams rated in that snapshot
-    week.
-  off_pace: Scrimmage plays per game through the snapshot week, the tempo input consumed by the totals model.
-  off_rank: Dense rank of adj_off_epa in descending order within the snapshot week, so rank 1 is the most efficient offense
-    at that point.
-  through_week: Regular-season week the snapshot runs through; the ratings were refit using only games kicking off on or before
-    that week's final kickoff date.
-load_cfb_receiving:
-  EPAgame: EPA generated per game.
-  EPAgame_rank: National rank of the team's EPA generated per game, where 1 is best.
-  EPAplay: EPA generated per play.
-  EPAplay_rank: National rank of the team's EPA generated per play, where 1 is best.
-  TEPA: Total EPA summed over every play.
-  TEPA_rank: National rank of the team's total EPA summed over every play, where 1 is best.
-  catchpct: Catch rate on a 0-to-1 scale, receptions divided by targets for the season.
-  catchpct_rank: Season rank of catchpct with the best catch rate first, computed only for receivers clearing the leaderboard
-    minimum of 1.875 targets per team game and using averaged ranks for ties.
-  comp: Completed passes.
-  fbs_class: 'Power/Group classification for the season: P4 or G6 from 2024 on, P5 or G5 through 2023, derived from conference
-    membership. Null for teams outside FBS.'
-  fumbles: Count of the receiver's targeted pass plays across the season whose play text mentions a fumble by either team.
-  playsgame: Plays per game.
-  receiver_player_name: Display name of the targeted receiver -- the FIRST participant in that role on the play.
-  success: Success rate across the team plays.
-  success_rank: National rank of the team's success rate across the team plays, where 1 is best.
-  team_games: Games the team played, used as the per-game denominator.
-  yards_rank: National rank of the team's total yards, where 1 is best.
-  yardsgame: Yards per game.
-  yardsgame_rank: National rank of the team's yards per game, where 1 is best.
-  yardsplay: Yards per play.
-  yardsplay_rank: National rank of the team's yards per play, where 1 is best.
-load_cfb_recruiting_proj:
-  pred_margin: Ridge projection of the team's average per-game scoring margin, from the same preseason-known feature set as
-    pred_wins.
-  pred_net_epa: Reserved slot for a projected adjusted net EPA; it ships all-null because the adjusted-EPA training target
-    is not currently loadable.
-  pred_wins: Ridge projection of the team's season win total, fit strictly on prior seasons from talent composite, blue-chip
-    ratio, offensive and defensive returning production, and prior wins.
-load_cfb_rosters:
-  recruit_ids: List of recruiting-database profile ids matched to the player; real ids run in the six-figure range and a lone
-    0 entry means no recruiting profile was matched.
-load_cfb_rushing:
-  EPAgame: EPA generated per game.
-  EPAgame_rank: National rank of the team's EPA generated per game, where 1 is best.
-  EPAplay: EPA generated per play.
-  EPAplay_rank: National rank of the team's EPA generated per play, where 1 is best.
-  TEPA: Total EPA summed over every play.
-  TEPA_rank: National rank of the team's total EPA summed over every play, where 1 is best.
-  fbs_class: 'Power/Group classification for the season: P4 or G6 from 2024 on, P5 or G5 through 2023, derived from conference
-    membership. Null for teams outside FBS.'
-  fumbles: Count of the ball carrier's rush attempts across the season whose play text mentions a fumble by either team.
-  playsgame: Plays per game.
-  rusher_player_name: Display name of the ball carrier on a rush -- the FIRST participant in that role on the play.
-  success: Success rate across the team plays.
-  success_rank: National rank of the team's success rate across the team plays, where 1 is best.
-  team_games: Games the team played, used as the per-game denominator.
-  yards_rank: National rank of the team's total yards, where 1 is best.
-  yardsgame: Yards per game.
-  yardsgame_rank: National rank of the team's yards per game, where 1 is best.
-  yardsplay: Yards per play.
-  yardsplay_rank: National rank of the team's yards per play, where 1 is best.
-load_cfb_schedule_crosswalk:
-  espn_date: Kickoff date as YYYY-MM-DD taken from ESPN's schedule, null on games that matched no ESPN row.
-  espn_game_id: ESPN game id for the crosswalk row.
-  fox_date: Kickoff date as YYYY-MM-DD taken from the Fox Sports schedule, null on games that matched no Fox row.
-  fox_game_id: Fox Sports game id for the same game.
-  matched_sources: Plus-joined provenance tag naming which of espn, fox, and yahoo actually supplied a row for this game.
-  matchup_key: 'Order-independent key for the game: the two normalized team names sorted alphabetically and joined with a
-    pipe.'
-  yahoo_date: Kickoff date as YYYY-MM-DD, parsed from Yahoo's RFC-2822 start_time string.
-  yahoo_game_id: Yahoo Sports game id for the same game.
-  yahoo_global_game_id: Yahoo's cross-season global game key in ncaaf.g.<number> form, distinct from the date-encoded yahoo_game_id.
-load_cfb_team_box:
-  completionAttempts: Completions and pass attempts as a slash-separated string, for example 23/41.
-  firstDowns: Total first downs ESPN credits the team, carried verbatim from the box score as a string.
-  fourthDownEff: Fourth-down efficiency as a conversions-attempts string, for example 3-4.
-  fumblesLost: Number of fumbles the team lost to the opponent, carried as a string.
-  netPassingYards: Passing yards after yardage lost to sacks is deducted, the numerator behind yardsPerPass.
-  possessionTime: Time of possession as mm:ss; the two teams' values add up to 60 minutes in a regulation game.
-  rushingAttempts: Rushing attempts.
-  rushingYards: Net rushing yards gained.
-  thirdDownEff: Third-down efficiency as ESPN's conversions-attempts string, for example 5-15.
-  totalPenaltiesYards: Penalties and penalty yards as a hyphen-separated string, for example 7-64.
-  totalYards: Total offensive yards for the team, matching rushingYards plus netPassingYards in about 99.8 percent of games.
-  yardsPerPass: Net passing yards per pass attempt, netPassingYards divided by the attempt count in completionAttempts and
-    rounded to one decimal.
-  yardsPerRushAttempt: Yards gained per rushing attempt.
-load_cfb_team_info:
-  logo_2: URL of the team's alternate dark-background 500-pixel logo on ESPN's CDN, null for programs with no dark variant.
-  twitter: The football program's Twitter/X handle including the leading at sign, populated for only a minority of listed
-    teams.
-load_cfb_teams_crosswalk:
-  espn_team: ESPN's full team display name, school plus mascot, null when the row was anchored on a non-ESPN provider.
-  espn_team_id: ESPN team id for the crosswalk row.
-  fox_abbreviation: Fox Sports' short team code, which frequently differs from the ESPN abbreviation for the same school.
-  fox_team: Fox Sports' team name, which that feed ships in all capitals.
-  fox_team_id: Fox Sports team id for the same team.
-  matched_sources: Plus-joined provenance tag naming which of espn, fox, and yahoo contributed a directory row for this team.
-  norm_key: 'Shared join key across providers: the team name lowercased, ASCII-folded, stripped of punctuation, whitespace-collapsed,
-    and alias-mapped.'
-  yahoo_abbreviation: Yahoo Sports' short team code for the school.
-  yahoo_team: Yahoo Sports' team display name, school plus mascot.
-  yahoo_team_id: Yahoo Sports team id for the same team.
-load_mbb_game_rosters:
-  athlete_headshot: URL of the player's ESPN headshot image, whose filename is the athlete_id (verified equal for all 190,365
-    non-null rows in 2025); null when ESPN publishes no photo for that player.
-load_mbb_officials:
-  official_display_name: Display form of the official's name used by ESPN's game feed, which duplicates official_full_name
-    for all 18,284 rows of the 2025 release.
-  official_full_name: Full name of the game official as published in ESPN's gameInfo officials list; in this release it is
-    byte-identical to official_display_name on every row.
-  official_position: ESPN's role label for the crew member, which is the constant Referee for every men's college basketball
-    official in this release rather than a distinct crew chief or umpire designation.
-  official_position_id: ESPN's numeric code for the official's role, constant at 40 (Referee) across the entire men's college
-    basketball officials release.
-load_mbb_pbp:
-  lag_period: Period number of the previous play in the same game (period_number shifted forward one row within game_id),
-    and null on each game's first play.
-  lead_period: Period number of the next play in the same game (period_number shifted back one row within game_id), and null
-    on each game's final play.
-  start_period_seconds_remaining: Seconds left in the current period when the play started, computed as 60 times the game
-    clock minutes plus the seconds, so 1200 at the tip of each 20-minute half and 300 at the start of an overtime.
-load_mbb_player_season_stats:
-  stat_description: ESPN's prose glossary definition of the statistic named in stat_name, for example defining assists as
-    a pass to a teammate that leads directly to a field goal.
-load_mbb_player_value:
-  box_bpm: Total box plus/minus in points per 100 possessions above an average player, exactly box_obpm plus box_dbpm (verified
-    to zero residual across all 9,805 rows of 2025).
-load_mbb_ratings:
-  adj_em_z: Within-season z-score of adj_em, computed as adj_em minus the season mean divided by the season standard deviation,
-    so each season is centered at zero with unit spread.
-  adj_tempo: Opponent-adjusted possessions per 40 minutes, solved by the same fixed point as the efficiency ratings under
-    the additive model that a game's pace is the two teams' tempos less the league baseline; it averages about 71 in 2025.
-load_mbb_standings:
-  group_short_name: Abbreviated conference label ESPN prints in standings tables, such as ACC, Big Ten or Am. East, one value
-    per group_id.
-  stat_abbreviation: Short code ESPN prints for the standings statistic in a table header, such as W, L, PCT, GB or STRK;
-    it diverges from stat_short_display_name for playoff seed and the home and conference record rows.
-  stat_description: ESPN's longer-form label for the standings statistic, which can differ from stat_display_name (streak
-    is described as Current Streak and playoffSeed as Playoff Seed).
-load_mbb_team_season_stats:
-  stat_description: ESPN's prose glossary definition of the statistic named in stat_name, for example defining field goal
-    percentage as the ratio of field goals made to field goals attempted.
-load_mlb_batter_projection:
-  proj_pa: Combined prior-three-season pa behind the projection, its effective sample size; it inherits the pitch-row counting
-    of load_mlb_expected_stats pa rather than true plate appearances.
-load_mlb_catcher_framing:
-  catcher_id: MLBAM identifier of the receiving catcher, taken from Savant's fielder_2 and published as a string rather than
-    an integer.
-  framing_runs: Runs saved by receiving, summing actual called strike minus modeled strike probability times that count's
-    strike run value over shadow-zone takes only.
-  strikes_gained: The same shadow-zone sum of actual called strike minus modeled strike probability left unweighted by run
-    value, so it measures stolen strikes rather than runs.
-  takes: Called strikes plus balls the catcher received across the season, a pure workload count; the framing figures themselves
-    sum only over the shadow-zone subset of these.
-load_mlb_command_plus:
-  command_plus: Command+/Location+ on the 100-is-average scale, exactly 100 minus 10 times (location_rv_hat minus the league
-    mean) over the league SD; it grades where the pitch finished, not intent, since Statcast ships no catcher target.
-  location_rv_hat: Mean predicted per-pitch run value from the bundled location model, which sees plate location, count, handedness
-    and pitch type but no raw pitch physics; lower is better for the pitcher.
-load_mlb_expected_hr:
-  hr_above_expected: Home runs actually hit minus xhr_neutral, so it grades over- and under-performance against the park-neutral
-    expectation rather than the park-adjusted one.
-  xhr_neutral: Park-neutral expected home runs, summing over the batter's balls in play the home-run probability read off
-    the exit-velocity by launch-angle by spray-angle grid.
-  xhr_park_adj: The same expected-home-run sum after scaling each ball by its ballpark's Savant home-run park factor over
-    100; published values run between 0.77 and 1.26 times xhr_neutral.
-load_mlb_expected_stats:
-  pa: Statcast rows charged to the batter for the season, counting balls in play carrying launch data plus every other pitch,
-    so it is a pitch-row total rather than a true plate-appearance count.
-  xba: Sum of grid-predicted hit probability over the batter's balls in play divided by ab, which lands far below conventional
-    batting-average scale because ab counts pitch rows rather than at-bats.
-  xslg: Sum of grid-predicted total bases over the batter's balls in play divided by ab, which lands far below conventional
-    slugging scale because ab counts pitch rows rather than at-bats.
-  xwoba: Expected wOBA blending the exit-velocity by launch-angle grid's predicted contact value on balls in play with realized
-    wOBA value on walks, hit-by-pitches and strikeouts, over the wOBA denominator; low-sample batters can exceed 1.
-load_mlb_oaa:
-  fielder_id: MLBAM identifier of the fielder charged with the ball in play, resolved from whichever fielder_N column matches
-    the responsible position and published as a string rather than an integer.
-  oaa: 'Outs above average: outs the fielder actually recorded minus what a per-position catch-probability logistic expected
-    from the same batted-ball trajectories, summed across their opportunities.'
-  opportunities: Balls in play charged to this fielder at this position, the sample the oaa sum runs over.
-load_mlb_re24_matrix:
-  base_state: Three-character pre-play base occupancy where each slot carries its base number when occupied and an underscore
-    when empty, so ___ is bases empty and 123 is bases loaded.
-  n: Plate appearances observed starting in this base-out state, the sample size behind re.
-  re: Mean runs the batting team went on to score from this base-out state through the end of the half-inning, with bottom-of-the-9th-and-later
-    halves excluded to avoid walk-off selection bias.
-load_mlb_stuff_plus:
-  stuff_plus: Stuff+ on the 100-is-average scale, exactly 100 minus 10 times (stuff_rv_hat minus the league mean) over the
-    league SD, so higher is better and outlier run-value predictions can push it well below zero.
-  stuff_rv_hat: Mean predicted per-pitch run value from the bundled xgboost stuff model over this pitcher's pitches of this
-    type, on Savant's batter-perspective delta_run_exp scale so lower is better for the pitcher.
-load_mlb_we_table:
-  base_state: Three-character pre-play base occupancy where each slot carries its base number when occupied and an underscore
-    when empty, so ___ is bases empty and 123 is bases loaded.
-  inning_capped: Inning number with the ninth and every extra inning collapsed into 9, so extras share the ninth-inning win-expectancy
-    cells.
-  n: Plate appearances observed in this state bucket, the sample size behind the Laplace-smoothed home_win_exp.
-  outs_start: Outs already recorded when the plate appearance began, normally 0 through 2, though a handful of published rows
-    carry a stale 3 that the RE24 matrix filters out but this table does not.
-  score_diff_bucket: Home score minus away score before the play, clipped to the range -6 through +6 so blowouts collapse
-    into the end buckets.
-load_mlb_xera:
-  x_era: ERA-scale conversion of x_woba as league_era plus (x_woba minus league_woba) over woba_scale times pa_per_9, an exact
-    linear function of x_woba that can go negative for extreme pitchers.
-load_nba_draft:
-  college_abbreviation: Abbreviation of the drafted player's college taken from the pick's nested college block; the ESPN
-    NBA draft feed omits that block entirely, so this and the other college columns are null throughout.
-  pick_notes: Free-text note ESPN can attach to a pick, read from the pick's notes or note field; the NBA draft payload never
-    populates it, so it is null across all released seasons.
-  pick_traded: ESPN's traded flag for the pick, carried through as a string rather than a boolean; every released NBA row
-    reads FALSE, so it does not currently identify traded picks.
-  round_display_name: ESPN's display label for the draft round a pick belongs to, read from the round object's displayName;
-    the NBA payload supplies no round metadata, so this is null for every released season 2003 through 2025.
-load_nba_officials:
-  official_display_name: ESPN's display-form name for the official, falling back to the full name when ESPN omits it; it never
-    diverges from official_full_name in the released NBA data.
-  official_full_name: Full name of an on-court game official as ESPN publishes it in the summary gameInfo.officials array;
-    it is identical to official_display_name in every released NBA row.
-  official_order: The official's listing index within the game's crew as ESPN orders them, normally 1 through 3 for a three-person
-    crew; a fourth entry appears in a small share of recent-season games and the sequence is not guaranteed to be gap-free.
-  official_position: ESPN's label for the official's assignment slot; the NBA summary feed only ever ships Referee, so this
-    reads the same on every released row.
-  official_position_id: ESPN's numeric identifier for the official's assignment slot, constant at 40 (Referee) across every
-    released NBA season.
-load_nba_player_impact:
-  adj_rapm: Total prior-informed RAPM per 100 possessions, exactly the sum of o_adj_rapm and d_adj_rapm.
-  d_rapm: Defensive regularized adjusted plus-minus per 100 possessions, negated from the raw points-allowed coefficient so
-    a positive value marks a defender who suppresses opponent scoring.
-  darko_filtered_skill: DARKO-style Kalman-filtered skill estimate at the end of the player's observed multi-season RAPM panel,
-    i.e. his current-form rating after aging drift and possession-weighted observation noise.
-  darko_projected_rating: One-season-ahead DARKO forecast, the filtered skill plus the empirical aging-curve drift at the
-    player's last observed age; both season_type rows of a player-season carry the same value because the projection is not
-    playoff-specific.
-  darko_projected_sd: Standard deviation of the one-season-ahead DARKO forecast, the square root of the filtered state variance
-    plus the Kalman process variance; it sits at roughly 10.19 for a player with only one season in the panel, whose diffuse
-    prior variance was never updated.
-  def_poss: Number of possessions the player was on the floor on defense, the sample size behind d_rapm; it tracks off_poss
-    almost exactly because substitutions rarely split an offense-defense pair.
-  dspm: Defensive statistical plus-minus per 100 possessions from the same box-score feature vector scored through coefficients
-    trained on the d_rapm target.
-  o_rapm: Offensive regularized adjusted plus-minus per 100 possessions from the single-season ridge fit over possession-level
-    lineup indicators; positive means the player raised his team's scoring rate while on offense.
-  off_poss: Number of possessions the player was on the floor on offense, the count of design-matrix rows carrying his offensive
-    indicator and therefore the offensive-side sample size behind o_rapm.
-  ospm: 'Offensive statistical plus-minus per 100 possessions: the player''s per-100 box-score feature vector scored through
-    ridge coefficients trained on that season''s o_rapm target.'
-  rapm: Total regularized adjusted plus-minus per 100 possessions, exactly the sum of o_rapm and d_rapm.
-  spm: Total statistical plus-minus per 100 possessions, exactly the sum of ospm and dspm.
-  war: Wins above replacement, computed as (rapm minus a replacement level of -2.0 per 100) times total possessions divided
-    by 100, divided by a points-per-win constant calibrated each season by regressing team wins on full-season point margin.
-load_nba_player_season_stats:
-  stat_description: ESPN's prose definition of the statistic on this row, for example the ratio of field goals made to field
-    goals attempted; for the paired Made-Attempted stats it is the two definitions joined with a hyphen.
-load_nba_standings:
-  group_short_name: ESPN's short name for the standings grouping the team sits in, read from the group node's shortName; the
-    NBA standings payload supplies only the group name and abbreviation, so this is null throughout.
-  stat_abbreviation: ESPN's short code for the standings statistic, such as PCT, GB or OPP PPG; it is null for the four record-style
-    splits (Home, Road, vs. Conf., vs. Div.), which ship no abbreviation.
-  stat_description: ESPN's prose gloss for the standings statistic on this row; for the clincher stat it is not a fixed label
-    but the team's actual status text, such as Clinched Playoff Berth or Eliminated From Playoff.
-load_nba_stats_schedules:
-  game_label: The stats.nba.com event label naming the round or special event a game belongs to, such as NBA Finals, East
-    First Round, Emirates NBA Cup or NBA Mexico City Game; an empty string for an ordinary regular-season game.
-load_nba_team_season_stats:
-  stat_description: ESPN's prose definition of the team statistic on this row, for example the average number of assists a
-    team records per turnover.
-load_nhl_penalties:
-  committedByPlayer.lastName.cs: Alternate rendering of the family name published under the NHL feed's Czech key. It differs
-    from the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips
-    them instead -- so treat it as an alternate spelling, not a canonical one.
-  committedByPlayer.lastName.fi: Alternate rendering of the family name published under the NHL feed's Finnish key. It differs
-    from the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips
-    them instead -- so treat it as an alternate spelling, not a canonical one.
-  committedByPlayer.lastName.sk: Alternate rendering of the family name published under the NHL feed's Slovak key. It differs
-    from the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips
-    them instead -- so treat it as an alternate spelling, not a canonical one.
-  committedByPlayer.lastName.sv: Alternate rendering of the family name published under the NHL feed's Swedish key. It differs
-    from the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips
-    them instead -- so treat it as an alternate spelling, not a canonical one.
-  drawnBy.firstName.default: Given name, in the feed's default English locale, of the opposing player credited with drawing
-    the penalty.
-  drawnBy.lastName.cs: Alternate rendering of the family name published under the NHL feed's Czech key. It differs from the
-    default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them
-    instead -- so treat it as an alternate spelling, not a canonical one.
-  drawnBy.lastName.default: Family name, in the feed's default English locale, of the opposing player credited with drawing
-    the penalty.
-  drawnBy.lastName.fi: Alternate rendering of the family name published under the NHL feed's Finnish key. It differs from
-    the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips
-    them instead -- so treat it as an alternate spelling, not a canonical one.
-  drawnBy.lastName.sk: Alternate rendering of the family name published under the NHL feed's Slovak key. It differs from the
-    default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them
-    instead -- so treat it as an alternate spelling, not a canonical one.
-  drawnBy.lastName.sv: Alternate rendering of the family name published under the NHL feed's Swedish key. It differs from
-    the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips
-    them instead -- so treat it as an alternate spelling, not a canonical one.
-  drawnBy.sweaterNumber: Jersey number of the opposing player credited with drawing the infraction; null whenever no victim
-    is credited, as on all bench and game-misconduct penalties.
-  servedBy.cs: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Czech key, differing
-    from the default by diacritics or by an alternate given-name form.
-  servedBy.de: Alternate abbreviated name (first initial plus family name) published under the NHL feed's German key, differing
-    from the default by diacritics or by an alternate given-name form.
-  servedBy.es: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Spanish key, differing
-    from the default by diacritics or by an alternate given-name form.
-  servedBy.fi: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Finnish key, differing
-    from the default by diacritics or by an alternate given-name form.
-  servedBy.sk: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Slovak key, differing
-    from the default by diacritics or by an alternate given-name form.
-  servedBy.sv: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Swedish key, differing
-    from the default by diacritics or by an alternate given-name form.
-  teamAbbrev.default: Three-letter code of the team charged with the penalty, matching the committing player's boxscore team
-    rather than the team that drew it.
-load_nhl_scoring:
-  discreteClipFr: Numeric NHL video identifier of the French-language standalone clip of the goal, always a different asset
-    id from discreteClip.
-  firstName.default: Given name of the goal scorer as rendered in the NHL feed's default English locale.
-  lastName.cs: Alternate rendering of the family name published under the NHL feed's Czech key. It differs from the default
-    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
-    -- so treat it as an alternate spelling, not a canonical one.
-  lastName.default: Family name of the goal scorer as rendered in the NHL feed's default English locale.
-  lastName.fi: Alternate rendering of the family name published under the NHL feed's Finnish key. It differs from the default
-    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
-    -- so treat it as an alternate spelling, not a canonical one.
-  lastName.fr: Alternate rendering of the family name published under the NHL feed's French key. It differs from the default
-    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
-    -- so treat it as an alternate spelling, not a canonical one.
-  lastName.sk: Alternate rendering of the family name published under the NHL feed's Slovak key. It differs from the default
-    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
-    -- so treat it as an alternate spelling, not a canonical one.
-  lastName.sv: Alternate rendering of the family name published under the NHL feed's Swedish key. It differs from the default
-    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
-    -- so treat it as an alternate spelling, not a canonical one.
-  leadingTeamAbbrev.default: Three-letter code of the team ahead on the scoreboard immediately after this goal, null exactly
-    when the goal tied the game and not always the scoring team.
-  name.cs: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Czech key, differing
-    from the default by diacritics or by an alternate given-name form.
-  name.de: Alternate abbreviated name (first initial plus family name) published under the NHL feed's German key, differing
-    from the default by diacritics or by an alternate given-name form.
-  name.es: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Spanish key, differing
-    from the default by diacritics or by an alternate given-name form.
-  name.fi: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Finnish key, differing
-    from the default by diacritics or by an alternate given-name form.
-  name.sk: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Slovak key, differing
-    from the default by diacritics or by an alternate given-name form.
-  name.sv: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Swedish key, differing
-    from the default by diacritics or by an alternate given-name form.
-  teamAbbrev.default: Three-letter code of the team that scored the goal, resolving to the home club exactly when isHome is
-    true and to the visitor otherwise.
-load_nhl_shootout:
-  discreteClipFr: Numeric NHL video identifier of the French-language clip of the shootout attempt, distinct from the id in
-    discreteClip.
-  firstName.cs: Alternate given name published under the NHL feed's Czech key. Verified against the data it is frequently
-    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
-    transliteration of the default.
-  firstName.de: Alternate given name published under the NHL feed's German key. Verified against the data it is frequently
-    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
-    transliteration of the default.
-  firstName.default: Given name of the shooter in the feed's default English locale; null on the per-game summary row.
-  firstName.es: Alternate given name published under the NHL feed's Spanish key. Verified against the data it is frequently
-    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
-    transliteration of the default.
-  firstName.fi: Alternate given name published under the NHL feed's Finnish key. Verified against the data it is frequently
-    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
-    transliteration of the default.
-  firstName.sk: Alternate given name published under the NHL feed's Slovak key. Verified against the data it is frequently
-    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
-    transliteration of the default.
-  firstName.sv: Alternate given name published under the NHL feed's Swedish key. Verified against the data it is frequently
-    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
-    transliteration of the default.
-  gameWinner: True on the single attempt per shootout credited as the game-deciding goal, false on every other attempt and
-    null on the per-game summary row.
-  lastName.cs: Alternate rendering of the family name published under the NHL feed's Czech key. It differs from the default
-    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
-    -- so treat it as an alternate spelling, not a canonical one.
-  lastName.default: Family name of the shooter in the feed's default English locale; null on the per-game summary row.
-  lastName.fi: Alternate rendering of the family name published under the NHL feed's Finnish key. It differs from the default
-    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
-    -- so treat it as an alternate spelling, not a canonical one.
-  lastName.sk: Alternate rendering of the family name published under the NHL feed's Slovak key. It differs from the default
-    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
-    -- so treat it as an alternate spelling, not a canonical one.
-  lastName.sv: Alternate rendering of the family name published under the NHL feed's Swedish key. It differs from the default
-    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
-    -- so treat it as an alternate spelling, not a canonical one.
-  teamAbbrev.default: Three-letter code of the shooting player's team; null on the per-game summary row that instead carries
-    the home and away shootout goal totals.
-load_nhl_shots_by_period:
-  max_regulation_periods: Number of regulation periods the game format defines before overtime, constant at 3 for every row
-    in the published seasons.
-  ot_periods: Overtime period ordinal taken from the NHL period descriptor, populated only from the second overtime onward
-    so period 5 rows carry 2 and all other rows are null.
-load_nhl_three_stars:
-  name.cs: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Czech key, differing
-    from the default by diacritics or by an alternate given-name form.
-  name.de: Alternate abbreviated name (first initial plus family name) published under the NHL feed's German key, differing
-    from the default by diacritics or by an alternate given-name form.
-  name.es: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Spanish key, differing
-    from the default by diacritics or by an alternate given-name form.
-  name.fi: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Finnish key, differing
-    from the default by diacritics or by an alternate given-name form.
-  name.sk: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Slovak key, differing
-    from the default by diacritics or by an alternate given-name form.
-  name.sv: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Swedish key, differing
-    from the default by diacritics or by an alternate given-name form.
-load_wbb_game_rosters:
-  athlete_headshot: URL of the player's ESPN headshot image on a.espncdn.com, whose filename is the athlete_id; null when
-    ESPN publishes no headshot for that player.
-load_wbb_officials:
-  official_display_name: ESPN's displayName for the official, which is identical to official_full_name in every published
-    row of the released data.
-  official_first_name: The official's given name as ESPN splits it out separately from the full name, excluding any middle
-    initial that appears in official_full_name.
-  official_full_name: ESPN's fullName for the official, falling back to displayName when fullName is absent; ESPN sometimes
-    ships it with a middle initial or a doubled internal space, so it is not simply first plus last name.
-  official_last_name: The official's surname as ESPN splits it out; joined to official_first_name it reconstructs roughly
-    98 percent of official_full_name values, the rest differing by middle initials or spacing.
-  official_order: ESPN's 1-based sequence of the official within that game's crew listing, unique within a game and running
-    1 to 3 for the standard three-person crew.
-  official_uid: ESPN's globally unique resource identifier for the official, read from the core-api items[] uid key; that
-    payload never ships it, so the column is null for every published row.
-load_wbb_player_season_stats:
-  stat_description: ESPN's prose definition of the statistic named in stat_name, for example The average assists per game
-    for avgAssists; combined made-attempted stats carry both definitions joined by a hyphen.
-load_wbb_player_value:
-  box_bpm: Total box plus/minus in points per 100 possessions above average, exactly box_obpm plus box_dbpm in every published
-    row.
-load_wbb_ratings:
-  adj_em_z: Within-season z-score of adj_em, computed as adj_em minus the season mean divided by the season standard deviation
-    over every team in the frame, so it is mean 0 and standard deviation 1 per season.
-  adj_tempo: Opponent-adjusted tempo in possessions per 40 minutes, produced by the same fixed-point adjustment as the efficiencies
-    applied to game possessions under the additive model poss = tempo_i + tempo_j minus the league baseline.
-load_wbb_standings:
-  stat_abbreviation: ESPN's abbreviation for the standings stat, such as GB, OPP PPG or VS CONF; always populated and matching
-    stat_short_display_name for about 90 percent of rows.
-  stat_description: ESPN's longer wording for the standings stat, for example Overall Record for the Team Season Record entry
-    and Current Streak for Streak; null for stats ESPN ships without one, such as vs AP Top 25.
-load_wbb_team_season_stats:
-  stat_description: ESPN's prose definition of the team statistic named in stat_name, for example The average blocks per game
-    for avgBlocks or the full sentence defining a blocked shot for blocks.
-load_wnba_draft:
-  college_abbreviation: Short code for the drafted player's school, read from the athlete's ESPN college block; null throughout
-    the published data because ESPN ships no college block on these picks.
-  pick_notes: Free-text annotation ESPN attaches to a pick, taken from notes and falling back to note; empty for every pick
-    published so far.
-  pick_traded: ESPN's pick-level traded flag stringified as TRUE or FALSE, marking selections made with a pick that had changed
-    hands (17 of the 45 published 2026 picks are TRUE).
-  round_display_name: Human-readable label for the draft round, read from the ESPN round object's displayName falling back
-    to its name; null whenever ESPN ships the modern flat picks array with no round objects, which is the case for every published
-    season.
-load_wnba_game_rosters:
-  athlete_headshot: Direct link to the player's ESPN headshot image, always of the form https://a.espncdn.com/i/headshots/wnba/players/full/{athlete_id}.png,
-    and null for the few players ESPN has no photo for.
-load_wnba_officials:
-  official_display_name: ESPN's display rendering of the official's name, which is byte-identical to official_full_name on
-    every published row and therefore adds nothing.
-  official_first_name: Given name of the official as ESPN splits it out, the leading token of official_full_name.
-  official_full_name: The official's full name, taken from ESPN fullName and falling back to displayName; it equals first
-    plus last name on every published row.
-  official_last_name: Family name of the official as ESPN splits it out, the trailing token of official_full_name, with hyphenated
-    surnames kept intact.
-  official_order: ESPN's 1-based position of the official within that game's crew; most games run 1 through 3 for a three-person
-    crew and 40 of 573 games in 2024-2025 add a fourth.
-  official_uid: ESPN's global uid string for the official, carried straight through from the officials payload; the Core v2
-    items ESPN serves omit it, so it is null in every published season.
-load_wnba_player_season_stats:
-  stat_description: ESPN's prose definition of the statistic on this row, for example The average number of points scored
-    per game for avgPoints; combined made-attempted stats carry both halves joined by a hyphen.
-load_wnba_standings:
-  group_short_name: Short label of the standings group node the team sits under, read from ESPN shortName; the WNBA conference
-    nodes ship only name and abbreviation, so it is null on every published row.
-  stat_abbreviation: ESPN's abbreviation for the standings stat, which can differ from stat_short_display_name (playoffSeed
-    is SEED here but POS there) and is null on the record-split rows such as Home and vs. Conf.
-  stat_description: ESPN's long-form explanation of the standings stat, such as Clinched Best League Record for clincher or
-    Record last 10 games for lasttengames.
-load_wnba_stats_coaches:
-  coach_name: Full name of the staff member as the feed renders it, exactly first_name plus a space plus last_name on every
-    published row.
-  coach_type: Job title of the staff member, one of Head Coach, Associate Head Coach, Assistant Coach or Trainer in the published
-    data.
-  is_assistant: 'Numeric staff-role code rather than a boolean flag: 1 head coach, 2 assistant coach, 3 trainer, 9 associate
-    head coach, mapping one-to-one onto coach_type.'
-  sort_sequence: Ordering field passed through unchanged from the stats.wnba.com coaches result set; it arrives empty, so
-    every published row is null.
-  sub_sort_sequence: 'Secondary display-ordering rank that tracks coach_type exactly: 1 head coach, 2 associate head coach,
-    5 assistant coach, 7 trainer.'
 load_contracts:
   cols: Placeholder column retained in the contracts loader output schema; contains no meaningful data in this context.
 load_depth_charts:

--- a/tools/codegen/manual_column_descriptions.yaml
+++ b/tools/codegen/manual_column_descriptions.yaml
@@ -4422,6 +4422,46 @@ load_cfb_pbp:
   type.id: ESPN's numeric identifier for the play type.
   type.text: ESPN's text label for the play type.
   wp_touchback: Win probability the offense would have had starting from a touchback.
+load_wnba_stats_pbp:
+  act_type: Action-type code for the play-by-play event.
+  msg_type: Message-type code for the play-by-play event.
+  number_event: Sequence number of the event within the game.
+  off_slug_team: Slug of the team on offense for the event.
+  secs_passed_game: Seconds elapsed in the game at the event.
+  shot_pts: Points scored on the shot, if the event was a made field goal.
+  slug_team: Slug of the team credited with the event.
+  team_away: Slug of the away team.
+  team_home: Slug of the home team.
+  total_starters_away: Number of the away team's starters on the floor for the event.
+  total_starters_home: Number of the home team's starters on the floor for the event.
+load_wnba_stats_player_game_logs:
+  ast: Assists credited.
+  blk: Total shots blocked.
+  dreb: Defensive rebounds collected.
+  fantasy_pts: Fantasy points.
+  fg3_pct: Three-point percentage.
+  fg3a: Three-point field goals attempted.
+  fg3m: Three-point field goals made.
+  fg_pct: Field-goal percentage.
+  fga: Field goals attempted.
+  fgm: Field goals made.
+  ft_pct: Free-throw percentage.
+  fta: Free throws attempted.
+  ftm: Free throws made.
+  min: Minutes played.
+  oreb: Offensive rebounds collected.
+  pf: Personal fouls committed.
+  plus_minus: Plus-minus point differential.
+  pts: Total points scored.
+  reb: Total rebounds collected.
+  stl: Steals recorded.
+  tov: Turnovers committed.
+load_wnba_stats_rosters:
+  how_acquired: How the team acquired the player (draft, trade, free agency).
+  season_2: Season label in the league's second display form.
+  team_id_lookup: Team id used to join the row back to the team tables.
+load_wnba_team_season_stats:
+  stat_description: Human-readable description of the statistic the row reports.
 load_contracts:
   cols: Placeholder column retained in the contracts loader output schema; contains no meaningful data in this context.
 load_depth_charts:

--- a/tools/codegen/manual_column_descriptions.yaml
+++ b/tools/codegen/manual_column_descriptions.yaml
@@ -2614,6 +2614,1200 @@ load_cfb_betting_lines:
     null for moneyline rows.
   opening_odds: Opening American-odds price for this selection before line movement (vig on spread/total rows, moneyline price
     on moneyline rows).
+load_cfb_team_summaries:
+  EPAdrive_def: EPA per drive (total EPA divided by drives), with the team on defense (i.e. allowed to opponents).
+  EPAdrive_def_pass: EPA per drive (total EPA divided by drives) on pass plays, with the team on defense (i.e. allowed to
+    opponents).
+  EPAdrive_def_pass_rank: National rank of the team's EPA per drive (total EPA divided by drives) on pass plays with the team
+    on defense (i.e. allowed to opponents), where 1 is best.
+  EPAdrive_def_rank: National rank of the team's EPA per drive (total EPA divided by drives) with the team on defense (i.e.
+    allowed to opponents), where 1 is best.
+  EPAdrive_def_rush: EPA per drive (total EPA divided by drives) on rush plays, with the team on defense (i.e. allowed to
+    opponents).
+  EPAdrive_def_rush_rank: National rank of the team's EPA per drive (total EPA divided by drives) on rush plays with the team
+    on defense (i.e. allowed to opponents), where 1 is best.
+  EPAdrive_margin: 'Margin in EPA per drive (total EPA divided by drives): the team''s offensive value minus the value it
+    allowed on defense.'
+  EPAdrive_margin_pass: 'Margin in EPA per drive (total EPA divided by drives) on pass plays: the team''s offensive value
+    minus the value it allowed on defense.'
+  EPAdrive_margin_pass_rank: 'Margin in EPA per drive (total EPA divided by drives) on pass plays: the team''s offensive value
+    minus the value it allowed on defense. National rank of that margin, 1 = largest.'
+  EPAdrive_margin_rank: 'Margin in EPA per drive (total EPA divided by drives): the team''s offensive value minus the value
+    it allowed on defense. National rank of that margin, 1 = largest.'
+  EPAdrive_margin_rush: 'Margin in EPA per drive (total EPA divided by drives) on rush plays: the team''s offensive value
+    minus the value it allowed on defense.'
+  EPAdrive_margin_rush_rank: 'Margin in EPA per drive (total EPA divided by drives) on rush plays: the team''s offensive value
+    minus the value it allowed on defense. National rank of that margin, 1 = largest.'
+  EPAdrive_off: EPA per drive (total EPA divided by drives), with the team on offense.
+  EPAdrive_off_pass: EPA per drive (total EPA divided by drives) on pass plays, with the team on offense.
+  EPAdrive_off_pass_rank: National rank of the team's EPA per drive (total EPA divided by drives) on pass plays with the team
+    on offense, where 1 is best.
+  EPAdrive_off_rank: National rank of the team's EPA per drive (total EPA divided by drives) with the team on offense, where
+    1 is best.
+  EPAdrive_off_rush: EPA per drive (total EPA divided by drives) on rush plays, with the team on offense.
+  EPAdrive_off_rush_rank: National rank of the team's EPA per drive (total EPA divided by drives) on rush plays with the team
+    on offense, where 1 is best.
+  EPAgame_def: EPA per game (total EPA divided by games), with the team on defense (i.e. allowed to opponents).
+  EPAgame_def_pass: EPA per game (total EPA divided by games) on pass plays, with the team on defense (i.e. allowed to opponents).
+  EPAgame_def_pass_rank: National rank of the team's EPA per game (total EPA divided by games) on pass plays with the team
+    on defense (i.e. allowed to opponents), where 1 is best.
+  EPAgame_def_rank: National rank of the team's EPA per game (total EPA divided by games) with the team on defense (i.e. allowed
+    to opponents), where 1 is best.
+  EPAgame_def_rush: EPA per game (total EPA divided by games) on rush plays, with the team on defense (i.e. allowed to opponents).
+  EPAgame_def_rush_rank: National rank of the team's EPA per game (total EPA divided by games) on rush plays with the team
+    on defense (i.e. allowed to opponents), where 1 is best.
+  EPAgame_margin: 'Margin in EPA per game (total EPA divided by games): the team''s offensive value minus the value it allowed
+    on defense.'
+  EPAgame_margin_pass: 'Margin in EPA per game (total EPA divided by games) on pass plays: the team''s offensive value minus
+    the value it allowed on defense.'
+  EPAgame_margin_pass_rank: 'Margin in EPA per game (total EPA divided by games) on pass plays: the team''s offensive value
+    minus the value it allowed on defense. National rank of that margin, 1 = largest.'
+  EPAgame_margin_rank: 'Margin in EPA per game (total EPA divided by games): the team''s offensive value minus the value it
+    allowed on defense. National rank of that margin, 1 = largest.'
+  EPAgame_margin_rush: 'Margin in EPA per game (total EPA divided by games) on rush plays: the team''s offensive value minus
+    the value it allowed on defense.'
+  EPAgame_margin_rush_rank: 'Margin in EPA per game (total EPA divided by games) on rush plays: the team''s offensive value
+    minus the value it allowed on defense. National rank of that margin, 1 = largest.'
+  EPAgame_off: EPA per game (total EPA divided by games), with the team on offense.
+  EPAgame_off_pass: EPA per game (total EPA divided by games) on pass plays, with the team on offense.
+  EPAgame_off_pass_rank: National rank of the team's EPA per game (total EPA divided by games) on pass plays with the team
+    on offense, where 1 is best.
+  EPAgame_off_rank: National rank of the team's EPA per game (total EPA divided by games) with the team on offense, where
+    1 is best.
+  EPAgame_off_rush: EPA per game (total EPA divided by games) on rush plays, with the team on offense.
+  EPAgame_off_rush_rank: National rank of the team's EPA per game (total EPA divided by games) on rush plays with the team
+    on offense, where 1 is best.
+  EPAplay_def: EPA per play, with the team on defense (i.e. allowed to opponents).
+  EPAplay_def_pass: EPA per play on pass plays, with the team on defense (i.e. allowed to opponents).
+  EPAplay_def_pass_rank: National rank of the team's EPA per play on pass plays with the team on defense (i.e. allowed to
+    opponents), where 1 is best.
+  EPAplay_def_rank: National rank of the team's EPA per play with the team on defense (i.e. allowed to opponents), where 1
+    is best.
+  EPAplay_def_rush: EPA per play on rush plays, with the team on defense (i.e. allowed to opponents).
+  EPAplay_def_rush_rank: National rank of the team's EPA per play on rush plays with the team on defense (i.e. allowed to
+    opponents), where 1 is best.
+  EPAplay_margin: 'Margin in EPA per play: the team''s offensive value minus the value it allowed on defense.'
+  EPAplay_margin_pass: 'Margin in EPA per play on pass plays: the team''s offensive value minus the value it allowed on defense.'
+  EPAplay_margin_pass_rank: 'Margin in EPA per play on pass plays: the team''s offensive value minus the value it allowed
+    on defense. National rank of that margin, 1 = largest.'
+  EPAplay_margin_rank: 'Margin in EPA per play: the team''s offensive value minus the value it allowed on defense. National
+    rank of that margin, 1 = largest.'
+  EPAplay_margin_rush: 'Margin in EPA per play on rush plays: the team''s offensive value minus the value it allowed on defense.'
+  EPAplay_margin_rush_rank: 'Margin in EPA per play on rush plays: the team''s offensive value minus the value it allowed
+    on defense. National rank of that margin, 1 = largest.'
+  EPAplay_off: EPA per play, with the team on offense.
+  EPAplay_off_pass: EPA per play on pass plays, with the team on offense.
+  EPAplay_off_pass_rank: National rank of the team's EPA per play on pass plays with the team on offense, where 1 is best.
+  EPAplay_off_rank: National rank of the team's EPA per play with the team on offense, where 1 is best.
+  EPAplay_off_rush: EPA per play on rush plays, with the team on offense.
+  EPAplay_off_rush_rank: National rank of the team's EPA per play on rush plays with the team on offense, where 1 is best.
+  TEPA_def: Total EPA summed over every play, with the team on defense (i.e. allowed to opponents).
+  TEPA_def_pass: Total EPA summed over every play on pass plays, with the team on defense (i.e. allowed to opponents).
+  TEPA_def_pass_rank: National rank of the team's total EPA summed over every play on pass plays with the team on defense
+    (i.e. allowed to opponents), where 1 is best.
+  TEPA_def_rank: National rank of the team's total EPA summed over every play with the team on defense (i.e. allowed to opponents),
+    where 1 is best.
+  TEPA_def_rush: Total EPA summed over every play on rush plays, with the team on defense (i.e. allowed to opponents).
+  TEPA_def_rush_rank: National rank of the team's total EPA summed over every play on rush plays with the team on defense
+    (i.e. allowed to opponents), where 1 is best.
+  TEPA_margin: 'Margin in total EPA summed over every play: the team''s offensive value minus the value it allowed on defense.'
+  TEPA_margin_pass: 'Margin in total EPA summed over every play on pass plays: the team''s offensive value minus the value
+    it allowed on defense.'
+  TEPA_margin_pass_rank: 'Margin in total EPA summed over every play on pass plays: the team''s offensive value minus the
+    value it allowed on defense. National rank of that margin, 1 = largest.'
+  TEPA_margin_rank: 'Margin in total EPA summed over every play: the team''s offensive value minus the value it allowed on
+    defense. National rank of that margin, 1 = largest.'
+  TEPA_margin_rush: 'Margin in total EPA summed over every play on rush plays: the team''s offensive value minus the value
+    it allowed on defense.'
+  TEPA_margin_rush_rank: 'Margin in total EPA summed over every play on rush plays: the team''s offensive value minus the
+    value it allowed on defense. National rank of that margin, 1 = largest.'
+  TEPA_off: Total EPA summed over every play, with the team on offense.
+  TEPA_off_pass: Total EPA summed over every play on pass plays, with the team on offense.
+  TEPA_off_pass_rank: National rank of the team's total EPA summed over every play on pass plays with the team on offense,
+    where 1 is best.
+  TEPA_off_rank: National rank of the team's total EPA summed over every play with the team on offense, where 1 is best.
+  TEPA_off_rush: Total EPA summed over every play on rush plays, with the team on offense.
+  TEPA_off_rush_rank: National rank of the team's total EPA summed over every play on rush plays with the team on offense,
+    where 1 is best.
+  adj_def_epa: Defensive opponent-adjusted EPA per play from the ridge (RAPM-style) regression on offense/defense team indicators
+    plus home field -- cfbfastR's adjust_epa adjustment, fit in-sample across the season, so the value is descriptive of that
+    window rather than predictive. Lower is better -- it is EPA allowed.
+  adj_def_epa_rank: National rank of the team's adj_def_epa, where 1 is best (fewest EPA allowed).
+  adj_off_epa: Offensive opponent-adjusted EPA per play from the ridge (RAPM-style) regression on offense/defense team indicators
+    plus home field -- cfbfastR's adjust_epa adjustment, fit in-sample across the season, so the value is descriptive of that
+    window rather than predictive.
+  adj_off_epa_rank: National rank of the team's adj_off_epa, where 1 is best.
+  available_yards_pct_def: Share of available yards the team's defense allowed opponents to gain. Lower is better.
+  available_yards_pct_def_rank: National rank of the team's defensive available-yards share, where 1 is best.
+  available_yards_pct_margin: Available-yards share gained by the offense minus the share allowed by the defense. Higher is
+    better.
+  available_yards_pct_margin_rank: National rank of available_yards_pct_margin, 1 = largest margin.
+  available_yards_pct_off: Share of available yards the team's offense actually gained (total_gained_yards_off divided by
+    total_available_yards_off). Higher is better.
+  available_yards_pct_off_rank: National rank of the team's offensive available-yards share, where 1 is best.
+  def_strength_faced: Average opponent-offense strength the team's defense faced, taken as the mean of the ridge's offensive
+    coefficients across its opponents. Higher means a tougher slate.
+  drives_def: Offensive drives, with the team on defense (i.e. allowed to opponents).
+  drives_def_pass: Offensive drives on pass plays, with the team on defense (i.e. allowed to opponents).
+  drives_def_rush: Offensive drives on rush plays, with the team on defense (i.e. allowed to opponents).
+  drives_off: Offensive drives, with the team on offense.
+  drives_off_pass: Offensive drives on pass plays, with the team on offense.
+  drives_off_rush: Offensive drives on rush plays, with the team on offense.
+  drivesgame_def: Drives per game, with the team on defense (i.e. allowed to opponents).
+  drivesgame_def_pass: Drives per game on pass plays, with the team on defense (i.e. allowed to opponents).
+  drivesgame_def_pass_rank: National rank of the team's drives per game on pass plays with the team on defense (i.e. allowed
+    to opponents), where 1 is best.
+  drivesgame_def_rank: National rank of the team's drives per game with the team on defense (i.e. allowed to opponents), where
+    1 is best.
+  drivesgame_def_rush: Drives per game on rush plays, with the team on defense (i.e. allowed to opponents).
+  drivesgame_def_rush_rank: National rank of the team's drives per game on rush plays with the team on defense (i.e. allowed
+    to opponents), where 1 is best.
+  drivesgame_off: Drives per game, with the team on offense.
+  drivesgame_off_pass: Drives per game on pass plays, with the team on offense.
+  drivesgame_off_pass_rank: National rank of the team's drives per game on pass plays with the team on offense, where 1 is
+    best.
+  drivesgame_off_rank: National rank of the team's drives per game with the team on offense, where 1 is best.
+  drivesgame_off_rush: Drives per game on rush plays, with the team on offense.
+  drivesgame_off_rush_rank: National rank of the team's drives per game on rush plays with the team on offense, where 1 is
+    best.
+  early_down_EPA_def: EPA per early-down play, with the team on defense (i.e. allowed to opponents).
+  early_down_EPA_def_pass: EPA per early-down play on pass plays, with the team on defense (i.e. allowed to opponents).
+  early_down_EPA_def_pass_rank: National rank of the team's EPA per early-down play on pass plays with the team on defense
+    (i.e. allowed to opponents), where 1 is best.
+  early_down_EPA_def_rank: National rank of the team's EPA per early-down play with the team on defense (i.e. allowed to opponents),
+    where 1 is best.
+  early_down_EPA_def_rush: EPA per early-down play on rush plays, with the team on defense (i.e. allowed to opponents).
+  early_down_EPA_def_rush_rank: National rank of the team's EPA per early-down play on rush plays with the team on defense
+    (i.e. allowed to opponents), where 1 is best.
+  early_down_EPA_off: EPA per early-down play, with the team on offense.
+  early_down_EPA_off_pass: EPA per early-down play on pass plays, with the team on offense.
+  early_down_EPA_off_pass_rank: National rank of the team's EPA per early-down play on pass plays with the team on offense,
+    where 1 is best.
+  early_down_EPA_off_rank: National rank of the team's EPA per early-down play with the team on offense, where 1 is best.
+  early_down_EPA_off_rush: EPA per early-down play on rush plays, with the team on offense.
+  early_down_EPA_off_rush_rank: National rank of the team's EPA per early-down play on rush plays with the team on offense,
+    where 1 is best.
+  explosive_def: Explosive-play rate -- the share of plays carrying the explosive flag, with the team on defense (i.e. allowed
+    to opponents).
+  explosive_def_pass: Explosive-play rate -- the share of plays carrying the explosive flag on pass plays, with the team on
+    defense (i.e. allowed to opponents).
+  explosive_def_pass_rank: National rank of the team's explosive-play rate -- the share of plays carrying the explosive flag
+    on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best.
+  explosive_def_rank: National rank of the team's explosive-play rate -- the share of plays carrying the explosive flag with
+    the team on defense (i.e. allowed to opponents), where 1 is best.
+  explosive_def_rush: Explosive-play rate -- the share of plays carrying the explosive flag on rush plays, with the team on
+    defense (i.e. allowed to opponents).
+  explosive_def_rush_rank: National rank of the team's explosive-play rate -- the share of plays carrying the explosive flag
+    on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best.
+  explosive_off: Explosive-play rate -- the share of plays carrying the explosive flag, with the team on offense.
+  explosive_off_pass: Explosive-play rate -- the share of plays carrying the explosive flag on pass plays, with the team on
+    offense.
+  explosive_off_pass_rank: National rank of the team's explosive-play rate -- the share of plays carrying the explosive flag
+    on pass plays with the team on offense, where 1 is best.
+  explosive_off_rank: National rank of the team's explosive-play rate -- the share of plays carrying the explosive flag with
+    the team on offense, where 1 is best.
+  explosive_off_rush: Explosive-play rate -- the share of plays carrying the explosive flag on rush plays, with the team on
+    offense.
+  explosive_off_rush_rank: National rank of the team's explosive-play rate -- the share of plays carrying the explosive flag
+    on rush plays with the team on offense, where 1 is best.
+  fbs_class: 'Power/Group classification for the season: P4 or G6 from 2024 on, P5 or G5 through 2023, derived from conference
+    membership (Notre Dame is classified with the power group). Null for teams outside FBS.'
+  havoc_def: Havoc rate -- the share of plays carrying the defensive-disruption flag, with the team on defense (i.e. allowed
+    to opponents).
+  havoc_def_pass: Havoc rate -- the share of plays carrying the defensive-disruption flag on pass plays, with the team on
+    defense (i.e. allowed to opponents).
+  havoc_def_pass_rank: National rank of the team's havoc rate -- the share of plays carrying the defensive-disruption flag
+    on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best.
+  havoc_def_rank: National rank of the team's havoc rate -- the share of plays carrying the defensive-disruption flag with
+    the team on defense (i.e. allowed to opponents), where 1 is best.
+  havoc_def_rush: Havoc rate -- the share of plays carrying the defensive-disruption flag on rush plays, with the team on
+    defense (i.e. allowed to opponents).
+  havoc_def_rush_rank: National rank of the team's havoc rate -- the share of plays carrying the defensive-disruption flag
+    on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best.
+  havoc_off: Havoc rate -- the share of plays carrying the defensive-disruption flag, with the team on offense.
+  havoc_off_pass: Havoc rate -- the share of plays carrying the defensive-disruption flag on pass plays, with the team on
+    offense.
+  havoc_off_pass_rank: National rank of the team's havoc rate -- the share of plays carrying the defensive-disruption flag
+    on pass plays with the team on offense, where 1 is best.
+  havoc_off_rank: National rank of the team's havoc rate -- the share of plays carrying the defensive-disruption flag with
+    the team on offense, where 1 is best.
+  havoc_off_rush: Havoc rate -- the share of plays carrying the defensive-disruption flag on rush plays, with the team on
+    offense.
+  havoc_off_rush_rank: National rank of the team's havoc rate -- the share of plays carrying the defensive-disruption flag
+    on rush plays with the team on offense, where 1 is best.
+  late_down_success_def: Success rate on late-down plays, with the team on defense (i.e. allowed to opponents).
+  late_down_success_def_pass: Success rate on late-down plays on pass plays, with the team on defense (i.e. allowed to opponents).
+  late_down_success_def_pass_rank: National rank of the team's success rate on late-down plays on pass plays with the team
+    on defense (i.e. allowed to opponents), where 1 is best.
+  late_down_success_def_rank: National rank of the team's success rate on late-down plays with the team on defense (i.e. allowed
+    to opponents), where 1 is best.
+  late_down_success_def_rush: Success rate on late-down plays on rush plays, with the team on defense (i.e. allowed to opponents).
+  late_down_success_def_rush_rank: National rank of the team's success rate on late-down plays on rush plays with the team
+    on defense (i.e. allowed to opponents), where 1 is best.
+  late_down_success_off: Success rate on late-down plays, with the team on offense.
+  late_down_success_off_pass: Success rate on late-down plays on pass plays, with the team on offense.
+  late_down_success_off_pass_rank: National rank of the team's success rate on late-down plays on pass plays with the team
+    on offense, where 1 is best.
+  late_down_success_off_rank: National rank of the team's success rate on late-down plays with the team on offense, where
+    1 is best.
+  late_down_success_off_rush: Success rate on late-down plays on rush plays, with the team on offense.
+  late_down_success_off_rush_rank: National rank of the team's success rate on late-down plays on rush plays with the team
+    on offense, where 1 is best.
+  line_yards_def: Average line yards credited to the offensive line on rushes, with the team on defense (i.e. allowed to opponents).
+  line_yards_def_pass: Average line yards credited to the offensive line on rushes on pass plays, with the team on defense
+    (i.e. allowed to opponents).
+  line_yards_def_pass_rank: National rank of the team's average line yards credited to the offensive line on rushes on pass
+    plays with the team on defense (i.e. allowed to opponents), where 1 is best.
+  line_yards_def_rank: National rank of the team's average line yards credited to the offensive line on rushes with the team
+    on defense (i.e. allowed to opponents), where 1 is best.
+  line_yards_def_rush: Average line yards credited to the offensive line on rushes on rush plays, with the team on defense
+    (i.e. allowed to opponents).
+  line_yards_def_rush_rank: National rank of the team's average line yards credited to the offensive line on rushes on rush
+    plays with the team on defense (i.e. allowed to opponents), where 1 is best.
+  line_yards_off: Average line yards credited to the offensive line on rushes, with the team on offense.
+  line_yards_off_pass: Average line yards credited to the offensive line on rushes on pass plays, with the team on offense.
+  line_yards_off_pass_rank: National rank of the team's average line yards credited to the offensive line on rushes on pass
+    plays with the team on offense, where 1 is best.
+  line_yards_off_rank: National rank of the team's average line yards credited to the offensive line on rushes with the team
+    on offense, where 1 is best.
+  line_yards_off_rush: Average line yards credited to the offensive line on rushes on rush plays, with the team on offense.
+  line_yards_off_rush_rank: National rank of the team's average line yards credited to the offensive line on rushes on rush
+    plays with the team on offense, where 1 is best.
+  net_adj_epa: 'Net opponent-adjusted EPA per play: adj_off_epa minus adj_def_epa. Higher is better.'
+  net_adj_epa_rank: National rank of the team's net_adj_epa, 1 = largest net adjusted EPA.
+  nonExplosiveEpaPerPlay_def: EPA per play with explosive plays excluded, with the team on defense (i.e. allowed to opponents).
+  nonExplosiveEpaPerPlay_def_pass: EPA per play with explosive plays excluded on pass plays, with the team on defense (i.e.
+    allowed to opponents).
+  nonExplosiveEpaPerPlay_def_pass_rank: National rank of the team's EPA per play with explosive plays excluded on pass plays
+    with the team on defense (i.e. allowed to opponents), where 1 is best.
+  nonExplosiveEpaPerPlay_def_rank: National rank of the team's EPA per play with explosive plays excluded with the team on
+    defense (i.e. allowed to opponents), where 1 is best.
+  nonExplosiveEpaPerPlay_def_rush: EPA per play with explosive plays excluded on rush plays, with the team on defense (i.e.
+    allowed to opponents).
+  nonExplosiveEpaPerPlay_def_rush_rank: National rank of the team's EPA per play with explosive plays excluded on rush plays
+    with the team on defense (i.e. allowed to opponents), where 1 is best.
+  nonExplosiveEpaPerPlay_off: EPA per play with explosive plays excluded, with the team on offense.
+  nonExplosiveEpaPerPlay_off_pass: EPA per play with explosive plays excluded on pass plays, with the team on offense.
+  nonExplosiveEpaPerPlay_off_pass_rank: National rank of the team's EPA per play with explosive plays excluded on pass plays
+    with the team on offense, where 1 is best.
+  nonExplosiveEpaPerPlay_off_rank: National rank of the team's EPA per play with explosive plays excluded with the team on
+    offense, where 1 is best.
+  nonExplosiveEpaPerPlay_off_rush: EPA per play with explosive plays excluded on rush plays, with the team on offense.
+  nonExplosiveEpaPerPlay_off_rush_rank: National rank of the team's EPA per play with explosive plays excluded on rush plays
+    with the team on offense, where 1 is best.
+  off_strength_faced: Average opponent-defense strength the team's offense faced, taken as the mean of the ridge's defensive
+    coefficients across its opponents. Higher means a tougher slate.
+  opportunity_rate_def: Opportunity rate -- the share of rushes carrying the opportunity flag, with the team on defense (i.e.
+    allowed to opponents).
+  opportunity_rate_def_pass: Opportunity rate -- the share of rushes carrying the opportunity flag on pass plays, with the
+    team on defense (i.e. allowed to opponents).
+  opportunity_rate_def_pass_rank: National rank of the team's opportunity rate -- the share of rushes carrying the opportunity
+    flag on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best.
+  opportunity_rate_def_rank: National rank of the team's opportunity rate -- the share of rushes carrying the opportunity
+    flag with the team on defense (i.e. allowed to opponents), where 1 is best.
+  opportunity_rate_def_rush: Opportunity rate -- the share of rushes carrying the opportunity flag on rush plays, with the
+    team on defense (i.e. allowed to opponents).
+  opportunity_rate_def_rush_rank: National rank of the team's opportunity rate -- the share of rushes carrying the opportunity
+    flag on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best.
+  opportunity_rate_off: Opportunity rate -- the share of rushes carrying the opportunity flag, with the team on offense.
+  opportunity_rate_off_pass: Opportunity rate -- the share of rushes carrying the opportunity flag on pass plays, with the
+    team on offense.
+  opportunity_rate_off_pass_rank: National rank of the team's opportunity rate -- the share of rushes carrying the opportunity
+    flag on pass plays with the team on offense, where 1 is best.
+  opportunity_rate_off_rank: National rank of the team's opportunity rate -- the share of rushes carrying the opportunity
+    flag with the team on offense, where 1 is best.
+  opportunity_rate_off_rush: Opportunity rate -- the share of rushes carrying the opportunity flag on rush plays, with the
+    team on offense.
+  opportunity_rate_off_rush_rank: National rank of the team's opportunity rate -- the share of rushes carrying the opportunity
+    flag on rush plays with the team on offense, where 1 is best.
+  passrate_def: Share of plays that were pass plays, with the team on defense (i.e. allowed to opponents).
+  passrate_def_pass: Share of plays that were pass plays on pass plays, with the team on defense (i.e. allowed to opponents).
+  passrate_def_pass_rank: National rank of the team's share of plays that were pass plays on pass plays with the team on defense
+    (i.e. allowed to opponents), where 1 is best.
+  passrate_def_rank: National rank of the team's share of plays that were pass plays with the team on defense (i.e. allowed
+    to opponents), where 1 is best.
+  passrate_def_rush: Share of plays that were pass plays on rush plays, with the team on defense (i.e. allowed to opponents).
+  passrate_def_rush_rank: National rank of the team's share of plays that were pass plays on rush plays with the team on defense
+    (i.e. allowed to opponents), where 1 is best.
+  passrate_off: Share of plays that were pass plays, with the team on offense.
+  passrate_off_pass: Share of plays that were pass plays on pass plays, with the team on offense.
+  passrate_off_pass_rank: National rank of the team's share of plays that were pass plays on pass plays with the team on offense,
+    where 1 is best.
+  passrate_off_rank: National rank of the team's share of plays that were pass plays with the team on offense, where 1 is
+    best.
+  passrate_off_rush: Share of plays that were pass plays on rush plays, with the team on offense.
+  passrate_off_rush_rank: National rank of the team's share of plays that were pass plays on rush plays with the team on offense,
+    where 1 is best.
+  play_stuffed_def: Stuffed-play rate -- the share of plays carrying the stuffed flag, with the team on defense (i.e. allowed
+    to opponents).
+  play_stuffed_def_pass: Stuffed-play rate -- the share of plays carrying the stuffed flag on pass plays, with the team on
+    defense (i.e. allowed to opponents).
+  play_stuffed_def_pass_rank: National rank of the team's stuffed-play rate -- the share of plays carrying the stuffed flag
+    on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best.
+  play_stuffed_def_rank: National rank of the team's stuffed-play rate -- the share of plays carrying the stuffed flag with
+    the team on defense (i.e. allowed to opponents), where 1 is best.
+  play_stuffed_def_rush: Stuffed-play rate -- the share of plays carrying the stuffed flag on rush plays, with the team on
+    defense (i.e. allowed to opponents).
+  play_stuffed_def_rush_rank: National rank of the team's stuffed-play rate -- the share of plays carrying the stuffed flag
+    on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best.
+  play_stuffed_off: Stuffed-play rate -- the share of plays carrying the stuffed flag, with the team on offense.
+  play_stuffed_off_pass: Stuffed-play rate -- the share of plays carrying the stuffed flag on pass plays, with the team on
+    offense.
+  play_stuffed_off_pass_rank: National rank of the team's stuffed-play rate -- the share of plays carrying the stuffed flag
+    on pass plays with the team on offense, where 1 is best.
+  play_stuffed_off_rank: National rank of the team's stuffed-play rate -- the share of plays carrying the stuffed flag with
+    the team on offense, where 1 is best.
+  play_stuffed_off_rush: Stuffed-play rate -- the share of plays carrying the stuffed flag on rush plays, with the team on
+    offense.
+  play_stuffed_off_rush_rank: National rank of the team's stuffed-play rate -- the share of plays carrying the stuffed flag
+    on rush plays with the team on offense, where 1 is best.
+  plays_def: Plays run, with the team on defense (i.e. allowed to opponents).
+  plays_def_pass: Plays run on pass plays, with the team on defense (i.e. allowed to opponents).
+  plays_def_rush: Plays run on rush plays, with the team on defense (i.e. allowed to opponents).
+  plays_off: Plays run, with the team on offense.
+  plays_off_pass: Plays run on pass plays, with the team on offense.
+  plays_off_rush: Plays run on rush plays, with the team on offense.
+  playsdrive_def: Plays run per drive, with the team on defense (i.e. allowed to opponents).
+  playsdrive_def_pass: Plays run per drive on pass plays, with the team on defense (i.e. allowed to opponents).
+  playsdrive_def_pass_rank: National rank of the team's plays run per drive on pass plays with the team on defense (i.e. allowed
+    to opponents), where 1 is best.
+  playsdrive_def_rank: National rank of the team's plays run per drive with the team on defense (i.e. allowed to opponents),
+    where 1 is best.
+  playsdrive_def_rush: Plays run per drive on rush plays, with the team on defense (i.e. allowed to opponents).
+  playsdrive_def_rush_rank: National rank of the team's plays run per drive on rush plays with the team on defense (i.e. allowed
+    to opponents), where 1 is best.
+  playsdrive_off: Plays run per drive, with the team on offense.
+  playsdrive_off_pass: Plays run per drive on pass plays, with the team on offense.
+  playsdrive_off_pass_rank: National rank of the team's plays run per drive on pass plays with the team on offense, where
+    1 is best.
+  playsdrive_off_rank: National rank of the team's plays run per drive with the team on offense, where 1 is best.
+  playsdrive_off_rush: Plays run per drive on rush plays, with the team on offense.
+  playsdrive_off_rush_rank: National rank of the team's plays run per drive on rush plays with the team on offense, where
+    1 is best.
+  playsgame_def: Plays run per game, with the team on defense (i.e. allowed to opponents).
+  playsgame_def_pass: Plays run per game on pass plays, with the team on defense (i.e. allowed to opponents).
+  playsgame_def_pass_rank: National rank of the team's plays run per game on pass plays with the team on defense (i.e. allowed
+    to opponents), where 1 is best.
+  playsgame_def_rank: National rank of the team's plays run per game with the team on defense (i.e. allowed to opponents),
+    where 1 is best.
+  playsgame_def_rush: Plays run per game on rush plays, with the team on defense (i.e. allowed to opponents).
+  playsgame_def_rush_rank: National rank of the team's plays run per game on rush plays with the team on defense (i.e. allowed
+    to opponents), where 1 is best.
+  playsgame_off: Plays run per game, with the team on offense.
+  playsgame_off_pass: Plays run per game on pass plays, with the team on offense.
+  playsgame_off_pass_rank: National rank of the team's plays run per game on pass plays with the team on offense, where 1
+    is best.
+  playsgame_off_rank: National rank of the team's plays run per game with the team on offense, where 1 is best.
+  playsgame_off_rush: Plays run per game on rush plays, with the team on offense.
+  playsgame_off_rush_rank: National rank of the team's plays run per game on rush plays with the team on offense, where 1
+    is best.
+  red_zone_success_def: Success rate on red-zone plays, with the team on defense (i.e. allowed to opponents).
+  red_zone_success_def_pass: Success rate on red-zone plays on pass plays, with the team on defense (i.e. allowed to opponents).
+  red_zone_success_def_pass_rank: National rank of the team's success rate on red-zone plays on pass plays with the team on
+    defense (i.e. allowed to opponents), where 1 is best.
+  red_zone_success_def_rank: National rank of the team's success rate on red-zone plays with the team on defense (i.e. allowed
+    to opponents), where 1 is best.
+  red_zone_success_def_rush: Success rate on red-zone plays on rush plays, with the team on defense (i.e. allowed to opponents).
+  red_zone_success_def_rush_rank: National rank of the team's success rate on red-zone plays on rush plays with the team on
+    defense (i.e. allowed to opponents), where 1 is best.
+  red_zone_success_off: Success rate on red-zone plays, with the team on offense.
+  red_zone_success_off_pass: Success rate on red-zone plays on pass plays, with the team on offense.
+  red_zone_success_off_pass_rank: National rank of the team's success rate on red-zone plays on pass plays with the team on
+    offense, where 1 is best.
+  red_zone_success_off_rank: National rank of the team's success rate on red-zone plays with the team on offense, where 1
+    is best.
+  red_zone_success_off_rush: Success rate on red-zone plays on rush plays, with the team on offense.
+  red_zone_success_off_rush_rank: National rank of the team's success rate on red-zone plays on rush plays with the team on
+    offense, where 1 is best.
+  rushrate_def: Share of plays that were rush plays, with the team on defense (i.e. allowed to opponents).
+  rushrate_def_pass: Share of plays that were rush plays on pass plays, with the team on defense (i.e. allowed to opponents).
+  rushrate_def_pass_rank: National rank of the team's share of plays that were rush plays on pass plays with the team on defense
+    (i.e. allowed to opponents), where 1 is best.
+  rushrate_def_rank: National rank of the team's share of plays that were rush plays with the team on defense (i.e. allowed
+    to opponents), where 1 is best.
+  rushrate_def_rush: Share of plays that were rush plays on rush plays, with the team on defense (i.e. allowed to opponents).
+  rushrate_def_rush_rank: National rank of the team's share of plays that were rush plays on rush plays with the team on defense
+    (i.e. allowed to opponents), where 1 is best.
+  rushrate_off: Share of plays that were rush plays, with the team on offense.
+  rushrate_off_pass: Share of plays that were rush plays on pass plays, with the team on offense.
+  rushrate_off_pass_rank: National rank of the team's share of plays that were rush plays on pass plays with the team on offense,
+    where 1 is best.
+  rushrate_off_rank: National rank of the team's share of plays that were rush plays with the team on offense, where 1 is
+    best.
+  rushrate_off_rush: Share of plays that were rush plays on rush plays, with the team on offense.
+  rushrate_off_rush_rank: National rank of the team's share of plays that were rush plays on rush plays with the team on offense,
+    where 1 is best.
+  start_position_def: Average drive start position, measured in yards from the opponent goal line, with the team on defense
+    (i.e. allowed to opponents).
+  start_position_def_rank: National rank of the team's average drive start position, measured in yards from the opponent goal
+    line with the team on defense (i.e. allowed to opponents), where 1 is best.
+  start_position_margin: 'Field-position margin: the team''s own average starting field position minus the average starting
+    field position it allowed, both measured as yards gained from their own goal line. Positive means the team started closer
+    to scoring than its opponents.'
+  start_position_margin_rank: 'Field-position margin: the team''s own average starting field position minus the average starting
+    field position it allowed, both measured as yards gained from their own goal line. Positive means the team started closer
+    to scoring than its opponents. National rank of that margin, 1 = largest.'
+  start_position_off: Average drive start position, measured in yards from the opponent goal line, with the team on offense.
+  start_position_off_rank: National rank of the team's average drive start position, measured in yards from the opponent goal
+    line with the team on offense, where 1 is best.
+  success_def: Success rate -- the share of plays flagged as successful by EPA, with the team on defense (i.e. allowed to
+    opponents).
+  success_def_pass: Success rate -- the share of plays flagged as successful by EPA on pass plays, with the team on defense
+    (i.e. allowed to opponents).
+  success_def_pass_rank: National rank of the team's success rate -- the share of plays flagged as successful by EPA on pass
+    plays with the team on defense (i.e. allowed to opponents), where 1 is best.
+  success_def_rank: National rank of the team's success rate -- the share of plays flagged as successful by EPA with the team
+    on defense (i.e. allowed to opponents), where 1 is best.
+  success_def_rush: Success rate -- the share of plays flagged as successful by EPA on rush plays, with the team on defense
+    (i.e. allowed to opponents).
+  success_def_rush_rank: National rank of the team's success rate -- the share of plays flagged as successful by EPA on rush
+    plays with the team on defense (i.e. allowed to opponents), where 1 is best.
+  success_margin: 'Margin in success rate -- the share of plays flagged as successful by EPA: the team''s offensive value
+    minus the value it allowed on defense.'
+  success_margin_pass: 'Margin in success rate -- the share of plays flagged as successful by EPA on pass plays: the team''s
+    offensive value minus the value it allowed on defense.'
+  success_margin_pass_rank: 'Margin in success rate -- the share of plays flagged as successful by EPA on pass plays: the
+    team''s offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest.'
+  success_margin_rank: 'Margin in success rate -- the share of plays flagged as successful by EPA: the team''s offensive value
+    minus the value it allowed on defense. National rank of that margin, 1 = largest.'
+  success_margin_rush: 'Margin in success rate -- the share of plays flagged as successful by EPA on rush plays: the team''s
+    offensive value minus the value it allowed on defense.'
+  success_margin_rush_rank: 'Margin in success rate -- the share of plays flagged as successful by EPA on rush plays: the
+    team''s offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest.'
+  success_off: Success rate -- the share of plays flagged as successful by EPA, with the team on offense.
+  success_off_pass: Success rate -- the share of plays flagged as successful by EPA on pass plays, with the team on offense.
+  success_off_pass_rank: National rank of the team's success rate -- the share of plays flagged as successful by EPA on pass
+    plays with the team on offense, where 1 is best.
+  success_off_rank: National rank of the team's success rate -- the share of plays flagged as successful by EPA with the team
+    on offense, where 1 is best.
+  success_off_rush: Success rate -- the share of plays flagged as successful by EPA on rush plays, with the team on offense.
+  success_off_rush_rank: National rank of the team's success rate -- the share of plays flagged as successful by EPA on rush
+    plays with the team on offense, where 1 is best.
+  third_down_distance_def: Average yards to go on third down, with the team on defense (i.e. allowed to opponents).
+  third_down_distance_def_pass: Average yards to go on third down on pass plays, with the team on defense (i.e. allowed to
+    opponents).
+  third_down_distance_def_pass_rank: National rank of the team's average yards to go on third down on pass plays with the
+    team on defense (i.e. allowed to opponents), where 1 is best.
+  third_down_distance_def_rank: National rank of the team's average yards to go on third down with the team on defense (i.e.
+    allowed to opponents), where 1 is best.
+  third_down_distance_def_rush: Average yards to go on third down on rush plays, with the team on defense (i.e. allowed to
+    opponents).
+  third_down_distance_def_rush_rank: National rank of the team's average yards to go on third down on rush plays with the
+    team on defense (i.e. allowed to opponents), where 1 is best.
+  third_down_distance_off: Average yards to go on third down, with the team on offense.
+  third_down_distance_off_pass: Average yards to go on third down on pass plays, with the team on offense.
+  third_down_distance_off_pass_rank: National rank of the team's average yards to go on third down on pass plays with the
+    team on offense, where 1 is best.
+  third_down_distance_off_rank: National rank of the team's average yards to go on third down with the team on offense, where
+    1 is best.
+  third_down_distance_off_rush: Average yards to go on third down on rush plays, with the team on offense.
+  third_down_distance_off_rush_rank: National rank of the team's average yards to go on third down on rush plays with the
+    team on offense, where 1 is best.
+  third_down_success_def: Success rate on third-down plays, with the team on defense (i.e. allowed to opponents).
+  third_down_success_def_pass: Success rate on third-down plays on pass plays, with the team on defense (i.e. allowed to opponents).
+  third_down_success_def_pass_rank: National rank of the team's success rate on third-down plays on pass plays with the team
+    on defense (i.e. allowed to opponents), where 1 is best.
+  third_down_success_def_rank: National rank of the team's success rate on third-down plays with the team on defense (i.e.
+    allowed to opponents), where 1 is best.
+  third_down_success_def_rush: Success rate on third-down plays on rush plays, with the team on defense (i.e. allowed to opponents).
+  third_down_success_def_rush_rank: National rank of the team's success rate on third-down plays on rush plays with the team
+    on defense (i.e. allowed to opponents), where 1 is best.
+  third_down_success_off: Success rate on third-down plays, with the team on offense.
+  third_down_success_off_pass: Success rate on third-down plays on pass plays, with the team on offense.
+  third_down_success_off_pass_rank: National rank of the team's success rate on third-down plays on pass plays with the team
+    on offense, where 1 is best.
+  third_down_success_off_rank: National rank of the team's success rate on third-down plays with the team on offense, where
+    1 is best.
+  third_down_success_off_rush: Success rate on third-down plays on rush plays, with the team on offense.
+  third_down_success_off_rush_rank: National rank of the team's success rate on third-down plays on rush plays with the team
+    on offense, where 1 is best.
+  total_available_yards_def: Available yards are the yards a drive could theoretically gain, summed from each drive's starting
+    distance to the opponent goal line. Total available yards on drives the team defended.
+  total_available_yards_margin: Available yards on the team's own drives minus available yards on drives it defended.
+  total_available_yards_margin_rank: National rank of total_available_yards_margin, 1 = largest margin.
+  total_available_yards_off: Available yards are the yards a drive could theoretically gain, summed from each drive's starting
+    distance to the opponent goal line. Total available yards on the team's own drives.
+  total_gained_yards_def: Total yards the team allowed across the drives it defended.
+  total_gained_yards_margin: Yards the team gained minus yards it allowed.
+  total_gained_yards_margin_rank: National rank of total_gained_yards_margin, 1 = largest margin.
+  total_gained_yards_off: Total yards the team actually gained across its own drives.
+  valid_games: Number of the team's games that produced both an offensive and a defensive adjusted-EPA value; teams below
+    two valid games are dropped from the adjusted ratings.
+  yards_def: Total yards gained, with the team on defense (i.e. allowed to opponents).
+  yards_def_pass: Total yards gained on pass plays, with the team on defense (i.e. allowed to opponents).
+  yards_def_pass_rank: National rank of the team's total yards gained on pass plays with the team on defense (i.e. allowed
+    to opponents), where 1 is best.
+  yards_def_rank: National rank of the team's total yards gained with the team on defense (i.e. allowed to opponents), where
+    1 is best.
+  yards_def_rush: Total yards gained on rush plays, with the team on defense (i.e. allowed to opponents).
+  yards_def_rush_rank: National rank of the team's total yards gained on rush plays with the team on defense (i.e. allowed
+    to opponents), where 1 is best.
+  yards_off: Total yards gained, with the team on offense.
+  yards_off_pass: Total yards gained on pass plays, with the team on offense.
+  yards_off_pass_rank: National rank of the team's total yards gained on pass plays with the team on offense, where 1 is best.
+  yards_off_rank: National rank of the team's total yards gained with the team on offense, where 1 is best.
+  yards_off_rush: Total yards gained on rush plays, with the team on offense.
+  yards_off_rush_rank: National rank of the team's total yards gained on rush plays with the team on offense, where 1 is best.
+  yardsdrive_def: Yards gained per drive, with the team on defense (i.e. allowed to opponents).
+  yardsdrive_def_pass: Yards gained per drive on pass plays, with the team on defense (i.e. allowed to opponents).
+  yardsdrive_def_pass_rank: National rank of the team's yards gained per drive on pass plays with the team on defense (i.e.
+    allowed to opponents), where 1 is best.
+  yardsdrive_def_rank: National rank of the team's yards gained per drive with the team on defense (i.e. allowed to opponents),
+    where 1 is best.
+  yardsdrive_def_rush: Yards gained per drive on rush plays, with the team on defense (i.e. allowed to opponents).
+  yardsdrive_def_rush_rank: National rank of the team's yards gained per drive on rush plays with the team on defense (i.e.
+    allowed to opponents), where 1 is best.
+  yardsdrive_off: Yards gained per drive, with the team on offense.
+  yardsdrive_off_pass: Yards gained per drive on pass plays, with the team on offense.
+  yardsdrive_off_pass_rank: National rank of the team's yards gained per drive on pass plays with the team on offense, where
+    1 is best.
+  yardsdrive_off_rank: National rank of the team's yards gained per drive with the team on offense, where 1 is best.
+  yardsdrive_off_rush: Yards gained per drive on rush plays, with the team on offense.
+  yardsdrive_off_rush_rank: National rank of the team's yards gained per drive on rush plays with the team on offense, where
+    1 is best.
+  yardsgame_def: Yards gained per game, with the team on defense (i.e. allowed to opponents).
+  yardsgame_def_pass: Yards gained per game on pass plays, with the team on defense (i.e. allowed to opponents).
+  yardsgame_def_pass_rank: National rank of the team's yards gained per game on pass plays with the team on defense (i.e.
+    allowed to opponents), where 1 is best.
+  yardsgame_def_rank: National rank of the team's yards gained per game with the team on defense (i.e. allowed to opponents),
+    where 1 is best.
+  yardsgame_def_rush: Yards gained per game on rush plays, with the team on defense (i.e. allowed to opponents).
+  yardsgame_def_rush_rank: National rank of the team's yards gained per game on rush plays with the team on defense (i.e.
+    allowed to opponents), where 1 is best.
+  yardsgame_off: Yards gained per game, with the team on offense.
+  yardsgame_off_pass: Yards gained per game on pass plays, with the team on offense.
+  yardsgame_off_pass_rank: National rank of the team's yards gained per game on pass plays with the team on offense, where
+    1 is best.
+  yardsgame_off_rank: National rank of the team's yards gained per game with the team on offense, where 1 is best.
+  yardsgame_off_rush: Yards gained per game on rush plays, with the team on offense.
+  yardsgame_off_rush_rank: National rank of the team's yards gained per game on rush plays with the team on offense, where
+    1 is best.
+  yardsplay_def: Yards gained per play, with the team on defense (i.e. allowed to opponents).
+  yardsplay_def_pass: Yards gained per play on pass plays, with the team on defense (i.e. allowed to opponents).
+  yardsplay_def_pass_rank: National rank of the team's yards gained per play on pass plays with the team on defense (i.e.
+    allowed to opponents), where 1 is best.
+  yardsplay_def_rank: National rank of the team's yards gained per play with the team on defense (i.e. allowed to opponents),
+    where 1 is best.
+  yardsplay_def_rush: Yards gained per play on rush plays, with the team on defense (i.e. allowed to opponents).
+  yardsplay_def_rush_rank: National rank of the team's yards gained per play on rush plays with the team on defense (i.e.
+    allowed to opponents), where 1 is best.
+  yardsplay_margin: 'Margin in yards gained per play: the team''s offensive value minus the value it allowed on defense.'
+  yardsplay_margin_pass: 'Margin in yards gained per play on pass plays: the team''s offensive value minus the value it allowed
+    on defense.'
+  yardsplay_margin_pass_rank: 'Margin in yards gained per play on pass plays: the team''s offensive value minus the value
+    it allowed on defense. National rank of that margin, 1 = largest.'
+  yardsplay_margin_rank: 'Margin in yards gained per play: the team''s offensive value minus the value it allowed on defense.
+    National rank of that margin, 1 = largest.'
+  yardsplay_margin_rush: 'Margin in yards gained per play on rush plays: the team''s offensive value minus the value it allowed
+    on defense.'
+  yardsplay_margin_rush_rank: 'Margin in yards gained per play on rush plays: the team''s offensive value minus the value
+    it allowed on defense. National rank of that margin, 1 = largest.'
+  yardsplay_off: Yards gained per play, with the team on offense.
+  yardsplay_off_pass: Yards gained per play on pass plays, with the team on offense.
+  yardsplay_off_pass_rank: National rank of the team's yards gained per play on pass plays with the team on offense, where
+    1 is best.
+  yardsplay_off_rank: National rank of the team's yards gained per play with the team on offense, where 1 is best.
+  yardsplay_off_rush: Yards gained per play on rush plays, with the team on offense.
+  yardsplay_off_rush_rank: National rank of the team's yards gained per play on rush plays with the team on offense, where
+    1 is best.
+load_cfb_team_summaries_weekly:
+  EPAdrive_def: EPA per drive (total EPA divided by drives), with the team on defense (i.e. allowed to opponents).
+  EPAdrive_def_pass: EPA per drive (total EPA divided by drives) on pass plays, with the team on defense (i.e. allowed to
+    opponents).
+  EPAdrive_def_pass_rank: National rank of the team's EPA per drive (total EPA divided by drives) on pass plays with the team
+    on defense (i.e. allowed to opponents), where 1 is best.
+  EPAdrive_def_rank: National rank of the team's EPA per drive (total EPA divided by drives) with the team on defense (i.e.
+    allowed to opponents), where 1 is best.
+  EPAdrive_def_rush: EPA per drive (total EPA divided by drives) on rush plays, with the team on defense (i.e. allowed to
+    opponents).
+  EPAdrive_def_rush_rank: National rank of the team's EPA per drive (total EPA divided by drives) on rush plays with the team
+    on defense (i.e. allowed to opponents), where 1 is best.
+  EPAdrive_margin: 'Margin in EPA per drive (total EPA divided by drives): the team''s offensive value minus the value it
+    allowed on defense.'
+  EPAdrive_margin_pass: 'Margin in EPA per drive (total EPA divided by drives) on pass plays: the team''s offensive value
+    minus the value it allowed on defense.'
+  EPAdrive_margin_pass_rank: 'Margin in EPA per drive (total EPA divided by drives) on pass plays: the team''s offensive value
+    minus the value it allowed on defense. National rank of that margin, 1 = largest.'
+  EPAdrive_margin_rank: 'Margin in EPA per drive (total EPA divided by drives): the team''s offensive value minus the value
+    it allowed on defense. National rank of that margin, 1 = largest.'
+  EPAdrive_margin_rush: 'Margin in EPA per drive (total EPA divided by drives) on rush plays: the team''s offensive value
+    minus the value it allowed on defense.'
+  EPAdrive_margin_rush_rank: 'Margin in EPA per drive (total EPA divided by drives) on rush plays: the team''s offensive value
+    minus the value it allowed on defense. National rank of that margin, 1 = largest.'
+  EPAdrive_off: EPA per drive (total EPA divided by drives), with the team on offense.
+  EPAdrive_off_pass: EPA per drive (total EPA divided by drives) on pass plays, with the team on offense.
+  EPAdrive_off_pass_rank: National rank of the team's EPA per drive (total EPA divided by drives) on pass plays with the team
+    on offense, where 1 is best.
+  EPAdrive_off_rank: National rank of the team's EPA per drive (total EPA divided by drives) with the team on offense, where
+    1 is best.
+  EPAdrive_off_rush: EPA per drive (total EPA divided by drives) on rush plays, with the team on offense.
+  EPAdrive_off_rush_rank: National rank of the team's EPA per drive (total EPA divided by drives) on rush plays with the team
+    on offense, where 1 is best.
+  EPAgame_def: EPA per game (total EPA divided by games), with the team on defense (i.e. allowed to opponents).
+  EPAgame_def_pass: EPA per game (total EPA divided by games) on pass plays, with the team on defense (i.e. allowed to opponents).
+  EPAgame_def_pass_rank: National rank of the team's EPA per game (total EPA divided by games) on pass plays with the team
+    on defense (i.e. allowed to opponents), where 1 is best.
+  EPAgame_def_rank: National rank of the team's EPA per game (total EPA divided by games) with the team on defense (i.e. allowed
+    to opponents), where 1 is best.
+  EPAgame_def_rush: EPA per game (total EPA divided by games) on rush plays, with the team on defense (i.e. allowed to opponents).
+  EPAgame_def_rush_rank: National rank of the team's EPA per game (total EPA divided by games) on rush plays with the team
+    on defense (i.e. allowed to opponents), where 1 is best.
+  EPAgame_margin: 'Margin in EPA per game (total EPA divided by games): the team''s offensive value minus the value it allowed
+    on defense.'
+  EPAgame_margin_pass: 'Margin in EPA per game (total EPA divided by games) on pass plays: the team''s offensive value minus
+    the value it allowed on defense.'
+  EPAgame_margin_pass_rank: 'Margin in EPA per game (total EPA divided by games) on pass plays: the team''s offensive value
+    minus the value it allowed on defense. National rank of that margin, 1 = largest.'
+  EPAgame_margin_rank: 'Margin in EPA per game (total EPA divided by games): the team''s offensive value minus the value it
+    allowed on defense. National rank of that margin, 1 = largest.'
+  EPAgame_margin_rush: 'Margin in EPA per game (total EPA divided by games) on rush plays: the team''s offensive value minus
+    the value it allowed on defense.'
+  EPAgame_margin_rush_rank: 'Margin in EPA per game (total EPA divided by games) on rush plays: the team''s offensive value
+    minus the value it allowed on defense. National rank of that margin, 1 = largest.'
+  EPAgame_off: EPA per game (total EPA divided by games), with the team on offense.
+  EPAgame_off_pass: EPA per game (total EPA divided by games) on pass plays, with the team on offense.
+  EPAgame_off_pass_rank: National rank of the team's EPA per game (total EPA divided by games) on pass plays with the team
+    on offense, where 1 is best.
+  EPAgame_off_rank: National rank of the team's EPA per game (total EPA divided by games) with the team on offense, where
+    1 is best.
+  EPAgame_off_rush: EPA per game (total EPA divided by games) on rush plays, with the team on offense.
+  EPAgame_off_rush_rank: National rank of the team's EPA per game (total EPA divided by games) on rush plays with the team
+    on offense, where 1 is best.
+  EPAplay_def: EPA per play, with the team on defense (i.e. allowed to opponents).
+  EPAplay_def_pass: EPA per play on pass plays, with the team on defense (i.e. allowed to opponents).
+  EPAplay_def_pass_rank: National rank of the team's EPA per play on pass plays with the team on defense (i.e. allowed to
+    opponents), where 1 is best.
+  EPAplay_def_rank: National rank of the team's EPA per play with the team on defense (i.e. allowed to opponents), where 1
+    is best.
+  EPAplay_def_rush: EPA per play on rush plays, with the team on defense (i.e. allowed to opponents).
+  EPAplay_def_rush_rank: National rank of the team's EPA per play on rush plays with the team on defense (i.e. allowed to
+    opponents), where 1 is best.
+  EPAplay_margin: 'Margin in EPA per play: the team''s offensive value minus the value it allowed on defense.'
+  EPAplay_margin_pass: 'Margin in EPA per play on pass plays: the team''s offensive value minus the value it allowed on defense.'
+  EPAplay_margin_pass_rank: 'Margin in EPA per play on pass plays: the team''s offensive value minus the value it allowed
+    on defense. National rank of that margin, 1 = largest.'
+  EPAplay_margin_rank: 'Margin in EPA per play: the team''s offensive value minus the value it allowed on defense. National
+    rank of that margin, 1 = largest.'
+  EPAplay_margin_rush: 'Margin in EPA per play on rush plays: the team''s offensive value minus the value it allowed on defense.'
+  EPAplay_margin_rush_rank: 'Margin in EPA per play on rush plays: the team''s offensive value minus the value it allowed
+    on defense. National rank of that margin, 1 = largest.'
+  EPAplay_off: EPA per play, with the team on offense.
+  EPAplay_off_pass: EPA per play on pass plays, with the team on offense.
+  EPAplay_off_pass_rank: National rank of the team's EPA per play on pass plays with the team on offense, where 1 is best.
+  EPAplay_off_rank: National rank of the team's EPA per play with the team on offense, where 1 is best.
+  EPAplay_off_rush: EPA per play on rush plays, with the team on offense.
+  EPAplay_off_rush_rank: National rank of the team's EPA per play on rush plays with the team on offense, where 1 is best.
+  TEPA_def: Total EPA summed over every play, with the team on defense (i.e. allowed to opponents).
+  TEPA_def_pass: Total EPA summed over every play on pass plays, with the team on defense (i.e. allowed to opponents).
+  TEPA_def_pass_rank: National rank of the team's total EPA summed over every play on pass plays with the team on defense
+    (i.e. allowed to opponents), where 1 is best.
+  TEPA_def_rank: National rank of the team's total EPA summed over every play with the team on defense (i.e. allowed to opponents),
+    where 1 is best.
+  TEPA_def_rush: Total EPA summed over every play on rush plays, with the team on defense (i.e. allowed to opponents).
+  TEPA_def_rush_rank: National rank of the team's total EPA summed over every play on rush plays with the team on defense
+    (i.e. allowed to opponents), where 1 is best.
+  TEPA_margin: 'Margin in total EPA summed over every play: the team''s offensive value minus the value it allowed on defense.'
+  TEPA_margin_pass: 'Margin in total EPA summed over every play on pass plays: the team''s offensive value minus the value
+    it allowed on defense.'
+  TEPA_margin_pass_rank: 'Margin in total EPA summed over every play on pass plays: the team''s offensive value minus the
+    value it allowed on defense. National rank of that margin, 1 = largest.'
+  TEPA_margin_rank: 'Margin in total EPA summed over every play: the team''s offensive value minus the value it allowed on
+    defense. National rank of that margin, 1 = largest.'
+  TEPA_margin_rush: 'Margin in total EPA summed over every play on rush plays: the team''s offensive value minus the value
+    it allowed on defense.'
+  TEPA_margin_rush_rank: 'Margin in total EPA summed over every play on rush plays: the team''s offensive value minus the
+    value it allowed on defense. National rank of that margin, 1 = largest.'
+  TEPA_off: Total EPA summed over every play, with the team on offense.
+  TEPA_off_pass: Total EPA summed over every play on pass plays, with the team on offense.
+  TEPA_off_pass_rank: National rank of the team's total EPA summed over every play on pass plays with the team on offense,
+    where 1 is best.
+  TEPA_off_rank: National rank of the team's total EPA summed over every play with the team on offense, where 1 is best.
+  TEPA_off_rush: Total EPA summed over every play on rush plays, with the team on offense.
+  TEPA_off_rush_rank: National rank of the team's total EPA summed over every play on rush plays with the team on offense,
+    where 1 is best.
+  adj_def_epa: Defensive opponent-adjusted EPA per play from the ridge (RAPM-style) regression on offense/defense team indicators
+    plus home field -- cfbfastR's adjust_epa adjustment, fit in-sample across the season, so the value is descriptive of that
+    window rather than predictive. Lower is better -- it is EPA allowed.
+  adj_def_epa_rank: National rank of the team's adj_def_epa, where 1 is best (fewest EPA allowed).
+  adj_off_epa: Offensive opponent-adjusted EPA per play from the ridge (RAPM-style) regression on offense/defense team indicators
+    plus home field -- cfbfastR's adjust_epa adjustment, fit in-sample across the season, so the value is descriptive of that
+    window rather than predictive.
+  adj_off_epa_rank: National rank of the team's adj_off_epa, where 1 is best.
+  available_yards_pct_def: Share of available yards the team's defense allowed opponents to gain. Lower is better.
+  available_yards_pct_def_rank: National rank of the team's defensive available-yards share, where 1 is best.
+  available_yards_pct_margin: Available-yards share gained by the offense minus the share allowed by the defense. Higher is
+    better.
+  available_yards_pct_margin_rank: National rank of available_yards_pct_margin, 1 = largest margin.
+  available_yards_pct_off: Share of available yards the team's offense actually gained (total_gained_yards_off divided by
+    total_available_yards_off). Higher is better.
+  available_yards_pct_off_rank: National rank of the team's offensive available-yards share, where 1 is best.
+  def_strength_faced: Average opponent-offense strength the team's defense faced, taken as the mean of the ridge's offensive
+    coefficients across its opponents. Higher means a tougher slate.
+  drives_def: Offensive drives, with the team on defense (i.e. allowed to opponents).
+  drives_def_pass: Offensive drives on pass plays, with the team on defense (i.e. allowed to opponents).
+  drives_def_rush: Offensive drives on rush plays, with the team on defense (i.e. allowed to opponents).
+  drives_off: Offensive drives, with the team on offense.
+  drives_off_pass: Offensive drives on pass plays, with the team on offense.
+  drives_off_rush: Offensive drives on rush plays, with the team on offense.
+  drivesgame_def: Drives per game, with the team on defense (i.e. allowed to opponents).
+  drivesgame_def_pass: Drives per game on pass plays, with the team on defense (i.e. allowed to opponents).
+  drivesgame_def_pass_rank: National rank of the team's drives per game on pass plays with the team on defense (i.e. allowed
+    to opponents), where 1 is best.
+  drivesgame_def_rank: National rank of the team's drives per game with the team on defense (i.e. allowed to opponents), where
+    1 is best.
+  drivesgame_def_rush: Drives per game on rush plays, with the team on defense (i.e. allowed to opponents).
+  drivesgame_def_rush_rank: National rank of the team's drives per game on rush plays with the team on defense (i.e. allowed
+    to opponents), where 1 is best.
+  drivesgame_off: Drives per game, with the team on offense.
+  drivesgame_off_pass: Drives per game on pass plays, with the team on offense.
+  drivesgame_off_pass_rank: National rank of the team's drives per game on pass plays with the team on offense, where 1 is
+    best.
+  drivesgame_off_rank: National rank of the team's drives per game with the team on offense, where 1 is best.
+  drivesgame_off_rush: Drives per game on rush plays, with the team on offense.
+  drivesgame_off_rush_rank: National rank of the team's drives per game on rush plays with the team on offense, where 1 is
+    best.
+  early_down_EPA_def: EPA per early-down play, with the team on defense (i.e. allowed to opponents).
+  early_down_EPA_def_pass: EPA per early-down play on pass plays, with the team on defense (i.e. allowed to opponents).
+  early_down_EPA_def_pass_rank: National rank of the team's EPA per early-down play on pass plays with the team on defense
+    (i.e. allowed to opponents), where 1 is best.
+  early_down_EPA_def_rank: National rank of the team's EPA per early-down play with the team on defense (i.e. allowed to opponents),
+    where 1 is best.
+  early_down_EPA_def_rush: EPA per early-down play on rush plays, with the team on defense (i.e. allowed to opponents).
+  early_down_EPA_def_rush_rank: National rank of the team's EPA per early-down play on rush plays with the team on defense
+    (i.e. allowed to opponents), where 1 is best.
+  early_down_EPA_off: EPA per early-down play, with the team on offense.
+  early_down_EPA_off_pass: EPA per early-down play on pass plays, with the team on offense.
+  early_down_EPA_off_pass_rank: National rank of the team's EPA per early-down play on pass plays with the team on offense,
+    where 1 is best.
+  early_down_EPA_off_rank: National rank of the team's EPA per early-down play with the team on offense, where 1 is best.
+  early_down_EPA_off_rush: EPA per early-down play on rush plays, with the team on offense.
+  early_down_EPA_off_rush_rank: National rank of the team's EPA per early-down play on rush plays with the team on offense,
+    where 1 is best.
+  explosive_def: Explosive-play rate -- the share of plays carrying the explosive flag, with the team on defense (i.e. allowed
+    to opponents).
+  explosive_def_pass: Explosive-play rate -- the share of plays carrying the explosive flag on pass plays, with the team on
+    defense (i.e. allowed to opponents).
+  explosive_def_pass_rank: National rank of the team's explosive-play rate -- the share of plays carrying the explosive flag
+    on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best.
+  explosive_def_rank: National rank of the team's explosive-play rate -- the share of plays carrying the explosive flag with
+    the team on defense (i.e. allowed to opponents), where 1 is best.
+  explosive_def_rush: Explosive-play rate -- the share of plays carrying the explosive flag on rush plays, with the team on
+    defense (i.e. allowed to opponents).
+  explosive_def_rush_rank: National rank of the team's explosive-play rate -- the share of plays carrying the explosive flag
+    on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best.
+  explosive_off: Explosive-play rate -- the share of plays carrying the explosive flag, with the team on offense.
+  explosive_off_pass: Explosive-play rate -- the share of plays carrying the explosive flag on pass plays, with the team on
+    offense.
+  explosive_off_pass_rank: National rank of the team's explosive-play rate -- the share of plays carrying the explosive flag
+    on pass plays with the team on offense, where 1 is best.
+  explosive_off_rank: National rank of the team's explosive-play rate -- the share of plays carrying the explosive flag with
+    the team on offense, where 1 is best.
+  explosive_off_rush: Explosive-play rate -- the share of plays carrying the explosive flag on rush plays, with the team on
+    offense.
+  explosive_off_rush_rank: National rank of the team's explosive-play rate -- the share of plays carrying the explosive flag
+    on rush plays with the team on offense, where 1 is best.
+  fbs_class: 'Power/Group classification for the season: P4 or G6 from 2024 on, P5 or G5 through 2023, derived from conference
+    membership (Notre Dame is classified with the power group). Null for teams outside FBS.'
+  havoc_def: Havoc rate -- the share of plays carrying the defensive-disruption flag, with the team on defense (i.e. allowed
+    to opponents).
+  havoc_def_pass: Havoc rate -- the share of plays carrying the defensive-disruption flag on pass plays, with the team on
+    defense (i.e. allowed to opponents).
+  havoc_def_pass_rank: National rank of the team's havoc rate -- the share of plays carrying the defensive-disruption flag
+    on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best.
+  havoc_def_rank: National rank of the team's havoc rate -- the share of plays carrying the defensive-disruption flag with
+    the team on defense (i.e. allowed to opponents), where 1 is best.
+  havoc_def_rush: Havoc rate -- the share of plays carrying the defensive-disruption flag on rush plays, with the team on
+    defense (i.e. allowed to opponents).
+  havoc_def_rush_rank: National rank of the team's havoc rate -- the share of plays carrying the defensive-disruption flag
+    on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best.
+  havoc_off: Havoc rate -- the share of plays carrying the defensive-disruption flag, with the team on offense.
+  havoc_off_pass: Havoc rate -- the share of plays carrying the defensive-disruption flag on pass plays, with the team on
+    offense.
+  havoc_off_pass_rank: National rank of the team's havoc rate -- the share of plays carrying the defensive-disruption flag
+    on pass plays with the team on offense, where 1 is best.
+  havoc_off_rank: National rank of the team's havoc rate -- the share of plays carrying the defensive-disruption flag with
+    the team on offense, where 1 is best.
+  havoc_off_rush: Havoc rate -- the share of plays carrying the defensive-disruption flag on rush plays, with the team on
+    offense.
+  havoc_off_rush_rank: National rank of the team's havoc rate -- the share of plays carrying the defensive-disruption flag
+    on rush plays with the team on offense, where 1 is best.
+  late_down_success_def: Success rate on late-down plays, with the team on defense (i.e. allowed to opponents).
+  late_down_success_def_pass: Success rate on late-down plays on pass plays, with the team on defense (i.e. allowed to opponents).
+  late_down_success_def_pass_rank: National rank of the team's success rate on late-down plays on pass plays with the team
+    on defense (i.e. allowed to opponents), where 1 is best.
+  late_down_success_def_rank: National rank of the team's success rate on late-down plays with the team on defense (i.e. allowed
+    to opponents), where 1 is best.
+  late_down_success_def_rush: Success rate on late-down plays on rush plays, with the team on defense (i.e. allowed to opponents).
+  late_down_success_def_rush_rank: National rank of the team's success rate on late-down plays on rush plays with the team
+    on defense (i.e. allowed to opponents), where 1 is best.
+  late_down_success_off: Success rate on late-down plays, with the team on offense.
+  late_down_success_off_pass: Success rate on late-down plays on pass plays, with the team on offense.
+  late_down_success_off_pass_rank: National rank of the team's success rate on late-down plays on pass plays with the team
+    on offense, where 1 is best.
+  late_down_success_off_rank: National rank of the team's success rate on late-down plays with the team on offense, where
+    1 is best.
+  late_down_success_off_rush: Success rate on late-down plays on rush plays, with the team on offense.
+  late_down_success_off_rush_rank: National rank of the team's success rate on late-down plays on rush plays with the team
+    on offense, where 1 is best.
+  line_yards_def: Average line yards credited to the offensive line on rushes, with the team on defense (i.e. allowed to opponents).
+  line_yards_def_pass: Average line yards credited to the offensive line on rushes on pass plays, with the team on defense
+    (i.e. allowed to opponents).
+  line_yards_def_pass_rank: National rank of the team's average line yards credited to the offensive line on rushes on pass
+    plays with the team on defense (i.e. allowed to opponents), where 1 is best.
+  line_yards_def_rank: National rank of the team's average line yards credited to the offensive line on rushes with the team
+    on defense (i.e. allowed to opponents), where 1 is best.
+  line_yards_def_rush: Average line yards credited to the offensive line on rushes on rush plays, with the team on defense
+    (i.e. allowed to opponents).
+  line_yards_def_rush_rank: National rank of the team's average line yards credited to the offensive line on rushes on rush
+    plays with the team on defense (i.e. allowed to opponents), where 1 is best.
+  line_yards_off: Average line yards credited to the offensive line on rushes, with the team on offense.
+  line_yards_off_pass: Average line yards credited to the offensive line on rushes on pass plays, with the team on offense.
+  line_yards_off_pass_rank: National rank of the team's average line yards credited to the offensive line on rushes on pass
+    plays with the team on offense, where 1 is best.
+  line_yards_off_rank: National rank of the team's average line yards credited to the offensive line on rushes with the team
+    on offense, where 1 is best.
+  line_yards_off_rush: Average line yards credited to the offensive line on rushes on rush plays, with the team on offense.
+  line_yards_off_rush_rank: National rank of the team's average line yards credited to the offensive line on rushes on rush
+    plays with the team on offense, where 1 is best.
+  net_adj_epa: 'Net opponent-adjusted EPA per play: adj_off_epa minus adj_def_epa. Higher is better.'
+  net_adj_epa_rank: National rank of the team's net_adj_epa, 1 = largest net adjusted EPA.
+  nonExplosiveEpaPerPlay_def: EPA per play with explosive plays excluded, with the team on defense (i.e. allowed to opponents).
+  nonExplosiveEpaPerPlay_def_pass: EPA per play with explosive plays excluded on pass plays, with the team on defense (i.e.
+    allowed to opponents).
+  nonExplosiveEpaPerPlay_def_pass_rank: National rank of the team's EPA per play with explosive plays excluded on pass plays
+    with the team on defense (i.e. allowed to opponents), where 1 is best.
+  nonExplosiveEpaPerPlay_def_rank: National rank of the team's EPA per play with explosive plays excluded with the team on
+    defense (i.e. allowed to opponents), where 1 is best.
+  nonExplosiveEpaPerPlay_def_rush: EPA per play with explosive plays excluded on rush plays, with the team on defense (i.e.
+    allowed to opponents).
+  nonExplosiveEpaPerPlay_def_rush_rank: National rank of the team's EPA per play with explosive plays excluded on rush plays
+    with the team on defense (i.e. allowed to opponents), where 1 is best.
+  nonExplosiveEpaPerPlay_off: EPA per play with explosive plays excluded, with the team on offense.
+  nonExplosiveEpaPerPlay_off_pass: EPA per play with explosive plays excluded on pass plays, with the team on offense.
+  nonExplosiveEpaPerPlay_off_pass_rank: National rank of the team's EPA per play with explosive plays excluded on pass plays
+    with the team on offense, where 1 is best.
+  nonExplosiveEpaPerPlay_off_rank: National rank of the team's EPA per play with explosive plays excluded with the team on
+    offense, where 1 is best.
+  nonExplosiveEpaPerPlay_off_rush: EPA per play with explosive plays excluded on rush plays, with the team on offense.
+  nonExplosiveEpaPerPlay_off_rush_rank: National rank of the team's EPA per play with explosive plays excluded on rush plays
+    with the team on offense, where 1 is best.
+  off_strength_faced: Average opponent-defense strength the team's offense faced, taken as the mean of the ridge's defensive
+    coefficients across its opponents. Higher means a tougher slate.
+  opportunity_rate_def: Opportunity rate -- the share of rushes carrying the opportunity flag, with the team on defense (i.e.
+    allowed to opponents).
+  opportunity_rate_def_pass: Opportunity rate -- the share of rushes carrying the opportunity flag on pass plays, with the
+    team on defense (i.e. allowed to opponents).
+  opportunity_rate_def_pass_rank: National rank of the team's opportunity rate -- the share of rushes carrying the opportunity
+    flag on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best.
+  opportunity_rate_def_rank: National rank of the team's opportunity rate -- the share of rushes carrying the opportunity
+    flag with the team on defense (i.e. allowed to opponents), where 1 is best.
+  opportunity_rate_def_rush: Opportunity rate -- the share of rushes carrying the opportunity flag on rush plays, with the
+    team on defense (i.e. allowed to opponents).
+  opportunity_rate_def_rush_rank: National rank of the team's opportunity rate -- the share of rushes carrying the opportunity
+    flag on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best.
+  opportunity_rate_off: Opportunity rate -- the share of rushes carrying the opportunity flag, with the team on offense.
+  opportunity_rate_off_pass: Opportunity rate -- the share of rushes carrying the opportunity flag on pass plays, with the
+    team on offense.
+  opportunity_rate_off_pass_rank: National rank of the team's opportunity rate -- the share of rushes carrying the opportunity
+    flag on pass plays with the team on offense, where 1 is best.
+  opportunity_rate_off_rank: National rank of the team's opportunity rate -- the share of rushes carrying the opportunity
+    flag with the team on offense, where 1 is best.
+  opportunity_rate_off_rush: Opportunity rate -- the share of rushes carrying the opportunity flag on rush plays, with the
+    team on offense.
+  opportunity_rate_off_rush_rank: National rank of the team's opportunity rate -- the share of rushes carrying the opportunity
+    flag on rush plays with the team on offense, where 1 is best.
+  passrate_def: Share of plays that were pass plays, with the team on defense (i.e. allowed to opponents).
+  passrate_def_pass: Share of plays that were pass plays on pass plays, with the team on defense (i.e. allowed to opponents).
+  passrate_def_pass_rank: National rank of the team's share of plays that were pass plays on pass plays with the team on defense
+    (i.e. allowed to opponents), where 1 is best.
+  passrate_def_rank: National rank of the team's share of plays that were pass plays with the team on defense (i.e. allowed
+    to opponents), where 1 is best.
+  passrate_def_rush: Share of plays that were pass plays on rush plays, with the team on defense (i.e. allowed to opponents).
+  passrate_def_rush_rank: National rank of the team's share of plays that were pass plays on rush plays with the team on defense
+    (i.e. allowed to opponents), where 1 is best.
+  passrate_off: Share of plays that were pass plays, with the team on offense.
+  passrate_off_pass: Share of plays that were pass plays on pass plays, with the team on offense.
+  passrate_off_pass_rank: National rank of the team's share of plays that were pass plays on pass plays with the team on offense,
+    where 1 is best.
+  passrate_off_rank: National rank of the team's share of plays that were pass plays with the team on offense, where 1 is
+    best.
+  passrate_off_rush: Share of plays that were pass plays on rush plays, with the team on offense.
+  passrate_off_rush_rank: National rank of the team's share of plays that were pass plays on rush plays with the team on offense,
+    where 1 is best.
+  play_stuffed_def: Stuffed-play rate -- the share of plays carrying the stuffed flag, with the team on defense (i.e. allowed
+    to opponents).
+  play_stuffed_def_pass: Stuffed-play rate -- the share of plays carrying the stuffed flag on pass plays, with the team on
+    defense (i.e. allowed to opponents).
+  play_stuffed_def_pass_rank: National rank of the team's stuffed-play rate -- the share of plays carrying the stuffed flag
+    on pass plays with the team on defense (i.e. allowed to opponents), where 1 is best.
+  play_stuffed_def_rank: National rank of the team's stuffed-play rate -- the share of plays carrying the stuffed flag with
+    the team on defense (i.e. allowed to opponents), where 1 is best.
+  play_stuffed_def_rush: Stuffed-play rate -- the share of plays carrying the stuffed flag on rush plays, with the team on
+    defense (i.e. allowed to opponents).
+  play_stuffed_def_rush_rank: National rank of the team's stuffed-play rate -- the share of plays carrying the stuffed flag
+    on rush plays with the team on defense (i.e. allowed to opponents), where 1 is best.
+  play_stuffed_off: Stuffed-play rate -- the share of plays carrying the stuffed flag, with the team on offense.
+  play_stuffed_off_pass: Stuffed-play rate -- the share of plays carrying the stuffed flag on pass plays, with the team on
+    offense.
+  play_stuffed_off_pass_rank: National rank of the team's stuffed-play rate -- the share of plays carrying the stuffed flag
+    on pass plays with the team on offense, where 1 is best.
+  play_stuffed_off_rank: National rank of the team's stuffed-play rate -- the share of plays carrying the stuffed flag with
+    the team on offense, where 1 is best.
+  play_stuffed_off_rush: Stuffed-play rate -- the share of plays carrying the stuffed flag on rush plays, with the team on
+    offense.
+  play_stuffed_off_rush_rank: National rank of the team's stuffed-play rate -- the share of plays carrying the stuffed flag
+    on rush plays with the team on offense, where 1 is best.
+  plays_def: Plays run, with the team on defense (i.e. allowed to opponents).
+  plays_def_pass: Plays run on pass plays, with the team on defense (i.e. allowed to opponents).
+  plays_def_rush: Plays run on rush plays, with the team on defense (i.e. allowed to opponents).
+  plays_off: Plays run, with the team on offense.
+  plays_off_pass: Plays run on pass plays, with the team on offense.
+  plays_off_rush: Plays run on rush plays, with the team on offense.
+  playsdrive_def: Plays run per drive, with the team on defense (i.e. allowed to opponents).
+  playsdrive_def_pass: Plays run per drive on pass plays, with the team on defense (i.e. allowed to opponents).
+  playsdrive_def_pass_rank: National rank of the team's plays run per drive on pass plays with the team on defense (i.e. allowed
+    to opponents), where 1 is best.
+  playsdrive_def_rank: National rank of the team's plays run per drive with the team on defense (i.e. allowed to opponents),
+    where 1 is best.
+  playsdrive_def_rush: Plays run per drive on rush plays, with the team on defense (i.e. allowed to opponents).
+  playsdrive_def_rush_rank: National rank of the team's plays run per drive on rush plays with the team on defense (i.e. allowed
+    to opponents), where 1 is best.
+  playsdrive_off: Plays run per drive, with the team on offense.
+  playsdrive_off_pass: Plays run per drive on pass plays, with the team on offense.
+  playsdrive_off_pass_rank: National rank of the team's plays run per drive on pass plays with the team on offense, where
+    1 is best.
+  playsdrive_off_rank: National rank of the team's plays run per drive with the team on offense, where 1 is best.
+  playsdrive_off_rush: Plays run per drive on rush plays, with the team on offense.
+  playsdrive_off_rush_rank: National rank of the team's plays run per drive on rush plays with the team on offense, where
+    1 is best.
+  playsgame_def: Plays run per game, with the team on defense (i.e. allowed to opponents).
+  playsgame_def_pass: Plays run per game on pass plays, with the team on defense (i.e. allowed to opponents).
+  playsgame_def_pass_rank: National rank of the team's plays run per game on pass plays with the team on defense (i.e. allowed
+    to opponents), where 1 is best.
+  playsgame_def_rank: National rank of the team's plays run per game with the team on defense (i.e. allowed to opponents),
+    where 1 is best.
+  playsgame_def_rush: Plays run per game on rush plays, with the team on defense (i.e. allowed to opponents).
+  playsgame_def_rush_rank: National rank of the team's plays run per game on rush plays with the team on defense (i.e. allowed
+    to opponents), where 1 is best.
+  playsgame_off: Plays run per game, with the team on offense.
+  playsgame_off_pass: Plays run per game on pass plays, with the team on offense.
+  playsgame_off_pass_rank: National rank of the team's plays run per game on pass plays with the team on offense, where 1
+    is best.
+  playsgame_off_rank: National rank of the team's plays run per game with the team on offense, where 1 is best.
+  playsgame_off_rush: Plays run per game on rush plays, with the team on offense.
+  playsgame_off_rush_rank: National rank of the team's plays run per game on rush plays with the team on offense, where 1
+    is best.
+  red_zone_success_def: Success rate on red-zone plays, with the team on defense (i.e. allowed to opponents).
+  red_zone_success_def_pass: Success rate on red-zone plays on pass plays, with the team on defense (i.e. allowed to opponents).
+  red_zone_success_def_pass_rank: National rank of the team's success rate on red-zone plays on pass plays with the team on
+    defense (i.e. allowed to opponents), where 1 is best.
+  red_zone_success_def_rank: National rank of the team's success rate on red-zone plays with the team on defense (i.e. allowed
+    to opponents), where 1 is best.
+  red_zone_success_def_rush: Success rate on red-zone plays on rush plays, with the team on defense (i.e. allowed to opponents).
+  red_zone_success_def_rush_rank: National rank of the team's success rate on red-zone plays on rush plays with the team on
+    defense (i.e. allowed to opponents), where 1 is best.
+  red_zone_success_off: Success rate on red-zone plays, with the team on offense.
+  red_zone_success_off_pass: Success rate on red-zone plays on pass plays, with the team on offense.
+  red_zone_success_off_pass_rank: National rank of the team's success rate on red-zone plays on pass plays with the team on
+    offense, where 1 is best.
+  red_zone_success_off_rank: National rank of the team's success rate on red-zone plays with the team on offense, where 1
+    is best.
+  red_zone_success_off_rush: Success rate on red-zone plays on rush plays, with the team on offense.
+  red_zone_success_off_rush_rank: National rank of the team's success rate on red-zone plays on rush plays with the team on
+    offense, where 1 is best.
+  rushrate_def: Share of plays that were rush plays, with the team on defense (i.e. allowed to opponents).
+  rushrate_def_pass: Share of plays that were rush plays on pass plays, with the team on defense (i.e. allowed to opponents).
+  rushrate_def_pass_rank: National rank of the team's share of plays that were rush plays on pass plays with the team on defense
+    (i.e. allowed to opponents), where 1 is best.
+  rushrate_def_rank: National rank of the team's share of plays that were rush plays with the team on defense (i.e. allowed
+    to opponents), where 1 is best.
+  rushrate_def_rush: Share of plays that were rush plays on rush plays, with the team on defense (i.e. allowed to opponents).
+  rushrate_def_rush_rank: National rank of the team's share of plays that were rush plays on rush plays with the team on defense
+    (i.e. allowed to opponents), where 1 is best.
+  rushrate_off: Share of plays that were rush plays, with the team on offense.
+  rushrate_off_pass: Share of plays that were rush plays on pass plays, with the team on offense.
+  rushrate_off_pass_rank: National rank of the team's share of plays that were rush plays on pass plays with the team on offense,
+    where 1 is best.
+  rushrate_off_rank: National rank of the team's share of plays that were rush plays with the team on offense, where 1 is
+    best.
+  rushrate_off_rush: Share of plays that were rush plays on rush plays, with the team on offense.
+  rushrate_off_rush_rank: National rank of the team's share of plays that were rush plays on rush plays with the team on offense,
+    where 1 is best.
+  start_position_def: Average drive start position, measured in yards from the opponent goal line, with the team on defense
+    (i.e. allowed to opponents).
+  start_position_def_rank: National rank of the team's average drive start position, measured in yards from the opponent goal
+    line with the team on defense (i.e. allowed to opponents), where 1 is best.
+  start_position_margin: 'Field-position margin: the team''s own average starting field position minus the average starting
+    field position it allowed, both measured as yards gained from their own goal line. Positive means the team started closer
+    to scoring than its opponents.'
+  start_position_margin_rank: 'Field-position margin: the team''s own average starting field position minus the average starting
+    field position it allowed, both measured as yards gained from their own goal line. Positive means the team started closer
+    to scoring than its opponents. National rank of that margin, 1 = largest.'
+  start_position_off: Average drive start position, measured in yards from the opponent goal line, with the team on offense.
+  start_position_off_rank: National rank of the team's average drive start position, measured in yards from the opponent goal
+    line with the team on offense, where 1 is best.
+  success_def: Success rate -- the share of plays flagged as successful by EPA, with the team on defense (i.e. allowed to
+    opponents).
+  success_def_pass: Success rate -- the share of plays flagged as successful by EPA on pass plays, with the team on defense
+    (i.e. allowed to opponents).
+  success_def_pass_rank: National rank of the team's success rate -- the share of plays flagged as successful by EPA on pass
+    plays with the team on defense (i.e. allowed to opponents), where 1 is best.
+  success_def_rank: National rank of the team's success rate -- the share of plays flagged as successful by EPA with the team
+    on defense (i.e. allowed to opponents), where 1 is best.
+  success_def_rush: Success rate -- the share of plays flagged as successful by EPA on rush plays, with the team on defense
+    (i.e. allowed to opponents).
+  success_def_rush_rank: National rank of the team's success rate -- the share of plays flagged as successful by EPA on rush
+    plays with the team on defense (i.e. allowed to opponents), where 1 is best.
+  success_margin: 'Margin in success rate -- the share of plays flagged as successful by EPA: the team''s offensive value
+    minus the value it allowed on defense.'
+  success_margin_pass: 'Margin in success rate -- the share of plays flagged as successful by EPA on pass plays: the team''s
+    offensive value minus the value it allowed on defense.'
+  success_margin_pass_rank: 'Margin in success rate -- the share of plays flagged as successful by EPA on pass plays: the
+    team''s offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest.'
+  success_margin_rank: 'Margin in success rate -- the share of plays flagged as successful by EPA: the team''s offensive value
+    minus the value it allowed on defense. National rank of that margin, 1 = largest.'
+  success_margin_rush: 'Margin in success rate -- the share of plays flagged as successful by EPA on rush plays: the team''s
+    offensive value minus the value it allowed on defense.'
+  success_margin_rush_rank: 'Margin in success rate -- the share of plays flagged as successful by EPA on rush plays: the
+    team''s offensive value minus the value it allowed on defense. National rank of that margin, 1 = largest.'
+  success_off: Success rate -- the share of plays flagged as successful by EPA, with the team on offense.
+  success_off_pass: Success rate -- the share of plays flagged as successful by EPA on pass plays, with the team on offense.
+  success_off_pass_rank: National rank of the team's success rate -- the share of plays flagged as successful by EPA on pass
+    plays with the team on offense, where 1 is best.
+  success_off_rank: National rank of the team's success rate -- the share of plays flagged as successful by EPA with the team
+    on offense, where 1 is best.
+  success_off_rush: Success rate -- the share of plays flagged as successful by EPA on rush plays, with the team on offense.
+  success_off_rush_rank: National rank of the team's success rate -- the share of plays flagged as successful by EPA on rush
+    plays with the team on offense, where 1 is best.
+  third_down_distance_def: Average yards to go on third down, with the team on defense (i.e. allowed to opponents).
+  third_down_distance_def_pass: Average yards to go on third down on pass plays, with the team on defense (i.e. allowed to
+    opponents).
+  third_down_distance_def_pass_rank: National rank of the team's average yards to go on third down on pass plays with the
+    team on defense (i.e. allowed to opponents), where 1 is best.
+  third_down_distance_def_rank: National rank of the team's average yards to go on third down with the team on defense (i.e.
+    allowed to opponents), where 1 is best.
+  third_down_distance_def_rush: Average yards to go on third down on rush plays, with the team on defense (i.e. allowed to
+    opponents).
+  third_down_distance_def_rush_rank: National rank of the team's average yards to go on third down on rush plays with the
+    team on defense (i.e. allowed to opponents), where 1 is best.
+  third_down_distance_off: Average yards to go on third down, with the team on offense.
+  third_down_distance_off_pass: Average yards to go on third down on pass plays, with the team on offense.
+  third_down_distance_off_pass_rank: National rank of the team's average yards to go on third down on pass plays with the
+    team on offense, where 1 is best.
+  third_down_distance_off_rank: National rank of the team's average yards to go on third down with the team on offense, where
+    1 is best.
+  third_down_distance_off_rush: Average yards to go on third down on rush plays, with the team on offense.
+  third_down_distance_off_rush_rank: National rank of the team's average yards to go on third down on rush plays with the
+    team on offense, where 1 is best.
+  third_down_success_def: Success rate on third-down plays, with the team on defense (i.e. allowed to opponents).
+  third_down_success_def_pass: Success rate on third-down plays on pass plays, with the team on defense (i.e. allowed to opponents).
+  third_down_success_def_pass_rank: National rank of the team's success rate on third-down plays on pass plays with the team
+    on defense (i.e. allowed to opponents), where 1 is best.
+  third_down_success_def_rank: National rank of the team's success rate on third-down plays with the team on defense (i.e.
+    allowed to opponents), where 1 is best.
+  third_down_success_def_rush: Success rate on third-down plays on rush plays, with the team on defense (i.e. allowed to opponents).
+  third_down_success_def_rush_rank: National rank of the team's success rate on third-down plays on rush plays with the team
+    on defense (i.e. allowed to opponents), where 1 is best.
+  third_down_success_off: Success rate on third-down plays, with the team on offense.
+  third_down_success_off_pass: Success rate on third-down plays on pass plays, with the team on offense.
+  third_down_success_off_pass_rank: National rank of the team's success rate on third-down plays on pass plays with the team
+    on offense, where 1 is best.
+  third_down_success_off_rank: National rank of the team's success rate on third-down plays with the team on offense, where
+    1 is best.
+  third_down_success_off_rush: Success rate on third-down plays on rush plays, with the team on offense.
+  third_down_success_off_rush_rank: National rank of the team's success rate on third-down plays on rush plays with the team
+    on offense, where 1 is best.
+  through_week: Regular-season week this cumulative snapshot covers -- the row reflects the team's state through the end of
+    that week. One asset holds every week, so filter on this column.
+  total_available_yards_def: Available yards are the yards a drive could theoretically gain, summed from each drive's starting
+    distance to the opponent goal line. Total available yards on drives the team defended.
+  total_available_yards_margin: Available yards on the team's own drives minus available yards on drives it defended.
+  total_available_yards_margin_rank: National rank of total_available_yards_margin, 1 = largest margin.
+  total_available_yards_off: Available yards are the yards a drive could theoretically gain, summed from each drive's starting
+    distance to the opponent goal line. Total available yards on the team's own drives.
+  total_gained_yards_def: Total yards the team allowed across the drives it defended.
+  total_gained_yards_margin: Yards the team gained minus yards it allowed.
+  total_gained_yards_margin_rank: National rank of total_gained_yards_margin, 1 = largest margin.
+  total_gained_yards_off: Total yards the team actually gained across its own drives.
+  valid_games: Number of the team's games that produced both an offensive and a defensive adjusted-EPA value; teams below
+    two valid games are dropped from the adjusted ratings.
+  yards_def: Total yards gained, with the team on defense (i.e. allowed to opponents).
+  yards_def_pass: Total yards gained on pass plays, with the team on defense (i.e. allowed to opponents).
+  yards_def_pass_rank: National rank of the team's total yards gained on pass plays with the team on defense (i.e. allowed
+    to opponents), where 1 is best.
+  yards_def_rank: National rank of the team's total yards gained with the team on defense (i.e. allowed to opponents), where
+    1 is best.
+  yards_def_rush: Total yards gained on rush plays, with the team on defense (i.e. allowed to opponents).
+  yards_def_rush_rank: National rank of the team's total yards gained on rush plays with the team on defense (i.e. allowed
+    to opponents), where 1 is best.
+  yards_off: Total yards gained, with the team on offense.
+  yards_off_pass: Total yards gained on pass plays, with the team on offense.
+  yards_off_pass_rank: National rank of the team's total yards gained on pass plays with the team on offense, where 1 is best.
+  yards_off_rank: National rank of the team's total yards gained with the team on offense, where 1 is best.
+  yards_off_rush: Total yards gained on rush plays, with the team on offense.
+  yards_off_rush_rank: National rank of the team's total yards gained on rush plays with the team on offense, where 1 is best.
+  yardsdrive_def: Yards gained per drive, with the team on defense (i.e. allowed to opponents).
+  yardsdrive_def_pass: Yards gained per drive on pass plays, with the team on defense (i.e. allowed to opponents).
+  yardsdrive_def_pass_rank: National rank of the team's yards gained per drive on pass plays with the team on defense (i.e.
+    allowed to opponents), where 1 is best.
+  yardsdrive_def_rank: National rank of the team's yards gained per drive with the team on defense (i.e. allowed to opponents),
+    where 1 is best.
+  yardsdrive_def_rush: Yards gained per drive on rush plays, with the team on defense (i.e. allowed to opponents).
+  yardsdrive_def_rush_rank: National rank of the team's yards gained per drive on rush plays with the team on defense (i.e.
+    allowed to opponents), where 1 is best.
+  yardsdrive_off: Yards gained per drive, with the team on offense.
+  yardsdrive_off_pass: Yards gained per drive on pass plays, with the team on offense.
+  yardsdrive_off_pass_rank: National rank of the team's yards gained per drive on pass plays with the team on offense, where
+    1 is best.
+  yardsdrive_off_rank: National rank of the team's yards gained per drive with the team on offense, where 1 is best.
+  yardsdrive_off_rush: Yards gained per drive on rush plays, with the team on offense.
+  yardsdrive_off_rush_rank: National rank of the team's yards gained per drive on rush plays with the team on offense, where
+    1 is best.
+  yardsgame_def: Yards gained per game, with the team on defense (i.e. allowed to opponents).
+  yardsgame_def_pass: Yards gained per game on pass plays, with the team on defense (i.e. allowed to opponents).
+  yardsgame_def_pass_rank: National rank of the team's yards gained per game on pass plays with the team on defense (i.e.
+    allowed to opponents), where 1 is best.
+  yardsgame_def_rank: National rank of the team's yards gained per game with the team on defense (i.e. allowed to opponents),
+    where 1 is best.
+  yardsgame_def_rush: Yards gained per game on rush plays, with the team on defense (i.e. allowed to opponents).
+  yardsgame_def_rush_rank: National rank of the team's yards gained per game on rush plays with the team on defense (i.e.
+    allowed to opponents), where 1 is best.
+  yardsgame_off: Yards gained per game, with the team on offense.
+  yardsgame_off_pass: Yards gained per game on pass plays, with the team on offense.
+  yardsgame_off_pass_rank: National rank of the team's yards gained per game on pass plays with the team on offense, where
+    1 is best.
+  yardsgame_off_rank: National rank of the team's yards gained per game with the team on offense, where 1 is best.
+  yardsgame_off_rush: Yards gained per game on rush plays, with the team on offense.
+  yardsgame_off_rush_rank: National rank of the team's yards gained per game on rush plays with the team on offense, where
+    1 is best.
+  yardsplay_def: Yards gained per play, with the team on defense (i.e. allowed to opponents).
+  yardsplay_def_pass: Yards gained per play on pass plays, with the team on defense (i.e. allowed to opponents).
+  yardsplay_def_pass_rank: National rank of the team's yards gained per play on pass plays with the team on defense (i.e.
+    allowed to opponents), where 1 is best.
+  yardsplay_def_rank: National rank of the team's yards gained per play with the team on defense (i.e. allowed to opponents),
+    where 1 is best.
+  yardsplay_def_rush: Yards gained per play on rush plays, with the team on defense (i.e. allowed to opponents).
+  yardsplay_def_rush_rank: National rank of the team's yards gained per play on rush plays with the team on defense (i.e.
+    allowed to opponents), where 1 is best.
+  yardsplay_margin: 'Margin in yards gained per play: the team''s offensive value minus the value it allowed on defense.'
+  yardsplay_margin_pass: 'Margin in yards gained per play on pass plays: the team''s offensive value minus the value it allowed
+    on defense.'
+  yardsplay_margin_pass_rank: 'Margin in yards gained per play on pass plays: the team''s offensive value minus the value
+    it allowed on defense. National rank of that margin, 1 = largest.'
+  yardsplay_margin_rank: 'Margin in yards gained per play: the team''s offensive value minus the value it allowed on defense.
+    National rank of that margin, 1 = largest.'
+  yardsplay_margin_rush: 'Margin in yards gained per play on rush plays: the team''s offensive value minus the value it allowed
+    on defense.'
+  yardsplay_margin_rush_rank: 'Margin in yards gained per play on rush plays: the team''s offensive value minus the value
+    it allowed on defense. National rank of that margin, 1 = largest.'
+  yardsplay_off: Yards gained per play, with the team on offense.
+  yardsplay_off_pass: Yards gained per play on pass plays, with the team on offense.
+  yardsplay_off_pass_rank: National rank of the team's yards gained per play on pass plays with the team on offense, where
+    1 is best.
+  yardsplay_off_rank: National rank of the team's yards gained per play with the team on offense, where 1 is best.
+  yardsplay_off_rush: Yards gained per play on rush plays, with the team on offense.
+  yardsplay_off_rush_rank: National rank of the team's yards gained per play on rush plays with the team on offense, where
+    1 is best.
 load_contracts:
   cols: Placeholder column retained in the contracts loader output schema; contains no meaningful data in this context.
 load_depth_charts:

--- a/tools/codegen/manual_column_descriptions.yaml
+++ b/tools/codegen/manual_column_descriptions.yaml
@@ -4048,6 +4048,124 @@ load_cfb_adv_situational:
   pos_team: Display name of the team on offense (e.g. 'Ohio State Buckeyes').
   pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
   standard_downs: Number of plays the team ran on standard downs (the team ahead of schedule for the series).
+load_phf_pbp:
+  away_goalie_jersey: Jersey number of the away goaltender on the ice.
+  away_nickname: Nickname of the away team.
+  away_score_total: Away team's cumulative score after the play.
+  defending_team_abbrev: Abbreviation of the team defending on the play.
+  defending_team_on_ice: Skaters the defending team had on the ice for the play.
+  defensive_player_jersey_1: Jersey number of the defending team's skater in on-ice slot 1 for the play.
+  defensive_player_jersey_2: Jersey number of the defending team's skater in on-ice slot 2 for the play.
+  defensive_player_jersey_3: Jersey number of the defending team's skater in on-ice slot 3 for the play.
+  defensive_player_jersey_4: Jersey number of the defending team's skater in on-ice slot 4 for the play.
+  defensive_player_jersey_5: Jersey number of the defending team's skater in on-ice slot 5 for the play.
+  defensive_player_jersey_6: Jersey number of the defending team's skater in on-ice slot 6 for the play.
+  defensive_player_name_1: Name of the defending team's skater in on-ice slot 1 for the play.
+  defensive_player_name_2: Name of the defending team's skater in on-ice slot 2 for the play.
+  defensive_player_name_3: Name of the defending team's skater in on-ice slot 3 for the play.
+  defensive_player_name_4: Name of the defending team's skater in on-ice slot 4 for the play.
+  defensive_player_name_5: Name of the defending team's skater in on-ice slot 5 for the play.
+  defensive_player_name_6: Name of the defending team's skater in on-ice slot 6 for the play.
+  end_power_play: True on the play where a power play ends.
+  goalie_change: True when the play records a goaltender change.
+  goalie_involved: Name of the goaltender involved in the play.
+  home_goalie_jersey: Jersey number of the home goaltender on the ice.
+  home_nickname: Nickname of the home team.
+  home_score_total: Home team's cumulative score after the play.
+  leader: Team leading the game at this point in the play sequence.
+  offensive_player_jersey_1: Jersey number of the attacking team's skater in on-ice slot 1 for the play.
+  offensive_player_jersey_2: Jersey number of the attacking team's skater in on-ice slot 2 for the play.
+  offensive_player_jersey_3: Jersey number of the attacking team's skater in on-ice slot 3 for the play.
+  offensive_player_jersey_4: Jersey number of the attacking team's skater in on-ice slot 4 for the play.
+  offensive_player_jersey_5: Jersey number of the attacking team's skater in on-ice slot 5 for the play.
+  offensive_player_jersey_6: Jersey number of the attacking team's skater in on-ice slot 6 for the play.
+  offensive_player_name_1: Name of the attacking team's skater in on-ice slot 1 for the play.
+  offensive_player_name_2: Name of the attacking team's skater in on-ice slot 2 for the play.
+  offensive_player_name_3: Name of the attacking team's skater in on-ice slot 3 for the play.
+  offensive_player_name_4: Name of the attacking team's skater in on-ice slot 4 for the play.
+  offensive_player_name_5: Name of the attacking team's skater in on-ice slot 5 for the play.
+  offensive_player_name_6: Name of the attacking team's skater in on-ice slot 6 for the play.
+  on_ice_situation: Strength situation on the ice for the play (e.g. even strength, power play).
+  penalty_level: Severity classification of the penalty (e.g. minor, major).
+  play_description: Free-text description of the play as published by the league.
+  player_jersey_1: Jersey number of the player in slot 1 of the play's participant list.
+  player_jersey_2: Jersey number of the player in slot 2 of the play's participant list.
+  player_jersey_3: Jersey number of the player in slot 3 of the play's participant list.
+  player_name_1: Name of the player in slot 1 of the play's participant list.
+  player_name_2: Name of the player in slot 2 of the play's participant list.
+  player_name_3: Name of the player in slot 3 of the play's participant list.
+  power_play_seconds: Elapsed seconds of the power play at this play.
+  scoring_team_abbrev: Abbreviation of the team credited with the goal.
+  scoring_team_on_ice: Skaters the scoring team had on the ice for the goal.
+  start_power_play: True on the play where a power play begins.
+load_phf_player_boxscores:
+  faceoffs_win_pct: Share of the player's faceoffs won.
+  faceoffs_won_lost: Faceoffs won and lost, as the league's combined won-lost string.
+  goalies_href: Relative link to the league's goaltender table for this game.
+  player_jersey: Player's jersey number.
+  powerplay_goals: Goals the player scored on the power play.
+  save_percent: Share of shots faced that the goaltender saved.
+  shots_blocked: Shots the player blocked.
+  skaters_href: Relative link to the league's skater table for this game.
+load_phf_schedules:
+  allow_players: League flag for whether player-level detail is published for the game.
+  away_division_id: League identifier for the away team's division.
+  away_penalty_minutes: Penalty minutes assessed to the away team.
+  away_roster_count: Number of players dressed for the away team.
+  away_team_logo_url_100: URL of the away team's logo at the 100px rendition.
+  away_team_logo_url_200: URL of the away team's logo at the 200px rendition.
+  away_team_logo_url_50: URL of the away team's logo at the 50px rendition.
+  away_team_logo_url_full: URL of the away team's logo at the full rendition.
+  away_team_logo_url_large: URL of the away team's logo at the large rendition.
+  away_team_logo_url_medium: URL of the away team's logo at the medium rendition.
+  away_team_logo_url_small: URL of the away team's logo at the small rendition.
+  away_team_short: Short display name of the away team.
+  created_at: Timestamp at which the league created the game record.
+  date_group: League grouping key for the game's date, used to bucket a slate.
+  datetime: Scheduled start of the game as a timestamp.
+  datetime_tz: Scheduled start of the game including its time-zone offset.
+  external_url: League-published external link for the game.
+  facility: Name of the facility hosting the game.
+  facility_address: Street address of the hosting facility.
+  facility_id: League identifier for the hosting facility.
+  has_play_by_play: True when a play-by-play feed exists for the game.
+  highlight_color: Display colour the league uses for the game in its schedule UI.
+  home_division_id: League identifier for the home team's division.
+  home_penalty_minutes: Penalty minutes assessed to the home team.
+  home_roster_count: Number of players dressed for the home team.
+  home_team_logo_url_100: URL of the home team's logo at the 100px rendition.
+  home_team_logo_url_200: URL of the home team's logo at the 200px rendition.
+  home_team_logo_url_50: URL of the home team's logo at the 50px rendition.
+  home_team_logo_url_full: URL of the home team's logo at the full rendition.
+  home_team_logo_url_large: URL of the home team's logo at the large rendition.
+  home_team_logo_url_medium: URL of the home team's logo at the medium rendition.
+  home_team_logo_url_small: URL of the home team's logo at the small rendition.
+  home_team_short: Short display name of the home team.
+  rink: Name of the rink within the facility.
+  rink_id: League identifier for the rink.
+  tickets_url: Link to purchase tickets for the game.
+  time_zone: Time zone in which the game is played.
+  time_zone_abbr: Abbreviated form of the game's time zone.
+  updated_at: Timestamp at which the league last updated the game record.
+  watch_live_url: Link to the live broadcast of the game.
+load_phf_team_boxscores:
+  blocked_opponent_shots: Opponent shots the team blocked.
+  overtime_scoring: Goals the team scored in overtime.
+  overtime_shots: Shots the team took in overtime.
+  period_1_scoring: Goals the team scored in period 1.
+  period_1_shots: Shots the team took in period 1.
+  period_2_scoring: Goals the team scored in period 2.
+  period_2_shots: Shots the team took in period 2.
+  period_3_scoring: Goals the team scored in period 3.
+  period_3_shots: Shots the team took in period 3.
+  power_play_percent: Share of the team's power plays that produced a goal.
+  shootout_made_scoring: Shootout attempts the team converted.
+  shootout_made_shots: Shootout shots the team took that scored.
+  shootout_missed_scoring: Shootout attempts the team failed to convert.
+  shootout_missed_shots: Shootout shots the team took that did not score.
+  successful_power_play: Number of power plays on which the team scored.
+  total_scoring: Goals the team scored in the game.
+  total_shots: Shots the team took in the game.
 load_cfb_pbp:
   A_score_diff: Away team's score minus the home team's, from the away perspective.
   EPA_explosive: True when the play was explosive.
@@ -4223,10 +4341,11 @@ load_cfb_pbp:
   new_down: Down after the play, including any penalty enforcement.
   non_fumble_sack: True when the play was a sack that did not produce a fumble.
   open_field_yards: Rushing yards gained beyond 8, credited to the ball carrier rather than the line.
-  opp_highlight_yards: 'Highlight yards on opportunity runs. DEGENERATE: this column is 0 in every published row, because
-    its gate requires a rush of 4 yards or fewer while highlight yards only accrue at 4 or more. Do not use it as a signal.'
-  opportunity_run: True when the play is a rush gaining 4 yards or fewer. Note this is the inverse of the conventional 'opportunity'
-    definition (a carry gaining 4 or more).
+  opp_highlight_yards: Highlight yards earned on opportunity runs, isolating carrier production on carries where the blocking
+    succeeded. Assets published before the 2026-08 fix are identically 0 here, because the inverted opportunity_run gate could
+    never co-occur with non-zero highlight yards.
+  opportunity_run: True when a rush reached 4 yards -- the carries on which the blocking did its job. Matches cfbfastR's espn_cfb_15
+    definition. Assets published before the 2026-08 fix carry the inverted (4 yards or fewer) flag.
   overUnder: Over/under total used as a model input.
   pass_breakup: True when a defender broke up the pass.
   pass_epa: EPA credited to the play when it is a pass.
@@ -4303,124 +4422,6 @@ load_cfb_pbp:
   type.id: ESPN's numeric identifier for the play type.
   type.text: ESPN's text label for the play type.
   wp_touchback: Win probability the offense would have had starting from a touchback.
-load_phf_pbp:
-  away_goalie_jersey: Jersey number of the away goaltender on the ice.
-  away_nickname: Nickname of the away team.
-  away_score_total: Away team's cumulative score after the play.
-  defending_team_abbrev: Abbreviation of the team defending on the play.
-  defending_team_on_ice: Skaters the defending team had on the ice for the play.
-  defensive_player_jersey_1: Jersey number of the defending team's skater in on-ice slot 1 for the play.
-  defensive_player_jersey_2: Jersey number of the defending team's skater in on-ice slot 2 for the play.
-  defensive_player_jersey_3: Jersey number of the defending team's skater in on-ice slot 3 for the play.
-  defensive_player_jersey_4: Jersey number of the defending team's skater in on-ice slot 4 for the play.
-  defensive_player_jersey_5: Jersey number of the defending team's skater in on-ice slot 5 for the play.
-  defensive_player_jersey_6: Jersey number of the defending team's skater in on-ice slot 6 for the play.
-  defensive_player_name_1: Name of the defending team's skater in on-ice slot 1 for the play.
-  defensive_player_name_2: Name of the defending team's skater in on-ice slot 2 for the play.
-  defensive_player_name_3: Name of the defending team's skater in on-ice slot 3 for the play.
-  defensive_player_name_4: Name of the defending team's skater in on-ice slot 4 for the play.
-  defensive_player_name_5: Name of the defending team's skater in on-ice slot 5 for the play.
-  defensive_player_name_6: Name of the defending team's skater in on-ice slot 6 for the play.
-  end_power_play: True on the play where a power play ends.
-  goalie_change: True when the play records a goaltender change.
-  goalie_involved: Name of the goaltender involved in the play.
-  home_goalie_jersey: Jersey number of the home goaltender on the ice.
-  home_nickname: Nickname of the home team.
-  home_score_total: Home team's cumulative score after the play.
-  leader: Team leading the game at this point in the play sequence.
-  offensive_player_jersey_1: Jersey number of the attacking team's skater in on-ice slot 1 for the play.
-  offensive_player_jersey_2: Jersey number of the attacking team's skater in on-ice slot 2 for the play.
-  offensive_player_jersey_3: Jersey number of the attacking team's skater in on-ice slot 3 for the play.
-  offensive_player_jersey_4: Jersey number of the attacking team's skater in on-ice slot 4 for the play.
-  offensive_player_jersey_5: Jersey number of the attacking team's skater in on-ice slot 5 for the play.
-  offensive_player_jersey_6: Jersey number of the attacking team's skater in on-ice slot 6 for the play.
-  offensive_player_name_1: Name of the attacking team's skater in on-ice slot 1 for the play.
-  offensive_player_name_2: Name of the attacking team's skater in on-ice slot 2 for the play.
-  offensive_player_name_3: Name of the attacking team's skater in on-ice slot 3 for the play.
-  offensive_player_name_4: Name of the attacking team's skater in on-ice slot 4 for the play.
-  offensive_player_name_5: Name of the attacking team's skater in on-ice slot 5 for the play.
-  offensive_player_name_6: Name of the attacking team's skater in on-ice slot 6 for the play.
-  on_ice_situation: Strength situation on the ice for the play (e.g. even strength, power play).
-  penalty_level: Severity classification of the penalty (e.g. minor, major).
-  play_description: Free-text description of the play as published by the league.
-  player_jersey_1: Jersey number of the player in slot 1 of the play's participant list.
-  player_jersey_2: Jersey number of the player in slot 2 of the play's participant list.
-  player_jersey_3: Jersey number of the player in slot 3 of the play's participant list.
-  player_name_1: Name of the player in slot 1 of the play's participant list.
-  player_name_2: Name of the player in slot 2 of the play's participant list.
-  player_name_3: Name of the player in slot 3 of the play's participant list.
-  power_play_seconds: Elapsed seconds of the power play at this play.
-  scoring_team_abbrev: Abbreviation of the team credited with the goal.
-  scoring_team_on_ice: Skaters the scoring team had on the ice for the goal.
-  start_power_play: True on the play where a power play begins.
-load_phf_player_boxscores:
-  faceoffs_win_pct: Share of the player's faceoffs won.
-  faceoffs_won_lost: Faceoffs won and lost, as the league's combined won-lost string.
-  goalies_href: Relative link to the league's goaltender table for this game.
-  player_jersey: Player's jersey number.
-  powerplay_goals: Goals the player scored on the power play.
-  save_percent: Share of shots faced that the goaltender saved.
-  shots_blocked: Shots the player blocked.
-  skaters_href: Relative link to the league's skater table for this game.
-load_phf_schedules:
-  allow_players: League flag for whether player-level detail is published for the game.
-  away_division_id: League identifier for the away team's division.
-  away_penalty_minutes: Penalty minutes assessed to the away team.
-  away_roster_count: Number of players dressed for the away team.
-  away_team_logo_url_100: URL of the away team's logo at the 100px rendition.
-  away_team_logo_url_200: URL of the away team's logo at the 200px rendition.
-  away_team_logo_url_50: URL of the away team's logo at the 50px rendition.
-  away_team_logo_url_full: URL of the away team's logo at the full rendition.
-  away_team_logo_url_large: URL of the away team's logo at the large rendition.
-  away_team_logo_url_medium: URL of the away team's logo at the medium rendition.
-  away_team_logo_url_small: URL of the away team's logo at the small rendition.
-  away_team_short: Short display name of the away team.
-  created_at: Timestamp at which the league created the game record.
-  date_group: League grouping key for the game's date, used to bucket a slate.
-  datetime: Scheduled start of the game as a timestamp.
-  datetime_tz: Scheduled start of the game including its time-zone offset.
-  external_url: League-published external link for the game.
-  facility: Name of the facility hosting the game.
-  facility_address: Street address of the hosting facility.
-  facility_id: League identifier for the hosting facility.
-  has_play_by_play: True when a play-by-play feed exists for the game.
-  highlight_color: Display colour the league uses for the game in its schedule UI.
-  home_division_id: League identifier for the home team's division.
-  home_penalty_minutes: Penalty minutes assessed to the home team.
-  home_roster_count: Number of players dressed for the home team.
-  home_team_logo_url_100: URL of the home team's logo at the 100px rendition.
-  home_team_logo_url_200: URL of the home team's logo at the 200px rendition.
-  home_team_logo_url_50: URL of the home team's logo at the 50px rendition.
-  home_team_logo_url_full: URL of the home team's logo at the full rendition.
-  home_team_logo_url_large: URL of the home team's logo at the large rendition.
-  home_team_logo_url_medium: URL of the home team's logo at the medium rendition.
-  home_team_logo_url_small: URL of the home team's logo at the small rendition.
-  home_team_short: Short display name of the home team.
-  rink: Name of the rink within the facility.
-  rink_id: League identifier for the rink.
-  tickets_url: Link to purchase tickets for the game.
-  time_zone: Time zone in which the game is played.
-  time_zone_abbr: Abbreviated form of the game's time zone.
-  updated_at: Timestamp at which the league last updated the game record.
-  watch_live_url: Link to the live broadcast of the game.
-load_phf_team_boxscores:
-  blocked_opponent_shots: Opponent shots the team blocked.
-  overtime_scoring: Goals the team scored in overtime.
-  overtime_shots: Shots the team took in overtime.
-  period_1_scoring: Goals the team scored in period 1.
-  period_1_shots: Shots the team took in period 1.
-  period_2_scoring: Goals the team scored in period 2.
-  period_2_shots: Shots the team took in period 2.
-  period_3_scoring: Goals the team scored in period 3.
-  period_3_shots: Shots the team took in period 3.
-  power_play_percent: Share of the team's power plays that produced a goal.
-  shootout_made_scoring: Shootout attempts the team converted.
-  shootout_made_shots: Shootout shots the team took that scored.
-  shootout_missed_scoring: Shootout attempts the team failed to convert.
-  shootout_missed_shots: Shootout shots the team took that did not score.
-  successful_power_play: Number of power plays on which the team scored.
-  total_scoring: Goals the team scored in the game.
-  total_shots: Shots the team took in the game.
 load_contracts:
   cols: Placeholder column retained in the contracts loader output schema; contains no meaningful data in this context.
 load_depth_charts:

--- a/tools/codegen/manual_column_descriptions.yaml
+++ b/tools/codegen/manual_column_descriptions.yaml
@@ -3949,6 +3949,105 @@ load_cfb_adv_team_gamelog:
   total_pen_yards: Total penalty yards assessed.
   yards_per_play: Yards gained per play.
   yards_per_rush: Yards gained per rushing attempt.
+load_cfb_adv_situational:
+  EPA_early_down: Total EPA the team generated on early downs.
+  EPA_early_down_pass: Total EPA the team generated on early downs on pass plays.
+  EPA_early_down_pass_per_play: EPA per play on early downs on pass plays.
+  EPA_early_down_per_play: EPA per play on early downs.
+  EPA_early_down_rush: Total EPA the team generated on early downs on rush plays.
+  EPA_early_down_rush_per_play: EPA per play on early downs on rush plays.
+  EPA_late_down: Total EPA the team generated on late downs.
+  EPA_late_down_per_play: EPA per play on late downs.
+  EPA_middle_8: Total EPA the team generated on the middle eight -- the closing minutes of the first half and opening minutes
+    of the second.
+  EPA_middle_8_pass: Total EPA the team generated on the middle eight -- the closing minutes of the first half and opening
+    minutes of the second on pass plays.
+  EPA_middle_8_pass_per_play: EPA per play on the middle eight -- the closing minutes of the first half and opening minutes
+    of the second on pass plays.
+  EPA_middle_8_per_play: EPA per play on the middle eight -- the closing minutes of the first half and opening minutes of
+    the second.
+  EPA_middle_8_rush: Total EPA the team generated on the middle eight -- the closing minutes of the first half and opening
+    minutes of the second on rush plays.
+  EPA_middle_8_rush_per_play: EPA per play on the middle eight -- the closing minutes of the first half and opening minutes
+    of the second on rush plays.
+  EPA_middle_8_success: Count of successful plays on the middle eight -- the closing minutes of the first half and opening
+    minutes of the second. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
+  EPA_middle_8_success_pass: Count of successful plays on the middle eight -- the closing minutes of the first half and opening
+    minutes of the second on pass plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
+  EPA_middle_8_success_pass_rate: Success rate on the middle eight -- the closing minutes of the first half and opening minutes
+    of the second on pass plays -- the share of those plays ESPN scored as successful.
+  EPA_middle_8_success_rate: Success rate on the middle eight -- the closing minutes of the first half and opening minutes
+    of the second -- the share of those plays ESPN scored as successful.
+  EPA_middle_8_success_rush: Count of successful plays on the middle eight -- the closing minutes of the first half and opening
+    minutes of the second on rush plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
+  EPA_middle_8_success_rush_rate: Success rate on the middle eight -- the closing minutes of the first half and opening minutes
+    of the second on rush plays -- the share of those plays ESPN scored as successful.
+  EPA_passing_down: Total EPA the team generated on passing downs (the team behind schedule for the series).
+  EPA_passing_down_per_play: EPA per play on passing downs (the team behind schedule for the series).
+  EPA_standard_down: Total EPA the team generated on standard downs (the team ahead of schedule for the series).
+  EPA_standard_down_per_play: EPA per play on standard downs (the team ahead of schedule for the series).
+  EPA_success: Count of successful plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
+  EPA_success_early_down: Count of successful plays on early downs. Despite the EPA_ prefix this is a play COUNT, not an EPA
+    total.
+  EPA_success_early_down_pass: Count of successful plays on early downs on pass plays. Despite the EPA_ prefix this is a play
+    COUNT, not an EPA total.
+  EPA_success_early_down_pass_rate: Success rate on early downs on pass plays -- the share of those plays ESPN scored as successful.
+  EPA_success_early_down_rate: Success rate on early downs -- the share of those plays ESPN scored as successful.
+  EPA_success_early_down_rush: Count of successful plays on early downs on rush plays. Despite the EPA_ prefix this is a play
+    COUNT, not an EPA total.
+  EPA_success_early_down_rush_rate: Success rate on early downs on rush plays -- the share of those plays ESPN scored as successful.
+  EPA_success_late_down: Count of successful plays on late downs. Despite the EPA_ prefix this is a play COUNT, not an EPA
+    total.
+  EPA_success_late_down_pass: Count of successful plays on late downs on pass plays. Despite the EPA_ prefix this is a play
+    COUNT, not an EPA total.
+  EPA_success_late_down_pass_rate: Success rate on late downs on pass plays -- the share of those plays ESPN scored as successful.
+  EPA_success_late_down_rate: Success rate on late downs -- the share of those plays ESPN scored as successful.
+  EPA_success_late_down_rush: Count of successful plays on late downs on rush plays. Despite the EPA_ prefix this is a play
+    COUNT, not an EPA total.
+  EPA_success_late_down_rush_rate: Success rate on late downs on rush plays -- the share of those plays ESPN scored as successful.
+  EPA_success_pass: Count of successful plays on pass plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
+  EPA_success_pass_rate: Success rate on pass plays -- the share of those plays ESPN scored as successful.
+  EPA_success_passing_down: Count of successful plays on passing downs (the team behind schedule for the series). Despite
+    the EPA_ prefix this is a play COUNT, not an EPA total.
+  EPA_success_passing_down_rate: Success rate on passing downs (the team behind schedule for the series) -- the share of those
+    plays ESPN scored as successful.
+  EPA_success_rate: Success rate -- the share of those plays ESPN scored as successful.
+  EPA_success_rate_rz: Success rate on the red zone -- the share of those plays ESPN scored as successful.
+  EPA_success_rate_third: Success rate on third down -- the share of those plays ESPN scored as successful.
+  EPA_success_rush: Count of successful plays on rush plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
+  EPA_success_rush_rate: Success rate on rush plays -- the share of those plays ESPN scored as successful.
+  EPA_success_rz: Count of successful plays on the red zone. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
+  EPA_success_standard_down: Count of successful plays on standard downs (the team ahead of schedule for the series). Despite
+    the EPA_ prefix this is a play COUNT, not an EPA total.
+  EPA_success_standard_down_rate: Success rate on standard downs (the team ahead of schedule for the series) -- the share
+    of those plays ESPN scored as successful.
+  EPA_success_third: Count of successful plays on third down. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
+  early_down_first_down: Number of early-down plays that produced a first down.
+  early_down_first_down_rate: Share of early-down plays that produced a first down.
+  early_down_pass: Number of pass plays the team ran on early downs.
+  early_down_pass_rate: Share of the team's plays on early downs that were pass plays.
+  early_down_rush: Number of rush plays the team ran on early downs.
+  early_down_rush_rate: Share of the team's plays on early downs that were rush plays.
+  early_downs: Number of plays the team ran on early downs.
+  late_down_pass: Number of pass plays the team ran on late downs.
+  late_down_pass_rate: Share of the team's plays on late downs that were pass plays.
+  late_down_rush: Number of rush plays the team ran on late downs.
+  late_down_rush_rate: Share of the team's plays on late downs that were rush plays.
+  late_downs: Number of plays the team ran on late downs.
+  middle_8: Number of plays the team ran in the middle eight -- the closing minutes of the first half and opening minutes
+    of the second.
+  middle_8_pass: Number of pass plays the team ran on the middle eight -- the closing minutes of the first half and opening
+    minutes of the second.
+  middle_8_pass_rate: Share of the team's plays on the middle eight -- the closing minutes of the first half and opening minutes
+    of the second that were pass plays.
+  middle_8_rush: Number of rush plays the team ran on the middle eight -- the closing minutes of the first half and opening
+    minutes of the second.
+  middle_8_rush_rate: Share of the team's plays on the middle eight -- the closing minutes of the first half and opening minutes
+    of the second that were rush plays.
+  passing_downs: Number of plays the team ran on passing downs (the team behind schedule for the series).
+  pos_team: Display name of the team on offense (e.g. 'Ohio State Buckeyes').
+  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
+  standard_downs: Number of plays the team ran on standard downs (the team ahead of schedule for the series).
 load_contracts:
   cols: Placeholder column retained in the contracts loader output schema; contains no meaningful data in this context.
 load_depth_charts:

--- a/tools/codegen/manual_column_descriptions.yaml
+++ b/tools/codegen/manual_column_descriptions.yaml
@@ -2585,21 +2585,6 @@ fit_field_position_ep:
 load_fp_curve:
   ep: Bundled expected points for a drive starting at this yard line (2018-2021 fit).
   yardline_own: Starting yard line from the offense's own goal (1-99).
-load_cfb_adv_defensive_players:
-  def_pos_team: Display name of the team on defense (e.g. 'Ohio State Buckeyes'). Held an ESPN team id until the
-    2026-08 republish; the id now lives in def_pos_team_id.
-  def_pos_team_id: ESPN team id of the team on defense. Present for every season 2004+.
-  forced_fumbles: Fumbles forced by the defender. Available from 2005 on; null for 2004, which ESPN ships with only
-    the fumble-recovery statistics.
-  fumble_recoveries: Fumbles recovered by the defender. Available for every season 2004+.
-  fumble_recoveries_yards: Yards returned on the defender's fumble recoveries. Available for every season 2004+.
-  interceptions: Passes intercepted by the defender. Available from 2014 on; null for 2004-2013, which ESPN ships
-    without interception statistics in this block.
-  interceptions_yards: Yards returned on the defender's interceptions. Available from 2014 on; null for 2004-2013.
-  pass_breakups: Passes broken up by the defender. Available from 2005 on; null for 2004.
-  player_name: Display name of the defender.
-  sacks: Sacks recorded by the defender. Available from 2005 on; null for 2004.
-  sacks_yards: Yards lost by the offense on the defender's sacks. Available from 2005 on; null for 2004.
 load_cfb_betting_lines:
   abbr: Selection/side this odds row applies to — a team abbreviation for spread and moneyline markets, or 'over'/'under'
     for total markets (the data is long-format, one row per book per selection per market_type).
@@ -3808,246 +3793,6 @@ load_cfb_team_summaries_weekly:
   yardsplay_off_rush: Yards gained per play on rush plays, with the team on offense.
   yardsplay_off_rush_rank: National rank of the team's yards gained per play on rush plays with the team on offense, where
     1 is best.
-load_cfb_adv_team:
-  EPA_explosive: Count of explosive plays, per ESPN's advanced box score. Despite the EPA_ prefix this is a play COUNT, not
-    an EPA total.
-  EPA_explosive_passing: Count of explosive pass plays. A play count, not an EPA total.
-  EPA_explosive_passing_rate: Explosive-play rate on pass plays, over ESPN's qualifying-play denominator.
-  EPA_explosive_rate: Explosive-play rate. Note this is NOT EPA_explosive divided by EPA_plays -- ESPN divides by its own
-    smaller qualifying-play count, so deriving it yourself will not reproduce this value.
-  EPA_explosive_rushing: Count of explosive rush plays. A play count, not an EPA total.
-  EPA_explosive_rushing_rate: Explosive-play rate on rush plays, over ESPN's qualifying-play denominator.
-  EPA_fg: Total EPA on field-goal attempts.
-  EPA_kickoff: Total EPA on kickoff plays.
-  EPA_non_explosive: Total EPA with explosive plays excluded, isolating the team's routine-down production.
-  EPA_non_explosive_passing: Total EPA on pass plays with explosive plays excluded.
-  EPA_non_explosive_passing_per_play: EPA per pass play with explosive plays excluded.
-  EPA_non_explosive_per_play: EPA per play with explosive plays excluded.
-  EPA_non_explosive_rushing: Total EPA on rush plays with explosive plays excluded.
-  EPA_non_explosive_rushing_per_play: EPA per rush play with explosive plays excluded.
-  EPA_overall_off: Total offensive EPA for the team. Duplicated exactly by EPA_overall_offense in every published season checked
-    -- prefer one and ignore the other.
-  EPA_overall_offense: Total offensive EPA. An exact duplicate of EPA_overall_off.
-  EPA_overall_total: Total EPA across all phases, which is why it differs from the offense-only EPA_overall_off.
-  EPA_passing_overall: Total EPA on pass plays.
-  EPA_passing_per_play: EPA per pass play.
-  EPA_penalty: Total EPA attributed to penalties.
-  EPA_per_play: Offensive EPA per play.
-  EPA_plays: Number of plays ESPN's advanced box score scored for the team.
-  EPA_punt: Total EPA on punt plays.
-  EPA_rushing_overall: Total EPA on rush plays.
-  EPA_rushing_per_play: EPA per rush play.
-  EPA_rushing_power: Total EPA on power rushing situations, as classified by ESPN's advanced box score.
-  EPA_rushing_power_per_play: EPA per play on power rushing situations.
-  EPA_sp: Total special-teams EPA, ESPN's abbreviated field for the same phase.
-  EPA_special_teams: Total EPA generated on special-teams plays.
-  field_goals: Number of field-goal attempts.
-  first_downs_created: Number of first downs the team created.
-  first_downs_created_rate: Share of the team's plays that created a first down.
-  kickoff_plays: Number of kickoff plays.
-  line_yards: Line yards -- the portion of rushing yardage credited to the offensive line under the standard rushing decomposition.
-    ESPN applies its own qualifying threshold for the yardage split.
-  line_yards_per_carry: Line yards per rushing attempt.
-  off_yards: Offensive yards gained from scrimmage.
-  open_field_yards: Open-field yards -- rushing yardage earned well downfield, past the second level.
-  passes_rate: Share of the team's plays from scrimmage that were pass plays.
-  passing_first_downs_created: Number of first downs created on pass plays.
-  passing_first_downs_created_rate: Share of pass plays that created a first down.
-  penalty_first_downs_created: Number of first downs the team gained via opponent penalty.
-  penalty_first_downs_created_rate: Share of the team's first downs that came via opponent penalty.
-  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
-  punt_plays: Number of punt plays.
-  rushes: Number of rushing attempts.
-  rushes_rate: Share of the team's plays from scrimmage that were rush plays.
-  rushing_first_downs_created: Number of first downs created on rush plays.
-  rushing_first_downs_created_rate: Share of rush plays that created a first down.
-  rushing_highlight: Highlight yards -- rushing yardage credited to the back rather than the offensive line.
-  rushing_highlight_rate: Share of rushing yardage that was highlight (back-credited) yardage.
-  rushing_highlight_yards_per_opp: Highlight yards per rushing opportunity.
-  rushing_opportunity: Count of rushing opportunities -- carries that reached ESPN's opportunity threshold.
-  rushing_opportunity_rate: Share of carries that qualified as rushing opportunities.
-  rushing_power: Count of power rushing attempts, in short-yardage situations as classified by ESPN's advanced box score.
-  rushing_power_rate: Share of carries that were power rushing attempts.
-  rushing_power_success_rate: Share of power rushing attempts that succeeded.
-  rushing_stopped: Count of rushing attempts stopped at or behind the line of scrimmage.
-  rushing_stopped_rate: Share of carries stopped at or behind the line of scrimmage.
-  rushing_stuff: Count of stuffed rushing attempts.
-  scrimmage_plays: Number of plays from scrimmage (rushes plus passes), excluding special teams.
-  second_level_yards: Second-level yards -- rushing yardage earned just beyond the line of scrimmage.
-  special_teams_plays: Number of special-teams plays.
-  total_off_yards: Total offensive yards across all plays.
-  total_pen_yards: Total penalty yards assessed.
-  yards_per_play: Yards gained per play.
-  yards_per_rush: Yards gained per rushing attempt.
-load_cfb_adv_team_gamelog:
-  EPA_explosive: Count of explosive plays, per ESPN's advanced box score. Despite the EPA_ prefix this is a play COUNT, not
-    an EPA total.
-  EPA_explosive_passing: Count of explosive pass plays. A play count, not an EPA total.
-  EPA_explosive_passing_rate: Explosive-play rate on pass plays, over ESPN's qualifying-play denominator.
-  EPA_explosive_rate: Explosive-play rate. Note this is NOT EPA_explosive divided by EPA_plays -- ESPN divides by its own
-    smaller qualifying-play count, so deriving it yourself will not reproduce this value.
-  EPA_explosive_rushing: Count of explosive rush plays. A play count, not an EPA total.
-  EPA_explosive_rushing_rate: Explosive-play rate on rush plays, over ESPN's qualifying-play denominator.
-  EPA_fg: Total EPA on field-goal attempts.
-  EPA_kickoff: Total EPA on kickoff plays.
-  EPA_non_explosive: Total EPA with explosive plays excluded, isolating the team's routine-down production.
-  EPA_non_explosive_passing: Total EPA on pass plays with explosive plays excluded.
-  EPA_non_explosive_passing_per_play: EPA per pass play with explosive plays excluded.
-  EPA_non_explosive_per_play: EPA per play with explosive plays excluded.
-  EPA_non_explosive_rushing: Total EPA on rush plays with explosive plays excluded.
-  EPA_non_explosive_rushing_per_play: EPA per rush play with explosive plays excluded.
-  EPA_overall_off: Total offensive EPA for the team. Duplicated exactly by EPA_overall_offense in every published season checked
-    -- prefer one and ignore the other.
-  EPA_overall_offense: Total offensive EPA. An exact duplicate of EPA_overall_off.
-  EPA_overall_total: Total EPA across all phases, which is why it differs from the offense-only EPA_overall_off.
-  EPA_passing_overall: Total EPA on pass plays.
-  EPA_passing_per_play: EPA per pass play.
-  EPA_penalty: Total EPA attributed to penalties.
-  EPA_per_play: Offensive EPA per play.
-  EPA_plays: Number of plays ESPN's advanced box score scored for the team.
-  EPA_punt: Total EPA on punt plays.
-  EPA_rushing_overall: Total EPA on rush plays.
-  EPA_rushing_per_play: EPA per rush play.
-  EPA_rushing_power: Total EPA on power rushing situations, as classified by ESPN's advanced box score.
-  EPA_rushing_power_per_play: EPA per play on power rushing situations.
-  EPA_sp: Total special-teams EPA, ESPN's abbreviated field for the same phase.
-  EPA_special_teams: Total EPA generated on special-teams plays.
-  field_goals: Number of field-goal attempts.
-  first_downs_created: Number of first downs the team created.
-  first_downs_created_rate: Share of the team's plays that created a first down.
-  kickoff_plays: Number of kickoff plays.
-  line_yards: Line yards -- the portion of rushing yardage credited to the offensive line under the standard rushing decomposition.
-    ESPN applies its own qualifying threshold for the yardage split.
-  line_yards_per_carry: Line yards per rushing attempt.
-  off_yards: Offensive yards gained from scrimmage.
-  open_field_yards: Open-field yards -- rushing yardage earned well downfield, past the second level.
-  passes_rate: Share of the team's plays from scrimmage that were pass plays.
-  passing_first_downs_created: Number of first downs created on pass plays.
-  passing_first_downs_created_rate: Share of pass plays that created a first down.
-  penalty_first_downs_created: Number of first downs the team gained via opponent penalty.
-  penalty_first_downs_created_rate: Share of the team's first downs that came via opponent penalty.
-  punt_plays: Number of punt plays.
-  rushes: Number of rushing attempts.
-  rushes_rate: Share of the team's plays from scrimmage that were rush plays.
-  rushing_first_downs_created: Number of first downs created on rush plays.
-  rushing_first_downs_created_rate: Share of rush plays that created a first down.
-  rushing_highlight: Highlight yards -- rushing yardage credited to the back rather than the offensive line.
-  rushing_highlight_rate: Share of rushing yardage that was highlight (back-credited) yardage.
-  rushing_highlight_yards_per_opp: Highlight yards per rushing opportunity.
-  rushing_opportunity: Count of rushing opportunities -- carries that reached ESPN's opportunity threshold.
-  rushing_opportunity_rate: Share of carries that qualified as rushing opportunities.
-  rushing_power: Count of power rushing attempts, in short-yardage situations as classified by ESPN's advanced box score.
-  rushing_power_rate: Share of carries that were power rushing attempts.
-  rushing_power_success_rate: Share of power rushing attempts that succeeded.
-  rushing_stopped: Count of rushing attempts stopped at or behind the line of scrimmage.
-  rushing_stopped_rate: Share of carries stopped at or behind the line of scrimmage.
-  rushing_stuff: Count of stuffed rushing attempts.
-  scrimmage_plays: Number of plays from scrimmage (rushes plus passes), excluding special teams.
-  second_level_yards: Second-level yards -- rushing yardage earned just beyond the line of scrimmage.
-  special_teams_plays: Number of special-teams plays.
-  total_off_yards: Total offensive yards across all plays.
-  total_pen_yards: Total penalty yards assessed.
-  yards_per_play: Yards gained per play.
-  yards_per_rush: Yards gained per rushing attempt.
-load_cfb_adv_situational:
-  EPA_early_down: Total EPA the team generated on early downs.
-  EPA_early_down_pass: Total EPA the team generated on early downs on pass plays.
-  EPA_early_down_pass_per_play: EPA per play on early downs on pass plays.
-  EPA_early_down_per_play: EPA per play on early downs.
-  EPA_early_down_rush: Total EPA the team generated on early downs on rush plays.
-  EPA_early_down_rush_per_play: EPA per play on early downs on rush plays.
-  EPA_late_down: Total EPA the team generated on late downs.
-  EPA_late_down_per_play: EPA per play on late downs.
-  EPA_middle_8: Total EPA the team generated on the middle eight -- the closing minutes of the first half and opening minutes
-    of the second.
-  EPA_middle_8_pass: Total EPA the team generated on the middle eight -- the closing minutes of the first half and opening
-    minutes of the second on pass plays.
-  EPA_middle_8_pass_per_play: EPA per play on the middle eight -- the closing minutes of the first half and opening minutes
-    of the second on pass plays.
-  EPA_middle_8_per_play: EPA per play on the middle eight -- the closing minutes of the first half and opening minutes of
-    the second.
-  EPA_middle_8_rush: Total EPA the team generated on the middle eight -- the closing minutes of the first half and opening
-    minutes of the second on rush plays.
-  EPA_middle_8_rush_per_play: EPA per play on the middle eight -- the closing minutes of the first half and opening minutes
-    of the second on rush plays.
-  EPA_middle_8_success: Count of successful plays on the middle eight -- the closing minutes of the first half and opening
-    minutes of the second. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
-  EPA_middle_8_success_pass: Count of successful plays on the middle eight -- the closing minutes of the first half and opening
-    minutes of the second on pass plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
-  EPA_middle_8_success_pass_rate: Success rate on the middle eight -- the closing minutes of the first half and opening minutes
-    of the second on pass plays -- the share of those plays ESPN scored as successful.
-  EPA_middle_8_success_rate: Success rate on the middle eight -- the closing minutes of the first half and opening minutes
-    of the second -- the share of those plays ESPN scored as successful.
-  EPA_middle_8_success_rush: Count of successful plays on the middle eight -- the closing minutes of the first half and opening
-    minutes of the second on rush plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
-  EPA_middle_8_success_rush_rate: Success rate on the middle eight -- the closing minutes of the first half and opening minutes
-    of the second on rush plays -- the share of those plays ESPN scored as successful.
-  EPA_passing_down: Total EPA the team generated on passing downs (the team behind schedule for the series).
-  EPA_passing_down_per_play: EPA per play on passing downs (the team behind schedule for the series).
-  EPA_standard_down: Total EPA the team generated on standard downs (the team ahead of schedule for the series).
-  EPA_standard_down_per_play: EPA per play on standard downs (the team ahead of schedule for the series).
-  EPA_success: Count of successful plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
-  EPA_success_early_down: Count of successful plays on early downs. Despite the EPA_ prefix this is a play COUNT, not an EPA
-    total.
-  EPA_success_early_down_pass: Count of successful plays on early downs on pass plays. Despite the EPA_ prefix this is a play
-    COUNT, not an EPA total.
-  EPA_success_early_down_pass_rate: Success rate on early downs on pass plays -- the share of those plays ESPN scored as successful.
-  EPA_success_early_down_rate: Success rate on early downs -- the share of those plays ESPN scored as successful.
-  EPA_success_early_down_rush: Count of successful plays on early downs on rush plays. Despite the EPA_ prefix this is a play
-    COUNT, not an EPA total.
-  EPA_success_early_down_rush_rate: Success rate on early downs on rush plays -- the share of those plays ESPN scored as successful.
-  EPA_success_late_down: Count of successful plays on late downs. Despite the EPA_ prefix this is a play COUNT, not an EPA
-    total.
-  EPA_success_late_down_pass: Count of successful plays on late downs on pass plays. Despite the EPA_ prefix this is a play
-    COUNT, not an EPA total.
-  EPA_success_late_down_pass_rate: Success rate on late downs on pass plays -- the share of those plays ESPN scored as successful.
-  EPA_success_late_down_rate: Success rate on late downs -- the share of those plays ESPN scored as successful.
-  EPA_success_late_down_rush: Count of successful plays on late downs on rush plays. Despite the EPA_ prefix this is a play
-    COUNT, not an EPA total.
-  EPA_success_late_down_rush_rate: Success rate on late downs on rush plays -- the share of those plays ESPN scored as successful.
-  EPA_success_pass: Count of successful plays on pass plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
-  EPA_success_pass_rate: Success rate on pass plays -- the share of those plays ESPN scored as successful.
-  EPA_success_passing_down: Count of successful plays on passing downs (the team behind schedule for the series). Despite
-    the EPA_ prefix this is a play COUNT, not an EPA total.
-  EPA_success_passing_down_rate: Success rate on passing downs (the team behind schedule for the series) -- the share of those
-    plays ESPN scored as successful.
-  EPA_success_rate: Success rate -- the share of those plays ESPN scored as successful.
-  EPA_success_rate_rz: Success rate on the red zone -- the share of those plays ESPN scored as successful.
-  EPA_success_rate_third: Success rate on third down -- the share of those plays ESPN scored as successful.
-  EPA_success_rush: Count of successful plays on rush plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
-  EPA_success_rush_rate: Success rate on rush plays -- the share of those plays ESPN scored as successful.
-  EPA_success_rz: Count of successful plays on the red zone. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
-  EPA_success_standard_down: Count of successful plays on standard downs (the team ahead of schedule for the series). Despite
-    the EPA_ prefix this is a play COUNT, not an EPA total.
-  EPA_success_standard_down_rate: Success rate on standard downs (the team ahead of schedule for the series) -- the share
-    of those plays ESPN scored as successful.
-  EPA_success_third: Count of successful plays on third down. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
-  early_down_first_down: Number of early-down plays that produced a first down.
-  early_down_first_down_rate: Share of early-down plays that produced a first down.
-  early_down_pass: Number of pass plays the team ran on early downs.
-  early_down_pass_rate: Share of the team's plays on early downs that were pass plays.
-  early_down_rush: Number of rush plays the team ran on early downs.
-  early_down_rush_rate: Share of the team's plays on early downs that were rush plays.
-  early_downs: Number of plays the team ran on early downs.
-  late_down_pass: Number of pass plays the team ran on late downs.
-  late_down_pass_rate: Share of the team's plays on late downs that were pass plays.
-  late_down_rush: Number of rush plays the team ran on late downs.
-  late_down_rush_rate: Share of the team's plays on late downs that were rush plays.
-  late_downs: Number of plays the team ran on late downs.
-  middle_8: Number of plays the team ran in the middle eight -- the closing minutes of the first half and opening minutes
-    of the second.
-  middle_8_pass: Number of pass plays the team ran on the middle eight -- the closing minutes of the first half and opening
-    minutes of the second.
-  middle_8_pass_rate: Share of the team's plays on the middle eight -- the closing minutes of the first half and opening minutes
-    of the second that were pass plays.
-  middle_8_rush: Number of rush plays the team ran on the middle eight -- the closing minutes of the first half and opening
-    minutes of the second.
-  middle_8_rush_rate: Share of the team's plays on the middle eight -- the closing minutes of the first half and opening minutes
-    of the second that were rush plays.
-  passing_downs: Number of plays the team ran on passing downs (the team behind schedule for the series).
-  pos_team: Display name of the team on offense (e.g. 'Ohio State Buckeyes').
-  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
-  standard_downs: Number of plays the team ran on standard downs (the team ahead of schedule for the series).
 load_phf_pbp:
   away_goalie_jersey: Jersey number of the away goaltender on the ice.
   away_nickname: Nickname of the away team.
@@ -4462,6 +4207,577 @@ load_wnba_stats_rosters:
   team_id_lookup: Team id used to join the row back to the team tables.
 load_wnba_team_season_stats:
   stat_description: Human-readable description of the statistic the row reports.
+load_cfb_adv_defensive:
+  scrimmage_plays: Number of plays from scrimmage (rushes plus passes), excluding special teams.
+load_cfb_adv_defensive_players:
+  def_pos_team: Display name of the team on defense (e.g. 'Ohio State Buckeyes'). Held an ESPN team id until the 2026-08 republish;
+    the id now lives in def_pos_team_id.
+  def_pos_team_id: ESPN team id of the team on defense. Present for every season 2004+.
+  forced_fumbles: Fumbles forced by the defender. Available from 2005 on; null for 2004, which ESPN ships with only the fumble-recovery
+    statistics.
+  fumble_recoveries: Fumbles recovered by the defender. Available for every season 2004+.
+  fumble_recoveries_yards: Yards returned on the defender's fumble recoveries. Available for every season 2004+.
+  interceptions: Passes intercepted by the defender. Available from 2014 on; null for 2004-2013, which ESPN ships without
+    interception statistics in this block.
+  interceptions_yards: Yards returned on the defender's interceptions. Available from 2014 on; null for 2004-2013.
+  pass_breakups: Passes broken up by the defender. Available from 2005 on; null for 2004.
+  player_name: Display name of the defender.
+  sacks: Sacks recorded by the defender. Available from 2005 on; null for 2004.
+  sacks_yards: Yards lost by the offense on the defender's sacks. Available from 2005 on; null for 2004.
+load_cfb_adv_drives:
+  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
+load_cfb_adv_passing:
+  Att: Pass attempts recorded in the advanced box score.
+  CPOE: Completion percentage over expected -- actual minus modelled completion rate.
+  Comp: Completed passes recorded in the advanced box score.
+  CompPct: Completion percentage from the advanced box score.
+  EPA_per_Play: EPA per play on the passer's plays.
+  Int: Interceptions thrown.
+  Pass_TD: Passing touchdowns.
+  SR: Success rate on the passer's plays.
+  Sck: Times the passer was sacked.
+  YPA: Yards per pass attempt.
+  Yds: Passing yards from the advanced box score.
+  era0: Rule-era indicator for the earliest modelled era.
+  era1: Rule-era indicator for the second modelled era.
+  era2: Rule-era indicator for the third modelled era.
+  era3: Rule-era indicator for the most recent modelled era.
+  exp_qbr: Expected QBR for the passer.
+  pass_epa: EPA credited to the player's pass plays.
+  passer_player_name: Display name of the passer -- the FIRST participant in that role on the play.
+  pen_epa: EPA attributable to penalties on the player's plays.
+  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
+  qbr_epa: EPA variant used as an input to the QBR calculation.
+  rush_epa: EPA credited to the player's rush plays.
+  sack_epa: EPA credited to the player's sacks taken.
+  xComp: Expected completions, summed from the per-play completion model.
+  xCompPct: Expected completion percentage from the per-play completion model.
+load_cfb_adv_receiving:
+  EPA_per_Play: EPA per play on the passer's plays.
+  SR: Success rate on the passer's plays.
+  Yds: Passing yards from the advanced box score.
+  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
+  receiver_player_name: Display name of the targeted receiver -- the FIRST participant in that role on the play.
+load_cfb_adv_rushing:
+  EPA_per_Play: EPA per play on the passer's plays.
+  SR: Success rate on the passer's plays.
+  Yds: Passing yards from the advanced box score.
+  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
+  rusher_player_name: Display name of the ball carrier on a rush -- the FIRST participant in that role on the play.
+load_cfb_adv_situational:
+  EPA_early_down: Total EPA the team generated on early downs.
+  EPA_early_down_pass: Total EPA the team generated on early downs on pass plays.
+  EPA_early_down_pass_per_play: EPA per play on early downs on pass plays.
+  EPA_early_down_per_play: EPA per play on early downs.
+  EPA_early_down_rush: Total EPA the team generated on early downs on rush plays.
+  EPA_early_down_rush_per_play: EPA per play on early downs on rush plays.
+  EPA_late_down: Total EPA the team generated on late downs.
+  EPA_late_down_per_play: EPA per play on late downs.
+  EPA_middle_8: Total EPA the team generated on the middle eight -- the closing minutes of the first half and opening minutes
+    of the second.
+  EPA_middle_8_pass: Total EPA the team generated on the middle eight -- the closing minutes of the first half and opening
+    minutes of the second on pass plays.
+  EPA_middle_8_pass_per_play: EPA per play on the middle eight -- the closing minutes of the first half and opening minutes
+    of the second on pass plays.
+  EPA_middle_8_per_play: EPA per play on the middle eight -- the closing minutes of the first half and opening minutes of
+    the second.
+  EPA_middle_8_rush: Total EPA the team generated on the middle eight -- the closing minutes of the first half and opening
+    minutes of the second on rush plays.
+  EPA_middle_8_rush_per_play: EPA per play on the middle eight -- the closing minutes of the first half and opening minutes
+    of the second on rush plays.
+  EPA_middle_8_success: Count of successful plays on the middle eight -- the closing minutes of the first half and opening
+    minutes of the second. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
+  EPA_middle_8_success_pass: Count of successful plays on the middle eight -- the closing minutes of the first half and opening
+    minutes of the second on pass plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
+  EPA_middle_8_success_pass_rate: Success rate on the middle eight -- the closing minutes of the first half and opening minutes
+    of the second on pass plays -- the share of those plays ESPN scored as successful.
+  EPA_middle_8_success_rate: Success rate on the middle eight -- the closing minutes of the first half and opening minutes
+    of the second -- the share of those plays ESPN scored as successful.
+  EPA_middle_8_success_rush: Count of successful plays on the middle eight -- the closing minutes of the first half and opening
+    minutes of the second on rush plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
+  EPA_middle_8_success_rush_rate: Success rate on the middle eight -- the closing minutes of the first half and opening minutes
+    of the second on rush plays -- the share of those plays ESPN scored as successful.
+  EPA_passing_down: Total EPA the team generated on passing downs (the team behind schedule for the series).
+  EPA_passing_down_per_play: EPA per play on passing downs (the team behind schedule for the series).
+  EPA_standard_down: Total EPA the team generated on standard downs (the team ahead of schedule for the series).
+  EPA_standard_down_per_play: EPA per play on standard downs (the team ahead of schedule for the series).
+  EPA_success: Count of successful plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
+  EPA_success_early_down: Count of successful plays on early downs. Despite the EPA_ prefix this is a play COUNT, not an EPA
+    total.
+  EPA_success_early_down_pass: Count of successful plays on early downs on pass plays. Despite the EPA_ prefix this is a play
+    COUNT, not an EPA total.
+  EPA_success_early_down_pass_rate: Success rate on early downs on pass plays -- the share of those plays ESPN scored as successful.
+  EPA_success_early_down_rate: Success rate on early downs -- the share of those plays ESPN scored as successful.
+  EPA_success_early_down_rush: Count of successful plays on early downs on rush plays. Despite the EPA_ prefix this is a play
+    COUNT, not an EPA total.
+  EPA_success_early_down_rush_rate: Success rate on early downs on rush plays -- the share of those plays ESPN scored as successful.
+  EPA_success_late_down: Count of successful plays on late downs. Despite the EPA_ prefix this is a play COUNT, not an EPA
+    total.
+  EPA_success_late_down_pass: Count of successful plays on late downs on pass plays. Despite the EPA_ prefix this is a play
+    COUNT, not an EPA total.
+  EPA_success_late_down_pass_rate: Success rate on late downs on pass plays -- the share of those plays ESPN scored as successful.
+  EPA_success_late_down_rate: Success rate on late downs -- the share of those plays ESPN scored as successful.
+  EPA_success_late_down_rush: Count of successful plays on late downs on rush plays. Despite the EPA_ prefix this is a play
+    COUNT, not an EPA total.
+  EPA_success_late_down_rush_rate: Success rate on late downs on rush plays -- the share of those plays ESPN scored as successful.
+  EPA_success_pass: Count of successful plays on pass plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
+  EPA_success_pass_rate: Success rate on pass plays -- the share of those plays ESPN scored as successful.
+  EPA_success_passing_down: Count of successful plays on passing downs (the team behind schedule for the series). Despite
+    the EPA_ prefix this is a play COUNT, not an EPA total.
+  EPA_success_passing_down_rate: Success rate on passing downs (the team behind schedule for the series) -- the share of those
+    plays ESPN scored as successful.
+  EPA_success_rate: Success rate -- the share of those plays ESPN scored as successful.
+  EPA_success_rate_rz: Success rate on the red zone -- the share of those plays ESPN scored as successful.
+  EPA_success_rate_third: Success rate on third down -- the share of those plays ESPN scored as successful.
+  EPA_success_rush: Count of successful plays on rush plays. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
+  EPA_success_rush_rate: Success rate on rush plays -- the share of those plays ESPN scored as successful.
+  EPA_success_rz: Count of successful plays on the red zone. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
+  EPA_success_standard_down: Count of successful plays on standard downs (the team ahead of schedule for the series). Despite
+    the EPA_ prefix this is a play COUNT, not an EPA total.
+  EPA_success_standard_down_rate: Success rate on standard downs (the team ahead of schedule for the series) -- the share
+    of those plays ESPN scored as successful.
+  EPA_success_third: Count of successful plays on third down. Despite the EPA_ prefix this is a play COUNT, not an EPA total.
+  early_down_first_down: Number of early-down plays that produced a first down.
+  early_down_first_down_rate: Share of early-down plays that produced a first down.
+  early_down_pass: Number of pass plays the team ran on early downs.
+  early_down_pass_rate: Share of the team's plays on early downs that were pass plays.
+  early_down_rush: Number of rush plays the team ran on early downs.
+  early_down_rush_rate: Share of the team's plays on early downs that were rush plays.
+  early_downs: Number of plays the team ran on early downs.
+  late_down_pass: Number of pass plays the team ran on late downs.
+  late_down_pass_rate: Share of the team's plays on late downs that were pass plays.
+  late_down_rush: Number of rush plays the team ran on late downs.
+  late_down_rush_rate: Share of the team's plays on late downs that were rush plays.
+  late_downs: Number of plays the team ran on late downs.
+  middle_8: Number of plays the team ran in the middle eight -- the closing minutes of the first half and opening minutes
+    of the second.
+  middle_8_pass: Number of pass plays the team ran on the middle eight -- the closing minutes of the first half and opening
+    minutes of the second.
+  middle_8_pass_rate: Share of the team's plays on the middle eight -- the closing minutes of the first half and opening minutes
+    of the second that were pass plays.
+  middle_8_rush: Number of rush plays the team ran on the middle eight -- the closing minutes of the first half and opening
+    minutes of the second.
+  middle_8_rush_rate: Share of the team's plays on the middle eight -- the closing minutes of the first half and opening minutes
+    of the second that were rush plays.
+  passing_downs: Number of plays the team ran on passing downs (the team behind schedule for the series).
+  pos_team: Display name of the team on offense (e.g. 'Ohio State Buckeyes').
+  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
+  standard_downs: Number of plays the team ran on standard downs (the team ahead of schedule for the series).
+load_cfb_adv_specialists:
+  field_goals: Number of field-goal attempts.
+  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
+  punts: Punts attempted.
+load_cfb_adv_team:
+  EPA_explosive: Count of explosive plays, per ESPN's advanced box score. Despite the EPA_ prefix this is a play COUNT, not
+    an EPA total.
+  EPA_explosive_passing: Count of explosive pass plays. A play count, not an EPA total.
+  EPA_explosive_passing_rate: Explosive-play rate on pass plays, over ESPN's qualifying-play denominator.
+  EPA_explosive_rate: Explosive-play rate. Note this is NOT EPA_explosive divided by EPA_plays -- ESPN divides by its own
+    smaller qualifying-play count, so deriving it yourself will not reproduce this value.
+  EPA_explosive_rushing: Count of explosive rush plays. A play count, not an EPA total.
+  EPA_explosive_rushing_rate: Explosive-play rate on rush plays, over ESPN's qualifying-play denominator.
+  EPA_fg: Total EPA on field-goal attempts.
+  EPA_kickoff: Total EPA on kickoff plays.
+  EPA_non_explosive: Total EPA with explosive plays excluded, isolating the team's routine-down production.
+  EPA_non_explosive_passing: Total EPA on pass plays with explosive plays excluded.
+  EPA_non_explosive_passing_per_play: EPA per pass play with explosive plays excluded.
+  EPA_non_explosive_per_play: EPA per play with explosive plays excluded.
+  EPA_non_explosive_rushing: Total EPA on rush plays with explosive plays excluded.
+  EPA_non_explosive_rushing_per_play: EPA per rush play with explosive plays excluded.
+  EPA_overall_off: Total offensive EPA for the team. Duplicated exactly by EPA_overall_offense in every published season checked
+    -- prefer one and ignore the other.
+  EPA_overall_offense: Total offensive EPA. An exact duplicate of EPA_overall_off.
+  EPA_overall_total: Total EPA across all phases, which is why it differs from the offense-only EPA_overall_off.
+  EPA_passing_overall: Total EPA on pass plays.
+  EPA_passing_per_play: EPA per pass play.
+  EPA_penalty: Total EPA attributed to penalties.
+  EPA_per_play: Offensive EPA per play.
+  EPA_plays: Number of plays ESPN's advanced box score scored for the team.
+  EPA_punt: Total EPA on punt plays.
+  EPA_rushing_overall: Total EPA on rush plays.
+  EPA_rushing_per_play: EPA per rush play.
+  EPA_rushing_power: Total EPA on power rushing situations, as classified by ESPN's advanced box score.
+  EPA_rushing_power_per_play: EPA per play on power rushing situations.
+  EPA_sp: Total special-teams EPA, ESPN's abbreviated field for the same phase.
+  EPA_special_teams: Total EPA generated on special-teams plays.
+  field_goals: Number of field-goal attempts.
+  first_downs_created: Number of first downs the team created.
+  first_downs_created_rate: Share of the team's plays that created a first down.
+  kickoff_plays: Number of kickoff plays.
+  line_yards: Line yards -- the portion of rushing yardage credited to the offensive line under the standard rushing decomposition.
+    ESPN applies its own qualifying threshold for the yardage split.
+  line_yards_per_carry: Line yards per rushing attempt.
+  off_yards: Offensive yards gained from scrimmage.
+  open_field_yards: Open-field yards -- rushing yardage earned well downfield, past the second level.
+  passes_rate: Share of the team's plays from scrimmage that were pass plays.
+  passing_first_downs_created: Number of first downs created on pass plays.
+  passing_first_downs_created_rate: Share of pass plays that created a first down.
+  penalty_first_downs_created: Number of first downs the team gained via opponent penalty.
+  penalty_first_downs_created_rate: Share of the team's first downs that came via opponent penalty.
+  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
+  punt_plays: Number of punt plays.
+  rushes: Number of rushing attempts.
+  rushes_rate: Share of the team's plays from scrimmage that were rush plays.
+  rushing_first_downs_created: Number of first downs created on rush plays.
+  rushing_first_downs_created_rate: Share of rush plays that created a first down.
+  rushing_highlight: Highlight yards -- rushing yardage credited to the back rather than the offensive line.
+  rushing_highlight_rate: Share of rushing yardage that was highlight (back-credited) yardage.
+  rushing_highlight_yards_per_opp: Highlight yards per rushing opportunity.
+  rushing_opportunity: Count of rushing opportunities -- carries that reached ESPN's opportunity threshold.
+  rushing_opportunity_rate: Share of carries that qualified as rushing opportunities.
+  rushing_power: Count of power rushing attempts, in short-yardage situations as classified by ESPN's advanced box score.
+  rushing_power_rate: Share of carries that were power rushing attempts.
+  rushing_power_success_rate: Share of power rushing attempts that succeeded.
+  rushing_stopped: Count of rushing attempts stopped at or behind the line of scrimmage.
+  rushing_stopped_rate: Share of carries stopped at or behind the line of scrimmage.
+  rushing_stuff: Count of stuffed rushing attempts.
+  scrimmage_plays: Number of plays from scrimmage (rushes plus passes), excluding special teams.
+  second_level_yards: Second-level yards -- rushing yardage earned just beyond the line of scrimmage.
+  special_teams_plays: Number of special-teams plays.
+  total_off_yards: Total offensive yards across all plays.
+  total_pen_yards: Total penalty yards assessed.
+  yards_per_play: Yards gained per play.
+  yards_per_rush: Yards gained per rushing attempt.
+load_cfb_adv_team_gamelog:
+  EPA_explosive: Count of explosive plays, per ESPN's advanced box score. Despite the EPA_ prefix this is a play COUNT, not
+    an EPA total.
+  EPA_explosive_passing: Count of explosive pass plays. A play count, not an EPA total.
+  EPA_explosive_passing_rate: Explosive-play rate on pass plays, over ESPN's qualifying-play denominator.
+  EPA_explosive_rate: Explosive-play rate. Note this is NOT EPA_explosive divided by EPA_plays -- ESPN divides by its own
+    smaller qualifying-play count, so deriving it yourself will not reproduce this value.
+  EPA_explosive_rushing: Count of explosive rush plays. A play count, not an EPA total.
+  EPA_explosive_rushing_rate: Explosive-play rate on rush plays, over ESPN's qualifying-play denominator.
+  EPA_fg: Total EPA on field-goal attempts.
+  EPA_kickoff: Total EPA on kickoff plays.
+  EPA_non_explosive: Total EPA with explosive plays excluded, isolating the team's routine-down production.
+  EPA_non_explosive_passing: Total EPA on pass plays with explosive plays excluded.
+  EPA_non_explosive_passing_per_play: EPA per pass play with explosive plays excluded.
+  EPA_non_explosive_per_play: EPA per play with explosive plays excluded.
+  EPA_non_explosive_rushing: Total EPA on rush plays with explosive plays excluded.
+  EPA_non_explosive_rushing_per_play: EPA per rush play with explosive plays excluded.
+  EPA_overall_off: Total offensive EPA for the team. Duplicated exactly by EPA_overall_offense in every published season checked
+    -- prefer one and ignore the other.
+  EPA_overall_offense: Total offensive EPA. An exact duplicate of EPA_overall_off.
+  EPA_overall_total: Total EPA across all phases, which is why it differs from the offense-only EPA_overall_off.
+  EPA_passing_overall: Total EPA on pass plays.
+  EPA_passing_per_play: EPA per pass play.
+  EPA_penalty: Total EPA attributed to penalties.
+  EPA_per_play: Offensive EPA per play.
+  EPA_plays: Number of plays ESPN's advanced box score scored for the team.
+  EPA_punt: Total EPA on punt plays.
+  EPA_rushing_overall: Total EPA on rush plays.
+  EPA_rushing_per_play: EPA per rush play.
+  EPA_rushing_power: Total EPA on power rushing situations, as classified by ESPN's advanced box score.
+  EPA_rushing_power_per_play: EPA per play on power rushing situations.
+  EPA_sp: Total special-teams EPA, ESPN's abbreviated field for the same phase.
+  EPA_special_teams: Total EPA generated on special-teams plays.
+  field_goals: Number of field-goal attempts.
+  first_downs_created: Number of first downs the team created.
+  first_downs_created_rate: Share of the team's plays that created a first down.
+  kickoff_plays: Number of kickoff plays.
+  line_yards: Line yards -- the portion of rushing yardage credited to the offensive line under the standard rushing decomposition.
+    ESPN applies its own qualifying threshold for the yardage split.
+  line_yards_per_carry: Line yards per rushing attempt.
+  off_yards: Offensive yards gained from scrimmage.
+  open_field_yards: Open-field yards -- rushing yardage earned well downfield, past the second level.
+  passes_rate: Share of the team's plays from scrimmage that were pass plays.
+  passing_first_downs_created: Number of first downs created on pass plays.
+  passing_first_downs_created_rate: Share of pass plays that created a first down.
+  penalty_first_downs_created: Number of first downs the team gained via opponent penalty.
+  penalty_first_downs_created_rate: Share of the team's first downs that came via opponent penalty.
+  punt_plays: Number of punt plays.
+  rushes: Number of rushing attempts.
+  rushes_rate: Share of the team's plays from scrimmage that were rush plays.
+  rushing_first_downs_created: Number of first downs created on rush plays.
+  rushing_first_downs_created_rate: Share of rush plays that created a first down.
+  rushing_highlight: Highlight yards -- rushing yardage credited to the back rather than the offensive line.
+  rushing_highlight_rate: Share of rushing yardage that was highlight (back-credited) yardage.
+  rushing_highlight_yards_per_opp: Highlight yards per rushing opportunity.
+  rushing_opportunity: Count of rushing opportunities -- carries that reached ESPN's opportunity threshold.
+  rushing_opportunity_rate: Share of carries that qualified as rushing opportunities.
+  rushing_power: Count of power rushing attempts, in short-yardage situations as classified by ESPN's advanced box score.
+  rushing_power_rate: Share of carries that were power rushing attempts.
+  rushing_power_success_rate: Share of power rushing attempts that succeeded.
+  rushing_stopped: Count of rushing attempts stopped at or behind the line of scrimmage.
+  rushing_stopped_rate: Share of carries stopped at or behind the line of scrimmage.
+  rushing_stuff: Count of stuffed rushing attempts.
+  scrimmage_plays: Number of plays from scrimmage (rushes plus passes), excluding special teams.
+  second_level_yards: Second-level yards -- rushing yardage earned just beyond the line of scrimmage.
+  special_teams_plays: Number of special-teams plays.
+  total_off_yards: Total offensive yards across all plays.
+  total_pen_yards: Total penalty yards assessed.
+  yards_per_play: Yards gained per play.
+  yards_per_rush: Yards gained per rushing attempt.
+load_cfb_adv_turnover:
+  Int: Interceptions thrown.
+  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
+load_cfb_model_pbp:
+  completion_prob: Modelled probability the pass is completed.
+  cp_model_version: Version of the completion-probability model that scored the play.
+  ep_model_version: Version of the expected-points model that scored the play.
+  model_pbp_version: Version of the model-scored play-by-play build.
+  passer_player_name: Display name of the passer -- the FIRST participant in that role on the play.
+  scored_date: Date on which the play was scored by the models.
+  wp_model_version: Version of the win-probability model that scored the play.
+load_cfb_passing:
+  EPAgame: EPA generated per game.
+  EPAgame_rank: National rank of the team's EPA generated per game, where 1 is best.
+  EPAplay: EPA generated per play.
+  EPAplay_rank: National rank of the team's EPA generated per play, where 1 is best.
+  TEPA: Total EPA summed over every play.
+  TEPA_rank: National rank of the team's total EPA summed over every play, where 1 is best.
+  att: Pass attempts thrown.
+  comp: Completed passes.
+  comppct: Completion percentage.
+  comppct_rank: National rank of the team's completion percentage, where 1 is best.
+  detmer: Detmer rating -- the composite passing-efficiency measure this pipeline publishes, named for the college passing-efficiency
+    tradition.
+  detmer_rank: National rank of the team's detmer rating -- the composite passing-efficiency measure this pipeline publishes,
+    named for the college passing-efficiency tradition, where 1 is best.
+  detmergame: Detmer rating expressed per game.
+  detmergame_rank: National rank of the team's detmer rating expressed per game, where 1 is best.
+  dropbacks: Dropbacks taken by the passer.
+  fbs_class: 'Power/Group classification for the season: P4 or G6 from 2024 on, P5 or G5 through 2023, derived from conference
+    membership. Null for teams outside FBS.'
+  pass_int: Interceptions thrown.
+  passer_player_name: Display name of the passer -- the FIRST participant in that role on the play.
+  playsgame: Plays per game.
+  sack_adj_yards: Passing yards adjusted for sack yardage lost.
+  sack_adj_yards_rank: National rank of the team's passing yards adjusted for sack yardage lost, where 1 is best.
+  sack_yds: Yards lost to sacks.
+  sacked: Times the passer was sacked.
+  success: Success rate across the team plays.
+  success_rank: National rank of the team's success rate across the team plays, where 1 is best.
+  team_games: Games the team played, used as the per-game denominator.
+  yards_rank: National rank of the team's total yards, where 1 is best.
+  yardsdropback: Yards per dropback.
+  yardsdropback_rank: National rank of the team's yards per dropback, where 1 is best.
+  yardsgame: Yards per game.
+  yardsgame_rank: National rank of the team's yards per game, where 1 is best.
+  yardsplay: Yards per play.
+  yardsplay_rank: National rank of the team's yards per play, where 1 is best.
+load_cfb_percentiles:
+  EPAdropback: Value of EPA generated per dropback at the percentile this row reports.
+  EPAplay: Value of EPA generated per play at the percentile this row reports.
+  EPArush: Value of EPA generated per rushing attempt at the percentile this row reports.
+  GEI: Value of game excitement index at the percentile this row reports.
+  dropbacks: Value of dropbacks taken by the passer at the percentile this row reports.
+  early_down_EPA: Value of EPA per early-down play at the percentile this row reports.
+  early_down_success: Value of success rate on early downs at the percentile this row reports.
+  explosive: Value of explosive-play rate at the percentile this row reports.
+  havoc: Value of havoc rate at the percentile this row reports.
+  late_down_success: Value of success rate on late downs at the percentile this row reports.
+  lineyards: Value of line yards per rush at the percentile this row reports.
+  nonExplosiveEpaPerPlay: Value of EPA per play excluding explosive plays at the percentile this row reports.
+  opportunity_run: Value of opportunity-run rate at the percentile this row reports.
+  pass_explosive: Value of explosive-play rate on pass plays at the percentile this row reports.
+  pass_success: Value of success rate on pass plays at the percentile this row reports.
+  pctile: Percentile bucket the row reports, from 0 to 100.
+  play_stuffed: Value of stuffed-play rate at the percentile this row reports.
+  red_zone_success: Value of success rate in the red zone at the percentile this row reports.
+  rush_explosive: Value of explosive-play rate on rush plays at the percentile this row reports.
+  rush_success: Value of success rate on rush plays at the percentile this row reports.
+  rushes: Value of rushing attempts at the percentile this row reports.
+  success: Value of success rate across the team plays at the percentile this row reports.
+  third_down_distance: Value of average yards to go on third down at the percentile this row reports.
+  third_down_success: Value of success rate on third down at the percentile this row reports.
+  yardsdropback: Value of yards per dropback at the percentile this row reports.
+  yardsplay: Value of yards per play at the percentile this row reports.
+  yardsrush: Value of yards per rush at the percentile this row reports.
+load_cfb_play_participants:
+  assisted_by_player_id: ESPN athlete id of a defender credited with an assisted tackle -- the FIRST participant in that role
+    on the play.
+  assisted_by_player_ids: List of the athlete ids of EVERY participant credited as a defender credited with an assisted tackle
+    on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  assisted_by_player_name: Display name of a defender credited with an assisted tackle -- the FIRST participant in that role
+    on the play.
+  assisted_by_player_names: List of the display names of EVERY participant credited as a defender credited with an assisted
+    tackle on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  forced_by_player_id: ESPN athlete id of the defender who forced the fumble -- the FIRST participant in that role on the
+    play.
+  forced_by_player_ids: List of the athlete ids of EVERY participant credited as the defender who forced the fumble on the
+    play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  forced_by_player_name: Display name of the defender who forced the fumble -- the FIRST participant in that role on the play.
+  forced_by_player_names: List of the display names of EVERY participant credited as the defender who forced the fumble on
+    the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  kicker_player_id: ESPN athlete id of the kicker -- the FIRST participant in that role on the play.
+  kicker_player_ids: List of the athlete ids of EVERY participant credited as the kicker on the play, so multi-entry roles
+    such as split sacks or gang tackles are not collapsed to one.
+  kicker_player_name: Display name of the kicker -- the FIRST participant in that role on the play.
+  kicker_player_names: List of the display names of EVERY participant credited as the kicker on the play, so multi-entry roles
+    such as split sacks or gang tackles are not collapsed to one.
+  pass_defender_player_id: ESPN athlete id of the defender credited with defending the pass -- the FIRST participant in that
+    role on the play.
+  pass_defender_player_ids: List of the athlete ids of EVERY participant credited as the defender credited with defending
+    the pass on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  pass_defender_player_name: Display name of the defender credited with defending the pass -- the FIRST participant in that
+    role on the play.
+  pass_defender_player_names: List of the display names of EVERY participant credited as the defender credited with defending
+    the pass on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  passer_player_id: ESPN athlete id of the passer -- the FIRST participant in that role on the play.
+  passer_player_ids: List of the athlete ids of EVERY participant credited as the passer on the play, so multi-entry roles
+    such as split sacks or gang tackles are not collapsed to one.
+  passer_player_name: Display name of the passer -- the FIRST participant in that role on the play.
+  passer_player_names: List of the display names of EVERY participant credited as the passer on the play, so multi-entry roles
+    such as split sacks or gang tackles are not collapsed to one.
+  pat_passer_player_id: ESPN athlete id of the passer on the point-after attempt -- the FIRST participant in that role on
+    the play.
+  pat_passer_player_ids: List of the athlete ids of EVERY participant credited as the passer on the point-after attempt on
+    the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  pat_passer_player_name: Display name of the passer on the point-after attempt -- the FIRST participant in that role on the
+    play.
+  pat_passer_player_names: List of the display names of EVERY participant credited as the passer on the point-after attempt
+    on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  pat_scorer_player_id: ESPN athlete id of the player credited with the point-after score -- the FIRST participant in that
+    role on the play.
+  pat_scorer_player_ids: List of the athlete ids of EVERY participant credited as the player credited with the point-after
+    score on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  pat_scorer_player_name: Display name of the player credited with the point-after score -- the FIRST participant in that
+    role on the play.
+  pat_scorer_player_names: List of the display names of EVERY participant credited as the player credited with the point-after
+    score on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  penalized_player_id: ESPN athlete id of the penalized player -- the FIRST participant in that role on the play.
+  penalized_player_ids: List of the athlete ids of EVERY participant credited as the penalized player on the play, so multi-entry
+    roles such as split sacks or gang tackles are not collapsed to one.
+  penalized_player_name: Display name of the penalized player -- the FIRST participant in that role on the play.
+  penalized_player_names: List of the display names of EVERY participant credited as the penalized player on the play, so
+    multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  punter_player_id: ESPN athlete id of the punter -- the FIRST participant in that role on the play.
+  punter_player_ids: List of the athlete ids of EVERY participant credited as the punter on the play, so multi-entry roles
+    such as split sacks or gang tackles are not collapsed to one.
+  punter_player_name: Display name of the punter -- the FIRST participant in that role on the play.
+  punter_player_names: List of the display names of EVERY participant credited as the punter on the play, so multi-entry roles
+    such as split sacks or gang tackles are not collapsed to one.
+  receiver_player_id: ESPN athlete id of the targeted receiver -- the FIRST participant in that role on the play.
+  receiver_player_ids: List of the athlete ids of EVERY participant credited as the targeted receiver on the play, so multi-entry
+    roles such as split sacks or gang tackles are not collapsed to one.
+  receiver_player_name: Display name of the targeted receiver -- the FIRST participant in that role on the play.
+  receiver_player_names: List of the display names of EVERY participant credited as the targeted receiver on the play, so
+    multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  recoverer_player_id: ESPN athlete id of the player who recovered the fumble -- the FIRST participant in that role on the
+    play.
+  recoverer_player_ids: List of the athlete ids of EVERY participant credited as the player who recovered the fumble on the
+    play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  recoverer_player_name: Display name of the player who recovered the fumble -- the FIRST participant in that role on the
+    play.
+  recoverer_player_names: List of the display names of EVERY participant credited as the player who recovered the fumble on
+    the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  returner_player_id: ESPN athlete id of the player returning the kick or punt -- the FIRST participant in that role on the
+    play.
+  returner_player_ids: List of the athlete ids of EVERY participant credited as the player returning the kick or punt on the
+    play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  returner_player_name: Display name of the player returning the kick or punt -- the FIRST participant in that role on the
+    play.
+  returner_player_names: List of the display names of EVERY participant credited as the player returning the kick or punt
+    on the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  rusher_player_id: ESPN athlete id of the ball carrier on a rush -- the FIRST participant in that role on the play.
+  rusher_player_ids: List of the athlete ids of EVERY participant credited as the ball carrier on a rush on the play, so multi-entry
+    roles such as split sacks or gang tackles are not collapsed to one.
+  rusher_player_name: Display name of the ball carrier on a rush -- the FIRST participant in that role on the play.
+  rusher_player_names: List of the display names of EVERY participant credited as the ball carrier on a rush on the play,
+    so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  sacked_by_player_id: ESPN athlete id of a defender credited with the sack -- the FIRST participant in that role on the play.
+  sacked_by_player_ids: List of the athlete ids of EVERY participant credited as a defender credited with the sack on the
+    play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  sacked_by_player_name: Display name of a defender credited with the sack -- the FIRST participant in that role on the play.
+  sacked_by_player_names: List of the display names of EVERY participant credited as a defender credited with the sack on
+    the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  scorer_player_id: ESPN athlete id of the player credited with the score -- the FIRST participant in that role on the play.
+  scorer_player_ids: List of the athlete ids of EVERY participant credited as the player credited with the score on the play,
+    so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  scorer_player_name: Display name of the player credited with the score -- the FIRST participant in that role on the play.
+  scorer_player_names: List of the display names of EVERY participant credited as the player credited with the score on the
+    play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  tackler_player_id: ESPN athlete id of a defender credited with the tackle -- the FIRST participant in that role on the play.
+  tackler_player_ids: List of the athlete ids of EVERY participant credited as a defender credited with the tackle on the
+    play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+  tackler_player_name: Display name of a defender credited with the tackle -- the FIRST participant in that role on the play.
+  tackler_player_names: List of the display names of EVERY participant credited as a defender credited with the tackle on
+    the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+load_cfb_player_box:
+  adjQBR: Adjusted Total QBR for the quarterback.
+  completions/passingAttempts: Completions and pass attempts, as ESPN's combined string.
+  extraPointsMade/extraPointAttempts: Extra points made and attempted, as ESPN's combined string.
+  fieldGoalPct: Field-goal percentage.
+  fieldGoalsMade/fieldGoalAttempts: Field goals made and attempted, as ESPN's combined string.
+  grossAvgPuntYards: Gross average yards per punt, before return yardage.
+  interceptionTouchdowns: Touchdowns scored on interception returns.
+  interceptionYards: Yards returned on interceptions.
+  longFieldGoalMade: Longest field goal made, in yards.
+  longPunt: Longest punt of the game, in yards.
+  longPuntReturn: Longest punt return of the game, in yards.
+  longReception: Longest reception of the game, in yards.
+  longRushing: Longest rush of the game, in yards.
+  passingTouchdowns: Passing touchdowns.
+  passingYards: Net passing yards gained.
+  puntReturnTouchdowns: Touchdowns scored on punt returns.
+  puntReturnYards: Yards gained on punt returns.
+  puntReturns: Punt returns attempted.
+  puntYards: Total punt yards.
+  punts: Punts attempted.
+  puntsInside20: Punts downed inside the opponent 20-yard line.
+  receivingTouchdowns: Receiving touchdowns.
+  receivingYards: Receiving yards gained.
+  rushingAttempts: Rushing attempts.
+  rushingTouchdowns: Rushing touchdowns.
+  rushingYards: Net rushing yards gained.
+  totalKickingPoints: Total points scored by kicking.
+  touchbacks: Punts or kickoffs that resulted in a touchback.
+  yardsPerPassAttempt: Yards gained per pass attempt.
+  yardsPerPuntReturn: Yards gained per punt return.
+  yardsPerReception: Yards gained per reception.
+  yardsPerRushAttempt: Yards gained per rushing attempt.
+load_cfb_receiving:
+  EPAgame: EPA generated per game.
+  EPAgame_rank: National rank of the team's EPA generated per game, where 1 is best.
+  EPAplay: EPA generated per play.
+  EPAplay_rank: National rank of the team's EPA generated per play, where 1 is best.
+  TEPA: Total EPA summed over every play.
+  TEPA_rank: National rank of the team's total EPA summed over every play, where 1 is best.
+  comp: Completed passes.
+  fbs_class: 'Power/Group classification for the season: P4 or G6 from 2024 on, P5 or G5 through 2023, derived from conference
+    membership. Null for teams outside FBS.'
+  playsgame: Plays per game.
+  receiver_player_name: Display name of the targeted receiver -- the FIRST participant in that role on the play.
+  success: Success rate across the team plays.
+  success_rank: National rank of the team's success rate across the team plays, where 1 is best.
+  team_games: Games the team played, used as the per-game denominator.
+  yards_rank: National rank of the team's total yards, where 1 is best.
+  yardsgame: Yards per game.
+  yardsgame_rank: National rank of the team's yards per game, where 1 is best.
+  yardsplay: Yards per play.
+  yardsplay_rank: National rank of the team's yards per play, where 1 is best.
+load_cfb_rushing:
+  EPAgame: EPA generated per game.
+  EPAgame_rank: National rank of the team's EPA generated per game, where 1 is best.
+  EPAplay: EPA generated per play.
+  EPAplay_rank: National rank of the team's EPA generated per play, where 1 is best.
+  TEPA: Total EPA summed over every play.
+  TEPA_rank: National rank of the team's total EPA summed over every play, where 1 is best.
+  fbs_class: 'Power/Group classification for the season: P4 or G6 from 2024 on, P5 or G5 through 2023, derived from conference
+    membership. Null for teams outside FBS.'
+  playsgame: Plays per game.
+  rusher_player_name: Display name of the ball carrier on a rush -- the FIRST participant in that role on the play.
+  success: Success rate across the team plays.
+  success_rank: National rank of the team's success rate across the team plays, where 1 is best.
+  team_games: Games the team played, used as the per-game denominator.
+  yards_rank: National rank of the team's total yards, where 1 is best.
+  yardsgame: Yards per game.
+  yardsgame_rank: National rank of the team's yards per game, where 1 is best.
+  yardsplay: Yards per play.
+  yardsplay_rank: National rank of the team's yards per play, where 1 is best.
+load_cfb_schedule_crosswalk:
+  espn_game_id: ESPN game id for the crosswalk row.
+  fox_game_id: Fox Sports game id for the same game.
+  yahoo_game_id: Yahoo Sports game id for the same game.
+load_cfb_team_box:
+  rushingAttempts: Rushing attempts.
+  rushingYards: Net rushing yards gained.
+  yardsPerRushAttempt: Yards gained per rushing attempt.
+load_cfb_teams_crosswalk:
+  espn_team_id: ESPN team id for the crosswalk row.
+  fox_team_id: Fox Sports team id for the same team.
+  yahoo_team_id: Yahoo Sports team id for the same team.
 load_contracts:
   cols: Placeholder column retained in the contracts loader output schema; contains no meaningful data in this context.
 load_depth_charts:

--- a/tools/codegen/manual_column_descriptions.yaml
+++ b/tools/codegen/manual_column_descriptions.yaml
@@ -4207,8 +4207,6 @@ load_wnba_stats_rosters:
   team_id_lookup: Team id used to join the row back to the team tables.
 load_wnba_team_season_stats:
   stat_description: Human-readable description of the statistic the row reports.
-load_cfb_adv_defensive:
-  scrimmage_plays: Number of plays from scrimmage (rushes plus passes), excluding special teams.
 load_cfb_adv_defensive_players:
   def_pos_team: Display name of the team on defense (e.g. 'Ohio State Buckeyes'). Held an ESPN team id until the 2026-08 republish;
     the id now lives in def_pos_team_id.
@@ -4224,8 +4222,6 @@ load_cfb_adv_defensive_players:
   player_name: Display name of the defender.
   sacks: Sacks recorded by the defender. Available from 2005 on; null for 2004.
   sacks_yards: Yards lost by the offense on the defender's sacks. Available from 2005 on; null for 2004.
-load_cfb_adv_drives:
-  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
 load_cfb_adv_passing:
   Att: Pass attempts recorded in the advanced box score.
   CPOE: Completion percentage over expected -- actual minus modelled completion rate.
@@ -4252,18 +4248,6 @@ load_cfb_adv_passing:
   sack_epa: EPA credited to the player's sacks taken.
   xComp: Expected completions, summed from the per-play completion model.
   xCompPct: Expected completion percentage from the per-play completion model.
-load_cfb_adv_receiving:
-  EPA_per_Play: EPA per play on the passer's plays.
-  SR: Success rate on the passer's plays.
-  Yds: Passing yards from the advanced box score.
-  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
-  receiver_player_name: Display name of the targeted receiver -- the FIRST participant in that role on the play.
-load_cfb_adv_rushing:
-  EPA_per_Play: EPA per play on the passer's plays.
-  SR: Success rate on the passer's plays.
-  Yds: Passing yards from the advanced box score.
-  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
-  rusher_player_name: Display name of the ball carrier on a rush -- the FIRST participant in that role on the play.
 load_cfb_adv_situational:
   EPA_early_down: Total EPA the team generated on early downs.
   EPA_early_down_pass: Total EPA the team generated on early downs on pass plays.
@@ -4363,10 +4347,6 @@ load_cfb_adv_situational:
   pos_team: Display name of the team on offense (e.g. 'Ohio State Buckeyes').
   pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
   standard_downs: Number of plays the team ran on standard downs (the team ahead of schedule for the series).
-load_cfb_adv_specialists:
-  field_goals: Number of field-goal attempts.
-  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
-  punts: Punts attempted.
 load_cfb_adv_team:
   EPA_explosive: Count of explosive plays, per ESPN's advanced box score. Despite the EPA_ prefix this is a play COUNT, not
     an EPA total.
@@ -4438,87 +4418,6 @@ load_cfb_adv_team:
   total_pen_yards: Total penalty yards assessed.
   yards_per_play: Yards gained per play.
   yards_per_rush: Yards gained per rushing attempt.
-load_cfb_adv_team_gamelog:
-  EPA_explosive: Count of explosive plays, per ESPN's advanced box score. Despite the EPA_ prefix this is a play COUNT, not
-    an EPA total.
-  EPA_explosive_passing: Count of explosive pass plays. A play count, not an EPA total.
-  EPA_explosive_passing_rate: Explosive-play rate on pass plays, over ESPN's qualifying-play denominator.
-  EPA_explosive_rate: Explosive-play rate. Note this is NOT EPA_explosive divided by EPA_plays -- ESPN divides by its own
-    smaller qualifying-play count, so deriving it yourself will not reproduce this value.
-  EPA_explosive_rushing: Count of explosive rush plays. A play count, not an EPA total.
-  EPA_explosive_rushing_rate: Explosive-play rate on rush plays, over ESPN's qualifying-play denominator.
-  EPA_fg: Total EPA on field-goal attempts.
-  EPA_kickoff: Total EPA on kickoff plays.
-  EPA_non_explosive: Total EPA with explosive plays excluded, isolating the team's routine-down production.
-  EPA_non_explosive_passing: Total EPA on pass plays with explosive plays excluded.
-  EPA_non_explosive_passing_per_play: EPA per pass play with explosive plays excluded.
-  EPA_non_explosive_per_play: EPA per play with explosive plays excluded.
-  EPA_non_explosive_rushing: Total EPA on rush plays with explosive plays excluded.
-  EPA_non_explosive_rushing_per_play: EPA per rush play with explosive plays excluded.
-  EPA_overall_off: Total offensive EPA for the team. Duplicated exactly by EPA_overall_offense in every published season checked
-    -- prefer one and ignore the other.
-  EPA_overall_offense: Total offensive EPA. An exact duplicate of EPA_overall_off.
-  EPA_overall_total: Total EPA across all phases, which is why it differs from the offense-only EPA_overall_off.
-  EPA_passing_overall: Total EPA on pass plays.
-  EPA_passing_per_play: EPA per pass play.
-  EPA_penalty: Total EPA attributed to penalties.
-  EPA_per_play: Offensive EPA per play.
-  EPA_plays: Number of plays ESPN's advanced box score scored for the team.
-  EPA_punt: Total EPA on punt plays.
-  EPA_rushing_overall: Total EPA on rush plays.
-  EPA_rushing_per_play: EPA per rush play.
-  EPA_rushing_power: Total EPA on power rushing situations, as classified by ESPN's advanced box score.
-  EPA_rushing_power_per_play: EPA per play on power rushing situations.
-  EPA_sp: Total special-teams EPA, ESPN's abbreviated field for the same phase.
-  EPA_special_teams: Total EPA generated on special-teams plays.
-  field_goals: Number of field-goal attempts.
-  first_downs_created: Number of first downs the team created.
-  first_downs_created_rate: Share of the team's plays that created a first down.
-  kickoff_plays: Number of kickoff plays.
-  line_yards: Line yards -- the portion of rushing yardage credited to the offensive line under the standard rushing decomposition.
-    ESPN applies its own qualifying threshold for the yardage split.
-  line_yards_per_carry: Line yards per rushing attempt.
-  off_yards: Offensive yards gained from scrimmage.
-  open_field_yards: Open-field yards -- rushing yardage earned well downfield, past the second level.
-  passes_rate: Share of the team's plays from scrimmage that were pass plays.
-  passing_first_downs_created: Number of first downs created on pass plays.
-  passing_first_downs_created_rate: Share of pass plays that created a first down.
-  penalty_first_downs_created: Number of first downs the team gained via opponent penalty.
-  penalty_first_downs_created_rate: Share of the team's first downs that came via opponent penalty.
-  punt_plays: Number of punt plays.
-  rushes: Number of rushing attempts.
-  rushes_rate: Share of the team's plays from scrimmage that were rush plays.
-  rushing_first_downs_created: Number of first downs created on rush plays.
-  rushing_first_downs_created_rate: Share of rush plays that created a first down.
-  rushing_highlight: Highlight yards -- rushing yardage credited to the back rather than the offensive line.
-  rushing_highlight_rate: Share of rushing yardage that was highlight (back-credited) yardage.
-  rushing_highlight_yards_per_opp: Highlight yards per rushing opportunity.
-  rushing_opportunity: Count of rushing opportunities -- carries that reached ESPN's opportunity threshold.
-  rushing_opportunity_rate: Share of carries that qualified as rushing opportunities.
-  rushing_power: Count of power rushing attempts, in short-yardage situations as classified by ESPN's advanced box score.
-  rushing_power_rate: Share of carries that were power rushing attempts.
-  rushing_power_success_rate: Share of power rushing attempts that succeeded.
-  rushing_stopped: Count of rushing attempts stopped at or behind the line of scrimmage.
-  rushing_stopped_rate: Share of carries stopped at or behind the line of scrimmage.
-  rushing_stuff: Count of stuffed rushing attempts.
-  scrimmage_plays: Number of plays from scrimmage (rushes plus passes), excluding special teams.
-  second_level_yards: Second-level yards -- rushing yardage earned just beyond the line of scrimmage.
-  special_teams_plays: Number of special-teams plays.
-  total_off_yards: Total offensive yards across all plays.
-  total_pen_yards: Total penalty yards assessed.
-  yards_per_play: Yards gained per play.
-  yards_per_rush: Yards gained per rushing attempt.
-load_cfb_adv_turnover:
-  Int: Interceptions thrown.
-  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
-load_cfb_model_pbp:
-  completion_prob: Modelled probability the pass is completed.
-  cp_model_version: Version of the completion-probability model that scored the play.
-  ep_model_version: Version of the expected-points model that scored the play.
-  model_pbp_version: Version of the model-scored play-by-play build.
-  passer_player_name: Display name of the passer -- the FIRST participant in that role on the play.
-  scored_date: Date on which the play was scored by the models.
-  wp_model_version: Version of the win-probability model that scored the play.
 load_cfb_passing:
   EPAgame: EPA generated per game.
   EPAgame_rank: National rank of the team's EPA generated per game, where 1 is best.
@@ -4694,6 +4593,212 @@ load_cfb_play_participants:
   tackler_player_name: Display name of a defender credited with the tackle -- the FIRST participant in that role on the play.
   tackler_player_names: List of the display names of EVERY participant credited as a defender credited with the tackle on
     the play, so multi-entry roles such as split sacks or gang tackles are not collapsed to one.
+load_cfb_adv_defensive:
+  TFL: Count of scrimmage plays the defense held to negative yardage (non-penalty, non-special-teams, ESPN statYardage below
+    zero) plus every sack.
+  TFL_pass: The TFL count restricted to plays classified as passes, so it covers sacks together with completions and laterals
+    stopped behind the line.
+  TFL_rush: The TFL count restricted to plays classified as rushes, that is rushing attempts the defense stopped for negative
+    yardage.
+  def_int: Interceptions the defense recorded, counted from plays ESPN types as Interception Return or Interception Return
+    Touchdown.
+  drive_stopped_rate: Percentage from 0 to 100 of the defense's scrimmage plays that occurred on drives ending in a punt,
+    fumble, interception, or turnover on downs; the denominator is plays, not drives.
+  fumbles: Fumbles the defense forced, counted from plays whose narrative contains the phrase forced by, not the total number
+    of fumbles on the play.
+  havoc_total_pass: Havoc events (tackle for loss, sack, interception, forced fumble, or pass breakup) recorded on the pass
+    plays the defense faced.
+  havoc_total_pass_rate: havoc_total_pass divided by num_pass_plays, the defense's havoc rate against the pass as a 0-to-1
+    fraction.
+  havoc_total_rate: Share of the defense's scrimmage plays producing a havoc event, a 0-to-1 fraction equal to havoc_total
+    divided by scrimmage_plays.
+  havoc_total_rush: Havoc events recorded on the rush plays the defense faced, in practice tackles for loss and forced fumbles.
+  havoc_total_rush_rate: Havoc events per rush play faced, the mean of the havoc flag over the defense's rush scrimmage plays.
+  num_pass_plays: Number of pass scrimmage plays the defense faced, the denominator behind havoc_total_pass_rate and sacks_rate.
+  pass_breakups: Passes the defense broke up, counted from plays whose narrative contains the phrase broken up by.
+  sacks_rate: Sacks divided by pass plays faced, the defense's per-pass-play sack rate as a 0-to-1 fraction.
+  scrimmage_plays: Number of plays from scrimmage (rushes plus passes), excluding special teams.
+load_cfb_adv_drives:
+  avg_field_position: Mean distance to the opponent end zone at drive start averaged over the team's scrimmage plays, exactly
+    drive_total_available_yards divided by that play count.
+  drive_total_available_yards: Sum of each drive's starting distance to the opponent end zone taken across every scrimmage
+    play, so a drive contributes its available yards once per play rather than once per drive.
+  drive_total_gained_yards: Sum of ESPN's per-drive yardage repeated across every scrimmage play of that drive, so a drive
+    contributes its yardage once per play.
+  drive_total_gained_yards_rate: Available-yards conversion as a percentage, 100 times drive_total_gained_yards over drive_total_available_yards
+    with both sums play-weighted.
+  drives: Number of distinct ESPN drive ids on which the team ran at least one scrimmage play.
+  plays_per_drive: Mean of ESPN's per-drive offensivePlays taken over plays rather than over drives, which weights every drive
+    by its own length.
+  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
+  yards_per_drive: Mean of ESPN's per-drive yardage taken over plays rather than over drives, exactly drive_total_gained_yards
+    divided by the team's scrimmage-play count.
+load_cfb_adv_receiving:
+  EPA_per_Play: EPA per play on the passer's plays.
+  Fum: Count of the receiver's targeted pass plays whose text mentions a fumble; it is a play-level flag, not a fumble charged
+    to this player.
+  Fum_Lost: Count of the receiver's targeted plays on which a fumble was lost to the opponent.
+  Rec: Receptions credited to the receiver, the number of completions on plays where this player was the targeted receiver.
+  Rec_TD: Receiving touchdowns, the count of the player's targeted plays that ended in a passing touchdown.
+  SR: Success rate on the passer's plays.
+  Tar: Times the player was targeted on a pass attempt, the denominator behind YPT.
+  YPT: Receiving yards per target, the mean of receiving yardage over every target rather than over receptions only.
+  Yds: Passing yards from the advanced box score.
+  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
+  receiver_player_name: Display name of the targeted receiver -- the FIRST participant in that role on the play.
+load_cfb_adv_rushing:
+  Car: Rushing attempts credited to this ball carrier in the game.
+  EPA_per_Play: EPA per play on the passer's plays.
+  Fum: Count of the carrier's rush attempts whose play text mentions a fumble; it is a play-level flag, not a fumble charged
+    to this player.
+  Fum_Lost: Count of the carrier's rush attempts on which a fumble was lost to the opponent.
+  Rush_TD: Rushing touchdowns scored by this ball carrier in the game.
+  SR: Success rate on the passer's plays.
+  YPC: Yards per carry, the mean rushing yardage across the player's attempts in the game.
+  Yds: Passing yards from the advanced box score.
+  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
+  rusher_player_name: Display name of the ball carrier on a rush -- the FIRST participant in that role on the play.
+load_cfb_adv_specialists:
+  field_goals: Number of field-goal attempts.
+  field_goals_yards: Sum of the field-goal attempt distances parsed out of the play text; it stays at zero when no distance
+    could be parsed from the narrative.
+  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
+  punt_returns_yards: Total punt-return yardage credited to this returner, with fair catches, downed punts, and out-of-bounds
+    punts scored as zero.
+  punts: Punts attempted.
+  punts_yards: Total gross punt yardage parsed from the play text for this punter, working out to roughly 42 yards per punt
+    league-wide.
+load_cfb_adv_team_gamelog:
+  EPA_explosive: Count of explosive plays, per ESPN's advanced box score. Despite the EPA_ prefix this is a play COUNT, not
+    an EPA total.
+  EPA_explosive_passing: Count of explosive pass plays. A play count, not an EPA total.
+  EPA_explosive_passing_rate: Explosive-play rate on pass plays, over ESPN's qualifying-play denominator.
+  EPA_explosive_rate: Explosive-play rate. Note this is NOT EPA_explosive divided by EPA_plays -- ESPN divides by its own
+    smaller qualifying-play count, so deriving it yourself will not reproduce this value.
+  EPA_explosive_rushing: Count of explosive rush plays. A play count, not an EPA total.
+  EPA_explosive_rushing_rate: Explosive-play rate on rush plays, over ESPN's qualifying-play denominator.
+  EPA_fg: Total EPA on field-goal attempts.
+  EPA_kickoff: Total EPA on kickoff plays.
+  EPA_non_explosive: Total EPA with explosive plays excluded, isolating the team's routine-down production.
+  EPA_non_explosive_passing: Total EPA on pass plays with explosive plays excluded.
+  EPA_non_explosive_passing_per_play: EPA per pass play with explosive plays excluded.
+  EPA_non_explosive_per_play: EPA per play with explosive plays excluded.
+  EPA_non_explosive_rushing: Total EPA on rush plays with explosive plays excluded.
+  EPA_non_explosive_rushing_per_play: EPA per rush play with explosive plays excluded.
+  EPA_overall_off: Total offensive EPA for the team. Duplicated exactly by EPA_overall_offense in every published season checked
+    -- prefer one and ignore the other.
+  EPA_overall_offense: Total offensive EPA. An exact duplicate of EPA_overall_off.
+  EPA_overall_total: Total EPA across all phases, which is why it differs from the offense-only EPA_overall_off.
+  EPA_passing_overall: Total EPA on pass plays.
+  EPA_passing_per_play: EPA per pass play.
+  EPA_penalty: Total EPA attributed to penalties.
+  EPA_per_play: Offensive EPA per play.
+  EPA_plays: Number of plays ESPN's advanced box score scored for the team.
+  EPA_punt: Total EPA on punt plays.
+  EPA_rushing_overall: Total EPA on rush plays.
+  EPA_rushing_per_play: EPA per rush play.
+  EPA_rushing_power: Total EPA on power rushing situations, as classified by ESPN's advanced box score.
+  EPA_rushing_power_per_play: EPA per play on power rushing situations.
+  EPA_sp: Total special-teams EPA, ESPN's abbreviated field for the same phase.
+  EPA_special_teams: Total EPA generated on special-teams plays.
+  field_goals: Number of field-goal attempts.
+  first_downs_created: Number of first downs the team created.
+  first_downs_created_rate: Share of the team's plays that created a first down.
+  kickoff_plays: Number of kickoff plays.
+  line_yards: Line yards -- the portion of rushing yardage credited to the offensive line under the standard rushing decomposition.
+    ESPN applies its own qualifying threshold for the yardage split.
+  line_yards_per_carry: Line yards per rushing attempt.
+  margin: Final scoring margin from this team's perspective, exactly points_for minus points_against.
+  off_yards: Offensive yards gained from scrimmage.
+  open_field_yards: Open-field yards -- rushing yardage earned well downfield, past the second level.
+  passes_rate: Share of the team's plays from scrimmage that were pass plays.
+  passing_first_downs_created: Number of first downs created on pass plays.
+  passing_first_downs_created_rate: Share of pass plays that created a first down.
+  penalty_first_downs_created: Number of first downs the team gained via opponent penalty.
+  penalty_first_downs_created_rate: Share of the team's first downs that came via opponent penalty.
+  punt_plays: Number of punt plays.
+  rushes: Number of rushing attempts.
+  rushes_rate: Share of the team's plays from scrimmage that were rush plays.
+  rushing_first_downs_created: Number of first downs created on rush plays.
+  rushing_first_downs_created_rate: Share of rush plays that created a first down.
+  rushing_highlight: Highlight yards -- rushing yardage credited to the back rather than the offensive line.
+  rushing_highlight_rate: Share of rushing yardage that was highlight (back-credited) yardage.
+  rushing_highlight_yards_per_opp: Highlight yards per rushing opportunity.
+  rushing_opportunity: Count of rushing opportunities -- carries that reached ESPN's opportunity threshold.
+  rushing_opportunity_rate: Share of carries that qualified as rushing opportunities.
+  rushing_power: Count of power rushing attempts, in short-yardage situations as classified by ESPN's advanced box score.
+  rushing_power_rate: Share of carries that were power rushing attempts.
+  rushing_power_success_rate: Share of power rushing attempts that succeeded.
+  rushing_stopped: Count of rushing attempts stopped at or behind the line of scrimmage.
+  rushing_stopped_rate: Share of carries stopped at or behind the line of scrimmage.
+  rushing_stuff: Count of stuffed rushing attempts.
+  scrimmage_plays: Number of plays from scrimmage (rushes plus passes), excluding special teams.
+  second_level_yards: Second-level yards -- rushing yardage earned just beyond the line of scrimmage.
+  special_teams_plays: Number of special-teams plays.
+  total_off_yards: Total offensive yards across all plays.
+  total_pen_yards: Total penalty yards assessed.
+  yards_per_play: Yards gained per play.
+  yards_per_rush: Yards gained per rushing attempt.
+load_cfb_adv_turnover:
+  Int: Interceptions thrown.
+  Int_pbp: Interception count derived from the play-by-play, kept alongside the ESPN-sourced Int for reconciliation.
+  expected_turnover_margin: The opponent's expected_turnovers minus this team's, so positive means the team was expected to
+    win the turnover battle.
+  expected_turnovers: Turnover expectation for this team, computed as half its total fumbles plus 0.22 times the sum of its
+    pass breakups and interceptions.
+  fumble_recoveries_gained: Opponent fumbles this team recovered, taken as the opponent's fumbles_lost.
+  fumbles_lost_pbp: Fumbles-lost count derived from the play-by-play, kept alongside the ESPN-sourced fumbles_lost for reconciliation.
+  pass_breakups: Passes thrown by this offense that the opposing defense broke up; it equals the opponent's row in the advanced
+    defensive table exactly.
+  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
+  st_turnovers_gained: Special-teams turnovers this team recovered, taken as the opponent's st_turnovers_lost.
+  turnover_luck: Points of scoring luck attributed to turnovers, five points per turnover times the gap between turnover_margin
+    and expected_turnover_margin.
+  turnover_margin: The opponent's turnovers minus this team's turnovers, positive when the team gained more possessions than
+    it gave away.
+  turnovers_pbp: Turnover count derived from the play-by-play, retained unchanged so it can be reconciled against the ESPN-sourced
+    turnovers total.
+load_cfb_drives:
+  n_plays: Number of entries in ESPN's raw plays array for the drive, which is generally at least offensive_plays because
+    it also counts penalties and other non-offensive snaps.
+load_cfb_game_rosters:
+  athlete_href: ESPN Core v2 API reference URL for the athlete's season record, ending in the athlete id.
+  birth_country_alternate_id: ESPN's internal alternate identifier for the athlete's birth country, paired with birth_place_country
+    and the flag fields.
+  flag_alt: Alt text ESPN attaches to the birth-country flag image, which is the country's name spelled out.
+  flag_href: URL of the birth-country flag image hosted on ESPN's CDN under teamlogos/countries.
+  flag_rel: Stringified relationship list ESPN ships with the flag image; the only non-null value observed is a single country-flag
+    entry.
+  position_href: ESPN Core v2 API reference URL for the position resource ESPN lists the athlete at.
+  statistics_href: ESPN Core v2 API reference URL for this athlete's stat line in this game, null for the roughly 71 percent
+    of listed players who recorded no stats.
+  team_alternate_ids_sdr: The team's Sportradar alternate identifier, which maps one-to-one with team_id.
+load_cfb_model_pbp:
+  awayTeamId: ESPN team id of the away team, read off the game header and stamped on every play.
+  awayTeamName: Away team's school name from ESPN's team location field, without the mascot.
+  completion_prob: Modelled probability the pass is completed.
+  cp_model_version: Version of the completion-probability model that scored the play.
+  drive.id: ESPN's drive identifier, formed as the game id followed by the drive's sequence number within that game.
+  ep_model_version: Version of the expected-points model that scored the play.
+  homeTeamId: ESPN team id of the home team, read off the game header and stamped on every play.
+  homeTeamName: Home team's school name from ESPN's team location field, without the mascot.
+  model_pbp_version: Version of the model-scored play-by-play build.
+  passer_player_name: Display name of the passer -- the FIRST participant in that role on the play.
+  passing_down: True on second and eight or longer, third and five or longer, or fourth and five or longer, the standard obvious-passing-situation
+    flag.
+  scored_date: Date on which the play was scored by the models.
+  start.TimeSecsRem: Seconds remaining in the half at the snap, so it tops out at 1800 rather than counting down from a full
+    game.
+  start.distance: Yards the offense needs for a first down at the snap, carried through from ESPN without correction.
+  start.down: Down at the snap as ESPN reports it; 0 marks the small share of rows ESPN leaves without a down, overwhelmingly
+    timeouts and penalty administrations.
+  start.is_home: True when the team holding possession at the snap is the home team.
+  start.pos_team.name: School name of the team with possession at the snap, taken from ESPN's team location field so it carries
+    no mascot.
+  start.yardsToEndzone: Distance in yards from the offense's spot at the snap to the opponent's end zone, ranging 0 to 100.
+  statYardage: Yards gained on the play as ESPN reports it, negative on plays that lost yardage.
+  type.text: ESPN's play-type label, for example Rush, Pass Reception, Sack, Punt, Penalty, or Timeout.
+  wp_model_version: Version of the win-probability model that scored the play.
 load_cfb_player_box:
   adjQBR: Adjusted Total QBR for the quarterback.
   completions/passingAttempts: Completions and pass attempts, as ESPN's combined string.
@@ -4721,12 +4826,68 @@ load_cfb_player_box:
   rushingAttempts: Rushing attempts.
   rushingTouchdowns: Rushing touchdowns.
   rushingYards: Net rushing yards gained.
+  stat_1: First value of ESPN's raw athlete stats array, written only when the category's key list does not line up with the
+    stats list; on those rows the named per-category columns are all null.
+  stat_2: Second value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and
+    the named columns could not be filled.
+  stat_3: Third value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and
+    the named columns could not be filled.
+  stat_4: Fourth value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and
+    the named columns could not be filled.
+  stat_5: Fifth value of ESPN's raw athlete stats array, written only on rows where the category keys did not line up and
+    the named columns could not be filled.
   totalKickingPoints: Total points scored by kicking.
   touchbacks: Punts or kickoffs that resulted in a touchback.
   yardsPerPassAttempt: Yards gained per pass attempt.
   yardsPerPuntReturn: Yards gained per punt return.
   yardsPerReception: Yards gained per reception.
   yardsPerRushAttempt: Yards gained per rushing attempt.
+load_cfb_power_index:
+  $ref: ESPN Core v2 API URL for one team's FPI projection on this game; the published asset carries only these links, not
+    the resolved projection numbers.
+load_cfb_ratings:
+  adj_def_epa: Opponent-adjusted EPA per play allowed, netted the same way as the offensive rating, so lower is better because
+    it measures EPA surrendered.
+  adj_net: adj_off_epa minus adj_def_epa, the team's overall efficiency rating in EPA per play; special teams is deliberately
+    excluded.
+  adj_off_epa: 'Opponent-adjusted offensive EPA per play: the team''s raw per-game EPA on pass and rush plays net of each
+    opponent''s ridge-fitted defensive strength, averaged over its games.'
+  adj_st_epa: 'Special-teams composite in EPA units: per-play mean EPA on field goals, punts, and kick returns, each centered
+    on that unit''s league mean and summed across the three units.'
+  def_rank: Dense rank of adj_def_epa in ascending order, so rank 1 is the season's stingiest defense.
+  fei_def: Drive-level defensive rating from the same per-drive ridge fit, on the same scale as fei_off.
+  fei_net: fei_off minus fei_def, the team's overall drive-efficiency rating, with the ridge's dropped reference team pinned
+    at zero.
+  fei_off: Drive-level offensive rating from a ridge fit on per-drive EPA, the Fremeau-style drive-efficiency counterpart
+    to adj_off_epa.
+  net_rank: Dense rank of adj_net in descending order, so rank 1 is the season's strongest overall team.
+  net_z: adj_net restated as a z-score against the mean and standard deviation of adj_net across the rated teams that season.
+  off_pace: 'Tempo measure: scrimmage plays (pass plus rush) per game, centering near 65 and used as the pace input to the
+    totals model.'
+  off_rank: Dense rank of adj_off_epa in descending order, so rank 1 is the season's most efficient offense.
+load_cfb_ratings_weekly:
+  adj_def_epa: Opponent-adjusted EPA per play allowed as of the snapshot week, netted the same way as the offensive rating,
+    so lower is better.
+  adj_net: adj_off_epa minus adj_def_epa at the snapshot week, the team's overall efficiency rating in EPA per play with special
+    teams excluded.
+  adj_off_epa: 'Opponent-adjusted offensive EPA per play as of the snapshot week: raw per-game EPA on pass and rush plays
+    net of each opponent''s ridge-fitted defensive strength.'
+  adj_st_epa: Special-teams composite in EPA units as of the snapshot week, summing the league-centered per-play EPA of the
+    field goal, punt, and kick-return units.
+  def_rank: Dense rank of adj_def_epa in ascending order within the snapshot week, so rank 1 is the stingiest defense at that
+    point.
+  fei_def: Drive-level defensive rating at the snapshot week, from the same per-drive ridge fit and on the same scale as fei_off.
+  fei_net: fei_off minus fei_def at the snapshot week, the team's overall drive-efficiency rating.
+  fei_off: Drive-level offensive rating at the snapshot week, from a ridge fit on per-drive EPA.
+  net_rank: Dense rank of adj_net in descending order within the snapshot week, so rank 1 is the strongest overall team at
+    that point.
+  net_z: adj_net restated as a z-score against the mean and standard deviation of adj_net across the teams rated in that snapshot
+    week.
+  off_pace: Scrimmage plays per game through the snapshot week, the tempo input consumed by the totals model.
+  off_rank: Dense rank of adj_off_epa in descending order within the snapshot week, so rank 1 is the most efficient offense
+    at that point.
+  through_week: Regular-season week the snapshot runs through; the ratings were refit using only games kicking off on or before
+    that week's final kickoff date.
 load_cfb_receiving:
   EPAgame: EPA generated per game.
   EPAgame_rank: National rank of the team's EPA generated per game, where 1 is best.
@@ -4734,9 +4895,13 @@ load_cfb_receiving:
   EPAplay_rank: National rank of the team's EPA generated per play, where 1 is best.
   TEPA: Total EPA summed over every play.
   TEPA_rank: National rank of the team's total EPA summed over every play, where 1 is best.
+  catchpct: Catch rate on a 0-to-1 scale, receptions divided by targets for the season.
+  catchpct_rank: Season rank of catchpct with the best catch rate first, computed only for receivers clearing the leaderboard
+    minimum of 1.875 targets per team game and using averaged ranks for ties.
   comp: Completed passes.
   fbs_class: 'Power/Group classification for the season: P4 or G6 from 2024 on, P5 or G5 through 2023, derived from conference
     membership. Null for teams outside FBS.'
+  fumbles: Count of the receiver's targeted pass plays across the season whose play text mentions a fumble by either team.
   playsgame: Plays per game.
   receiver_player_name: Display name of the targeted receiver -- the FIRST participant in that role on the play.
   success: Success rate across the team plays.
@@ -4747,6 +4912,16 @@ load_cfb_receiving:
   yardsgame_rank: National rank of the team's yards per game, where 1 is best.
   yardsplay: Yards per play.
   yardsplay_rank: National rank of the team's yards per play, where 1 is best.
+load_cfb_recruiting_proj:
+  pred_margin: Ridge projection of the team's average per-game scoring margin, from the same preseason-known feature set as
+    pred_wins.
+  pred_net_epa: Reserved slot for a projected adjusted net EPA; it ships all-null because the adjusted-EPA training target
+    is not currently loadable.
+  pred_wins: Ridge projection of the team's season win total, fit strictly on prior seasons from talent composite, blue-chip
+    ratio, offensive and defensive returning production, and prior wins.
+load_cfb_rosters:
+  recruit_ids: List of recruiting-database profile ids matched to the player; real ids run in the six-figure range and a lone
+    0 entry means no recruiting profile was matched.
 load_cfb_rushing:
   EPAgame: EPA generated per game.
   EPAgame_rank: National rank of the team's EPA generated per game, where 1 is best.
@@ -4756,6 +4931,7 @@ load_cfb_rushing:
   TEPA_rank: National rank of the team's total EPA summed over every play, where 1 is best.
   fbs_class: 'Power/Group classification for the season: P4 or G6 from 2024 on, P5 or G5 through 2023, derived from conference
     membership. Null for teams outside FBS.'
+  fumbles: Count of the ball carrier's rush attempts across the season whose play text mentions a fumble by either team.
   playsgame: Plays per game.
   rusher_player_name: Display name of the ball carrier on a rush -- the FIRST participant in that role on the play.
   success: Success rate across the team plays.
@@ -4767,17 +4943,431 @@ load_cfb_rushing:
   yardsplay: Yards per play.
   yardsplay_rank: National rank of the team's yards per play, where 1 is best.
 load_cfb_schedule_crosswalk:
+  espn_date: Kickoff date as YYYY-MM-DD taken from ESPN's schedule, null on games that matched no ESPN row.
   espn_game_id: ESPN game id for the crosswalk row.
+  fox_date: Kickoff date as YYYY-MM-DD taken from the Fox Sports schedule, null on games that matched no Fox row.
   fox_game_id: Fox Sports game id for the same game.
+  matched_sources: Plus-joined provenance tag naming which of espn, fox, and yahoo actually supplied a row for this game.
+  matchup_key: 'Order-independent key for the game: the two normalized team names sorted alphabetically and joined with a
+    pipe.'
+  yahoo_date: Kickoff date as YYYY-MM-DD, parsed from Yahoo's RFC-2822 start_time string.
   yahoo_game_id: Yahoo Sports game id for the same game.
+  yahoo_global_game_id: Yahoo's cross-season global game key in ncaaf.g.<number> form, distinct from the date-encoded yahoo_game_id.
 load_cfb_team_box:
+  completionAttempts: Completions and pass attempts as a slash-separated string, for example 23/41.
+  firstDowns: Total first downs ESPN credits the team, carried verbatim from the box score as a string.
+  fourthDownEff: Fourth-down efficiency as a conversions-attempts string, for example 3-4.
+  fumblesLost: Number of fumbles the team lost to the opponent, carried as a string.
+  netPassingYards: Passing yards after yardage lost to sacks is deducted, the numerator behind yardsPerPass.
+  possessionTime: Time of possession as mm:ss; the two teams' values add up to 60 minutes in a regulation game.
   rushingAttempts: Rushing attempts.
   rushingYards: Net rushing yards gained.
+  thirdDownEff: Third-down efficiency as ESPN's conversions-attempts string, for example 5-15.
+  totalPenaltiesYards: Penalties and penalty yards as a hyphen-separated string, for example 7-64.
+  totalYards: Total offensive yards for the team, matching rushingYards plus netPassingYards in about 99.8 percent of games.
+  yardsPerPass: Net passing yards per pass attempt, netPassingYards divided by the attempt count in completionAttempts and
+    rounded to one decimal.
   yardsPerRushAttempt: Yards gained per rushing attempt.
+load_cfb_team_info:
+  logo_2: URL of the team's alternate dark-background 500-pixel logo on ESPN's CDN, null for programs with no dark variant.
+  twitter: The football program's Twitter/X handle including the leading at sign, populated for only a minority of listed
+    teams.
 load_cfb_teams_crosswalk:
+  espn_team: ESPN's full team display name, school plus mascot, null when the row was anchored on a non-ESPN provider.
   espn_team_id: ESPN team id for the crosswalk row.
+  fox_abbreviation: Fox Sports' short team code, which frequently differs from the ESPN abbreviation for the same school.
+  fox_team: Fox Sports' team name, which that feed ships in all capitals.
   fox_team_id: Fox Sports team id for the same team.
+  matched_sources: Plus-joined provenance tag naming which of espn, fox, and yahoo contributed a directory row for this team.
+  norm_key: 'Shared join key across providers: the team name lowercased, ASCII-folded, stripped of punctuation, whitespace-collapsed,
+    and alias-mapped.'
+  yahoo_abbreviation: Yahoo Sports' short team code for the school.
+  yahoo_team: Yahoo Sports' team display name, school plus mascot.
   yahoo_team_id: Yahoo Sports team id for the same team.
+load_mbb_game_rosters:
+  athlete_headshot: URL of the player's ESPN headshot image, whose filename is the athlete_id (verified equal for all 190,365
+    non-null rows in 2025); null when ESPN publishes no photo for that player.
+load_mbb_officials:
+  official_display_name: Display form of the official's name used by ESPN's game feed, which duplicates official_full_name
+    for all 18,284 rows of the 2025 release.
+  official_full_name: Full name of the game official as published in ESPN's gameInfo officials list; in this release it is
+    byte-identical to official_display_name on every row.
+  official_position: ESPN's role label for the crew member, which is the constant Referee for every men's college basketball
+    official in this release rather than a distinct crew chief or umpire designation.
+  official_position_id: ESPN's numeric code for the official's role, constant at 40 (Referee) across the entire men's college
+    basketball officials release.
+load_mbb_pbp:
+  lag_period: Period number of the previous play in the same game (period_number shifted forward one row within game_id),
+    and null on each game's first play.
+  lead_period: Period number of the next play in the same game (period_number shifted back one row within game_id), and null
+    on each game's final play.
+  start_period_seconds_remaining: Seconds left in the current period when the play started, computed as 60 times the game
+    clock minutes plus the seconds, so 1200 at the tip of each 20-minute half and 300 at the start of an overtime.
+load_mbb_player_season_stats:
+  stat_description: ESPN's prose glossary definition of the statistic named in stat_name, for example defining assists as
+    a pass to a teammate that leads directly to a field goal.
+load_mbb_player_value:
+  box_bpm: Total box plus/minus in points per 100 possessions above an average player, exactly box_obpm plus box_dbpm (verified
+    to zero residual across all 9,805 rows of 2025).
+load_mbb_ratings:
+  adj_em_z: Within-season z-score of adj_em, computed as adj_em minus the season mean divided by the season standard deviation,
+    so each season is centered at zero with unit spread.
+  adj_tempo: Opponent-adjusted possessions per 40 minutes, solved by the same fixed point as the efficiency ratings under
+    the additive model that a game's pace is the two teams' tempos less the league baseline; it averages about 71 in 2025.
+load_mbb_standings:
+  group_short_name: Abbreviated conference label ESPN prints in standings tables, such as ACC, Big Ten or Am. East, one value
+    per group_id.
+  stat_abbreviation: Short code ESPN prints for the standings statistic in a table header, such as W, L, PCT, GB or STRK;
+    it diverges from stat_short_display_name for playoff seed and the home and conference record rows.
+  stat_description: ESPN's longer-form label for the standings statistic, which can differ from stat_display_name (streak
+    is described as Current Streak and playoffSeed as Playoff Seed).
+load_mbb_team_season_stats:
+  stat_description: ESPN's prose glossary definition of the statistic named in stat_name, for example defining field goal
+    percentage as the ratio of field goals made to field goals attempted.
+load_mlb_batter_projection:
+  proj_pa: Combined prior-three-season pa behind the projection, its effective sample size; it inherits the pitch-row counting
+    of load_mlb_expected_stats pa rather than true plate appearances.
+load_mlb_catcher_framing:
+  catcher_id: MLBAM identifier of the receiving catcher, taken from Savant's fielder_2 and published as a string rather than
+    an integer.
+  framing_runs: Runs saved by receiving, summing actual called strike minus modeled strike probability times that count's
+    strike run value over shadow-zone takes only.
+  strikes_gained: The same shadow-zone sum of actual called strike minus modeled strike probability left unweighted by run
+    value, so it measures stolen strikes rather than runs.
+  takes: Called strikes plus balls the catcher received across the season, a pure workload count; the framing figures themselves
+    sum only over the shadow-zone subset of these.
+load_mlb_command_plus:
+  command_plus: Command+/Location+ on the 100-is-average scale, exactly 100 minus 10 times (location_rv_hat minus the league
+    mean) over the league SD; it grades where the pitch finished, not intent, since Statcast ships no catcher target.
+  location_rv_hat: Mean predicted per-pitch run value from the bundled location model, which sees plate location, count, handedness
+    and pitch type but no raw pitch physics; lower is better for the pitcher.
+load_mlb_expected_hr:
+  hr_above_expected: Home runs actually hit minus xhr_neutral, so it grades over- and under-performance against the park-neutral
+    expectation rather than the park-adjusted one.
+  xhr_neutral: Park-neutral expected home runs, summing over the batter's balls in play the home-run probability read off
+    the exit-velocity by launch-angle by spray-angle grid.
+  xhr_park_adj: The same expected-home-run sum after scaling each ball by its ballpark's Savant home-run park factor over
+    100; published values run between 0.77 and 1.26 times xhr_neutral.
+load_mlb_expected_stats:
+  pa: Statcast rows charged to the batter for the season, counting balls in play carrying launch data plus every other pitch,
+    so it is a pitch-row total rather than a true plate-appearance count.
+  xba: Sum of grid-predicted hit probability over the batter's balls in play divided by ab, which lands far below conventional
+    batting-average scale because ab counts pitch rows rather than at-bats.
+  xslg: Sum of grid-predicted total bases over the batter's balls in play divided by ab, which lands far below conventional
+    slugging scale because ab counts pitch rows rather than at-bats.
+  xwoba: Expected wOBA blending the exit-velocity by launch-angle grid's predicted contact value on balls in play with realized
+    wOBA value on walks, hit-by-pitches and strikeouts, over the wOBA denominator; low-sample batters can exceed 1.
+load_mlb_oaa:
+  fielder_id: MLBAM identifier of the fielder charged with the ball in play, resolved from whichever fielder_N column matches
+    the responsible position and published as a string rather than an integer.
+  oaa: 'Outs above average: outs the fielder actually recorded minus what a per-position catch-probability logistic expected
+    from the same batted-ball trajectories, summed across their opportunities.'
+  opportunities: Balls in play charged to this fielder at this position, the sample the oaa sum runs over.
+load_mlb_re24_matrix:
+  base_state: Three-character pre-play base occupancy where each slot carries its base number when occupied and an underscore
+    when empty, so ___ is bases empty and 123 is bases loaded.
+  n: Plate appearances observed starting in this base-out state, the sample size behind re.
+  re: Mean runs the batting team went on to score from this base-out state through the end of the half-inning, with bottom-of-the-9th-and-later
+    halves excluded to avoid walk-off selection bias.
+load_mlb_stuff_plus:
+  stuff_plus: Stuff+ on the 100-is-average scale, exactly 100 minus 10 times (stuff_rv_hat minus the league mean) over the
+    league SD, so higher is better and outlier run-value predictions can push it well below zero.
+  stuff_rv_hat: Mean predicted per-pitch run value from the bundled xgboost stuff model over this pitcher's pitches of this
+    type, on Savant's batter-perspective delta_run_exp scale so lower is better for the pitcher.
+load_mlb_we_table:
+  base_state: Three-character pre-play base occupancy where each slot carries its base number when occupied and an underscore
+    when empty, so ___ is bases empty and 123 is bases loaded.
+  inning_capped: Inning number with the ninth and every extra inning collapsed into 9, so extras share the ninth-inning win-expectancy
+    cells.
+  n: Plate appearances observed in this state bucket, the sample size behind the Laplace-smoothed home_win_exp.
+  outs_start: Outs already recorded when the plate appearance began, normally 0 through 2, though a handful of published rows
+    carry a stale 3 that the RE24 matrix filters out but this table does not.
+  score_diff_bucket: Home score minus away score before the play, clipped to the range -6 through +6 so blowouts collapse
+    into the end buckets.
+load_mlb_xera:
+  x_era: ERA-scale conversion of x_woba as league_era plus (x_woba minus league_woba) over woba_scale times pa_per_9, an exact
+    linear function of x_woba that can go negative for extreme pitchers.
+load_nba_draft:
+  college_abbreviation: Abbreviation of the drafted player's college taken from the pick's nested college block; the ESPN
+    NBA draft feed omits that block entirely, so this and the other college columns are null throughout.
+  pick_notes: Free-text note ESPN can attach to a pick, read from the pick's notes or note field; the NBA draft payload never
+    populates it, so it is null across all released seasons.
+  pick_traded: ESPN's traded flag for the pick, carried through as a string rather than a boolean; every released NBA row
+    reads FALSE, so it does not currently identify traded picks.
+  round_display_name: ESPN's display label for the draft round a pick belongs to, read from the round object's displayName;
+    the NBA payload supplies no round metadata, so this is null for every released season 2003 through 2025.
+load_nba_officials:
+  official_display_name: ESPN's display-form name for the official, falling back to the full name when ESPN omits it; it never
+    diverges from official_full_name in the released NBA data.
+  official_full_name: Full name of an on-court game official as ESPN publishes it in the summary gameInfo.officials array;
+    it is identical to official_display_name in every released NBA row.
+  official_order: The official's listing index within the game's crew as ESPN orders them, normally 1 through 3 for a three-person
+    crew; a fourth entry appears in a small share of recent-season games and the sequence is not guaranteed to be gap-free.
+  official_position: ESPN's label for the official's assignment slot; the NBA summary feed only ever ships Referee, so this
+    reads the same on every released row.
+  official_position_id: ESPN's numeric identifier for the official's assignment slot, constant at 40 (Referee) across every
+    released NBA season.
+load_nba_player_impact:
+  adj_rapm: Total prior-informed RAPM per 100 possessions, exactly the sum of o_adj_rapm and d_adj_rapm.
+  d_rapm: Defensive regularized adjusted plus-minus per 100 possessions, negated from the raw points-allowed coefficient so
+    a positive value marks a defender who suppresses opponent scoring.
+  darko_filtered_skill: DARKO-style Kalman-filtered skill estimate at the end of the player's observed multi-season RAPM panel,
+    i.e. his current-form rating after aging drift and possession-weighted observation noise.
+  darko_projected_rating: One-season-ahead DARKO forecast, the filtered skill plus the empirical aging-curve drift at the
+    player's last observed age; both season_type rows of a player-season carry the same value because the projection is not
+    playoff-specific.
+  darko_projected_sd: Standard deviation of the one-season-ahead DARKO forecast, the square root of the filtered state variance
+    plus the Kalman process variance; it sits at roughly 10.19 for a player with only one season in the panel, whose diffuse
+    prior variance was never updated.
+  def_poss: Number of possessions the player was on the floor on defense, the sample size behind d_rapm; it tracks off_poss
+    almost exactly because substitutions rarely split an offense-defense pair.
+  dspm: Defensive statistical plus-minus per 100 possessions from the same box-score feature vector scored through coefficients
+    trained on the d_rapm target.
+  o_rapm: Offensive regularized adjusted plus-minus per 100 possessions from the single-season ridge fit over possession-level
+    lineup indicators; positive means the player raised his team's scoring rate while on offense.
+  off_poss: Number of possessions the player was on the floor on offense, the count of design-matrix rows carrying his offensive
+    indicator and therefore the offensive-side sample size behind o_rapm.
+  ospm: 'Offensive statistical plus-minus per 100 possessions: the player''s per-100 box-score feature vector scored through
+    ridge coefficients trained on that season''s o_rapm target.'
+  rapm: Total regularized adjusted plus-minus per 100 possessions, exactly the sum of o_rapm and d_rapm.
+  spm: Total statistical plus-minus per 100 possessions, exactly the sum of ospm and dspm.
+  war: Wins above replacement, computed as (rapm minus a replacement level of -2.0 per 100) times total possessions divided
+    by 100, divided by a points-per-win constant calibrated each season by regressing team wins on full-season point margin.
+load_nba_player_season_stats:
+  stat_description: ESPN's prose definition of the statistic on this row, for example the ratio of field goals made to field
+    goals attempted; for the paired Made-Attempted stats it is the two definitions joined with a hyphen.
+load_nba_standings:
+  group_short_name: ESPN's short name for the standings grouping the team sits in, read from the group node's shortName; the
+    NBA standings payload supplies only the group name and abbreviation, so this is null throughout.
+  stat_abbreviation: ESPN's short code for the standings statistic, such as PCT, GB or OPP PPG; it is null for the four record-style
+    splits (Home, Road, vs. Conf., vs. Div.), which ship no abbreviation.
+  stat_description: ESPN's prose gloss for the standings statistic on this row; for the clincher stat it is not a fixed label
+    but the team's actual status text, such as Clinched Playoff Berth or Eliminated From Playoff.
+load_nba_stats_schedules:
+  game_label: The stats.nba.com event label naming the round or special event a game belongs to, such as NBA Finals, East
+    First Round, Emirates NBA Cup or NBA Mexico City Game; an empty string for an ordinary regular-season game.
+load_nba_team_season_stats:
+  stat_description: ESPN's prose definition of the team statistic on this row, for example the average number of assists a
+    team records per turnover.
+load_nhl_penalties:
+  committedByPlayer.lastName.cs: Alternate rendering of the family name published under the NHL feed's Czech key. It differs
+    from the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips
+    them instead -- so treat it as an alternate spelling, not a canonical one.
+  committedByPlayer.lastName.fi: Alternate rendering of the family name published under the NHL feed's Finnish key. It differs
+    from the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips
+    them instead -- so treat it as an alternate spelling, not a canonical one.
+  committedByPlayer.lastName.sk: Alternate rendering of the family name published under the NHL feed's Slovak key. It differs
+    from the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips
+    them instead -- so treat it as an alternate spelling, not a canonical one.
+  committedByPlayer.lastName.sv: Alternate rendering of the family name published under the NHL feed's Swedish key. It differs
+    from the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips
+    them instead -- so treat it as an alternate spelling, not a canonical one.
+  drawnBy.firstName.default: Given name, in the feed's default English locale, of the opposing player credited with drawing
+    the penalty.
+  drawnBy.lastName.cs: Alternate rendering of the family name published under the NHL feed's Czech key. It differs from the
+    default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them
+    instead -- so treat it as an alternate spelling, not a canonical one.
+  drawnBy.lastName.default: Family name, in the feed's default English locale, of the opposing player credited with drawing
+    the penalty.
+  drawnBy.lastName.fi: Alternate rendering of the family name published under the NHL feed's Finnish key. It differs from
+    the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips
+    them instead -- so treat it as an alternate spelling, not a canonical one.
+  drawnBy.lastName.sk: Alternate rendering of the family name published under the NHL feed's Slovak key. It differs from the
+    default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them
+    instead -- so treat it as an alternate spelling, not a canonical one.
+  drawnBy.lastName.sv: Alternate rendering of the family name published under the NHL feed's Swedish key. It differs from
+    the default in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips
+    them instead -- so treat it as an alternate spelling, not a canonical one.
+  drawnBy.sweaterNumber: Jersey number of the opposing player credited with drawing the infraction; null whenever no victim
+    is credited, as on all bench and game-misconduct penalties.
+  servedBy.cs: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Czech key, differing
+    from the default by diacritics or by an alternate given-name form.
+  servedBy.de: Alternate abbreviated name (first initial plus family name) published under the NHL feed's German key, differing
+    from the default by diacritics or by an alternate given-name form.
+  servedBy.es: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Spanish key, differing
+    from the default by diacritics or by an alternate given-name form.
+  servedBy.fi: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Finnish key, differing
+    from the default by diacritics or by an alternate given-name form.
+  servedBy.sk: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Slovak key, differing
+    from the default by diacritics or by an alternate given-name form.
+  servedBy.sv: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Swedish key, differing
+    from the default by diacritics or by an alternate given-name form.
+  teamAbbrev.default: Three-letter code of the team charged with the penalty, matching the committing player's boxscore team
+    rather than the team that drew it.
+load_nhl_scoring:
+  discreteClipFr: Numeric NHL video identifier of the French-language standalone clip of the goal, always a different asset
+    id from discreteClip.
+  firstName.default: Given name of the goal scorer as rendered in the NHL feed's default English locale.
+  lastName.cs: Alternate rendering of the family name published under the NHL feed's Czech key. It differs from the default
+    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
+    -- so treat it as an alternate spelling, not a canonical one.
+  lastName.default: Family name of the goal scorer as rendered in the NHL feed's default English locale.
+  lastName.fi: Alternate rendering of the family name published under the NHL feed's Finnish key. It differs from the default
+    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
+    -- so treat it as an alternate spelling, not a canonical one.
+  lastName.fr: Alternate rendering of the family name published under the NHL feed's French key. It differs from the default
+    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
+    -- so treat it as an alternate spelling, not a canonical one.
+  lastName.sk: Alternate rendering of the family name published under the NHL feed's Slovak key. It differs from the default
+    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
+    -- so treat it as an alternate spelling, not a canonical one.
+  lastName.sv: Alternate rendering of the family name published under the NHL feed's Swedish key. It differs from the default
+    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
+    -- so treat it as an alternate spelling, not a canonical one.
+  leadingTeamAbbrev.default: Three-letter code of the team ahead on the scoreboard immediately after this goal, null exactly
+    when the goal tied the game and not always the scoring team.
+  name.cs: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Czech key, differing
+    from the default by diacritics or by an alternate given-name form.
+  name.de: Alternate abbreviated name (first initial plus family name) published under the NHL feed's German key, differing
+    from the default by diacritics or by an alternate given-name form.
+  name.es: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Spanish key, differing
+    from the default by diacritics or by an alternate given-name form.
+  name.fi: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Finnish key, differing
+    from the default by diacritics or by an alternate given-name form.
+  name.sk: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Slovak key, differing
+    from the default by diacritics or by an alternate given-name form.
+  name.sv: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Swedish key, differing
+    from the default by diacritics or by an alternate given-name form.
+  teamAbbrev.default: Three-letter code of the team that scored the goal, resolving to the home club exactly when isHome is
+    true and to the visitor otherwise.
+load_nhl_shootout:
+  discreteClipFr: Numeric NHL video identifier of the French-language clip of the shootout attempt, distinct from the id in
+    discreteClip.
+  firstName.cs: Alternate given name published under the NHL feed's Czech key. Verified against the data it is frequently
+    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
+    transliteration of the default.
+  firstName.de: Alternate given name published under the NHL feed's German key. Verified against the data it is frequently
+    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
+    transliteration of the default.
+  firstName.default: Given name of the shooter in the feed's default English locale; null on the per-game summary row.
+  firstName.es: Alternate given name published under the NHL feed's Spanish key. Verified against the data it is frequently
+    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
+    transliteration of the default.
+  firstName.fi: Alternate given name published under the NHL feed's Finnish key. Verified against the data it is frequently
+    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
+    transliteration of the default.
+  firstName.sk: Alternate given name published under the NHL feed's Slovak key. Verified against the data it is frequently
+    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
+    transliteration of the default.
+  firstName.sv: Alternate given name published under the NHL feed's Swedish key. Verified against the data it is frequently
+    a different name form rather than a re-spelling (Joshua published as Josh, Aliaksei as Alexei), so it is not a reliable
+    transliteration of the default.
+  gameWinner: True on the single attempt per shootout credited as the game-deciding goal, false on every other attempt and
+    null on the per-game summary row.
+  lastName.cs: Alternate rendering of the family name published under the NHL feed's Czech key. It differs from the default
+    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
+    -- so treat it as an alternate spelling, not a canonical one.
+  lastName.default: Family name of the shooter in the feed's default English locale; null on the per-game summary row.
+  lastName.fi: Alternate rendering of the family name published under the NHL feed's Finnish key. It differs from the default
+    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
+    -- so treat it as an alternate spelling, not a canonical one.
+  lastName.sk: Alternate rendering of the family name published under the NHL feed's Slovak key. It differs from the default
+    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
+    -- so treat it as an alternate spelling, not a canonical one.
+  lastName.sv: Alternate rendering of the family name published under the NHL feed's Swedish key. It differs from the default
+    in orthography -- usually restoring diacritics the default folds to ASCII, though for some names it strips them instead
+    -- so treat it as an alternate spelling, not a canonical one.
+  teamAbbrev.default: Three-letter code of the shooting player's team; null on the per-game summary row that instead carries
+    the home and away shootout goal totals.
+load_nhl_shots_by_period:
+  max_regulation_periods: Number of regulation periods the game format defines before overtime, constant at 3 for every row
+    in the published seasons.
+  ot_periods: Overtime period ordinal taken from the NHL period descriptor, populated only from the second overtime onward
+    so period 5 rows carry 2 and all other rows are null.
+load_nhl_three_stars:
+  name.cs: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Czech key, differing
+    from the default by diacritics or by an alternate given-name form.
+  name.de: Alternate abbreviated name (first initial plus family name) published under the NHL feed's German key, differing
+    from the default by diacritics or by an alternate given-name form.
+  name.es: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Spanish key, differing
+    from the default by diacritics or by an alternate given-name form.
+  name.fi: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Finnish key, differing
+    from the default by diacritics or by an alternate given-name form.
+  name.sk: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Slovak key, differing
+    from the default by diacritics or by an alternate given-name form.
+  name.sv: Alternate abbreviated name (first initial plus family name) published under the NHL feed's Swedish key, differing
+    from the default by diacritics or by an alternate given-name form.
+load_wbb_game_rosters:
+  athlete_headshot: URL of the player's ESPN headshot image on a.espncdn.com, whose filename is the athlete_id; null when
+    ESPN publishes no headshot for that player.
+load_wbb_officials:
+  official_display_name: ESPN's displayName for the official, which is identical to official_full_name in every published
+    row of the released data.
+  official_first_name: The official's given name as ESPN splits it out separately from the full name, excluding any middle
+    initial that appears in official_full_name.
+  official_full_name: ESPN's fullName for the official, falling back to displayName when fullName is absent; ESPN sometimes
+    ships it with a middle initial or a doubled internal space, so it is not simply first plus last name.
+  official_last_name: The official's surname as ESPN splits it out; joined to official_first_name it reconstructs roughly
+    98 percent of official_full_name values, the rest differing by middle initials or spacing.
+  official_order: ESPN's 1-based sequence of the official within that game's crew listing, unique within a game and running
+    1 to 3 for the standard three-person crew.
+  official_uid: ESPN's globally unique resource identifier for the official, read from the core-api items[] uid key; that
+    payload never ships it, so the column is null for every published row.
+load_wbb_player_season_stats:
+  stat_description: ESPN's prose definition of the statistic named in stat_name, for example The average assists per game
+    for avgAssists; combined made-attempted stats carry both definitions joined by a hyphen.
+load_wbb_player_value:
+  box_bpm: Total box plus/minus in points per 100 possessions above average, exactly box_obpm plus box_dbpm in every published
+    row.
+load_wbb_ratings:
+  adj_em_z: Within-season z-score of adj_em, computed as adj_em minus the season mean divided by the season standard deviation
+    over every team in the frame, so it is mean 0 and standard deviation 1 per season.
+  adj_tempo: Opponent-adjusted tempo in possessions per 40 minutes, produced by the same fixed-point adjustment as the efficiencies
+    applied to game possessions under the additive model poss = tempo_i + tempo_j minus the league baseline.
+load_wbb_standings:
+  stat_abbreviation: ESPN's abbreviation for the standings stat, such as GB, OPP PPG or VS CONF; always populated and matching
+    stat_short_display_name for about 90 percent of rows.
+  stat_description: ESPN's longer wording for the standings stat, for example Overall Record for the Team Season Record entry
+    and Current Streak for Streak; null for stats ESPN ships without one, such as vs AP Top 25.
+load_wbb_team_season_stats:
+  stat_description: ESPN's prose definition of the team statistic named in stat_name, for example The average blocks per game
+    for avgBlocks or the full sentence defining a blocked shot for blocks.
+load_wnba_draft:
+  college_abbreviation: Short code for the drafted player's school, read from the athlete's ESPN college block; null throughout
+    the published data because ESPN ships no college block on these picks.
+  pick_notes: Free-text annotation ESPN attaches to a pick, taken from notes and falling back to note; empty for every pick
+    published so far.
+  pick_traded: ESPN's pick-level traded flag stringified as TRUE or FALSE, marking selections made with a pick that had changed
+    hands (17 of the 45 published 2026 picks are TRUE).
+  round_display_name: Human-readable label for the draft round, read from the ESPN round object's displayName falling back
+    to its name; null whenever ESPN ships the modern flat picks array with no round objects, which is the case for every published
+    season.
+load_wnba_game_rosters:
+  athlete_headshot: Direct link to the player's ESPN headshot image, always of the form https://a.espncdn.com/i/headshots/wnba/players/full/{athlete_id}.png,
+    and null for the few players ESPN has no photo for.
+load_wnba_officials:
+  official_display_name: ESPN's display rendering of the official's name, which is byte-identical to official_full_name on
+    every published row and therefore adds nothing.
+  official_first_name: Given name of the official as ESPN splits it out, the leading token of official_full_name.
+  official_full_name: The official's full name, taken from ESPN fullName and falling back to displayName; it equals first
+    plus last name on every published row.
+  official_last_name: Family name of the official as ESPN splits it out, the trailing token of official_full_name, with hyphenated
+    surnames kept intact.
+  official_order: ESPN's 1-based position of the official within that game's crew; most games run 1 through 3 for a three-person
+    crew and 40 of 573 games in 2024-2025 add a fourth.
+  official_uid: ESPN's global uid string for the official, carried straight through from the officials payload; the Core v2
+    items ESPN serves omit it, so it is null in every published season.
+load_wnba_player_season_stats:
+  stat_description: ESPN's prose definition of the statistic on this row, for example The average number of points scored
+    per game for avgPoints; combined made-attempted stats carry both halves joined by a hyphen.
+load_wnba_standings:
+  group_short_name: Short label of the standings group node the team sits under, read from ESPN shortName; the WNBA conference
+    nodes ship only name and abbreviation, so it is null on every published row.
+  stat_abbreviation: ESPN's abbreviation for the standings stat, which can differ from stat_short_display_name (playoffSeed
+    is SEED here but POS there) and is null on the record-split rows such as Home and vs. Conf.
+  stat_description: ESPN's long-form explanation of the standings stat, such as Clinched Best League Record for clincher or
+    Record last 10 games for lasttengames.
+load_wnba_stats_coaches:
+  coach_name: Full name of the staff member as the feed renders it, exactly first_name plus a space plus last_name on every
+    published row.
+  coach_type: Job title of the staff member, one of Head Coach, Associate Head Coach, Assistant Coach or Trainer in the published
+    data.
+  is_assistant: 'Numeric staff-role code rather than a boolean flag: 1 head coach, 2 assistant coach, 3 trainer, 9 associate
+    head coach, mapping one-to-one onto coach_type.'
+  sort_sequence: Ordering field passed through unchanged from the stats.wnba.com coaches result set; it arrives empty, so
+    every published row is null.
+  sub_sort_sequence: 'Secondary display-ordering rank that tracks coach_type exactly: 1 head coach, 2 associate head coach,
+    5 assistant coach, 7 trainer.'
 load_contracts:
   cols: Placeholder column retained in the contracts loader output schema; contains no meaningful data in this context.
 load_depth_charts:

--- a/tools/codegen/manual_column_descriptions.yaml
+++ b/tools/codegen/manual_column_descriptions.yaml
@@ -4048,6 +4048,379 @@ load_cfb_adv_situational:
   pos_team: Display name of the team on offense (e.g. 'Ohio State Buckeyes').
   pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
   standard_downs: Number of plays the team ran on standard downs (the team ahead of schedule for the series).
+load_cfb_pbp:
+  A_score_diff: Away team's score minus the home team's, from the away perspective.
+  EPA_explosive: True when the play was explosive.
+  EPA_explosive_pass: True when the pass play was explosive.
+  EPA_explosive_rush: True when the rush play was explosive.
+  EPA_fg: EPA credited to the play on field-goal attempts.
+  EPA_kickoff: EPA credited to the play on kickoff plays.
+  EPA_middle_8_success: True when the play in the middle eight was successful by EPA.
+  EPA_middle_8_success_pass: True when the pass play in the middle eight was successful by EPA.
+  EPA_middle_8_success_rush: True when the rush play in the middle eight was successful by EPA.
+  EPA_non_explosive: EPA credited to the play on non-explosive plays.
+  EPA_pass: EPA credited to the play on pass plays.
+  EPA_penalty: EPA credited to the play attributable to penalties.
+  EPA_punt: EPA credited to the play on punt plays.
+  EPA_rush: EPA credited to the play on rush plays.
+  EPA_scrimmage: EPA credited to the play on plays from scrimmage.
+  EPA_sp: EPA credited to the play on special-teams plays.
+  EPA_success: True when the play was successful by EPA.
+  EPA_success_EPA: EPA on successful plays.
+  EPA_success_early_down: True when the play on an early down was successful by EPA.
+  EPA_success_early_down_pass: True when the pass play on an early down was successful by EPA.
+  EPA_success_early_down_rush: True when the rush play on an early down was successful by EPA.
+  EPA_success_late_down: True when the play on a late down was successful by EPA.
+  EPA_success_late_down_pass: True when the pass play on a late down was successful by EPA.
+  EPA_success_late_down_rush: True when the rush play on a late down was successful by EPA.
+  EPA_success_pass: True when the pass play was successful by EPA.
+  EPA_success_pass_EPA: EPA on successful pass plays.
+  EPA_success_passing_down: True when the play on a passing down was successful by EPA.
+  EPA_success_passing_down_EPA: EPA on successful plays on a passing down.
+  EPA_success_rush: True when the rush play was successful by EPA.
+  EPA_success_rush_EPA: EPA on successful rush plays.
+  EPA_success_standard_down: True when the play on a standard down was successful by EPA.
+  EPA_success_standard_down_EPA: EPA on successful plays on a standard down.
+  EP_between: Change in expected points across the play, before penalty adjustment.
+  EP_end: Expected points for the offense at the end of the play.
+  EP_start: Expected points for the offense at the start of the play.
+  EP_start_touchback: Expected points the offense would have had from a touchback on this play.
+  HA_score_diff: Home score minus away score for the play.
+  H_score_diff: Home team's score minus the away team's, from the home perspective.
+  TFL: True when the play was a tackle for loss.
+  TFL_pass: True when the play was a tackle for loss on a pass play (a sack).
+  TFL_rush: True when the play was a tackle for loss on a rush play.
+  action_play: True when the play advanced the game state -- excludes timeouts, end-of-period markers and other non-action
+    rows.
+  adj_rush_yardage: Rushing yards capped at 8, the input to the line-yards decomposition.
+  awayTeamAbbrev: ESPN's away-team Abbrev for the game, stamped on every play.
+  awayTeamId: ESPN's away-team Id for the game, stamped on every play.
+  awayTeamMascot: ESPN's away-team Mascot for the game, stamped on every play.
+  awayTeamName: ESPN's away-team Name for the game, stamped on every play.
+  awayTeamNameAlt: ESPN's away-team NameAlt for the game, stamped on every play.
+  awayTimeoutCalled: True when the away team called a timeout on the play.
+  clock.displayValue: Game clock at the play, as the displayed mm:ss string.
+  clock.minutes: Minutes remaining on the game clock at the play.
+  clock.seconds: Seconds component of the game clock at the play.
+  down_1: True when it is 1st down at the start of the play.
+  down_1_end: True when it is 1st down at the end of the play.
+  down_2: True when it is 2nd down at the start of the play.
+  down_2_end: True when it is 2nd down at the end of the play.
+  down_3: True when it is 3rd down at the start of the play.
+  down_3_end: True when it is 3rd down at the end of the play.
+  down_4: True when it is 4th down at the start of the play.
+  down_4_end: True when it is 4th down at the end of the play.
+  drive.description: ESPN's `description` field for the drive containing this play.
+  drive.displayResult: ESPN's `displayResult` field for the drive containing this play.
+  drive.end.clock.displayValue: ESPN's `end.clock.displayValue` field for the drive containing this play.
+  drive.end.period.number: ESPN's `end.period.number` field for the drive containing this play.
+  drive.end.period.type: ESPN's `end.period.type` field for the drive containing this play.
+  drive.end.yardLine: ESPN's `end.yardLine` field for the drive containing this play.
+  drive.id: ESPN's `id` field for the drive containing this play.
+  drive.isScore: ESPN's `isScore` field for the drive containing this play.
+  drive.offensivePlays: ESPN's `offensivePlays` field for the drive containing this play.
+  drive.result: ESPN's `result` field for the drive containing this play.
+  drive.shortDisplayResult: ESPN's `shortDisplayResult` field for the drive containing this play.
+  drive.start.clock.displayValue: ESPN's `start.clock.displayValue` field for the drive containing this play.
+  drive.start.period.number: ESPN's `start.period.number` field for the drive containing this play.
+  drive.start.period.type: ESPN's `start.period.type` field for the drive containing this play.
+  drive.start.text: ESPN's `start.text` field for the drive containing this play.
+  drive.start.yardLine: ESPN's `start.yardLine` field for the drive containing this play.
+  drive.team.abbreviation: ESPN's `team.abbreviation` field for the drive containing this play.
+  drive.team.displayName: ESPN's `team.displayName` field for the drive containing this play.
+  drive.team.name: ESPN's `team.name` field for the drive containing this play.
+  drive.team.shortDisplayName: ESPN's `team.shortDisplayName` field for the drive containing this play.
+  drive.timeElapsed.displayValue: ESPN's `timeElapsed.displayValue` field for the drive containing this play.
+  drive.yards: ESPN's `yards` field for the drive containing this play.
+  drive_offense_plays: Offensive plays run on the drive.
+  drive_offense_yards: Offensive yards gained on the drive.
+  drive_play_index: Sequence number of the play within its drive.
+  drive_start: Yard line at which the drive began.
+  drive_stopped: True when the play ended the drive.
+  drive_total_yards: Total yards gained on the drive.
+  early_down: True when the play is a scrimmage play on first or second down.
+  early_down_pass: True when the play is a pass on an early down.
+  early_down_rush: True when the play is a rush on an early down.
+  end.ExpScoreDiff: ESPN's `ExpScoreDiff` value for the play state at the end of the play.
+  end.ExpScoreDiff_Time_Ratio: ESPN's `ExpScoreDiff_Time_Ratio` value for the play state at the end of the play.
+  end.TimeSecsRem: ESPN's `TimeSecsRem` value for the play state at the end of the play.
+  end.adj_TimeSecsRem: ESPN's `adj_TimeSecsRem` value for the play state at the end of the play.
+  end.awayScore: ESPN's `awayScore` value for the play state at the end of the play.
+  end.awayTeamTimeouts: ESPN's `awayTeamTimeouts` value for the play state at the end of the play.
+  end.defPosTeamTimeouts: ESPN's `defPosTeamTimeouts` value for the play state at the end of the play.
+  end.def_pos_team.id: ESPN's `def_pos_team.id` value for the play state at the end of the play.
+  end.def_pos_team.name: ESPN's `def_pos_team.name` value for the play state at the end of the play.
+  end.def_pos_team_score: ESPN's `def_pos_team_score` value for the play state at the end of the play.
+  end.def_team.id: ESPN's `def_team.id` value for the play state at the end of the play.
+  end.distance: ESPN's `distance` value for the play state at the end of the play.
+  end.down: ESPN's `down` value for the play state at the end of the play.
+  end.downDistanceText: ESPN's `downDistanceText` value for the play state at the end of the play.
+  end.elapsed_share: ESPN's `elapsed_share` value for the play state at the end of the play.
+  end.homeScore: ESPN's `homeScore` value for the play state at the end of the play.
+  end.homeTeamTimeouts: ESPN's `homeTeamTimeouts` value for the play state at the end of the play.
+  end.is_home: ESPN's `is_home` value for the play state at the end of the play.
+  end.posTeamTimeouts: ESPN's `posTeamTimeouts` value for the play state at the end of the play.
+  end.pos_score_diff: ESPN's `pos_score_diff` value for the play state at the end of the play.
+  end.pos_team.id: ESPN's `pos_team.id` value for the play state at the end of the play.
+  end.pos_team.name: ESPN's `pos_team.name` value for the play state at the end of the play.
+  end.pos_team_receives_2H_kickoff: ESPN's `pos_team_receives_2H_kickoff` value for the play state at the end of the play.
+  end.pos_team_score: ESPN's `pos_team_score` value for the play state at the end of the play.
+  end.pos_team_spread: ESPN's `pos_team_spread` value for the play state at the end of the play.
+  end.possessionText: ESPN's `possessionText` value for the play state at the end of the play.
+  end.shortDownDistanceText: ESPN's `shortDownDistanceText` value for the play state at the end of the play.
+  end.spread_time: ESPN's `spread_time` value for the play state at the end of the play.
+  end.team.id: ESPN's `team.id` value for the play state at the end of the play.
+  end.yard: ESPN's `yard` value for the play state at the end of the play.
+  end.yardLine: ESPN's `yardLine` value for the play state at the end of the play.
+  end.yardsToEndzone: ESPN's `yardsToEndzone` value for the play state at the end of the play.
+  fg_attempt: True when the play was a field-goal attempt.
+  firstHalfKickoffTeamId: ESPN id of the team that received the opening kickoff.
+  first_down_created: True when the play produced a first down for the offense.
+  forced_fumble: True when the defense forced a fumble on the play.
+  fumble_recovered: True when a fumble on the play was recovered.
+  gameSpread: Point spread used as an input to the win-probability model.
+  gameSpreadAvailable: True when a spread was available for the game.
+  havoc: 'True when the defense disrupted the play: a pass breakup, tackle for loss, interception or forced fumble.'
+  highlight_run: True when the rush gained 8 or more yards.
+  highlight_yards: Second-level plus open-field yards -- the yardage credited to the carrier.
+  homeFavorite: True when the home team was favoured by the spread.
+  homeTeamAbbrev: ESPN's home-team Abbrev for the game, stamped on every play.
+  homeTeamId: ESPN's home-team Id for the game, stamped on every play.
+  homeTeamMascot: ESPN's home-team Mascot for the game, stamped on every play.
+  homeTeamName: ESPN's home-team Name for the game, stamped on every play.
+  homeTeamNameAlt: ESPN's home-team NameAlt for the game, stamped on every play.
+  homeTeamSpread: ESPN's home-team Spread for the game, stamped on every play.
+  homeTimeoutCalled: True when the home team called a timeout on the play.
+  kickoff_return_player_name: Name of the player returning the kickoff.
+  lag_EP_end: Value of EP_end on the previous play, used for sequence-aware derivations.
+  lag_HA_score_diff: Value of HA_score_diff on the previous play, used for sequence-aware derivations.
+  lag_awayScore: Value of awayScore on the previous play, used for sequence-aware derivations.
+  lag_change_of_pos_team: Value of change_of_pos_team on the previous play, used for sequence-aware derivations.
+  lag_half: Value of half on the previous play, used for sequence-aware derivations.
+  lag_homeScore: Value of homeScore on the previous play, used for sequence-aware derivations.
+  lag_pos_score_diff: Value of pos_score_diff on the previous play, used for sequence-aware derivations.
+  lag_pos_team: Value of pos_team on the previous play, used for sequence-aware derivations.
+  lag_scoringPlay: Value of scoringPlay on the previous play, used for sequence-aware derivations.
+  late_down: True when the play is a scrimmage play on third or fourth down.
+  late_down_pass: True when the play is a pass on a late down.
+  late_down_rush: True when the play is a rush on a late down.
+  lead_half: Value of half on the next play, used for sequence-aware derivations.
+  lead_play_type: Value of play_type on the next play, used for sequence-aware derivations.
+  lead_pos_team: Value of pos_team on the next play, used for sequence-aware derivations.
+  lead_pos_team2: Value of pos_team on the next 2 plays play, used for sequence-aware derivations.
+  lead_scoringPlay: Value of scoringPlay on the next play, used for sequence-aware derivations.
+  lead_start_distance: Value of start_distance on the next play, used for sequence-aware derivations.
+  lead_start_down: Value of start_down on the next play, used for sequence-aware derivations.
+  lead_start_team: Value of start_team on the next play, used for sequence-aware derivations.
+  lead_start_yardsToEndzone: Value of start_yardsToEndzone on the next play, used for sequence-aware derivations.
+  lead_text: Value of text on the next play, used for sequence-aware derivations.
+  lead_wp_before: Value of wp_before on the next play, used for sequence-aware derivations.
+  lead_wp_before2: Value of wp_before on the next 2 plays play, used for sequence-aware derivations.
+  line_yards: 'Yards credited to the offensive line on a rush, using the standard sliding scale: 1.2x the capped yardage on
+    a loss, all of it through 3 yards, half of each yard from 4 to 8, and a 5.5-yard ceiling beyond that.'
+  net_HA_score_pts: Net points the play added to the home-minus-away score margin.
+  new_distance: Distance to go after the play, including any penalty enforcement.
+  new_down: Down after the play, including any penalty enforcement.
+  non_fumble_sack: True when the play was a sack that did not produce a fumble.
+  open_field_yards: Rushing yards gained beyond 8, credited to the ball carrier rather than the line.
+  opp_highlight_yards: 'Highlight yards on opportunity runs. DEGENERATE: this column is 0 in every published row, because
+    its gate requires a rush of 4 yards or fewer while highlight yards only accrue at 4 or more. Do not use it as a signal.'
+  opportunity_run: True when the play is a rush gaining 4 yards or fewer. Note this is the inverse of the conventional 'opportunity'
+    definition (a carry gaining 4 or more).
+  overUnder: Over/under total used as a model input.
+  pass_breakup: True when a defender broke up the pass.
+  pass_epa: EPA credited to the play when it is a pass.
+  pass_weight: Weighting applied to the pass component of the play.
+  passing_down: True when the offense is behind schedule for the series -- second down needing 8 or more, or third/fourth
+    down needing 5 or more.
+  pen_epa: EPA attributable to a penalty on the play.
+  pen_weight: Weighting applied to the penalty component of the play.
+  penalty_in_text: True when the play description mentions a penalty.
+  period.number: Period (quarter) number in which the play occurred.
+  playType: ESPN's play-type label for the play.
+  pos_score_diff_end: Score differential from the possessing team's perspective at the end of the play.
+  power_rush_attempt: True when the play is a short-yardage power rushing attempt.
+  power_rush_success: True when a power rushing attempt gained the yardage needed.
+  prog_drive_EPA: Cumulative EPA accrued by the drive up to and including this play.
+  prog_drive_WPA: Cumulative win-probability added by the drive up to and including this play.
+  punt_return_player_name: Name of the player returning the punt.
+  qbr_epa: EPA variant used as an input to the QBR calculation.
+  rush_epa: EPA credited to the play when it is a rush.
+  rush_weight: Weighting applied to the rush component of the play.
+  sack_epa: EPA credited to the play when it is a sack.
+  sack_weight: Weighting applied to the sack component of the play.
+  scoringPlay: ESPN flag marking the play as a scoring play.
+  scoringType.abbreviation: ESPN's abbreviation for the scoring type.
+  scoringType.displayName: ESPN's display label for the scoring type.
+  scoringType.name: ESPN's name for the scoring type (e.g. touchdown, field goal).
+  scrimmage_play: True when the play is a play from scrimmage rather than a special-teams or administrative row.
+  seasonType: ESPN season type for the game (2 = regular season, 3 = postseason).
+  second_level_yards: Rushing yards earned from 4 to 8, split evenly between line and carrier under the line-yards decomposition.
+  short_rush_attempt: True when the play is a rush in a short-yardage situation.
+  short_rush_success: True when a short-yardage rush gained the yardage needed.
+  standard_down: True when the offense is on schedule for the series -- first down, second down needing fewer than 8, or third/fourth
+    down needing fewer than 5.
+  start.ExpScoreDiff: ESPN's `ExpScoreDiff` value for the play state at the start of the play.
+  start.ExpScoreDiff_Time_Ratio: ESPN's `ExpScoreDiff_Time_Ratio` value for the play state at the start of the play.
+  start.ExpScoreDiff_Time_Ratio_touchback: ESPN's `ExpScoreDiff_Time_Ratio_touchback` value for the play state at the start
+    of the play.
+  start.ExpScoreDiff_touchback: ESPN's `ExpScoreDiff_touchback` value for the play state at the start of the play.
+  start.TimeSecsRem: ESPN's `TimeSecsRem` value for the play state at the start of the play.
+  start.adj_TimeSecsRem: ESPN's `adj_TimeSecsRem` value for the play state at the start of the play.
+  start.awayScore: ESPN's `awayScore` value for the play state at the start of the play.
+  start.awayTeamTimeouts: ESPN's `awayTeamTimeouts` value for the play state at the start of the play.
+  start.defPosTeamTimeouts: ESPN's `defPosTeamTimeouts` value for the play state at the start of the play.
+  start.def_pos_team.id: ESPN's `def_pos_team.id` value for the play state at the start of the play.
+  start.def_pos_team.name: ESPN's `def_pos_team.name` value for the play state at the start of the play.
+  start.def_pos_team_score: ESPN's `def_pos_team_score` value for the play state at the start of the play.
+  start.distance: ESPN's `distance` value for the play state at the start of the play.
+  start.down: ESPN's `down` value for the play state at the start of the play.
+  start.downDistanceText: ESPN's `downDistanceText` value for the play state at the start of the play.
+  start.elapsed_share: ESPN's `elapsed_share` value for the play state at the start of the play.
+  start.homeScore: ESPN's `homeScore` value for the play state at the start of the play.
+  start.homeTeamTimeouts: ESPN's `homeTeamTimeouts` value for the play state at the start of the play.
+  start.is_home: ESPN's `is_home` value for the play state at the start of the play.
+  start.posTeamTimeouts: ESPN's `posTeamTimeouts` value for the play state at the start of the play.
+  start.pos_score_diff: ESPN's `pos_score_diff` value for the play state at the start of the play.
+  start.pos_team.id: ESPN's `pos_team.id` value for the play state at the start of the play.
+  start.pos_team.name: ESPN's `pos_team.name` value for the play state at the start of the play.
+  start.pos_team_receives_2H_kickoff: ESPN's `pos_team_receives_2H_kickoff` value for the play state at the start of the play.
+  start.pos_team_score: ESPN's `pos_team_score` value for the play state at the start of the play.
+  start.pos_team_spread: ESPN's `pos_team_spread` value for the play state at the start of the play.
+  start.possessionText: ESPN's `possessionText` value for the play state at the start of the play.
+  start.shortDownDistanceText: ESPN's `shortDownDistanceText` value for the play state at the start of the play.
+  start.spread_time: ESPN's `spread_time` value for the play state at the start of the play.
+  start.team.id: ESPN's `team.id` value for the play state at the start of the play.
+  start.yard: ESPN's `yard` value for the play state at the start of the play.
+  start.yardLine: ESPN's `yardLine` value for the play state at the start of the play.
+  start.yardsToEndzone: ESPN's `yardsToEndzone` value for the play state at the start of the play.
+  start.yardsToEndzone.touchback: ESPN's `yardsToEndzone.touchback` value for the play state at the start of the play.
+  statYardage: Yardage ESPN credits to the play for statistical purposes.
+  stopped_run: True when the rush was stopped at or behind the line of scrimmage.
+  td_check: Internal flag used while reconciling whether the play produced a touchdown.
+  text_dupe: True when the play description duplicates the previous row's text.
+  type.abbreviation: ESPN's abbreviation for the play type.
+  type.id: ESPN's numeric identifier for the play type.
+  type.text: ESPN's text label for the play type.
+  wp_touchback: Win probability the offense would have had starting from a touchback.
+load_phf_pbp:
+  away_goalie_jersey: Jersey number of the away goaltender on the ice.
+  away_nickname: Nickname of the away team.
+  away_score_total: Away team's cumulative score after the play.
+  defending_team_abbrev: Abbreviation of the team defending on the play.
+  defending_team_on_ice: Skaters the defending team had on the ice for the play.
+  defensive_player_jersey_1: Jersey number of the defending team's skater in on-ice slot 1 for the play.
+  defensive_player_jersey_2: Jersey number of the defending team's skater in on-ice slot 2 for the play.
+  defensive_player_jersey_3: Jersey number of the defending team's skater in on-ice slot 3 for the play.
+  defensive_player_jersey_4: Jersey number of the defending team's skater in on-ice slot 4 for the play.
+  defensive_player_jersey_5: Jersey number of the defending team's skater in on-ice slot 5 for the play.
+  defensive_player_jersey_6: Jersey number of the defending team's skater in on-ice slot 6 for the play.
+  defensive_player_name_1: Name of the defending team's skater in on-ice slot 1 for the play.
+  defensive_player_name_2: Name of the defending team's skater in on-ice slot 2 for the play.
+  defensive_player_name_3: Name of the defending team's skater in on-ice slot 3 for the play.
+  defensive_player_name_4: Name of the defending team's skater in on-ice slot 4 for the play.
+  defensive_player_name_5: Name of the defending team's skater in on-ice slot 5 for the play.
+  defensive_player_name_6: Name of the defending team's skater in on-ice slot 6 for the play.
+  end_power_play: True on the play where a power play ends.
+  goalie_change: True when the play records a goaltender change.
+  goalie_involved: Name of the goaltender involved in the play.
+  home_goalie_jersey: Jersey number of the home goaltender on the ice.
+  home_nickname: Nickname of the home team.
+  home_score_total: Home team's cumulative score after the play.
+  leader: Team leading the game at this point in the play sequence.
+  offensive_player_jersey_1: Jersey number of the attacking team's skater in on-ice slot 1 for the play.
+  offensive_player_jersey_2: Jersey number of the attacking team's skater in on-ice slot 2 for the play.
+  offensive_player_jersey_3: Jersey number of the attacking team's skater in on-ice slot 3 for the play.
+  offensive_player_jersey_4: Jersey number of the attacking team's skater in on-ice slot 4 for the play.
+  offensive_player_jersey_5: Jersey number of the attacking team's skater in on-ice slot 5 for the play.
+  offensive_player_jersey_6: Jersey number of the attacking team's skater in on-ice slot 6 for the play.
+  offensive_player_name_1: Name of the attacking team's skater in on-ice slot 1 for the play.
+  offensive_player_name_2: Name of the attacking team's skater in on-ice slot 2 for the play.
+  offensive_player_name_3: Name of the attacking team's skater in on-ice slot 3 for the play.
+  offensive_player_name_4: Name of the attacking team's skater in on-ice slot 4 for the play.
+  offensive_player_name_5: Name of the attacking team's skater in on-ice slot 5 for the play.
+  offensive_player_name_6: Name of the attacking team's skater in on-ice slot 6 for the play.
+  on_ice_situation: Strength situation on the ice for the play (e.g. even strength, power play).
+  penalty_level: Severity classification of the penalty (e.g. minor, major).
+  play_description: Free-text description of the play as published by the league.
+  player_jersey_1: Jersey number of the player in slot 1 of the play's participant list.
+  player_jersey_2: Jersey number of the player in slot 2 of the play's participant list.
+  player_jersey_3: Jersey number of the player in slot 3 of the play's participant list.
+  player_name_1: Name of the player in slot 1 of the play's participant list.
+  player_name_2: Name of the player in slot 2 of the play's participant list.
+  player_name_3: Name of the player in slot 3 of the play's participant list.
+  power_play_seconds: Elapsed seconds of the power play at this play.
+  scoring_team_abbrev: Abbreviation of the team credited with the goal.
+  scoring_team_on_ice: Skaters the scoring team had on the ice for the goal.
+  start_power_play: True on the play where a power play begins.
+load_phf_player_boxscores:
+  faceoffs_win_pct: Share of the player's faceoffs won.
+  faceoffs_won_lost: Faceoffs won and lost, as the league's combined won-lost string.
+  goalies_href: Relative link to the league's goaltender table for this game.
+  player_jersey: Player's jersey number.
+  powerplay_goals: Goals the player scored on the power play.
+  save_percent: Share of shots faced that the goaltender saved.
+  shots_blocked: Shots the player blocked.
+  skaters_href: Relative link to the league's skater table for this game.
+load_phf_schedules:
+  allow_players: League flag for whether player-level detail is published for the game.
+  away_division_id: League identifier for the away team's division.
+  away_penalty_minutes: Penalty minutes assessed to the away team.
+  away_roster_count: Number of players dressed for the away team.
+  away_team_logo_url_100: URL of the away team's logo at the 100px rendition.
+  away_team_logo_url_200: URL of the away team's logo at the 200px rendition.
+  away_team_logo_url_50: URL of the away team's logo at the 50px rendition.
+  away_team_logo_url_full: URL of the away team's logo at the full rendition.
+  away_team_logo_url_large: URL of the away team's logo at the large rendition.
+  away_team_logo_url_medium: URL of the away team's logo at the medium rendition.
+  away_team_logo_url_small: URL of the away team's logo at the small rendition.
+  away_team_short: Short display name of the away team.
+  created_at: Timestamp at which the league created the game record.
+  date_group: League grouping key for the game's date, used to bucket a slate.
+  datetime: Scheduled start of the game as a timestamp.
+  datetime_tz: Scheduled start of the game including its time-zone offset.
+  external_url: League-published external link for the game.
+  facility: Name of the facility hosting the game.
+  facility_address: Street address of the hosting facility.
+  facility_id: League identifier for the hosting facility.
+  has_play_by_play: True when a play-by-play feed exists for the game.
+  highlight_color: Display colour the league uses for the game in its schedule UI.
+  home_division_id: League identifier for the home team's division.
+  home_penalty_minutes: Penalty minutes assessed to the home team.
+  home_roster_count: Number of players dressed for the home team.
+  home_team_logo_url_100: URL of the home team's logo at the 100px rendition.
+  home_team_logo_url_200: URL of the home team's logo at the 200px rendition.
+  home_team_logo_url_50: URL of the home team's logo at the 50px rendition.
+  home_team_logo_url_full: URL of the home team's logo at the full rendition.
+  home_team_logo_url_large: URL of the home team's logo at the large rendition.
+  home_team_logo_url_medium: URL of the home team's logo at the medium rendition.
+  home_team_logo_url_small: URL of the home team's logo at the small rendition.
+  home_team_short: Short display name of the home team.
+  rink: Name of the rink within the facility.
+  rink_id: League identifier for the rink.
+  tickets_url: Link to purchase tickets for the game.
+  time_zone: Time zone in which the game is played.
+  time_zone_abbr: Abbreviated form of the game's time zone.
+  updated_at: Timestamp at which the league last updated the game record.
+  watch_live_url: Link to the live broadcast of the game.
+load_phf_team_boxscores:
+  blocked_opponent_shots: Opponent shots the team blocked.
+  overtime_scoring: Goals the team scored in overtime.
+  overtime_shots: Shots the team took in overtime.
+  period_1_scoring: Goals the team scored in period 1.
+  period_1_shots: Shots the team took in period 1.
+  period_2_scoring: Goals the team scored in period 2.
+  period_2_shots: Shots the team took in period 2.
+  period_3_scoring: Goals the team scored in period 3.
+  period_3_shots: Shots the team took in period 3.
+  power_play_percent: Share of the team's power plays that produced a goal.
+  shootout_made_scoring: Shootout attempts the team converted.
+  shootout_made_shots: Shootout shots the team took that scored.
+  shootout_missed_scoring: Shootout attempts the team failed to convert.
+  shootout_missed_shots: Shootout shots the team took that did not score.
+  successful_power_play: Number of power plays on which the team scored.
+  total_scoring: Goals the team scored in the game.
+  total_shots: Shots the team took in the game.
 load_contracts:
   cols: Placeholder column retained in the contracts loader output schema; contains no meaningful data in this context.
 load_depth_charts:

--- a/tools/codegen/manual_column_descriptions.yaml
+++ b/tools/codegen/manual_column_descriptions.yaml
@@ -3808,6 +3808,147 @@ load_cfb_team_summaries_weekly:
   yardsplay_off_rush: Yards gained per play on rush plays, with the team on offense.
   yardsplay_off_rush_rank: National rank of the team's yards gained per play on rush plays with the team on offense, where
     1 is best.
+load_cfb_adv_team:
+  EPA_explosive: Count of explosive plays, per ESPN's advanced box score. Despite the EPA_ prefix this is a play COUNT, not
+    an EPA total.
+  EPA_explosive_passing: Count of explosive pass plays. A play count, not an EPA total.
+  EPA_explosive_passing_rate: Explosive-play rate on pass plays, over ESPN's qualifying-play denominator.
+  EPA_explosive_rate: Explosive-play rate. Note this is NOT EPA_explosive divided by EPA_plays -- ESPN divides by its own
+    smaller qualifying-play count, so deriving it yourself will not reproduce this value.
+  EPA_explosive_rushing: Count of explosive rush plays. A play count, not an EPA total.
+  EPA_explosive_rushing_rate: Explosive-play rate on rush plays, over ESPN's qualifying-play denominator.
+  EPA_fg: Total EPA on field-goal attempts.
+  EPA_kickoff: Total EPA on kickoff plays.
+  EPA_non_explosive: Total EPA with explosive plays excluded, isolating the team's routine-down production.
+  EPA_non_explosive_passing: Total EPA on pass plays with explosive plays excluded.
+  EPA_non_explosive_passing_per_play: EPA per pass play with explosive plays excluded.
+  EPA_non_explosive_per_play: EPA per play with explosive plays excluded.
+  EPA_non_explosive_rushing: Total EPA on rush plays with explosive plays excluded.
+  EPA_non_explosive_rushing_per_play: EPA per rush play with explosive plays excluded.
+  EPA_overall_off: Total offensive EPA for the team. Duplicated exactly by EPA_overall_offense in every published season checked
+    -- prefer one and ignore the other.
+  EPA_overall_offense: Total offensive EPA. An exact duplicate of EPA_overall_off.
+  EPA_overall_total: Total EPA across all phases, which is why it differs from the offense-only EPA_overall_off.
+  EPA_passing_overall: Total EPA on pass plays.
+  EPA_passing_per_play: EPA per pass play.
+  EPA_penalty: Total EPA attributed to penalties.
+  EPA_per_play: Offensive EPA per play.
+  EPA_plays: Number of plays ESPN's advanced box score scored for the team.
+  EPA_punt: Total EPA on punt plays.
+  EPA_rushing_overall: Total EPA on rush plays.
+  EPA_rushing_per_play: EPA per rush play.
+  EPA_rushing_power: Total EPA on power rushing situations, as classified by ESPN's advanced box score.
+  EPA_rushing_power_per_play: EPA per play on power rushing situations.
+  EPA_sp: Total special-teams EPA, ESPN's abbreviated field for the same phase.
+  EPA_special_teams: Total EPA generated on special-teams plays.
+  field_goals: Number of field-goal attempts.
+  first_downs_created: Number of first downs the team created.
+  first_downs_created_rate: Share of the team's plays that created a first down.
+  kickoff_plays: Number of kickoff plays.
+  line_yards: Line yards -- the portion of rushing yardage credited to the offensive line under the standard rushing decomposition.
+    ESPN applies its own qualifying threshold for the yardage split.
+  line_yards_per_carry: Line yards per rushing attempt.
+  off_yards: Offensive yards gained from scrimmage.
+  open_field_yards: Open-field yards -- rushing yardage earned well downfield, past the second level.
+  passes_rate: Share of the team's plays from scrimmage that were pass plays.
+  passing_first_downs_created: Number of first downs created on pass plays.
+  passing_first_downs_created_rate: Share of pass plays that created a first down.
+  penalty_first_downs_created: Number of first downs the team gained via opponent penalty.
+  penalty_first_downs_created_rate: Share of the team's first downs that came via opponent penalty.
+  pos_team_id: ESPN team id of the team on offense. Present for every season 2004+.
+  punt_plays: Number of punt plays.
+  rushes: Number of rushing attempts.
+  rushes_rate: Share of the team's plays from scrimmage that were rush plays.
+  rushing_first_downs_created: Number of first downs created on rush plays.
+  rushing_first_downs_created_rate: Share of rush plays that created a first down.
+  rushing_highlight: Highlight yards -- rushing yardage credited to the back rather than the offensive line.
+  rushing_highlight_rate: Share of rushing yardage that was highlight (back-credited) yardage.
+  rushing_highlight_yards_per_opp: Highlight yards per rushing opportunity.
+  rushing_opportunity: Count of rushing opportunities -- carries that reached ESPN's opportunity threshold.
+  rushing_opportunity_rate: Share of carries that qualified as rushing opportunities.
+  rushing_power: Count of power rushing attempts, in short-yardage situations as classified by ESPN's advanced box score.
+  rushing_power_rate: Share of carries that were power rushing attempts.
+  rushing_power_success_rate: Share of power rushing attempts that succeeded.
+  rushing_stopped: Count of rushing attempts stopped at or behind the line of scrimmage.
+  rushing_stopped_rate: Share of carries stopped at or behind the line of scrimmage.
+  rushing_stuff: Count of stuffed rushing attempts.
+  scrimmage_plays: Number of plays from scrimmage (rushes plus passes), excluding special teams.
+  second_level_yards: Second-level yards -- rushing yardage earned just beyond the line of scrimmage.
+  special_teams_plays: Number of special-teams plays.
+  total_off_yards: Total offensive yards across all plays.
+  total_pen_yards: Total penalty yards assessed.
+  yards_per_play: Yards gained per play.
+  yards_per_rush: Yards gained per rushing attempt.
+load_cfb_adv_team_gamelog:
+  EPA_explosive: Count of explosive plays, per ESPN's advanced box score. Despite the EPA_ prefix this is a play COUNT, not
+    an EPA total.
+  EPA_explosive_passing: Count of explosive pass plays. A play count, not an EPA total.
+  EPA_explosive_passing_rate: Explosive-play rate on pass plays, over ESPN's qualifying-play denominator.
+  EPA_explosive_rate: Explosive-play rate. Note this is NOT EPA_explosive divided by EPA_plays -- ESPN divides by its own
+    smaller qualifying-play count, so deriving it yourself will not reproduce this value.
+  EPA_explosive_rushing: Count of explosive rush plays. A play count, not an EPA total.
+  EPA_explosive_rushing_rate: Explosive-play rate on rush plays, over ESPN's qualifying-play denominator.
+  EPA_fg: Total EPA on field-goal attempts.
+  EPA_kickoff: Total EPA on kickoff plays.
+  EPA_non_explosive: Total EPA with explosive plays excluded, isolating the team's routine-down production.
+  EPA_non_explosive_passing: Total EPA on pass plays with explosive plays excluded.
+  EPA_non_explosive_passing_per_play: EPA per pass play with explosive plays excluded.
+  EPA_non_explosive_per_play: EPA per play with explosive plays excluded.
+  EPA_non_explosive_rushing: Total EPA on rush plays with explosive plays excluded.
+  EPA_non_explosive_rushing_per_play: EPA per rush play with explosive plays excluded.
+  EPA_overall_off: Total offensive EPA for the team. Duplicated exactly by EPA_overall_offense in every published season checked
+    -- prefer one and ignore the other.
+  EPA_overall_offense: Total offensive EPA. An exact duplicate of EPA_overall_off.
+  EPA_overall_total: Total EPA across all phases, which is why it differs from the offense-only EPA_overall_off.
+  EPA_passing_overall: Total EPA on pass plays.
+  EPA_passing_per_play: EPA per pass play.
+  EPA_penalty: Total EPA attributed to penalties.
+  EPA_per_play: Offensive EPA per play.
+  EPA_plays: Number of plays ESPN's advanced box score scored for the team.
+  EPA_punt: Total EPA on punt plays.
+  EPA_rushing_overall: Total EPA on rush plays.
+  EPA_rushing_per_play: EPA per rush play.
+  EPA_rushing_power: Total EPA on power rushing situations, as classified by ESPN's advanced box score.
+  EPA_rushing_power_per_play: EPA per play on power rushing situations.
+  EPA_sp: Total special-teams EPA, ESPN's abbreviated field for the same phase.
+  EPA_special_teams: Total EPA generated on special-teams plays.
+  field_goals: Number of field-goal attempts.
+  first_downs_created: Number of first downs the team created.
+  first_downs_created_rate: Share of the team's plays that created a first down.
+  kickoff_plays: Number of kickoff plays.
+  line_yards: Line yards -- the portion of rushing yardage credited to the offensive line under the standard rushing decomposition.
+    ESPN applies its own qualifying threshold for the yardage split.
+  line_yards_per_carry: Line yards per rushing attempt.
+  off_yards: Offensive yards gained from scrimmage.
+  open_field_yards: Open-field yards -- rushing yardage earned well downfield, past the second level.
+  passes_rate: Share of the team's plays from scrimmage that were pass plays.
+  passing_first_downs_created: Number of first downs created on pass plays.
+  passing_first_downs_created_rate: Share of pass plays that created a first down.
+  penalty_first_downs_created: Number of first downs the team gained via opponent penalty.
+  penalty_first_downs_created_rate: Share of the team's first downs that came via opponent penalty.
+  punt_plays: Number of punt plays.
+  rushes: Number of rushing attempts.
+  rushes_rate: Share of the team's plays from scrimmage that were rush plays.
+  rushing_first_downs_created: Number of first downs created on rush plays.
+  rushing_first_downs_created_rate: Share of rush plays that created a first down.
+  rushing_highlight: Highlight yards -- rushing yardage credited to the back rather than the offensive line.
+  rushing_highlight_rate: Share of rushing yardage that was highlight (back-credited) yardage.
+  rushing_highlight_yards_per_opp: Highlight yards per rushing opportunity.
+  rushing_opportunity: Count of rushing opportunities -- carries that reached ESPN's opportunity threshold.
+  rushing_opportunity_rate: Share of carries that qualified as rushing opportunities.
+  rushing_power: Count of power rushing attempts, in short-yardage situations as classified by ESPN's advanced box score.
+  rushing_power_rate: Share of carries that were power rushing attempts.
+  rushing_power_success_rate: Share of power rushing attempts that succeeded.
+  rushing_stopped: Count of rushing attempts stopped at or behind the line of scrimmage.
+  rushing_stopped_rate: Share of carries stopped at or behind the line of scrimmage.
+  rushing_stuff: Count of stuffed rushing attempts.
+  scrimmage_plays: Number of plays from scrimmage (rushes plus passes), excluding special teams.
+  second_level_yards: Second-level yards -- rushing yardage earned just beyond the line of scrimmage.
+  special_teams_plays: Number of special-teams plays.
+  total_off_yards: Total offensive yards across all plays.
+  total_pen_yards: Total penalty yards assessed.
+  yards_per_play: Yards gained per play.
+  yards_per_rush: Yards gained per rushing attempt.
 load_contracts:
   cols: Placeholder column retained in the contracts loader output schema; contains no meaningful data in this context.
 load_depth_charts:

--- a/tools/codegen/merge_column_descriptions.py
+++ b/tools/codegen/merge_column_descriptions.py
@@ -1,0 +1,49 @@
+"""Additive merge: union new descriptions INTO each loader block.
+
+Block-REPLACE is wrong here -- two generators contribute to the same loader
+(adv_* vocabulary plus the cfb-rest tail), so replacing the block makes the
+second generator erase the first one's columns. Existing entries win, so a
+hand-authored description is never clobbered by a composed one.
+"""
+
+import re
+import sys
+import pathlib
+import yaml
+
+files = sys.argv[1:]
+new = {}
+for f in files:
+    for k, v in (yaml.safe_load(pathlib.Path(f).read_text(encoding="utf-8")) or {}).items():
+        new.setdefault(k, {}).update(v)
+
+p = pathlib.Path("tools/codegen/manual_column_descriptions.yaml")
+cur = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+added = 0
+for k, cols in new.items():
+    have = cur.get(k, {})
+    for c, d in cols.items():
+        if c not in have:
+            have[c] = d
+            added += 1
+    cur[k] = have
+
+lines = p.read_text(encoding="utf-8").splitlines(keepends=True)
+KEY = re.compile(r"^[A-Za-z_]\w*:\s*$")
+out, i = [], 0
+while i < len(lines):
+    k = lines[i].rstrip()[:-1] if KEY.match(lines[i]) else None
+    if k in new:
+        i += 1
+        while i < len(lines) and not KEY.match(lines[i]):
+            i += 1
+        continue
+    out.append(lines[i])
+    i += 1
+block = "".join(
+    yaml.safe_dump({k: dict(sorted(cur[k].items()))}, sort_keys=False, allow_unicode=True, width=120)
+    for k in sorted(new)
+    if cur.get(k)
+)
+p.write_text("".join(out).replace("\nload_contracts:", "\n" + block + "load_contracts:", 1), encoding="utf-8")
+print(f"additively merged: +{added} new entries across {len(new)} loaders")


### PR DESCRIPTION
Follows #310, which gave generated loader returns tables a `description` column and exposed ~5,850 loader columns to the coverage ratchet — 2,407 of them uncovered. This describes **957 of those (40%)**, all CFB.

| batch | cols | how it was grounded |
|---|---|---|
| `team_summaries` + `_weekly` | **757** | producer arithmetic — `cfb_data_build/team_summaries.py::_summarize_team` |
| `adv_team` + `_gamelog` | **131** | empirical profile of the published 2024 asset |
| `adv_situational` | **71** | empirical profile |

Loader deferred **2,407 → 1,450**. Residual ratchet stays **0**.

## These are grids, not 2,407 independent concepts

`team_summaries` is `{base}_{off|def|margin}[_{pass|rush}][_rank]` — ~28 base metrics generating 378 columns, 179 of them pure `_rank` derivations. So the descriptions are **composed from a verified vocabulary**, and the three generators are committed (`tools/codegen/gen_cfb_*_descriptions.py`) so the derivation stays reproducible and auditable rather than becoming opaque YAML. They enumerate `loader_schemas.yaml`, so re-running is idempotent.

## Grounding came from source, not column names

- **Base metrics** are transcribed from the producer (`EPAdrive = TEPA/n_drives`, `EPAgame = TEPA/n_games`, `success = mean(epa_success)`), not inferred.
- **Rank direction was verified**: offense ranks `ascending=False`, defense `ascending=True`, and lower-is-better metrics flip again — so **rank 1 = best on both sides of the ball**. Documenting that backwards would have been a docs lie in 179 places.
- **`start_position_margin`** uses the special `(100-off) - (100-def)` form, so it is described as field position gained rather than yards-to-goal.
- **Adjusted EPA / strength / valid_games** come from `cfb_adjusted_epa.py` — a ridge (RAPM-style) opponent adjustment fit in-sample, so the text says descriptive-not-predictive.

## The ESPN blocks needed empirical profiling — their names lie

`adv_team` / `adv_situational` are raw ESPN `advBoxScore` fields with no producer arithmetic to read, so each column was profiled against real published data first. That caught three things naming alone would have gotten wrong:

- **The bare `EPA_explosive*` and `EPA_success*` columns are integer play COUNTS** (0–13, 7–56), not EPA totals, despite the `EPA_` prefix. ~40 columns would have been mislabelled.
- **`EPA_overall_off` and `EPA_overall_offense` are exact duplicates** (max abs diff 0). Both now say so, so consumers do not treat them as two signals.
- **`EPA_explosive_rate` is NOT `EPA_explosive / EPA_plays`** — the implied denominator runs 1–27 plays smaller. The text warns that deriving it yourself will not reproduce ESPN value, rather than inventing a formula.

ESPN also emits **both orders** for the same concept (`EPA_success_{situation}` and `EPA_middle_8_success`). That was only caught because the generators **report unparsed columns instead of guessing** — a permissive regex would have left five columns silently blank.

## Nothing was invented

Where a base metric is the mean of an upstream ESPN flag this repo does not define (`havoc`, `explosive`, `opportunity_rate`), the description says "share of plays carrying the flag" instead of asserting a threshold. Anything a generator could not ground is left **blank and reported** — the handful remaining (`season`, `conference`, `game_id`, `week`) resolve through the R-package dict instead.

## Gates

- `generate.py --check` → all generated files current
- `ruff format` + `ruff check` → clean
- `tests/codegen/test_manual_descriptions.py` → **6 passed**, including the filler-quality gate and the orphan-key gate
- residual ratchet **0**, unchanged

## Remaining

1,450 deferred, and the character changes from here — `load_cfb_pbp` (237), `wnba_stats_*` (438), `phf` (114), plus a ~660-column tail across ~80 loaders. Those need genuinely different grounding, so they are better reviewed separately.

## Summary by Sourcery

Document ESPN CFB advanced and team summary loader columns with grounded, empirically verified descriptions, and add generators to keep these descriptions reproducible from source schemas.

Enhancements:
- Introduce codegen scripts to synthesize cfb team_summaries, adv team, and situational column descriptions directly from loader_schemas.yaml, ensuring idempotent, auditable documentation generation.
- Ensure unparsed or ungrounded columns are left blank and reported by the generators rather than described heuristically.

Documentation:
- Fill previously blank descriptions for CFB ESPN advanced team, team gamelog, situational, and team_summaries weekly loader columns, clarifying units, semantics, and relationships (counts vs rates vs EPA).
- Document adjusted EPA, opponent strength, available-yards, and margin/rank metrics in team summaries assets with consistent wording and best-direction notes.
- Clarify quirks in ESPN advBoxScore data such as duplicate overall EPA fields and non-EPA EPA_explosive* counters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected college football rushing opportunity, highlight-run, and adjusted rushing yardage metrics, including touchdown and fumble-recovery rushes.

* **Documentation**
  * Expanded loader field definitions across college football, hockey, basketball, baseball, and women’s basketball datasets.
  * Added detailed descriptions for play-by-play, advanced statistics, schedules, rosters, ratings, projections, standings, and team summaries.
  * Documented more than 1,300 loader columns and clarified metric calculations and field semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->