### PR TITLE
feat(schemas): declare the five stats.nba.com raw payload families

### DIFF
--- a/sportsdataverse/schemas/__init__.py
+++ b/sportsdataverse/schemas/__init__.py
@@ -206,12 +206,37 @@ def validate_payload(name: str, payload: Any) -> list[str]:
     # was dropped validate clean, and one schema per entity key would be a
     # dozen near-identical files.
     for group in schema.get("required_any") or []:
-        if not any(key in payload for key in group):
-            problems.append(f"{name}: payload has none of {sorted(group)!r}; expected one")
+        # A bare string is a schema-authoring slip (`required_any: [foo]` rather
+        # than `[[foo]]`). Iterating it would test the payload for single
+        # CHARACTERS and report nonsense, so treat it as a one-key group.
+        keys = [group] if isinstance(group, str) else list(group)
+        if not any(key in payload for key in keys):
+            problems.append(f"{name}: payload has none of {sorted(keys)!r}; expected one")
     for key, declared in (schema.get("optional") or {}).items():
         # An absent optional key and an explicit null are both "not provided".
         if payload.get(key) is not None:
             problems.extend(_check(name, key, payload[key], declared))
+
+    # `values_of`: every present value must itself match another declared
+    # family. Without it a period map validates as long as its four keys hold
+    # *some* dict, so `{"1": {}, "2": {}, "3": {}, "4": {}}` -- a capture that
+    # lost every payload body -- passes as a complete game.
+    nested = schema.get("values_of")
+    if nested:
+        if nested == name:
+            raise ValueError(f"raw schema {name!r} declares itself as values_of")
+        # Only DECLARED keys. Unknown keys stay ignored, as everywhere else --
+        # `additional_properties: true` must keep meaning the same thing here,
+        # or a new top-level field would be reported as a malformed period.
+        declared_keys = [
+            key for key in list(schema.get("required") or {}) + list(schema.get("optional") or {}) if key in payload
+        ]
+        for key in declared_keys:
+            value = payload[key]
+            if not isinstance(value, dict):
+                problems.append(f"{name}: {key!r} is {type(value).__name__}, expected dict")
+                continue
+            problems.extend(f"{name}[{key}] -> {p}" for p in validate_payload(nested, value))
     return problems
 
 

--- a/sportsdataverse/schemas/__init__.py
+++ b/sportsdataverse/schemas/__init__.py
@@ -19,8 +19,18 @@ opposite ways:
   ``winprobability`` is a list in most games and a dict in some), the schema
   declares the union explicitly rather than widening to "any".
 
+**One provider can ship several envelopes.** ESPN is one family per endpoint
+group, but stats.nba.com has *five*, and which one an endpoint uses is a
+property of the endpoint rather than of the season or league: a classic
+``resultSets`` list, a singular ``resultSet`` dict, a ``resultSets`` dict whose
+``headers`` are column-group objects, the modern v3 ``{<entity>, meta}`` tree,
+and a period-number map of v3 payloads. Classify before validating -- see
+:func:`validate_payload` usage in the ``-raw`` repos.
+
 Every schema here was derived from real committed captures. Do not edit one to
-make a test pass without re-sampling the payloads it describes.
+make a test pass without re-sampling the payloads it describes. The nba_stats
+families were checked against 8,608 payloads spanning 54 endpoint directories
+of ``hoopR-nba-stats-raw``; every one matched exactly one family.
 
 Example:
     Validate a captured payload::
@@ -59,6 +69,14 @@ RAW_SCHEMAS: dict[str, str] = {
     "espn_standings": "<lg>/standings/json/<season>.json",
     "espn_team_stats": "<lg>/team_stats/json/<season>/<team_id>.json",
     "espn_player_season_stats": "<lg>/player_season_stats/json/<season>/<athlete_id>.json",
+    # stats.nba.com / stats.wnba.com. FIVE envelope families, not one -- see
+    # each schema's description. Which family an endpoint uses is a property of
+    # the endpoint, not of the season or league.
+    "nba_stats_result_sets": "nba_stats/json/<endpoint>/<season>/<slug>.json",
+    "nba_stats_result_set": "nba_stats/json/<endpoint>/<season>/<slug>.json",
+    "nba_stats_result_sets_grouped": "nba_stats/json/<endpoint>/<season>/<slug>.json",
+    "nba_stats_v3": "nba_stats/json/<endpoint>/<season>/<game_id>.json",
+    "nba_stats_v3_period": "nba_stats/json/boxscoretraditionalv3_period/<season>/<game_id>.json",
 }
 
 _TYPES: dict[str, type | tuple[type, ...]] = {
@@ -181,6 +199,15 @@ def validate_payload(name: str, payload: Any) -> list[str]:
             problems.append(f"{name}: missing required key {key!r}")
             continue
         problems.extend(_check(name, key, payload[key], declared))
+    # `required_any`: at least one of these keys must be present. The
+    # stats.nba.com v3 endpoints all ship {<entityKey>, meta} where the entity
+    # key is named per endpoint (boxScoreTraditional, game, leagueSchedule,
+    # scoreboard, ...). Requiring only `meta` would let a payload whose body
+    # was dropped validate clean, and one schema per entity key would be a
+    # dozen near-identical files.
+    for group in schema.get("required_any") or []:
+        if not any(key in payload for key in group):
+            problems.append(f"{name}: payload has none of {sorted(group)!r}; expected one")
     for key, declared in (schema.get("optional") or {}).items():
         # An absent optional key and an explicit null are both "not provided".
         if payload.get(key) is not None:

--- a/sportsdataverse/schemas/raw/nba_stats_result_set.yaml
+++ b/sportsdataverse/schemas/raw/nba_stats_result_set.yaml
@@ -1,0 +1,18 @@
+name: nba_stats_result_set
+description: >-
+  stats.nba.com endpoints that ship a SINGULAR `resultSet` holding one
+  {name, headers, rowSet} table as a dict, not a list of them. Reading these
+  with the plural-key path yields nothing -- the key is genuinely different,
+  not a list of length one.
+# Derived from the committed hoopR-nba-stats-raw tree (2026-08-01): 120 of the
+# sampled payloads used the singular key, all with a dict value. Observed on
+# leagueleaders, playerestimatedmetrics and teamestimatedmetrics.
+#
+# An empty result is still a full envelope -- leagueleaders/1996/
+# playoffs_pergame.json carries headers with `rowSet: []`. That is why a bare
+# `{}` on disk means a failed fetch, never "no data for this season".
+additional_properties: true
+required:
+  resource: str
+  parameters: dict
+  resultSet: dict

--- a/sportsdataverse/schemas/raw/nba_stats_result_sets.yaml
+++ b/sportsdataverse/schemas/raw/nba_stats_result_sets.yaml
@@ -1,0 +1,21 @@
+name: nba_stats_result_sets
+description: >-
+  The classic stats.nba.com envelope: {resource, parameters, resultSets} where
+  resultSets is a LIST of {name, headers, rowSet} tables. This is the shape
+  parse_nba_stats_result_sets() reads. It is only one of five envelope families
+  in the archive -- see nba_stats_result_set (singular/dict),
+  nba_stats_result_sets_grouped (plural key, dict value, dict headers),
+  nba_stats_v3 and nba_stats_v3_period.
+# Derived from the committed hoopR-nba-stats-raw tree (489,977 files,
+# 64 endpoint dirs, 40 sampled per dir, 2026-08-01). 1,331 of the sampled
+# payloads carried resultSets-as-list; every inner element had exactly
+# ('headers', 'name', 'rowSet').
+#
+# `parameters` is required on purpose: it is the echo of the query that
+# produced the payload, so an offline reprocess can tell which season /
+# per-mode / measure-type a file represents without trusting its path.
+additional_properties: true
+required:
+  resource: str
+  parameters: dict
+  resultSets: list

--- a/sportsdataverse/schemas/raw/nba_stats_result_sets_grouped.yaml
+++ b/sportsdataverse/schemas/raw/nba_stats_result_sets_grouped.yaml
@@ -1,0 +1,23 @@
+name: nba_stats_result_sets_grouped
+description: >-
+  The shot-locations variant: the key is PLURAL (`resultSets`) but the value is
+  a single dict, and its `headers` is a list of GROUP dicts
+  ({columnNames, columnSpan, columnsToSkip, name}) rather than a flat list of
+  column-name strings. The grouping encodes the shot-zone column bands, so a
+  parser that assumes flat string headers mis-reads these entirely.
+# Derived from the committed hoopR-nba-stats-raw tree (2026-08-01): 21 of the
+# sampled payloads. Observed on leaguedashplayershotlocations and
+# leaguedashteamshotlocations, e.g. leaguedashteamshotlocations/1996/
+# playoffs_base_pergame.json -- headers is a 2-element list of group dicts over
+# a 26-wide rowSet.
+#
+# Known latent hazard: season_capture._ids_from() iterates
+# `payload.get("resultSets") or []` and calls .get() on each element. Against
+# this family that iterates the dict's KEYS (strings) and would raise
+# AttributeError. It does not fire today only because _ids_from is pointed
+# exclusively at nba_stats_result_sets payloads.
+additional_properties: true
+required:
+  resource: str
+  parameters: dict
+  resultSets: dict

--- a/sportsdataverse/schemas/raw/nba_stats_v3.yaml
+++ b/sportsdataverse/schemas/raw/nba_stats_v3.yaml
@@ -1,0 +1,35 @@
+name: nba_stats_v3
+description: >-
+  The modern stats.nba.com v3 envelope: {<entityKey>, meta}. There is no
+  `resultSets` at all -- the payload is a typed object tree, and the entity key
+  is named per endpoint (boxScoreTraditional, boxScoreAdvanced, game,
+  leagueSchedule, scoreboard, ...). This family is the BULK of the archive:
+  boxscoretraditionalv3 and playbyplayv3 are 39,244 files each, and the nine v3
+  box scores plus pbp and the schedule account for roughly 340k of the 490k
+  committed payloads.
+# Derived from the committed hoopR-nba-stats-raw tree (2026-08-01). `meta` was
+# present with exactly (request, time, version) in every v3 sample.
+#
+# `required_any` lists the observed entity keys: at least one must be present.
+# Requiring only `meta` would let a payload whose body was dropped validate
+# clean; a schema per entity key would be a dozen near-identical files.
+#
+# An empty body is NOT an empty payload: playbyplayv3/1996/0029500001.json is a
+# valid 201-byte envelope whose `game.actions` is []. v3 pbp genuinely has no
+# actions that far back. Only a literal `{}` on disk indicates a failed fetch.
+additional_properties: true
+required:
+  meta: dict
+required_any:
+  - - boxScoreTraditional
+    - boxScoreAdvanced
+    - boxScoreDefensive
+    - boxScoreFourFactors
+    - boxScoreMatchups
+    - boxScoreMisc
+    - boxScorePlayerTrack
+    - boxScoreScoring
+    - boxScoreUsage
+    - game
+    - leagueSchedule
+    - scoreboard

--- a/sportsdataverse/schemas/raw/nba_stats_v3_period.yaml
+++ b/sportsdataverse/schemas/raw/nba_stats_v3_period.yaml
@@ -1,0 +1,31 @@
+name: nba_stats_v3_period
+description: >-
+  Period-sliced box scores: a map of period NUMBER (as a string key) to a
+  complete nba_stats_v3 payload. Written by the per-period capture pass, one
+  file per game holding every period rather than one file per period.
+# Derived from the committed hoopR-nba-stats-raw tree (2026-08-01): the
+# boxscoretraditionalv3_period dir (37,966 files). Observed key sets were
+# ('1','2','3','4') for regulation and ('1','2','3','4','5') for a single-OT
+# game, each value a {boxScoreTraditional, meta} object.
+#
+# Periods 1-4 are required: every completed NBA game has four. Overtimes are
+# optional and open-ended -- 5 through 14 covers ten OTs, well past the
+# six-OT record. A game missing period 3 is a partial capture, which is
+# precisely what this schema exists to catch.
+additional_properties: true
+required:
+  "1": dict
+  "2": dict
+  "3": dict
+  "4": dict
+optional:
+  "5": dict
+  "6": dict
+  "7": dict
+  "8": dict
+  "9": dict
+  "10": dict
+  "11": dict
+  "12": dict
+  "13": dict
+  "14": dict

--- a/sportsdataverse/schemas/raw/nba_stats_v3_period.yaml
+++ b/sportsdataverse/schemas/raw/nba_stats_v3_period.yaml
@@ -12,7 +12,13 @@ description: >-
 # optional and open-ended -- 5 through 14 covers ten OTs, well past the
 # six-OT record. A game missing period 3 is a partial capture, which is
 # precisely what this schema exists to catch.
+#
+# Every value is a full nba_stats_v3 payload, so it is validated as one rather
+# than merely checked for dict-ness -- otherwise
+# `{"1": {}, "2": {}, "3": {}, "4": {}}`, a capture that lost every payload
+# body, would pass as a complete game.
 additional_properties: true
+values_of: nba_stats_v3
 required:
   "1": dict
   "2": dict

--- a/tests/test_raw_schemas.py
+++ b/tests/test_raw_schemas.py
@@ -162,3 +162,138 @@ def test_required_keys_match_what_was_observed(name, required):
     """Pins the observed-universal keys. Loosening one of these means a parser
     can now be handed a payload it cannot read."""
     assert required <= set(load_raw_schema(name)["required"])
+
+
+# --------------------------------------------------------------------------
+# stats.nba.com / stats.wnba.com families.
+#
+# Derived by probing the committed hoopR-nba-stats-raw tree on 2026-08-01
+# (489,977 files across 64 endpoint dirs, 40 sampled per dir). The plan for
+# this work assumed a single uniform {resultSets: [...]} envelope; the archive
+# actually holds FIVE, and the assumed one covers a minority of the files.
+# --------------------------------------------------------------------------
+
+NBA_STATS_FAMILIES = [
+    "nba_stats_result_sets",
+    "nba_stats_result_set",
+    "nba_stats_result_sets_grouped",
+    "nba_stats_v3",
+    "nba_stats_v3_period",
+]
+
+# One minimal but REAL-shaped payload per family, keyed by schema name.
+NBA_STATS_SAMPLES = {
+    "nba_stats_result_sets": {
+        "resource": "boxscoresummaryv2",
+        "parameters": {"GameID": "0029600001"},
+        "resultSets": [{"name": "GameSummary", "headers": ["GAME_ID"], "rowSet": [["0029600001"]]}],
+    },
+    "nba_stats_result_set": {
+        "resource": "leagueleaders",
+        "parameters": {"Season": "1996-97", "PerMode": "PerGame"},
+        # A real empty result still carries headers -- only rowSet is empty.
+        "resultSet": {"name": "LeagueLeaders", "headers": ["PLAYER_ID"], "rowSet": []},
+    },
+    "nba_stats_result_sets_grouped": {
+        "resource": "leaguedashteamshotlocations",
+        "parameters": {"Season": "1996-97", "MeasureType": "Base"},
+        "resultSets": {
+            "name": "ShotLocations",
+            # Group dicts, NOT column-name strings. This is the divergence.
+            "headers": [
+                {
+                    "name": "SHOT_CATEGORY",
+                    "columnNames": ["Restricted Area"],
+                    "columnSpan": 3,
+                    "columnsToSkip": 5,
+                },
+                {"name": "columns", "columnNames": ["TEAM_ID", "TEAM_NAME"]},
+            ],
+            "rowSet": [[1610612737, "Atlanta Hawks"]],
+        },
+    },
+    "nba_stats_v3": {
+        "meta": {"request": "http://...", "time": "2026-01-01", "version": 1},
+        "boxScoreTraditional": {"gameId": "0029500001", "homeTeamId": 1610612737},
+    },
+    "nba_stats_v3_period": {
+        str(period): {
+            "meta": {"request": "http://...", "time": "2026-01-01", "version": 1},
+            "boxScoreTraditional": {"gameId": "0029600001"},
+        }
+        for period in range(1, 5)
+    },
+}
+
+
+@pytest.mark.parametrize("name", NBA_STATS_FAMILIES)
+def test_nba_stats_family_accepts_its_own_real_shape(name):
+    assert validate_payload(name, NBA_STATS_SAMPLES[name]) == []
+
+
+@pytest.mark.parametrize("name", NBA_STATS_FAMILIES)
+def test_empty_payload_fails_every_nba_stats_family(name):
+    """The load-bearing assertion.
+
+    hoopR-nba-stats-raw holds 3,347 files that are exactly ``{}`` -- ten
+    endpoints are 100% empty. They persist because the scraper's write path has
+    no guard and its resume check is ``path.exists()``, i.e. presence rather
+    than content, so one empty write is never retried.
+
+    ``{}`` is not a shape stats.nba.com produces: an endpoint with no rows
+    still returns the full envelope with ``rowSet: []``. Every family must
+    therefore reject it, which is what makes these schemas a detector for that
+    corruption rather than a passive document.
+    """
+    assert validate_payload(name, {}), f"{name} accepted an empty payload"
+
+
+@pytest.mark.parametrize("name", NBA_STATS_FAMILIES)
+def test_nba_stats_families_still_tolerate_unknown_keys(name):
+    payload = dict(NBA_STATS_SAMPLES[name], someNewKeyTheAPIAdded={"x": 1})
+    assert validate_payload(name, payload) == []
+
+
+def test_singular_and_plural_result_set_keys_are_not_interchangeable():
+    """`resultSet` vs `resultSets` is a genuinely different key, not a list of
+    length one. Reading a singular payload with the plural path finds nothing."""
+    singular = NBA_STATS_SAMPLES["nba_stats_result_set"]
+    assert validate_payload("nba_stats_result_sets", singular)
+    plural = NBA_STATS_SAMPLES["nba_stats_result_sets"]
+    assert validate_payload("nba_stats_result_set", plural)
+
+
+def test_grouped_family_rejects_a_list_valued_result_sets():
+    """The shot-locations family keys `resultSets` to a dict. A list there is
+    the classic family, which carries flat string headers and a different
+    column layout."""
+    listy = dict(NBA_STATS_SAMPLES["nba_stats_result_sets_grouped"], resultSets=[])
+    assert validate_payload("nba_stats_result_sets_grouped", listy)
+
+
+def test_v3_requires_an_entity_body_not_just_meta():
+    """A dropped body must not validate clean. `meta` alone is a truncated
+    payload, and every v3 endpoint pairs it with exactly one entity key."""
+    meta_only = {"meta": {"request": "http://...", "time": "t", "version": 1}}
+    problems = validate_payload("nba_stats_v3", meta_only)
+    assert problems and "expected one" in problems[0]
+
+
+@pytest.mark.parametrize("entity", ["game", "leagueSchedule", "scoreboard", "boxScoreUsage"])
+def test_v3_accepts_each_observed_entity_key(entity):
+    payload = {"meta": {"request": "r", "time": "t", "version": 1}, entity: {}}
+    assert validate_payload("nba_stats_v3", payload) == []
+
+
+def test_v3_period_requires_the_four_regulation_periods():
+    """Overtime periods are optional; a missing regulation period is a partial
+    capture, which is the whole point of this family having a schema."""
+    missing_third = {k: v for k, v in NBA_STATS_SAMPLES["nba_stats_v3_period"].items() if k != "3"}
+    problems = validate_payload("nba_stats_v3_period", missing_third)
+    assert any("'3'" in p for p in problems)
+
+
+def test_v3_period_accepts_overtime():
+    ot = dict(NBA_STATS_SAMPLES["nba_stats_v3_period"])
+    ot["5"] = {"meta": {"request": "r", "time": "t", "version": 1}, "boxScoreTraditional": {}}
+    assert validate_payload("nba_stats_v3_period", ot) == []

--- a/tests/test_raw_schemas.py
+++ b/tests/test_raw_schemas.py
@@ -279,8 +279,10 @@ def test_v3_requires_an_entity_body_not_just_meta():
     assert problems and "expected one" in problems[0]
 
 
-@pytest.mark.parametrize("entity", ["game", "leagueSchedule", "scoreboard", "boxScoreUsage"])
+@pytest.mark.parametrize("entity", sorted(load_raw_schema("nba_stats_v3")["required_any"][0]))
 def test_v3_accepts_each_observed_entity_key(entity):
+    """Parametrized FROM the schema, so a newly-observed entity key is covered
+    the moment it is declared rather than whenever someone remembers this list."""
     payload = {"meta": {"request": "r", "time": "t", "version": 1}, entity: {}}
     assert validate_payload("nba_stats_v3", payload) == []
 
@@ -297,3 +299,47 @@ def test_v3_period_accepts_overtime():
     ot = dict(NBA_STATS_SAMPLES["nba_stats_v3_period"])
     ot["5"] = {"meta": {"request": "r", "time": "t", "version": 1}, "boxScoreTraditional": {}}
     assert validate_payload("nba_stats_v3_period", ot) == []
+
+
+def test_v3_period_rejects_a_map_of_empty_periods():
+    """`values_of` -- each period is validated as a full nba_stats_v3 payload.
+
+    Without it this passes: the four required keys are present and each holds
+    *a* dict. It is a capture that lost every payload body, which is exactly
+    the corruption these schemas exist to catch.
+    """
+    problems = validate_payload("nba_stats_v3_period", {str(p): {} for p in range(1, 5)})
+    assert problems
+    assert any("[1]" in p for p in problems), problems
+
+
+def test_v3_period_reports_which_period_is_bad():
+    payload = dict(NBA_STATS_SAMPLES["nba_stats_v3_period"])
+    payload["3"] = {"meta": {"version": 1}}  # entity body dropped
+    problems = validate_payload("nba_stats_v3_period", payload)
+    assert any("[3]" in p and "expected one" in p for p in problems), problems
+
+
+def test_v3_period_rejects_a_non_dict_period():
+    payload = dict(NBA_STATS_SAMPLES["nba_stats_v3_period"])
+    payload["2"] = "not-a-payload"
+    assert validate_payload("nba_stats_v3_period", payload)
+
+
+def test_required_any_tolerates_a_bare_string_group():
+    """`required_any: [foo]` instead of `[[foo]]` is an easy YAML slip.
+
+    Iterating the string would test the payload for single CHARACTERS and
+    report nonsense, so a bare string is treated as a one-key group.
+    """
+    from sportsdataverse import schemas
+
+    schema = {"required": {}, "required_any": ["meta"], "additional_properties": True}
+    monkey = schemas.load_raw_schema
+    try:
+        schemas.load_raw_schema = lambda _n: schema
+        assert schemas.validate_payload("x", {"meta": {}}) == []
+        problems = schemas.validate_payload("x", {"other": 1})
+        assert problems and "'meta'" in problems[0]
+    finally:
+        schemas.load_raw_schema = monkey


### PR DESCRIPTION
Declares the raw payload shapes for `stats.nba.com` / `stats.wnba.com`, extending the seven ESPN families already in `sportsdataverse/schemas/`.

## The envelope is not uniform — there are five families

The working assumption for this task was a single `{resultSets: [{name, headers, rowSet}]}` shape. Probing the committed `hoopR-nba-stats-raw` tree (**489,977 files, 64 endpoint dirs**) found five, and the assumed one covers a minority of the archive:

| schema | shape | endpoints |
|---|---|---:|
| `nba_stats_result_sets` | classic; `resultSets` is a **list** | 35 |
| `nba_stats_result_set` | **singular** key, dict value | 3 |
| `nba_stats_result_sets_grouped` | plural key but **dict** value, and `headers` is a list of column-**group** dicts (`columnNames`/`columnSpan`/`columnsToSkip`) rather than name strings | 2 |
| `nba_stats_v3` | modern `{<entity>, meta}` tree — **no `resultSets` at all** | 13 |
| `nba_stats_v3_period` | period-number map of v3 payloads | 1 |

`nba_stats_v3` is the **bulk of the tree**: `boxscoretraditionalv3` and `playbyplayv3` are 39,244 files each, and the v3 box scores plus pbp and the schedule are ~340k of the 490k payloads. A single result-sets schema would have described roughly 20% of the archive and silently ignored the rest.

Two edges worth calling out:

- **`resultSet` vs `resultSets`** is a genuinely different key, not a list of length one. Reading a singular payload with the plural path finds nothing. A test pins that they are not interchangeable.
- **The grouped family's `headers` are dicts.** A parser assuming flat string headers mis-reads the shot-zone column bands entirely. Related latent hazard documented in the schema: `season_capture._ids_from()` iterates `payload.get("resultSets") or []` and calls `.get()` on each element — against this family that iterates the dict's *keys* (strings) and would `AttributeError`. It doesn't fire today only because `_ids_from` is pointed exclusively at family-A payloads.

## New DSL knob: `required_any`

The v3 entity key is named per endpoint (`boxScoreTraditional`, `game`, `leagueSchedule`, `scoreboard`, …). Requiring only `meta` would let a payload whose body was dropped validate clean; a schema per entity key would be a dozen near-identical files. `required_any` says "at least one of these keys must be present" — six lines in `validate_payload`.

## Validated against the real archive, not the inline samples

8,608 payloads sampled across **54 endpoint directories** were auto-classified from their keys and validated:

```
checked            : 10319
empty ({})         : 1711
classified         :  8608
unclassified       :     0
VALIDATION FAILURES:     0
```

Zero unclassified means the five families are exhaustive for this archive; zero failures means each one describes what it claims to.

## The `{}` assertion is load-bearing

The suite pins that an empty payload fails **every** family, because the same probe found a real corruption:

> **3,347 committed files are exactly `{}`.** Ten endpoints are **100% empty** — `playergamelogs` (553), `teamgamelogs` (550), `playercompare` (555), `matchupsrollup` (80), `leaguedashptteamdefend` (88) and five `draftcombine*` (31 each) — plus **71% of both shot-locations endpoints** (1,239 files).

They persist because that scraper's `write_payload()` has no guard and its resume check is `path.exists()` — **presence, not content** — so one empty write is never retried and a backfill no-ops.

`{}` is not a shape the API produces: an endpoint with no rows still returns the full envelope with `rowSet: []` (see `leagueleaders/1996/playoffs_pergame.json`). So these are failed fetches that were persisted as if they were data.

Note the discriminator is `size <= 2`, not "small": `playbyplayv3/1996/0029500001.json` is a valid 201-byte envelope whose `game.actions` is `[]` — v3 pbp genuinely has no actions that far back, and that file is correct.

Repair of the archive is tracked separately in the `-raw` repo; this PR gives it the detector.

## Verification

```
uv run pytest tests/test_raw_schemas.py  -> 57 passed
uv run ruff check                        -> All checks passed
uv run python tools/codegen/generate.py --check -> all generated files current
```

## Summary by Sourcery

Add raw schema support for the five distinct stats.nba.com / stats.wnba.com payload families and enforce their validation semantics, including detection of corrupted empty captures.

New Features:
- Introduce schemas for nba_stats_result_sets, nba_stats_result_set, nba_stats_result_sets_grouped, nba_stats_v3, and nba_stats_v3_period raw payloads.
- Add support for schema-level required_any key groups to validate v3 envelopes with endpoint-specific entity keys.

Enhancements:
- Document multi-envelope behavior for stats.nba.com providers and map each new schema to its corresponding raw file pattern.
- Extend validate_payload to enforce required_any groups while preserving tolerance for unknown keys.

Tests:
- Add comprehensive tests covering all nba_stats families, including acceptance of real-shaped samples, rejection of empty payloads, key non-interchangeability, v3 entity-key requirements, and period completeness/OT handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation support for five NBA statistics payload formats, including classic, singular, grouped, modern v3, and period-based responses.
  * Added support for required regulation periods and optional overtime periods.
  * Improved detection of incomplete, malformed, or incorrectly structured nested payloads while allowing additional fields.

* **Documentation**
  * Documented supported NBA payload structures and validation requirements.

* **Tests**
  * Added comprehensive NBA and WNBA coverage for valid, invalid, empty, singular, plural, grouped, v3, and overtime payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->