### PR TITLE
feat(mbb,wbb): NCAA<->ESPN team-id crosswalk + fix season_group_children pagination

### DIFF
--- a/docs/docs/bundesliga/reference/core.md
+++ b/docs/docs/bundesliga/reference/core.md
@@ -250,6 +250,7 @@ ESPN endpoint.
 | `season` | `season` |  | `Y` |  | season path parameter. |
 | `season_type` | `season_type` |  | `Y` |  | season_type path parameter. |
 | `group_id` | `group_id` |  | `Y` |  | group_id path parameter. |
+| `limit` | `limit` |  |  | `Y` | Maximum number of items to return. |
 
 ### Returns
 

--- a/docs/docs/cfb/reference/core.md
+++ b/docs/docs/cfb/reference/core.md
@@ -250,6 +250,7 @@ ESPN endpoint.
 | `season` | `season` |  | `Y` |  | season path parameter. |
 | `season_type` | `season_type` |  | `Y` |  | season_type path parameter. |
 | `group_id` | `group_id` |  | `Y` |  | group_id path parameter. |
+| `limit` | `limit` |  |  | `Y` | Maximum number of items to return. |
 
 ### Returns
 

--- a/docs/docs/cfl/reference/core.md
+++ b/docs/docs/cfl/reference/core.md
@@ -250,6 +250,7 @@ ESPN endpoint.
 | `season` | `season` |  | `Y` |  | season path parameter. |
 | `season_type` | `season_type` |  | `Y` |  | season_type path parameter. |
 | `group_id` | `group_id` |  | `Y` |  | group_id path parameter. |
+| `limit` | `limit` |  |  | `Y` | Maximum number of items to return. |
 
 ### Returns
 

--- a/docs/docs/college_baseball/reference/core.md
+++ b/docs/docs/college_baseball/reference/core.md
@@ -250,6 +250,7 @@ ESPN endpoint.
 | `season` | `season` |  | `Y` |  | season path parameter. |
 | `season_type` | `season_type` |  | `Y` |  | season_type path parameter. |
 | `group_id` | `group_id` |  | `Y` |  | group_id path parameter. |
+| `limit` | `limit` |  |  | `Y` | Maximum number of items to return. |
 
 ### Returns
 

--- a/docs/docs/college_softball/reference/core.md
+++ b/docs/docs/college_softball/reference/core.md
@@ -250,6 +250,7 @@ ESPN endpoint.
 | `season` | `season` |  | `Y` |  | season path parameter. |
 | `season_type` | `season_type` |  | `Y` |  | season_type path parameter. |
 | `group_id` | `group_id` |  | `Y` |  | group_id path parameter. |
+| `limit` | `limit` |  |  | `Y` | Maximum number of items to return. |
 
 ### Returns
 

--- a/docs/docs/cricket/reference/core.md
+++ b/docs/docs/cricket/reference/core.md
@@ -250,6 +250,7 @@ ESPN endpoint.
 | `season` | `season` |  | `Y` |  | season path parameter. |
 | `season_type` | `season_type` |  | `Y` |  | season_type path parameter. |
 | `group_id` | `group_id` |  | `Y` |  | group_id path parameter. |
+| `limit` | `limit` |  |  | `Y` | Maximum number of items to return. |
 
 ### Returns
 

--- a/docs/docs/epl/reference/core.md
+++ b/docs/docs/epl/reference/core.md
@@ -250,6 +250,7 @@ ESPN endpoint.
 | `season` | `season` |  | `Y` |  | season path parameter. |
 | `season_type` | `season_type` |  | `Y` |  | season_type path parameter. |
 | `group_id` | `group_id` |  | `Y` |  | group_id path parameter. |
+| `limit` | `limit` |  |  | `Y` | Maximum number of items to return. |
 
 ### Returns
 

--- a/docs/docs/laliga/reference/core.md
+++ b/docs/docs/laliga/reference/core.md
@@ -250,6 +250,7 @@ ESPN endpoint.
 | `season` | `season` |  | `Y` |  | season path parameter. |
 | `season_type` | `season_type` |  | `Y` |  | season_type path parameter. |
 | `group_id` | `group_id` |  | `Y` |  | group_id path parameter. |
+| `limit` | `limit` |  |  | `Y` | Maximum number of items to return. |
 
 ### Returns
 

--- a/docs/docs/ligamx/reference/core.md
+++ b/docs/docs/ligamx/reference/core.md
@@ -250,6 +250,7 @@ ESPN endpoint.
 | `season` | `season` |  | `Y` |  | season path parameter. |
 | `season_type` | `season_type` |  | `Y` |  | season_type path parameter. |
 | `group_id` | `group_id` |  | `Y` |  | group_id path parameter. |
+| `limit` | `limit` |  |  | `Y` | Maximum number of items to return. |
 
 ### Returns
 

--- a/docs/docs/ligue1/reference/core.md
+++ b/docs/docs/ligue1/reference/core.md
@@ -250,6 +250,7 @@ ESPN endpoint.
 | `season` | `season` |  | `Y` |  | season path parameter. |
 | `season_type` | `season_type` |  | `Y` |  | season_type path parameter. |
 | `group_id` | `group_id` |  | `Y` |  | group_id path parameter. |
+| `limit` | `limit` |  |  | `Y` | Maximum number of items to return. |
 
 ### Returns
 

--- a/docs/docs/mbb/index.md
+++ b/docs/docs/mbb/index.md
@@ -10,7 +10,7 @@ sidebar_label: MBB
 | [ESPN web API (v3)](reference/web) | 5 | `https://site.web.api.espn.com/apis/common/v3/sports` |
 | [ESPN core API (v2)](reference/core) | 86 | `https://sports.core.api.espn.com/v2/sports` |
 | [Dataset loaders](reference/loaders) | 13 | sportsdataverse-data releases |
-| [Additional functions](reference/additional) | 304 | hand-written wrappers, loaders & helpers |
+| [Additional functions](reference/additional) | 305 | hand-written wrappers, loaders & helpers |
 
 ## Examples
 

--- a/docs/docs/mbb/reference/additional.md
+++ b/docs/docs/mbb/reference/additional.md
@@ -7122,6 +7122,42 @@ reject initials-only roster rows).
 
 `(p1, p2)` -- `p1` is the leading initial in a `"A B"`-style string, or the trailing initial in a `"B, A"`-style string; `None` if `name` doesn't fit either 3- or 4-character shape.
 
+### `ncaa_espn_team_crosswalk(league: 'str' = 'mbb', *, return_as_pandas: 'bool' = False) -> "Union[pl.DataFrame, 'pd.DataFrame']"` {#ncaa_espn_team_crosswalk}
+
+Season-keyed stats.ncaa.org -> ESPN team-id crosswalk.
+
+One row per `(season, ncaa_team_id)`. Teams that could not be resolved to
+an ESPN team are kept with a null `espn_team_id` and
+`match_method="unmatched"` -- never dropped -- so the row count always
+equals `ncaa_{league}_team_ids()`.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `league` | `str` | `'mbb'` | `"mbb"` (men's, 2009-10 onward) or `"wbb"` (women's). |
+| `return_as_pandas` | `bool` | `False` | Return a pandas DataFrame instead of polars. |
+
+**Returns**
+
+DataFrame with columns `season` (str, `"YYYY-YY"`), `ncaa_team_id` (Int64 -- the season-specific stats.ncaa.org id), `ncaa_team` / `ncaa_conference` (str), `espn_team_id` (str, nullable -- ESPN ids are strings throughout sdv-py), `espn_display_name` / `espn_location` / `espn_mascot` / `espn_abbreviation` / `espn_conference_name` / `espn_conference_id` (str, nullable), and `match_method` (str -- `"exact"`, `"dict"`, `"alias"` or `"unmatched"`).
+
+**Example**
+
+```python
+from sportsdataverse.mbb import ncaa_espn_team_crosswalk
+df = ncaa_espn_team_crosswalk()
+print(df.shape)
+
+# Women's crosswalk as pandas
+
+wdf = ncaa_espn_team_crosswalk(league="wbb", return_as_pandas=True)
+
+# Pipeline next step (one line)
+
+df.filter(pl.col("season") == "2025-26").select("ncaa_team_id", "espn_team_id")
+```
+
 ### `ncaa_mbb_box_scores(game_ids: 'Union[str, int, Iterable[Union[str, int]]]', *, multi_games: 'bool' = False, fetcher: 'Optional[_SupportsFetchIndividualStats]' = None, return_as_pandas: 'bool' = False) -> "'Union[pl.DataFrame, pd.DataFrame]'"` {#ncaa_mbb_box_scores}
 
 Box scores for one or more NCAA games (bigballR `get_box_scores` port).

--- a/docs/docs/mbb/reference/core.md
+++ b/docs/docs/mbb/reference/core.md
@@ -250,6 +250,7 @@ ESPN endpoint.
 | `season` | `season` |  | `Y` |  | season path parameter. |
 | `season_type` | `season_type` |  | `Y` |  | season_type path parameter. |
 | `group_id` | `group_id` |  | `Y` |  | group_id path parameter. |
+| `limit` | `limit` |  |  | `Y` | Maximum number of items to return. |
 
 ### Returns
 

--- a/docs/docs/mch/reference/core.md
+++ b/docs/docs/mch/reference/core.md
@@ -250,6 +250,7 @@ ESPN endpoint.
 | `season` | `season` |  | `Y` |  | season path parameter. |
 | `season_type` | `season_type` |  | `Y` |  | season_type path parameter. |
 | `group_id` | `group_id` |  | `Y` |  | group_id path parameter. |
+| `limit` | `limit` |  |  | `Y` | Maximum number of items to return. |
 
 ### Returns
 

--- a/docs/docs/mlb/reference/core.md
+++ b/docs/docs/mlb/reference/core.md
@@ -250,6 +250,7 @@ ESPN endpoint.
 | `season` | `season` |  | `Y` |  | season path parameter. |
 | `season_type` | `season_type` |  | `Y` |  | season_type path parameter. |
 | `group_id` | `group_id` |  | `Y` |  | group_id path parameter. |
+| `limit` | `limit` |  |  | `Y` | Maximum number of items to return. |
 
 ### Returns
 

--- a/docs/docs/mls/reference/core.md
+++ b/docs/docs/mls/reference/core.md
@@ -250,6 +250,7 @@ ESPN endpoint.
 | `season` | `season` |  | `Y` |  | season path parameter. |
 | `season_type` | `season_type` |  | `Y` |  | season_type path parameter. |
 | `group_id` | `group_id` |  | `Y` |  | group_id path parameter. |
+| `limit` | `limit` |  |  | `Y` | Maximum number of items to return. |
 
 ### Returns
 

--- a/docs/docs/nba/reference/core.md
+++ b/docs/docs/nba/reference/core.md
@@ -250,6 +250,7 @@ ESPN endpoint.
 | `season` | `season` |  | `Y` |  | season path parameter. |
 | `season_type` | `season_type` |  | `Y` |  | season_type path parameter. |
 | `group_id` | `group_id` |  | `Y` |  | group_id path parameter. |
+| `limit` | `limit` |  |  | `Y` | Maximum number of items to return. |
 
 ### Returns
 

--- a/docs/docs/nfl/reference/core.md
+++ b/docs/docs/nfl/reference/core.md
@@ -250,6 +250,7 @@ ESPN endpoint.
 | `season` | `season` |  | `Y` |  | season path parameter. |
 | `season_type` | `season_type` |  | `Y` |  | season_type path parameter. |
 | `group_id` | `group_id` |  | `Y` |  | group_id path parameter. |
+| `limit` | `limit` |  |  | `Y` | Maximum number of items to return. |
 
 ### Returns
 

--- a/docs/docs/nhl/reference/core.md
+++ b/docs/docs/nhl/reference/core.md
@@ -250,6 +250,7 @@ ESPN endpoint.
 | `season` | `season` |  | `Y` |  | season path parameter. |
 | `season_type` | `season_type` |  | `Y` |  | season_type path parameter. |
 | `group_id` | `group_id` |  | `Y` |  | group_id path parameter. |
+| `limit` | `limit` |  |  | `Y` | Maximum number of items to return. |
 
 ### Returns
 

--- a/docs/docs/nwsl/reference/core.md
+++ b/docs/docs/nwsl/reference/core.md
@@ -250,6 +250,7 @@ ESPN endpoint.
 | `season` | `season` |  | `Y` |  | season path parameter. |
 | `season_type` | `season_type` |  | `Y` |  | season_type path parameter. |
 | `group_id` | `group_id` |  | `Y` |  | group_id path parameter. |
+| `limit` | `limit` |  |  | `Y` | Maximum number of items to return. |
 
 ### Returns
 

--- a/docs/docs/seriea/reference/core.md
+++ b/docs/docs/seriea/reference/core.md
@@ -250,6 +250,7 @@ ESPN endpoint.
 | `season` | `season` |  | `Y` |  | season path parameter. |
 | `season_type` | `season_type` |  | `Y` |  | season_type path parameter. |
 | `group_id` | `group_id` |  | `Y` |  | group_id path parameter. |
+| `limit` | `limit` |  |  | `Y` | Maximum number of items to return. |
 
 ### Returns
 

--- a/docs/docs/soccer/reference/core.md
+++ b/docs/docs/soccer/reference/core.md
@@ -250,6 +250,7 @@ ESPN endpoint.
 | `season` | `season` |  | `Y` |  | season path parameter. |
 | `season_type` | `season_type` |  | `Y` |  | season_type path parameter. |
 | `group_id` | `group_id` |  | `Y` |  | group_id path parameter. |
+| `limit` | `limit` |  |  | `Y` | Maximum number of items to return. |
 
 ### Returns
 

--- a/docs/docs/ucl/reference/core.md
+++ b/docs/docs/ucl/reference/core.md
@@ -250,6 +250,7 @@ ESPN endpoint.
 | `season` | `season` |  | `Y` |  | season path parameter. |
 | `season_type` | `season_type` |  | `Y` |  | season_type path parameter. |
 | `group_id` | `group_id` |  | `Y` |  | group_id path parameter. |
+| `limit` | `limit` |  |  | `Y` | Maximum number of items to return. |
 
 ### Returns
 

--- a/docs/docs/uel/reference/core.md
+++ b/docs/docs/uel/reference/core.md
@@ -250,6 +250,7 @@ ESPN endpoint.
 | `season` | `season` |  | `Y` |  | season path parameter. |
 | `season_type` | `season_type` |  | `Y` |  | season_type path parameter. |
 | `group_id` | `group_id` |  | `Y` |  | group_id path parameter. |
+| `limit` | `limit` |  |  | `Y` | Maximum number of items to return. |
 
 ### Returns
 

--- a/docs/docs/ufl/reference/core.md
+++ b/docs/docs/ufl/reference/core.md
@@ -250,6 +250,7 @@ ESPN endpoint.
 | `season` | `season` |  | `Y` |  | season path parameter. |
 | `season_type` | `season_type` |  | `Y` |  | season_type path parameter. |
 | `group_id` | `group_id` |  | `Y` |  | group_id path parameter. |
+| `limit` | `limit` |  |  | `Y` | Maximum number of items to return. |
 
 ### Returns
 

--- a/docs/docs/wbb/index.md
+++ b/docs/docs/wbb/index.md
@@ -10,7 +10,7 @@ sidebar_label: WBB
 | [ESPN web API (v3)](reference/web) | 5 | `https://site.web.api.espn.com/apis/common/v3/sports` |
 | [ESPN core API (v2)](reference/core) | 85 | `https://sports.core.api.espn.com/v2/sports` |
 | [Dataset loaders](reference/loaders) | 13 | sportsdataverse-data releases |
-| [Additional functions](reference/additional) | 281 | hand-written wrappers, loaders & helpers |
+| [Additional functions](reference/additional) | 282 | hand-written wrappers, loaders & helpers |
 
 ## Examples
 

--- a/docs/docs/wbb/reference/additional.md
+++ b/docs/docs/wbb/reference/additional.md
@@ -6314,6 +6314,42 @@ misspellings(TeamId("Some Unlisted Team"))  # {} (generic fallback)
 misspellings(None)  # {} (generic fallback)
 ```
 
+### `ncaa_espn_team_crosswalk(league: 'str' = 'mbb', *, return_as_pandas: 'bool' = False) -> "Union[pl.DataFrame, 'pd.DataFrame']"` {#ncaa_espn_team_crosswalk}
+
+Season-keyed stats.ncaa.org -> ESPN team-id crosswalk.
+
+One row per `(season, ncaa_team_id)`. Teams that could not be resolved to
+an ESPN team are kept with a null `espn_team_id` and
+`match_method="unmatched"` -- never dropped -- so the row count always
+equals `ncaa_{league}_team_ids()`.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `league` | `str` | `'mbb'` | `"mbb"` (men's, 2009-10 onward) or `"wbb"` (women's). |
+| `return_as_pandas` | `bool` | `False` | Return a pandas DataFrame instead of polars. |
+
+**Returns**
+
+DataFrame with columns `season` (str, `"YYYY-YY"`), `ncaa_team_id` (Int64 -- the season-specific stats.ncaa.org id), `ncaa_team` / `ncaa_conference` (str), `espn_team_id` (str, nullable -- ESPN ids are strings throughout sdv-py), `espn_display_name` / `espn_location` / `espn_mascot` / `espn_abbreviation` / `espn_conference_name` / `espn_conference_id` (str, nullable), and `match_method` (str -- `"exact"`, `"dict"`, `"alias"` or `"unmatched"`).
+
+**Example**
+
+```python
+from sportsdataverse.mbb import ncaa_espn_team_crosswalk
+df = ncaa_espn_team_crosswalk()
+print(df.shape)
+
+# Women's crosswalk as pandas
+
+wdf = ncaa_espn_team_crosswalk(league="wbb", return_as_pandas=True)
+
+# Pipeline next step (one line)
+
+df.filter(pl.col("season") == "2025-26").select("ncaa_team_id", "espn_team_id")
+```
+
 ### `ncaa_wbb_box_scores(game_ids: 'Union[str, int, Iterable[Union[str, int]]]', *, multi_games: 'bool' = False, fetcher: 'Optional[Any]' = None, return_as_pandas: 'bool' = False) -> "Union['pl.DataFrame', 'pd.DataFrame']"` {#ncaa_wbb_box_scores}
 
 Scrape WBB per-player box scores (wbigballR `get_box_scores`/`scrape_box`).

--- a/docs/docs/wbb/reference/core.md
+++ b/docs/docs/wbb/reference/core.md
@@ -250,6 +250,7 @@ ESPN endpoint.
 | `season` | `season` |  | `Y` |  | season path parameter. |
 | `season_type` | `season_type` |  | `Y` |  | season_type path parameter. |
 | `group_id` | `group_id` |  | `Y` |  | group_id path parameter. |
+| `limit` | `limit` |  |  | `Y` | Maximum number of items to return. |
 
 ### Returns
 

--- a/docs/docs/wc/reference/core.md
+++ b/docs/docs/wc/reference/core.md
@@ -250,6 +250,7 @@ ESPN endpoint.
 | `season` | `season` |  | `Y` |  | season path parameter. |
 | `season_type` | `season_type` |  | `Y` |  | season_type path parameter. |
 | `group_id` | `group_id` |  | `Y` |  | group_id path parameter. |
+| `limit` | `limit` |  |  | `Y` | Maximum number of items to return. |
 
 ### Returns
 

--- a/docs/docs/wch/reference/core.md
+++ b/docs/docs/wch/reference/core.md
@@ -250,6 +250,7 @@ ESPN endpoint.
 | `season` | `season` |  | `Y` |  | season path parameter. |
 | `season_type` | `season_type` |  | `Y` |  | season_type path parameter. |
 | `group_id` | `group_id` |  | `Y` |  | group_id path parameter. |
+| `limit` | `limit` |  |  | `Y` | Maximum number of items to return. |
 
 ### Returns
 

--- a/docs/docs/wnba/reference/core.md
+++ b/docs/docs/wnba/reference/core.md
@@ -250,6 +250,7 @@ ESPN endpoint.
 | `season` | `season` |  | `Y` |  | season path parameter. |
 | `season_type` | `season_type` |  | `Y` |  | season_type path parameter. |
 | `group_id` | `group_id` |  | `Y` |  | group_id path parameter. |
+| `limit` | `limit` |  |  | `Y` | Maximum number of items to return. |
 
 ### Returns
 

--- a/docs/docs/wwc/reference/core.md
+++ b/docs/docs/wwc/reference/core.md
@@ -250,6 +250,7 @@ ESPN endpoint.
 | `season` | `season` |  | `Y` |  | season path parameter. |
 | `season_type` | `season_type` |  | `Y` |  | season_type path parameter. |
 | `group_id` | `group_id` |  | `Y` |  | group_id path parameter. |
+| `limit` | `limit` |  |  | `Y` | Maximum number of items to return. |
 
 ### Returns
 

--- a/docs/docs/xfl/reference/core.md
+++ b/docs/docs/xfl/reference/core.md
@@ -250,6 +250,7 @@ ESPN endpoint.
 | `season` | `season` |  | `Y` |  | season path parameter. |
 | `season_type` | `season_type` |  | `Y` |  | season_type path parameter. |
 | `group_id` | `group_id` |  | `Y` |  | group_id path parameter. |
+| `limit` | `limit` |  |  | `Y` | Maximum number of items to return. |
 
 ### Returns
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -533,6 +533,7 @@ files = [
     "sportsdataverse/mbb/mbb_ncaa_scoreboard.py",
     "sportsdataverse/mbb/mbb_ncaa_shots.py",
     "sportsdataverse/mbb/mbb_ncaa_stats_agg.py",
+    "sportsdataverse/mbb/mbb_ncaa_espn_crosswalk.py",
     "sportsdataverse/mbb/mbb_ncaa_team_ids.py",
     "sportsdataverse/wbb/wbb_ncaa_box_stats.py",
     "sportsdataverse/wbb/wbb_ncaa_box_tabs.py",

--- a/sportsdataverse/baseball/college_baseball/college_baseball_espn_ext.py
+++ b/sportsdataverse/baseball/college_baseball/college_baseball_espn_ext.py
@@ -1664,6 +1664,7 @@ def espn_college_baseball_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1680,6 +1681,7 @@ def espn_college_baseball_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1693,7 +1695,9 @@ def espn_college_baseball_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/baseball/leagues/college-baseball/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/sportsdataverse/baseball/college_softball/college_softball_espn_ext.py
+++ b/sportsdataverse/baseball/college_softball/college_softball_espn_ext.py
@@ -1664,6 +1664,7 @@ def espn_college_softball_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1680,6 +1681,7 @@ def espn_college_softball_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1693,7 +1695,9 @@ def espn_college_softball_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/baseball/leagues/college-softball/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/sportsdataverse/cfb/cfb_espn_ext.py
+++ b/sportsdataverse/cfb/cfb_espn_ext.py
@@ -1666,6 +1666,7 @@ def espn_cfb_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1682,6 +1683,7 @@ def espn_cfb_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1695,7 +1697,9 @@ def espn_cfb_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/sportsdataverse/cricket/cricket_espn_ext.py
+++ b/sportsdataverse/cricket/cricket_espn_ext.py
@@ -1665,6 +1665,7 @@ def espn_cricket_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1681,6 +1682,7 @@ def espn_cricket_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1694,7 +1696,9 @@ def espn_cricket_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/cricket/leagues/{league}/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/sportsdataverse/football/cfl/cfl_espn_ext.py
+++ b/sportsdataverse/football/cfl/cfl_espn_ext.py
@@ -1623,6 +1623,7 @@ def espn_cfl_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1639,6 +1640,7 @@ def espn_cfl_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1652,7 +1654,9 @@ def espn_cfl_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/football/leagues/cfl/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/sportsdataverse/football/ufl/ufl_espn_ext.py
+++ b/sportsdataverse/football/ufl/ufl_espn_ext.py
@@ -1623,6 +1623,7 @@ def espn_ufl_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1639,6 +1640,7 @@ def espn_ufl_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1652,7 +1654,9 @@ def espn_ufl_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/football/leagues/ufl/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/sportsdataverse/football/xfl/xfl_espn_ext.py
+++ b/sportsdataverse/football/xfl/xfl_espn_ext.py
@@ -1623,6 +1623,7 @@ def espn_xfl_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1639,6 +1640,7 @@ def espn_xfl_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1652,7 +1654,9 @@ def espn_xfl_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/football/leagues/xfl/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/sportsdataverse/hockey/mch/mch_espn_ext.py
+++ b/sportsdataverse/hockey/mch/mch_espn_ext.py
@@ -1664,6 +1664,7 @@ def espn_mch_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1680,6 +1681,7 @@ def espn_mch_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1693,7 +1695,9 @@ def espn_mch_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/hockey/leagues/mens-college-hockey/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/sportsdataverse/hockey/wch/wch_espn_ext.py
+++ b/sportsdataverse/hockey/wch/wch_espn_ext.py
@@ -1664,6 +1664,7 @@ def espn_wch_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1680,6 +1681,7 @@ def espn_wch_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1693,7 +1695,9 @@ def espn_wch_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/hockey/leagues/womens-college-hockey/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/sportsdataverse/mbb/__init__.py
+++ b/sportsdataverse/mbb/__init__.py
@@ -44,6 +44,7 @@ from sportsdataverse.mbb.mbb_ncaa_schedule import *
 from sportsdataverse.mbb.mbb_ncaa_scoreboard import *
 from sportsdataverse.mbb.mbb_ncaa_shots import *
 from sportsdataverse.mbb.mbb_ncaa_stats_agg import *
+from sportsdataverse.mbb.mbb_ncaa_espn_crosswalk import *
 from sportsdataverse.mbb.mbb_ncaa_team_ids import *
 from sportsdataverse.mbb.mbb_archetypes import *
 from sportsdataverse.mbb.mbb_box_bpm import *

--- a/sportsdataverse/mbb/data/ncaa_espn_team_crosswalk_mbb.csv
+++ b/sportsdataverse/mbb/data/ncaa_espn_team_crosswalk_mbb.csv
@@ -1,0 +1,6007 @@
+season,ncaa_team_id,ncaa_team,ncaa_conference,espn_team_id,espn_display_name,espn_location,espn_mascot,espn_abbreviation,espn_conference_name,espn_conference_id,match_method
+2009-10,51431,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2009-10,51381,Air Force,MWC,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2009-10,51088,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2009-10,51091,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2009-10,51089,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2009-10,51090,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2009-10,51094,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2009-10,51095,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2009-10,51096,App State,Sun Belt,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2009-10,51098,Arizona,Pac-12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Pac-12 Conference,21,exact
+2009-10,51097,Arizona St.,Pac-12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Pac-12 Conference,21,exact
+2009-10,51423,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2009-10,51100,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2009-10,51099,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2009-10,51382,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2009-10,51102,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2009-10,51103,Austin Peay,OVC,2046,Austin Peay Governors,Austin Peay,Governors,APSU,ASUN Conference,46,exact
+2009-10,51114,BYU,WCC,252,BYU Cougars,BYU,Cougars,BYU,West Coast Conference,29,exact
+2009-10,51104,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2009-10,51106,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2009-10,51429,Belmont,OVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2009-10,51107,Bethune-Cookman,MEAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2009-10,51108,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2009-10,51109,Boise St.,MWC,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2009-10,51110,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2009-10,51111,Boston U.,Patriot,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2009-10,51112,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2009-10,51113,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2009-10,51115,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2009-10,51116,Bryant,NEC,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2009-10,51117,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2009-10,51118,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2009-10,51119,Butler,Big East,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2009-10,51121,CSU Bakersfield,WAC,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2009-10,51125,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2009-10,51120,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2009-10,51123,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2009-10,51128,California,Pac-12,25,California Golden Bears,California,Golden Bears,CAL,Pac-12 Conference,21,exact
+2009-10,51133,Campbell,Big South,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Big South Conference,6,exact
+2009-10,51134,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Atlantic Athletic Conference,13,exact
+2009-10,51416,Central Ark.,Southland,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,ASUN Conference,46,exact
+2009-10,51136,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2009-10,51138,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2009-10,51105,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2009-10,51262,Charlotte,C-USA,2429,Charlotte 49ers,Charlotte,49ers,CLT,Conference USA,11,exact
+2009-10,51365,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2009-10,51139,Chicago St.,WAC,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Division I Independents,43,exact
+2009-10,51140,Cincinnati,AAC,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,American Athletic Conference,62,exact
+2009-10,51142,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2009-10,51143,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2009-10,51144,Coastal Carolina,Sun Belt,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2009-10,51417,Col. of Charleston,CAA,232,Charleston Cougars,Charleston,Cougars,COFC,Colonial Athletic Association,10,dict
+2009-10,51145,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2009-10,51147,Colorado,Pac-12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Pac-12 Conference,21,exact
+2009-10,51146,Colorado St.,MWC,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2009-10,51148,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2009-10,51150,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2009-10,51151,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2009-10,51152,Creighton,Big East,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2009-10,51153,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2009-10,51154,Davidson,Atlantic 10,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2009-10,51155,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2009-10,51156,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2009-10,51158,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Colonial Athletic Association,10,exact
+2009-10,51157,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2009-10,51159,Denver,Summit League,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,49,exact
+2009-10,51160,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2009-10,51161,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2009-10,51162,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Colonial Athletic Association,10,exact
+2009-10,51163,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2009-10,51164,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2009-10,51166,ETSU,SoCon,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2009-10,51165,East Carolina,AAC,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Athletic Conference,62,exact
+2009-10,51167,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2009-10,51168,Eastern Ky.,OVC,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,ASUN Conference,46,exact
+2009-10,51169,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2009-10,51170,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2009-10,51418,Elon,CAA,2210,Elon Phoenix,Elon,Phoenix,ELON,Colonial Athletic Association,10,exact
+2009-10,51171,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2009-10,51433,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,ASUN Conference,46,exact
+2009-10,51176,FIU,C-USA,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2009-10,51172,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Atlantic Athletic Conference,13,exact
+2009-10,51173,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2009-10,51175,Fla. Atlantic,C-USA,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,Conference USA,11,exact
+2009-10,51178,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2009-10,51174,Florida A&M,MEAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2009-10,51177,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2009-10,51179,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2009-10,51122,Fresno St.,MWC,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2009-10,51180,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2009-10,51184,Ga. Southern,Sun Belt,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2009-10,51419,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2009-10,51181,George Mason,Atlantic 10,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2009-10,51182,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2009-10,51183,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2009-10,51187,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2009-10,51185,Georgia St.,Sun Belt,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2009-10,51186,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2009-10,51188,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2009-10,51189,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2009-10,51408,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2009-10,51190,Hampton,Big South,2261,Hampton Pirates,Hampton,Pirates,HAMP,Colonial Athletic Association,10,exact
+2009-10,51191,Hartford,America East,42,Hartford Hawks,Hartford,Hawks,HART,Division I Independents,43,exact
+2009-10,51192,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2009-10,51193,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2009-10,51430,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2009-10,51194,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Colonial Athletic Association,10,exact
+2009-10,51195,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2009-10,51197,Houston,AAC,248,Houston Cougars,Houston,Cougars,HOU,American Athletic Conference,62,exact
+2009-10,51196,Houston Christian,Southland,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,exact
+2009-10,51198,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2009-10,51424,IUPUI,Horizon,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,alias
+2009-10,51200,Idaho,Big Sky,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2009-10,51199,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2009-10,51202,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2009-10,51201,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2009-10,51205,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2009-10,51204,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2009-10,51207,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Atlantic Athletic Conference,13,exact
+2009-10,51209,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2009-10,51208,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2009-10,51210,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2009-10,51212,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,ASUN Conference,46,exact
+2009-10,51211,Jacksonville St.,OVC,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,ASUN Conference,46,exact
+2009-10,51213,James Madison,CAA,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2009-10,51215,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2009-10,51425,Kansas City,WAC,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,49,exact
+2009-10,51214,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2009-10,51420,Kennesaw St.,ASUN,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,ASUN Conference,46,exact
+2009-10,51216,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2009-10,51217,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2009-10,51223,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2009-10,51229,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2009-10,51225,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2009-10,51218,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2009-10,51219,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2009-10,51220,Lamar University,Southland,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2009-10,51221,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2009-10,51222,Liberty,ASUN,2335,Liberty Flames,Liberty,Flames,LIB,ASUN Conference,46,exact
+2009-10,51432,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,ASUN Conference,46,exact
+2009-10,51101,Little Rock,Sun Belt,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2009-10,51124,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2009-10,51224,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2009-10,51356,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2009-10,51226,Louisiana Tech,C-USA,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2009-10,51227,Louisville,ACC,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2009-10,51230,Loyola Chicago,MVC,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2009-10,51228,Loyola Maryland,Patriot,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2009-10,51231,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2009-10,51232,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Atlantic Athletic Conference,13,exact
+2009-10,51233,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Atlantic Athletic Conference,13,exact
+2009-10,51234,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2009-10,51235,Marshall,C-USA,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2009-10,51237,Maryland,Big Ten,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2009-10,51239,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2009-10,51240,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2009-10,51241,Memphis,AAC,235,Memphis Tigers,Memphis,Tigers,MEM,American Athletic Conference,62,exact
+2009-10,51242,Mercer,SoCon,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2009-10,51244,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2009-10,51243,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2009-10,51246,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2009-10,51245,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2009-10,51247,Middle Tenn.,C-USA,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2009-10,51410,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2009-10,51248,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2009-10,51249,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2009-10,51250,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2009-10,51252,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2009-10,51354,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2009-10,51253,Monmouth,MAAC,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Colonial Athletic Association,10,exact
+2009-10,51255,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2009-10,51254,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2009-10,51256,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2009-10,51257,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2009-10,51258,Mount St. Mary's,NEC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Atlantic Athletic Conference,13,exact
+2009-10,51259,Murray St.,OVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2009-10,51276,N.C. A&T,MEAC,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Colonial Athletic Association,10,exact
+2009-10,51277,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2009-10,51278,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2009-10,51286,NIU,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2009-10,51269,NJIT,ASUN,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2009-10,51383,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2009-10,51265,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2009-10,51267,Nevada,MWC,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2009-10,51268,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2009-10,51271,New Mexico,MWC,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2009-10,51270,New Mexico St.,WAC,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Western Athletic Conference,30,exact
+2009-10,51272,New Orleans,Southland,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2009-10,51273,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Atlantic Athletic Conference,13,exact
+2009-10,51274,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2009-10,51275,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2009-10,51261,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2009-10,51280,North Dakota,Summit League,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,49,exact
+2009-10,51279,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,49,exact
+2009-10,51426,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,ASUN Conference,46,exact
+2009-10,51281,North Texas,C-USA,249,North Texas Mean Green,North Texas,Mean Green,UNT,Conference USA,11,exact
+2009-10,51283,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Colonial Athletic Association,10,exact
+2009-10,51284,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2009-10,51285,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2009-10,51289,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2009-10,51288,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2009-10,51290,Notre Dame,ACC,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2009-10,51291,Oakland,Horizon,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2009-10,51293,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2009-10,51292,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2009-10,51295,Oklahoma,Big 12,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Big 12 Conference,8,exact
+2009-10,51294,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2009-10,51296,Old Dominion,C-USA,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2009-10,51251,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2009-10,51297,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,49,exact
+2009-10,51299,Oregon,Pac-12,2483,Oregon Ducks,Oregon,Ducks,ORE,Pac-12 Conference,21,exact
+2009-10,51298,Oregon St.,Pac-12,204,Oregon State Beavers,Oregon State,Beavers,ORST,Pac-12 Conference,21,exact
+2009-10,51300,Pacific,WCC,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2009-10,51303,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2009-10,51302,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2009-10,51304,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2009-10,51305,Pittsburgh,ACC,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2009-10,51307,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2009-10,51306,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2009-10,51308,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2009-10,51421,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2009-10,51309,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2009-10,51310,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2009-10,51311,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2009-10,51206,Purdue Fort Wayne,Summit League,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2009-10,51312,Quinnipiac,MAAC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Atlantic Athletic Conference,13,exact
+2009-10,51313,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2009-10,51314,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2009-10,51315,Rice,C-USA,242,Rice Owls,Rice,Owls,RICE,Conference USA,11,exact
+2009-10,51316,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2009-10,51317,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Atlantic Athletic Conference,13,exact
+2009-10,51318,Robert Morris,NEC,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2009-10,51319,Rutgers,Big Ten,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2009-10,51358,SFA,Southland,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Western Athletic Conference,30,exact
+2009-10,51349,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2009-10,51350,SMU,AAC,2567,SMU Mustangs,SMU,Mustangs,SMU,American Athletic Conference,62,exact
+2009-10,51126,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2009-10,51320,Sacred Heart,NEC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Northeast Conference,19,exact
+2009-10,51323,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2009-10,51325,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2009-10,51326,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2009-10,51327,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2009-10,51328,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Atlantic Athletic Conference,13,exact
+2009-10,51329,Sam Houston,Southland,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Western Athletic Conference,30,exact
+2009-10,51330,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2009-10,51332,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2009-10,51331,San Diego St.,MWC,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2009-10,51333,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2009-10,51334,San Jose St.,MWC,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2009-10,51335,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2009-10,51336,Savannah St.,MEAC,2542,Savannah State Tigers,Savannah State,Tigers,SAV,,,alias
+2009-10,51422,Seattle U,WAC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,Western Athletic Conference,30,exact
+2009-10,51337,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2009-10,51338,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Atlantic Athletic Conference,13,exact
+2009-10,51339,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2009-10,51341,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2009-10,51340,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2009-10,51343,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,49,exact
+2009-10,51342,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,49,exact
+2009-10,51344,South Fla.,AAC,58,South Florida Bulls,South Florida,Bulls,USF,American Athletic Conference,62,exact
+2009-10,51345,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2009-10,51346,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2009-10,51347,Southern California,Pac-12,30,USC Trojans,USC,Trojans,USC,Pac-12 Conference,21,dict
+2009-10,51348,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2009-10,51351,Southern Miss.,C-USA,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2009-10,51352,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2009-10,51353,Southern Utah,Big Sky,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,Western Athletic Conference,30,exact
+2009-10,51321,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2009-10,51322,St. Francis Brooklyn,NEC,2597,St. Francis Brooklyn Terriers,St. Francis Brooklyn,Terriers,SFNY,Northeast Conference,19,exact
+2009-10,51324,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2009-10,51357,Stanford,Pac-12,24,Stanford Cardinal,Stanford,Cardinal,STAN,Pac-12 Conference,21,exact
+2009-10,51359,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,ASUN Conference,46,exact
+2009-10,51360,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Colonial Athletic Association,10,exact
+2009-10,51361,Syracuse,ACC,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2009-10,51369,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2009-10,51362,Temple,AAC,218,Temple Owls,Temple,Owls,TEM,American Athletic Conference,62,exact
+2009-10,51366,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2009-10,51363,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2009-10,51364,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2009-10,51373,Texas,Big 12,251,Texas Longhorns,Texas,Longhorns,TEX,Big 12 Conference,8,exact
+2009-10,51368,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2009-10,51370,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2009-10,51355,Texas St.,Sun Belt,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2009-10,51371,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2009-10,51141,The Citadel,SoCon,2643,The Citadel Bulldogs,The Citadel,Bulldogs,CIT,Southern Conference,24,exact
+2009-10,51376,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2009-10,51377,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Colonial Athletic Association,10,exact
+2009-10,51378,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2009-10,51379,Tulane,AAC,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Athletic Conference,62,exact
+2009-10,51380,Tulsa,AAC,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Athletic Conference,62,exact
+2009-10,51092,UAB,C-USA,5,UAB Blazers,UAB,Blazers,UAB,Conference USA,11,exact
+2009-10,51093,UAlbany,America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,exact
+2009-10,51129,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2009-10,51130,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2009-10,51132,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2009-10,51127,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2009-10,51137,UCF,AAC,2116,UCF Knights,UCF,Knights,UCF,American Athletic Conference,62,exact
+2009-10,51131,UCLA,Pac-12,26,UCLA Bruins,UCLA,Bruins,UCLA,Pac-12 Conference,21,exact
+2009-10,51149,UConn,AAC,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2009-10,51203,UIC,Horizon,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2009-10,51282,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2009-10,51236,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2009-10,51238,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2009-10,51260,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2009-10,51263,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2009-10,51264,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Colonial Athletic Association,10,exact
+2009-10,51287,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2009-10,51266,UNLV,MWC,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2009-10,51428,USC Upstate,Big South,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2009-10,51372,UT Arlington,Sun Belt,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,Western Athletic Conference,30,exact
+2009-10,51367,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2009-10,51374,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2009-10,51301,UTRGV,WAC,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Western Athletic Conference,30,dict
+2009-10,51375,UTSA,C-USA,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,Conference USA,11,exact
+2009-10,51385,Utah,Pac-12,254,Utah Utes,Utah,Utes,UTAH,Pac-12 Conference,21,exact
+2009-10,51384,Utah St.,MWC,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2009-10,51434,Utah Valley,WAC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,Western Athletic Conference,30,exact
+2009-10,51390,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2009-10,51391,VMI,SoCon,2678,VMI Keydets,VMI,Keydets,VMI,Southern Conference,24,exact
+2009-10,51386,Valparaiso,MVC,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2009-10,51387,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2009-10,51388,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2009-10,51389,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2009-10,51393,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2009-10,51392,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2009-10,51394,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2009-10,51395,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2009-10,51397,Washington,Pac-12,264,Washington Huskies,Washington,Huskies,WASH,Pac-12 Conference,21,exact
+2009-10,51396,Washington St.,Pac-12,265,Washington State Cougars,Washington State,Cougars,WSU,Pac-12 Conference,21,exact
+2009-10,51398,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2009-10,51399,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2009-10,51400,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2009-10,51401,Western Ill.,Summit League,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Summit League,49,exact
+2009-10,51402,Western Ky.,C-USA,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2009-10,51403,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2009-10,51404,Wichita St.,AAC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Athletic Conference,62,exact
+2009-10,51405,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Colonial Athletic Association,10,exact
+2009-10,51407,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2009-10,51409,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2009-10,51427,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2009-10,51411,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2009-10,51412,Wyoming,MWC,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2009-10,51413,Xavier,Big East,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2009-10,51414,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2009-10,51415,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2010-11,28588,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2010-11,28539,Air Force,MWC,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2010-11,28246,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2010-11,28249,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2010-11,28247,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2010-11,28248,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2010-11,28252,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2010-11,28253,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2010-11,28254,App State,Sun Belt,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2010-11,28256,Arizona,Pac-12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Pac-12 Conference,21,exact
+2010-11,28255,Arizona St.,Pac-12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Pac-12 Conference,21,exact
+2010-11,28580,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2010-11,28258,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2010-11,28257,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2010-11,28540,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2010-11,28260,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2010-11,28261,Austin Peay,OVC,2046,Austin Peay Governors,Austin Peay,Governors,APSU,ASUN Conference,46,exact
+2010-11,28272,BYU,WCC,252,BYU Cougars,BYU,Cougars,BYU,West Coast Conference,29,exact
+2010-11,28262,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2010-11,28264,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2010-11,28586,Belmont,OVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2010-11,28265,Bethune-Cookman,MEAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2010-11,28266,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2010-11,28267,Boise St.,MWC,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2010-11,28268,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2010-11,28269,Boston U.,Patriot,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2010-11,28270,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2010-11,28271,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2010-11,28273,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2010-11,28274,Bryant,NEC,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2010-11,28275,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2010-11,28276,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2010-11,28277,Butler,Big East,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2010-11,28279,CSU Bakersfield,WAC,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2010-11,28283,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2010-11,28278,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2010-11,28281,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2010-11,28286,California,Pac-12,25,California Golden Bears,California,Golden Bears,CAL,Pac-12 Conference,21,exact
+2010-11,28291,Campbell,Big South,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Big South Conference,6,exact
+2010-11,28292,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Atlantic Athletic Conference,13,exact
+2010-11,28573,Central Ark.,Southland,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,ASUN Conference,46,exact
+2010-11,28294,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2010-11,28296,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2010-11,28263,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2010-11,28420,Charlotte,C-USA,2429,Charlotte 49ers,Charlotte,49ers,CLT,Conference USA,11,exact
+2010-11,28523,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2010-11,28297,Chicago St.,WAC,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Division I Independents,43,exact
+2010-11,28298,Cincinnati,AAC,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,American Athletic Conference,62,exact
+2010-11,28300,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2010-11,28301,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2010-11,28302,Coastal Carolina,Sun Belt,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2010-11,28574,Col. of Charleston,CAA,232,Charleston Cougars,Charleston,Cougars,COFC,Colonial Athletic Association,10,dict
+2010-11,28303,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2010-11,28305,Colorado,Pac-12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Pac-12 Conference,21,exact
+2010-11,28304,Colorado St.,MWC,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2010-11,28306,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2010-11,28308,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2010-11,28309,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2010-11,28310,Creighton,Big East,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2010-11,28311,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2010-11,28312,Davidson,Atlantic 10,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2010-11,28313,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2010-11,28314,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2010-11,28316,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Colonial Athletic Association,10,exact
+2010-11,28315,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2010-11,28317,Denver,Summit League,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,49,exact
+2010-11,28318,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2010-11,28319,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2010-11,28320,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Colonial Athletic Association,10,exact
+2010-11,28321,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2010-11,28322,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2010-11,28324,ETSU,SoCon,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2010-11,28323,East Carolina,AAC,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Athletic Conference,62,exact
+2010-11,28325,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2010-11,28326,Eastern Ky.,OVC,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,ASUN Conference,46,exact
+2010-11,28327,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2010-11,28328,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2010-11,28575,Elon,CAA,2210,Elon Phoenix,Elon,Phoenix,ELON,Colonial Athletic Association,10,exact
+2010-11,28329,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2010-11,28590,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,ASUN Conference,46,exact
+2010-11,28334,FIU,C-USA,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2010-11,28330,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Atlantic Athletic Conference,13,exact
+2010-11,28331,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2010-11,28333,Fla. Atlantic,C-USA,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,Conference USA,11,exact
+2010-11,28336,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2010-11,28332,Florida A&M,MEAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2010-11,28335,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2010-11,28337,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2010-11,28280,Fresno St.,MWC,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2010-11,28338,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2010-11,28342,Ga. Southern,Sun Belt,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2010-11,28576,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2010-11,28339,George Mason,Atlantic 10,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2010-11,28340,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2010-11,28341,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2010-11,28345,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2010-11,28343,Georgia St.,Sun Belt,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2010-11,28344,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2010-11,28346,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2010-11,28347,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2010-11,28565,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2010-11,28348,Hampton,Big South,2261,Hampton Pirates,Hampton,Pirates,HAMP,Colonial Athletic Association,10,exact
+2010-11,28349,Hartford,America East,42,Hartford Hawks,Hartford,Hawks,HART,Division I Independents,43,exact
+2010-11,28350,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2010-11,28351,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2010-11,28587,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2010-11,28352,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Colonial Athletic Association,10,exact
+2010-11,28353,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2010-11,28355,Houston,AAC,248,Houston Cougars,Houston,Cougars,HOU,American Athletic Conference,62,exact
+2010-11,28354,Houston Christian,Southland,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,exact
+2010-11,28356,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2010-11,28581,IUPUI,Horizon,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,alias
+2010-11,28358,Idaho,Big Sky,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2010-11,28357,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2010-11,28360,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2010-11,28359,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2010-11,28363,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2010-11,28362,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2010-11,28365,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Atlantic Athletic Conference,13,exact
+2010-11,28367,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2010-11,28366,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2010-11,28368,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2010-11,28370,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,ASUN Conference,46,exact
+2010-11,28369,Jacksonville St.,OVC,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,ASUN Conference,46,exact
+2010-11,28371,James Madison,CAA,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2010-11,28373,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2010-11,28582,Kansas City,WAC,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,49,exact
+2010-11,28372,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2010-11,28577,Kennesaw St.,ASUN,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,ASUN Conference,46,exact
+2010-11,28374,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2010-11,28375,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2010-11,28381,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2010-11,28387,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2010-11,28383,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2010-11,28376,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2010-11,28377,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2010-11,28378,Lamar University,Southland,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2010-11,28379,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2010-11,28380,Liberty,ASUN,2335,Liberty Flames,Liberty,Flames,LIB,ASUN Conference,46,exact
+2010-11,28589,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,ASUN Conference,46,exact
+2010-11,28259,Little Rock,Sun Belt,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2010-11,28282,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2010-11,28382,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2010-11,28514,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2010-11,28384,Louisiana Tech,C-USA,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2010-11,28385,Louisville,ACC,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2010-11,28388,Loyola Chicago,MVC,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2010-11,28386,Loyola Maryland,Patriot,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2010-11,28389,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2010-11,28390,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Atlantic Athletic Conference,13,exact
+2010-11,28391,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Atlantic Athletic Conference,13,exact
+2010-11,28392,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2010-11,28393,Marshall,C-USA,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2010-11,28395,Maryland,Big Ten,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2010-11,28397,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2010-11,28398,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2010-11,28399,Memphis,AAC,235,Memphis Tigers,Memphis,Tigers,MEM,American Athletic Conference,62,exact
+2010-11,28400,Mercer,SoCon,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2010-11,28402,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2010-11,28401,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2010-11,28404,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2010-11,28403,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2010-11,28405,Middle Tenn.,C-USA,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2010-11,28567,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2010-11,28406,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2010-11,28407,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2010-11,28408,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2010-11,28410,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2010-11,28512,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2010-11,28411,Monmouth,MAAC,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Colonial Athletic Association,10,exact
+2010-11,28413,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2010-11,28412,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2010-11,28414,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2010-11,28415,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2010-11,28416,Mount St. Mary's,NEC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Atlantic Athletic Conference,13,exact
+2010-11,28417,Murray St.,OVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2010-11,28434,N.C. A&T,MEAC,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Colonial Athletic Association,10,exact
+2010-11,28435,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2010-11,28436,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2010-11,28444,NIU,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2010-11,28427,NJIT,ASUN,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2010-11,28541,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2010-11,28423,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2010-11,28425,Nevada,MWC,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2010-11,28426,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2010-11,28429,New Mexico,MWC,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2010-11,28428,New Mexico St.,WAC,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Western Athletic Conference,30,exact
+2010-11,28431,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Atlantic Athletic Conference,13,exact
+2010-11,28432,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2010-11,28433,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2010-11,28419,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2010-11,28438,North Dakota,Summit League,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,49,exact
+2010-11,28437,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,49,exact
+2010-11,28583,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,ASUN Conference,46,exact
+2010-11,28439,North Texas,C-USA,249,North Texas Mean Green,North Texas,Mean Green,UNT,Conference USA,11,exact
+2010-11,28441,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Colonial Athletic Association,10,exact
+2010-11,28442,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2010-11,28443,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2010-11,28447,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2010-11,28446,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2010-11,28448,Notre Dame,ACC,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2010-11,28449,Oakland,Horizon,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2010-11,28451,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2010-11,28450,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2010-11,28453,Oklahoma,Big 12,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Big 12 Conference,8,exact
+2010-11,28452,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2010-11,28454,Old Dominion,C-USA,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2010-11,28409,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2010-11,28455,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,49,exact
+2010-11,28457,Oregon,Pac-12,2483,Oregon Ducks,Oregon,Ducks,ORE,Pac-12 Conference,21,exact
+2010-11,28456,Oregon St.,Pac-12,204,Oregon State Beavers,Oregon State,Beavers,ORST,Pac-12 Conference,21,exact
+2010-11,28458,Pacific,WCC,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2010-11,28461,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2010-11,28460,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2010-11,28462,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2010-11,28463,Pittsburgh,ACC,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2010-11,28465,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2010-11,28464,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2010-11,28466,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2010-11,28578,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2010-11,28467,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2010-11,28468,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2010-11,28469,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2010-11,28364,Purdue Fort Wayne,Summit League,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2010-11,28470,Quinnipiac,MAAC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Atlantic Athletic Conference,13,exact
+2010-11,28471,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2010-11,28472,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2010-11,28473,Rice,C-USA,242,Rice Owls,Rice,Owls,RICE,Conference USA,11,exact
+2010-11,28474,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2010-11,28475,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Atlantic Athletic Conference,13,exact
+2010-11,28476,Robert Morris,NEC,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2010-11,28477,Rutgers,Big Ten,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2010-11,28516,SFA,Southland,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Western Athletic Conference,30,exact
+2010-11,28507,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2010-11,28508,SMU,AAC,2567,SMU Mustangs,SMU,Mustangs,SMU,American Athletic Conference,62,exact
+2010-11,28284,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2010-11,28478,Sacred Heart,NEC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Northeast Conference,19,exact
+2010-11,28481,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2010-11,28483,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2010-11,28484,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2010-11,28485,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2010-11,28486,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Atlantic Athletic Conference,13,exact
+2010-11,28487,Sam Houston,Southland,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Western Athletic Conference,30,exact
+2010-11,28488,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2010-11,28490,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2010-11,28489,San Diego St.,MWC,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2010-11,28491,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2010-11,28492,San Jose St.,MWC,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2010-11,28493,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2010-11,28494,Savannah St.,MEAC,2542,Savannah State Tigers,Savannah State,Tigers,SAV,,,alias
+2010-11,28579,Seattle U,WAC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,Western Athletic Conference,30,exact
+2010-11,28495,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2010-11,28496,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Atlantic Athletic Conference,13,exact
+2010-11,28497,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2010-11,28499,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2010-11,28498,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2010-11,28501,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,49,exact
+2010-11,28500,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,49,exact
+2010-11,28502,South Fla.,AAC,58,South Florida Bulls,South Florida,Bulls,USF,American Athletic Conference,62,exact
+2010-11,28503,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2010-11,28504,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2010-11,28505,Southern California,Pac-12,30,USC Trojans,USC,Trojans,USC,Pac-12 Conference,21,dict
+2010-11,28506,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2010-11,28509,Southern Miss.,C-USA,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2010-11,28510,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2010-11,28511,Southern Utah,Big Sky,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,Western Athletic Conference,30,exact
+2010-11,28479,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2010-11,28480,St. Francis Brooklyn,NEC,2597,St. Francis Brooklyn Terriers,St. Francis Brooklyn,Terriers,SFNY,Northeast Conference,19,exact
+2010-11,28482,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2010-11,28515,Stanford,Pac-12,24,Stanford Cardinal,Stanford,Cardinal,STAN,Pac-12 Conference,21,exact
+2010-11,28517,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,ASUN Conference,46,exact
+2010-11,28518,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Colonial Athletic Association,10,exact
+2010-11,28519,Syracuse,ACC,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2010-11,28527,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2010-11,28520,Temple,AAC,218,Temple Owls,Temple,Owls,TEM,American Athletic Conference,62,exact
+2010-11,28524,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2010-11,28521,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2010-11,28522,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2010-11,28531,Texas,Big 12,251,Texas Longhorns,Texas,Longhorns,TEX,Big 12 Conference,8,exact
+2010-11,28526,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2010-11,28528,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2010-11,28513,Texas St.,Sun Belt,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2010-11,28529,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2010-11,28299,The Citadel,SoCon,2643,The Citadel Bulldogs,The Citadel,Bulldogs,CIT,Southern Conference,24,exact
+2010-11,28534,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2010-11,28535,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Colonial Athletic Association,10,exact
+2010-11,28536,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2010-11,28537,Tulane,AAC,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Athletic Conference,62,exact
+2010-11,28538,Tulsa,AAC,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Athletic Conference,62,exact
+2010-11,28250,UAB,C-USA,5,UAB Blazers,UAB,Blazers,UAB,Conference USA,11,exact
+2010-11,28251,UAlbany,America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,exact
+2010-11,28287,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2010-11,28288,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2010-11,28290,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2010-11,28285,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2010-11,28295,UCF,AAC,2116,UCF Knights,UCF,Knights,UCF,American Athletic Conference,62,exact
+2010-11,28289,UCLA,Pac-12,26,UCLA Bruins,UCLA,Bruins,UCLA,Pac-12 Conference,21,exact
+2010-11,28307,UConn,AAC,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2010-11,28361,UIC,Horizon,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2010-11,28440,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2010-11,28394,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2010-11,28396,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2010-11,28418,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2010-11,28421,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2010-11,28422,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Colonial Athletic Association,10,exact
+2010-11,28445,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2010-11,28424,UNLV,MWC,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2010-11,28585,USC Upstate,Big South,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2010-11,28530,UT Arlington,Sun Belt,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,Western Athletic Conference,30,exact
+2010-11,28525,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2010-11,28532,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2010-11,28459,UTRGV,WAC,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Western Athletic Conference,30,dict
+2010-11,28533,UTSA,C-USA,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,Conference USA,11,exact
+2010-11,28543,Utah,Pac-12,254,Utah Utes,Utah,Utes,UTAH,Pac-12 Conference,21,exact
+2010-11,28542,Utah St.,MWC,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2010-11,28591,Utah Valley,WAC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,Western Athletic Conference,30,exact
+2010-11,28548,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2010-11,28549,VMI,SoCon,2678,VMI Keydets,VMI,Keydets,VMI,Southern Conference,24,exact
+2010-11,28544,Valparaiso,MVC,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2010-11,28545,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2010-11,28546,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2010-11,28547,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2010-11,28551,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2010-11,28550,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2010-11,28552,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2010-11,28553,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2010-11,28555,Washington,Pac-12,264,Washington Huskies,Washington,Huskies,WASH,Pac-12 Conference,21,exact
+2010-11,28554,Washington St.,Pac-12,265,Washington State Cougars,Washington State,Cougars,WSU,Pac-12 Conference,21,exact
+2010-11,28556,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2010-11,28557,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2010-11,28558,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2010-11,28559,Western Ill.,Summit League,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Summit League,49,exact
+2010-11,28560,Western Ky.,C-USA,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2010-11,28561,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2010-11,28562,Wichita St.,AAC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Athletic Conference,62,exact
+2010-11,28563,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Colonial Athletic Association,10,exact
+2010-11,28564,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2010-11,28566,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2010-11,28584,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2010-11,28568,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2010-11,28569,Wyoming,MWC,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2010-11,28570,Xavier,Big East,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2010-11,28571,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2010-11,28572,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2011-12,57342,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2011-12,57293,Air Force,MWC,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2011-12,57001,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2011-12,57004,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2011-12,57002,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2011-12,57003,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2011-12,57007,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2011-12,57008,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2011-12,57009,App State,Sun Belt,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2011-12,57011,Arizona,Pac-12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Pac-12 Conference,21,exact
+2011-12,57010,Arizona St.,Pac-12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Pac-12 Conference,21,exact
+2011-12,57334,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2011-12,57013,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2011-12,57012,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2011-12,57294,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2011-12,57015,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2011-12,57016,Austin Peay,OVC,2046,Austin Peay Governors,Austin Peay,Governors,APSU,ASUN Conference,46,exact
+2011-12,57027,BYU,WCC,252,BYU Cougars,BYU,Cougars,BYU,West Coast Conference,29,exact
+2011-12,57017,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2011-12,57019,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2011-12,57340,Belmont,OVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2011-12,57020,Bethune-Cookman,MEAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2011-12,57021,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2011-12,57022,Boise St.,MWC,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2011-12,57023,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2011-12,57024,Boston U.,Patriot,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2011-12,57025,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2011-12,57026,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2011-12,57028,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2011-12,57029,Bryant,NEC,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2011-12,57030,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2011-12,57031,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2011-12,57032,Butler,Big East,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2011-12,57034,CSU Bakersfield,WAC,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2011-12,57038,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2011-12,57033,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2011-12,57036,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2011-12,57041,California,Pac-12,25,California Golden Bears,California,Golden Bears,CAL,Pac-12 Conference,21,exact
+2011-12,57046,Campbell,Big South,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Big South Conference,6,exact
+2011-12,57047,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Atlantic Athletic Conference,13,exact
+2011-12,57327,Central Ark.,Southland,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,ASUN Conference,46,exact
+2011-12,57048,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2011-12,57050,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2011-12,57018,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2011-12,57174,Charlotte,C-USA,2429,Charlotte 49ers,Charlotte,49ers,CLT,Conference USA,11,exact
+2011-12,57277,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2011-12,57051,Chicago St.,WAC,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Division I Independents,43,exact
+2011-12,57052,Cincinnati,AAC,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,American Athletic Conference,62,exact
+2011-12,57054,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2011-12,57055,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2011-12,57056,Coastal Carolina,Sun Belt,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2011-12,57328,Col. of Charleston,CAA,232,Charleston Cougars,Charleston,Cougars,COFC,Colonial Athletic Association,10,dict
+2011-12,57057,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2011-12,57059,Colorado,Pac-12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Pac-12 Conference,21,exact
+2011-12,57058,Colorado St.,MWC,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2011-12,57060,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2011-12,57062,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2011-12,57063,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2011-12,57064,Creighton,Big East,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2011-12,57065,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2011-12,57066,Davidson,Atlantic 10,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2011-12,57067,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2011-12,57068,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2011-12,57070,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Colonial Athletic Association,10,exact
+2011-12,57069,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2011-12,57071,Denver,Summit League,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,49,exact
+2011-12,57072,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2011-12,57073,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2011-12,57074,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Colonial Athletic Association,10,exact
+2011-12,57075,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2011-12,57076,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2011-12,57078,ETSU,SoCon,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2011-12,57077,East Carolina,AAC,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Athletic Conference,62,exact
+2011-12,57079,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2011-12,57080,Eastern Ky.,OVC,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,ASUN Conference,46,exact
+2011-12,57081,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2011-12,57082,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2011-12,57329,Elon,CAA,2210,Elon Phoenix,Elon,Phoenix,ELON,Colonial Athletic Association,10,exact
+2011-12,57083,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2011-12,57344,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,ASUN Conference,46,exact
+2011-12,57088,FIU,C-USA,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2011-12,57084,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Atlantic Athletic Conference,13,exact
+2011-12,57085,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2011-12,57087,Fla. Atlantic,C-USA,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,Conference USA,11,exact
+2011-12,57090,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2011-12,57086,Florida A&M,MEAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2011-12,57089,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2011-12,57091,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2011-12,57035,Fresno St.,MWC,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2011-12,57092,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2011-12,57096,Ga. Southern,Sun Belt,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2011-12,57330,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2011-12,57093,George Mason,Atlantic 10,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2011-12,57094,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2011-12,57095,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2011-12,57099,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2011-12,57097,Georgia St.,Sun Belt,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2011-12,57098,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2011-12,57100,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2011-12,57101,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2011-12,57319,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2011-12,57102,Hampton,Big South,2261,Hampton Pirates,Hampton,Pirates,HAMP,Colonial Athletic Association,10,exact
+2011-12,57103,Hartford,America East,42,Hartford Hawks,Hartford,Hawks,HART,Division I Independents,43,exact
+2011-12,57104,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2011-12,57105,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2011-12,57341,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2011-12,57106,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Colonial Athletic Association,10,exact
+2011-12,57107,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2011-12,57109,Houston,AAC,248,Houston Cougars,Houston,Cougars,HOU,American Athletic Conference,62,exact
+2011-12,57108,Houston Christian,Southland,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,exact
+2011-12,57110,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2011-12,57335,IUPUI,Horizon,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,alias
+2011-12,57112,Idaho,Big Sky,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2011-12,57111,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2011-12,57114,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2011-12,57113,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2011-12,57117,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2011-12,57116,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2011-12,57119,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Atlantic Athletic Conference,13,exact
+2011-12,57121,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2011-12,57120,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2011-12,57122,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2011-12,57124,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,ASUN Conference,46,exact
+2011-12,57123,Jacksonville St.,OVC,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,ASUN Conference,46,exact
+2011-12,57125,James Madison,CAA,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2011-12,57127,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2011-12,57336,Kansas City,WAC,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,49,exact
+2011-12,57126,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2011-12,57331,Kennesaw St.,ASUN,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,ASUN Conference,46,exact
+2011-12,57128,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2011-12,57129,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2011-12,57135,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2011-12,57141,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2011-12,57137,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2011-12,57130,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2011-12,57131,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2011-12,57132,Lamar University,Southland,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2011-12,57133,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2011-12,57134,Liberty,ASUN,2335,Liberty Flames,Liberty,Flames,LIB,ASUN Conference,46,exact
+2011-12,57343,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,ASUN Conference,46,exact
+2011-12,57014,Little Rock,Sun Belt,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2011-12,57037,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2011-12,57136,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2011-12,57268,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2011-12,57138,Louisiana Tech,C-USA,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2011-12,57139,Louisville,ACC,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2011-12,57142,Loyola Chicago,MVC,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2011-12,57140,Loyola Maryland,Patriot,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2011-12,57143,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2011-12,57144,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Atlantic Athletic Conference,13,exact
+2011-12,57145,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Atlantic Athletic Conference,13,exact
+2011-12,57146,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2011-12,57147,Marshall,C-USA,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2011-12,57149,Maryland,Big Ten,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2011-12,57151,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2011-12,57152,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2011-12,57153,Memphis,AAC,235,Memphis Tigers,Memphis,Tigers,MEM,American Athletic Conference,62,exact
+2011-12,57154,Mercer,SoCon,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2011-12,57156,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2011-12,57155,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2011-12,57158,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2011-12,57157,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2011-12,57159,Middle Tenn.,C-USA,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2011-12,57321,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2011-12,57160,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2011-12,57161,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2011-12,57162,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2011-12,57164,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2011-12,57266,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2011-12,57165,Monmouth,MAAC,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Colonial Athletic Association,10,exact
+2011-12,57167,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2011-12,57166,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2011-12,57168,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2011-12,57169,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2011-12,57170,Mount St. Mary's,NEC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Atlantic Athletic Conference,13,exact
+2011-12,57171,Murray St.,OVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2011-12,57188,N.C. A&T,MEAC,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Colonial Athletic Association,10,exact
+2011-12,57189,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2011-12,57190,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2011-12,57198,NIU,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2011-12,57182,NJIT,ASUN,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2011-12,57295,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2011-12,57177,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2011-12,57180,Nevada,MWC,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2011-12,57181,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2011-12,57184,New Mexico,MWC,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2011-12,57183,New Mexico St.,WAC,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Western Athletic Conference,30,exact
+2011-12,57185,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Atlantic Athletic Conference,13,exact
+2011-12,57186,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2011-12,57187,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2011-12,57173,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2011-12,57192,North Dakota,Summit League,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,49,exact
+2011-12,57191,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,49,exact
+2011-12,57337,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,ASUN Conference,46,exact
+2011-12,57193,North Texas,C-USA,249,North Texas Mean Green,North Texas,Mean Green,UNT,Conference USA,11,exact
+2011-12,57195,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Colonial Athletic Association,10,exact
+2011-12,57196,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2011-12,57197,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2011-12,57201,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2011-12,57200,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2011-12,57202,Notre Dame,ACC,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2011-12,57203,Oakland,Horizon,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2011-12,57205,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2011-12,57204,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2011-12,57207,Oklahoma,Big 12,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Big 12 Conference,8,exact
+2011-12,57206,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2011-12,57208,Old Dominion,C-USA,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2011-12,57163,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2011-12,57178,Omaha,Summit League,2437,Omaha Mavericks,Omaha,Mavericks,OMA,Summit League,49,exact
+2011-12,57209,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,49,exact
+2011-12,57211,Oregon,Pac-12,2483,Oregon Ducks,Oregon,Ducks,ORE,Pac-12 Conference,21,exact
+2011-12,57210,Oregon St.,Pac-12,204,Oregon State Beavers,Oregon State,Beavers,ORST,Pac-12 Conference,21,exact
+2011-12,57212,Pacific,WCC,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2011-12,57215,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2011-12,57214,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2011-12,57216,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2011-12,57217,Pittsburgh,ACC,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2011-12,57219,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2011-12,57218,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2011-12,57220,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2011-12,57332,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2011-12,57221,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2011-12,57222,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2011-12,57223,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2011-12,57118,Purdue Fort Wayne,Summit League,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2011-12,57224,Quinnipiac,MAAC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Atlantic Athletic Conference,13,exact
+2011-12,57225,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2011-12,57226,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2011-12,57227,Rice,C-USA,242,Rice Owls,Rice,Owls,RICE,Conference USA,11,exact
+2011-12,57228,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2011-12,57229,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Atlantic Athletic Conference,13,exact
+2011-12,57230,Robert Morris,NEC,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2011-12,57231,Rutgers,Big Ten,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2011-12,57270,SFA,Southland,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Western Athletic Conference,30,exact
+2011-12,57261,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2011-12,57262,SMU,AAC,2567,SMU Mustangs,SMU,Mustangs,SMU,American Athletic Conference,62,exact
+2011-12,57039,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2011-12,57232,Sacred Heart,NEC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Northeast Conference,19,exact
+2011-12,57235,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2011-12,57237,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2011-12,57238,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2011-12,57239,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2011-12,57240,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Atlantic Athletic Conference,13,exact
+2011-12,57241,Sam Houston,Southland,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Western Athletic Conference,30,exact
+2011-12,57242,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2011-12,57244,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2011-12,57243,San Diego St.,MWC,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2011-12,57245,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2011-12,57246,San Jose St.,MWC,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2011-12,57247,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2011-12,57248,Savannah St.,MEAC,2542,Savannah State Tigers,Savannah State,Tigers,SAV,,,alias
+2011-12,57333,Seattle U,WAC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,Western Athletic Conference,30,exact
+2011-12,57249,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2011-12,57250,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Atlantic Athletic Conference,13,exact
+2011-12,57251,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2011-12,57253,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2011-12,57252,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2011-12,57255,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,49,exact
+2011-12,57254,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,49,exact
+2011-12,57256,South Fla.,AAC,58,South Florida Bulls,South Florida,Bulls,USF,American Athletic Conference,62,exact
+2011-12,57257,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2011-12,57258,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2011-12,57259,Southern California,Pac-12,30,USC Trojans,USC,Trojans,USC,Pac-12 Conference,21,dict
+2011-12,57260,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2011-12,57263,Southern Miss.,C-USA,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2011-12,57264,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2011-12,57265,Southern Utah,Big Sky,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,Western Athletic Conference,30,exact
+2011-12,57233,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2011-12,57234,St. Francis Brooklyn,NEC,2597,St. Francis Brooklyn Terriers,St. Francis Brooklyn,Terriers,SFNY,Northeast Conference,19,exact
+2011-12,57236,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2011-12,57269,Stanford,Pac-12,24,Stanford Cardinal,Stanford,Cardinal,STAN,Pac-12 Conference,21,exact
+2011-12,57271,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,ASUN Conference,46,exact
+2011-12,57272,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Colonial Athletic Association,10,exact
+2011-12,57273,Syracuse,ACC,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2011-12,57281,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2011-12,57274,Temple,AAC,218,Temple Owls,Temple,Owls,TEM,American Athletic Conference,62,exact
+2011-12,57278,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2011-12,57275,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2011-12,57276,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2011-12,57285,Texas,Big 12,251,Texas Longhorns,Texas,Longhorns,TEX,Big 12 Conference,8,exact
+2011-12,57280,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2011-12,57282,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2011-12,57267,Texas St.,Sun Belt,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2011-12,57283,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2011-12,57053,The Citadel,SoCon,2643,The Citadel Bulldogs,The Citadel,Bulldogs,CIT,Southern Conference,24,exact
+2011-12,57288,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2011-12,57289,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Colonial Athletic Association,10,exact
+2011-12,57290,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2011-12,57291,Tulane,AAC,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Athletic Conference,62,exact
+2011-12,57292,Tulsa,AAC,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Athletic Conference,62,exact
+2011-12,57005,UAB,C-USA,5,UAB Blazers,UAB,Blazers,UAB,Conference USA,11,exact
+2011-12,57006,UAlbany,America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,exact
+2011-12,57042,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2011-12,57043,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2011-12,57045,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2011-12,57040,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2011-12,57049,UCF,AAC,2116,UCF Knights,UCF,Knights,UCF,American Athletic Conference,62,exact
+2011-12,57044,UCLA,Pac-12,26,UCLA Bruins,UCLA,Bruins,UCLA,Pac-12 Conference,21,exact
+2011-12,57061,UConn,AAC,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2011-12,57115,UIC,Horizon,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2011-12,57194,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2011-12,57148,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2011-12,57150,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2011-12,57172,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2011-12,57175,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2011-12,57176,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Colonial Athletic Association,10,exact
+2011-12,57199,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2011-12,57179,UNLV,MWC,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2011-12,57339,USC Upstate,Big South,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2011-12,57284,UT Arlington,Sun Belt,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,Western Athletic Conference,30,exact
+2011-12,57279,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2011-12,57286,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2011-12,57213,UTRGV,WAC,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Western Athletic Conference,30,dict
+2011-12,57287,UTSA,C-USA,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,Conference USA,11,exact
+2011-12,57297,Utah,Pac-12,254,Utah Utes,Utah,Utes,UTAH,Pac-12 Conference,21,exact
+2011-12,57296,Utah St.,MWC,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2011-12,57345,Utah Valley,WAC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,Western Athletic Conference,30,exact
+2011-12,57302,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2011-12,57303,VMI,SoCon,2678,VMI Keydets,VMI,Keydets,VMI,Southern Conference,24,exact
+2011-12,57298,Valparaiso,MVC,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2011-12,57299,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2011-12,57300,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2011-12,57301,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2011-12,57305,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2011-12,57304,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2011-12,57306,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2011-12,57307,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2011-12,57309,Washington,Pac-12,264,Washington Huskies,Washington,Huskies,WASH,Pac-12 Conference,21,exact
+2011-12,57308,Washington St.,Pac-12,265,Washington State Cougars,Washington State,Cougars,WSU,Pac-12 Conference,21,exact
+2011-12,57310,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2011-12,57311,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2011-12,57312,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2011-12,57313,Western Ill.,Summit League,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Summit League,49,exact
+2011-12,57314,Western Ky.,C-USA,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2011-12,57315,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2011-12,57316,Wichita St.,AAC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Athletic Conference,62,exact
+2011-12,57317,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Colonial Athletic Association,10,exact
+2011-12,57318,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2011-12,57320,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2011-12,57338,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2011-12,57322,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2011-12,57323,Wyoming,MWC,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2011-12,57324,Xavier,Big East,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2011-12,57325,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2011-12,57326,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2012-13,14820,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2012-13,14771,Air Force,MWC,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2012-13,14477,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2012-13,14480,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2012-13,14478,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2012-13,14479,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2012-13,14483,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2012-13,14484,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2012-13,14485,App State,Sun Belt,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2012-13,14487,Arizona,Pac-12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Pac-12 Conference,21,exact
+2012-13,14486,Arizona St.,Pac-12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Pac-12 Conference,21,exact
+2012-13,14812,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2012-13,14489,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2012-13,14488,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2012-13,14772,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2012-13,14491,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2012-13,14492,Austin Peay,OVC,2046,Austin Peay Governors,Austin Peay,Governors,APSU,ASUN Conference,46,exact
+2012-13,14503,BYU,WCC,252,BYU Cougars,BYU,Cougars,BYU,West Coast Conference,29,exact
+2012-13,14493,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2012-13,14495,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2012-13,14818,Belmont,OVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2012-13,14496,Bethune-Cookman,MEAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2012-13,14497,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2012-13,14498,Boise St.,MWC,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2012-13,14499,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2012-13,14500,Boston U.,Patriot,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2012-13,14501,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2012-13,14502,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2012-13,14504,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2012-13,14505,Bryant,NEC,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2012-13,14506,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2012-13,14507,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2012-13,14508,Butler,Big East,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2012-13,14510,CSU Bakersfield,WAC,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2012-13,14514,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2012-13,14509,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2012-13,14512,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2012-13,14517,California,Pac-12,25,California Golden Bears,California,Golden Bears,CAL,Pac-12 Conference,21,exact
+2012-13,14522,Campbell,Big South,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Big South Conference,6,exact
+2012-13,14523,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Atlantic Athletic Conference,13,exact
+2012-13,14805,Central Ark.,Southland,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,ASUN Conference,46,exact
+2012-13,14524,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2012-13,14526,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2012-13,14494,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2012-13,14650,Charlotte,C-USA,2429,Charlotte 49ers,Charlotte,49ers,CLT,Conference USA,11,exact
+2012-13,14755,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2012-13,14527,Chicago St.,WAC,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Division I Independents,43,exact
+2012-13,14528,Cincinnati,AAC,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,American Athletic Conference,62,exact
+2012-13,14530,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2012-13,14531,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2012-13,14532,Coastal Carolina,Sun Belt,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2012-13,14806,Col. of Charleston,CAA,232,Charleston Cougars,Charleston,Cougars,COFC,Colonial Athletic Association,10,dict
+2012-13,14533,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2012-13,14535,Colorado,Pac-12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Pac-12 Conference,21,exact
+2012-13,14534,Colorado St.,MWC,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2012-13,14536,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2012-13,14538,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2012-13,14539,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2012-13,14540,Creighton,Big East,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2012-13,14541,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2012-13,14542,Davidson,Atlantic 10,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2012-13,14543,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2012-13,14544,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2012-13,14546,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Colonial Athletic Association,10,exact
+2012-13,14545,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2012-13,14547,Denver,Summit League,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,49,exact
+2012-13,14548,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2012-13,14549,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2012-13,14550,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Colonial Athletic Association,10,exact
+2012-13,14551,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2012-13,14552,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2012-13,14554,ETSU,SoCon,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2012-13,14553,East Carolina,AAC,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Athletic Conference,62,exact
+2012-13,14555,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2012-13,14556,Eastern Ky.,OVC,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,ASUN Conference,46,exact
+2012-13,14557,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2012-13,14558,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2012-13,14807,Elon,CAA,2210,Elon Phoenix,Elon,Phoenix,ELON,Colonial Athletic Association,10,exact
+2012-13,14559,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2012-13,14822,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,ASUN Conference,46,exact
+2012-13,14564,FIU,C-USA,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2012-13,14560,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Atlantic Athletic Conference,13,exact
+2012-13,14561,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2012-13,14563,Fla. Atlantic,C-USA,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,Conference USA,11,exact
+2012-13,14566,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2012-13,14562,Florida A&M,MEAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2012-13,14565,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2012-13,14567,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2012-13,14511,Fresno St.,MWC,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2012-13,14568,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2012-13,14572,Ga. Southern,Sun Belt,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2012-13,14808,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2012-13,14569,George Mason,Atlantic 10,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2012-13,14570,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2012-13,14571,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2012-13,14575,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2012-13,14573,Georgia St.,Sun Belt,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2012-13,14574,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2012-13,14576,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2012-13,14577,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2012-13,14797,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2012-13,14578,Hampton,Big South,2261,Hampton Pirates,Hampton,Pirates,HAMP,Colonial Athletic Association,10,exact
+2012-13,14579,Hartford,America East,42,Hartford Hawks,Hartford,Hawks,HART,Division I Independents,43,exact
+2012-13,14580,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2012-13,14581,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2012-13,14819,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2012-13,14582,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Colonial Athletic Association,10,exact
+2012-13,14583,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2012-13,14585,Houston,AAC,248,Houston Cougars,Houston,Cougars,HOU,American Athletic Conference,62,exact
+2012-13,14584,Houston Christian,Southland,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,exact
+2012-13,14586,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2012-13,14813,IUPUI,Horizon,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,alias
+2012-13,14588,Idaho,Big Sky,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2012-13,14587,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2012-13,14590,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2012-13,14589,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2012-13,14593,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2012-13,14592,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2012-13,14595,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Atlantic Athletic Conference,13,exact
+2012-13,14597,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2012-13,14596,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2012-13,14598,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2012-13,14600,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,ASUN Conference,46,exact
+2012-13,14599,Jacksonville St.,OVC,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,ASUN Conference,46,exact
+2012-13,14601,James Madison,CAA,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2012-13,14603,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2012-13,14814,Kansas City,WAC,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,49,exact
+2012-13,14602,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2012-13,14809,Kennesaw St.,ASUN,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,ASUN Conference,46,exact
+2012-13,14604,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2012-13,14605,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2012-13,14611,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2012-13,14617,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2012-13,14613,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2012-13,14606,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2012-13,14607,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2012-13,14608,Lamar University,Southland,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2012-13,14609,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2012-13,14610,Liberty,ASUN,2335,Liberty Flames,Liberty,Flames,LIB,ASUN Conference,46,exact
+2012-13,14821,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,ASUN Conference,46,exact
+2012-13,14490,Little Rock,Sun Belt,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2012-13,14513,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2012-13,14612,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2012-13,14746,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2012-13,14614,Louisiana Tech,C-USA,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2012-13,14615,Louisville,ACC,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2012-13,14618,Loyola Chicago,MVC,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2012-13,14616,Loyola Maryland,Patriot,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2012-13,14619,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2012-13,14620,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Atlantic Athletic Conference,13,exact
+2012-13,14621,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Atlantic Athletic Conference,13,exact
+2012-13,14622,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2012-13,14623,Marshall,C-USA,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2012-13,14625,Maryland,Big Ten,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2012-13,14627,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2012-13,14628,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2012-13,14629,Memphis,AAC,235,Memphis Tigers,Memphis,Tigers,MEM,American Athletic Conference,62,exact
+2012-13,14630,Mercer,SoCon,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2012-13,14632,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2012-13,14631,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2012-13,14634,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2012-13,14633,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2012-13,14635,Middle Tenn.,C-USA,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2012-13,14799,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2012-13,14636,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2012-13,14637,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2012-13,14638,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2012-13,14640,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2012-13,14744,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2012-13,14641,Monmouth,MAAC,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Colonial Athletic Association,10,exact
+2012-13,14643,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2012-13,14642,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2012-13,14644,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2012-13,14645,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2012-13,14646,Mount St. Mary's,NEC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Atlantic Athletic Conference,13,exact
+2012-13,14647,Murray St.,OVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2012-13,14665,N.C. A&T,MEAC,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Colonial Athletic Association,10,exact
+2012-13,14666,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2012-13,14667,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2012-13,14675,NIU,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2012-13,14658,NJIT,ASUN,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2012-13,14773,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2012-13,14653,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2012-13,14656,Nevada,MWC,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2012-13,14657,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2012-13,14660,New Mexico,MWC,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2012-13,14659,New Mexico St.,WAC,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Western Athletic Conference,30,exact
+2012-13,14661,New Orleans,Southland,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2012-13,14662,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Atlantic Athletic Conference,13,exact
+2012-13,14663,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2012-13,14664,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2012-13,14649,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2012-13,14669,North Dakota,Summit League,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,49,exact
+2012-13,14668,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,49,exact
+2012-13,14815,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,ASUN Conference,46,exact
+2012-13,14670,North Texas,C-USA,249,North Texas Mean Green,North Texas,Mean Green,UNT,Conference USA,11,exact
+2012-13,14672,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Colonial Athletic Association,10,exact
+2012-13,14673,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2012-13,14674,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2012-13,14677,Northern Ky.,Horizon,94,Northern Kentucky Norse,Northern Kentucky,Norse,NKU,Horizon League,45,exact
+2012-13,14679,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2012-13,14678,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2012-13,14680,Notre Dame,ACC,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2012-13,14681,Oakland,Horizon,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2012-13,14683,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2012-13,14682,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2012-13,14685,Oklahoma,Big 12,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Big 12 Conference,8,exact
+2012-13,14684,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2012-13,14686,Old Dominion,C-USA,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2012-13,14639,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2012-13,14654,Omaha,Summit League,2437,Omaha Mavericks,Omaha,Mavericks,OMA,Summit League,49,exact
+2012-13,14687,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,49,exact
+2012-13,14689,Oregon,Pac-12,2483,Oregon Ducks,Oregon,Ducks,ORE,Pac-12 Conference,21,exact
+2012-13,14688,Oregon St.,Pac-12,204,Oregon State Beavers,Oregon State,Beavers,ORST,Pac-12 Conference,21,exact
+2012-13,14690,Pacific,WCC,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2012-13,14693,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2012-13,14692,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2012-13,14694,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2012-13,14695,Pittsburgh,ACC,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2012-13,14697,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2012-13,14696,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2012-13,14698,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2012-13,14810,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2012-13,14699,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2012-13,14700,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2012-13,14701,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2012-13,14594,Purdue Fort Wayne,Summit League,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2012-13,14702,Quinnipiac,MAAC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Atlantic Athletic Conference,13,exact
+2012-13,14703,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2012-13,14704,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2012-13,14705,Rice,C-USA,242,Rice Owls,Rice,Owls,RICE,Conference USA,11,exact
+2012-13,14706,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2012-13,14707,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Atlantic Athletic Conference,13,exact
+2012-13,14708,Robert Morris,NEC,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2012-13,14709,Rutgers,Big Ten,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2012-13,14748,SFA,Southland,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Western Athletic Conference,30,exact
+2012-13,14739,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2012-13,14740,SMU,AAC,2567,SMU Mustangs,SMU,Mustangs,SMU,American Athletic Conference,62,exact
+2012-13,14515,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2012-13,14710,Sacred Heart,NEC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Northeast Conference,19,exact
+2012-13,14713,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2012-13,14715,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2012-13,14716,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2012-13,14717,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2012-13,14718,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Atlantic Athletic Conference,13,exact
+2012-13,14719,Sam Houston,Southland,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Western Athletic Conference,30,exact
+2012-13,14720,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2012-13,14722,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2012-13,14721,San Diego St.,MWC,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2012-13,14723,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2012-13,14724,San Jose St.,MWC,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2012-13,14725,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2012-13,14726,Savannah St.,MEAC,2542,Savannah State Tigers,Savannah State,Tigers,SAV,,,alias
+2012-13,14811,Seattle U,WAC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,Western Athletic Conference,30,exact
+2012-13,14727,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2012-13,14728,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Atlantic Athletic Conference,13,exact
+2012-13,14729,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2012-13,14731,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2012-13,14730,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2012-13,14733,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,49,exact
+2012-13,14732,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,49,exact
+2012-13,14734,South Fla.,AAC,58,South Florida Bulls,South Florida,Bulls,USF,American Athletic Conference,62,exact
+2012-13,14735,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2012-13,14736,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2012-13,14737,Southern California,Pac-12,30,USC Trojans,USC,Trojans,USC,Pac-12 Conference,21,dict
+2012-13,14738,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2012-13,14741,Southern Miss.,C-USA,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2012-13,14742,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2012-13,14743,Southern Utah,Big Sky,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,Western Athletic Conference,30,exact
+2012-13,14711,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2012-13,14712,St. Francis Brooklyn,NEC,2597,St. Francis Brooklyn Terriers,St. Francis Brooklyn,Terriers,SFNY,Northeast Conference,19,exact
+2012-13,14714,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2012-13,14747,Stanford,Pac-12,24,Stanford Cardinal,Stanford,Cardinal,STAN,Pac-12 Conference,21,exact
+2012-13,14749,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,ASUN Conference,46,exact
+2012-13,14750,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Colonial Athletic Association,10,exact
+2012-13,14751,Syracuse,ACC,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2012-13,14759,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2012-13,14752,Temple,AAC,218,Temple Owls,Temple,Owls,TEM,American Athletic Conference,62,exact
+2012-13,14756,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2012-13,14753,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2012-13,14754,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2012-13,14763,Texas,Big 12,251,Texas Longhorns,Texas,Longhorns,TEX,Big 12 Conference,8,exact
+2012-13,14758,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2012-13,14760,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2012-13,14745,Texas St.,Sun Belt,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2012-13,14761,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2012-13,14529,The Citadel,SoCon,2643,The Citadel Bulldogs,The Citadel,Bulldogs,CIT,Southern Conference,24,exact
+2012-13,14766,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2012-13,14767,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Colonial Athletic Association,10,exact
+2012-13,14768,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2012-13,14769,Tulane,AAC,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Athletic Conference,62,exact
+2012-13,14770,Tulsa,AAC,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Athletic Conference,62,exact
+2012-13,14481,UAB,C-USA,5,UAB Blazers,UAB,Blazers,UAB,Conference USA,11,exact
+2012-13,14482,UAlbany,America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,exact
+2012-13,14518,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2012-13,14519,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2012-13,14521,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2012-13,14516,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2012-13,14525,UCF,AAC,2116,UCF Knights,UCF,Knights,UCF,American Athletic Conference,62,exact
+2012-13,14520,UCLA,Pac-12,26,UCLA Bruins,UCLA,Bruins,UCLA,Pac-12 Conference,21,exact
+2012-13,14537,UConn,AAC,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2012-13,14591,UIC,Horizon,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2012-13,14671,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2012-13,14624,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2012-13,14626,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2012-13,14648,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2012-13,14651,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2012-13,14652,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Colonial Athletic Association,10,exact
+2012-13,14676,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2012-13,14655,UNLV,MWC,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2012-13,14817,USC Upstate,Big South,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2012-13,14762,UT Arlington,Sun Belt,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,Western Athletic Conference,30,exact
+2012-13,14757,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2012-13,14764,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2012-13,14691,UTRGV,WAC,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Western Athletic Conference,30,dict
+2012-13,14765,UTSA,C-USA,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,Conference USA,11,exact
+2012-13,14775,Utah,Pac-12,254,Utah Utes,Utah,Utes,UTAH,Pac-12 Conference,21,exact
+2012-13,14774,Utah St.,MWC,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2012-13,14823,Utah Valley,WAC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,Western Athletic Conference,30,exact
+2012-13,14780,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2012-13,14781,VMI,SoCon,2678,VMI Keydets,VMI,Keydets,VMI,Southern Conference,24,exact
+2012-13,14776,Valparaiso,MVC,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2012-13,14777,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2012-13,14778,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2012-13,14779,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2012-13,14783,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2012-13,14782,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2012-13,14784,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2012-13,14785,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2012-13,14787,Washington,Pac-12,264,Washington Huskies,Washington,Huskies,WASH,Pac-12 Conference,21,exact
+2012-13,14786,Washington St.,Pac-12,265,Washington State Cougars,Washington State,Cougars,WSU,Pac-12 Conference,21,exact
+2012-13,14788,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2012-13,14789,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2012-13,14790,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2012-13,14791,Western Ill.,Summit League,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Summit League,49,exact
+2012-13,14792,Western Ky.,C-USA,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2012-13,14793,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2012-13,14794,Wichita St.,AAC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Athletic Conference,62,exact
+2012-13,14795,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Colonial Athletic Association,10,exact
+2012-13,14796,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2012-13,14798,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2012-13,14816,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2012-13,14800,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2012-13,14801,Wyoming,MWC,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2012-13,14802,Xavier,Big East,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2012-13,14803,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2012-13,14804,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2013-14,102770,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2013-14,102423,Abilene Christian,Southland,2000,Abilene Christian Wildcats,Abilene Christian,Wildcats,ACU,Western Athletic Conference,30,exact
+2013-14,102719,Air Force,MWC,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2013-14,102424,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2013-14,102427,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2013-14,102425,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2013-14,102426,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2013-14,102430,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2013-14,102431,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2013-14,102432,App State,Sun Belt,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2013-14,102434,Arizona,Pac-12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Pac-12 Conference,21,exact
+2013-14,102433,Arizona St.,Pac-12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Pac-12 Conference,21,exact
+2013-14,102761,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2013-14,102436,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2013-14,102435,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2013-14,102720,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2013-14,102438,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2013-14,102439,Austin Peay,OVC,2046,Austin Peay Governors,Austin Peay,Governors,APSU,ASUN Conference,46,exact
+2013-14,102450,BYU,WCC,252,BYU Cougars,BYU,Cougars,BYU,West Coast Conference,29,exact
+2013-14,102440,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2013-14,102442,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2013-14,102768,Belmont,OVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2013-14,102443,Bethune-Cookman,MEAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2013-14,102444,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2013-14,102445,Boise St.,MWC,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2013-14,102446,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2013-14,102447,Boston U.,Patriot,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2013-14,102448,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2013-14,102449,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2013-14,102451,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2013-14,102452,Bryant,NEC,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2013-14,102453,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2013-14,102454,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2013-14,102455,Butler,Big East,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2013-14,102457,CSU Bakersfield,WAC,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2013-14,102461,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2013-14,102456,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2013-14,102459,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2013-14,102464,California,Pac-12,25,California Golden Bears,California,Golden Bears,CAL,Pac-12 Conference,21,exact
+2013-14,102469,Campbell,Big South,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Big South Conference,6,exact
+2013-14,102470,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Atlantic Athletic Conference,13,exact
+2013-14,102753,Central Ark.,Southland,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,ASUN Conference,46,exact
+2013-14,102471,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2013-14,102473,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2013-14,102441,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2013-14,102598,Charlotte,C-USA,2429,Charlotte 49ers,Charlotte,49ers,CLT,Conference USA,11,exact
+2013-14,102703,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2013-14,102474,Chicago St.,WAC,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Division I Independents,43,exact
+2013-14,102475,Cincinnati,AAC,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,American Athletic Conference,62,exact
+2013-14,102477,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2013-14,102478,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2013-14,102479,Coastal Carolina,Sun Belt,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2013-14,102754,Col. of Charleston,CAA,232,Charleston Cougars,Charleston,Cougars,COFC,Colonial Athletic Association,10,dict
+2013-14,102480,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2013-14,102482,Colorado,Pac-12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Pac-12 Conference,21,exact
+2013-14,102481,Colorado St.,MWC,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2013-14,102483,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2013-14,102485,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2013-14,102486,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2013-14,102487,Creighton,Big East,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2013-14,102488,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2013-14,102489,Davidson,Atlantic 10,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2013-14,102490,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2013-14,102491,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2013-14,102493,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Colonial Athletic Association,10,exact
+2013-14,102492,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2013-14,102494,Denver,Summit League,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,49,exact
+2013-14,102495,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2013-14,102496,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2013-14,102497,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Colonial Athletic Association,10,exact
+2013-14,102498,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2013-14,102499,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2013-14,102501,ETSU,SoCon,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2013-14,102500,East Carolina,AAC,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Athletic Conference,62,exact
+2013-14,102502,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2013-14,102503,Eastern Ky.,OVC,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,ASUN Conference,46,exact
+2013-14,102504,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2013-14,102505,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2013-14,102755,Elon,CAA,2210,Elon Phoenix,Elon,Phoenix,ELON,Colonial Athletic Association,10,exact
+2013-14,102506,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2013-14,102772,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,ASUN Conference,46,exact
+2013-14,102511,FIU,C-USA,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2013-14,102507,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Atlantic Athletic Conference,13,exact
+2013-14,102508,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2013-14,102510,Fla. Atlantic,C-USA,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,Conference USA,11,exact
+2013-14,102513,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2013-14,102509,Florida A&M,MEAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2013-14,102512,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2013-14,102514,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2013-14,102458,Fresno St.,MWC,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2013-14,102515,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2013-14,102519,Ga. Southern,Sun Belt,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2013-14,102756,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2013-14,102516,George Mason,Atlantic 10,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2013-14,102517,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2013-14,102518,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2013-14,102522,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2013-14,102520,Georgia St.,Sun Belt,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2013-14,102521,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2013-14,102523,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2013-14,102524,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2013-14,102757,Grand Canyon,WAC,2253,Grand Canyon Lopes,Grand Canyon,Lopes,GCU,Western Athletic Conference,30,exact
+2013-14,102745,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2013-14,102525,Hampton,Big South,2261,Hampton Pirates,Hampton,Pirates,HAMP,Colonial Athletic Association,10,exact
+2013-14,102526,Hartford,America East,42,Hartford Hawks,Hartford,Hawks,HART,Division I Independents,43,exact
+2013-14,102527,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2013-14,102528,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2013-14,102769,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2013-14,102529,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Colonial Athletic Association,10,exact
+2013-14,102530,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2013-14,102532,Houston,AAC,248,Houston Cougars,Houston,Cougars,HOU,American Athletic Conference,62,exact
+2013-14,102531,Houston Christian,Southland,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,exact
+2013-14,102533,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2013-14,102762,IUPUI,Horizon,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,alias
+2013-14,102535,Idaho,Big Sky,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2013-14,102534,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2013-14,102537,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2013-14,102536,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2013-14,102540,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2013-14,102539,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2013-14,102542,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Atlantic Athletic Conference,13,exact
+2013-14,102544,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2013-14,102543,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2013-14,102545,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2013-14,102547,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,ASUN Conference,46,exact
+2013-14,102546,Jacksonville St.,OVC,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,ASUN Conference,46,exact
+2013-14,102548,James Madison,CAA,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2013-14,102550,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2013-14,102763,Kansas City,WAC,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,49,exact
+2013-14,102549,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2013-14,102758,Kennesaw St.,ASUN,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,ASUN Conference,46,exact
+2013-14,102551,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2013-14,102552,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2013-14,102558,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2013-14,102565,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2013-14,102560,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2013-14,102553,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2013-14,102554,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2013-14,102555,Lamar University,Southland,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2013-14,102556,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2013-14,102557,Liberty,ASUN,2335,Liberty Flames,Liberty,Flames,LIB,ASUN Conference,46,exact
+2013-14,102771,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,ASUN Conference,46,exact
+2013-14,102437,Little Rock,Sun Belt,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2013-14,102460,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2013-14,102559,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2013-14,102694,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2013-14,102561,Louisiana Tech,C-USA,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2013-14,102562,Louisville,ACC,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2013-14,102566,Loyola Chicago,MVC,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2013-14,102564,Loyola Maryland,Patriot,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2013-14,102567,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2013-14,102568,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Atlantic Athletic Conference,13,exact
+2013-14,102569,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Atlantic Athletic Conference,13,exact
+2013-14,102570,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2013-14,102571,Marshall,C-USA,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2013-14,102573,Maryland,Big Ten,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2013-14,102575,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2013-14,102576,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2013-14,102577,Memphis,AAC,235,Memphis Tigers,Memphis,Tigers,MEM,American Athletic Conference,62,exact
+2013-14,102578,Mercer,SoCon,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2013-14,102580,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2013-14,102579,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2013-14,102582,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2013-14,102581,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2013-14,102583,Middle Tenn.,C-USA,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2013-14,102747,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2013-14,102584,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2013-14,102585,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2013-14,102586,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2013-14,102588,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2013-14,102692,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2013-14,102589,Monmouth,MAAC,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Colonial Athletic Association,10,exact
+2013-14,102591,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2013-14,102590,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2013-14,102592,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2013-14,102593,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2013-14,102594,Mount St. Mary's,NEC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Atlantic Athletic Conference,13,exact
+2013-14,102595,Murray St.,OVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2013-14,102613,N.C. A&T,MEAC,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Colonial Athletic Association,10,exact
+2013-14,102614,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2013-14,102615,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2013-14,102623,NIU,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2013-14,102606,NJIT,ASUN,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2013-14,102721,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2013-14,102601,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2013-14,102604,Nevada,MWC,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2013-14,102605,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2013-14,102608,New Mexico,MWC,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2013-14,102607,New Mexico St.,WAC,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Western Athletic Conference,30,exact
+2013-14,102609,New Orleans,Southland,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2013-14,102610,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Atlantic Athletic Conference,13,exact
+2013-14,102611,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2013-14,102612,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2013-14,102597,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2013-14,102617,North Dakota,Summit League,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,49,exact
+2013-14,102616,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,49,exact
+2013-14,102764,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,ASUN Conference,46,exact
+2013-14,102618,North Texas,C-USA,249,North Texas Mean Green,North Texas,Mean Green,UNT,Conference USA,11,exact
+2013-14,102620,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Colonial Athletic Association,10,exact
+2013-14,102621,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2013-14,102622,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2013-14,102625,Northern Ky.,Horizon,94,Northern Kentucky Norse,Northern Kentucky,Norse,NKU,Horizon League,45,exact
+2013-14,102627,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2013-14,102626,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2013-14,102628,Notre Dame,ACC,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2013-14,102629,Oakland,Horizon,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2013-14,102631,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2013-14,102630,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2013-14,102633,Oklahoma,Big 12,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Big 12 Conference,8,exact
+2013-14,102632,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2013-14,102634,Old Dominion,C-USA,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2013-14,102587,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2013-14,102602,Omaha,Summit League,2437,Omaha Mavericks,Omaha,Mavericks,OMA,Summit League,49,exact
+2013-14,102635,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,49,exact
+2013-14,102637,Oregon,Pac-12,2483,Oregon Ducks,Oregon,Ducks,ORE,Pac-12 Conference,21,exact
+2013-14,102636,Oregon St.,Pac-12,204,Oregon State Beavers,Oregon State,Beavers,ORST,Pac-12 Conference,21,exact
+2013-14,102638,Pacific,WCC,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2013-14,102641,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2013-14,102640,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2013-14,102642,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2013-14,102643,Pittsburgh,ACC,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2013-14,102645,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2013-14,102644,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2013-14,102646,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2013-14,102759,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2013-14,102647,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2013-14,102648,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2013-14,102649,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2013-14,102541,Purdue Fort Wayne,Summit League,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2013-14,102650,Quinnipiac,MAAC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Atlantic Athletic Conference,13,exact
+2013-14,102651,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2013-14,102652,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2013-14,102653,Rice,C-USA,242,Rice Owls,Rice,Owls,RICE,Conference USA,11,exact
+2013-14,102654,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2013-14,102655,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Atlantic Athletic Conference,13,exact
+2013-14,102656,Robert Morris,NEC,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2013-14,102657,Rutgers,Big Ten,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2013-14,102696,SFA,Southland,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Western Athletic Conference,30,exact
+2013-14,102687,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2013-14,102688,SMU,AAC,2567,SMU Mustangs,SMU,Mustangs,SMU,American Athletic Conference,62,exact
+2013-14,102462,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2013-14,102658,Sacred Heart,NEC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Northeast Conference,19,exact
+2013-14,102661,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2013-14,102663,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2013-14,102664,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2013-14,102665,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2013-14,102666,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Atlantic Athletic Conference,13,exact
+2013-14,102667,Sam Houston,Southland,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Western Athletic Conference,30,exact
+2013-14,102668,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2013-14,102670,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2013-14,102669,San Diego St.,MWC,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2013-14,102671,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2013-14,102672,San Jose St.,MWC,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2013-14,102673,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2013-14,102674,Savannah St.,MEAC,2542,Savannah State Tigers,Savannah State,Tigers,SAV,,,alias
+2013-14,102760,Seattle U,WAC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,Western Athletic Conference,30,exact
+2013-14,102675,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2013-14,102676,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Atlantic Athletic Conference,13,exact
+2013-14,102677,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2013-14,102679,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2013-14,102678,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2013-14,102681,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,49,exact
+2013-14,102680,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,49,exact
+2013-14,102682,South Fla.,AAC,58,South Florida Bulls,South Florida,Bulls,USF,American Athletic Conference,62,exact
+2013-14,102683,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2013-14,102684,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2013-14,102685,Southern California,Pac-12,30,USC Trojans,USC,Trojans,USC,Pac-12 Conference,21,dict
+2013-14,102686,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2013-14,102689,Southern Miss.,C-USA,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2013-14,102690,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2013-14,102691,Southern Utah,Big Sky,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,Western Athletic Conference,30,exact
+2013-14,102659,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2013-14,102660,St. Francis Brooklyn,NEC,2597,St. Francis Brooklyn Terriers,St. Francis Brooklyn,Terriers,SFNY,Northeast Conference,19,exact
+2013-14,102662,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2013-14,102695,Stanford,Pac-12,24,Stanford Cardinal,Stanford,Cardinal,STAN,Pac-12 Conference,21,exact
+2013-14,102697,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,ASUN Conference,46,exact
+2013-14,102698,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Colonial Athletic Association,10,exact
+2013-14,102699,Syracuse,ACC,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2013-14,102707,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2013-14,102700,Temple,AAC,218,Temple Owls,Temple,Owls,TEM,American Athletic Conference,62,exact
+2013-14,102704,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2013-14,102701,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2013-14,102702,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2013-14,102711,Texas,Big 12,251,Texas Longhorns,Texas,Longhorns,TEX,Big 12 Conference,8,exact
+2013-14,102706,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2013-14,102708,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2013-14,102693,Texas St.,Sun Belt,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2013-14,102709,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2013-14,102476,The Citadel,SoCon,2643,The Citadel Bulldogs,The Citadel,Bulldogs,CIT,Southern Conference,24,exact
+2013-14,102714,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2013-14,102715,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Colonial Athletic Association,10,exact
+2013-14,102716,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2013-14,102717,Tulane,AAC,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Athletic Conference,62,exact
+2013-14,102718,Tulsa,AAC,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Athletic Conference,62,exact
+2013-14,102428,UAB,C-USA,5,UAB Blazers,UAB,Blazers,UAB,Conference USA,11,exact
+2013-14,102429,UAlbany,America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,exact
+2013-14,102465,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2013-14,102466,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2013-14,102468,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2013-14,102463,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2013-14,102472,UCF,AAC,2116,UCF Knights,UCF,Knights,UCF,American Athletic Conference,62,exact
+2013-14,102467,UCLA,Pac-12,26,UCLA Bruins,UCLA,Bruins,UCLA,Pac-12 Conference,21,exact
+2013-14,102484,UConn,AAC,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2013-14,102538,UIC,Horizon,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2013-14,102765,UIW,Southland,2916,Incarnate Word Cardinals,Incarnate Word,Cardinals,UIW,Southland Conference,25,exact
+2013-14,102619,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2013-14,102572,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2013-14,102574,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2013-14,102563,UMass Lowell,America East,2349,UMass Lowell River Hawks,UMass Lowell,River Hawks,UML,America East Conference,1,exact
+2013-14,102596,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2013-14,102599,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2013-14,102600,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Colonial Athletic Association,10,exact
+2013-14,102624,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2013-14,102603,UNLV,MWC,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2013-14,102767,USC Upstate,Big South,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2013-14,102710,UT Arlington,Sun Belt,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,Western Athletic Conference,30,exact
+2013-14,102705,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2013-14,102712,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2013-14,102639,UTRGV,WAC,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Western Athletic Conference,30,dict
+2013-14,102713,UTSA,C-USA,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,Conference USA,11,exact
+2013-14,102723,Utah,Pac-12,254,Utah Utes,Utah,Utes,UTAH,Pac-12 Conference,21,exact
+2013-14,102722,Utah St.,MWC,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2013-14,102773,Utah Valley,WAC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,Western Athletic Conference,30,exact
+2013-14,102728,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2013-14,102729,VMI,SoCon,2678,VMI Keydets,VMI,Keydets,VMI,Southern Conference,24,exact
+2013-14,102724,Valparaiso,MVC,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2013-14,102725,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2013-14,102726,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2013-14,102727,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2013-14,102731,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2013-14,102730,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2013-14,102732,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2013-14,102733,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2013-14,102735,Washington,Pac-12,264,Washington Huskies,Washington,Huskies,WASH,Pac-12 Conference,21,exact
+2013-14,102734,Washington St.,Pac-12,265,Washington State Cougars,Washington State,Cougars,WSU,Pac-12 Conference,21,exact
+2013-14,102736,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2013-14,102737,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2013-14,102738,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2013-14,102739,Western Ill.,Summit League,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Summit League,49,exact
+2013-14,102740,Western Ky.,C-USA,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2013-14,102741,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2013-14,102742,Wichita St.,AAC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Athletic Conference,62,exact
+2013-14,102743,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Colonial Athletic Association,10,exact
+2013-14,102744,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2013-14,102746,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2013-14,102766,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2013-14,102748,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2013-14,102749,Wyoming,MWC,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2013-14,102750,Xavier,Big East,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2013-14,102751,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2013-14,102752,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2014-15,84290,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2014-15,83943,Abilene Christian,Southland,2000,Abilene Christian Wildcats,Abilene Christian,Wildcats,ACU,Western Athletic Conference,30,exact
+2014-15,84239,Air Force,MWC,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2014-15,83944,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2014-15,83947,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2014-15,83945,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2014-15,83946,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2014-15,83950,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2014-15,83951,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2014-15,83952,App State,Sun Belt,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2014-15,83954,Arizona,Pac-12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Pac-12 Conference,21,exact
+2014-15,83953,Arizona St.,Pac-12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Pac-12 Conference,21,exact
+2014-15,84281,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2014-15,83956,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2014-15,83955,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2014-15,84240,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2014-15,83958,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2014-15,83959,Austin Peay,OVC,2046,Austin Peay Governors,Austin Peay,Governors,APSU,ASUN Conference,46,exact
+2014-15,83970,BYU,WCC,252,BYU Cougars,BYU,Cougars,BYU,West Coast Conference,29,exact
+2014-15,83960,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2014-15,83962,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2014-15,84288,Belmont,OVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2014-15,83963,Bethune-Cookman,MEAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2014-15,83964,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2014-15,83965,Boise St.,MWC,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2014-15,83966,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2014-15,83967,Boston U.,Patriot,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2014-15,83968,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2014-15,83969,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2014-15,83971,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2014-15,83972,Bryant,NEC,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2014-15,83973,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2014-15,83974,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2014-15,83975,Butler,Big East,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2014-15,83977,CSU Bakersfield,WAC,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2014-15,83981,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2014-15,83976,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2014-15,83979,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2014-15,83984,California,Pac-12,25,California Golden Bears,California,Golden Bears,CAL,Pac-12 Conference,21,exact
+2014-15,83989,Campbell,Big South,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Big South Conference,6,exact
+2014-15,83990,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Atlantic Athletic Conference,13,exact
+2014-15,84273,Central Ark.,Southland,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,ASUN Conference,46,exact
+2014-15,83991,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2014-15,83993,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2014-15,83961,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2014-15,84118,Charlotte,C-USA,2429,Charlotte 49ers,Charlotte,49ers,CLT,Conference USA,11,exact
+2014-15,84223,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2014-15,83994,Chicago St.,WAC,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Division I Independents,43,exact
+2014-15,83995,Cincinnati,AAC,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,American Athletic Conference,62,exact
+2014-15,83997,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2014-15,83998,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2014-15,83999,Coastal Carolina,Sun Belt,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2014-15,84274,Col. of Charleston,CAA,232,Charleston Cougars,Charleston,Cougars,COFC,Colonial Athletic Association,10,dict
+2014-15,84000,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2014-15,84002,Colorado,Pac-12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Pac-12 Conference,21,exact
+2014-15,84001,Colorado St.,MWC,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2014-15,84003,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2014-15,84005,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2014-15,84006,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2014-15,84007,Creighton,Big East,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2014-15,84008,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2014-15,84009,Davidson,Atlantic 10,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2014-15,84010,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2014-15,84011,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2014-15,84013,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Colonial Athletic Association,10,exact
+2014-15,84012,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2014-15,84014,Denver,Summit League,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,49,exact
+2014-15,84015,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2014-15,84016,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2014-15,84017,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Colonial Athletic Association,10,exact
+2014-15,84018,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2014-15,84019,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2014-15,84021,ETSU,SoCon,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2014-15,84020,East Carolina,AAC,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Athletic Conference,62,exact
+2014-15,84022,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2014-15,84023,Eastern Ky.,OVC,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,ASUN Conference,46,exact
+2014-15,84024,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2014-15,84025,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2014-15,84275,Elon,CAA,2210,Elon Phoenix,Elon,Phoenix,ELON,Colonial Athletic Association,10,exact
+2014-15,84026,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2014-15,84292,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,ASUN Conference,46,exact
+2014-15,84031,FIU,C-USA,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2014-15,84027,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Atlantic Athletic Conference,13,exact
+2014-15,84028,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2014-15,84030,Fla. Atlantic,C-USA,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,Conference USA,11,exact
+2014-15,84033,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2014-15,84029,Florida A&M,MEAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2014-15,84032,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2014-15,84034,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2014-15,83978,Fresno St.,MWC,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2014-15,84035,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2014-15,84039,Ga. Southern,Sun Belt,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2014-15,84276,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2014-15,84036,George Mason,Atlantic 10,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2014-15,84037,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2014-15,84038,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2014-15,84042,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2014-15,84040,Georgia St.,Sun Belt,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2014-15,84041,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2014-15,84043,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2014-15,84044,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2014-15,84277,Grand Canyon,WAC,2253,Grand Canyon Lopes,Grand Canyon,Lopes,GCU,Western Athletic Conference,30,exact
+2014-15,84265,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2014-15,84045,Hampton,Big South,2261,Hampton Pirates,Hampton,Pirates,HAMP,Colonial Athletic Association,10,exact
+2014-15,84046,Hartford,America East,42,Hartford Hawks,Hartford,Hawks,HART,Division I Independents,43,exact
+2014-15,84047,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2014-15,84048,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2014-15,84289,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2014-15,84049,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Colonial Athletic Association,10,exact
+2014-15,84050,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2014-15,84052,Houston,AAC,248,Houston Cougars,Houston,Cougars,HOU,American Athletic Conference,62,exact
+2014-15,84051,Houston Christian,Southland,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,exact
+2014-15,84053,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2014-15,84282,IUPUI,Horizon,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,alias
+2014-15,84055,Idaho,Big Sky,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2014-15,84054,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2014-15,84057,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2014-15,84056,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2014-15,84060,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2014-15,84059,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2014-15,84062,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Atlantic Athletic Conference,13,exact
+2014-15,84064,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2014-15,84063,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2014-15,84065,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2014-15,84067,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,ASUN Conference,46,exact
+2014-15,84066,Jacksonville St.,OVC,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,ASUN Conference,46,exact
+2014-15,84068,James Madison,CAA,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2014-15,84070,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2014-15,84283,Kansas City,WAC,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,49,exact
+2014-15,84069,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2014-15,84278,Kennesaw St.,ASUN,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,ASUN Conference,46,exact
+2014-15,84071,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2014-15,84072,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2014-15,84078,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2014-15,84085,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2014-15,84080,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2014-15,84073,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2014-15,84074,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2014-15,84075,Lamar University,Southland,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2014-15,84076,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2014-15,84077,Liberty,ASUN,2335,Liberty Flames,Liberty,Flames,LIB,ASUN Conference,46,exact
+2014-15,84291,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,ASUN Conference,46,exact
+2014-15,83957,Little Rock,Sun Belt,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2014-15,83980,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2014-15,84079,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2014-15,84214,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2014-15,84081,Louisiana Tech,C-USA,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2014-15,84082,Louisville,ACC,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2014-15,84086,Loyola Chicago,MVC,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2014-15,84084,Loyola Maryland,Patriot,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2014-15,84087,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2014-15,84088,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Atlantic Athletic Conference,13,exact
+2014-15,84089,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Atlantic Athletic Conference,13,exact
+2014-15,84090,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2014-15,84091,Marshall,C-USA,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2014-15,84093,Maryland,Big Ten,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2014-15,84095,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2014-15,84096,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2014-15,84097,Memphis,AAC,235,Memphis Tigers,Memphis,Tigers,MEM,American Athletic Conference,62,exact
+2014-15,84098,Mercer,SoCon,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2014-15,84100,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2014-15,84099,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2014-15,84102,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2014-15,84101,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2014-15,84103,Middle Tenn.,C-USA,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2014-15,84267,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2014-15,84104,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2014-15,84105,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2014-15,84106,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2014-15,84108,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2014-15,84212,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2014-15,84109,Monmouth,MAAC,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Colonial Athletic Association,10,exact
+2014-15,84111,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2014-15,84110,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2014-15,84112,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2014-15,84113,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2014-15,84114,Mount St. Mary's,NEC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Atlantic Athletic Conference,13,exact
+2014-15,84115,Murray St.,OVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2014-15,84133,N.C. A&T,MEAC,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Colonial Athletic Association,10,exact
+2014-15,84134,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2014-15,84135,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2014-15,84143,NIU,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2014-15,84126,NJIT,ASUN,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2014-15,84241,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2014-15,84121,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2014-15,84124,Nevada,MWC,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2014-15,84125,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2014-15,84128,New Mexico,MWC,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2014-15,84127,New Mexico St.,WAC,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Western Athletic Conference,30,exact
+2014-15,84129,New Orleans,Southland,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2014-15,84130,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Atlantic Athletic Conference,13,exact
+2014-15,84131,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2014-15,84132,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2014-15,84117,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2014-15,84137,North Dakota,Summit League,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,49,exact
+2014-15,84136,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,49,exact
+2014-15,84284,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,ASUN Conference,46,exact
+2014-15,84138,North Texas,C-USA,249,North Texas Mean Green,North Texas,Mean Green,UNT,Conference USA,11,exact
+2014-15,84140,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Colonial Athletic Association,10,exact
+2014-15,84141,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2014-15,84142,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2014-15,84145,Northern Ky.,Horizon,94,Northern Kentucky Norse,Northern Kentucky,Norse,NKU,Horizon League,45,exact
+2014-15,84147,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2014-15,84146,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2014-15,84148,Notre Dame,ACC,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2014-15,84149,Oakland,Horizon,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2014-15,84151,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2014-15,84150,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2014-15,84153,Oklahoma,Big 12,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Big 12 Conference,8,exact
+2014-15,84152,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2014-15,84154,Old Dominion,C-USA,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2014-15,84107,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2014-15,84122,Omaha,Summit League,2437,Omaha Mavericks,Omaha,Mavericks,OMA,Summit League,49,exact
+2014-15,84155,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,49,exact
+2014-15,84157,Oregon,Pac-12,2483,Oregon Ducks,Oregon,Ducks,ORE,Pac-12 Conference,21,exact
+2014-15,84156,Oregon St.,Pac-12,204,Oregon State Beavers,Oregon State,Beavers,ORST,Pac-12 Conference,21,exact
+2014-15,84158,Pacific,WCC,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2014-15,84161,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2014-15,84160,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2014-15,84162,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2014-15,84163,Pittsburgh,ACC,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2014-15,84165,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2014-15,84164,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2014-15,84166,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2014-15,84279,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2014-15,84167,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2014-15,84168,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2014-15,84169,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2014-15,84061,Purdue Fort Wayne,Summit League,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2014-15,84170,Quinnipiac,MAAC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Atlantic Athletic Conference,13,exact
+2014-15,84171,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2014-15,84172,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2014-15,84173,Rice,C-USA,242,Rice Owls,Rice,Owls,RICE,Conference USA,11,exact
+2014-15,84174,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2014-15,84175,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Atlantic Athletic Conference,13,exact
+2014-15,84176,Robert Morris,NEC,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2014-15,84177,Rutgers,Big Ten,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2014-15,84216,SFA,Southland,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Western Athletic Conference,30,exact
+2014-15,84207,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2014-15,84208,SMU,AAC,2567,SMU Mustangs,SMU,Mustangs,SMU,American Athletic Conference,62,exact
+2014-15,83982,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2014-15,84178,Sacred Heart,NEC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Northeast Conference,19,exact
+2014-15,84181,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2014-15,84183,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2014-15,84184,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2014-15,84185,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2014-15,84186,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Atlantic Athletic Conference,13,exact
+2014-15,84187,Sam Houston,Southland,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Western Athletic Conference,30,exact
+2014-15,84188,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2014-15,84190,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2014-15,84189,San Diego St.,MWC,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2014-15,84191,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2014-15,84192,San Jose St.,MWC,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2014-15,84193,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2014-15,84194,Savannah St.,MEAC,2542,Savannah State Tigers,Savannah State,Tigers,SAV,,,alias
+2014-15,84280,Seattle U,WAC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,Western Athletic Conference,30,exact
+2014-15,84195,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2014-15,84196,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Atlantic Athletic Conference,13,exact
+2014-15,84197,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2014-15,84199,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2014-15,84198,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2014-15,84201,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,49,exact
+2014-15,84200,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,49,exact
+2014-15,84202,South Fla.,AAC,58,South Florida Bulls,South Florida,Bulls,USF,American Athletic Conference,62,exact
+2014-15,84203,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2014-15,84204,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2014-15,84205,Southern California,Pac-12,30,USC Trojans,USC,Trojans,USC,Pac-12 Conference,21,dict
+2014-15,84206,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2014-15,84209,Southern Miss.,C-USA,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2014-15,84210,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2014-15,84211,Southern Utah,Big Sky,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,Western Athletic Conference,30,exact
+2014-15,84179,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2014-15,84180,St. Francis Brooklyn,NEC,2597,St. Francis Brooklyn Terriers,St. Francis Brooklyn,Terriers,SFNY,Northeast Conference,19,exact
+2014-15,84182,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2014-15,84215,Stanford,Pac-12,24,Stanford Cardinal,Stanford,Cardinal,STAN,Pac-12 Conference,21,exact
+2014-15,84217,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,ASUN Conference,46,exact
+2014-15,84218,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Colonial Athletic Association,10,exact
+2014-15,84219,Syracuse,ACC,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2014-15,84227,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2014-15,84220,Temple,AAC,218,Temple Owls,Temple,Owls,TEM,American Athletic Conference,62,exact
+2014-15,84224,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2014-15,84221,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2014-15,84222,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2014-15,84231,Texas,Big 12,251,Texas Longhorns,Texas,Longhorns,TEX,Big 12 Conference,8,exact
+2014-15,84226,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2014-15,84228,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2014-15,84213,Texas St.,Sun Belt,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2014-15,84229,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2014-15,83996,The Citadel,SoCon,2643,The Citadel Bulldogs,The Citadel,Bulldogs,CIT,Southern Conference,24,exact
+2014-15,84234,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2014-15,84235,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Colonial Athletic Association,10,exact
+2014-15,84236,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2014-15,84237,Tulane,AAC,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Athletic Conference,62,exact
+2014-15,84238,Tulsa,AAC,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Athletic Conference,62,exact
+2014-15,83948,UAB,C-USA,5,UAB Blazers,UAB,Blazers,UAB,Conference USA,11,exact
+2014-15,83949,UAlbany,America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,exact
+2014-15,83985,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2014-15,83986,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2014-15,83988,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2014-15,83983,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2014-15,83992,UCF,AAC,2116,UCF Knights,UCF,Knights,UCF,American Athletic Conference,62,exact
+2014-15,83987,UCLA,Pac-12,26,UCLA Bruins,UCLA,Bruins,UCLA,Pac-12 Conference,21,exact
+2014-15,84004,UConn,AAC,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2014-15,84058,UIC,Horizon,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2014-15,84285,UIW,Southland,2916,Incarnate Word Cardinals,Incarnate Word,Cardinals,UIW,Southland Conference,25,exact
+2014-15,84139,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2014-15,84092,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2014-15,84094,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2014-15,84083,UMass Lowell,America East,2349,UMass Lowell River Hawks,UMass Lowell,River Hawks,UML,America East Conference,1,exact
+2014-15,84116,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2014-15,84119,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2014-15,84120,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Colonial Athletic Association,10,exact
+2014-15,84144,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2014-15,84123,UNLV,MWC,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2014-15,84287,USC Upstate,Big South,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2014-15,84230,UT Arlington,Sun Belt,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,Western Athletic Conference,30,exact
+2014-15,84225,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2014-15,84232,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2014-15,84159,UTRGV,WAC,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Western Athletic Conference,30,dict
+2014-15,84233,UTSA,C-USA,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,Conference USA,11,exact
+2014-15,84243,Utah,Pac-12,254,Utah Utes,Utah,Utes,UTAH,Pac-12 Conference,21,exact
+2014-15,84242,Utah St.,MWC,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2014-15,84293,Utah Valley,WAC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,Western Athletic Conference,30,exact
+2014-15,84248,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2014-15,84249,VMI,SoCon,2678,VMI Keydets,VMI,Keydets,VMI,Southern Conference,24,exact
+2014-15,84244,Valparaiso,MVC,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2014-15,84245,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2014-15,84246,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2014-15,84247,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2014-15,84251,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2014-15,84250,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2014-15,84252,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2014-15,84253,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2014-15,84255,Washington,Pac-12,264,Washington Huskies,Washington,Huskies,WASH,Pac-12 Conference,21,exact
+2014-15,84254,Washington St.,Pac-12,265,Washington State Cougars,Washington State,Cougars,WSU,Pac-12 Conference,21,exact
+2014-15,84256,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2014-15,84257,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2014-15,84258,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2014-15,84259,Western Ill.,Summit League,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Summit League,49,exact
+2014-15,84260,Western Ky.,C-USA,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2014-15,84261,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2014-15,84262,Wichita St.,AAC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Athletic Conference,62,exact
+2014-15,84263,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Colonial Athletic Association,10,exact
+2014-15,84264,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2014-15,84266,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2014-15,84286,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2014-15,84268,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2014-15,84269,Wyoming,MWC,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2014-15,84270,Xavier,Big East,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2014-15,84271,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2014-15,84272,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2015-16,22078,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2015-16,21731,Abilene Christian,Southland,2000,Abilene Christian Wildcats,Abilene Christian,Wildcats,ACU,Western Athletic Conference,30,exact
+2015-16,22027,Air Force,MWC,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2015-16,21732,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2015-16,21735,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2015-16,21733,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2015-16,21734,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2015-16,21738,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2015-16,21739,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2015-16,21740,App State,Sun Belt,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2015-16,21742,Arizona,Pac-12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Pac-12 Conference,21,exact
+2015-16,21741,Arizona St.,Pac-12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Pac-12 Conference,21,exact
+2015-16,22069,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2015-16,21744,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2015-16,21743,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2015-16,22028,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2015-16,21746,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2015-16,21747,Austin Peay,OVC,2046,Austin Peay Governors,Austin Peay,Governors,APSU,ASUN Conference,46,exact
+2015-16,21758,BYU,WCC,252,BYU Cougars,BYU,Cougars,BYU,West Coast Conference,29,exact
+2015-16,21748,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2015-16,21750,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2015-16,22076,Belmont,OVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2015-16,21751,Bethune-Cookman,MEAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2015-16,21752,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2015-16,21753,Boise St.,MWC,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2015-16,21754,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2015-16,21755,Boston U.,Patriot,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2015-16,21756,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2015-16,21757,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2015-16,21759,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2015-16,21760,Bryant,NEC,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2015-16,21761,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2015-16,21762,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2015-16,21763,Butler,Big East,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2015-16,21765,CSU Bakersfield,WAC,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2015-16,21769,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2015-16,21764,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2015-16,21767,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2015-16,21772,California,Pac-12,25,California Golden Bears,California,Golden Bears,CAL,Pac-12 Conference,21,exact
+2015-16,21777,Campbell,Big South,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Big South Conference,6,exact
+2015-16,21778,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Atlantic Athletic Conference,13,exact
+2015-16,22061,Central Ark.,Southland,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,ASUN Conference,46,exact
+2015-16,21779,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2015-16,21781,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2015-16,21749,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2015-16,21906,Charlotte,C-USA,2429,Charlotte 49ers,Charlotte,49ers,CLT,Conference USA,11,exact
+2015-16,22011,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2015-16,21782,Chicago St.,WAC,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Division I Independents,43,exact
+2015-16,21783,Cincinnati,AAC,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,American Athletic Conference,62,exact
+2015-16,21785,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2015-16,21786,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2015-16,21787,Coastal Carolina,Sun Belt,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2015-16,22062,Col. of Charleston,CAA,232,Charleston Cougars,Charleston,Cougars,COFC,Colonial Athletic Association,10,dict
+2015-16,21788,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2015-16,21790,Colorado,Pac-12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Pac-12 Conference,21,exact
+2015-16,21789,Colorado St.,MWC,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2015-16,21791,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2015-16,21793,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2015-16,21794,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2015-16,21795,Creighton,Big East,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2015-16,21796,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2015-16,21797,Davidson,Atlantic 10,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2015-16,21798,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2015-16,21799,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2015-16,21801,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Colonial Athletic Association,10,exact
+2015-16,21800,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2015-16,21802,Denver,Summit League,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,49,exact
+2015-16,21803,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2015-16,21804,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2015-16,21805,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Colonial Athletic Association,10,exact
+2015-16,21806,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2015-16,21807,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2015-16,21809,ETSU,SoCon,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2015-16,21808,East Carolina,AAC,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Athletic Conference,62,exact
+2015-16,21810,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2015-16,21811,Eastern Ky.,OVC,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,ASUN Conference,46,exact
+2015-16,21812,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2015-16,21813,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2015-16,22063,Elon,CAA,2210,Elon Phoenix,Elon,Phoenix,ELON,Colonial Athletic Association,10,exact
+2015-16,21814,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2015-16,22080,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,ASUN Conference,46,exact
+2015-16,21819,FIU,C-USA,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2015-16,21815,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Atlantic Athletic Conference,13,exact
+2015-16,21816,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2015-16,21818,Fla. Atlantic,C-USA,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,Conference USA,11,exact
+2015-16,21821,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2015-16,21817,Florida A&M,MEAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2015-16,21820,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2015-16,21822,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2015-16,21766,Fresno St.,MWC,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2015-16,21823,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2015-16,21827,Ga. Southern,Sun Belt,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2015-16,22064,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2015-16,21824,George Mason,Atlantic 10,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2015-16,21825,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2015-16,21826,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2015-16,21830,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2015-16,21828,Georgia St.,Sun Belt,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2015-16,21829,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2015-16,21831,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2015-16,21832,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2015-16,22065,Grand Canyon,WAC,2253,Grand Canyon Lopes,Grand Canyon,Lopes,GCU,Western Athletic Conference,30,exact
+2015-16,22053,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2015-16,21833,Hampton,Big South,2261,Hampton Pirates,Hampton,Pirates,HAMP,Colonial Athletic Association,10,exact
+2015-16,21834,Hartford,America East,42,Hartford Hawks,Hartford,Hawks,HART,Division I Independents,43,exact
+2015-16,21835,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2015-16,21836,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2015-16,22077,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2015-16,21837,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Colonial Athletic Association,10,exact
+2015-16,21838,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2015-16,21840,Houston,AAC,248,Houston Cougars,Houston,Cougars,HOU,American Athletic Conference,62,exact
+2015-16,21839,Houston Christian,Southland,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,exact
+2015-16,21841,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2015-16,22070,IUPUI,Horizon,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,alias
+2015-16,21843,Idaho,Big Sky,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2015-16,21842,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2015-16,21845,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2015-16,21844,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2015-16,21848,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2015-16,21847,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2015-16,21850,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Atlantic Athletic Conference,13,exact
+2015-16,21852,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2015-16,21851,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2015-16,21853,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2015-16,21855,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,ASUN Conference,46,exact
+2015-16,21854,Jacksonville St.,OVC,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,ASUN Conference,46,exact
+2015-16,21856,James Madison,CAA,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2015-16,21858,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2015-16,22071,Kansas City,WAC,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,49,exact
+2015-16,21857,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2015-16,22066,Kennesaw St.,ASUN,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,ASUN Conference,46,exact
+2015-16,21859,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2015-16,21860,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2015-16,21866,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2015-16,21873,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2015-16,21868,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2015-16,21861,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2015-16,21862,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2015-16,21863,Lamar University,Southland,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2015-16,21864,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2015-16,21865,Liberty,ASUN,2335,Liberty Flames,Liberty,Flames,LIB,ASUN Conference,46,exact
+2015-16,22079,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,ASUN Conference,46,exact
+2015-16,21745,Little Rock,Sun Belt,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2015-16,21768,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2015-16,21867,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2015-16,22002,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2015-16,21869,Louisiana Tech,C-USA,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2015-16,21870,Louisville,ACC,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2015-16,21874,Loyola Chicago,MVC,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2015-16,21872,Loyola Maryland,Patriot,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2015-16,21875,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2015-16,21876,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Atlantic Athletic Conference,13,exact
+2015-16,21877,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Atlantic Athletic Conference,13,exact
+2015-16,21878,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2015-16,21879,Marshall,C-USA,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2015-16,21881,Maryland,Big Ten,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2015-16,21883,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2015-16,21884,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2015-16,21885,Memphis,AAC,235,Memphis Tigers,Memphis,Tigers,MEM,American Athletic Conference,62,exact
+2015-16,21886,Mercer,SoCon,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2015-16,21888,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2015-16,21887,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2015-16,21890,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2015-16,21889,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2015-16,21891,Middle Tenn.,C-USA,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2015-16,22055,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2015-16,21892,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2015-16,21893,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2015-16,21894,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2015-16,21896,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2015-16,22000,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2015-16,21897,Monmouth,MAAC,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Colonial Athletic Association,10,exact
+2015-16,21899,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2015-16,21898,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2015-16,21900,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2015-16,21901,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2015-16,21902,Mount St. Mary's,NEC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Atlantic Athletic Conference,13,exact
+2015-16,21903,Murray St.,OVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2015-16,21921,N.C. A&T,MEAC,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Colonial Athletic Association,10,exact
+2015-16,21922,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2015-16,21923,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2015-16,21931,NIU,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2015-16,21914,NJIT,ASUN,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2015-16,22029,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2015-16,21909,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2015-16,21912,Nevada,MWC,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2015-16,21913,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2015-16,21916,New Mexico,MWC,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2015-16,21915,New Mexico St.,WAC,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Western Athletic Conference,30,exact
+2015-16,21917,New Orleans,Southland,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2015-16,21918,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Atlantic Athletic Conference,13,exact
+2015-16,21919,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2015-16,21920,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2015-16,21905,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2015-16,21925,North Dakota,Summit League,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,49,exact
+2015-16,21924,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,49,exact
+2015-16,22072,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,ASUN Conference,46,exact
+2015-16,21926,North Texas,C-USA,249,North Texas Mean Green,North Texas,Mean Green,UNT,Conference USA,11,exact
+2015-16,21928,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Colonial Athletic Association,10,exact
+2015-16,21929,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2015-16,21930,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2015-16,21933,Northern Ky.,Horizon,94,Northern Kentucky Norse,Northern Kentucky,Norse,NKU,Horizon League,45,exact
+2015-16,21935,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2015-16,21934,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2015-16,21936,Notre Dame,ACC,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2015-16,21937,Oakland,Horizon,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2015-16,21939,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2015-16,21938,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2015-16,21941,Oklahoma,Big 12,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Big 12 Conference,8,exact
+2015-16,21940,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2015-16,21942,Old Dominion,C-USA,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2015-16,21895,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2015-16,21910,Omaha,Summit League,2437,Omaha Mavericks,Omaha,Mavericks,OMA,Summit League,49,exact
+2015-16,21943,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,49,exact
+2015-16,21945,Oregon,Pac-12,2483,Oregon Ducks,Oregon,Ducks,ORE,Pac-12 Conference,21,exact
+2015-16,21944,Oregon St.,Pac-12,204,Oregon State Beavers,Oregon State,Beavers,ORST,Pac-12 Conference,21,exact
+2015-16,21946,Pacific,WCC,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2015-16,21949,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2015-16,21948,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2015-16,21950,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2015-16,21951,Pittsburgh,ACC,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2015-16,21953,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2015-16,21952,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2015-16,21954,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2015-16,22067,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2015-16,21955,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2015-16,21956,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2015-16,21957,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2015-16,21849,Purdue Fort Wayne,Summit League,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2015-16,21958,Quinnipiac,MAAC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Atlantic Athletic Conference,13,exact
+2015-16,21959,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2015-16,21960,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2015-16,21961,Rice,C-USA,242,Rice Owls,Rice,Owls,RICE,Conference USA,11,exact
+2015-16,21962,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2015-16,21963,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Atlantic Athletic Conference,13,exact
+2015-16,21964,Robert Morris,NEC,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2015-16,21965,Rutgers,Big Ten,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2015-16,22004,SFA,Southland,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Western Athletic Conference,30,exact
+2015-16,21995,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2015-16,21996,SMU,AAC,2567,SMU Mustangs,SMU,Mustangs,SMU,American Athletic Conference,62,exact
+2015-16,21770,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2015-16,21966,Sacred Heart,NEC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Northeast Conference,19,exact
+2015-16,21969,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2015-16,21971,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2015-16,21972,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2015-16,21973,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2015-16,21974,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Atlantic Athletic Conference,13,exact
+2015-16,21975,Sam Houston,Southland,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Western Athletic Conference,30,exact
+2015-16,21976,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2015-16,21978,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2015-16,21977,San Diego St.,MWC,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2015-16,21979,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2015-16,21980,San Jose St.,MWC,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2015-16,21981,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2015-16,21982,Savannah St.,MEAC,2542,Savannah State Tigers,Savannah State,Tigers,SAV,,,alias
+2015-16,22068,Seattle U,WAC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,Western Athletic Conference,30,exact
+2015-16,21983,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2015-16,21984,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Atlantic Athletic Conference,13,exact
+2015-16,21985,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2015-16,21987,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2015-16,21986,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2015-16,21989,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,49,exact
+2015-16,21988,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,49,exact
+2015-16,21990,South Fla.,AAC,58,South Florida Bulls,South Florida,Bulls,USF,American Athletic Conference,62,exact
+2015-16,21991,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2015-16,21992,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2015-16,21993,Southern California,Pac-12,30,USC Trojans,USC,Trojans,USC,Pac-12 Conference,21,dict
+2015-16,21994,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2015-16,21997,Southern Miss.,C-USA,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2015-16,21998,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2015-16,21999,Southern Utah,Big Sky,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,Western Athletic Conference,30,exact
+2015-16,21967,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2015-16,21968,St. Francis Brooklyn,NEC,2597,St. Francis Brooklyn Terriers,St. Francis Brooklyn,Terriers,SFNY,Northeast Conference,19,exact
+2015-16,21970,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2015-16,22003,Stanford,Pac-12,24,Stanford Cardinal,Stanford,Cardinal,STAN,Pac-12 Conference,21,exact
+2015-16,22005,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,ASUN Conference,46,exact
+2015-16,22006,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Colonial Athletic Association,10,exact
+2015-16,22007,Syracuse,ACC,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2015-16,22015,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2015-16,22008,Temple,AAC,218,Temple Owls,Temple,Owls,TEM,American Athletic Conference,62,exact
+2015-16,22012,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2015-16,22009,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2015-16,22010,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2015-16,22019,Texas,Big 12,251,Texas Longhorns,Texas,Longhorns,TEX,Big 12 Conference,8,exact
+2015-16,22014,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2015-16,22016,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2015-16,22001,Texas St.,Sun Belt,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2015-16,22017,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2015-16,21784,The Citadel,SoCon,2643,The Citadel Bulldogs,The Citadel,Bulldogs,CIT,Southern Conference,24,exact
+2015-16,22022,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2015-16,22023,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Colonial Athletic Association,10,exact
+2015-16,22024,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2015-16,22025,Tulane,AAC,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Athletic Conference,62,exact
+2015-16,22026,Tulsa,AAC,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Athletic Conference,62,exact
+2015-16,21736,UAB,C-USA,5,UAB Blazers,UAB,Blazers,UAB,Conference USA,11,exact
+2015-16,21737,UAlbany,America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,exact
+2015-16,21773,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2015-16,21774,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2015-16,21776,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2015-16,21771,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2015-16,21780,UCF,AAC,2116,UCF Knights,UCF,Knights,UCF,American Athletic Conference,62,exact
+2015-16,21775,UCLA,Pac-12,26,UCLA Bruins,UCLA,Bruins,UCLA,Pac-12 Conference,21,exact
+2015-16,21792,UConn,AAC,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2015-16,21846,UIC,Horizon,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2015-16,22073,UIW,Southland,2916,Incarnate Word Cardinals,Incarnate Word,Cardinals,UIW,Southland Conference,25,exact
+2015-16,21927,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2015-16,21880,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2015-16,21882,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2015-16,21871,UMass Lowell,America East,2349,UMass Lowell River Hawks,UMass Lowell,River Hawks,UML,America East Conference,1,exact
+2015-16,21904,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2015-16,21907,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2015-16,21908,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Colonial Athletic Association,10,exact
+2015-16,21932,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2015-16,21911,UNLV,MWC,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2015-16,22075,USC Upstate,Big South,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2015-16,22018,UT Arlington,Sun Belt,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,Western Athletic Conference,30,exact
+2015-16,22013,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2015-16,22020,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2015-16,21947,UTRGV,WAC,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Western Athletic Conference,30,dict
+2015-16,22021,UTSA,C-USA,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,Conference USA,11,exact
+2015-16,22031,Utah,Pac-12,254,Utah Utes,Utah,Utes,UTAH,Pac-12 Conference,21,exact
+2015-16,22030,Utah St.,MWC,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2015-16,22081,Utah Valley,WAC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,Western Athletic Conference,30,exact
+2015-16,22036,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2015-16,22037,VMI,SoCon,2678,VMI Keydets,VMI,Keydets,VMI,Southern Conference,24,exact
+2015-16,22032,Valparaiso,MVC,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2015-16,22033,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2015-16,22034,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2015-16,22035,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2015-16,22039,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2015-16,22038,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2015-16,22040,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2015-16,22041,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2015-16,22043,Washington,Pac-12,264,Washington Huskies,Washington,Huskies,WASH,Pac-12 Conference,21,exact
+2015-16,22042,Washington St.,Pac-12,265,Washington State Cougars,Washington State,Cougars,WSU,Pac-12 Conference,21,exact
+2015-16,22044,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2015-16,22045,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2015-16,22046,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2015-16,22047,Western Ill.,Summit League,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Summit League,49,exact
+2015-16,22048,Western Ky.,C-USA,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2015-16,22049,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2015-16,22050,Wichita St.,AAC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Athletic Conference,62,exact
+2015-16,22051,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Colonial Athletic Association,10,exact
+2015-16,22052,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2015-16,22054,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2015-16,22074,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2015-16,22056,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2015-16,22057,Wyoming,MWC,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2015-16,22058,Xavier,Big East,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2015-16,22059,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2015-16,22060,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2016-17,42723,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2016-17,42376,Abilene Christian,Southland,2000,Abilene Christian Wildcats,Abilene Christian,Wildcats,ACU,Western Athletic Conference,30,exact
+2016-17,42672,Air Force,MWC,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2016-17,42377,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2016-17,42380,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2016-17,42378,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2016-17,42379,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2016-17,42383,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2016-17,42384,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2016-17,42385,App State,Sun Belt,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2016-17,42387,Arizona,Pac-12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Pac-12 Conference,21,exact
+2016-17,42386,Arizona St.,Pac-12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Pac-12 Conference,21,exact
+2016-17,42714,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2016-17,42389,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2016-17,42388,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2016-17,42673,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2016-17,42391,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2016-17,42392,Austin Peay,OVC,2046,Austin Peay Governors,Austin Peay,Governors,APSU,ASUN Conference,46,exact
+2016-17,42403,BYU,WCC,252,BYU Cougars,BYU,Cougars,BYU,West Coast Conference,29,exact
+2016-17,42393,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2016-17,42395,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2016-17,42721,Belmont,OVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2016-17,42396,Bethune-Cookman,MEAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2016-17,42397,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2016-17,42398,Boise St.,MWC,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2016-17,42399,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2016-17,42400,Boston U.,Patriot,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2016-17,42401,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2016-17,42402,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2016-17,42404,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2016-17,42405,Bryant,NEC,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2016-17,42406,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2016-17,42407,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2016-17,42408,Butler,Big East,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2016-17,42410,CSU Bakersfield,WAC,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2016-17,42414,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2016-17,42409,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2016-17,42412,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2016-17,42417,California,Pac-12,25,California Golden Bears,California,Golden Bears,CAL,Pac-12 Conference,21,exact
+2016-17,42422,Campbell,Big South,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Big South Conference,6,exact
+2016-17,42423,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Atlantic Athletic Conference,13,exact
+2016-17,42706,Central Ark.,Southland,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,ASUN Conference,46,exact
+2016-17,42424,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2016-17,42426,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2016-17,42394,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2016-17,42551,Charlotte,C-USA,2429,Charlotte 49ers,Charlotte,49ers,CLT,Conference USA,11,exact
+2016-17,42656,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2016-17,42427,Chicago St.,WAC,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Division I Independents,43,exact
+2016-17,42428,Cincinnati,AAC,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,American Athletic Conference,62,exact
+2016-17,42430,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2016-17,42431,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2016-17,42432,Coastal Carolina,Sun Belt,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2016-17,42707,Col. of Charleston,CAA,232,Charleston Cougars,Charleston,Cougars,COFC,Colonial Athletic Association,10,dict
+2016-17,42433,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2016-17,42435,Colorado,Pac-12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Pac-12 Conference,21,exact
+2016-17,42434,Colorado St.,MWC,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2016-17,42436,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2016-17,42438,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2016-17,42439,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2016-17,42440,Creighton,Big East,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2016-17,42441,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2016-17,42442,Davidson,Atlantic 10,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2016-17,42443,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2016-17,42444,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2016-17,42446,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Colonial Athletic Association,10,exact
+2016-17,42445,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2016-17,42447,Denver,Summit League,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,49,exact
+2016-17,42448,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2016-17,42449,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2016-17,42450,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Colonial Athletic Association,10,exact
+2016-17,42451,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2016-17,42452,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2016-17,42454,ETSU,SoCon,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2016-17,42453,East Carolina,AAC,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Athletic Conference,62,exact
+2016-17,42455,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2016-17,42456,Eastern Ky.,OVC,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,ASUN Conference,46,exact
+2016-17,42457,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2016-17,42458,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2016-17,42708,Elon,CAA,2210,Elon Phoenix,Elon,Phoenix,ELON,Colonial Athletic Association,10,exact
+2016-17,42459,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2016-17,42725,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,ASUN Conference,46,exact
+2016-17,42464,FIU,C-USA,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2016-17,42460,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Atlantic Athletic Conference,13,exact
+2016-17,42461,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2016-17,42463,Fla. Atlantic,C-USA,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,Conference USA,11,exact
+2016-17,42466,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2016-17,42462,Florida A&M,MEAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2016-17,42465,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2016-17,42467,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2016-17,42411,Fresno St.,MWC,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2016-17,42468,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2016-17,42472,Ga. Southern,Sun Belt,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2016-17,42709,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2016-17,42469,George Mason,Atlantic 10,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2016-17,42470,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2016-17,42471,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2016-17,42475,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2016-17,42473,Georgia St.,Sun Belt,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2016-17,42474,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2016-17,42476,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2016-17,42477,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2016-17,42710,Grand Canyon,WAC,2253,Grand Canyon Lopes,Grand Canyon,Lopes,GCU,Western Athletic Conference,30,exact
+2016-17,42698,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2016-17,42478,Hampton,Big South,2261,Hampton Pirates,Hampton,Pirates,HAMP,Colonial Athletic Association,10,exact
+2016-17,42479,Hartford,America East,42,Hartford Hawks,Hartford,Hawks,HART,Division I Independents,43,exact
+2016-17,42480,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2016-17,42481,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2016-17,42722,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2016-17,42482,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Colonial Athletic Association,10,exact
+2016-17,42483,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2016-17,42485,Houston,AAC,248,Houston Cougars,Houston,Cougars,HOU,American Athletic Conference,62,exact
+2016-17,42484,Houston Christian,Southland,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,exact
+2016-17,42486,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2016-17,42715,IUPUI,Horizon,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,alias
+2016-17,42488,Idaho,Big Sky,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2016-17,42487,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2016-17,42490,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2016-17,42489,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2016-17,42493,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2016-17,42492,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2016-17,42495,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Atlantic Athletic Conference,13,exact
+2016-17,42497,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2016-17,42496,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2016-17,42498,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2016-17,42500,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,ASUN Conference,46,exact
+2016-17,42499,Jacksonville St.,OVC,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,ASUN Conference,46,exact
+2016-17,42501,James Madison,CAA,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2016-17,42503,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2016-17,42716,Kansas City,WAC,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,49,exact
+2016-17,42502,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2016-17,42711,Kennesaw St.,ASUN,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,ASUN Conference,46,exact
+2016-17,42504,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2016-17,42505,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2016-17,42511,LIU Brooklyn,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,alias
+2016-17,42518,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2016-17,42513,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2016-17,42506,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2016-17,42507,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2016-17,42508,Lamar University,Southland,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2016-17,42509,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2016-17,42510,Liberty,ASUN,2335,Liberty Flames,Liberty,Flames,LIB,ASUN Conference,46,exact
+2016-17,42724,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,ASUN Conference,46,exact
+2016-17,42390,Little Rock,Sun Belt,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2016-17,42413,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2016-17,42512,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2016-17,42647,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2016-17,42514,Louisiana Tech,C-USA,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2016-17,42515,Louisville,ACC,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2016-17,42519,Loyola Chicago,MVC,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2016-17,42517,Loyola Maryland,Patriot,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2016-17,42520,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2016-17,42521,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Atlantic Athletic Conference,13,exact
+2016-17,42522,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Atlantic Athletic Conference,13,exact
+2016-17,42523,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2016-17,42524,Marshall,C-USA,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2016-17,42526,Maryland,Big Ten,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2016-17,42528,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2016-17,42529,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2016-17,42530,Memphis,AAC,235,Memphis Tigers,Memphis,Tigers,MEM,American Athletic Conference,62,exact
+2016-17,42531,Mercer,SoCon,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2016-17,42533,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2016-17,42532,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2016-17,42535,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2016-17,42534,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2016-17,42536,Middle Tenn.,C-USA,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2016-17,42700,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2016-17,42537,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2016-17,42538,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2016-17,42539,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2016-17,42541,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2016-17,42645,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2016-17,42542,Monmouth,MAAC,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Colonial Athletic Association,10,exact
+2016-17,42544,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2016-17,42543,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2016-17,42545,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2016-17,42546,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2016-17,42547,Mount St. Mary's,NEC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Atlantic Athletic Conference,13,exact
+2016-17,42548,Murray St.,OVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2016-17,42566,N.C. A&T,MEAC,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Colonial Athletic Association,10,exact
+2016-17,42567,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2016-17,42568,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2016-17,42576,NIU,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2016-17,42559,NJIT,ASUN,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2016-17,42674,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2016-17,42554,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2016-17,42557,Nevada,MWC,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2016-17,42558,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2016-17,42561,New Mexico,MWC,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2016-17,42560,New Mexico St.,WAC,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Western Athletic Conference,30,exact
+2016-17,42562,New Orleans,Southland,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2016-17,42563,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Atlantic Athletic Conference,13,exact
+2016-17,42564,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2016-17,42565,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2016-17,42550,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2016-17,42570,North Dakota,Summit League,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,49,exact
+2016-17,42569,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,49,exact
+2016-17,42717,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,ASUN Conference,46,exact
+2016-17,42571,North Texas,C-USA,249,North Texas Mean Green,North Texas,Mean Green,UNT,Conference USA,11,exact
+2016-17,42573,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Colonial Athletic Association,10,exact
+2016-17,42574,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2016-17,42575,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2016-17,42578,Northern Ky.,Horizon,94,Northern Kentucky Norse,Northern Kentucky,Norse,NKU,Horizon League,45,exact
+2016-17,42580,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2016-17,42579,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2016-17,42581,Notre Dame,ACC,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2016-17,42582,Oakland,Horizon,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2016-17,42584,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2016-17,42583,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2016-17,42586,Oklahoma,Big 12,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Big 12 Conference,8,exact
+2016-17,42585,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2016-17,42587,Old Dominion,C-USA,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2016-17,42540,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2016-17,42555,Omaha,Summit League,2437,Omaha Mavericks,Omaha,Mavericks,OMA,Summit League,49,exact
+2016-17,42588,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,49,exact
+2016-17,42590,Oregon,Pac-12,2483,Oregon Ducks,Oregon,Ducks,ORE,Pac-12 Conference,21,exact
+2016-17,42589,Oregon St.,Pac-12,204,Oregon State Beavers,Oregon State,Beavers,ORST,Pac-12 Conference,21,exact
+2016-17,42591,Pacific,WCC,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2016-17,42594,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2016-17,42593,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2016-17,42595,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2016-17,42596,Pittsburgh,ACC,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2016-17,42598,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2016-17,42597,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2016-17,42599,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2016-17,42712,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2016-17,42600,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2016-17,42601,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2016-17,42602,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2016-17,42494,Purdue Fort Wayne,Summit League,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2016-17,42603,Quinnipiac,MAAC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Atlantic Athletic Conference,13,exact
+2016-17,42604,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2016-17,42605,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2016-17,42606,Rice,C-USA,242,Rice Owls,Rice,Owls,RICE,Conference USA,11,exact
+2016-17,42607,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2016-17,42608,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Atlantic Athletic Conference,13,exact
+2016-17,42609,Robert Morris,NEC,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2016-17,42610,Rutgers,Big Ten,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2016-17,42649,SFA,Southland,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Western Athletic Conference,30,exact
+2016-17,42640,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2016-17,42641,SMU,AAC,2567,SMU Mustangs,SMU,Mustangs,SMU,American Athletic Conference,62,exact
+2016-17,42415,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2016-17,42611,Sacred Heart,NEC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Northeast Conference,19,exact
+2016-17,42614,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2016-17,42616,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2016-17,42617,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2016-17,42618,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2016-17,42619,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Atlantic Athletic Conference,13,exact
+2016-17,42620,Sam Houston,Southland,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Western Athletic Conference,30,exact
+2016-17,42621,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2016-17,42623,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2016-17,42622,San Diego St.,MWC,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2016-17,42624,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2016-17,42625,San Jose St.,MWC,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2016-17,42626,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2016-17,42627,Savannah St.,MEAC,2542,Savannah State Tigers,Savannah State,Tigers,SAV,,,alias
+2016-17,42713,Seattle U,WAC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,Western Athletic Conference,30,exact
+2016-17,42628,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2016-17,42629,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Atlantic Athletic Conference,13,exact
+2016-17,42630,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2016-17,42632,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2016-17,42631,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2016-17,42634,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,49,exact
+2016-17,42633,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,49,exact
+2016-17,42635,South Fla.,AAC,58,South Florida Bulls,South Florida,Bulls,USF,American Athletic Conference,62,exact
+2016-17,42636,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2016-17,42637,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2016-17,42638,Southern California,Pac-12,30,USC Trojans,USC,Trojans,USC,Pac-12 Conference,21,dict
+2016-17,42639,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2016-17,42642,Southern Miss.,C-USA,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2016-17,42643,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2016-17,42644,Southern Utah,Big Sky,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,Western Athletic Conference,30,exact
+2016-17,42612,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2016-17,42613,St. Francis Brooklyn,NEC,2597,St. Francis Brooklyn Terriers,St. Francis Brooklyn,Terriers,SFNY,Northeast Conference,19,exact
+2016-17,42615,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2016-17,42648,Stanford,Pac-12,24,Stanford Cardinal,Stanford,Cardinal,STAN,Pac-12 Conference,21,exact
+2016-17,42650,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,ASUN Conference,46,exact
+2016-17,42651,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Colonial Athletic Association,10,exact
+2016-17,42652,Syracuse,ACC,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2016-17,42660,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2016-17,42653,Temple,AAC,218,Temple Owls,Temple,Owls,TEM,American Athletic Conference,62,exact
+2016-17,42657,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2016-17,42654,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2016-17,42655,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2016-17,42664,Texas,Big 12,251,Texas Longhorns,Texas,Longhorns,TEX,Big 12 Conference,8,exact
+2016-17,42659,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2016-17,42661,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2016-17,42646,Texas St.,Sun Belt,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2016-17,42662,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2016-17,42429,The Citadel,SoCon,2643,The Citadel Bulldogs,The Citadel,Bulldogs,CIT,Southern Conference,24,exact
+2016-17,42667,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2016-17,42668,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Colonial Athletic Association,10,exact
+2016-17,42669,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2016-17,42670,Tulane,AAC,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Athletic Conference,62,exact
+2016-17,42671,Tulsa,AAC,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Athletic Conference,62,exact
+2016-17,42381,UAB,C-USA,5,UAB Blazers,UAB,Blazers,UAB,Conference USA,11,exact
+2016-17,42382,UAlbany,America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,exact
+2016-17,42418,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2016-17,42419,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2016-17,42421,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2016-17,42416,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2016-17,42425,UCF,AAC,2116,UCF Knights,UCF,Knights,UCF,American Athletic Conference,62,exact
+2016-17,42420,UCLA,Pac-12,26,UCLA Bruins,UCLA,Bruins,UCLA,Pac-12 Conference,21,exact
+2016-17,42437,UConn,AAC,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2016-17,42491,UIC,Horizon,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2016-17,42718,UIW,Southland,2916,Incarnate Word Cardinals,Incarnate Word,Cardinals,UIW,Southland Conference,25,exact
+2016-17,42572,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2016-17,42525,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2016-17,42527,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2016-17,42516,UMass Lowell,America East,2349,UMass Lowell River Hawks,UMass Lowell,River Hawks,UML,America East Conference,1,exact
+2016-17,42549,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2016-17,42552,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2016-17,42553,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Colonial Athletic Association,10,exact
+2016-17,42577,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2016-17,42556,UNLV,MWC,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2016-17,42720,USC Upstate,Big South,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2016-17,42663,UT Arlington,Sun Belt,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,Western Athletic Conference,30,exact
+2016-17,42658,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2016-17,42665,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2016-17,42592,UTRGV,WAC,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Western Athletic Conference,30,dict
+2016-17,42666,UTSA,C-USA,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,Conference USA,11,exact
+2016-17,42676,Utah,Pac-12,254,Utah Utes,Utah,Utes,UTAH,Pac-12 Conference,21,exact
+2016-17,42675,Utah St.,MWC,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2016-17,42726,Utah Valley,WAC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,Western Athletic Conference,30,exact
+2016-17,42681,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2016-17,42682,VMI,SoCon,2678,VMI Keydets,VMI,Keydets,VMI,Southern Conference,24,exact
+2016-17,42677,Valparaiso,MVC,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2016-17,42678,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2016-17,42679,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2016-17,42680,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2016-17,42684,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2016-17,42683,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2016-17,42685,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2016-17,42686,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2016-17,42688,Washington,Pac-12,264,Washington Huskies,Washington,Huskies,WASH,Pac-12 Conference,21,exact
+2016-17,42687,Washington St.,Pac-12,265,Washington State Cougars,Washington State,Cougars,WSU,Pac-12 Conference,21,exact
+2016-17,42689,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2016-17,42690,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2016-17,42691,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2016-17,42692,Western Ill.,Summit League,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Summit League,49,exact
+2016-17,42693,Western Ky.,C-USA,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2016-17,42694,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2016-17,42695,Wichita St.,AAC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Athletic Conference,62,exact
+2016-17,42696,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Colonial Athletic Association,10,exact
+2016-17,42697,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2016-17,42699,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2016-17,42719,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2016-17,42701,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2016-17,42702,Wyoming,MWC,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2016-17,42703,Xavier,Big East,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2016-17,42704,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2016-17,42705,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2017-18,111285,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2017-18,110938,Abilene Christian,Southland,2000,Abilene Christian Wildcats,Abilene Christian,Wildcats,ACU,Western Athletic Conference,30,exact
+2017-18,111234,Air Force,MWC,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2017-18,110939,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2017-18,110942,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2017-18,110940,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2017-18,110941,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2017-18,110945,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2017-18,110946,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2017-18,110947,App State,Sun Belt,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2017-18,110949,Arizona,Pac-12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Pac-12 Conference,21,exact
+2017-18,110948,Arizona St.,Pac-12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Pac-12 Conference,21,exact
+2017-18,111276,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2017-18,110951,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2017-18,110950,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2017-18,111235,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2017-18,110953,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2017-18,110954,Austin Peay,OVC,2046,Austin Peay Governors,Austin Peay,Governors,APSU,ASUN Conference,46,exact
+2017-18,110965,BYU,WCC,252,BYU Cougars,BYU,Cougars,BYU,West Coast Conference,29,exact
+2017-18,110955,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2017-18,110957,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2017-18,111283,Belmont,OVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2017-18,110958,Bethune-Cookman,MEAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2017-18,110959,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2017-18,110960,Boise St.,MWC,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2017-18,110961,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2017-18,110962,Boston U.,Patriot,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2017-18,110963,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2017-18,110964,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2017-18,110966,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2017-18,110967,Bryant,NEC,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2017-18,110968,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2017-18,110969,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2017-18,110970,Butler,Big East,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2017-18,110972,CSU Bakersfield,WAC,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2017-18,110976,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2017-18,110971,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2017-18,110974,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2017-18,110979,California,Pac-12,25,California Golden Bears,California,Golden Bears,CAL,Pac-12 Conference,21,exact
+2017-18,110984,Campbell,Big South,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Big South Conference,6,exact
+2017-18,110985,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Atlantic Athletic Conference,13,exact
+2017-18,111268,Central Ark.,Southland,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,ASUN Conference,46,exact
+2017-18,110986,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2017-18,110988,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2017-18,110956,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2017-18,111113,Charlotte,C-USA,2429,Charlotte 49ers,Charlotte,49ers,CLT,Conference USA,11,exact
+2017-18,111218,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2017-18,110989,Chicago St.,WAC,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Division I Independents,43,exact
+2017-18,110990,Cincinnati,AAC,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,American Athletic Conference,62,exact
+2017-18,110992,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2017-18,110993,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2017-18,110994,Coastal Carolina,Sun Belt,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2017-18,111269,Col. of Charleston,CAA,232,Charleston Cougars,Charleston,Cougars,COFC,Colonial Athletic Association,10,dict
+2017-18,110995,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2017-18,110997,Colorado,Pac-12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Pac-12 Conference,21,exact
+2017-18,110996,Colorado St.,MWC,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2017-18,110998,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2017-18,111000,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2017-18,111001,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2017-18,111002,Creighton,Big East,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2017-18,111003,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2017-18,111004,Davidson,Atlantic 10,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2017-18,111005,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2017-18,111006,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2017-18,111008,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Colonial Athletic Association,10,exact
+2017-18,111007,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2017-18,111009,Denver,Summit League,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,49,exact
+2017-18,111010,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2017-18,111011,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2017-18,111012,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Colonial Athletic Association,10,exact
+2017-18,111013,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2017-18,111014,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2017-18,111016,ETSU,SoCon,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2017-18,111015,East Carolina,AAC,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Athletic Conference,62,exact
+2017-18,111017,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2017-18,111018,Eastern Ky.,OVC,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,ASUN Conference,46,exact
+2017-18,111019,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2017-18,111020,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2017-18,111270,Elon,CAA,2210,Elon Phoenix,Elon,Phoenix,ELON,Colonial Athletic Association,10,exact
+2017-18,111021,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2017-18,111287,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,ASUN Conference,46,exact
+2017-18,111026,FIU,C-USA,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2017-18,111022,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Atlantic Athletic Conference,13,exact
+2017-18,111023,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2017-18,111025,Fla. Atlantic,C-USA,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,Conference USA,11,exact
+2017-18,111028,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2017-18,111024,Florida A&M,MEAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2017-18,111027,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2017-18,111029,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2017-18,110973,Fresno St.,MWC,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2017-18,111030,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2017-18,111034,Ga. Southern,Sun Belt,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2017-18,111271,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2017-18,111031,George Mason,Atlantic 10,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2017-18,111032,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2017-18,111033,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2017-18,111037,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2017-18,111035,Georgia St.,Sun Belt,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2017-18,111036,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2017-18,111038,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2017-18,111039,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2017-18,111272,Grand Canyon,WAC,2253,Grand Canyon Lopes,Grand Canyon,Lopes,GCU,Western Athletic Conference,30,exact
+2017-18,111260,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2017-18,111040,Hampton,MEAC,2261,Hampton Pirates,Hampton,Pirates,HAMP,Colonial Athletic Association,10,exact
+2017-18,111041,Hartford,America East,42,Hartford Hawks,Hartford,Hawks,HART,Division I Independents,43,exact
+2017-18,111042,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2017-18,111043,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2017-18,111284,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2017-18,111044,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Colonial Athletic Association,10,exact
+2017-18,111045,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2017-18,111047,Houston,AAC,248,Houston Cougars,Houston,Cougars,HOU,American Athletic Conference,62,exact
+2017-18,111046,Houston Christian,Southland,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,exact
+2017-18,111048,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2017-18,111277,IUPUI,Horizon,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,alias
+2017-18,111050,Idaho,Big Sky,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2017-18,111049,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2017-18,111052,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2017-18,111051,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2017-18,111055,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2017-18,111054,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2017-18,111057,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Atlantic Athletic Conference,13,exact
+2017-18,111059,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2017-18,111058,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2017-18,111060,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2017-18,111062,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,ASUN Conference,46,exact
+2017-18,111061,Jacksonville St.,OVC,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,ASUN Conference,46,exact
+2017-18,111063,James Madison,CAA,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2017-18,111065,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2017-18,111278,Kansas City,WAC,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,49,exact
+2017-18,111064,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2017-18,111273,Kennesaw St.,ASUN,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,ASUN Conference,46,exact
+2017-18,111066,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2017-18,111067,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2017-18,111073,LIU Brooklyn,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,alias
+2017-18,111080,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2017-18,111075,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2017-18,111068,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2017-18,111069,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2017-18,111070,Lamar University,Southland,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2017-18,111071,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2017-18,111072,Liberty,Big South,2335,Liberty Flames,Liberty,Flames,LIB,ASUN Conference,46,exact
+2017-18,111286,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,ASUN Conference,46,exact
+2017-18,110952,Little Rock,Sun Belt,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2017-18,110975,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2017-18,111074,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2017-18,111209,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2017-18,111076,Louisiana Tech,C-USA,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2017-18,111077,Louisville,ACC,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2017-18,111081,Loyola Chicago,MVC,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2017-18,111079,Loyola Maryland,Patriot,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2017-18,111082,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2017-18,111083,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Atlantic Athletic Conference,13,exact
+2017-18,111084,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Atlantic Athletic Conference,13,exact
+2017-18,111085,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2017-18,111086,Marshall,C-USA,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2017-18,111088,Maryland,Big Ten,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2017-18,111090,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2017-18,111091,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2017-18,111092,Memphis,AAC,235,Memphis Tigers,Memphis,Tigers,MEM,American Athletic Conference,62,exact
+2017-18,111093,Mercer,SoCon,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2017-18,111095,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2017-18,111094,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2017-18,111097,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2017-18,111096,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2017-18,111098,Middle Tenn.,C-USA,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2017-18,111262,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2017-18,111099,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2017-18,111100,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2017-18,111101,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2017-18,111103,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2017-18,111207,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2017-18,111104,Monmouth,MAAC,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Colonial Athletic Association,10,exact
+2017-18,111106,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2017-18,111105,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2017-18,111107,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2017-18,111108,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2017-18,111109,Mount St. Mary's,NEC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Atlantic Athletic Conference,13,exact
+2017-18,111110,Murray St.,OVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2017-18,111128,N.C. A&T,MEAC,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Colonial Athletic Association,10,exact
+2017-18,111129,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2017-18,111130,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2017-18,111138,NIU,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2017-18,111121,NJIT,ASUN,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2017-18,111236,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2017-18,111116,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2017-18,111119,Nevada,MWC,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2017-18,111120,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2017-18,111123,New Mexico,MWC,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2017-18,111122,New Mexico St.,WAC,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Western Athletic Conference,30,exact
+2017-18,111124,New Orleans,Southland,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2017-18,111125,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Atlantic Athletic Conference,13,exact
+2017-18,111126,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2017-18,111127,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2017-18,111112,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2017-18,111132,North Dakota,Big Sky,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,49,exact
+2017-18,111131,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,49,exact
+2017-18,111279,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,ASUN Conference,46,exact
+2017-18,111133,North Texas,C-USA,249,North Texas Mean Green,North Texas,Mean Green,UNT,Conference USA,11,exact
+2017-18,111135,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Colonial Athletic Association,10,exact
+2017-18,111136,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2017-18,111137,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2017-18,111140,Northern Ky.,Horizon,94,Northern Kentucky Norse,Northern Kentucky,Norse,NKU,Horizon League,45,exact
+2017-18,111142,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2017-18,111141,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2017-18,111143,Notre Dame,ACC,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2017-18,111144,Oakland,Horizon,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2017-18,111146,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2017-18,111145,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2017-18,111148,Oklahoma,Big 12,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Big 12 Conference,8,exact
+2017-18,111147,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2017-18,111149,Old Dominion,C-USA,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2017-18,111102,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2017-18,111117,Omaha,Summit League,2437,Omaha Mavericks,Omaha,Mavericks,OMA,Summit League,49,exact
+2017-18,111150,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,49,exact
+2017-18,111152,Oregon,Pac-12,2483,Oregon Ducks,Oregon,Ducks,ORE,Pac-12 Conference,21,exact
+2017-18,111151,Oregon St.,Pac-12,204,Oregon State Beavers,Oregon State,Beavers,ORST,Pac-12 Conference,21,exact
+2017-18,111153,Pacific,WCC,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2017-18,111156,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2017-18,111155,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2017-18,111157,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2017-18,111158,Pittsburgh,ACC,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2017-18,111160,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2017-18,111159,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2017-18,111161,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2017-18,111274,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2017-18,111162,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2017-18,111163,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2017-18,111164,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2017-18,111056,Purdue Fort Wayne,Summit League,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2017-18,111165,Quinnipiac,MAAC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Atlantic Athletic Conference,13,exact
+2017-18,111166,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2017-18,111167,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2017-18,111168,Rice,C-USA,242,Rice Owls,Rice,Owls,RICE,Conference USA,11,exact
+2017-18,111169,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2017-18,111170,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Atlantic Athletic Conference,13,exact
+2017-18,111171,Robert Morris,NEC,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2017-18,111172,Rutgers,Big Ten,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2017-18,111211,SFA,Southland,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Western Athletic Conference,30,exact
+2017-18,111202,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2017-18,111203,SMU,AAC,2567,SMU Mustangs,SMU,Mustangs,SMU,American Athletic Conference,62,exact
+2017-18,110977,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2017-18,111173,Sacred Heart,NEC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Northeast Conference,19,exact
+2017-18,111176,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2017-18,111178,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2017-18,111179,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2017-18,111180,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2017-18,111181,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Atlantic Athletic Conference,13,exact
+2017-18,111182,Sam Houston,Southland,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Western Athletic Conference,30,exact
+2017-18,111183,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2017-18,111185,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2017-18,111184,San Diego St.,MWC,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2017-18,111186,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2017-18,111187,San Jose St.,MWC,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2017-18,111188,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2017-18,111189,Savannah St.,MEAC,2542,Savannah State Tigers,Savannah State,Tigers,SAV,,,alias
+2017-18,111275,Seattle U,WAC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,Western Athletic Conference,30,exact
+2017-18,111190,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2017-18,111191,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Atlantic Athletic Conference,13,exact
+2017-18,111192,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2017-18,111194,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2017-18,111193,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2017-18,111196,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,49,exact
+2017-18,111195,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,49,exact
+2017-18,111197,South Fla.,AAC,58,South Florida Bulls,South Florida,Bulls,USF,American Athletic Conference,62,exact
+2017-18,111198,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2017-18,111199,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2017-18,111200,Southern California,Pac-12,30,USC Trojans,USC,Trojans,USC,Pac-12 Conference,21,dict
+2017-18,111201,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2017-18,111204,Southern Miss.,C-USA,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2017-18,111205,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2017-18,111206,Southern Utah,Big Sky,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,Western Athletic Conference,30,exact
+2017-18,111174,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2017-18,111175,St. Francis Brooklyn,NEC,2597,St. Francis Brooklyn Terriers,St. Francis Brooklyn,Terriers,SFNY,Northeast Conference,19,exact
+2017-18,111177,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2017-18,111210,Stanford,Pac-12,24,Stanford Cardinal,Stanford,Cardinal,STAN,Pac-12 Conference,21,exact
+2017-18,111212,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,ASUN Conference,46,exact
+2017-18,111213,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Colonial Athletic Association,10,exact
+2017-18,111214,Syracuse,ACC,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2017-18,111222,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2017-18,111215,Temple,AAC,218,Temple Owls,Temple,Owls,TEM,American Athletic Conference,62,exact
+2017-18,111219,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2017-18,111216,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2017-18,111217,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2017-18,111226,Texas,Big 12,251,Texas Longhorns,Texas,Longhorns,TEX,Big 12 Conference,8,exact
+2017-18,111221,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2017-18,111223,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2017-18,111208,Texas St.,Sun Belt,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2017-18,111224,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2017-18,110991,The Citadel,SoCon,2643,The Citadel Bulldogs,The Citadel,Bulldogs,CIT,Southern Conference,24,exact
+2017-18,111229,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2017-18,111230,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Colonial Athletic Association,10,exact
+2017-18,111231,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2017-18,111232,Tulane,AAC,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Athletic Conference,62,exact
+2017-18,111233,Tulsa,AAC,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Athletic Conference,62,exact
+2017-18,110943,UAB,C-USA,5,UAB Blazers,UAB,Blazers,UAB,Conference USA,11,exact
+2017-18,110944,UAlbany,America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,exact
+2017-18,110980,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2017-18,110981,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2017-18,110983,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2017-18,110978,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2017-18,110987,UCF,AAC,2116,UCF Knights,UCF,Knights,UCF,American Athletic Conference,62,exact
+2017-18,110982,UCLA,Pac-12,26,UCLA Bruins,UCLA,Bruins,UCLA,Pac-12 Conference,21,exact
+2017-18,110999,UConn,AAC,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2017-18,111053,UIC,Horizon,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2017-18,111280,UIW,Southland,2916,Incarnate Word Cardinals,Incarnate Word,Cardinals,UIW,Southland Conference,25,exact
+2017-18,111134,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2017-18,111087,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2017-18,111089,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2017-18,111078,UMass Lowell,America East,2349,UMass Lowell River Hawks,UMass Lowell,River Hawks,UML,America East Conference,1,exact
+2017-18,111111,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2017-18,111114,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2017-18,111115,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Colonial Athletic Association,10,exact
+2017-18,111139,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2017-18,111118,UNLV,MWC,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2017-18,111282,USC Upstate,ASUN,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2017-18,111225,UT Arlington,Sun Belt,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,Western Athletic Conference,30,exact
+2017-18,111220,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2017-18,111227,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2017-18,111154,UTRGV,WAC,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Western Athletic Conference,30,dict
+2017-18,111228,UTSA,C-USA,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,Conference USA,11,exact
+2017-18,111238,Utah,Pac-12,254,Utah Utes,Utah,Utes,UTAH,Pac-12 Conference,21,exact
+2017-18,111237,Utah St.,MWC,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2017-18,111288,Utah Valley,WAC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,Western Athletic Conference,30,exact
+2017-18,111243,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2017-18,111244,VMI,SoCon,2678,VMI Keydets,VMI,Keydets,VMI,Southern Conference,24,exact
+2017-18,111239,Valparaiso,MVC,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2017-18,111240,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2017-18,111241,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2017-18,111242,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2017-18,111246,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2017-18,111245,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2017-18,111247,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2017-18,111248,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2017-18,111250,Washington,Pac-12,264,Washington Huskies,Washington,Huskies,WASH,Pac-12 Conference,21,exact
+2017-18,111249,Washington St.,Pac-12,265,Washington State Cougars,Washington State,Cougars,WSU,Pac-12 Conference,21,exact
+2017-18,111251,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2017-18,111252,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2017-18,111253,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2017-18,111254,Western Ill.,Summit League,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Summit League,49,exact
+2017-18,111255,Western Ky.,C-USA,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2017-18,111256,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2017-18,111257,Wichita St.,AAC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Athletic Conference,62,exact
+2017-18,111258,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Colonial Athletic Association,10,exact
+2017-18,111259,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2017-18,111261,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2017-18,111281,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2017-18,111263,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2017-18,111264,Wyoming,MWC,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2017-18,111265,Xavier,Big East,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2017-18,111266,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2017-18,111267,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2018-19,450809,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2018-19,450462,Abilene Christian,Southland,2000,Abilene Christian Wildcats,Abilene Christian,Wildcats,ACU,Western Athletic Conference,30,exact
+2018-19,450758,Air Force,MWC,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2018-19,450463,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2018-19,450466,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2018-19,450464,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2018-19,450465,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2018-19,450469,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2018-19,450470,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2018-19,450471,App State,Sun Belt,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2018-19,450473,Arizona,Pac-12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Pac-12 Conference,21,exact
+2018-19,450472,Arizona St.,Pac-12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Pac-12 Conference,21,exact
+2018-19,450800,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2018-19,450475,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2018-19,450474,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2018-19,450759,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2018-19,450477,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2018-19,450478,Austin Peay,OVC,2046,Austin Peay Governors,Austin Peay,Governors,APSU,ASUN Conference,46,exact
+2018-19,450489,BYU,WCC,252,BYU Cougars,BYU,Cougars,BYU,West Coast Conference,29,exact
+2018-19,450479,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2018-19,450481,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2018-19,450807,Belmont,OVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2018-19,450482,Bethune-Cookman,MEAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2018-19,450483,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2018-19,450484,Boise St.,MWC,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2018-19,450485,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2018-19,450486,Boston U.,Patriot,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2018-19,450487,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2018-19,450488,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2018-19,450490,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2018-19,450491,Bryant,NEC,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2018-19,450492,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2018-19,450493,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2018-19,450494,Butler,Big East,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2018-19,450496,CSU Bakersfield,WAC,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2018-19,450500,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2018-19,450495,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2018-19,450498,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2018-19,450503,California,Pac-12,25,California Golden Bears,California,Golden Bears,CAL,Pac-12 Conference,21,exact
+2018-19,450508,Campbell,Big South,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Big South Conference,6,exact
+2018-19,450509,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Atlantic Athletic Conference,13,exact
+2018-19,450792,Central Ark.,Southland,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,ASUN Conference,46,exact
+2018-19,450510,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2018-19,450512,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2018-19,450480,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2018-19,450637,Charlotte,C-USA,2429,Charlotte 49ers,Charlotte,49ers,CLT,Conference USA,11,exact
+2018-19,450742,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2018-19,450513,Chicago St.,WAC,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Division I Independents,43,exact
+2018-19,450514,Cincinnati,AAC,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,American Athletic Conference,62,exact
+2018-19,450516,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2018-19,450517,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2018-19,450518,Coastal Carolina,Sun Belt,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2018-19,450793,Col. of Charleston,CAA,232,Charleston Cougars,Charleston,Cougars,COFC,Colonial Athletic Association,10,dict
+2018-19,450519,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2018-19,450521,Colorado,Pac-12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Pac-12 Conference,21,exact
+2018-19,450520,Colorado St.,MWC,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2018-19,450522,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2018-19,450524,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2018-19,450525,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2018-19,450526,Creighton,Big East,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2018-19,450527,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2018-19,450528,Davidson,Atlantic 10,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2018-19,450529,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2018-19,450530,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2018-19,450532,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Colonial Athletic Association,10,exact
+2018-19,450531,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2018-19,450533,Denver,Summit League,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,49,exact
+2018-19,450534,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2018-19,450535,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2018-19,450536,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Colonial Athletic Association,10,exact
+2018-19,450537,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2018-19,450538,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2018-19,450540,ETSU,SoCon,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2018-19,450539,East Carolina,AAC,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Athletic Conference,62,exact
+2018-19,450541,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2018-19,450542,Eastern Ky.,OVC,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,ASUN Conference,46,exact
+2018-19,450543,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2018-19,450544,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2018-19,450794,Elon,CAA,2210,Elon Phoenix,Elon,Phoenix,ELON,Colonial Athletic Association,10,exact
+2018-19,450545,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2018-19,450811,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,ASUN Conference,46,exact
+2018-19,450550,FIU,C-USA,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2018-19,450546,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Atlantic Athletic Conference,13,exact
+2018-19,450547,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2018-19,450549,Fla. Atlantic,C-USA,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,Conference USA,11,exact
+2018-19,450552,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2018-19,450548,Florida A&M,MEAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2018-19,450551,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2018-19,450553,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2018-19,450497,Fresno St.,MWC,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2018-19,450554,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2018-19,450558,Ga. Southern,Sun Belt,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2018-19,450795,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2018-19,450555,George Mason,Atlantic 10,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2018-19,450556,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2018-19,450557,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2018-19,450561,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2018-19,450559,Georgia St.,Sun Belt,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2018-19,450560,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2018-19,450562,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2018-19,450563,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2018-19,450796,Grand Canyon,WAC,2253,Grand Canyon Lopes,Grand Canyon,Lopes,GCU,Western Athletic Conference,30,exact
+2018-19,450784,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2018-19,450564,Hampton,Big South,2261,Hampton Pirates,Hampton,Pirates,HAMP,Colonial Athletic Association,10,exact
+2018-19,450565,Hartford,America East,42,Hartford Hawks,Hartford,Hawks,HART,Division I Independents,43,exact
+2018-19,450566,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2018-19,450567,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2018-19,450808,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2018-19,450568,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Colonial Athletic Association,10,exact
+2018-19,450569,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2018-19,450571,Houston,AAC,248,Houston Cougars,Houston,Cougars,HOU,American Athletic Conference,62,exact
+2018-19,450570,Houston Christian,Southland,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,exact
+2018-19,450572,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2018-19,450801,IUPUI,Horizon,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,alias
+2018-19,450574,Idaho,Big Sky,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2018-19,450573,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2018-19,450576,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2018-19,450575,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2018-19,450579,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2018-19,450578,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2018-19,450581,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Atlantic Athletic Conference,13,exact
+2018-19,450583,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2018-19,450582,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2018-19,450584,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2018-19,450586,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,ASUN Conference,46,exact
+2018-19,450585,Jacksonville St.,OVC,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,ASUN Conference,46,exact
+2018-19,450587,James Madison,CAA,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2018-19,450589,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2018-19,450802,Kansas City,WAC,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,49,exact
+2018-19,450588,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2018-19,450797,Kennesaw St.,ASUN,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,ASUN Conference,46,exact
+2018-19,450590,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2018-19,450591,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2018-19,450597,LIU Brooklyn,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,alias
+2018-19,450604,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2018-19,450599,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2018-19,450592,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2018-19,450593,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2018-19,450594,Lamar University,Southland,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2018-19,450595,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2018-19,450596,Liberty,ASUN,2335,Liberty Flames,Liberty,Flames,LIB,ASUN Conference,46,exact
+2018-19,450810,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,ASUN Conference,46,exact
+2018-19,450476,Little Rock,Sun Belt,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2018-19,450499,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2018-19,450598,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2018-19,450733,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2018-19,450600,Louisiana Tech,C-USA,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2018-19,450601,Louisville,ACC,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2018-19,450605,Loyola Chicago,MVC,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2018-19,450603,Loyola Maryland,Patriot,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2018-19,450606,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2018-19,450607,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Atlantic Athletic Conference,13,exact
+2018-19,450608,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Atlantic Athletic Conference,13,exact
+2018-19,450609,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2018-19,450610,Marshall,C-USA,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2018-19,450612,Maryland,Big Ten,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2018-19,450614,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2018-19,450615,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2018-19,450616,Memphis,AAC,235,Memphis Tigers,Memphis,Tigers,MEM,American Athletic Conference,62,exact
+2018-19,450617,Mercer,SoCon,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2018-19,450619,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2018-19,450618,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2018-19,450621,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2018-19,450620,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2018-19,450622,Middle Tenn.,C-USA,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2018-19,450786,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2018-19,450623,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2018-19,450624,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2018-19,450625,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2018-19,450627,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2018-19,450731,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2018-19,450628,Monmouth,MAAC,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Colonial Athletic Association,10,exact
+2018-19,450630,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2018-19,450629,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2018-19,450631,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2018-19,450632,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2018-19,450633,Mount St. Mary's,NEC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Atlantic Athletic Conference,13,exact
+2018-19,450634,Murray St.,OVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2018-19,450652,N.C. A&T,MEAC,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Colonial Athletic Association,10,exact
+2018-19,450653,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2018-19,450654,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2018-19,450662,NIU,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2018-19,450645,NJIT,ASUN,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2018-19,450760,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2018-19,450640,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2018-19,450643,Nevada,MWC,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2018-19,450644,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2018-19,450647,New Mexico,MWC,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2018-19,450646,New Mexico St.,WAC,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Western Athletic Conference,30,exact
+2018-19,450648,New Orleans,Southland,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2018-19,450649,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Atlantic Athletic Conference,13,exact
+2018-19,450650,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2018-19,450651,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2018-19,450636,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2018-19,450656,North Dakota,Summit League,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,49,exact
+2018-19,450655,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,49,exact
+2018-19,450803,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,ASUN Conference,46,exact
+2018-19,450657,North Texas,C-USA,249,North Texas Mean Green,North Texas,Mean Green,UNT,Conference USA,11,exact
+2018-19,450659,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Colonial Athletic Association,10,exact
+2018-19,450660,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2018-19,450661,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2018-19,450664,Northern Ky.,Horizon,94,Northern Kentucky Norse,Northern Kentucky,Norse,NKU,Horizon League,45,exact
+2018-19,450666,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2018-19,450665,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2018-19,450667,Notre Dame,ACC,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2018-19,450668,Oakland,Horizon,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2018-19,450670,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2018-19,450669,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2018-19,450672,Oklahoma,Big 12,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Big 12 Conference,8,exact
+2018-19,450671,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2018-19,450673,Old Dominion,C-USA,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2018-19,450626,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2018-19,450641,Omaha,Summit League,2437,Omaha Mavericks,Omaha,Mavericks,OMA,Summit League,49,exact
+2018-19,450674,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,49,exact
+2018-19,450676,Oregon,Pac-12,2483,Oregon Ducks,Oregon,Ducks,ORE,Pac-12 Conference,21,exact
+2018-19,450675,Oregon St.,Pac-12,204,Oregon State Beavers,Oregon State,Beavers,ORST,Pac-12 Conference,21,exact
+2018-19,450677,Pacific,WCC,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2018-19,450680,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2018-19,450679,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2018-19,450681,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2018-19,450682,Pittsburgh,ACC,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2018-19,450684,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2018-19,450683,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2018-19,450685,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2018-19,450798,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2018-19,450686,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2018-19,450687,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2018-19,450688,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2018-19,450580,Purdue Fort Wayne,Summit League,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2018-19,450689,Quinnipiac,MAAC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Atlantic Athletic Conference,13,exact
+2018-19,450690,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2018-19,450691,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2018-19,450692,Rice,C-USA,242,Rice Owls,Rice,Owls,RICE,Conference USA,11,exact
+2018-19,450693,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2018-19,450694,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Atlantic Athletic Conference,13,exact
+2018-19,450695,Robert Morris,NEC,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2018-19,450696,Rutgers,Big Ten,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2018-19,450735,SFA,Southland,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Western Athletic Conference,30,exact
+2018-19,450726,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2018-19,450727,SMU,AAC,2567,SMU Mustangs,SMU,Mustangs,SMU,American Athletic Conference,62,exact
+2018-19,450501,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2018-19,450697,Sacred Heart,NEC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Northeast Conference,19,exact
+2018-19,450700,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2018-19,450702,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2018-19,450703,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2018-19,450704,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2018-19,450705,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Atlantic Athletic Conference,13,exact
+2018-19,450706,Sam Houston,Southland,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Western Athletic Conference,30,exact
+2018-19,450707,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2018-19,450709,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2018-19,450708,San Diego St.,MWC,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2018-19,450710,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2018-19,450711,San Jose St.,MWC,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2018-19,450712,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2018-19,450713,Savannah St.,MEAC,2542,Savannah State Tigers,Savannah State,Tigers,SAV,,,alias
+2018-19,450799,Seattle U,WAC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,Western Athletic Conference,30,exact
+2018-19,450714,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2018-19,450715,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Atlantic Athletic Conference,13,exact
+2018-19,450716,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2018-19,450718,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2018-19,450717,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2018-19,450720,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,49,exact
+2018-19,450719,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,49,exact
+2018-19,450721,South Fla.,AAC,58,South Florida Bulls,South Florida,Bulls,USF,American Athletic Conference,62,exact
+2018-19,450722,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2018-19,450723,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2018-19,450724,Southern California,Pac-12,30,USC Trojans,USC,Trojans,USC,Pac-12 Conference,21,dict
+2018-19,450725,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2018-19,450728,Southern Miss.,C-USA,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2018-19,450729,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2018-19,450730,Southern Utah,Big Sky,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,Western Athletic Conference,30,exact
+2018-19,450698,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2018-19,450699,St. Francis Brooklyn,NEC,2597,St. Francis Brooklyn Terriers,St. Francis Brooklyn,Terriers,SFNY,Northeast Conference,19,exact
+2018-19,450701,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2018-19,450734,Stanford,Pac-12,24,Stanford Cardinal,Stanford,Cardinal,STAN,Pac-12 Conference,21,exact
+2018-19,450736,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,ASUN Conference,46,exact
+2018-19,450737,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Colonial Athletic Association,10,exact
+2018-19,450738,Syracuse,ACC,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2018-19,450746,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2018-19,450739,Temple,AAC,218,Temple Owls,Temple,Owls,TEM,American Athletic Conference,62,exact
+2018-19,450743,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2018-19,450740,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2018-19,450741,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2018-19,450750,Texas,Big 12,251,Texas Longhorns,Texas,Longhorns,TEX,Big 12 Conference,8,exact
+2018-19,450745,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2018-19,450747,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2018-19,450732,Texas St.,Sun Belt,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2018-19,450748,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2018-19,450515,The Citadel,SoCon,2643,The Citadel Bulldogs,The Citadel,Bulldogs,CIT,Southern Conference,24,exact
+2018-19,450753,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2018-19,450754,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Colonial Athletic Association,10,exact
+2018-19,450755,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2018-19,450756,Tulane,AAC,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Athletic Conference,62,exact
+2018-19,450757,Tulsa,AAC,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Athletic Conference,62,exact
+2018-19,450467,UAB,C-USA,5,UAB Blazers,UAB,Blazers,UAB,Conference USA,11,exact
+2018-19,450468,UAlbany,America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,exact
+2018-19,450504,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2018-19,450505,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2018-19,450507,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2018-19,450502,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2018-19,450511,UCF,AAC,2116,UCF Knights,UCF,Knights,UCF,American Athletic Conference,62,exact
+2018-19,450506,UCLA,Pac-12,26,UCLA Bruins,UCLA,Bruins,UCLA,Pac-12 Conference,21,exact
+2018-19,450523,UConn,AAC,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2018-19,450577,UIC,Horizon,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2018-19,450804,UIW,Southland,2916,Incarnate Word Cardinals,Incarnate Word,Cardinals,UIW,Southland Conference,25,exact
+2018-19,450658,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2018-19,450611,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2018-19,450613,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2018-19,450602,UMass Lowell,America East,2349,UMass Lowell River Hawks,UMass Lowell,River Hawks,UML,America East Conference,1,exact
+2018-19,450635,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2018-19,450638,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2018-19,450639,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Colonial Athletic Association,10,exact
+2018-19,450663,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2018-19,450642,UNLV,MWC,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2018-19,450806,USC Upstate,Big South,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2018-19,450749,UT Arlington,Sun Belt,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,Western Athletic Conference,30,exact
+2018-19,450744,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2018-19,450751,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2018-19,450678,UTRGV,WAC,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Western Athletic Conference,30,dict
+2018-19,450752,UTSA,C-USA,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,Conference USA,11,exact
+2018-19,450762,Utah,Pac-12,254,Utah Utes,Utah,Utes,UTAH,Pac-12 Conference,21,exact
+2018-19,450761,Utah St.,MWC,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2018-19,450812,Utah Valley,WAC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,Western Athletic Conference,30,exact
+2018-19,450767,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2018-19,450768,VMI,SoCon,2678,VMI Keydets,VMI,Keydets,VMI,Southern Conference,24,exact
+2018-19,450763,Valparaiso,MVC,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2018-19,450764,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2018-19,450765,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2018-19,450766,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2018-19,450770,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2018-19,450769,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2018-19,450771,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2018-19,450772,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2018-19,450774,Washington,Pac-12,264,Washington Huskies,Washington,Huskies,WASH,Pac-12 Conference,21,exact
+2018-19,450773,Washington St.,Pac-12,265,Washington State Cougars,Washington State,Cougars,WSU,Pac-12 Conference,21,exact
+2018-19,450775,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2018-19,450776,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2018-19,450777,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2018-19,450778,Western Ill.,Summit League,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Summit League,49,exact
+2018-19,450779,Western Ky.,C-USA,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2018-19,450780,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2018-19,450781,Wichita St.,AAC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Athletic Conference,62,exact
+2018-19,450782,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Colonial Athletic Association,10,exact
+2018-19,450783,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2018-19,450785,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2018-19,450805,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2018-19,450787,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2018-19,450788,Wyoming,MWC,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2018-19,450789,Xavier,Big East,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2018-19,450790,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2018-19,450791,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2019-20,486746,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2019-20,486751,Abilene Christian,Southland,2000,Abilene Christian Wildcats,Abilene Christian,Wildcats,ACU,Western Athletic Conference,30,exact
+2019-20,486695,Air Force,MWC,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2019-20,486752,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2019-20,486755,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2019-20,486753,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2019-20,486754,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2019-20,486758,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2019-20,486759,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2019-20,486760,App State,Sun Belt,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2019-20,486762,Arizona,Pac-12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Pac-12 Conference,21,exact
+2019-20,486761,Arizona St.,Pac-12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Pac-12 Conference,21,exact
+2019-20,486737,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2019-20,486764,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2019-20,486763,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2019-20,486696,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2019-20,486766,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2019-20,486767,Austin Peay,OVC,2046,Austin Peay Governors,Austin Peay,Governors,APSU,ASUN Conference,46,exact
+2019-20,486778,BYU,WCC,252,BYU Cougars,BYU,Cougars,BYU,West Coast Conference,29,exact
+2019-20,486768,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2019-20,486770,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2019-20,486744,Belmont,OVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2019-20,486771,Bethune-Cookman,MEAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2019-20,486772,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2019-20,486773,Boise St.,MWC,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2019-20,486774,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2019-20,486775,Boston U.,Patriot,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2019-20,486776,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2019-20,486777,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2019-20,486779,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2019-20,486780,Bryant,NEC,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2019-20,486781,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2019-20,486782,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2019-20,486783,Butler,Big East,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2019-20,486785,CSU Bakersfield,WAC,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2019-20,486789,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2019-20,486784,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2019-20,486787,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2019-20,486792,California,Pac-12,25,California Golden Bears,California,Golden Bears,CAL,Pac-12 Conference,21,exact
+2019-20,486797,Campbell,Big South,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Big South Conference,6,exact
+2019-20,486798,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Atlantic Athletic Conference,13,exact
+2019-20,486729,Central Ark.,Southland,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,ASUN Conference,46,exact
+2019-20,486799,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2019-20,486801,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2019-20,486769,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2019-20,486926,Charlotte,C-USA,2429,Charlotte 49ers,Charlotte,49ers,CLT,Conference USA,11,exact
+2019-20,486679,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2019-20,486802,Chicago St.,WAC,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Division I Independents,43,exact
+2019-20,486803,Cincinnati,AAC,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,American Athletic Conference,62,exact
+2019-20,486805,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2019-20,486806,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2019-20,486807,Coastal Carolina,Sun Belt,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2019-20,486730,Col. of Charleston,CAA,232,Charleston Cougars,Charleston,Cougars,COFC,Colonial Athletic Association,10,dict
+2019-20,486808,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2019-20,486810,Colorado,Pac-12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Pac-12 Conference,21,exact
+2019-20,486809,Colorado St.,MWC,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2019-20,486811,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2019-20,486813,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2019-20,486814,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2019-20,486815,Creighton,Big East,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2019-20,486816,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2019-20,486817,Davidson,Atlantic 10,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2019-20,486818,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2019-20,486819,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2019-20,486821,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Colonial Athletic Association,10,exact
+2019-20,486820,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2019-20,486822,Denver,Summit League,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,49,exact
+2019-20,486823,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2019-20,486824,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2019-20,486825,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Colonial Athletic Association,10,exact
+2019-20,486826,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2019-20,486827,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2019-20,486829,ETSU,SoCon,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2019-20,486828,East Carolina,AAC,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Athletic Conference,62,exact
+2019-20,486830,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2019-20,486831,Eastern Ky.,OVC,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,ASUN Conference,46,exact
+2019-20,486832,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2019-20,486833,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2019-20,486731,Elon,CAA,2210,Elon Phoenix,Elon,Phoenix,ELON,Colonial Athletic Association,10,exact
+2019-20,486834,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2019-20,486748,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,ASUN Conference,46,exact
+2019-20,486839,FIU,C-USA,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2019-20,486835,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Atlantic Athletic Conference,13,exact
+2019-20,486836,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2019-20,486838,Fla. Atlantic,C-USA,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,Conference USA,11,exact
+2019-20,486841,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2019-20,486837,Florida A&M,MEAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2019-20,486840,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2019-20,486842,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2019-20,486786,Fresno St.,MWC,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2019-20,486843,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2019-20,486847,Ga. Southern,Sun Belt,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2019-20,486732,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2019-20,486844,George Mason,Atlantic 10,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2019-20,486845,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2019-20,486846,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2019-20,486850,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2019-20,486848,Georgia St.,Sun Belt,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2019-20,486849,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2019-20,486851,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2019-20,486852,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2019-20,486733,Grand Canyon,WAC,2253,Grand Canyon Lopes,Grand Canyon,Lopes,GCU,Western Athletic Conference,30,exact
+2019-20,486721,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2019-20,486853,Hampton,Big South,2261,Hampton Pirates,Hampton,Pirates,HAMP,Colonial Athletic Association,10,exact
+2019-20,486854,Hartford,America East,42,Hartford Hawks,Hartford,Hawks,HART,Division I Independents,43,exact
+2019-20,486855,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2019-20,486856,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2019-20,486745,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2019-20,486857,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Colonial Athletic Association,10,exact
+2019-20,486858,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2019-20,486860,Houston,AAC,248,Houston Cougars,Houston,Cougars,HOU,American Athletic Conference,62,exact
+2019-20,486859,Houston Christian,Southland,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,exact
+2019-20,486861,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2019-20,486738,IUPUI,Horizon,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,alias
+2019-20,486863,Idaho,Big Sky,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2019-20,486862,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2019-20,486865,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2019-20,486864,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2019-20,486868,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2019-20,486867,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2019-20,486870,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Atlantic Athletic Conference,13,exact
+2019-20,486872,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2019-20,486871,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2019-20,486873,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2019-20,486875,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,ASUN Conference,46,exact
+2019-20,486874,Jacksonville St.,OVC,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,ASUN Conference,46,exact
+2019-20,486876,James Madison,CAA,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2019-20,486878,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2019-20,486739,Kansas City,WAC,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,49,exact
+2019-20,486877,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2019-20,486734,Kennesaw St.,ASUN,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,ASUN Conference,46,exact
+2019-20,486879,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2019-20,486880,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2019-20,486886,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2019-20,486893,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2019-20,486888,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2019-20,486881,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2019-20,486882,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2019-20,486883,Lamar University,Southland,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2019-20,486884,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2019-20,486885,Liberty,ASUN,2335,Liberty Flames,Liberty,Flames,LIB,ASUN Conference,46,exact
+2019-20,486747,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,ASUN Conference,46,exact
+2019-20,486765,Little Rock,Sun Belt,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2019-20,486788,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2019-20,486887,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2019-20,486670,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2019-20,486889,Louisiana Tech,C-USA,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2019-20,486890,Louisville,ACC,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2019-20,486894,Loyola Chicago,MVC,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2019-20,486892,Loyola Maryland,Patriot,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2019-20,486895,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2019-20,486896,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Atlantic Athletic Conference,13,exact
+2019-20,486897,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Atlantic Athletic Conference,13,exact
+2019-20,486898,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2019-20,486899,Marshall,C-USA,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2019-20,486901,Maryland,Big Ten,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2019-20,486903,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2019-20,486904,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2019-20,486905,Memphis,AAC,235,Memphis Tigers,Memphis,Tigers,MEM,American Athletic Conference,62,exact
+2019-20,486906,Mercer,SoCon,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2019-20,486908,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2019-20,486907,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2019-20,486910,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2019-20,486909,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2019-20,486911,Middle Tenn.,C-USA,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2019-20,486723,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2019-20,486912,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2019-20,486913,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2019-20,486914,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2019-20,486916,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2019-20,486668,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2019-20,486917,Monmouth,MAAC,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Colonial Athletic Association,10,exact
+2019-20,486919,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2019-20,486918,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2019-20,486920,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2019-20,486921,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2019-20,487652,Mount St. Mary's,NEC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Atlantic Athletic Conference,13,exact
+2019-20,486923,Murray St.,OVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2019-20,486941,N.C. A&T,MEAC,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Colonial Athletic Association,10,exact
+2019-20,486942,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2019-20,486943,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2019-20,486951,NIU,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2019-20,486934,NJIT,ASUN,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2019-20,486697,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2019-20,486929,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2019-20,486932,Nevada,MWC,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2019-20,486933,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2019-20,486936,New Mexico,MWC,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2019-20,486935,New Mexico St.,WAC,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Western Athletic Conference,30,exact
+2019-20,486937,New Orleans,Southland,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2019-20,486938,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Atlantic Athletic Conference,13,exact
+2019-20,486939,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2019-20,486940,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2019-20,486925,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2019-20,486945,North Dakota,Summit League,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,49,exact
+2019-20,486944,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,49,exact
+2019-20,486740,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,ASUN Conference,46,exact
+2019-20,486946,North Texas,C-USA,249,North Texas Mean Green,North Texas,Mean Green,UNT,Conference USA,11,exact
+2019-20,486948,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Colonial Athletic Association,10,exact
+2019-20,486949,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2019-20,486950,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2019-20,486953,Northern Ky.,Horizon,94,Northern Kentucky Norse,Northern Kentucky,Norse,NKU,Horizon League,45,exact
+2019-20,486955,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2019-20,486954,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2019-20,486956,Notre Dame,ACC,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2019-20,486957,Oakland,Horizon,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2019-20,486959,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2019-20,486958,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2019-20,486961,Oklahoma,Big 12,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Big 12 Conference,8,exact
+2019-20,486960,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2019-20,486962,Old Dominion,C-USA,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2019-20,486915,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2019-20,486930,Omaha,Summit League,2437,Omaha Mavericks,Omaha,Mavericks,OMA,Summit League,49,exact
+2019-20,486963,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,49,exact
+2019-20,486965,Oregon,Pac-12,2483,Oregon Ducks,Oregon,Ducks,ORE,Pac-12 Conference,21,exact
+2019-20,486964,Oregon St.,Pac-12,204,Oregon State Beavers,Oregon State,Beavers,ORST,Pac-12 Conference,21,exact
+2019-20,486966,Pacific,WCC,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2019-20,486969,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2019-20,486968,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2019-20,486970,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2019-20,486971,Pittsburgh,ACC,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2019-20,486973,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2019-20,486972,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2019-20,486974,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2019-20,486735,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2019-20,486975,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2019-20,486976,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2019-20,486977,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2019-20,486869,Purdue Fort Wayne,Summit League,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2019-20,486978,Quinnipiac,MAAC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Atlantic Athletic Conference,13,exact
+2019-20,486979,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2019-20,486980,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2019-20,486981,Rice,C-USA,242,Rice Owls,Rice,Owls,RICE,Conference USA,11,exact
+2019-20,486982,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2019-20,486983,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Atlantic Athletic Conference,13,exact
+2019-20,486984,Robert Morris,NEC,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2019-20,486985,Rutgers,Big Ten,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2019-20,486672,SFA,Southland,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Western Athletic Conference,30,exact
+2019-20,486663,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2019-20,486664,SMU,AAC,2567,SMU Mustangs,SMU,Mustangs,SMU,American Athletic Conference,62,exact
+2019-20,486790,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2019-20,486986,Sacred Heart,NEC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Northeast Conference,19,exact
+2019-20,486989,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2019-20,486991,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2019-20,486992,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2019-20,486993,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2019-20,486994,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Atlantic Athletic Conference,13,exact
+2019-20,486995,Sam Houston,Southland,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Western Athletic Conference,30,exact
+2019-20,486996,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2019-20,486998,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2019-20,486997,San Diego St.,MWC,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2019-20,486999,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2019-20,487000,San Jose St.,MWC,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2019-20,486649,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2019-20,486736,Seattle U,WAC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,Western Athletic Conference,30,exact
+2019-20,486651,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2019-20,486652,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Atlantic Athletic Conference,13,exact
+2019-20,486653,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2019-20,486655,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2019-20,486654,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2019-20,486657,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,49,exact
+2019-20,486656,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,49,exact
+2019-20,486658,South Fla.,AAC,58,South Florida Bulls,South Florida,Bulls,USF,American Athletic Conference,62,exact
+2019-20,486659,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2019-20,486660,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2019-20,486661,Southern California,Pac-12,30,USC Trojans,USC,Trojans,USC,Pac-12 Conference,21,dict
+2019-20,486662,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2019-20,486665,Southern Miss.,C-USA,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2019-20,486666,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2019-20,486667,Southern Utah,Big Sky,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,Western Athletic Conference,30,exact
+2019-20,486987,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2019-20,486988,St. Francis Brooklyn,NEC,2597,St. Francis Brooklyn Terriers,St. Francis Brooklyn,Terriers,SFNY,Northeast Conference,19,exact
+2019-20,486990,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2019-20,486671,Stanford,Pac-12,24,Stanford Cardinal,Stanford,Cardinal,STAN,Pac-12 Conference,21,exact
+2019-20,486673,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,ASUN Conference,46,exact
+2019-20,486674,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Colonial Athletic Association,10,exact
+2019-20,486675,Syracuse,ACC,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2019-20,486683,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2019-20,486676,Temple,AAC,218,Temple Owls,Temple,Owls,TEM,American Athletic Conference,62,exact
+2019-20,486680,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2019-20,486677,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2019-20,486678,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2019-20,486687,Texas,Big 12,251,Texas Longhorns,Texas,Longhorns,TEX,Big 12 Conference,8,exact
+2019-20,486682,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2019-20,486684,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2019-20,486669,Texas St.,Sun Belt,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2019-20,486685,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2019-20,486804,The Citadel,SoCon,2643,The Citadel Bulldogs,The Citadel,Bulldogs,CIT,Southern Conference,24,exact
+2019-20,486690,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2019-20,486691,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Colonial Athletic Association,10,exact
+2019-20,486692,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2019-20,486693,Tulane,AAC,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Athletic Conference,62,exact
+2019-20,486694,Tulsa,AAC,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Athletic Conference,62,exact
+2019-20,486756,UAB,C-USA,5,UAB Blazers,UAB,Blazers,UAB,Conference USA,11,exact
+2019-20,486757,UAlbany,America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,exact
+2019-20,486793,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2019-20,486794,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2019-20,486796,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2019-20,486791,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2019-20,486800,UCF,AAC,2116,UCF Knights,UCF,Knights,UCF,American Athletic Conference,62,exact
+2019-20,486795,UCLA,Pac-12,26,UCLA Bruins,UCLA,Bruins,UCLA,Pac-12 Conference,21,exact
+2019-20,486812,UConn,AAC,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2019-20,486866,UIC,Horizon,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2019-20,486741,UIW,Southland,2916,Incarnate Word Cardinals,Incarnate Word,Cardinals,UIW,Southland Conference,25,exact
+2019-20,486947,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2019-20,486900,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2019-20,486902,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2019-20,486891,UMass Lowell,America East,2349,UMass Lowell River Hawks,UMass Lowell,River Hawks,UML,America East Conference,1,exact
+2019-20,486924,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2019-20,486927,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2019-20,486928,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Colonial Athletic Association,10,exact
+2019-20,486952,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2019-20,486931,UNLV,MWC,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2019-20,486743,USC Upstate,Big South,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2019-20,486686,UT Arlington,Sun Belt,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,Western Athletic Conference,30,exact
+2019-20,486681,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2019-20,486688,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2019-20,486967,UTRGV,WAC,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Western Athletic Conference,30,dict
+2019-20,486689,UTSA,C-USA,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,Conference USA,11,exact
+2019-20,486699,Utah,Pac-12,254,Utah Utes,Utah,Utes,UTAH,Pac-12 Conference,21,exact
+2019-20,486698,Utah St.,MWC,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2019-20,486749,Utah Valley,WAC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,Western Athletic Conference,30,exact
+2019-20,486704,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2019-20,486705,VMI,SoCon,2678,VMI Keydets,VMI,Keydets,VMI,Southern Conference,24,exact
+2019-20,486700,Valparaiso,MVC,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2019-20,486701,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2019-20,486702,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2019-20,486703,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2019-20,486707,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2019-20,486706,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2019-20,486708,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2019-20,486709,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2019-20,486711,Washington,Pac-12,264,Washington Huskies,Washington,Huskies,WASH,Pac-12 Conference,21,exact
+2019-20,486710,Washington St.,Pac-12,265,Washington State Cougars,Washington State,Cougars,WSU,Pac-12 Conference,21,exact
+2019-20,486712,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2019-20,486713,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2019-20,486714,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2019-20,486715,Western Ill.,Summit League,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Summit League,49,exact
+2019-20,486716,Western Ky.,C-USA,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2019-20,486717,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2019-20,486718,Wichita St.,AAC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Athletic Conference,62,exact
+2019-20,486719,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Colonial Athletic Association,10,exact
+2019-20,486720,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2019-20,486722,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2019-20,486742,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2019-20,486724,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2019-20,486725,Wyoming,MWC,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2019-20,486726,Xavier,Big East,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2019-20,486727,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2019-20,486728,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2020-21,505566,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2020-21,505571,Abilene Christian,Southland,2000,Abilene Christian Wildcats,Abilene Christian,Wildcats,ACU,Western Athletic Conference,30,exact
+2020-21,505515,Air Force,MWC,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2020-21,505572,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2020-21,505575,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2020-21,505573,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2020-21,505574,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2020-21,505578,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2020-21,505579,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2020-21,505580,App State,Sun Belt,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2020-21,505582,Arizona,Pac-12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Pac-12 Conference,21,exact
+2020-21,505581,Arizona St.,Pac-12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Pac-12 Conference,21,exact
+2020-21,505557,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2020-21,505584,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2020-21,505583,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2020-21,505516,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2020-21,505586,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2020-21,505587,Austin Peay,OVC,2046,Austin Peay Governors,Austin Peay,Governors,APSU,ASUN Conference,46,exact
+2020-21,505598,BYU,WCC,252,BYU Cougars,BYU,Cougars,BYU,West Coast Conference,29,exact
+2020-21,505588,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2020-21,505590,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2020-21,505877,Bellarmine,ASUN,91,Bellarmine Knights,Bellarmine,Knights,BELL,ASUN Conference,46,exact
+2020-21,505564,Belmont,OVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2020-21,505591,Bethune-Cookman,MEAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2020-21,505592,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2020-21,505593,Boise St.,MWC,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2020-21,505594,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2020-21,505595,Boston U.,Patriot,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2020-21,505596,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2020-21,505597,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2020-21,505599,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2020-21,505600,Bryant,NEC,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2020-21,505601,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2020-21,505602,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2020-21,505603,Butler,Big East,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2020-21,505605,CSU Bakersfield,WAC,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2020-21,505609,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2020-21,505604,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2020-21,505607,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2020-21,505612,California,Pac-12,25,California Golden Bears,California,Golden Bears,CAL,Pac-12 Conference,21,exact
+2020-21,505841,California Baptist,WAC,2856,California Baptist Lancers,California Baptist,Lancers,CBU,Western Athletic Conference,30,exact
+2020-21,505617,Campbell,Big South,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Big South Conference,6,exact
+2020-21,505618,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Atlantic Athletic Conference,13,exact
+2020-21,505549,Central Ark.,Southland,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,ASUN Conference,46,exact
+2020-21,505619,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2020-21,505621,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2020-21,505589,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2020-21,505746,Charlotte,C-USA,2429,Charlotte 49ers,Charlotte,49ers,CLT,Conference USA,11,exact
+2020-21,505499,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2020-21,505622,Chicago St.,WAC,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Division I Independents,43,exact
+2020-21,505623,Cincinnati,AAC,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,American Athletic Conference,62,exact
+2020-21,505625,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2020-21,505626,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2020-21,505627,Coastal Carolina,Sun Belt,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2020-21,505550,Col. of Charleston,CAA,232,Charleston Cougars,Charleston,Cougars,COFC,Colonial Athletic Association,10,dict
+2020-21,505628,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2020-21,505630,Colorado,Pac-12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Pac-12 Conference,21,exact
+2020-21,505629,Colorado St.,MWC,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2020-21,505631,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2020-21,505633,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2020-21,505634,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2020-21,505635,Creighton,Big East,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2020-21,505636,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2020-21,505637,Davidson,Atlantic 10,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2020-21,505638,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2020-21,505639,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2020-21,505641,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Colonial Athletic Association,10,exact
+2020-21,505640,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2020-21,505642,Denver,Summit League,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,49,exact
+2020-21,505643,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2020-21,505644,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2020-21,505645,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Colonial Athletic Association,10,exact
+2020-21,505646,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2020-21,505647,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2020-21,505649,ETSU,SoCon,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2020-21,505648,East Carolina,AAC,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Athletic Conference,62,exact
+2020-21,505650,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2020-21,505651,Eastern Ky.,OVC,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,ASUN Conference,46,exact
+2020-21,505652,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2020-21,505653,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2020-21,505551,Elon,CAA,2210,Elon Phoenix,Elon,Phoenix,ELON,Colonial Athletic Association,10,exact
+2020-21,505654,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2020-21,505568,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,ASUN Conference,46,exact
+2020-21,505659,FIU,C-USA,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2020-21,505655,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Atlantic Athletic Conference,13,exact
+2020-21,505656,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2020-21,505658,Fla. Atlantic,C-USA,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,Conference USA,11,exact
+2020-21,505661,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2020-21,505657,Florida A&M,MEAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2020-21,505660,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2020-21,505662,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2020-21,505606,Fresno St.,MWC,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2020-21,505663,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2020-21,505667,Ga. Southern,Sun Belt,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2020-21,505552,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2020-21,505664,George Mason,Atlantic 10,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2020-21,505665,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2020-21,505666,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2020-21,505670,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2020-21,505668,Georgia St.,Sun Belt,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2020-21,505669,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2020-21,505671,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2020-21,505672,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2020-21,505553,Grand Canyon,WAC,2253,Grand Canyon Lopes,Grand Canyon,Lopes,GCU,Western Athletic Conference,30,exact
+2020-21,505541,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2020-21,505673,Hampton,Big South,2261,Hampton Pirates,Hampton,Pirates,HAMP,Colonial Athletic Association,10,exact
+2020-21,505674,Hartford,America East,42,Hartford Hawks,Hartford,Hawks,HART,Division I Independents,43,exact
+2020-21,505675,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2020-21,505676,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2020-21,505565,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2020-21,505677,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Colonial Athletic Association,10,exact
+2020-21,505678,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2020-21,505680,Houston,AAC,248,Houston Cougars,Houston,Cougars,HOU,American Athletic Conference,62,exact
+2020-21,505679,Houston Christian,Southland,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,exact
+2020-21,505681,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2020-21,505558,IUPUI,Horizon,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,alias
+2020-21,505683,Idaho,Big Sky,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2020-21,505682,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2020-21,505685,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2020-21,505684,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2020-21,505688,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2020-21,505687,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2020-21,505690,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Atlantic Athletic Conference,13,exact
+2020-21,505692,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2020-21,505691,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2020-21,505693,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2020-21,505695,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,ASUN Conference,46,exact
+2020-21,505694,Jacksonville St.,OVC,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,ASUN Conference,46,exact
+2020-21,505696,James Madison,CAA,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2020-21,505698,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2020-21,505559,Kansas City,WAC,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,49,exact
+2020-21,505697,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2020-21,505554,Kennesaw St.,ASUN,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,ASUN Conference,46,exact
+2020-21,505699,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2020-21,505700,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2020-21,505706,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2020-21,505713,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2020-21,505708,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2020-21,505701,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2020-21,505702,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2020-21,505703,Lamar University,Southland,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2020-21,505704,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2020-21,505705,Liberty,ASUN,2335,Liberty Flames,Liberty,Flames,LIB,ASUN Conference,46,exact
+2020-21,505567,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,ASUN Conference,46,exact
+2020-21,505585,Little Rock,Sun Belt,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2020-21,505608,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2020-21,505707,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2020-21,505490,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2020-21,505709,Louisiana Tech,C-USA,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2020-21,505710,Louisville,ACC,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2020-21,505714,Loyola Chicago,MVC,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2020-21,505712,Loyola Maryland,Patriot,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2020-21,505715,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2020-21,505716,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Atlantic Athletic Conference,13,exact
+2020-21,505717,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Atlantic Athletic Conference,13,exact
+2020-21,505718,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2020-21,505719,Marshall,C-USA,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2020-21,505721,Maryland,Big Ten,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2020-21,505723,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2020-21,505724,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2020-21,505725,Memphis,AAC,235,Memphis Tigers,Memphis,Tigers,MEM,American Athletic Conference,62,exact
+2020-21,505726,Mercer,SoCon,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2020-21,505842,Merrimack,NEC,2771,Merrimack Warriors,Merrimack,Warriors,MRMK,Northeast Conference,19,exact
+2020-21,505728,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2020-21,505727,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2020-21,505730,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2020-21,505729,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2020-21,505731,Middle Tenn.,C-USA,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2020-21,505543,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2020-21,505732,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2020-21,505733,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2020-21,505734,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2020-21,505736,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2020-21,505488,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2020-21,505737,Monmouth,MAAC,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Colonial Athletic Association,10,exact
+2020-21,505739,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2020-21,505738,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2020-21,505740,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2020-21,505741,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2020-21,505742,Mount St. Mary's,NEC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Atlantic Athletic Conference,13,exact
+2020-21,505743,Murray St.,OVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2020-21,505761,N.C. A&T,MEAC,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Colonial Athletic Association,10,exact
+2020-21,505762,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2020-21,505763,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2020-21,505771,NIU,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2020-21,505754,NJIT,ASUN,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2020-21,505517,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2020-21,505749,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2020-21,505752,Nevada,MWC,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2020-21,505753,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2020-21,505756,New Mexico,MWC,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2020-21,505755,New Mexico St.,WAC,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Western Athletic Conference,30,exact
+2020-21,505757,New Orleans,Southland,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2020-21,505758,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Atlantic Athletic Conference,13,exact
+2020-21,505759,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2020-21,505760,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2020-21,505570,North Ala.,ASUN,2453,North Alabama Lions,North Alabama,Lions,UNA,ASUN Conference,46,exact
+2020-21,505745,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2020-21,505765,North Dakota,Summit League,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,49,exact
+2020-21,505764,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,49,exact
+2020-21,505560,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,ASUN Conference,46,exact
+2020-21,505766,North Texas,C-USA,249,North Texas Mean Green,North Texas,Mean Green,UNT,Conference USA,11,exact
+2020-21,505768,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Colonial Athletic Association,10,exact
+2020-21,505769,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2020-21,505770,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2020-21,505773,Northern Ky.,Horizon,94,Northern Kentucky Norse,Northern Kentucky,Norse,NKU,Horizon League,45,exact
+2020-21,505775,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2020-21,505774,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2020-21,505776,Notre Dame,ACC,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2020-21,505777,Oakland,Horizon,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2020-21,505779,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2020-21,505778,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2020-21,505781,Oklahoma,Big 12,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Big 12 Conference,8,exact
+2020-21,505780,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2020-21,505782,Old Dominion,C-USA,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2020-21,505735,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2020-21,505750,Omaha,Summit League,2437,Omaha Mavericks,Omaha,Mavericks,OMA,Summit League,49,exact
+2020-21,505783,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,49,exact
+2020-21,505785,Oregon,Pac-12,2483,Oregon Ducks,Oregon,Ducks,ORE,Pac-12 Conference,21,exact
+2020-21,505784,Oregon St.,Pac-12,204,Oregon State Beavers,Oregon State,Beavers,ORST,Pac-12 Conference,21,exact
+2020-21,505786,Pacific,WCC,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2020-21,505789,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2020-21,505788,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2020-21,505790,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2020-21,505791,Pittsburgh,ACC,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2020-21,505793,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2020-21,505792,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2020-21,505794,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2020-21,505555,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2020-21,505795,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2020-21,505796,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2020-21,505797,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2020-21,505689,Purdue Fort Wayne,Summit League,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2020-21,505798,Quinnipiac,MAAC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Atlantic Athletic Conference,13,exact
+2020-21,505799,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2020-21,505800,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2020-21,505801,Rice,C-USA,242,Rice Owls,Rice,Owls,RICE,Conference USA,11,exact
+2020-21,505802,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2020-21,505803,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Atlantic Athletic Conference,13,exact
+2020-21,505804,Robert Morris,NEC,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2020-21,505805,Rutgers,Big Ten,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2020-21,505492,SFA,Southland,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Western Athletic Conference,30,exact
+2020-21,505483,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2020-21,505484,SMU,AAC,2567,SMU Mustangs,SMU,Mustangs,SMU,American Athletic Conference,62,exact
+2020-21,505610,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2020-21,505806,Sacred Heart,NEC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Northeast Conference,19,exact
+2020-21,505809,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2020-21,505831,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2020-21,505832,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2020-21,505833,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2020-21,505834,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Atlantic Athletic Conference,13,exact
+2020-21,505835,Sam Houston,Southland,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Western Athletic Conference,30,exact
+2020-21,505836,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2020-21,505838,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2020-21,505837,San Diego St.,MWC,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2020-21,505839,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2020-21,505840,San Jose St.,MWC,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2020-21,505470,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2020-21,505556,Seattle U,WAC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,Western Athletic Conference,30,exact
+2020-21,505471,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2020-21,505472,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Atlantic Athletic Conference,13,exact
+2020-21,505473,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2020-21,505475,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2020-21,505474,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2020-21,505477,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,49,exact
+2020-21,505476,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,49,exact
+2020-21,505478,South Fla.,AAC,58,South Florida Bulls,South Florida,Bulls,USF,American Athletic Conference,62,exact
+2020-21,505479,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2020-21,505480,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2020-21,505481,Southern California,Pac-12,30,USC Trojans,USC,Trojans,USC,Pac-12 Conference,21,dict
+2020-21,505482,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2020-21,505485,Southern Miss.,C-USA,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2020-21,505486,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2020-21,505487,Southern Utah,Big Sky,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,Western Athletic Conference,30,exact
+2020-21,505807,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2020-21,505808,St. Francis Brooklyn,NEC,2597,St. Francis Brooklyn Terriers,St. Francis Brooklyn,Terriers,SFNY,Northeast Conference,19,exact
+2020-21,505830,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2020-21,505491,Stanford,Pac-12,24,Stanford Cardinal,Stanford,Cardinal,STAN,Pac-12 Conference,21,exact
+2020-21,505493,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,ASUN Conference,46,exact
+2020-21,505494,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Colonial Athletic Association,10,exact
+2020-21,505495,Syracuse,ACC,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2020-21,505503,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2020-21,506541,Tarleton St.,WAC,2627,Tarleton State Texans,Tarleton State,Texans,TAR,Western Athletic Conference,30,exact
+2020-21,505496,Temple,AAC,218,Temple Owls,Temple,Owls,TEM,American Athletic Conference,62,exact
+2020-21,505500,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2020-21,505497,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2020-21,505498,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2020-21,505507,Texas,Big 12,251,Texas Longhorns,Texas,Longhorns,TEX,Big 12 Conference,8,exact
+2020-21,505502,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2020-21,505504,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2020-21,505489,Texas St.,Sun Belt,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2020-21,505505,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2020-21,505624,The Citadel,SoCon,2643,The Citadel Bulldogs,The Citadel,Bulldogs,CIT,Southern Conference,24,exact
+2020-21,505510,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2020-21,505511,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Colonial Athletic Association,10,exact
+2020-21,505512,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2020-21,505513,Tulane,AAC,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Athletic Conference,62,exact
+2020-21,505514,Tulsa,AAC,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Athletic Conference,62,exact
+2020-21,505576,UAB,C-USA,5,UAB Blazers,UAB,Blazers,UAB,Conference USA,11,exact
+2020-21,505577,UAlbany,America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,exact
+2020-21,505613,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2020-21,505614,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2020-21,505616,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2020-21,505932,UC San Diego,Big West,28,UC San Diego Tritons,UC San Diego,Tritons,UCSD,Big West Conference,9,exact
+2020-21,505611,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2020-21,505620,UCF,AAC,2116,UCF Knights,UCF,Knights,UCF,American Athletic Conference,62,exact
+2020-21,505615,UCLA,Pac-12,26,UCLA Bruins,UCLA,Bruins,UCLA,Pac-12 Conference,21,exact
+2020-21,505632,UConn,AAC,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2020-21,505686,UIC,Horizon,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2020-21,505561,UIW,Southland,2916,Incarnate Word Cardinals,Incarnate Word,Cardinals,UIW,Southland Conference,25,exact
+2020-21,505767,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2020-21,505720,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2020-21,505722,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2020-21,505711,UMass Lowell,America East,2349,UMass Lowell River Hawks,UMass Lowell,River Hawks,UML,America East Conference,1,exact
+2020-21,505744,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2020-21,505747,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2020-21,505748,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Colonial Athletic Association,10,exact
+2020-21,505772,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2020-21,505751,UNLV,MWC,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2020-21,505563,USC Upstate,Big South,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2020-21,505506,UT Arlington,Sun Belt,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,Western Athletic Conference,30,exact
+2020-21,505501,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2020-21,505508,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2020-21,505787,UTRGV,WAC,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Western Athletic Conference,30,dict
+2020-21,505509,UTSA,C-USA,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,Conference USA,11,exact
+2020-21,505519,Utah,Pac-12,254,Utah Utes,Utah,Utes,UTAH,Pac-12 Conference,21,exact
+2020-21,505518,Utah St.,MWC,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2020-21,506427,Utah Tech,WAC,3101,Utah Tech Trailblazers,Utah Tech,Trailblazers,UTU,Western Athletic Conference,30,exact
+2020-21,505569,Utah Valley,WAC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,Western Athletic Conference,30,exact
+2020-21,505524,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2020-21,505525,VMI,SoCon,2678,VMI Keydets,VMI,Keydets,VMI,Southern Conference,24,exact
+2020-21,505520,Valparaiso,MVC,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2020-21,505521,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2020-21,505522,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2020-21,505523,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2020-21,505527,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2020-21,505526,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2020-21,505528,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2020-21,505529,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2020-21,505531,Washington,Pac-12,264,Washington Huskies,Washington,Huskies,WASH,Pac-12 Conference,21,exact
+2020-21,505530,Washington St.,Pac-12,265,Washington State Cougars,Washington State,Cougars,WSU,Pac-12 Conference,21,exact
+2020-21,505532,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2020-21,505533,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2020-21,505534,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2020-21,505535,Western Ill.,Summit League,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Summit League,49,exact
+2020-21,505536,Western Ky.,C-USA,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2020-21,505537,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2020-21,505538,Wichita St.,AAC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Athletic Conference,62,exact
+2020-21,505539,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Colonial Athletic Association,10,exact
+2020-21,505540,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2020-21,505542,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2020-21,505562,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2020-21,505544,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2020-21,505545,Wyoming,MWC,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2020-21,505546,Xavier,Big East,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2020-21,505547,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2020-21,505548,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2021-22,527481,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2021-22,527486,Abilene Christian,WAC,2000,Abilene Christian Wildcats,Abilene Christian,Wildcats,ACU,Western Athletic Conference,30,exact
+2021-22,527430,Air Force,MWC,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2021-22,527487,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2021-22,527490,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2021-22,527488,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2021-22,527489,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2021-22,527493,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2021-22,527494,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2021-22,527495,App State,Sun Belt,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2021-22,527497,Arizona,Pac-12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Pac-12 Conference,21,exact
+2021-22,527496,Arizona St.,Pac-12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Pac-12 Conference,21,exact
+2021-22,527472,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2021-22,527499,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2021-22,527498,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2021-22,527431,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2021-22,527501,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2021-22,527502,Austin Peay,OVC,2046,Austin Peay Governors,Austin Peay,Governors,APSU,ASUN Conference,46,exact
+2021-22,527513,BYU,WCC,252,BYU Cougars,BYU,Cougars,BYU,West Coast Conference,29,exact
+2021-22,527503,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2021-22,527505,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2021-22,527738,Bellarmine,ASUN,91,Bellarmine Knights,Bellarmine,Knights,BELL,ASUN Conference,46,exact
+2021-22,527479,Belmont,OVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2021-22,527506,Bethune-Cookman,SWAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2021-22,527507,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2021-22,527508,Boise St.,MWC,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2021-22,527509,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2021-22,527510,Boston U.,Patriot,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2021-22,527511,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2021-22,527512,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2021-22,527514,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2021-22,527515,Bryant,NEC,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2021-22,527516,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2021-22,527517,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2021-22,527518,Butler,Big East,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2021-22,527520,CSU Bakersfield,WAC,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2021-22,527524,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2021-22,527519,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2021-22,527522,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2021-22,527527,California,Pac-12,25,California Golden Bears,California,Golden Bears,CAL,Pac-12 Conference,21,exact
+2021-22,527736,California Baptist,WAC,2856,California Baptist Lancers,California Baptist,Lancers,CBU,Western Athletic Conference,30,exact
+2021-22,527532,Campbell,Big South,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Big South Conference,6,exact
+2021-22,527533,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Atlantic Athletic Conference,13,exact
+2021-22,527464,Central Ark.,ASUN,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,ASUN Conference,46,exact
+2021-22,527534,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2021-22,527536,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2021-22,527504,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2021-22,527661,Charlotte,C-USA,2429,Charlotte 49ers,Charlotte,49ers,CLT,Conference USA,11,exact
+2021-22,527414,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2021-22,527537,Chicago St.,WAC,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Division I Independents,43,exact
+2021-22,527538,Cincinnati,AAC,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,American Athletic Conference,62,exact
+2021-22,527540,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2021-22,527541,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2021-22,527542,Coastal Carolina,Sun Belt,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2021-22,527465,Col. of Charleston,CAA,232,Charleston Cougars,Charleston,Cougars,COFC,Colonial Athletic Association,10,dict
+2021-22,527543,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2021-22,527545,Colorado,Pac-12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Pac-12 Conference,21,exact
+2021-22,527544,Colorado St.,MWC,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2021-22,527546,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2021-22,527548,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2021-22,527549,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2021-22,527550,Creighton,Big East,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2021-22,527551,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2021-22,527552,Davidson,Atlantic 10,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2021-22,527553,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2021-22,527554,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2021-22,527556,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Colonial Athletic Association,10,exact
+2021-22,527555,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2021-22,527557,Denver,Summit League,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,49,exact
+2021-22,527558,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2021-22,527559,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2021-22,527560,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Colonial Athletic Association,10,exact
+2021-22,527561,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2021-22,527562,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2021-22,527564,ETSU,SoCon,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2021-22,527563,East Carolina,AAC,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Athletic Conference,62,exact
+2021-22,527565,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2021-22,527566,Eastern Ky.,ASUN,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,ASUN Conference,46,exact
+2021-22,527567,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2021-22,527568,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2021-22,527466,Elon,CAA,2210,Elon Phoenix,Elon,Phoenix,ELON,Colonial Athletic Association,10,exact
+2021-22,527569,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2021-22,527483,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,ASUN Conference,46,exact
+2021-22,527574,FIU,C-USA,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2021-22,527570,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Atlantic Athletic Conference,13,exact
+2021-22,527571,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2021-22,527573,Fla. Atlantic,C-USA,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,Conference USA,11,exact
+2021-22,527576,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2021-22,527572,Florida A&M,SWAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2021-22,527575,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2021-22,527577,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2021-22,527521,Fresno St.,MWC,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2021-22,527578,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2021-22,527582,Ga. Southern,Sun Belt,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2021-22,527467,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2021-22,527579,George Mason,Atlantic 10,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2021-22,527580,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2021-22,527581,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2021-22,527585,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2021-22,527583,Georgia St.,Sun Belt,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2021-22,527584,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2021-22,527586,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2021-22,527587,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2021-22,527468,Grand Canyon,WAC,2253,Grand Canyon Lopes,Grand Canyon,Lopes,GCU,Western Athletic Conference,30,exact
+2021-22,527456,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2021-22,527588,Hampton,Big South,2261,Hampton Pirates,Hampton,Pirates,HAMP,Colonial Athletic Association,10,exact
+2021-22,527589,Hartford,America East,42,Hartford Hawks,Hartford,Hawks,HART,Division I Independents,43,exact
+2021-22,527590,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2021-22,527591,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2021-22,527480,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2021-22,527592,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Colonial Athletic Association,10,exact
+2021-22,527593,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2021-22,527595,Houston,AAC,248,Houston Cougars,Houston,Cougars,HOU,American Athletic Conference,62,exact
+2021-22,527594,Houston Christian,Southland,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,exact
+2021-22,527596,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2021-22,527473,IUPUI,Horizon,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,alias
+2021-22,527598,Idaho,Big Sky,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2021-22,527597,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2021-22,527600,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2021-22,527599,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2021-22,527603,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2021-22,527602,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2021-22,527605,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Atlantic Athletic Conference,13,exact
+2021-22,527607,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2021-22,527606,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2021-22,527608,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2021-22,527610,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,ASUN Conference,46,exact
+2021-22,527609,Jacksonville St.,ASUN,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,ASUN Conference,46,exact
+2021-22,527611,James Madison,CAA,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2021-22,527613,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2021-22,527474,Kansas City,WAC,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,49,exact
+2021-22,527612,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2021-22,527469,Kennesaw St.,ASUN,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,ASUN Conference,46,exact
+2021-22,527614,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2021-22,527615,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2021-22,527621,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2021-22,527628,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2021-22,527623,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2021-22,527616,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2021-22,527617,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2021-22,527618,Lamar University,WAC,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2021-22,527619,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2021-22,527620,Liberty,ASUN,2335,Liberty Flames,Liberty,Flames,LIB,ASUN Conference,46,exact
+2021-22,527482,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,ASUN Conference,46,exact
+2021-22,527500,Little Rock,Sun Belt,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2021-22,527523,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2021-22,527622,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2021-22,527405,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2021-22,527624,Louisiana Tech,C-USA,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2021-22,527625,Louisville,ACC,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2021-22,527629,Loyola Chicago,MVC,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2021-22,527627,Loyola Maryland,Patriot,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2021-22,527630,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2021-22,527631,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Atlantic Athletic Conference,13,exact
+2021-22,527632,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Atlantic Athletic Conference,13,exact
+2021-22,527633,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2021-22,527634,Marshall,C-USA,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2021-22,527636,Maryland,Big Ten,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2021-22,527638,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2021-22,527639,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2021-22,527640,Memphis,AAC,235,Memphis Tigers,Memphis,Tigers,MEM,American Athletic Conference,62,exact
+2021-22,527641,Mercer,SoCon,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2021-22,527737,Merrimack,NEC,2771,Merrimack Warriors,Merrimack,Warriors,MRMK,Northeast Conference,19,exact
+2021-22,527643,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2021-22,527642,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2021-22,527645,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2021-22,527644,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2021-22,527646,Middle Tenn.,C-USA,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2021-22,527458,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2021-22,527647,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2021-22,527648,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2021-22,527649,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2021-22,527651,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2021-22,527403,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2021-22,527652,Monmouth,MAAC,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Colonial Athletic Association,10,exact
+2021-22,527654,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2021-22,527653,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2021-22,527655,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2021-22,527656,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2021-22,527657,Mount St. Mary's,NEC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Atlantic Athletic Conference,13,exact
+2021-22,527658,Murray St.,OVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2021-22,527676,N.C. A&T,Big South,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Colonial Athletic Association,10,exact
+2021-22,527677,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2021-22,527678,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2021-22,527686,NIU,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2021-22,527669,NJIT,ASUN,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2021-22,527432,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2021-22,527664,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2021-22,527667,Nevada,MWC,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2021-22,527668,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2021-22,527671,New Mexico,MWC,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2021-22,527670,New Mexico St.,WAC,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Western Athletic Conference,30,exact
+2021-22,527672,New Orleans,Southland,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2021-22,527673,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Atlantic Athletic Conference,13,exact
+2021-22,527674,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2021-22,527675,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2021-22,527485,North Ala.,ASUN,2453,North Alabama Lions,North Alabama,Lions,UNA,ASUN Conference,46,exact
+2021-22,527660,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2021-22,527680,North Dakota,Summit League,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,49,exact
+2021-22,527679,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,49,exact
+2021-22,527475,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,ASUN Conference,46,exact
+2021-22,527681,North Texas,C-USA,249,North Texas Mean Green,North Texas,Mean Green,UNT,Conference USA,11,exact
+2021-22,527683,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Colonial Athletic Association,10,exact
+2021-22,527684,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2021-22,527685,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2021-22,527688,Northern Ky.,Horizon,94,Northern Kentucky Norse,Northern Kentucky,Norse,NKU,Horizon League,45,exact
+2021-22,527690,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2021-22,527689,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2021-22,527691,Notre Dame,ACC,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2021-22,527692,Oakland,Horizon,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2021-22,527694,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2021-22,527693,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2021-22,527696,Oklahoma,Big 12,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Big 12 Conference,8,exact
+2021-22,527695,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2021-22,527697,Old Dominion,C-USA,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2021-22,527650,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2021-22,527665,Omaha,Summit League,2437,Omaha Mavericks,Omaha,Mavericks,OMA,Summit League,49,exact
+2021-22,527698,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,49,exact
+2021-22,527700,Oregon,Pac-12,2483,Oregon Ducks,Oregon,Ducks,ORE,Pac-12 Conference,21,exact
+2021-22,527699,Oregon St.,Pac-12,204,Oregon State Beavers,Oregon State,Beavers,ORST,Pac-12 Conference,21,exact
+2021-22,527701,Pacific,WCC,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2021-22,527704,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2021-22,527703,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2021-22,527705,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2021-22,527706,Pittsburgh,ACC,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2021-22,527708,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2021-22,527707,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2021-22,527709,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2021-22,527470,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2021-22,527710,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2021-22,527711,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2021-22,527712,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2021-22,527604,Purdue Fort Wayne,Summit League,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2021-22,527713,Quinnipiac,MAAC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Atlantic Athletic Conference,13,exact
+2021-22,527714,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2021-22,527715,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2021-22,527716,Rice,C-USA,242,Rice Owls,Rice,Owls,RICE,Conference USA,11,exact
+2021-22,527717,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2021-22,527718,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Atlantic Athletic Conference,13,exact
+2021-22,527719,Robert Morris,NEC,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2021-22,527720,Rutgers,Big Ten,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2021-22,527407,SFA,WAC,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Western Athletic Conference,30,exact
+2021-22,527398,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2021-22,527399,SMU,AAC,2567,SMU Mustangs,SMU,Mustangs,SMU,American Athletic Conference,62,exact
+2021-22,527525,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2021-22,527721,Sacred Heart,NEC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Northeast Conference,19,exact
+2021-22,527724,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2021-22,527726,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2021-22,527727,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2021-22,527728,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2021-22,527729,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Atlantic Athletic Conference,13,exact
+2021-22,527730,Sam Houston,WAC,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Western Athletic Conference,30,exact
+2021-22,527731,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2021-22,527733,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2021-22,527732,San Diego St.,MWC,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2021-22,527734,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2021-22,527735,San Jose St.,MWC,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2021-22,527385,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2021-22,527471,Seattle U,WAC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,Western Athletic Conference,30,exact
+2021-22,527386,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2021-22,527387,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Atlantic Athletic Conference,13,exact
+2021-22,527388,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2021-22,527390,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2021-22,527389,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2021-22,527392,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,49,exact
+2021-22,527391,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,49,exact
+2021-22,527393,South Fla.,AAC,58,South Florida Bulls,South Florida,Bulls,USF,American Athletic Conference,62,exact
+2021-22,527394,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2021-22,527395,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2021-22,527396,Southern California,Pac-12,30,USC Trojans,USC,Trojans,USC,Pac-12 Conference,21,dict
+2021-22,527397,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2021-22,527400,Southern Miss.,C-USA,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2021-22,527401,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2021-22,527402,Southern Utah,Big Sky,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,Western Athletic Conference,30,exact
+2021-22,527722,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2021-22,527723,St. Francis Brooklyn,NEC,2597,St. Francis Brooklyn Terriers,St. Francis Brooklyn,Terriers,SFNY,Northeast Conference,19,exact
+2021-22,527725,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2021-22,528150,St. Thomas (MN),Summit League,2900,St. Thomas Tommies,St. Thomas,Tommies,STMN,Summit League,49,alias
+2021-22,527406,Stanford,Pac-12,24,Stanford Cardinal,Stanford,Cardinal,STAN,Pac-12 Conference,21,exact
+2021-22,527408,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,ASUN Conference,46,exact
+2021-22,527409,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Colonial Athletic Association,10,exact
+2021-22,527410,Syracuse,ACC,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2021-22,527418,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2021-22,527741,Tarleton St.,WAC,2627,Tarleton State Texans,Tarleton State,Texans,TAR,Western Athletic Conference,30,exact
+2021-22,527411,Temple,AAC,218,Temple Owls,Temple,Owls,TEM,American Athletic Conference,62,exact
+2021-22,527415,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2021-22,527412,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2021-22,527413,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2021-22,527422,Texas,Big 12,251,Texas Longhorns,Texas,Longhorns,TEX,Big 12 Conference,8,exact
+2021-22,527417,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2021-22,527419,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2021-22,527404,Texas St.,Sun Belt,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2021-22,527420,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2021-22,527539,The Citadel,SoCon,2643,The Citadel Bulldogs,The Citadel,Bulldogs,CIT,Southern Conference,24,exact
+2021-22,527425,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2021-22,527426,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Colonial Athletic Association,10,exact
+2021-22,527427,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2021-22,527428,Tulane,AAC,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Athletic Conference,62,exact
+2021-22,527429,Tulsa,AAC,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Athletic Conference,62,exact
+2021-22,527491,UAB,C-USA,5,UAB Blazers,UAB,Blazers,UAB,Conference USA,11,exact
+2021-22,527492,UAlbany,America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,exact
+2021-22,527528,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2021-22,527529,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2021-22,527531,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2021-22,527739,UC San Diego,Big West,28,UC San Diego Tritons,UC San Diego,Tritons,UCSD,Big West Conference,9,exact
+2021-22,527526,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2021-22,527535,UCF,AAC,2116,UCF Knights,UCF,Knights,UCF,American Athletic Conference,62,exact
+2021-22,527530,UCLA,Pac-12,26,UCLA Bruins,UCLA,Bruins,UCLA,Pac-12 Conference,21,exact
+2021-22,527547,UConn,AAC,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2021-22,527601,UIC,Horizon,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2021-22,527476,UIW,Southland,2916,Incarnate Word Cardinals,Incarnate Word,Cardinals,UIW,Southland Conference,25,exact
+2021-22,527682,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2021-22,527635,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2021-22,527637,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2021-22,527626,UMass Lowell,America East,2349,UMass Lowell River Hawks,UMass Lowell,River Hawks,UML,America East Conference,1,exact
+2021-22,527659,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2021-22,527662,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2021-22,527663,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Colonial Athletic Association,10,exact
+2021-22,527687,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2021-22,527666,UNLV,MWC,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2021-22,527478,USC Upstate,Big South,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2021-22,527421,UT Arlington,Sun Belt,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,Western Athletic Conference,30,exact
+2021-22,527416,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2021-22,527423,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2021-22,527702,UTRGV,WAC,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Western Athletic Conference,30,dict
+2021-22,527424,UTSA,C-USA,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,Conference USA,11,exact
+2021-22,527434,Utah,Pac-12,254,Utah Utes,Utah,Utes,UTAH,Pac-12 Conference,21,exact
+2021-22,527433,Utah St.,MWC,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2021-22,527740,Utah Tech,WAC,3101,Utah Tech Trailblazers,Utah Tech,Trailblazers,UTU,Western Athletic Conference,30,exact
+2021-22,527484,Utah Valley,WAC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,Western Athletic Conference,30,exact
+2021-22,527439,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2021-22,527440,VMI,SoCon,2678,VMI Keydets,VMI,Keydets,VMI,Southern Conference,24,exact
+2021-22,527435,Valparaiso,MVC,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2021-22,527436,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2021-22,527437,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2021-22,527438,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2021-22,527442,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2021-22,527441,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2021-22,527443,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2021-22,527444,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2021-22,527446,Washington,Pac-12,264,Washington Huskies,Washington,Huskies,WASH,Pac-12 Conference,21,exact
+2021-22,527445,Washington St.,Pac-12,265,Washington State Cougars,Washington State,Cougars,WSU,Pac-12 Conference,21,exact
+2021-22,527447,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2021-22,527448,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2021-22,527449,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2021-22,527450,Western Ill.,Summit League,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Summit League,49,exact
+2021-22,527451,Western Ky.,C-USA,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2021-22,527452,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2021-22,527453,Wichita St.,AAC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Athletic Conference,62,exact
+2021-22,527454,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Colonial Athletic Association,10,exact
+2021-22,527455,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2021-22,527457,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2021-22,527477,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2021-22,527459,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2021-22,527460,Wyoming,MWC,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2021-22,527461,Xavier,Big East,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2021-22,527462,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2021-22,527463,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2022-23,541982,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2022-23,541987,Abilene Christian,WAC,2000,Abilene Christian Wildcats,Abilene Christian,Wildcats,ACU,Western Athletic Conference,30,exact
+2022-23,542492,Air Force,MWC,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2022-23,541988,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2022-23,541991,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2022-23,541989,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2022-23,541990,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2022-23,541994,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2022-23,541995,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2022-23,541996,App State,Sun Belt,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2022-23,541998,Arizona,Pac-12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Pac-12 Conference,21,exact
+2022-23,541997,Arizona St.,Pac-12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Pac-12 Conference,21,exact
+2022-23,541973,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2022-23,542000,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2022-23,541999,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2022-23,542494,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2022-23,542002,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2022-23,542003,Austin Peay,ASUN,2046,Austin Peay Governors,Austin Peay,Governors,APSU,ASUN Conference,46,exact
+2022-23,542014,BYU,WCC,252,BYU Cougars,BYU,Cougars,BYU,West Coast Conference,29,exact
+2022-23,542004,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2022-23,542006,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2022-23,542398,Bellarmine,ASUN,91,Bellarmine Knights,Bellarmine,Knights,BELL,ASUN Conference,46,exact
+2022-23,541980,Belmont,MVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2022-23,542007,Bethune-Cookman,SWAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2022-23,542008,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2022-23,542009,Boise St.,MWC,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2022-23,542010,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2022-23,542011,Boston U.,Patriot,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2022-23,542012,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2022-23,542013,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2022-23,542015,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2022-23,542016,Bryant,America East,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2022-23,542017,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2022-23,542018,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2022-23,542019,Butler,Big East,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2022-23,542021,CSU Bakersfield,WAC,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2022-23,542025,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2022-23,542020,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2022-23,542023,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2022-23,542028,California,Pac-12,25,California Golden Bears,California,Golden Bears,CAL,Pac-12 Conference,21,exact
+2022-23,542395,California Baptist,WAC,2856,California Baptist Lancers,California Baptist,Lancers,CBU,Western Athletic Conference,30,exact
+2022-23,542033,Campbell,Big South,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Big South Conference,6,exact
+2022-23,542034,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Atlantic Athletic Conference,13,exact
+2022-23,542554,Central Ark.,ASUN,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,ASUN Conference,46,exact
+2022-23,542035,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2022-23,542037,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2022-23,542005,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2022-23,542251,Charlotte,C-USA,2429,Charlotte 49ers,Charlotte,49ers,CLT,Conference USA,11,exact
+2022-23,542460,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2022-23,542038,Chicago St.,Independent,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Division I Independents,43,exact
+2022-23,542039,Cincinnati,AAC,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,American Athletic Conference,62,exact
+2022-23,542041,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2022-23,542042,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2022-23,542043,Coastal Carolina,Sun Belt,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2022-23,541966,Col. of Charleston,CAA,232,Charleston Cougars,Charleston,Cougars,COFC,Colonial Athletic Association,10,dict
+2022-23,542044,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2022-23,542046,Colorado,Pac-12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Pac-12 Conference,21,exact
+2022-23,542045,Colorado St.,MWC,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2022-23,542047,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2022-23,542049,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2022-23,542051,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2022-23,542052,Creighton,Big East,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2022-23,542053,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2022-23,542054,Davidson,Atlantic 10,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2022-23,542056,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2022-23,542058,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2022-23,542061,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Colonial Athletic Association,10,exact
+2022-23,542060,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2022-23,542062,Denver,Summit League,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,49,exact
+2022-23,542064,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2022-23,542066,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2022-23,542068,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Colonial Athletic Association,10,exact
+2022-23,542070,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2022-23,542071,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2022-23,542074,ETSU,SoCon,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2022-23,542073,East Carolina,AAC,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Athletic Conference,62,exact
+2022-23,542076,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2022-23,542078,Eastern Ky.,ASUN,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,ASUN Conference,46,exact
+2022-23,542080,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2022-23,542081,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2022-23,541967,Elon,CAA,2210,Elon Phoenix,Elon,Phoenix,ELON,Colonial Athletic Association,10,exact
+2022-23,542082,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2022-23,541984,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,ASUN Conference,46,exact
+2022-23,542091,FIU,C-USA,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2022-23,542085,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Atlantic Athletic Conference,13,exact
+2022-23,542086,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2022-23,542089,Fla. Atlantic,C-USA,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,Conference USA,11,exact
+2022-23,542095,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2022-23,542087,Florida A&M,SWAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2022-23,542093,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2022-23,542096,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2022-23,542022,Fresno St.,MWC,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2022-23,542098,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2022-23,542106,Ga. Southern,Sun Belt,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2022-23,541968,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2022-23,542100,George Mason,Atlantic 10,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2022-23,542102,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2022-23,542104,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2022-23,542112,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2022-23,542108,Georgia St.,Sun Belt,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2022-23,542110,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2022-23,542113,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2022-23,542115,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2022-23,541969,Grand Canyon,WAC,2253,Grand Canyon Lopes,Grand Canyon,Lopes,GCU,Western Athletic Conference,30,exact
+2022-23,542541,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2022-23,542117,Hampton,CAA,2261,Hampton Pirates,Hampton,Pirates,HAMP,Colonial Athletic Association,10,exact
+2022-23,542119,Hartford,America East,42,Hartford Hawks,Hartford,Hawks,HART,Division I Independents,43,exact
+2022-23,542121,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2022-23,542123,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2022-23,541981,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2022-23,542125,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Colonial Athletic Association,10,exact
+2022-23,542127,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2022-23,542130,Houston,AAC,248,Houston Cougars,Houston,Cougars,HOU,American Athletic Conference,62,exact
+2022-23,542128,Houston Christian,Southland,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,exact
+2022-23,542132,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2022-23,541974,IUPUI,Horizon,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,alias
+2022-23,542136,Idaho,Big Sky,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2022-23,542134,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2022-23,542138,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2022-23,542137,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2022-23,542143,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2022-23,542141,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2022-23,542147,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Atlantic Athletic Conference,13,exact
+2022-23,542152,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2022-23,542150,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2022-23,542154,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2022-23,542157,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,ASUN Conference,46,exact
+2022-23,542155,Jacksonville St.,ASUN,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,ASUN Conference,46,exact
+2022-23,542159,James Madison,Sun Belt,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2022-23,542162,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2022-23,541975,Kansas City,WAC,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,49,exact
+2022-23,542161,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2022-23,541970,Kennesaw St.,ASUN,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,ASUN Conference,46,exact
+2022-23,542165,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2022-23,542167,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2022-23,542179,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2022-23,542192,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2022-23,542183,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2022-23,542170,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2022-23,542171,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2022-23,542173,Lamar University,WAC,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2022-23,542175,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2022-23,542177,Liberty,ASUN,2335,Liberty Flames,Liberty,Flames,LIB,ASUN Conference,46,exact
+2022-23,542986,Lindenwood,OVC,2815,Lindenwood Lions,Lindenwood,Lions,LIN,,,exact
+2022-23,541983,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,ASUN Conference,46,exact
+2022-23,542001,Little Rock,OVC,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2022-23,542024,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2022-23,542181,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2022-23,542442,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2022-23,542185,Louisiana Tech,C-USA,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2022-23,542187,Louisville,ACC,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2022-23,542193,Loyola Chicago,Atlantic 10,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2022-23,542190,Loyola Maryland,Patriot,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2022-23,542195,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2022-23,542196,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Atlantic Athletic Conference,13,exact
+2022-23,542198,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Atlantic Athletic Conference,13,exact
+2022-23,542200,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2022-23,542202,Marshall,Sun Belt,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2022-23,542205,Maryland,Big Ten,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2022-23,542209,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2022-23,542210,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2022-23,542211,Memphis,AAC,235,Memphis Tigers,Memphis,Tigers,MEM,American Athletic Conference,62,exact
+2022-23,542213,Mercer,SoCon,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2022-23,542397,Merrimack,NEC,2771,Merrimack Warriors,Merrimack,Warriors,MRMK,Northeast Conference,19,exact
+2022-23,542216,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2022-23,542214,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2022-23,542222,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2022-23,542219,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2022-23,542223,Middle Tenn.,C-USA,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2022-23,542544,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2022-23,542225,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2022-23,542227,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2022-23,542230,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2022-23,542234,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2022-23,542438,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2022-23,542235,Monmouth,CAA,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Colonial Athletic Association,10,exact
+2022-23,542239,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2022-23,542237,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2022-23,542240,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2022-23,542242,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2022-23,542244,Mount St. Mary's,MAAC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Atlantic Athletic Conference,13,exact
+2022-23,542246,Murray St.,MVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2022-23,542278,N.C. A&T,CAA,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Colonial Athletic Association,10,exact
+2022-23,542281,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2022-23,542283,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2022-23,542298,NIU,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2022-23,542266,NJIT,ASUN,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2022-23,542496,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2022-23,542257,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2022-23,542262,Nevada,MWC,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2022-23,542264,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2022-23,542269,New Mexico,MWC,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2022-23,542268,New Mexico St.,WAC,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Western Athletic Conference,30,exact
+2022-23,542271,New Orleans,Southland,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2022-23,542273,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Atlantic Athletic Conference,13,exact
+2022-23,542274,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2022-23,542276,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2022-23,541986,North Ala.,ASUN,2453,North Alabama Lions,North Alabama,Lions,UNA,ASUN Conference,46,exact
+2022-23,542249,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2022-23,542287,North Dakota,Summit League,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,49,exact
+2022-23,542285,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,49,exact
+2022-23,541976,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,ASUN Conference,46,exact
+2022-23,542289,North Texas,C-USA,249,North Texas Mean Green,North Texas,Mean Green,UNT,Conference USA,11,exact
+2022-23,542292,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Colonial Athletic Association,10,exact
+2022-23,542294,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2022-23,542296,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2022-23,542301,Northern Ky.,Horizon,94,Northern Kentucky Norse,Northern Kentucky,Norse,NKU,Horizon League,45,exact
+2022-23,542307,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2022-23,542305,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2022-23,542309,Notre Dame,ACC,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2022-23,542311,Oakland,Horizon,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2022-23,542316,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2022-23,542314,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2022-23,542319,Oklahoma,Big 12,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Big 12 Conference,8,exact
+2022-23,542317,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2022-23,542321,Old Dominion,Sun Belt,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2022-23,542232,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2022-23,542259,Omaha,Summit League,2437,Omaha Mavericks,Omaha,Mavericks,OMA,Summit League,49,exact
+2022-23,542323,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,49,exact
+2022-23,542327,Oregon,Pac-12,2483,Oregon Ducks,Oregon,Ducks,ORE,Pac-12 Conference,21,exact
+2022-23,542325,Oregon St.,Pac-12,204,Oregon State Beavers,Oregon State,Beavers,ORST,Pac-12 Conference,21,exact
+2022-23,542329,Pacific,WCC,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2022-23,542335,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2022-23,542333,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2022-23,542337,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2022-23,542339,Pittsburgh,ACC,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2022-23,542342,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2022-23,542341,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2022-23,542344,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2022-23,541971,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2022-23,542346,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2022-23,542349,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2022-23,542350,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2022-23,542145,Purdue Fort Wayne,Summit League,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2022-23,542941,Queens (NC),ASUN,2511,Queens University Royals,Queens University,Royals,QUC,,,dict
+2022-23,542352,Quinnipiac,MAAC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Atlantic Athletic Conference,13,exact
+2022-23,542354,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2022-23,542356,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2022-23,542357,Rice,C-USA,242,Rice Owls,Rice,Owls,RICE,Conference USA,11,exact
+2022-23,542359,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2022-23,542361,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Atlantic Athletic Conference,13,exact
+2022-23,542363,Robert Morris,NEC,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2022-23,542366,Rutgers,Big Ten,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2022-23,542445,SFA,WAC,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Western Athletic Conference,30,exact
+2022-23,542429,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2022-23,542431,SMU,AAC,2567,SMU Mustangs,SMU,Mustangs,SMU,American Athletic Conference,62,exact
+2022-23,542026,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2022-23,542368,Sacred Heart,NEC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Northeast Conference,19,exact
+2022-23,542374,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2022-23,542377,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2022-23,542379,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2022-23,542381,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2022-23,542383,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Atlantic Athletic Conference,13,exact
+2022-23,542385,Sam Houston,WAC,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Western Athletic Conference,30,exact
+2022-23,542387,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2022-23,542390,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2022-23,542388,San Diego St.,MWC,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2022-23,542391,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2022-23,542393,San Jose St.,MWC,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2022-23,542407,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2022-23,541972,Seattle U,WAC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,Western Athletic Conference,30,exact
+2022-23,542410,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2022-23,542411,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Atlantic Athletic Conference,13,exact
+2022-23,542413,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2022-23,542416,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2022-23,542414,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2022-23,542419,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,49,exact
+2022-23,542417,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,49,exact
+2022-23,542420,South Fla.,AAC,58,South Florida Bulls,South Florida,Bulls,USF,American Athletic Conference,62,exact
+2022-23,542422,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2022-23,542424,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2022-23,542425,Southern California,Pac-12,30,USC Trojans,USC,Trojans,USC,Pac-12 Conference,21,dict
+2022-23,542427,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2022-23,542773,Southern Ind.,OVC,88,Southern Indiana Screaming Eagles,Southern Indiana,Screaming Eagles,USI,,,alias
+2022-23,542433,Southern Miss.,Sun Belt,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2022-23,542434,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2022-23,542436,Southern Utah,WAC,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,Western Athletic Conference,30,exact
+2022-23,542370,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2022-23,542372,St. Francis Brooklyn,NEC,2597,St. Francis Brooklyn Terriers,St. Francis Brooklyn,Terriers,SFNY,Northeast Conference,19,exact
+2022-23,542376,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2022-23,542406,St. Thomas (MN),Summit League,2900,St. Thomas Tommies,St. Thomas,Tommies,STMN,Summit League,49,alias
+2022-23,542444,Stanford,Pac-12,24,Stanford Cardinal,Stanford,Cardinal,STAN,Pac-12 Conference,21,exact
+2022-23,542447,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,ASUN Conference,46,exact
+2022-23,542774,Stonehill,NEC,284,Stonehill Skyhawks,Stonehill,Skyhawks,STO,Northeast Conference,19,exact
+2022-23,542449,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Colonial Athletic Association,10,exact
+2022-23,542451,Syracuse,ACC,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2022-23,542469,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2022-23,542404,Tarleton St.,WAC,2627,Tarleton State Texans,Tarleton State,Texans,TAR,Western Athletic Conference,30,exact
+2022-23,542454,Temple,AAC,218,Temple Owls,Temple,Owls,TEM,American Athletic Conference,62,exact
+2022-23,542462,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2022-23,542456,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2022-23,542457,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2022-23,542631,Tex. A&M-Commerce,Southland,2837,East Texas A&M Lions,East Texas A&M,Lions,ETAM,Southland Conference,25,alias
+2022-23,542477,Texas,Big 12,251,Texas Longhorns,Texas,Longhorns,TEX,Big 12 Conference,8,exact
+2022-23,542467,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2022-23,542471,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2022-23,542440,Texas St.,Sun Belt,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2022-23,542473,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2022-23,542040,The Citadel,SoCon,2643,The Citadel Bulldogs,The Citadel,Bulldogs,CIT,Southern Conference,24,exact
+2022-23,542483,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2022-23,542485,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Colonial Athletic Association,10,exact
+2022-23,542487,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2022-23,542489,Tulane,AAC,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Athletic Conference,62,exact
+2022-23,542491,Tulsa,AAC,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Athletic Conference,62,exact
+2022-23,541992,UAB,C-USA,5,UAB Blazers,UAB,Blazers,UAB,Conference USA,11,exact
+2022-23,541993,UAlbany,America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,exact
+2022-23,542029,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2022-23,542030,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2022-23,542032,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2022-23,542400,UC San Diego,Big West,28,UC San Diego Tritons,UC San Diego,Tritons,UCSD,Big West Conference,9,exact
+2022-23,542027,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2022-23,542036,UCF,AAC,2116,UCF Knights,UCF,Knights,UCF,American Athletic Conference,62,exact
+2022-23,542031,UCLA,Pac-12,26,UCLA Bruins,UCLA,Bruins,UCLA,Pac-12 Conference,21,exact
+2022-23,542048,UConn,AAC,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2022-23,542140,UIC,MVC,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2022-23,541977,UIW,Southland,2916,Incarnate Word Cardinals,Incarnate Word,Cardinals,UIW,Southland Conference,25,exact
+2022-23,542290,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2022-23,542204,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2022-23,542207,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2022-23,542188,UMass Lowell,America East,2349,UMass Lowell River Hawks,UMass Lowell,River Hawks,UML,America East Conference,1,exact
+2022-23,542248,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2022-23,542253,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2022-23,542255,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Colonial Athletic Association,10,exact
+2022-23,542299,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2022-23,542260,UNLV,MWC,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2022-23,541979,USC Upstate,Big South,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2022-23,542475,UT Arlington,WAC,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,Western Athletic Conference,30,exact
+2022-23,542465,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2022-23,542479,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2022-23,542331,UTRGV,WAC,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Western Athletic Conference,30,dict
+2022-23,542481,UTSA,C-USA,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,Conference USA,11,exact
+2022-23,542501,Utah,Pac-12,254,Utah Utes,Utah,Utes,UTAH,Pac-12 Conference,21,exact
+2022-23,542499,Utah St.,MWC,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2022-23,542402,Utah Tech,WAC,3101,Utah Tech Trailblazers,Utah Tech,Trailblazers,UTU,Western Athletic Conference,30,exact
+2022-23,541985,Utah Valley,WAC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,Western Athletic Conference,30,exact
+2022-23,542509,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2022-23,542511,VMI,SoCon,2678,VMI Keydets,VMI,Keydets,VMI,Southern Conference,24,exact
+2022-23,542502,Valparaiso,MVC,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2022-23,542504,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2022-23,542505,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2022-23,542507,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2022-23,542515,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2022-23,542513,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2022-23,542517,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2022-23,542519,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2022-23,542523,Washington,Pac-12,264,Washington Huskies,Washington,Huskies,WASH,Pac-12 Conference,21,exact
+2022-23,542521,Washington St.,Pac-12,265,Washington State Cougars,Washington State,Cougars,WSU,Pac-12 Conference,21,exact
+2022-23,542524,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2022-23,542526,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2022-23,542529,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2022-23,542530,Western Ill.,Summit League,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Summit League,49,exact
+2022-23,542532,Western Ky.,C-USA,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2022-23,542534,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2022-23,542535,Wichita St.,AAC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Athletic Conference,62,exact
+2022-23,542537,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Colonial Athletic Association,10,exact
+2022-23,542539,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2022-23,542542,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2022-23,541978,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2022-23,542545,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2022-23,542547,Wyoming,MWC,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2022-23,542549,Xavier,Big East,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2022-23,542550,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2022-23,542552,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2023-24,560639,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2023-24,560649,Abilene Christian,WAC,2000,Abilene Christian Wildcats,Abilene Christian,Wildcats,ACU,Western Athletic Conference,30,exact
+2023-24,561195,Air Force,MWC,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2023-24,560651,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2023-24,560658,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2023-24,560654,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2023-24,560655,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2023-24,560664,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2023-24,560666,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2023-24,560667,App State,Sun Belt,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2023-24,560672,Arizona,Pac-12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Pac-12 Conference,21,exact
+2023-24,560669,Arizona St.,Pac-12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Pac-12 Conference,21,exact
+2023-24,560622,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2023-24,560676,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2023-24,560674,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2023-24,561197,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2023-24,560680,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2023-24,560682,Austin Peay,ASUN,2046,Austin Peay Governors,Austin Peay,Governors,APSU,ASUN Conference,46,exact
+2023-24,560702,BYU,Big 12,252,BYU Cougars,BYU,Cougars,BYU,West Coast Conference,29,exact
+2023-24,560683,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2023-24,560687,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2023-24,561098,Bellarmine,ASUN,91,Bellarmine Knights,Bellarmine,Knights,BELL,ASUN Conference,46,exact
+2023-24,560635,Belmont,MVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2023-24,560689,Bethune-Cookman,SWAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2023-24,560691,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2023-24,560693,Boise St.,MWC,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2023-24,560695,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2023-24,560696,Boston U.,Patriot,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2023-24,560699,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2023-24,560700,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2023-24,560704,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2023-24,560705,Bryant,America East,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2023-24,560707,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2023-24,560709,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2023-24,560711,Butler,Big East,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2023-24,560714,CSU Bakersfield,WAC,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2023-24,560723,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2023-24,560712,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2023-24,560718,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2023-24,560729,California,Pac-12,25,California Golden Bears,California,Golden Bears,CAL,Pac-12 Conference,21,exact
+2023-24,561094,California Baptist,WAC,2856,California Baptist Lancers,California Baptist,Lancers,CBU,Western Athletic Conference,30,exact
+2023-24,560820,Campbell,CAA,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Big South Conference,6,exact
+2023-24,560822,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Atlantic Athletic Conference,13,exact
+2023-24,561265,Central Ark.,ASUN,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,ASUN Conference,46,exact
+2023-24,560824,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2023-24,560828,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2023-24,560685,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2023-24,560798,Charlotte,AAC,2429,Charlotte 49ers,Charlotte,49ers,CLT,Conference USA,11,exact
+2023-24,561164,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2023-24,560830,Chicago St.,Independent,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Division I Independents,43,exact
+2023-24,560832,Cincinnati,Big 12,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,American Athletic Conference,62,exact
+2023-24,560836,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2023-24,560838,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2023-24,560840,Coastal Carolina,Sun Belt,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2023-24,560608,Col. of Charleston,CAA,232,Charleston Cougars,Charleston,Cougars,COFC,Colonial Athletic Association,10,dict
+2023-24,560843,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2023-24,560847,Colorado,Pac-12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Pac-12 Conference,21,exact
+2023-24,560845,Colorado St.,MWC,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2023-24,560849,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2023-24,560853,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2023-24,560855,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2023-24,560857,Creighton,Big East,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2023-24,560859,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2023-24,560861,Davidson,Atlantic 10,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2023-24,560863,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2023-24,560865,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2023-24,560869,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Colonial Athletic Association,10,exact
+2023-24,560867,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2023-24,560871,Denver,Summit League,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,49,exact
+2023-24,560873,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2023-24,560875,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2023-24,560877,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Colonial Athletic Association,10,exact
+2023-24,560879,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2023-24,560881,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2023-24,560885,ETSU,SoCon,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2023-24,560883,East Carolina,AAC,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Athletic Conference,62,exact
+2023-24,560887,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2023-24,560889,Eastern Ky.,ASUN,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,ASUN Conference,46,exact
+2023-24,560891,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2023-24,560892,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2023-24,560610,Elon,CAA,2210,Elon Phoenix,Elon,Phoenix,ELON,Colonial Athletic Association,10,exact
+2023-24,560893,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2023-24,560643,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,ASUN Conference,46,exact
+2023-24,560903,FIU,C-USA,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2023-24,560895,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Atlantic Athletic Conference,13,exact
+2023-24,560897,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2023-24,560901,Fla. Atlantic,AAC,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,Conference USA,11,exact
+2023-24,560908,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2023-24,560899,Florida A&M,SWAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2023-24,560905,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2023-24,560909,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2023-24,560716,Fresno St.,MWC,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2023-24,560911,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2023-24,560919,Ga. Southern,Sun Belt,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2023-24,560612,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2023-24,560913,George Mason,Atlantic 10,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2023-24,560915,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2023-24,560917,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2023-24,560924,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2023-24,560920,Georgia St.,Sun Belt,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2023-24,560922,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2023-24,560926,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2023-24,560929,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2023-24,560614,Grand Canyon,WAC,2253,Grand Canyon Lopes,Grand Canyon,Lopes,GCU,Western Athletic Conference,30,exact
+2023-24,561249,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2023-24,560931,Hampton,CAA,2261,Hampton Pirates,Hampton,Pirates,HAMP,Colonial Athletic Association,10,exact
+2023-24,560935,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2023-24,560937,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2023-24,560637,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2023-24,560939,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Colonial Athletic Association,10,exact
+2023-24,560941,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2023-24,560945,Houston,Big 12,248,Houston Cougars,Houston,Cougars,HOU,American Athletic Conference,62,exact
+2023-24,560943,Houston Christian,Southland,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,exact
+2023-24,560947,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2023-24,560624,IUPUI,Horizon,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,alias
+2023-24,560951,Idaho,Big Sky,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2023-24,560949,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2023-24,560955,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2023-24,560953,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2023-24,560558,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2023-24,560557,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2023-24,560562,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Atlantic Athletic Conference,13,exact
+2023-24,560567,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2023-24,560565,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2023-24,560569,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2023-24,560573,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,ASUN Conference,46,exact
+2023-24,560571,Jacksonville St.,C-USA,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,ASUN Conference,46,exact
+2023-24,560575,James Madison,Sun Belt,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2023-24,560579,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2023-24,560626,Kansas City,WAC,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,49,exact
+2023-24,560577,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2023-24,560616,Kennesaw St.,ASUN,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,ASUN Conference,46,exact
+2023-24,560581,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2023-24,560583,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2023-24,560596,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2023-24,560733,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2023-24,560600,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2023-24,560585,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2023-24,560587,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2023-24,560589,Lamar University,WAC,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2023-24,561749,Le Moyne,NEC,2330,Le Moyne Dolphins,Le Moyne,Dolphins,LEM,,,exact
+2023-24,560591,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2023-24,560593,Liberty,C-USA,2335,Liberty Flames,Liberty,Flames,LIB,ASUN Conference,46,exact
+2023-24,560555,Lindenwood,OVC,2815,Lindenwood Lions,Lindenwood,Lions,LIN,,,exact
+2023-24,560641,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,ASUN Conference,46,exact
+2023-24,560678,Little Rock,OVC,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2023-24,560721,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2023-24,560598,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2023-24,561145,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2023-24,560602,Louisiana Tech,C-USA,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2023-24,560604,Louisville,ACC,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2023-24,560735,Loyola Chicago,Atlantic 10,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2023-24,560731,Loyola Maryland,Patriot,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2023-24,560736,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2023-24,560738,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Atlantic Athletic Conference,13,exact
+2023-24,560740,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Atlantic Athletic Conference,13,exact
+2023-24,560742,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2023-24,560744,Marshall,Sun Belt,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2023-24,560747,Maryland,Big Ten,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2023-24,560752,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2023-24,560755,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2023-24,560756,Memphis,AAC,235,Memphis Tigers,Memphis,Tigers,MEM,American Athletic Conference,62,exact
+2023-24,560758,Mercer,SoCon,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2023-24,561096,Merrimack,NEC,2771,Merrimack Warriors,Merrimack,Warriors,MRMK,Northeast Conference,19,exact
+2023-24,560763,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2023-24,560761,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2023-24,560767,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2023-24,560765,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2023-24,560769,Middle Tenn.,C-USA,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2023-24,561253,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2023-24,560772,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2023-24,560773,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2023-24,560775,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2023-24,560780,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2023-24,561141,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2023-24,560781,Monmouth,CAA,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Colonial Athletic Association,10,exact
+2023-24,560785,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2023-24,560783,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2023-24,560787,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2023-24,560789,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2023-24,560791,Mount St. Mary's,MAAC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Atlantic Athletic Conference,13,exact
+2023-24,560792,Murray St.,MVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2023-24,560974,N.C. A&T,CAA,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Colonial Athletic Association,10,exact
+2023-24,560976,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2023-24,560978,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2023-24,560994,NIU,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2023-24,560961,NJIT,ASUN,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2023-24,561199,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2023-24,560804,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2023-24,560810,Nevada,MWC,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2023-24,560958,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2023-24,560964,New Mexico,MWC,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2023-24,560963,New Mexico St.,C-USA,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Western Athletic Conference,30,exact
+2023-24,560966,New Orleans,Southland,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2023-24,560968,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Atlantic Athletic Conference,13,exact
+2023-24,560970,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2023-24,560972,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2023-24,560647,North Ala.,ASUN,2453,North Alabama Lions,North Alabama,Lions,UNA,ASUN Conference,46,exact
+2023-24,560796,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2023-24,560981,North Dakota,Summit League,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,49,exact
+2023-24,560980,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,49,exact
+2023-24,560628,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,ASUN Conference,46,exact
+2023-24,560983,North Texas,AAC,249,North Texas Mean Green,North Texas,Mean Green,UNT,Conference USA,11,exact
+2023-24,560988,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Colonial Athletic Association,10,exact
+2023-24,560989,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2023-24,560992,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2023-24,560998,Northern Ky.,Horizon,94,Northern Kentucky Norse,Northern Kentucky,Norse,NKU,Horizon League,45,exact
+2023-24,561002,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2023-24,561000,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2023-24,561004,Notre Dame,ACC,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2023-24,561006,Oakland,Horizon,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2023-24,561010,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2023-24,561008,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2023-24,561014,Oklahoma,Big 12,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Big 12 Conference,8,exact
+2023-24,561012,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2023-24,561016,Old Dominion,Sun Belt,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2023-24,560777,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2023-24,560806,Omaha,Summit League,2437,Omaha Mavericks,Omaha,Mavericks,OMA,Summit League,49,exact
+2023-24,561018,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,49,exact
+2023-24,561022,Oregon,Pac-12,2483,Oregon Ducks,Oregon,Ducks,ORE,Pac-12 Conference,21,exact
+2023-24,561020,Oregon St.,Pac-12,204,Oregon State Beavers,Oregon State,Beavers,ORST,Pac-12 Conference,21,exact
+2023-24,561024,Pacific,WCC,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2023-24,561029,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2023-24,561028,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2023-24,561031,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2023-24,561033,Pittsburgh,ACC,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2023-24,561036,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2023-24,561035,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2023-24,561038,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2023-24,560618,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2023-24,561040,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2023-24,561042,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2023-24,561044,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2023-24,560560,Purdue Fort Wayne,Summit League,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2023-24,560552,Queens (NC),ASUN,2511,Queens University Royals,Queens University,Royals,QUC,,,dict
+2023-24,561047,Quinnipiac,MAAC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Atlantic Athletic Conference,13,exact
+2023-24,561049,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2023-24,561050,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2023-24,561052,Rice,AAC,242,Rice Owls,Rice,Owls,RICE,Conference USA,11,exact
+2023-24,561055,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2023-24,561056,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Atlantic Athletic Conference,13,exact
+2023-24,561059,Robert Morris,NEC,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2023-24,561061,Rutgers,Big Ten,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2023-24,561150,SFA,WAC,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Western Athletic Conference,30,exact
+2023-24,561131,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2023-24,561133,SMU,AAC,2567,SMU Mustangs,SMU,Mustangs,SMU,American Athletic Conference,62,exact
+2023-24,560726,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2023-24,561063,Sacred Heart,NEC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Northeast Conference,19,exact
+2023-24,561072,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2023-24,561077,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2023-24,561078,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2023-24,561080,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2023-24,561082,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Atlantic Athletic Conference,13,exact
+2023-24,561084,Sam Houston,C-USA,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Western Athletic Conference,30,exact
+2023-24,561086,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2023-24,561090,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2023-24,561088,San Diego St.,MWC,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2023-24,561091,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2023-24,561092,San Jose St.,MWC,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2023-24,561108,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2023-24,560620,Seattle U,WAC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,Western Athletic Conference,30,exact
+2023-24,561110,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2023-24,561112,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Atlantic Athletic Conference,13,exact
+2023-24,561113,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2023-24,561117,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2023-24,561115,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2023-24,561121,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,49,exact
+2023-24,561119,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,49,exact
+2023-24,561122,South Fla.,AAC,58,South Florida Bulls,South Florida,Bulls,USF,American Athletic Conference,62,exact
+2023-24,561124,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2023-24,561126,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2023-24,561127,Southern California,Pac-12,30,USC Trojans,USC,Trojans,USC,Pac-12 Conference,21,dict
+2023-24,561129,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2023-24,561269,Southern Ind.,OVC,88,Southern Indiana Screaming Eagles,Southern Indiana,Screaming Eagles,USI,,,alias
+2023-24,561134,Southern Miss.,Sun Belt,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2023-24,561136,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2023-24,561139,Southern Utah,WAC,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,Western Athletic Conference,30,exact
+2023-24,561067,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2023-24,561074,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2023-24,561106,St. Thomas (MN),Summit League,2900,St. Thomas Tommies,St. Thomas,Tommies,STMN,Summit League,49,alias
+2023-24,561147,Stanford,Pac-12,24,Stanford Cardinal,Stanford,Cardinal,STAN,Pac-12 Conference,21,exact
+2023-24,561152,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,ASUN Conference,46,exact
+2023-24,561271,Stonehill,NEC,284,Stonehill Skyhawks,Stonehill,Skyhawks,STO,Northeast Conference,19,exact
+2023-24,561154,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Colonial Athletic Association,10,exact
+2023-24,561156,Syracuse,ACC,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2023-24,561172,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2023-24,561104,Tarleton St.,WAC,2627,Tarleton State Texans,Tarleton State,Texans,TAR,Western Athletic Conference,30,exact
+2023-24,561158,Temple,AAC,218,Temple Owls,Temple,Owls,TEM,American Athletic Conference,62,exact
+2023-24,561166,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2023-24,561160,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2023-24,561162,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2023-24,561267,Tex. A&M-Commerce,Southland,2837,East Texas A&M Lions,East Texas A&M,Lions,ETAM,Southland Conference,25,alias
+2023-24,561179,Texas,Big 12,251,Texas Longhorns,Texas,Longhorns,TEX,Big 12 Conference,8,exact
+2023-24,561170,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2023-24,561174,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2023-24,561143,Texas St.,Sun Belt,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2023-24,561176,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2023-24,560834,The Citadel,SoCon,2643,The Citadel Bulldogs,The Citadel,Bulldogs,CIT,Southern Conference,24,exact
+2023-24,561186,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2023-24,561188,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Colonial Athletic Association,10,exact
+2023-24,561190,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2023-24,561192,Tulane,AAC,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Athletic Conference,62,exact
+2023-24,561194,Tulsa,AAC,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Athletic Conference,62,exact
+2023-24,560659,UAB,AAC,5,UAB Blazers,UAB,Blazers,UAB,Conference USA,11,exact
+2023-24,560662,UAlbany,America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,exact
+2023-24,560813,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2023-24,560815,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2023-24,560819,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2023-24,561100,UC San Diego,Big West,28,UC San Diego Tritons,UC San Diego,Tritons,UCSD,Big West Conference,9,exact
+2023-24,560727,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2023-24,560826,UCF,Big 12,2116,UCF Knights,UCF,Knights,UCF,American Athletic Conference,62,exact
+2023-24,560817,UCLA,Pac-12,26,UCLA Bruins,UCLA,Bruins,UCLA,Pac-12 Conference,21,exact
+2023-24,560851,UConn,AAC,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2023-24,560956,UIC,MVC,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2023-24,560631,UIW,Southland,2916,Incarnate Word Cardinals,Incarnate Word,Cardinals,UIW,Southland Conference,25,exact
+2023-24,560985,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2023-24,560746,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2023-24,560750,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2023-24,560606,UMass Lowell,America East,2349,UMass Lowell River Hawks,UMass Lowell,River Hawks,UML,America East Conference,1,exact
+2023-24,560795,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2023-24,560800,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2023-24,560802,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Colonial Athletic Association,10,exact
+2023-24,560995,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2023-24,560808,UNLV,MWC,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2023-24,560633,USC Upstate,Big South,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2023-24,561178,UT Arlington,WAC,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,Western Athletic Conference,30,exact
+2023-24,561168,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2023-24,561182,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2023-24,561026,UTRGV,WAC,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Western Athletic Conference,30,dict
+2023-24,561184,UTSA,AAC,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,Conference USA,11,exact
+2023-24,561204,Utah,Pac-12,254,Utah Utes,Utah,Utes,UTAH,Pac-12 Conference,21,exact
+2023-24,561202,Utah St.,MWC,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2023-24,561102,Utah Tech,WAC,3101,Utah Tech Trailblazers,Utah Tech,Trailblazers,UTU,Western Athletic Conference,30,exact
+2023-24,560646,Utah Valley,WAC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,Western Athletic Conference,30,exact
+2023-24,561214,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2023-24,561216,VMI,SoCon,2678,VMI Keydets,VMI,Keydets,VMI,Southern Conference,24,exact
+2023-24,561206,Valparaiso,MVC,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2023-24,561208,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2023-24,561210,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2023-24,561212,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2023-24,561220,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2023-24,561218,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2023-24,561222,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2023-24,561224,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2023-24,561228,Washington,Pac-12,264,Washington Huskies,Washington,Huskies,WASH,Pac-12 Conference,21,exact
+2023-24,561226,Washington St.,Pac-12,265,Washington State Cougars,Washington State,Cougars,WSU,Pac-12 Conference,21,exact
+2023-24,561230,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2023-24,561232,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2023-24,561235,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2023-24,561238,Western Ill.,OVC,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Summit League,49,exact
+2023-24,561239,Western Ky.,C-USA,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2023-24,561241,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2023-24,561243,Wichita St.,AAC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Athletic Conference,62,exact
+2023-24,561245,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Colonial Athletic Association,10,exact
+2023-24,561247,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2023-24,561251,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2023-24,560632,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2023-24,561255,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2023-24,561258,Wyoming,MWC,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2023-24,561259,Xavier,Big East,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2023-24,561262,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2023-24,561264,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2024-25,590505,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2024-25,590510,Abilene Christian,WAC,2000,Abilene Christian Wildcats,Abilene Christian,Wildcats,ACU,Western Athletic Conference,30,exact
+2024-25,590762,Air Force,MWC,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2024-25,590801,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2024-25,590513,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2024-25,590511,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2024-25,590512,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2024-25,590515,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2024-25,590516,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2024-25,590517,App State,Sun Belt,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2024-25,590519,Arizona,Big 12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Pac-12 Conference,21,exact
+2024-25,590518,Arizona St.,Big 12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Pac-12 Conference,21,exact
+2024-25,590496,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2024-25,590521,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2024-25,590520,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2024-25,590763,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2024-25,590803,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2024-25,590523,Austin Peay,ASUN,2046,Austin Peay Governors,Austin Peay,Governors,APSU,ASUN Conference,46,exact
+2024-25,590534,BYU,Big 12,252,BYU Cougars,BYU,Cougars,BYU,West Coast Conference,29,exact
+2024-25,590524,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2024-25,590526,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2024-25,590714,Bellarmine,NA,91,Bellarmine Knights,Bellarmine,Knights,BELL,ASUN Conference,46,exact
+2024-25,590503,Belmont,MVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2024-25,590527,Bethune-Cookman,SWAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2024-25,590528,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2024-25,590529,Boise St.,MWC,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2024-25,590530,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2024-25,590531,Boston U.,Patriot,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2024-25,590532,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2024-25,590533,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2024-25,590535,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2024-25,590536,Bryant,America East,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2024-25,590537,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2024-25,590538,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2024-25,590539,Butler,Big East,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2024-25,590541,CSU Bakersfield,WAC,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2024-25,590544,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2024-25,590540,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2024-25,590543,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2024-25,590547,California,ACC,25,California Golden Bears,California,Golden Bears,CAL,Pac-12 Conference,21,exact
+2024-25,590712,California Baptist,NA,2856,California Baptist Lancers,California Baptist,Lancers,CBU,Western Athletic Conference,30,exact
+2024-25,590590,Campbell,CAA,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Big South Conference,6,exact
+2024-25,590591,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Atlantic Athletic Conference,13,exact
+2024-25,590792,Central Ark.,ASUN,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,ASUN Conference,46,exact
+2024-25,590592,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2024-25,590594,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2024-25,590525,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2024-25,590579,Charlotte,AAC,2429,Charlotte 49ers,Charlotte,49ers,CLT,Conference USA,11,exact
+2024-25,590746,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2024-25,590595,Chicago St.,NEC,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Division I Independents,43,exact
+2024-25,590596,Cincinnati,Big 12,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,American Athletic Conference,62,exact
+2024-25,590598,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2024-25,590599,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2024-25,590600,Coastal Carolina,Sun Belt,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2024-25,590799,Col. of Charleston,CAA,232,Charleston Cougars,Charleston,Cougars,COFC,Colonial Athletic Association,10,dict
+2024-25,590808,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2024-25,590602,Colorado,Big 12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Pac-12 Conference,21,exact
+2024-25,590601,Colorado St.,MWC,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2024-25,590603,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2024-25,590604,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2024-25,590605,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2024-25,590606,Creighton,Big East,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2024-25,590607,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2024-25,590608,Davidson,Atlantic 10,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2024-25,590609,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2024-25,590610,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2024-25,590612,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Colonial Athletic Association,10,exact
+2024-25,590611,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2024-25,590613,Denver,Summit League,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,49,exact
+2024-25,590614,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2024-25,590810,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2024-25,590615,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Colonial Athletic Association,10,exact
+2024-25,590616,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2024-25,590811,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2024-25,590618,ETSU,SoCon,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2024-25,590617,East Carolina,AAC,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Athletic Conference,62,exact
+2024-25,590619,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2024-25,590620,Eastern Ky.,ASUN,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,ASUN Conference,46,exact
+2024-25,590621,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2024-25,590622,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2024-25,590491,Elon,CAA,2210,Elon Phoenix,Elon,Phoenix,ELON,Colonial Athletic Association,10,exact
+2024-25,590623,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2024-25,590507,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,ASUN Conference,46,exact
+2024-25,590628,FIU,C-USA,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2024-25,590624,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Atlantic Athletic Conference,13,exact
+2024-25,590625,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2024-25,590627,Fla. Atlantic,AAC,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,Conference USA,11,exact
+2024-25,590630,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2024-25,590626,Florida A&M,SWAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2024-25,590629,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2024-25,590631,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2024-25,590542,Fresno St.,MWC,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2024-25,590632,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2024-25,590636,Ga. Southern,Sun Belt,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2024-25,590492,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2024-25,590633,George Mason,Atlantic 10,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2024-25,590634,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2024-25,590635,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2024-25,590639,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2024-25,590637,Georgia St.,Sun Belt,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2024-25,590638,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2024-25,590640,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2024-25,590812,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2024-25,590800,Grand Canyon,WAC,2253,Grand Canyon Lopes,Grand Canyon,Lopes,GCU,Western Athletic Conference,30,exact
+2024-25,590785,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2024-25,590641,Hampton,CAA,2261,Hampton Pirates,Hampton,Pirates,HAMP,Colonial Athletic Association,10,exact
+2024-25,590642,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2024-25,590643,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2024-25,590504,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2024-25,590644,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Colonial Athletic Association,10,exact
+2024-25,590645,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2024-25,590647,Houston,Big 12,248,Houston Cougars,Houston,Cougars,HOU,American Athletic Conference,62,exact
+2024-25,590646,Houston Christian,Southland,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,exact
+2024-25,590813,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2024-25,590497,IU Indy,Horizon,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,exact
+2024-25,590649,Idaho,Big Sky,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2024-25,590648,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2024-25,590814,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2024-25,590650,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2024-25,590470,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2024-25,590469,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2024-25,590472,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Atlantic Athletic Conference,13,exact
+2024-25,590473,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2024-25,590796,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2024-25,590474,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2024-25,590476,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,ASUN Conference,46,exact
+2024-25,590475,Jacksonville St.,C-USA,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,ASUN Conference,46,exact
+2024-25,590797,James Madison,Sun Belt,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2024-25,590478,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2024-25,590498,Kansas City,WAC,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,49,exact
+2024-25,590477,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2024-25,590493,Kennesaw St.,C-USA,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,ASUN Conference,46,exact
+2024-25,590479,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2024-25,590480,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2024-25,590486,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2024-25,590549,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2024-25,590487,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2024-25,590481,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2024-25,590482,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2024-25,590483,Lamar University,WAC,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2024-25,590466,Le Moyne,NEC,2330,Le Moyne Dolphins,Le Moyne,Dolphins,LEM,,,exact
+2024-25,590484,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2024-25,590485,Liberty,C-USA,2335,Liberty Flames,Liberty,Flames,LIB,ASUN Conference,46,exact
+2024-25,590468,Lindenwood,OVC,2815,Lindenwood Lions,Lindenwood,Lions,LIN,,,exact
+2024-25,590506,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,ASUN Conference,46,exact
+2024-25,590522,Little Rock,OVC,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2024-25,590804,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2024-25,590798,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2024-25,590738,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2024-25,590488,Louisiana Tech,C-USA,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2024-25,590489,Louisville,ACC,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2024-25,590550,Loyola Chicago,Atlantic 10,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2024-25,590548,Loyola Maryland,Patriot,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2024-25,590551,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2024-25,590552,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Atlantic Athletic Conference,13,exact
+2024-25,590553,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Atlantic Athletic Conference,13,exact
+2024-25,590554,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2024-25,590555,Marshall,Sun Belt,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2024-25,590557,Maryland,Big Ten,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2024-25,590559,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2024-25,590805,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2024-25,590560,Memphis,AAC,235,Memphis Tigers,Memphis,Tigers,MEM,American Athletic Conference,62,exact
+2024-25,590561,Mercer,SoCon,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2024-25,591002,Mercyhurst,NEC,2385,Mercyhurst Lakers,Mercyhurst,Lakers,MERC,,,exact
+2024-25,590713,Merrimack,MAAC,2771,Merrimack Warriors,Merrimack,Warriors,MRMK,Northeast Conference,19,exact
+2024-25,590563,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2024-25,590562,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2024-25,590565,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2024-25,590564,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2024-25,590566,Middle Tenn.,C-USA,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2024-25,590787,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2024-25,590567,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2024-25,590568,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2024-25,590569,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2024-25,590571,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2024-25,590736,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2024-25,590572,Monmouth,CAA,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Colonial Athletic Association,10,exact
+2024-25,590573,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2024-25,590806,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2024-25,590807,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2024-25,590574,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2024-25,590575,Mount St. Mary's,MAAC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Atlantic Athletic Conference,13,exact
+2024-25,590576,Murray St.,MVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2024-25,590659,N.C. A&T,CAA,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Colonial Athletic Association,10,exact
+2024-25,590660,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2024-25,590816,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2024-25,590668,NIU,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2024-25,590653,NJIT,ASUN,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2024-25,590764,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2024-25,590582,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2024-25,590585,Nevada,MWC,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2024-25,590652,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2024-25,590815,New Mexico,MWC,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2024-25,590654,New Mexico St.,C-USA,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Western Athletic Conference,30,exact
+2024-25,590655,New Orleans,Southland,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2024-25,590656,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Atlantic Athletic Conference,13,exact
+2024-25,590657,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2024-25,590658,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2024-25,590509,North Ala.,NA,2453,North Alabama Lions,North Alabama,Lions,UNA,ASUN Conference,46,exact
+2024-25,590578,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2024-25,590662,North Dakota,Summit League,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,49,exact
+2024-25,590661,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,49,exact
+2024-25,590499,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,ASUN Conference,46,exact
+2024-25,590663,North Texas,AAC,249,North Texas Mean Green,North Texas,Mean Green,UNT,Conference USA,11,exact
+2024-25,590665,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Colonial Athletic Association,10,exact
+2024-25,590666,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2024-25,590667,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2024-25,590670,Northern Ky.,Horizon,94,Northern Kentucky Norse,Northern Kentucky,Norse,NKU,Horizon League,45,exact
+2024-25,590672,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2024-25,590671,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2024-25,590673,Notre Dame,ACC,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2024-25,590817,Oakland,Horizon,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2024-25,590675,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2024-25,590674,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2024-25,590677,Oklahoma,SEC,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Big 12 Conference,8,exact
+2024-25,590676,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2024-25,590678,Old Dominion,Sun Belt,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2024-25,590570,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2024-25,590583,Omaha,Summit League,2437,Omaha Mavericks,Omaha,Mavericks,OMA,Summit League,49,exact
+2024-25,590679,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,49,exact
+2024-25,590818,Oregon,Big Ten,2483,Oregon Ducks,Oregon,Ducks,ORE,Pac-12 Conference,21,exact
+2024-25,590680,Oregon St.,WCC,204,Oregon State Beavers,Oregon State,Beavers,ORST,Pac-12 Conference,21,exact
+2024-25,590681,Pacific,WCC,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2024-25,590684,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2024-25,590683,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2024-25,590685,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2024-25,590686,Pittsburgh,ACC,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2024-25,590688,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2024-25,590687,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2024-25,590689,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2024-25,590494,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2024-25,590690,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2024-25,590691,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2024-25,590692,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2024-25,590471,Purdue Fort Wayne,Summit League,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2024-25,590467,Queens (NC),ASUN,2511,Queens University Royals,Queens University,Royals,QUC,,,dict
+2024-25,590693,Quinnipiac,MAAC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Atlantic Athletic Conference,13,exact
+2024-25,590694,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2024-25,590695,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2024-25,590696,Rice,AAC,242,Rice Owls,Rice,Owls,RICE,Conference USA,11,exact
+2024-25,590697,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2024-25,590698,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Atlantic Athletic Conference,13,exact
+2024-25,590699,Robert Morris,NEC,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2024-25,590700,Rutgers,Big Ten,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2024-25,590740,SFA,Southland,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Western Athletic Conference,30,exact
+2024-25,590731,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2024-25,590732,SMU,ACC,2567,SMU Mustangs,SMU,Mustangs,SMU,American Athletic Conference,62,exact
+2024-25,590545,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2024-25,590701,Sacred Heart,MAAC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Northeast Conference,19,exact
+2024-25,590703,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2024-25,590705,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2024-25,590706,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2024-25,590819,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2024-25,590820,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Atlantic Athletic Conference,13,exact
+2024-25,590707,Sam Houston,C-USA,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Western Athletic Conference,30,exact
+2024-25,590821,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2024-25,590709,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2024-25,590708,San Diego St.,MWC,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2024-25,590710,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2024-25,590711,San Jose St.,MWC,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2024-25,590719,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2024-25,590495,Seattle U,WAC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,Western Athletic Conference,30,exact
+2024-25,590720,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2024-25,590721,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Atlantic Athletic Conference,13,exact
+2024-25,590722,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2024-25,590724,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2024-25,590723,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2024-25,590725,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,49,exact
+2024-25,590822,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,49,exact
+2024-25,590726,South Fla.,AAC,58,South Florida Bulls,South Florida,Bulls,USF,American Athletic Conference,62,exact
+2024-25,590727,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2024-25,590728,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2024-25,590729,Southern California,Big Ten,30,USC Trojans,USC,Trojans,USC,Pac-12 Conference,21,dict
+2024-25,590730,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2024-25,590794,Southern Ind.,OVC,88,Southern Indiana Screaming Eagles,Southern Indiana,Screaming Eagles,USI,,,alias
+2024-25,590733,Southern Miss.,Sun Belt,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2024-25,590734,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2024-25,590735,Southern Utah,WAC,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,Western Athletic Conference,30,exact
+2024-25,590702,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2024-25,590704,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2024-25,590718,St. Thomas (MN),Summit League,2900,St. Thomas Tommies,St. Thomas,Tommies,STMN,Summit League,49,alias
+2024-25,590739,Stanford,ACC,24,Stanford Cardinal,Stanford,Cardinal,STAN,Pac-12 Conference,21,exact
+2024-25,590823,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,ASUN Conference,46,exact
+2024-25,590795,Stonehill,NEC,284,Stonehill Skyhawks,Stonehill,Skyhawks,STO,Northeast Conference,19,exact
+2024-25,590741,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Colonial Athletic Association,10,exact
+2024-25,590742,Syracuse,ACC,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2024-25,590750,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2024-25,590717,Tarleton St.,NA,2627,Tarleton State Texans,Tarleton State,Texans,TAR,Western Athletic Conference,30,exact
+2024-25,590743,Temple,AAC,218,Temple Owls,Temple,Owls,TEM,American Athletic Conference,62,exact
+2024-25,590747,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2024-25,590744,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2024-25,590745,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2024-25,590793,Tex. A&M-Commerce,Southland,2837,East Texas A&M Lions,East Texas A&M,Lions,ETAM,Southland Conference,25,alias
+2024-25,590754,Texas,SEC,251,Texas Longhorns,Texas,Longhorns,TEX,Big 12 Conference,8,exact
+2024-25,590749,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2024-25,590751,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2024-25,590737,Texas St.,Sun Belt,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2024-25,590752,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2024-25,590597,The Citadel,SoCon,2643,The Citadel Bulldogs,The Citadel,Bulldogs,CIT,Southern Conference,24,exact
+2024-25,590757,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2024-25,590758,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Colonial Athletic Association,10,exact
+2024-25,590759,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2024-25,590760,Tulane,AAC,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Athletic Conference,62,exact
+2024-25,590761,Tulsa,AAC,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Athletic Conference,62,exact
+2024-25,590802,UAB,AAC,5,UAB Blazers,UAB,Blazers,UAB,Conference USA,11,exact
+2024-25,590514,UAlbany,America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,exact
+2024-25,590586,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2024-25,590587,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2024-25,590589,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2024-25,590715,UC San Diego,NA,28,UC San Diego Tritons,UC San Diego,Tritons,UCSD,Big West Conference,9,exact
+2024-25,590546,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2024-25,590593,UCF,Big 12,2116,UCF Knights,UCF,Knights,UCF,American Athletic Conference,62,exact
+2024-25,590588,UCLA,Big Ten,26,UCLA Bruins,UCLA,Bruins,UCLA,Pac-12 Conference,21,exact
+2024-25,590809,UConn,AAC,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2024-25,590651,UIC,MVC,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2024-25,590500,UIW,Southland,2916,Incarnate Word Cardinals,Incarnate Word,Cardinals,UIW,Southland Conference,25,exact
+2024-25,590664,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2024-25,590556,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2024-25,590558,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2024-25,590490,UMass Lowell,America East,2349,UMass Lowell River Hawks,UMass Lowell,River Hawks,UML,America East Conference,1,exact
+2024-25,590577,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2024-25,590580,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2024-25,590581,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Colonial Athletic Association,10,exact
+2024-25,590669,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2024-25,590584,UNLV,MWC,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2024-25,590502,USC Upstate,Big South,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2024-25,590753,UT Arlington,WAC,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,Western Athletic Conference,30,exact
+2024-25,590748,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2024-25,590755,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2024-25,590682,UTRGV,Southland,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Western Athletic Conference,30,dict
+2024-25,590756,UTSA,AAC,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,Conference USA,11,exact
+2024-25,590766,Utah,Big 12,254,Utah Utes,Utah,Utes,UTAH,Pac-12 Conference,21,exact
+2024-25,590765,Utah St.,MWC,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2024-25,590716,Utah Tech,WAC,3101,Utah Tech Trailblazers,Utah Tech,Trailblazers,UTU,Western Athletic Conference,30,exact
+2024-25,590508,Utah Valley,WAC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,Western Athletic Conference,30,exact
+2024-25,590770,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2024-25,590771,VMI,SoCon,2678,VMI Keydets,VMI,Keydets,VMI,Southern Conference,24,exact
+2024-25,590767,Valparaiso,MVC,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2024-25,590768,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2024-25,590824,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2024-25,590769,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2024-25,590773,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2024-25,590772,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2024-25,590825,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2024-25,590774,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2024-25,590776,Washington,Big Ten,264,Washington Huskies,Washington,Huskies,WASH,Pac-12 Conference,21,exact
+2024-25,590775,Washington St.,WCC,265,Washington State Cougars,Washington State,Cougars,WSU,Pac-12 Conference,21,exact
+2024-25,590777,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2024-25,591125,West Ga.,ASUN,2698,West Georgia Wolves,West Georgia,Wolves,WGA,,,exact
+2024-25,590778,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2024-25,590779,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2024-25,590780,Western Ill.,OVC,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Summit League,49,exact
+2024-25,590826,Western Ky.,C-USA,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2024-25,590781,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2024-25,590782,Wichita St.,AAC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Athletic Conference,62,exact
+2024-25,590783,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Colonial Athletic Association,10,exact
+2024-25,590784,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2024-25,590786,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2024-25,590501,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2024-25,590788,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2024-25,590789,Wyoming,MWC,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2024-25,590790,Xavier,Big East,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2024-25,590827,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2024-25,590791,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2025-26,609609,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2025-26,609614,Abilene Christian,WAC,2000,Abilene Christian Wildcats,Abilene Christian,Wildcats,ACU,Western Athletic Conference,30,exact
+2025-26,609502,Air Force,MWC,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2025-26,609541,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2025-26,609617,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2025-26,609615,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2025-26,609616,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2025-26,609619,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2025-26,609620,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2025-26,609621,App State,Sun Belt,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2025-26,609623,Arizona,Big 12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Pac-12 Conference,21,exact
+2025-26,609622,Arizona St.,Big 12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Pac-12 Conference,21,exact
+2025-26,609600,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2025-26,609625,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2025-26,609624,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2025-26,609503,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2025-26,609543,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2025-26,609627,Austin Peay,ASUN,2046,Austin Peay Governors,Austin Peay,Governors,APSU,ASUN Conference,46,exact
+2025-26,609638,BYU,Big 12,252,BYU Cougars,BYU,Cougars,BYU,West Coast Conference,29,exact
+2025-26,609628,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2025-26,609630,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2025-26,609882,Bellarmine,ASUN,91,Bellarmine Knights,Bellarmine,Knights,BELL,ASUN Conference,46,exact
+2025-26,609607,Belmont,MVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2025-26,609631,Bethune-Cookman,SWAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2025-26,609632,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2025-26,609633,Boise St.,MWC,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2025-26,609634,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2025-26,609635,Boston U.,Patriot,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2025-26,609636,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2025-26,609637,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2025-26,609639,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2025-26,609640,Bryant,America East,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2025-26,609641,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2025-26,609642,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2025-26,609643,Butler,Big East,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2025-26,609645,CSU Bakersfield,Big West,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2025-26,609648,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2025-26,609644,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2025-26,609647,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2025-26,609651,California,ACC,25,California Golden Bears,California,Golden Bears,CAL,Pac-12 Conference,21,exact
+2025-26,609878,California Baptist,WAC,2856,California Baptist Lancers,California Baptist,Lancers,CBU,Western Athletic Conference,30,exact
+2025-26,609694,Campbell,CAA,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Big South Conference,6,exact
+2025-26,609695,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Atlantic Athletic Conference,13,exact
+2025-26,609532,Central Ark.,ASUN,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,ASUN Conference,46,exact
+2025-26,609696,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2025-26,609698,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2025-26,609629,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2025-26,609683,Charlotte,AAC,2429,Charlotte 49ers,Charlotte,49ers,CLT,Conference USA,11,exact
+2025-26,609486,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2025-26,609699,Chicago St.,NEC,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Division I Independents,43,exact
+2025-26,609700,Cincinnati,Big 12,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,American Athletic Conference,62,exact
+2025-26,609702,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2025-26,609703,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2025-26,609704,Coastal Carolina,Sun Belt,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2025-26,609539,Col. of Charleston,CAA,232,Charleston Cougars,Charleston,Cougars,COFC,Colonial Athletic Association,10,dict
+2025-26,609548,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2025-26,609706,Colorado,Big 12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Pac-12 Conference,21,exact
+2025-26,609705,Colorado St.,MWC,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2025-26,609707,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2025-26,609708,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2025-26,609709,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2025-26,609710,Creighton,Big East,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2025-26,609711,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2025-26,609712,Davidson,Atlantic 10,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2025-26,609713,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2025-26,609714,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2025-26,609716,Delaware,C-USA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Colonial Athletic Association,10,exact
+2025-26,609715,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2025-26,609717,Denver,Summit League,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,49,exact
+2025-26,609718,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2025-26,609550,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2025-26,609719,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Colonial Athletic Association,10,exact
+2025-26,609720,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2025-26,609551,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2025-26,609722,ETSU,SoCon,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2025-26,609721,East Carolina,AAC,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Athletic Conference,62,exact
+2025-26,609533,East Texas A&M,Southland,2837,East Texas A&M Lions,East Texas A&M,Lions,ETAM,Southland Conference,25,exact
+2025-26,609723,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2025-26,609724,Eastern Ky.,ASUN,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,ASUN Conference,46,exact
+2025-26,609725,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2025-26,609726,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2025-26,609595,Elon,CAA,2210,Elon Phoenix,Elon,Phoenix,ELON,Colonial Athletic Association,10,exact
+2025-26,609727,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2025-26,609729,FDU,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2025-26,609611,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,ASUN Conference,46,exact
+2025-26,609732,FIU,C-USA,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2025-26,609728,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Atlantic Athletic Conference,13,exact
+2025-26,609731,Fla. Atlantic,AAC,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,Conference USA,11,exact
+2025-26,609734,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2025-26,609730,Florida A&M,SWAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2025-26,609733,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2025-26,609735,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2025-26,609646,Fresno St.,MWC,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2025-26,609736,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2025-26,609740,Ga. Southern,Sun Belt,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2025-26,609596,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2025-26,609737,George Mason,Atlantic 10,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2025-26,609738,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2025-26,609739,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2025-26,609743,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2025-26,609741,Georgia St.,Sun Belt,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2025-26,609742,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2025-26,609744,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2025-26,609552,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2025-26,609540,Grand Canyon,MWC,2253,Grand Canyon Lopes,Grand Canyon,Lopes,GCU,Western Athletic Conference,30,exact
+2025-26,609525,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2025-26,609745,Hampton,CAA,2261,Hampton Pirates,Hampton,Pirates,HAMP,Colonial Athletic Association,10,exact
+2025-26,609746,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2025-26,609747,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2025-26,609608,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2025-26,609748,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Colonial Athletic Association,10,exact
+2025-26,609749,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2025-26,609752,Houston,Big 12,248,Houston Cougars,Houston,Cougars,HOU,American Athletic Conference,62,exact
+2025-26,609750,Houston Christian,Southland,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,exact
+2025-26,609553,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2025-26,609601,IU Indy,Horizon,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,exact
+2025-26,609756,Idaho,Big Sky,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2025-26,609753,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2025-26,609554,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2025-26,609758,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2025-26,609574,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2025-26,609573,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2025-26,609576,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Atlantic Athletic Conference,13,exact
+2025-26,609577,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2025-26,609536,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2025-26,609578,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2025-26,609580,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,ASUN Conference,46,exact
+2025-26,609579,Jacksonville St.,C-USA,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,ASUN Conference,46,exact
+2025-26,609537,James Madison,Sun Belt,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2025-26,609582,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2025-26,609602,Kansas City,Summit League,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,49,exact
+2025-26,609581,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2025-26,609597,Kennesaw St.,C-USA,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,ASUN Conference,46,exact
+2025-26,609583,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2025-26,609584,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2025-26,609590,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2025-26,609653,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2025-26,609591,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2025-26,609585,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2025-26,609586,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2025-26,609587,Lamar University,Southland,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2025-26,609570,Le Moyne,NEC,2330,Le Moyne Dolphins,Le Moyne,Dolphins,LEM,,,exact
+2025-26,609588,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2025-26,609589,Liberty,C-USA,2335,Liberty Flames,Liberty,Flames,LIB,ASUN Conference,46,exact
+2025-26,609572,Lindenwood,OVC,2815,Lindenwood Lions,Lindenwood,Lions,LIN,,,exact
+2025-26,609610,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,ASUN Conference,46,exact
+2025-26,609626,Little Rock,OVC,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2025-26,609544,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2025-26,609538,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2025-26,609478,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2025-26,609592,Louisiana Tech,C-USA,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2025-26,609593,Louisville,ACC,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2025-26,609654,Loyola Chicago,Atlantic 10,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2025-26,609652,Loyola Maryland,Patriot,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2025-26,609655,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2025-26,609656,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Atlantic Athletic Conference,13,exact
+2025-26,609657,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Atlantic Athletic Conference,13,exact
+2025-26,609658,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2025-26,609659,Marshall,Sun Belt,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2025-26,609661,Maryland,Big Ten,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2025-26,609663,Massachusetts,MAC,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2025-26,609545,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2025-26,609664,Memphis,AAC,235,Memphis Tigers,Memphis,Tigers,MEM,American Athletic Conference,62,exact
+2025-26,609665,Mercer,SoCon,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2025-26,609568,Mercyhurst,NEC,2385,Mercyhurst Lakers,Mercyhurst,Lakers,MERC,,,exact
+2025-26,609880,Merrimack,MAAC,2771,Merrimack Warriors,Merrimack,Warriors,MRMK,Northeast Conference,19,exact
+2025-26,609667,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2025-26,609666,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2025-26,609669,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2025-26,609668,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2025-26,609670,Middle Tenn.,C-USA,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2025-26,609527,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2025-26,609671,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2025-26,609672,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2025-26,609673,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2025-26,609675,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2025-26,609476,Missouri St.,C-USA,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2025-26,609676,Monmouth,CAA,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Colonial Athletic Association,10,exact
+2025-26,609677,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2025-26,609546,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2025-26,609547,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2025-26,609678,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2025-26,609679,Mount St. Mary's,MAAC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Atlantic Athletic Conference,13,exact
+2025-26,609680,Murray St.,MVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2025-26,609775,N.C. A&T,CAA,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Colonial Athletic Association,10,exact
+2025-26,609777,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2025-26,609556,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2025-26,609792,NIU,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2025-26,609764,NJIT,America East,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2025-26,609504,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2025-26,609686,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2025-26,609689,Nevada,MWC,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2025-26,609762,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2025-26,610406,New Haven,NEC,2441,New Haven Chargers,New Haven,Chargers,NHVN,,,exact
+2025-26,609555,New Mexico,MWC,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2025-26,609765,New Mexico St.,C-USA,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Western Athletic Conference,30,exact
+2025-26,609767,New Orleans,Southland,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2025-26,609769,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Atlantic Athletic Conference,13,exact
+2025-26,609771,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2025-26,609773,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2025-26,609613,North Ala.,ASUN,2453,North Alabama Lions,North Alabama,Lions,UNA,ASUN Conference,46,exact
+2025-26,609682,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2025-26,609781,North Dakota,Summit League,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,49,exact
+2025-26,609779,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,49,exact
+2025-26,609603,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,ASUN Conference,46,exact
+2025-26,609783,North Texas,AAC,249,North Texas Mean Green,North Texas,Mean Green,UNT,Conference USA,11,exact
+2025-26,609786,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Colonial Athletic Association,10,exact
+2025-26,609788,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2025-26,609790,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2025-26,609796,Northern Ky.,Horizon,94,Northern Kentucky Norse,Northern Kentucky,Norse,NKU,Horizon League,45,exact
+2025-26,609799,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2025-26,609797,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2025-26,609801,Notre Dame,ACC,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2025-26,609557,Oakland,Horizon,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2025-26,609805,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2025-26,609803,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2025-26,609808,Oklahoma,SEC,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Big 12 Conference,8,exact
+2025-26,609807,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2025-26,609810,Old Dominion,Sun Belt,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2025-26,609674,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2025-26,609687,Omaha,Summit League,2437,Omaha Mavericks,Omaha,Mavericks,OMA,Summit League,49,exact
+2025-26,609812,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,49,exact
+2025-26,609558,Oregon,Big Ten,2483,Oregon Ducks,Oregon,Ducks,ORE,Pac-12 Conference,21,exact
+2025-26,609813,Oregon St.,WCC,204,Oregon State Beavers,Oregon State,Beavers,ORST,Pac-12 Conference,21,exact
+2025-26,609815,Pacific,WCC,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2025-26,609821,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2025-26,609819,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2025-26,609822,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2025-26,609824,Pittsburgh,ACC,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2025-26,609828,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2025-26,609826,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2025-26,609830,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2025-26,609598,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2025-26,609832,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2025-26,609834,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2025-26,609836,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2025-26,609575,Purdue Fort Wayne,Horizon,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2025-26,609571,Queens (NC),ASUN,2511,Queens University Royals,Queens University,Royals,QUC,,,dict
+2025-26,609838,Quinnipiac,MAAC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Atlantic Athletic Conference,13,exact
+2025-26,609840,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2025-26,609841,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2025-26,609843,Rice,AAC,242,Rice Owls,Rice,Owls,RICE,Conference USA,11,exact
+2025-26,609845,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2025-26,609848,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Atlantic Athletic Conference,13,exact
+2025-26,609850,Robert Morris,Horizon,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2025-26,609851,Rutgers,Big Ten,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2025-26,609480,SFA,Southland,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Western Athletic Conference,30,exact
+2025-26,609471,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2025-26,609472,SMU,ACC,2567,SMU Mustangs,SMU,Mustangs,SMU,American Athletic Conference,62,exact
+2025-26,609649,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2025-26,609854,Sacred Heart,MAAC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Northeast Conference,19,exact
+2025-26,609859,Saint Francis,NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,alias
+2025-26,609864,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2025-26,609866,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2025-26,609559,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2025-26,609560,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Atlantic Athletic Conference,13,exact
+2025-26,609868,Sam Houston,C-USA,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Western Athletic Conference,30,exact
+2025-26,609561,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2025-26,609871,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2025-26,609870,San Diego St.,MWC,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2025-26,609874,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2025-26,609876,San Jose St.,MWC,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2025-26,609891,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2025-26,609599,Seattle U,WCC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,Western Athletic Conference,30,exact
+2025-26,609893,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2025-26,609895,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Atlantic Athletic Conference,13,exact
+2025-26,609897,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2025-26,609901,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2025-26,609899,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2025-26,609903,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,49,exact
+2025-26,609562,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,49,exact
+2025-26,609905,South Fla.,AAC,58,South Florida Bulls,South Florida,Bulls,USF,American Athletic Conference,62,exact
+2025-26,609907,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2025-26,609909,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2025-26,609469,Southern California,Big Ten,30,USC Trojans,USC,Trojans,USC,Pac-12 Conference,21,dict
+2025-26,609470,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2025-26,609534,Southern Ind.,OVC,88,Southern Indiana Screaming Eagles,Southern Indiana,Screaming Eagles,USI,,,alias
+2025-26,609473,Southern Miss.,Sun Belt,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2025-26,609474,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2025-26,609475,Southern Utah,WAC,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,Western Athletic Conference,30,exact
+2025-26,609856,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2025-26,609861,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2025-26,609889,St. Thomas (MN),Summit League,2900,St. Thomas Tommies,St. Thomas,Tommies,STMN,Summit League,49,alias
+2025-26,609479,Stanford,ACC,24,Stanford Cardinal,Stanford,Cardinal,STAN,Pac-12 Conference,21,exact
+2025-26,609563,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,ASUN Conference,46,exact
+2025-26,609535,Stonehill,NEC,284,Stonehill Skyhawks,Stonehill,Skyhawks,STO,Northeast Conference,19,exact
+2025-26,609481,Stony Brook,CAA,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Colonial Athletic Association,10,exact
+2025-26,609482,Syracuse,ACC,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2025-26,609490,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2025-26,609887,Tarleton St.,WAC,2627,Tarleton State Texans,Tarleton State,Texans,TAR,Western Athletic Conference,30,exact
+2025-26,609483,Temple,AAC,218,Temple Owls,Temple,Owls,TEM,American Athletic Conference,62,exact
+2025-26,609487,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2025-26,609484,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2025-26,609485,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2025-26,609494,Texas,SEC,251,Texas Longhorns,Texas,Longhorns,TEX,Big 12 Conference,8,exact
+2025-26,609489,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2025-26,609491,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2025-26,609477,Texas St.,Sun Belt,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2025-26,609492,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2025-26,609701,The Citadel,SoCon,2643,The Citadel Bulldogs,The Citadel,Bulldogs,CIT,Southern Conference,24,exact
+2025-26,609497,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2025-26,609498,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Colonial Athletic Association,10,exact
+2025-26,609499,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2025-26,609500,Tulane,AAC,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Athletic Conference,62,exact
+2025-26,609501,Tulsa,AAC,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Athletic Conference,62,exact
+2025-26,609542,UAB,AAC,5,UAB Blazers,UAB,Blazers,UAB,Conference USA,11,exact
+2025-26,609618,UAlbany,America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,exact
+2025-26,609690,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2025-26,609691,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2025-26,609693,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2025-26,609883,UC San Diego,Big West,28,UC San Diego Tritons,UC San Diego,Tritons,UCSD,Big West Conference,9,exact
+2025-26,609650,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2025-26,609697,UCF,Big 12,2116,UCF Knights,UCF,Knights,UCF,American Athletic Conference,62,exact
+2025-26,609692,UCLA,Big Ten,26,UCLA Bruins,UCLA,Bruins,UCLA,Pac-12 Conference,21,exact
+2025-26,609549,UConn,Big East,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2025-26,609759,UIC,MVC,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2025-26,609604,UIW,Southland,2916,Incarnate Word Cardinals,Incarnate Word,Cardinals,UIW,Southland Conference,25,exact
+2025-26,609785,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2025-26,609660,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2025-26,609662,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2025-26,609594,UMass Lowell,America East,2349,UMass Lowell River Hawks,UMass Lowell,River Hawks,UML,America East Conference,1,exact
+2025-26,609681,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2025-26,609684,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2025-26,609685,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Colonial Athletic Association,10,exact
+2025-26,609793,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2025-26,609688,UNLV,MWC,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2025-26,609606,USC Upstate,Big South,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2025-26,609493,UT Arlington,WAC,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,Western Athletic Conference,30,exact
+2025-26,609488,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2025-26,609495,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2025-26,609817,UTRGV,Southland,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Western Athletic Conference,30,dict
+2025-26,609496,UTSA,AAC,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,Conference USA,11,exact
+2025-26,609506,Utah,Big 12,254,Utah Utes,Utah,Utes,UTAH,Pac-12 Conference,21,exact
+2025-26,609505,Utah St.,MWC,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2025-26,609885,Utah Tech,WAC,3101,Utah Tech Trailblazers,Utah Tech,Trailblazers,UTU,Western Athletic Conference,30,exact
+2025-26,609612,Utah Valley,WAC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,Western Athletic Conference,30,exact
+2025-26,609510,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2025-26,609511,VMI,SoCon,2678,VMI Keydets,VMI,Keydets,VMI,Southern Conference,24,exact
+2025-26,609507,Valparaiso,MVC,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2025-26,609508,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2025-26,609564,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2025-26,609509,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2025-26,609513,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2025-26,609512,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2025-26,609565,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2025-26,609514,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2025-26,609516,Washington,Big Ten,264,Washington Huskies,Washington,Huskies,WASH,Pac-12 Conference,21,exact
+2025-26,609515,Washington St.,WCC,265,Washington State Cougars,Washington State,Cougars,WSU,Pac-12 Conference,21,exact
+2025-26,609517,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2025-26,609569,West Ga.,ASUN,2698,West Georgia Wolves,West Georgia,Wolves,WGA,,,exact
+2025-26,609518,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2025-26,609519,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2025-26,609520,Western Ill.,OVC,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Summit League,49,exact
+2025-26,609566,Western Ky.,C-USA,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2025-26,609521,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2025-26,609522,Wichita St.,AAC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Athletic Conference,62,exact
+2025-26,609523,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Colonial Athletic Association,10,exact
+2025-26,609524,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2025-26,609526,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2025-26,609605,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2025-26,609528,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2025-26,609529,Wyoming,MWC,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2025-26,609530,Xavier,Big East,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2025-26,609567,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2025-26,609531,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact

--- a/sportsdataverse/mbb/mbb_espn_ext.py
+++ b/sportsdataverse/mbb/mbb_espn_ext.py
@@ -1664,6 +1664,7 @@ def espn_mbb_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1680,6 +1681,7 @@ def espn_mbb_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1693,7 +1695,9 @@ def espn_mbb_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/basketball/leagues/mens-college-basketball/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/sportsdataverse/mbb/mbb_ncaa_espn_crosswalk.py
+++ b/sportsdataverse/mbb/mbb_ncaa_espn_crosswalk.py
@@ -1,0 +1,109 @@
+"""stats.ncaa.org <-> ESPN college-basketball team-id crosswalk.
+
+stats.ncaa.org mints a NEW numeric team id every season and writes school
+names in AP style (``Central Conn. St.``, ``Ark.-Pine Bluff``); ESPN keeps one
+stable id per school and spells the names out. Joining the two therefore needs
+a **season-keyed** crosswalk, which sdv-py bundles as CSV:
+
+- ``sportsdataverse/mbb/data/ncaa_espn_team_crosswalk_mbb.csv``
+- ``sportsdataverse/wbb/data/ncaa_espn_team_crosswalk_wbb.csv``
+
+Both are generated offline by ``tools/crosswalk/build_ncaa_espn_crosswalk.py``
+from three committed inputs -- the ESPN team reference tables, hoopR's
+cross-provider name dictionary, and a hand-curated alias table. The build is
+deterministic: there is no fuzzy matching at runtime OR at build time, and a
+school that cannot be resolved is emitted with a null ``espn_team_id`` rather
+than dropped.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import TYPE_CHECKING, Dict, Union
+
+import polars as pl
+
+from sportsdataverse.mbb.mbb_ncaa_team_ids import _LEAGUE_PKG, _league_data_bytes
+
+if TYPE_CHECKING:  # pragma: no cover
+    import pandas as pd
+
+_CROSSWALK_CACHE: Dict[str, pl.DataFrame] = {}
+
+#: ESPN ids stay Utf8 (the convention everywhere else in sdv-py); NCAA ids stay
+#: Int64 to match ``ncaa_{mbb,wbb}_team_ids().id``.
+_SCHEMA: Dict[str, pl.DataType] = {
+    "season": pl.Utf8,
+    "ncaa_team_id": pl.Int64,
+    "ncaa_team": pl.Utf8,
+    "ncaa_conference": pl.Utf8,
+    "espn_team_id": pl.Utf8,
+    "espn_display_name": pl.Utf8,
+    "espn_location": pl.Utf8,
+    "espn_mascot": pl.Utf8,
+    "espn_abbreviation": pl.Utf8,
+    "espn_conference_name": pl.Utf8,
+    "espn_conference_id": pl.Utf8,
+    "match_method": pl.Utf8,
+}
+
+
+def ncaa_espn_team_crosswalk(
+    league: str = "mbb", *, return_as_pandas: bool = False
+) -> Union[pl.DataFrame, "pd.DataFrame"]:
+    """Season-keyed stats.ncaa.org -> ESPN team-id crosswalk.
+
+    One row per ``(season, ncaa_team_id)``. Teams that could not be resolved to
+    an ESPN team are kept with a null ``espn_team_id`` and
+    ``match_method="unmatched"`` -- never dropped -- so the row count always
+    equals ``ncaa_{league}_team_ids()``.
+
+    Args:
+        league: ``"mbb"`` (men's, 2009-10 onward) or ``"wbb"`` (women's).
+        return_as_pandas: Return a pandas DataFrame instead of polars.
+
+    Returns:
+        DataFrame with columns ``season`` (str, ``"YYYY-YY"``),
+        ``ncaa_team_id`` (Int64 -- the season-specific stats.ncaa.org id),
+        ``ncaa_team`` / ``ncaa_conference`` (str), ``espn_team_id`` (str,
+        nullable -- ESPN ids are strings throughout sdv-py),
+        ``espn_display_name`` / ``espn_location`` / ``espn_mascot`` /
+        ``espn_abbreviation`` / ``espn_conference_name`` /
+        ``espn_conference_id`` (str, nullable), and ``match_method`` (str --
+        ``"exact"``, ``"dict"``, ``"alias"`` or ``"unmatched"``).
+
+    Raises:
+        ValueError: If *league* is not ``"mbb"`` or ``"wbb"``.
+
+    Example:
+        Quick start::
+
+            from sportsdataverse.mbb import ncaa_espn_team_crosswalk
+            df = ncaa_espn_team_crosswalk()
+            print(df.shape)
+
+        Women's crosswalk as pandas::
+
+            wdf = ncaa_espn_team_crosswalk(league="wbb", return_as_pandas=True)
+
+        Pipeline next step (one line)::
+
+            df.filter(pl.col("season") == "2025-26").select("ncaa_team_id", "espn_team_id")
+
+    See Also:
+        * `hoopR`_ -- men's college basketball in R, source of the name dictionary
+        * `wehoop`_ -- women's college basketball in R
+
+    .. _hoopR: https://hoopR.sportsdataverse.org
+    .. _wehoop: https://wehoop.sportsdataverse.org
+    """
+    if league not in _LEAGUE_PKG:
+        raise ValueError(f"league must be one of {sorted(_LEAGUE_PKG)}, got {league!r}")
+    if league not in _CROSSWALK_CACHE:
+        raw = _league_data_bytes(league, f"ncaa_espn_team_crosswalk_{league}.csv")
+        _CROSSWALK_CACHE[league] = pl.read_csv(io.BytesIO(raw), schema_overrides=_SCHEMA).select(list(_SCHEMA))
+    df = _CROSSWALK_CACHE[league]
+    return df.to_pandas() if return_as_pandas else df
+
+
+__all__ = ["ncaa_espn_team_crosswalk"]

--- a/sportsdataverse/mbb/mbb_ncaa_team_ids.py
+++ b/sportsdataverse/mbb/mbb_ncaa_team_ids.py
@@ -43,19 +43,23 @@ _LEADING_WS_RE = re.compile(r"^ +")
 _RECORD_RE = re.compile(r" \([0-9]-[0-9]\)")
 
 
-def _teamids_csv_bytes(league: str) -> bytes:
-    """Bundled-CSV bytes for *league*, importlib.resources first, Path fallback.
+def _league_data_bytes(league: str, fname: str) -> bytes:
+    """Bundled ``<league>/data/<fname>`` bytes, importlib.resources first.
 
-    The plain-``Path`` fallback keeps tests green before the CSVs are wired
-    into ``[tool.setuptools.package-data]``.
+    The plain-``Path`` fallback keeps tests green before a CSV is wired into
+    ``[tool.setuptools.package-data]``.
     """
     if league not in _LEAGUE_PKG:
         raise ValueError(f"league must be one of {sorted(_LEAGUE_PKG)}, got {league!r}")
-    fname = f"ncaa_teamids_{league}.csv"
     try:
         return resources.files(_LEAGUE_PKG[league]).joinpath("data", fname).read_bytes()
     except (FileNotFoundError, ModuleNotFoundError, NotADirectoryError, OSError):
         return (Path(__file__).resolve().parents[1] / league / "data" / fname).read_bytes()
+
+
+def _teamids_csv_bytes(league: str) -> bytes:
+    """Bundled team-id CSV bytes for *league*."""
+    return _league_data_bytes(league, f"ncaa_teamids_{league}.csv")
 
 
 def _ncaa_bb_team_ids(league: str) -> pl.DataFrame:

--- a/sportsdataverse/mlb/mlb_espn_ext.py
+++ b/sportsdataverse/mlb/mlb_espn_ext.py
@@ -1624,6 +1624,7 @@ def espn_mlb_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1640,6 +1641,7 @@ def espn_mlb_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1653,7 +1655,9 @@ def espn_mlb_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/sportsdataverse/nba/nba_espn_ext.py
+++ b/sportsdataverse/nba/nba_espn_ext.py
@@ -1623,6 +1623,7 @@ def espn_nba_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1639,6 +1640,7 @@ def espn_nba_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1652,7 +1654,9 @@ def espn_nba_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/basketball/leagues/nba/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/sportsdataverse/nfl/nfl_espn_ext.py
+++ b/sportsdataverse/nfl/nfl_espn_ext.py
@@ -1625,6 +1625,7 @@ def espn_nfl_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1641,6 +1642,7 @@ def espn_nfl_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1654,7 +1656,9 @@ def espn_nfl_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/football/leagues/nfl/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/sportsdataverse/nhl/nhl_espn_ext.py
+++ b/sportsdataverse/nhl/nhl_espn_ext.py
@@ -1623,6 +1623,7 @@ def espn_nhl_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1639,6 +1640,7 @@ def espn_nhl_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1652,7 +1654,9 @@ def espn_nhl_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/hockey/leagues/nhl/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/sportsdataverse/parsed/mbb.py
+++ b/sportsdataverse/parsed/mbb.py
@@ -411,6 +411,7 @@ from sportsdataverse.mbb import misspellings as misspellings  # noqa: F401
 from sportsdataverse.mbb import most_recent_mbb_season as most_recent_mbb_season  # noqa: F401
 from sportsdataverse.mbb import name_in_v0_box_format as name_in_v0_box_format  # noqa: F401
 from sportsdataverse.mbb import name_is_initials as name_is_initials  # noqa: F401
+from sportsdataverse.mbb import ncaa_espn_team_crosswalk as ncaa_espn_team_crosswalk  # noqa: F401
 from sportsdataverse.mbb import ncaa_mbb_box_scores as ncaa_mbb_box_scores  # noqa: F401
 from sportsdataverse.mbb import ncaa_mbb_date_games as ncaa_mbb_date_games  # noqa: F401
 from sportsdataverse.mbb import ncaa_mbb_game_pbp as ncaa_mbb_game_pbp  # noqa: F401
@@ -933,6 +934,7 @@ __all__ = [
     "most_recent_mbb_season",
     "name_in_v0_box_format",
     "name_is_initials",
+    "ncaa_espn_team_crosswalk",
     "ncaa_mbb_box_scores",
     "ncaa_mbb_date_games",
     "ncaa_mbb_game_pbp",

--- a/sportsdataverse/parsed/wbb.py
+++ b/sportsdataverse/parsed/wbb.py
@@ -381,6 +381,7 @@ from sportsdataverse.wbb import mae as mae  # noqa: F401
 from sportsdataverse.wbb import matching_player as matching_player  # noqa: F401
 from sportsdataverse.wbb import misspellings as misspellings  # noqa: F401
 from sportsdataverse.wbb import most_recent_wbb_season as most_recent_wbb_season  # noqa: F401
+from sportsdataverse.wbb import ncaa_espn_team_crosswalk as ncaa_espn_team_crosswalk  # noqa: F401
 from sportsdataverse.wbb import ncaa_wbb_box_scores as ncaa_wbb_box_scores  # noqa: F401
 from sportsdataverse.wbb import ncaa_wbb_date_games as ncaa_wbb_date_games  # noqa: F401
 from sportsdataverse.wbb import ncaa_wbb_game_pbp as ncaa_wbb_game_pbp  # noqa: F401
@@ -871,6 +872,7 @@ __all__ = [
     "matching_player",
     "misspellings",
     "most_recent_wbb_season",
+    "ncaa_espn_team_crosswalk",
     "ncaa_wbb_box_scores",
     "ncaa_wbb_date_games",
     "ncaa_wbb_game_pbp",

--- a/sportsdataverse/soccer/bundesliga/bundesliga_espn_ext.py
+++ b/sportsdataverse/soccer/bundesliga/bundesliga_espn_ext.py
@@ -1627,6 +1627,7 @@ def espn_bundesliga_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1643,6 +1644,7 @@ def espn_bundesliga_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1656,7 +1658,9 @@ def espn_bundesliga_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/soccer/leagues/ger.1/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/sportsdataverse/soccer/epl/epl_espn_ext.py
+++ b/sportsdataverse/soccer/epl/epl_espn_ext.py
@@ -1627,6 +1627,7 @@ def espn_epl_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1643,6 +1644,7 @@ def espn_epl_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1656,7 +1658,9 @@ def espn_epl_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/soccer/leagues/eng.1/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/sportsdataverse/soccer/laliga/laliga_espn_ext.py
+++ b/sportsdataverse/soccer/laliga/laliga_espn_ext.py
@@ -1627,6 +1627,7 @@ def espn_laliga_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1643,6 +1644,7 @@ def espn_laliga_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1656,7 +1658,9 @@ def espn_laliga_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/soccer/leagues/esp.1/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/sportsdataverse/soccer/ligamx/ligamx_espn_ext.py
+++ b/sportsdataverse/soccer/ligamx/ligamx_espn_ext.py
@@ -1627,6 +1627,7 @@ def espn_ligamx_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1643,6 +1644,7 @@ def espn_ligamx_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1656,7 +1658,9 @@ def espn_ligamx_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/soccer/leagues/mex.1/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/sportsdataverse/soccer/ligue1/ligue1_espn_ext.py
+++ b/sportsdataverse/soccer/ligue1/ligue1_espn_ext.py
@@ -1627,6 +1627,7 @@ def espn_ligue1_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1643,6 +1644,7 @@ def espn_ligue1_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1656,7 +1658,9 @@ def espn_ligue1_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/soccer/leagues/fra.1/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/sportsdataverse/soccer/mls/mls_espn_ext.py
+++ b/sportsdataverse/soccer/mls/mls_espn_ext.py
@@ -1627,6 +1627,7 @@ def espn_mls_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1643,6 +1644,7 @@ def espn_mls_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1656,7 +1658,9 @@ def espn_mls_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/soccer/leagues/usa.1/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/sportsdataverse/soccer/nwsl/nwsl_espn_ext.py
+++ b/sportsdataverse/soccer/nwsl/nwsl_espn_ext.py
@@ -1627,6 +1627,7 @@ def espn_nwsl_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1643,6 +1644,7 @@ def espn_nwsl_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1656,7 +1658,9 @@ def espn_nwsl_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/soccer/leagues/usa.nwsl/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/sportsdataverse/soccer/seriea/seriea_espn_ext.py
+++ b/sportsdataverse/soccer/seriea/seriea_espn_ext.py
@@ -1627,6 +1627,7 @@ def espn_seriea_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1643,6 +1644,7 @@ def espn_seriea_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1656,7 +1658,9 @@ def espn_seriea_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/soccer/leagues/ita.1/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/sportsdataverse/soccer/soccer_espn_ext.py
+++ b/sportsdataverse/soccer/soccer_espn_ext.py
@@ -1666,6 +1666,7 @@ def espn_soccer_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1682,6 +1683,7 @@ def espn_soccer_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1695,7 +1697,9 @@ def espn_soccer_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/soccer/leagues/{league}/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/sportsdataverse/soccer/ucl/ucl_espn_ext.py
+++ b/sportsdataverse/soccer/ucl/ucl_espn_ext.py
@@ -1627,6 +1627,7 @@ def espn_ucl_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1643,6 +1644,7 @@ def espn_ucl_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1656,7 +1658,9 @@ def espn_ucl_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/soccer/leagues/uefa.champions/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/sportsdataverse/soccer/uel/uel_espn_ext.py
+++ b/sportsdataverse/soccer/uel/uel_espn_ext.py
@@ -1627,6 +1627,7 @@ def espn_uel_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1643,6 +1644,7 @@ def espn_uel_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1656,7 +1658,9 @@ def espn_uel_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/soccer/leagues/uefa.europa/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/sportsdataverse/soccer/wc/wc_espn_ext.py
+++ b/sportsdataverse/soccer/wc/wc_espn_ext.py
@@ -1627,6 +1627,7 @@ def espn_wc_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1643,6 +1644,7 @@ def espn_wc_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1656,7 +1658,9 @@ def espn_wc_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/soccer/leagues/fifa.world/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/sportsdataverse/soccer/wwc/wwc_espn_ext.py
+++ b/sportsdataverse/soccer/wwc/wwc_espn_ext.py
@@ -1627,6 +1627,7 @@ def espn_wwc_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1643,6 +1644,7 @@ def espn_wwc_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1656,7 +1658,9 @@ def espn_wwc_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/soccer/leagues/fifa.wwc/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/sportsdataverse/wbb/__init__.py
+++ b/sportsdataverse/wbb/__init__.py
@@ -35,6 +35,7 @@ from sportsdataverse.wbb.wbb_ncaa_schedule import *
 from sportsdataverse.wbb.wbb_ncaa_scoreboard import *
 from sportsdataverse.wbb.wbb_ncaa_shots import *
 from sportsdataverse.wbb.wbb_ncaa_stats_agg import *
+from sportsdataverse.wbb.wbb_ncaa_espn_crosswalk import *
 from sportsdataverse.wbb.wbb_ncaa_team_ids import *
 from sportsdataverse.wbb.wbb_pbp import *
 from sportsdataverse.wbb.wbb_play_by_play import *

--- a/sportsdataverse/wbb/data/ncaa_espn_team_crosswalk_wbb.csv
+++ b/sportsdataverse/wbb/data/ncaa_espn_team_crosswalk_wbb.csv
@@ -1,0 +1,5973 @@
+season,ncaa_team_id,ncaa_team,ncaa_conference,espn_team_id,espn_display_name,espn_location,espn_mascot,espn_abbreviation,espn_conference_name,espn_conference_id,match_method
+2009-10,52488,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2009-10,52439,Air Force,Mountain West,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2009-10,52147,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2009-10,52150,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2009-10,52148,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2009-10,52149,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2009-10,52152,Albany (NY),America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,alias
+2009-10,52153,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2009-10,52154,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2009-10,52155,App State,SoCon,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2009-10,52157,Arizona,Pac-12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Big 12 Conference,8,exact
+2009-10,52156,Arizona St.,Pac-12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Big 12 Conference,8,exact
+2009-10,52480,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2009-10,52159,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2009-10,52158,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2009-10,52440,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2009-10,52161,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2009-10,52162,Austin Peay,OVC,2046,Austin Peay Governors,Austin Peay,Governors,APSU,Atlantic Sun Conference,46,exact
+2009-10,52173,BYU,Mountain West,252,BYU Cougars,BYU,Cougars,BYU,Big 12 Conference,8,exact
+2009-10,52163,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2009-10,52165,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2009-10,52486,Belmont,ASUN,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2009-10,52166,Bethune-Cookman,MEAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2009-10,52167,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2009-10,52168,Boise St.,WAC,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2009-10,52169,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2009-10,52170,Boston U.,America East,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2009-10,52171,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2009-10,52172,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2009-10,52174,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2009-10,52175,Bryant,NEC,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2009-10,52176,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2009-10,52177,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2009-10,52178,Butler,Horizon,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2009-10,52180,CSU Bakersfield,-,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2009-10,52184,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2009-10,52179,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2009-10,52182,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2009-10,52187,California,Pac-12,25,California Golden Bears,California,Golden Bears,CAL,Atlantic Coast Conference,2,exact
+2009-10,52192,Campbell,ASUN,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Coastal Athletic Association,10,exact
+2009-10,52193,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Conference,13,exact
+2009-10,52194,Centenary (LA),Summit League,2113,Centenary (LA) Gentlemen,Centenary (LA),Gentlemen,CTLA,,,alias
+2009-10,52473,Central Ark.,Southland,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,Atlantic Sun Conference,46,exact
+2009-10,52195,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2009-10,52197,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2009-10,52164,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2009-10,52320,Charlotte,Atlantic 10,2429,Charlotte 49ers,Charlotte,49ers,CLT,American Conference,62,exact
+2009-10,52423,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2009-10,52198,Chicago St.,GWC,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Northeast Conference,19,exact
+2009-10,52199,Cincinnati,Big East,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,Big 12 Conference,8,exact
+2009-10,52200,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2009-10,52201,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2009-10,52202,Coastal Carolina,Big South,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2009-10,52474,Col. of Charleston,SoCon,232,Charleston Cougars,Charleston,Cougars,COFC,Coastal Athletic Association,10,dict
+2009-10,52203,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2009-10,52205,Colorado,Big 12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Big 12 Conference,8,exact
+2009-10,52204,Colorado St.,Mountain West,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2009-10,52206,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2009-10,52208,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2009-10,52209,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2009-10,52210,Creighton,MVC,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2009-10,52211,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2009-10,52212,Davidson,SoCon,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2009-10,52213,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2009-10,52214,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2009-10,52216,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Coastal Athletic Association,10,exact
+2009-10,52215,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2009-10,52217,Denver,Sun Belt,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,47,exact
+2009-10,52218,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2009-10,52219,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2009-10,52220,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Coastal Athletic Association,10,exact
+2009-10,52221,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2009-10,52222,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2009-10,52224,ETSU,ASUN,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2009-10,52223,East Carolina,C-USA,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Conference,62,exact
+2009-10,52225,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2009-10,52226,Eastern Ky.,OVC,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,Atlantic Sun Conference,46,exact
+2009-10,52227,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2009-10,52228,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2009-10,52475,Elon,SoCon,2210,Elon Phoenix,Elon,Phoenix,ELON,Coastal Athletic Association,10,exact
+2009-10,52229,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2009-10,52490,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,Atlantic Sun Conference,46,exact
+2009-10,52234,FIU,Sun Belt,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2009-10,52230,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Conference,13,exact
+2009-10,52231,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2009-10,52233,Fla. Atlantic,Sun Belt,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,American Conference,62,exact
+2009-10,52236,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2009-10,52232,Florida A&M,MEAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2009-10,52235,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2009-10,52237,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2009-10,52181,Fresno St.,WAC,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2009-10,52238,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2009-10,52242,Ga. Southern,SoCon,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2009-10,52476,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2009-10,52239,George Mason,CAA,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2009-10,52240,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2009-10,52241,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2009-10,52245,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2009-10,52243,Georgia St.,CAA,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2009-10,52244,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2009-10,52246,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2009-10,52247,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2009-10,52465,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2009-10,52248,Hampton,MEAC,2261,Hampton Pirates,Hampton,Pirates,HAMP,Coastal Athletic Association,10,exact
+2009-10,52249,Hartford,America East,42,Hartford Hawks,Hartford,Hawks,HART,,,exact
+2009-10,52250,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2009-10,52251,Hawaii,WAC,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2009-10,52487,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2009-10,52252,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Coastal Athletic Association,10,exact
+2009-10,52253,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2009-10,52255,Houston,C-USA,248,Houston Cougars,Houston,Cougars,HOU,Big 12 Conference,8,exact
+2009-10,52254,Houston Baptist,GWC,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,alias
+2009-10,52256,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2009-10,52481,IUPUI,Summit League,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,alias
+2009-10,52258,Idaho,WAC,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2009-10,52257,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2009-10,52260,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2009-10,52259,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2009-10,52263,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2009-10,52262,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2009-10,52265,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Conference,13,exact
+2009-10,52267,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2009-10,52266,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2009-10,52268,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2009-10,52270,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,Atlantic Sun Conference,46,exact
+2009-10,52269,Jacksonville St.,OVC,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,Conference USA,11,exact
+2009-10,52271,James Madison,CAA,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2009-10,52273,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2009-10,52482,Kansas City,Summit League,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,47,exact
+2009-10,52272,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2009-10,52477,Kennesaw St.,ASUN,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,Conference USA,11,exact
+2009-10,52274,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2009-10,52275,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2009-10,52281,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2009-10,52287,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2009-10,52283,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2009-10,52276,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2009-10,52277,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2009-10,52278,Lamar University,Southland,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2009-10,52279,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2009-10,52280,Liberty,Big South,2335,Liberty Flames,Liberty,Flames,LIB,Conference USA,11,exact
+2009-10,52489,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,Atlantic Sun Conference,46,exact
+2009-10,52160,Little Rock,Sun Belt,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2009-10,52183,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2009-10,52282,Longwood,-,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2009-10,52414,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2009-10,52284,Louisiana Tech,WAC,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2009-10,52285,Louisville,Big East,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2009-10,52288,Loyola Chicago,Horizon,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2009-10,52286,Loyola Maryland,MAAC,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2009-10,52289,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2009-10,52290,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Conference,13,exact
+2009-10,52291,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Conference,13,exact
+2009-10,52292,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2009-10,52293,Marshall,C-USA,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2009-10,52295,Maryland,ACC,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2009-10,52297,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2009-10,52298,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2009-10,52299,Memphis,C-USA,235,Memphis Tigers,Memphis,Tigers,MEM,American Conference,62,exact
+2009-10,52300,Mercer,ASUN,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2009-10,52302,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2009-10,52301,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2009-10,52304,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2009-10,52303,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2009-10,52305,Middle Tenn.,Sun Belt,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2009-10,52467,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2009-10,52306,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2009-10,52307,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2009-10,52308,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2009-10,52310,Missouri,Big 12,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2009-10,52412,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2009-10,52311,Monmouth,NEC,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Coastal Athletic Association,10,exact
+2009-10,52313,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2009-10,52312,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2009-10,52314,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2009-10,52315,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2009-10,52316,Mount St. Mary's,NEC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Conference,13,exact
+2009-10,52317,Murray St.,OVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2009-10,52334,N.C. A&T,MEAC,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Coastal Athletic Association,10,exact
+2009-10,52335,N.C. Central,-,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2009-10,52336,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2009-10,52327,NJIT,GWC,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2009-10,52441,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2009-10,52323,Nebraska,Big 12,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2009-10,52325,Nevada,WAC,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2009-10,52326,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2009-10,52329,New Mexico,Mountain West,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2009-10,52328,New Mexico St.,WAC,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Conference USA,11,exact
+2009-10,52330,New Orleans,Sun Belt,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2009-10,52331,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Conference,13,exact
+2009-10,52332,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2009-10,52333,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2009-10,52319,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2009-10,52338,North Dakota,GWC,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,47,exact
+2009-10,52337,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,47,exact
+2009-10,52483,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,Atlantic Sun Conference,46,exact
+2009-10,52339,North Texas,Sun Belt,249,North Texas Mean Green,North Texas,Mean Green,UNT,American Conference,62,exact
+2009-10,52341,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Coastal Athletic Association,10,exact
+2009-10,52342,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2009-10,52343,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2009-10,52344,Northern Ill.,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2009-10,52347,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2009-10,52346,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2009-10,52348,Notre Dame,Big East,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2009-10,52349,Oakland,Summit League,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2009-10,52351,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2009-10,52350,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2009-10,52353,Oklahoma,Big 12,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Southeastern Conference,23,exact
+2009-10,52352,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2009-10,52354,Old Dominion,CAA,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2009-10,52309,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2009-10,52355,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,47,exact
+2009-10,52357,Oregon,Pac-12,2483,Oregon Ducks,Oregon,Ducks,ORE,Big Ten Conference,7,exact
+2009-10,52356,Oregon St.,Pac-12,204,Oregon State Beavers,Oregon State,Beavers,ORST,West Coast Conference,29,exact
+2009-10,52358,Pacific,Big West,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2009-10,52361,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2009-10,52360,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2009-10,52362,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2009-10,52363,Pittsburgh,Big East,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2009-10,52365,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2009-10,52364,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2009-10,52366,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2009-10,52478,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2009-10,52367,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2009-10,52368,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2009-10,52369,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2009-10,52264,Purdue Fort Wayne,Summit League,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2009-10,52370,Quinnipiac,NEC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Conference,13,exact
+2009-10,52371,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2009-10,52372,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2009-10,52373,Rice,C-USA,242,Rice Owls,Rice,Owls,RICE,American Conference,62,exact
+2009-10,52374,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2009-10,52375,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Conference,13,exact
+2009-10,52376,Robert Morris,NEC,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2009-10,52377,Rutgers,Big East,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2009-10,52416,SFA,Southland,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Southland Conference,25,exact
+2009-10,52407,SIUE,-,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2009-10,52408,SMU,C-USA,2567,SMU Mustangs,SMU,Mustangs,SMU,Atlantic Coast Conference,2,exact
+2009-10,52185,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2009-10,52378,Sacred Heart,NEC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Metro Conference,13,exact
+2009-10,52381,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2009-10,52383,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2009-10,52384,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2009-10,52385,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2009-10,52386,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Conference,13,exact
+2009-10,52387,Sam Houston,Southland,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Conference USA,11,exact
+2009-10,52388,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2009-10,52390,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2009-10,52389,San Diego St.,Mountain West,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2009-10,52391,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2009-10,52392,San Jose St.,WAC,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2009-10,52393,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2009-10,52394,Savannah St.,-,2542,Savannah State Tigers,Savannah State,Tigers,SAV,,,alias
+2009-10,52479,Seattle U,-,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,United Athletic Conference,30,exact
+2009-10,52395,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2009-10,52396,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Conference,13,exact
+2009-10,52397,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2009-10,52399,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2009-10,52398,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2009-10,52401,South Dakota,GWC,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,47,exact
+2009-10,52400,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,47,exact
+2009-10,52402,South Fla.,Big East,58,South Florida Bulls,South Florida,Bulls,USF,American Conference,62,exact
+2009-10,52403,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2009-10,52404,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2009-10,52405,Southern California,Pac-12,30,USC Trojans,USC,Trojans,USC,Big Ten Conference,7,dict
+2009-10,52406,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2009-10,52409,Southern Miss.,C-USA,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2009-10,52410,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2009-10,52411,Southern Utah,Summit League,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,United Athletic Conference,30,exact
+2009-10,52379,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2009-10,52380,St. Francis Brooklyn,NEC,2597,St. Francis Brooklyn Terriers,St. Francis Brooklyn,Terriers,SFNY,,,exact
+2009-10,52382,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2009-10,52415,Stanford,Pac-12,24,Stanford Cardinal,Stanford,Cardinal,STAN,Atlantic Coast Conference,2,exact
+2009-10,52417,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,Atlantic Sun Conference,46,exact
+2009-10,52418,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Coastal Athletic Association,10,exact
+2009-10,52419,Syracuse,Big East,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2009-10,52427,TCU,Mountain West,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2009-10,52420,Temple,Atlantic 10,218,Temple Owls,Temple,Owls,TEM,American Conference,62,exact
+2009-10,52424,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2009-10,52421,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2009-10,52422,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2009-10,52431,Texas,Big 12,251,Texas Longhorns,Texas,Longhorns,TEX,Southeastern Conference,23,exact
+2009-10,52426,Texas A&M,Big 12,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2009-10,52428,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2009-10,52413,Texas St.,Southland,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2009-10,52429,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2009-10,52434,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2009-10,52435,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Coastal Athletic Association,10,exact
+2009-10,52436,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2009-10,52437,Tulane,C-USA,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Conference,62,exact
+2009-10,52438,Tulsa,C-USA,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Conference,62,exact
+2009-10,52151,UAB,C-USA,5,UAB Blazers,UAB,Blazers,UAB,American Conference,62,exact
+2009-10,52188,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2009-10,52189,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2009-10,52191,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2009-10,52186,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2009-10,52196,UCF,C-USA,2116,UCF Knights,UCF,Knights,UCF,Big 12 Conference,8,exact
+2009-10,52190,UCLA,Pac-12,26,UCLA Bruins,UCLA,Bruins,UCLA,Big Ten Conference,7,exact
+2009-10,52207,UConn,Big East,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2009-10,52261,UIC,Horizon,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2009-10,52340,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2009-10,52294,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2009-10,52296,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2009-10,52318,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2009-10,52321,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2009-10,52322,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Coastal Athletic Association,10,exact
+2009-10,52345,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2009-10,52324,UNLV,Mountain West,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2009-10,52485,USC Upstate,ASUN,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2009-10,52430,UT Arlington,Southland,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,United Athletic Conference,30,exact
+2009-10,52425,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2009-10,52432,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2009-10,52359,UTRGV,GWC,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Southland Conference,25,dict
+2009-10,52433,UTSA,Southland,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,American Conference,62,exact
+2009-10,52443,Utah,Mountain West,254,Utah Utes,Utah,Utes,UTAH,Big 12 Conference,8,exact
+2009-10,52442,Utah St.,WAC,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2009-10,52491,Utah Valley,GWC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,United Athletic Conference,30,exact
+2009-10,52448,VCU,CAA,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2009-10,52444,Valparaiso,Horizon,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2009-10,52445,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2009-10,52446,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2009-10,52447,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2009-10,52450,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2009-10,52449,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2009-10,52451,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2009-10,52452,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2009-10,52454,Washington,Pac-12,264,Washington Huskies,Washington,Huskies,WASH,Big Ten Conference,7,exact
+2009-10,52453,Washington St.,Pac-12,265,Washington State Cougars,Washington State,Cougars,WSU,West Coast Conference,29,exact
+2009-10,52455,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2009-10,52456,West Virginia,Big East,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2009-10,52457,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2009-10,52458,Western Ill.,Summit League,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Ohio Valley Conference,20,exact
+2009-10,52459,Western Ky.,Sun Belt,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2009-10,52460,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2009-10,52461,Wichita St.,MVC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Conference,62,exact
+2009-10,52462,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Coastal Athletic Association,10,exact
+2009-10,52463,Winston-Salem,-,2736,Winston-Salem State Rams,Winston-Salem State,Rams,WSSU,,,alias
+2009-10,52464,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2009-10,52466,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2009-10,52484,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2009-10,52468,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2009-10,52469,Wyoming,Mountain West,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2009-10,52470,Xavier,Atlantic 10,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2009-10,52471,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2009-10,52472,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2010-11,55871,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2010-11,55824,Air Force,Mountain West,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2010-11,55532,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2010-11,55535,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2010-11,55533,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2010-11,55534,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2010-11,55537,Albany (NY),America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,alias
+2010-11,55538,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2010-11,55539,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2010-11,55540,App State,SoCon,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2010-11,55542,Arizona,Pac-12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Big 12 Conference,8,exact
+2010-11,55541,Arizona St.,Pac-12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Big 12 Conference,8,exact
+2010-11,55863,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2010-11,55544,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2010-11,55543,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2010-11,55825,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2010-11,55546,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2010-11,55547,Austin Peay,OVC,2046,Austin Peay Governors,Austin Peay,Governors,APSU,Atlantic Sun Conference,46,exact
+2010-11,55558,BYU,Mountain West,252,BYU Cougars,BYU,Cougars,BYU,Big 12 Conference,8,exact
+2010-11,55548,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2010-11,55550,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2010-11,55869,Belmont,ASUN,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2010-11,55551,Bethune-Cookman,MEAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2010-11,55552,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2010-11,55553,Boise St.,WAC,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2010-11,55554,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2010-11,55555,Boston U.,America East,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2010-11,55556,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2010-11,55557,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2010-11,55559,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2010-11,55560,Bryant,NEC,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2010-11,55561,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2010-11,55562,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2010-11,55563,Butler,Horizon,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2010-11,55565,CSU Bakersfield,-,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2010-11,55569,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2010-11,55564,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2010-11,55567,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2010-11,55572,California,Pac-12,25,California Golden Bears,California,Golden Bears,CAL,Atlantic Coast Conference,2,exact
+2010-11,55577,Campbell,ASUN,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Coastal Athletic Association,10,exact
+2010-11,55578,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Conference,13,exact
+2010-11,55579,Centenary (LA),Summit League,2113,Centenary (LA) Gentlemen,Centenary (LA),Gentlemen,CTLA,,,alias
+2010-11,55857,Central Ark.,Southland,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,Atlantic Sun Conference,46,exact
+2010-11,55580,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2010-11,55582,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2010-11,55549,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2010-11,55705,Charlotte,Atlantic 10,2429,Charlotte 49ers,Charlotte,49ers,CLT,American Conference,62,exact
+2010-11,55808,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2010-11,55583,Chicago St.,GWC,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Northeast Conference,19,exact
+2010-11,55584,Cincinnati,Big East,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,Big 12 Conference,8,exact
+2010-11,55585,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2010-11,55586,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2010-11,55587,Coastal Carolina,Big South,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2010-11,55858,Col. of Charleston,SoCon,232,Charleston Cougars,Charleston,Cougars,COFC,Coastal Athletic Association,10,dict
+2010-11,55588,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2010-11,55590,Colorado,Big 12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Big 12 Conference,8,exact
+2010-11,55589,Colorado St.,Mountain West,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2010-11,55591,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2010-11,55593,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2010-11,55594,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2010-11,55595,Creighton,MVC,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2010-11,55596,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2010-11,55597,Davidson,SoCon,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2010-11,55598,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2010-11,55599,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2010-11,55601,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Coastal Athletic Association,10,exact
+2010-11,55600,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2010-11,55602,Denver,Sun Belt,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,47,exact
+2010-11,55603,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2010-11,55604,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2010-11,55605,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Coastal Athletic Association,10,exact
+2010-11,55606,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2010-11,55607,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2010-11,55609,ETSU,ASUN,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2010-11,55608,East Carolina,C-USA,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Conference,62,exact
+2010-11,55610,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2010-11,55611,Eastern Ky.,OVC,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,Atlantic Sun Conference,46,exact
+2010-11,55612,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2010-11,55613,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2010-11,55859,Elon,SoCon,2210,Elon Phoenix,Elon,Phoenix,ELON,Coastal Athletic Association,10,exact
+2010-11,55614,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2010-11,55873,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,Atlantic Sun Conference,46,exact
+2010-11,55619,FIU,Sun Belt,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2010-11,55615,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Conference,13,exact
+2010-11,55616,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2010-11,55618,Fla. Atlantic,Sun Belt,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,American Conference,62,exact
+2010-11,55621,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2010-11,55617,Florida A&M,MEAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2010-11,55620,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2010-11,55622,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2010-11,55566,Fresno St.,WAC,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2010-11,55623,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2010-11,55627,Ga. Southern,SoCon,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2010-11,55860,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2010-11,55624,George Mason,CAA,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2010-11,55625,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2010-11,55626,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2010-11,55630,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2010-11,55628,Georgia St.,CAA,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2010-11,55629,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2010-11,55631,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2010-11,55632,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2010-11,55849,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2010-11,55633,Hampton,MEAC,2261,Hampton Pirates,Hampton,Pirates,HAMP,Coastal Athletic Association,10,exact
+2010-11,55634,Hartford,America East,42,Hartford Hawks,Hartford,Hawks,HART,,,exact
+2010-11,55635,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2010-11,55636,Hawaii,WAC,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2010-11,55870,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2010-11,55637,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Coastal Athletic Association,10,exact
+2010-11,55638,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2010-11,55640,Houston,C-USA,248,Houston Cougars,Houston,Cougars,HOU,Big 12 Conference,8,exact
+2010-11,55639,Houston Baptist,GWC,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,alias
+2010-11,55641,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2010-11,55864,IUPUI,Summit League,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,alias
+2010-11,55643,Idaho,WAC,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2010-11,55642,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2010-11,55645,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2010-11,55644,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2010-11,55648,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2010-11,55647,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2010-11,55650,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Conference,13,exact
+2010-11,55652,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2010-11,55651,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2010-11,55653,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2010-11,55655,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,Atlantic Sun Conference,46,exact
+2010-11,55654,Jacksonville St.,OVC,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,Conference USA,11,exact
+2010-11,55656,James Madison,CAA,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2010-11,55658,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2010-11,55865,Kansas City,Summit League,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,47,exact
+2010-11,55657,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2010-11,55861,Kennesaw St.,ASUN,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,Conference USA,11,exact
+2010-11,55659,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2010-11,55660,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2010-11,55666,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2010-11,55672,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2010-11,55668,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2010-11,55661,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2010-11,55662,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2010-11,55663,Lamar University,Southland,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2010-11,55664,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2010-11,55665,Liberty,Big South,2335,Liberty Flames,Liberty,Flames,LIB,Conference USA,11,exact
+2010-11,55872,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,Atlantic Sun Conference,46,exact
+2010-11,55545,Little Rock,Sun Belt,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2010-11,55568,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2010-11,55667,Longwood,-,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2010-11,55799,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2010-11,55669,Louisiana Tech,WAC,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2010-11,55670,Louisville,Big East,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2010-11,55673,Loyola Chicago,Horizon,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2010-11,55671,Loyola Maryland,MAAC,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2010-11,55674,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2010-11,55675,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Conference,13,exact
+2010-11,55676,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Conference,13,exact
+2010-11,55677,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2010-11,55678,Marshall,C-USA,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2010-11,55680,Maryland,ACC,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2010-11,55682,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2010-11,55683,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2010-11,55684,Memphis,C-USA,235,Memphis Tigers,Memphis,Tigers,MEM,American Conference,62,exact
+2010-11,55685,Mercer,ASUN,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2010-11,55687,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2010-11,55686,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2010-11,55689,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2010-11,55688,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2010-11,55690,Middle Tenn.,Sun Belt,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2010-11,55851,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2010-11,55691,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2010-11,55692,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2010-11,55693,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2010-11,55695,Missouri,Big 12,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2010-11,55797,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2010-11,55696,Monmouth,NEC,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Coastal Athletic Association,10,exact
+2010-11,55698,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2010-11,55697,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2010-11,55699,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2010-11,55700,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2010-11,55701,Mount St. Mary's,NEC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Conference,13,exact
+2010-11,55702,Murray St.,OVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2010-11,55719,N.C. A&T,MEAC,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Coastal Athletic Association,10,exact
+2010-11,55720,N.C. Central,-,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2010-11,55721,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2010-11,55712,NJIT,GWC,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2010-11,55826,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2010-11,55708,Nebraska,Big 12,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2010-11,55710,Nevada,WAC,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2010-11,55711,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2010-11,55714,New Mexico,Mountain West,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2010-11,55713,New Mexico St.,WAC,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Conference USA,11,exact
+2010-11,55715,New Orleans,-,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2010-11,55716,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Conference,13,exact
+2010-11,55717,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2010-11,55718,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2010-11,55704,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2010-11,55723,North Dakota,GWC,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,47,exact
+2010-11,55722,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,47,exact
+2010-11,55866,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,Atlantic Sun Conference,46,exact
+2010-11,55724,North Texas,Sun Belt,249,North Texas Mean Green,North Texas,Mean Green,UNT,American Conference,62,exact
+2010-11,55726,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Coastal Athletic Association,10,exact
+2010-11,55727,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2010-11,55728,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2010-11,55729,Northern Ill.,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2010-11,55732,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2010-11,55731,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2010-11,55733,Notre Dame,Big East,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2010-11,55734,Oakland,Summit League,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2010-11,55736,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2010-11,55735,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2010-11,55738,Oklahoma,Big 12,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Southeastern Conference,23,exact
+2010-11,55737,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2010-11,55739,Old Dominion,CAA,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2010-11,55694,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2010-11,55740,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,47,exact
+2010-11,55742,Oregon,Pac-12,2483,Oregon Ducks,Oregon,Ducks,ORE,Big Ten Conference,7,exact
+2010-11,55741,Oregon St.,Pac-12,204,Oregon State Beavers,Oregon State,Beavers,ORST,West Coast Conference,29,exact
+2010-11,55743,Pacific,Big West,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2010-11,55746,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2010-11,55745,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2010-11,55747,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2010-11,55748,Pittsburgh,Big East,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2010-11,55750,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2010-11,55749,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2010-11,55751,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2010-11,223989,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2010-11,55752,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2010-11,55753,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2010-11,55754,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2010-11,55649,Purdue Fort Wayne,Summit League,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2010-11,55755,Quinnipiac,NEC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Conference,13,exact
+2010-11,55756,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2010-11,55757,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2010-11,55758,Rice,C-USA,242,Rice Owls,Rice,Owls,RICE,American Conference,62,exact
+2010-11,55759,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2010-11,55760,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Conference,13,exact
+2010-11,55761,Robert Morris,NEC,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2010-11,55762,Rutgers,Big East,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2010-11,55801,SFA,Southland,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Southland Conference,25,exact
+2010-11,55792,SIUE,-,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2010-11,55793,SMU,C-USA,2567,SMU Mustangs,SMU,Mustangs,SMU,Atlantic Coast Conference,2,exact
+2010-11,55570,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2010-11,55763,Sacred Heart,NEC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Metro Conference,13,exact
+2010-11,55766,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2010-11,55768,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2010-11,55769,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2010-11,55770,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2010-11,55771,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Conference,13,exact
+2010-11,55772,Sam Houston,Southland,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Conference USA,11,exact
+2010-11,55773,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2010-11,55775,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2010-11,55774,San Diego St.,Mountain West,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2010-11,55776,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2010-11,55777,San Jose St.,WAC,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2010-11,55778,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2010-11,55779,Savannah St.,-,2542,Savannah State Tigers,Savannah State,Tigers,SAV,,,alias
+2010-11,55862,Seattle U,-,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,United Athletic Conference,30,exact
+2010-11,55780,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2010-11,55781,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Conference,13,exact
+2010-11,55782,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2010-11,55784,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2010-11,55783,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2010-11,55786,South Dakota,GWC,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,47,exact
+2010-11,55785,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,47,exact
+2010-11,55787,South Fla.,Big East,58,South Florida Bulls,South Florida,Bulls,USF,American Conference,62,exact
+2010-11,55788,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2010-11,55789,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2010-11,55790,Southern California,Pac-12,30,USC Trojans,USC,Trojans,USC,Big Ten Conference,7,dict
+2010-11,55791,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2010-11,55794,Southern Miss.,C-USA,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2010-11,55795,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2010-11,55796,Southern Utah,Summit League,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,United Athletic Conference,30,exact
+2010-11,55764,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2010-11,55765,St. Francis Brooklyn,NEC,2597,St. Francis Brooklyn Terriers,St. Francis Brooklyn,Terriers,SFNY,,,exact
+2010-11,55767,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2010-11,55800,Stanford,Pac-12,24,Stanford Cardinal,Stanford,Cardinal,STAN,Atlantic Coast Conference,2,exact
+2010-11,55802,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,Atlantic Sun Conference,46,exact
+2010-11,55803,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Coastal Athletic Association,10,exact
+2010-11,55804,Syracuse,Big East,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2010-11,55812,TCU,Mountain West,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2010-11,55805,Temple,Atlantic 10,218,Temple Owls,Temple,Owls,TEM,American Conference,62,exact
+2010-11,55809,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2010-11,55806,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2010-11,55807,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2010-11,55816,Texas,Big 12,251,Texas Longhorns,Texas,Longhorns,TEX,Southeastern Conference,23,exact
+2010-11,55811,Texas A&M,Big 12,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2010-11,55813,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2010-11,55798,Texas St.,Southland,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2010-11,55814,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2010-11,55819,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2010-11,55820,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Coastal Athletic Association,10,exact
+2010-11,55821,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2010-11,55822,Tulane,C-USA,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Conference,62,exact
+2010-11,55823,Tulsa,C-USA,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Conference,62,exact
+2010-11,55536,UAB,C-USA,5,UAB Blazers,UAB,Blazers,UAB,American Conference,62,exact
+2010-11,55573,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2010-11,55574,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2010-11,55576,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2010-11,55571,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2010-11,55581,UCF,C-USA,2116,UCF Knights,UCF,Knights,UCF,Big 12 Conference,8,exact
+2010-11,55575,UCLA,Pac-12,26,UCLA Bruins,UCLA,Bruins,UCLA,Big Ten Conference,7,exact
+2010-11,55592,UConn,Big East,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2010-11,55646,UIC,Horizon,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2010-11,55725,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2010-11,55679,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2010-11,55681,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2010-11,55703,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2010-11,55706,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2010-11,55707,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Coastal Athletic Association,10,exact
+2010-11,55730,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2010-11,55709,UNLV,Mountain West,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2010-11,55868,USC Upstate,ASUN,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2010-11,55815,UT Arlington,Southland,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,United Athletic Conference,30,exact
+2010-11,55810,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2010-11,55817,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2010-11,55744,UTRGV,GWC,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Southland Conference,25,dict
+2010-11,55818,UTSA,Southland,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,American Conference,62,exact
+2010-11,55828,Utah,Mountain West,254,Utah Utes,Utah,Utes,UTAH,Big 12 Conference,8,exact
+2010-11,55827,Utah St.,WAC,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2010-11,55874,Utah Valley,GWC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,United Athletic Conference,30,exact
+2010-11,55833,VCU,CAA,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2010-11,55829,Valparaiso,Horizon,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2010-11,55830,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2010-11,55831,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2010-11,55832,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2010-11,55835,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2010-11,55834,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2010-11,55836,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2010-11,55837,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2010-11,55839,Washington,Pac-12,264,Washington Huskies,Washington,Huskies,WASH,Big Ten Conference,7,exact
+2010-11,55838,Washington St.,Pac-12,265,Washington State Cougars,Washington State,Cougars,WSU,West Coast Conference,29,exact
+2010-11,55840,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2010-11,55841,West Virginia,Big East,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2010-11,55842,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2010-11,55843,Western Ill.,Summit League,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Ohio Valley Conference,20,exact
+2010-11,55844,Western Ky.,Sun Belt,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2010-11,55845,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2010-11,55846,Wichita St.,MVC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Conference,62,exact
+2010-11,55847,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Coastal Athletic Association,10,exact
+2010-11,55848,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2010-11,55850,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2010-11,55867,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2010-11,55852,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2010-11,55853,Wyoming,Mountain West,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2010-11,55854,Xavier,Atlantic 10,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2010-11,55855,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2010-11,55856,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2011-12,30600,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2011-12,30552,Air Force,Mountain West,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2011-12,30261,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2011-12,30264,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2011-12,30262,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2011-12,30263,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2011-12,30266,Albany (NY),America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,alias
+2011-12,30267,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2011-12,30268,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2011-12,30269,App State,SoCon,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2011-12,30271,Arizona,Pac-12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Big 12 Conference,8,exact
+2011-12,30270,Arizona St.,Pac-12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Big 12 Conference,8,exact
+2011-12,30592,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2011-12,30273,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2011-12,30272,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2011-12,30553,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2011-12,30275,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2011-12,30276,Austin Peay,OVC,2046,Austin Peay Governors,Austin Peay,Governors,APSU,Atlantic Sun Conference,46,exact
+2011-12,30287,BYU,WCC,252,BYU Cougars,BYU,Cougars,BYU,Big 12 Conference,8,exact
+2011-12,30277,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2011-12,30279,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2011-12,30598,Belmont,ASUN,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2011-12,30280,Bethune-Cookman,MEAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2011-12,30281,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2011-12,30282,Boise St.,Mountain West,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2011-12,30283,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2011-12,30284,Boston U.,America East,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2011-12,30285,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2011-12,30286,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2011-12,30288,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2011-12,30289,Bryant,NEC,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2011-12,30290,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2011-12,30291,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2011-12,30292,Butler,Horizon,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2011-12,30294,CSU Bakersfield,-,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2011-12,30298,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2011-12,30293,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2011-12,30296,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2011-12,30301,California,Pac-12,25,California Golden Bears,California,Golden Bears,CAL,Atlantic Coast Conference,2,exact
+2011-12,30306,Campbell,Big South,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Coastal Athletic Association,10,exact
+2011-12,30307,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Conference,13,exact
+2011-12,30585,Central Ark.,Southland,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,Atlantic Sun Conference,46,exact
+2011-12,30308,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2011-12,30310,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2011-12,30278,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2011-12,30433,Charlotte,Atlantic 10,2429,Charlotte 49ers,Charlotte,49ers,CLT,American Conference,62,exact
+2011-12,30536,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2011-12,30311,Chicago St.,GWC,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Northeast Conference,19,exact
+2011-12,30312,Cincinnati,Big East,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,Big 12 Conference,8,exact
+2011-12,30313,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2011-12,30314,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2011-12,30315,Coastal Carolina,Big South,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2011-12,30586,Col. of Charleston,SoCon,232,Charleston Cougars,Charleston,Cougars,COFC,Coastal Athletic Association,10,dict
+2011-12,30316,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2011-12,30318,Colorado,Pac-12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Big 12 Conference,8,exact
+2011-12,30317,Colorado St.,Mountain West,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2011-12,30319,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2011-12,30321,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2011-12,30322,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2011-12,30323,Creighton,MVC,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2011-12,30324,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2011-12,30325,Davidson,SoCon,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2011-12,30326,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2011-12,30327,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2011-12,30329,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Coastal Athletic Association,10,exact
+2011-12,30328,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2011-12,30330,Denver,Sun Belt,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,47,exact
+2011-12,30331,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2011-12,30332,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2011-12,30333,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Coastal Athletic Association,10,exact
+2011-12,30334,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2011-12,30335,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2011-12,30337,ETSU,ASUN,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2011-12,30336,East Carolina,C-USA,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Conference,62,exact
+2011-12,30338,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2011-12,30339,Eastern Ky.,OVC,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,Atlantic Sun Conference,46,exact
+2011-12,30340,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2011-12,30341,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2011-12,30587,Elon,SoCon,2210,Elon Phoenix,Elon,Phoenix,ELON,Coastal Athletic Association,10,exact
+2011-12,30342,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2011-12,30602,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,Atlantic Sun Conference,46,exact
+2011-12,30347,FIU,Sun Belt,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2011-12,30343,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Conference,13,exact
+2011-12,30344,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2011-12,30346,Fla. Atlantic,Sun Belt,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,American Conference,62,exact
+2011-12,30349,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2011-12,30345,Florida A&M,MEAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2011-12,30348,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2011-12,30350,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2011-12,30295,Fresno St.,WAC,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2011-12,30351,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2011-12,30355,Ga. Southern,SoCon,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2011-12,30588,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2011-12,30352,George Mason,CAA,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2011-12,30353,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2011-12,30354,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2011-12,30358,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2011-12,30356,Georgia St.,CAA,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2011-12,30357,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2011-12,30359,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2011-12,30360,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2011-12,30577,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2011-12,30361,Hampton,MEAC,2261,Hampton Pirates,Hampton,Pirates,HAMP,Coastal Athletic Association,10,exact
+2011-12,30362,Hartford,America East,42,Hartford Hawks,Hartford,Hawks,HART,,,exact
+2011-12,30363,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2011-12,30364,Hawaii,WAC,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2011-12,30599,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2011-12,30365,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Coastal Athletic Association,10,exact
+2011-12,30366,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2011-12,30368,Houston,C-USA,248,Houston Cougars,Houston,Cougars,HOU,Big 12 Conference,8,exact
+2011-12,30367,Houston Baptist,GWC,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,alias
+2011-12,30369,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2011-12,30593,IUPUI,Summit League,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,alias
+2011-12,30371,Idaho,WAC,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2011-12,30370,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2011-12,30373,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2011-12,30372,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2011-12,30376,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2011-12,30375,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2011-12,30378,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Conference,13,exact
+2011-12,30380,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2011-12,30379,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2011-12,30381,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2011-12,30383,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,Atlantic Sun Conference,46,exact
+2011-12,30382,Jacksonville St.,OVC,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,Conference USA,11,exact
+2011-12,30384,James Madison,CAA,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2011-12,30386,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2011-12,30594,Kansas City,Summit League,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,47,exact
+2011-12,30385,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2011-12,30589,Kennesaw St.,ASUN,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,Conference USA,11,exact
+2011-12,30387,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2011-12,30388,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2011-12,30394,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2011-12,30400,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2011-12,30396,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2011-12,30389,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2011-12,30390,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2011-12,30391,Lamar University,Southland,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2011-12,30392,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2011-12,30393,Liberty,Big South,2335,Liberty Flames,Liberty,Flames,LIB,Conference USA,11,exact
+2011-12,30601,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,Atlantic Sun Conference,46,exact
+2011-12,30274,Little Rock,Sun Belt,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2011-12,30297,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2011-12,30395,Longwood,-,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2011-12,30527,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2011-12,30397,Louisiana Tech,WAC,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2011-12,30398,Louisville,Big East,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2011-12,30401,Loyola Chicago,Horizon,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2011-12,30399,Loyola Maryland,MAAC,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2011-12,30402,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2011-12,30403,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Conference,13,exact
+2011-12,30404,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Conference,13,exact
+2011-12,30405,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2011-12,30406,Marshall,C-USA,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2011-12,30408,Maryland,ACC,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2011-12,30410,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2011-12,30411,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2011-12,30412,Memphis,C-USA,235,Memphis Tigers,Memphis,Tigers,MEM,American Conference,62,exact
+2011-12,30413,Mercer,ASUN,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2011-12,30415,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2011-12,30414,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2011-12,30417,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2011-12,30416,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2011-12,30418,Middle Tenn.,Sun Belt,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2011-12,30579,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2011-12,30419,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2011-12,30420,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2011-12,30421,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2011-12,30423,Missouri,Big 12,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2011-12,30525,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2011-12,30424,Monmouth,NEC,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Coastal Athletic Association,10,exact
+2011-12,30426,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2011-12,30425,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2011-12,30427,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2011-12,30428,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2011-12,30429,Mount St. Mary's,NEC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Conference,13,exact
+2011-12,30430,Murray St.,OVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2011-12,30447,N.C. A&T,MEAC,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Coastal Athletic Association,10,exact
+2011-12,30448,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2011-12,30449,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2011-12,30441,NJIT,GWC,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2011-12,30554,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2011-12,30436,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2011-12,30439,Nevada,WAC,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2011-12,30440,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2011-12,30443,New Mexico,Mountain West,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2011-12,30442,New Mexico St.,WAC,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Conference USA,11,exact
+2011-12,30444,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Conference,13,exact
+2011-12,30445,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2011-12,30446,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2011-12,30432,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2011-12,30451,North Dakota,GWC,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,47,exact
+2011-12,30450,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,47,exact
+2011-12,30595,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,Atlantic Sun Conference,46,exact
+2011-12,30452,North Texas,Sun Belt,249,North Texas Mean Green,North Texas,Mean Green,UNT,American Conference,62,exact
+2011-12,30454,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Coastal Athletic Association,10,exact
+2011-12,30455,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2011-12,30456,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2011-12,30457,Northern Ill.,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2011-12,30460,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2011-12,30459,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2011-12,30461,Notre Dame,Big East,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2011-12,30462,Oakland,Summit League,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2011-12,30464,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2011-12,30463,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2011-12,30466,Oklahoma,Big 12,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Southeastern Conference,23,exact
+2011-12,30465,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2011-12,30467,Old Dominion,CAA,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2011-12,30422,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2011-12,30437,Omaha,-,2437,Omaha Mavericks,Omaha,Mavericks,OMA,Summit League,47,exact
+2011-12,30468,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,47,exact
+2011-12,30470,Oregon,Pac-12,2483,Oregon Ducks,Oregon,Ducks,ORE,Big Ten Conference,7,exact
+2011-12,30469,Oregon St.,Pac-12,204,Oregon State Beavers,Oregon State,Beavers,ORST,West Coast Conference,29,exact
+2011-12,30471,Pacific,Big West,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2011-12,30474,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2011-12,30473,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2011-12,30475,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2011-12,30476,Pittsburgh,Big East,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2011-12,30478,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2011-12,30477,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2011-12,30479,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2011-12,30590,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2011-12,30480,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2011-12,30481,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2011-12,30482,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2011-12,30377,Purdue Fort Wayne,Summit League,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2011-12,30483,Quinnipiac,NEC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Conference,13,exact
+2011-12,30484,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2011-12,30485,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2011-12,30486,Rice,C-USA,242,Rice Owls,Rice,Owls,RICE,American Conference,62,exact
+2011-12,30487,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2011-12,30488,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Conference,13,exact
+2011-12,30489,Robert Morris,NEC,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2011-12,30490,Rutgers,Big East,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2011-12,30529,SFA,Southland,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Southland Conference,25,exact
+2011-12,30520,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2011-12,30521,SMU,C-USA,2567,SMU Mustangs,SMU,Mustangs,SMU,Atlantic Coast Conference,2,exact
+2011-12,30299,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2011-12,30491,Sacred Heart,NEC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Metro Conference,13,exact
+2011-12,30494,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2011-12,30496,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2011-12,30497,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2011-12,30498,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2011-12,30499,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Conference,13,exact
+2011-12,30500,Sam Houston,Southland,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Conference USA,11,exact
+2011-12,30501,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2011-12,30503,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2011-12,30502,San Diego St.,Mountain West,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2011-12,30504,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2011-12,30505,San Jose St.,WAC,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2011-12,30506,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2011-12,30507,Savannah St.,MEAC,2542,Savannah State Tigers,Savannah State,Tigers,SAV,,,alias
+2011-12,30591,Seattle U,-,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,United Athletic Conference,30,exact
+2011-12,30508,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2011-12,30509,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Conference,13,exact
+2011-12,30510,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2011-12,30512,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2011-12,30511,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2011-12,30514,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,47,exact
+2011-12,30513,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,47,exact
+2011-12,30515,South Fla.,Big East,58,South Florida Bulls,South Florida,Bulls,USF,American Conference,62,exact
+2011-12,30516,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2011-12,30517,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2011-12,30518,Southern California,Pac-12,30,USC Trojans,USC,Trojans,USC,Big Ten Conference,7,dict
+2011-12,30519,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2011-12,30522,Southern Miss.,C-USA,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2011-12,30523,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2011-12,30524,Southern Utah,Summit League,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,United Athletic Conference,30,exact
+2011-12,30492,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2011-12,30493,St. Francis Brooklyn,NEC,2597,St. Francis Brooklyn Terriers,St. Francis Brooklyn,Terriers,SFNY,,,exact
+2011-12,30495,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2011-12,30528,Stanford,Pac-12,24,Stanford Cardinal,Stanford,Cardinal,STAN,Atlantic Coast Conference,2,exact
+2011-12,30530,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,Atlantic Sun Conference,46,exact
+2011-12,30531,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Coastal Athletic Association,10,exact
+2011-12,30532,Syracuse,Big East,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2011-12,30540,TCU,Mountain West,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2011-12,30533,Temple,Atlantic 10,218,Temple Owls,Temple,Owls,TEM,American Conference,62,exact
+2011-12,30537,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2011-12,30534,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2011-12,30535,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2011-12,30544,Texas,Big 12,251,Texas Longhorns,Texas,Longhorns,TEX,Southeastern Conference,23,exact
+2011-12,30539,Texas A&M,Big 12,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2011-12,30541,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2011-12,30526,Texas St.,Southland,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2011-12,30542,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2011-12,30547,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2011-12,30548,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Coastal Athletic Association,10,exact
+2011-12,30549,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2011-12,30550,Tulane,C-USA,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Conference,62,exact
+2011-12,30551,Tulsa,C-USA,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Conference,62,exact
+2011-12,30265,UAB,C-USA,5,UAB Blazers,UAB,Blazers,UAB,American Conference,62,exact
+2011-12,30302,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2011-12,30303,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2011-12,30305,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2011-12,30300,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2011-12,30309,UCF,C-USA,2116,UCF Knights,UCF,Knights,UCF,Big 12 Conference,8,exact
+2011-12,30304,UCLA,Pac-12,26,UCLA Bruins,UCLA,Bruins,UCLA,Big Ten Conference,7,exact
+2011-12,30320,UConn,Big East,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2011-12,30374,UIC,Horizon,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2011-12,30453,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2011-12,30407,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2011-12,30409,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2011-12,30431,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2011-12,30434,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2011-12,30435,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Coastal Athletic Association,10,exact
+2011-12,30458,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2011-12,30438,UNLV,Mountain West,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2011-12,30597,USC Upstate,ASUN,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2011-12,30543,UT Arlington,Southland,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,United Athletic Conference,30,exact
+2011-12,30538,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2011-12,30545,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2011-12,30472,UTRGV,GWC,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Southland Conference,25,dict
+2011-12,30546,UTSA,Southland,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,American Conference,62,exact
+2011-12,30556,Utah,Pac-12,254,Utah Utes,Utah,Utes,UTAH,Big 12 Conference,8,exact
+2011-12,30555,Utah St.,WAC,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2011-12,30603,Utah Valley,GWC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,United Athletic Conference,30,exact
+2011-12,30561,VCU,CAA,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2011-12,30557,Valparaiso,Horizon,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2011-12,30558,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2011-12,30559,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2011-12,30560,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2011-12,30563,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2011-12,30562,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2011-12,30564,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2011-12,30565,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2011-12,30567,Washington,Pac-12,264,Washington Huskies,Washington,Huskies,WASH,Big Ten Conference,7,exact
+2011-12,30566,Washington St.,Pac-12,265,Washington State Cougars,Washington State,Cougars,WSU,West Coast Conference,29,exact
+2011-12,30568,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2011-12,30569,West Virginia,Big East,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2011-12,30570,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2011-12,30571,Western Ill.,Summit League,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Ohio Valley Conference,20,exact
+2011-12,30572,Western Ky.,Sun Belt,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2011-12,30573,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2011-12,30574,Wichita St.,MVC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Conference,62,exact
+2011-12,30575,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Coastal Athletic Association,10,exact
+2011-12,30576,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2011-12,30578,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2011-12,30596,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2011-12,30580,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2011-12,30581,Wyoming,Mountain West,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2011-12,30582,Xavier,Atlantic 10,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2011-12,30583,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2011-12,30584,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2012-13,77617,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2012-13,77569,Air Force,Mountain West,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2012-13,77276,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2012-13,77279,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2012-13,77277,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2012-13,77278,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2012-13,77281,Albany (NY),America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,alias
+2012-13,77282,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2012-13,77283,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2012-13,77284,App State,SoCon,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2012-13,77286,Arizona,Pac-12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Big 12 Conference,8,exact
+2012-13,77285,Arizona St.,Pac-12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Big 12 Conference,8,exact
+2012-13,77609,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2012-13,77288,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2012-13,77287,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2012-13,77570,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2012-13,77290,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2012-13,77291,Austin Peay,OVC,2046,Austin Peay Governors,Austin Peay,Governors,APSU,Atlantic Sun Conference,46,exact
+2012-13,77302,BYU,WCC,252,BYU Cougars,BYU,Cougars,BYU,Big 12 Conference,8,exact
+2012-13,77292,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2012-13,77294,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2012-13,77615,Belmont,OVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2012-13,77295,Bethune-Cookman,MEAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2012-13,77296,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2012-13,77297,Boise St.,Mountain West,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2012-13,77298,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2012-13,77299,Boston U.,America East,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2012-13,77300,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2012-13,77301,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2012-13,77303,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2012-13,77304,Bryant,NEC,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2012-13,77305,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2012-13,77306,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2012-13,77307,Butler,Atlantic 10,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2012-13,77309,CSU Bakersfield,-,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2012-13,77313,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2012-13,77308,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2012-13,77311,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2012-13,77316,California,Pac-12,25,California Golden Bears,California,Golden Bears,CAL,Atlantic Coast Conference,2,exact
+2012-13,77321,Campbell,Big South,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Coastal Athletic Association,10,exact
+2012-13,77322,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Conference,13,exact
+2012-13,77602,Central Ark.,Southland,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,Atlantic Sun Conference,46,exact
+2012-13,77323,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2012-13,77325,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2012-13,77293,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2012-13,77448,Charlotte,Atlantic 10,2429,Charlotte 49ers,Charlotte,49ers,CLT,American Conference,62,exact
+2012-13,77553,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2012-13,77326,Chicago St.,GWC,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Northeast Conference,19,exact
+2012-13,77327,Cincinnati,Big East,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,Big 12 Conference,8,exact
+2012-13,77328,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2012-13,77329,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2012-13,77330,Coastal Carolina,Big South,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2012-13,77603,Col. of Charleston,SoCon,232,Charleston Cougars,Charleston,Cougars,COFC,Coastal Athletic Association,10,dict
+2012-13,77331,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2012-13,77333,Colorado,Pac-12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Big 12 Conference,8,exact
+2012-13,77332,Colorado St.,Mountain West,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2012-13,77334,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2012-13,77336,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2012-13,77337,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2012-13,77338,Creighton,MVC,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2012-13,77339,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2012-13,77340,Davidson,SoCon,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2012-13,77341,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2012-13,77342,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2012-13,77344,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Coastal Athletic Association,10,exact
+2012-13,77343,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2012-13,77345,Denver,WAC,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,47,exact
+2012-13,77346,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2012-13,77347,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2012-13,77348,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Coastal Athletic Association,10,exact
+2012-13,77349,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2012-13,77350,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2012-13,77352,ETSU,ASUN,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2012-13,77351,East Carolina,C-USA,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Conference,62,exact
+2012-13,77353,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2012-13,77354,Eastern Ky.,OVC,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,Atlantic Sun Conference,46,exact
+2012-13,77355,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2012-13,77356,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2012-13,77604,Elon,SoCon,2210,Elon Phoenix,Elon,Phoenix,ELON,Coastal Athletic Association,10,exact
+2012-13,77357,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2012-13,77619,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,Atlantic Sun Conference,46,exact
+2012-13,77362,FIU,Sun Belt,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2012-13,77358,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Conference,13,exact
+2012-13,77359,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2012-13,77361,Fla. Atlantic,Sun Belt,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,American Conference,62,exact
+2012-13,77364,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2012-13,77360,Florida A&M,MEAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2012-13,77363,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2012-13,77365,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2012-13,77310,Fresno St.,Mountain West,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2012-13,77366,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2012-13,77370,Ga. Southern,SoCon,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2012-13,77605,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2012-13,77367,George Mason,CAA,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2012-13,77368,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2012-13,77369,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2012-13,77373,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2012-13,77371,Georgia St.,CAA,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2012-13,77372,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2012-13,77374,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2012-13,77375,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2012-13,77594,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2012-13,77376,Hampton,MEAC,2261,Hampton Pirates,Hampton,Pirates,HAMP,Coastal Athletic Association,10,exact
+2012-13,77377,Hartford,America East,42,Hartford Hawks,Hartford,Hawks,HART,,,exact
+2012-13,77378,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2012-13,77379,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2012-13,77616,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2012-13,77380,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Coastal Athletic Association,10,exact
+2012-13,77381,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2012-13,77383,Houston,C-USA,248,Houston Cougars,Houston,Cougars,HOU,Big 12 Conference,8,exact
+2012-13,77382,Houston Baptist,GWC,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,alias
+2012-13,77384,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2012-13,77610,IUPUI,Summit League,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,alias
+2012-13,77386,Idaho,WAC,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2012-13,77385,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2012-13,77388,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2012-13,77387,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2012-13,77391,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2012-13,77390,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2012-13,77393,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Conference,13,exact
+2012-13,77395,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2012-13,77394,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2012-13,77396,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2012-13,77398,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,Atlantic Sun Conference,46,exact
+2012-13,77397,Jacksonville St.,OVC,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,Conference USA,11,exact
+2012-13,77399,James Madison,CAA,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2012-13,77401,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2012-13,77611,Kansas City,Summit League,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,47,exact
+2012-13,77400,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2012-13,77606,Kennesaw St.,ASUN,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,Conference USA,11,exact
+2012-13,77402,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2012-13,77403,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2012-13,77409,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2012-13,77415,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2012-13,77411,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2012-13,77404,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2012-13,77405,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2012-13,77406,Lamar University,Southland,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2012-13,77407,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2012-13,77408,Liberty,Big South,2335,Liberty Flames,Liberty,Flames,LIB,Conference USA,11,exact
+2012-13,77618,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,Atlantic Sun Conference,46,exact
+2012-13,77289,Little Rock,Sun Belt,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2012-13,77312,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2012-13,77410,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2012-13,77544,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2012-13,77412,Louisiana Tech,WAC,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2012-13,77413,Louisville,Big East,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2012-13,77416,Loyola Chicago,Horizon,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2012-13,77414,Loyola Maryland,MAAC,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2012-13,77417,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2012-13,77418,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Conference,13,exact
+2012-13,77419,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Conference,13,exact
+2012-13,77420,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2012-13,77421,Marshall,C-USA,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2012-13,77423,Maryland,ACC,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2012-13,77425,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2012-13,77426,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2012-13,77427,Memphis,C-USA,235,Memphis Tigers,Memphis,Tigers,MEM,American Conference,62,exact
+2012-13,77428,Mercer,ASUN,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2012-13,77430,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2012-13,77429,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2012-13,77432,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2012-13,77431,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2012-13,77433,Middle Tenn.,Sun Belt,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2012-13,77596,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2012-13,77434,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2012-13,77435,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2012-13,77436,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2012-13,77438,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2012-13,77542,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2012-13,77439,Monmouth,NEC,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Coastal Athletic Association,10,exact
+2012-13,77441,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2012-13,77440,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2012-13,77442,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2012-13,77443,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2012-13,77444,Mount St. Mary's,NEC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Conference,13,exact
+2012-13,77445,Murray St.,OVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2012-13,77463,N.C. A&T,MEAC,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Coastal Athletic Association,10,exact
+2012-13,77464,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2012-13,77465,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2012-13,77456,NJIT,GWC,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2012-13,77571,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2012-13,77451,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2012-13,77454,Nevada,Mountain West,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2012-13,77455,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2012-13,77458,New Mexico,Mountain West,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2012-13,77457,New Mexico St.,WAC,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Conference USA,11,exact
+2012-13,77459,New Orleans,-,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2012-13,77460,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Conference,13,exact
+2012-13,77461,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2012-13,77462,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2012-13,77447,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2012-13,77467,North Dakota,Big Sky,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,47,exact
+2012-13,77466,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,47,exact
+2012-13,77612,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,Atlantic Sun Conference,46,exact
+2012-13,77468,North Texas,Sun Belt,249,North Texas Mean Green,North Texas,Mean Green,UNT,American Conference,62,exact
+2012-13,77470,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Coastal Athletic Association,10,exact
+2012-13,77471,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2012-13,77472,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2012-13,77473,Northern Ill.,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2012-13,77475,Northern Ky.,ASUN,94,Northern Kentucky Norse,Northern Kentucky,Norse,NKU,Horizon League,45,exact
+2012-13,77477,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2012-13,77476,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2012-13,77478,Notre Dame,Big East,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2012-13,77479,Oakland,Summit League,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2012-13,77481,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2012-13,77480,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2012-13,77483,Oklahoma,Big 12,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Southeastern Conference,23,exact
+2012-13,77482,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2012-13,77484,Old Dominion,CAA,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2012-13,77437,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2012-13,77452,Omaha,Summit League,2437,Omaha Mavericks,Omaha,Mavericks,OMA,Summit League,47,exact
+2012-13,77485,Oral Roberts,Southland,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,47,exact
+2012-13,77487,Oregon,Pac-12,2483,Oregon Ducks,Oregon,Ducks,ORE,Big Ten Conference,7,exact
+2012-13,77486,Oregon St.,Pac-12,204,Oregon State Beavers,Oregon State,Beavers,ORST,West Coast Conference,29,exact
+2012-13,77488,Pacific,Big West,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2012-13,77491,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2012-13,77490,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2012-13,77492,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2012-13,77493,Pittsburgh,Big East,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2012-13,77495,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2012-13,77494,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2012-13,77496,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2012-13,77607,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2012-13,77497,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2012-13,77498,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2012-13,77499,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2012-13,77392,Purdue Fort Wayne,Summit League,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2012-13,77500,Quinnipiac,NEC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Conference,13,exact
+2012-13,77501,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2012-13,77502,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2012-13,77503,Rice,C-USA,242,Rice Owls,Rice,Owls,RICE,American Conference,62,exact
+2012-13,77504,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2012-13,77505,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Conference,13,exact
+2012-13,77506,Robert Morris,NEC,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2012-13,77507,Rutgers,Big East,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2012-13,77546,SFA,Southland,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Southland Conference,25,exact
+2012-13,77537,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2012-13,77538,SMU,C-USA,2567,SMU Mustangs,SMU,Mustangs,SMU,Atlantic Coast Conference,2,exact
+2012-13,77314,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2012-13,77508,Sacred Heart,NEC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Metro Conference,13,exact
+2012-13,77511,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2012-13,77513,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2012-13,77514,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2012-13,77515,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2012-13,77516,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Conference,13,exact
+2012-13,77517,Sam Houston,Southland,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Conference USA,11,exact
+2012-13,77518,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2012-13,77520,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2012-13,77519,San Diego St.,Mountain West,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2012-13,77521,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2012-13,77522,San Jose St.,WAC,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2012-13,77523,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2012-13,77524,Savannah St.,MEAC,2542,Savannah State Tigers,Savannah State,Tigers,SAV,,,alias
+2012-13,77608,Seattle U,WAC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,United Athletic Conference,30,exact
+2012-13,77525,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2012-13,77526,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Conference,13,exact
+2012-13,77527,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2012-13,77529,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2012-13,77528,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2012-13,77531,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,47,exact
+2012-13,77530,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,47,exact
+2012-13,77532,South Fla.,Big East,58,South Florida Bulls,South Florida,Bulls,USF,American Conference,62,exact
+2012-13,77533,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2012-13,77534,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2012-13,77535,Southern California,Pac-12,30,USC Trojans,USC,Trojans,USC,Big Ten Conference,7,dict
+2012-13,77536,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2012-13,77539,Southern Miss.,C-USA,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2012-13,77540,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2012-13,77541,Southern Utah,Big Sky,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,United Athletic Conference,30,exact
+2012-13,77509,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2012-13,77510,St. Francis Brooklyn,NEC,2597,St. Francis Brooklyn Terriers,St. Francis Brooklyn,Terriers,SFNY,,,exact
+2012-13,77512,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2012-13,77545,Stanford,Pac-12,24,Stanford Cardinal,Stanford,Cardinal,STAN,Atlantic Coast Conference,2,exact
+2012-13,77547,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,Atlantic Sun Conference,46,exact
+2012-13,77548,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Coastal Athletic Association,10,exact
+2012-13,77549,Syracuse,Big East,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2012-13,77557,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2012-13,77550,Temple,Atlantic 10,218,Temple Owls,Temple,Owls,TEM,American Conference,62,exact
+2012-13,77554,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2012-13,77551,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2012-13,77552,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2012-13,77561,Texas,Big 12,251,Texas Longhorns,Texas,Longhorns,TEX,Southeastern Conference,23,exact
+2012-13,77556,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2012-13,77558,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2012-13,77543,Texas St.,WAC,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2012-13,77559,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2012-13,77564,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2012-13,77565,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Coastal Athletic Association,10,exact
+2012-13,77566,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2012-13,77567,Tulane,C-USA,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Conference,62,exact
+2012-13,77568,Tulsa,C-USA,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Conference,62,exact
+2012-13,77280,UAB,C-USA,5,UAB Blazers,UAB,Blazers,UAB,American Conference,62,exact
+2012-13,77317,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2012-13,77318,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2012-13,77320,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2012-13,77315,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2012-13,77324,UCF,C-USA,2116,UCF Knights,UCF,Knights,UCF,Big 12 Conference,8,exact
+2012-13,77319,UCLA,Pac-12,26,UCLA Bruins,UCLA,Bruins,UCLA,Big Ten Conference,7,exact
+2012-13,77335,UConn,Big East,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2012-13,77389,UIC,Horizon,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2012-13,77469,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2012-13,77422,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2012-13,77424,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2012-13,77446,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2012-13,77449,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2012-13,77450,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Coastal Athletic Association,10,exact
+2012-13,77474,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2012-13,77453,UNLV,Mountain West,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2012-13,77614,USC Upstate,ASUN,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2012-13,77560,UT Arlington,WAC,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,United Athletic Conference,30,exact
+2012-13,77555,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2012-13,77562,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2012-13,77489,UTRGV,GWC,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Southland Conference,25,dict
+2012-13,77563,UTSA,WAC,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,American Conference,62,exact
+2012-13,77573,Utah,Pac-12,254,Utah Utes,Utah,Utes,UTAH,Big 12 Conference,8,exact
+2012-13,77572,Utah St.,WAC,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2012-13,77620,Utah Valley,GWC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,United Athletic Conference,30,exact
+2012-13,77578,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2012-13,77574,Valparaiso,Horizon,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2012-13,77575,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2012-13,77576,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2012-13,77577,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2012-13,77580,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2012-13,77579,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2012-13,77581,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2012-13,77582,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2012-13,77584,Washington,Pac-12,264,Washington Huskies,Washington,Huskies,WASH,Big Ten Conference,7,exact
+2012-13,77583,Washington St.,Pac-12,265,Washington State Cougars,Washington State,Cougars,WSU,West Coast Conference,29,exact
+2012-13,77585,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2012-13,77586,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2012-13,77587,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2012-13,77588,Western Ill.,Summit League,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Ohio Valley Conference,20,exact
+2012-13,77589,Western Ky.,Sun Belt,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2012-13,77590,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2012-13,77591,Wichita St.,MVC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Conference,62,exact
+2012-13,77592,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Coastal Athletic Association,10,exact
+2012-13,77593,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2012-13,77595,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2012-13,77613,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2012-13,77597,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2012-13,77598,Wyoming,Mountain West,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2012-13,77599,Xavier,Atlantic 10,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2012-13,77600,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2012-13,77601,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2013-14,38007,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2013-14,37662,Abilene Christian,Southland,2000,Abilene Christian Wildcats,Abilene Christian,Wildcats,ACU,United Athletic Conference,30,exact
+2013-14,37957,Air Force,Mountain West,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2013-14,37663,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2013-14,37666,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2013-14,37664,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2013-14,37665,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2013-14,37668,Albany (NY),America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,alias
+2013-14,37669,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2013-14,37670,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2013-14,37671,App State,SoCon,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2013-14,37673,Arizona,Pac-12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Big 12 Conference,8,exact
+2013-14,37672,Arizona St.,Pac-12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Big 12 Conference,8,exact
+2013-14,37998,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2013-14,37675,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2013-14,37674,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2013-14,37958,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2013-14,37677,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2013-14,37678,Austin Peay,OVC,2046,Austin Peay Governors,Austin Peay,Governors,APSU,Atlantic Sun Conference,46,exact
+2013-14,37689,BYU,WCC,252,BYU Cougars,BYU,Cougars,BYU,Big 12 Conference,8,exact
+2013-14,37679,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2013-14,37681,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2013-14,38005,Belmont,OVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2013-14,37682,Bethune-Cookman,MEAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2013-14,37683,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2013-14,37684,Boise St.,Mountain West,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2013-14,37685,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2013-14,37686,Boston U.,Patriot,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2013-14,37687,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2013-14,37688,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2013-14,37690,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2013-14,37691,Bryant,NEC,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2013-14,37692,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2013-14,37693,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2013-14,37694,Butler,Big East,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2013-14,37696,CSU Bakersfield,WAC,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2013-14,37700,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2013-14,37695,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2013-14,37698,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2013-14,37703,California,Pac-12,25,California Golden Bears,California,Golden Bears,CAL,Atlantic Coast Conference,2,exact
+2013-14,37708,Campbell,Big South,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Coastal Athletic Association,10,exact
+2013-14,37709,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Conference,13,exact
+2013-14,37990,Central Ark.,Southland,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,Atlantic Sun Conference,46,exact
+2013-14,37710,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2013-14,37712,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2013-14,37680,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2013-14,37836,Charlotte,C-USA,2429,Charlotte 49ers,Charlotte,49ers,CLT,American Conference,62,exact
+2013-14,37941,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2013-14,37713,Chicago St.,WAC,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Northeast Conference,19,exact
+2013-14,37714,Cincinnati,AAC,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,Big 12 Conference,8,exact
+2013-14,37715,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2013-14,37716,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2013-14,37717,Coastal Carolina,Big South,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2013-14,37991,Col. of Charleston,CAA,232,Charleston Cougars,Charleston,Cougars,COFC,Coastal Athletic Association,10,dict
+2013-14,37718,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2013-14,37720,Colorado,Pac-12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Big 12 Conference,8,exact
+2013-14,37719,Colorado St.,Mountain West,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2013-14,37721,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2013-14,37723,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2013-14,37724,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2013-14,37725,Creighton,Big East,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2013-14,37726,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2013-14,37727,Davidson,SoCon,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2013-14,37728,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2013-14,37729,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2013-14,37731,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Coastal Athletic Association,10,exact
+2013-14,37730,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2013-14,37732,Denver,Summit League,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,47,exact
+2013-14,37733,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2013-14,37734,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2013-14,37735,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Coastal Athletic Association,10,exact
+2013-14,37736,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2013-14,37737,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2013-14,37739,ETSU,ASUN,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2013-14,37738,East Carolina,C-USA,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Conference,62,exact
+2013-14,37740,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2013-14,37741,Eastern Ky.,OVC,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,Atlantic Sun Conference,46,exact
+2013-14,37742,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2013-14,37743,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2013-14,37992,Elon,SoCon,2210,Elon Phoenix,Elon,Phoenix,ELON,Coastal Athletic Association,10,exact
+2013-14,37744,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2013-14,38009,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,Atlantic Sun Conference,46,exact
+2013-14,37749,FIU,C-USA,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2013-14,37745,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Conference,13,exact
+2013-14,37746,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2013-14,37748,Fla. Atlantic,C-USA,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,American Conference,62,exact
+2013-14,37751,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2013-14,37747,Florida A&M,MEAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2013-14,37750,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2013-14,37752,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2013-14,37697,Fresno St.,Mountain West,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2013-14,37753,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2013-14,37757,Ga. Southern,SoCon,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2013-14,37993,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2013-14,37754,George Mason,Atlantic 10,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2013-14,37755,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2013-14,37756,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2013-14,37760,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2013-14,37758,Georgia St.,Sun Belt,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2013-14,37759,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2013-14,37761,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2013-14,37762,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2013-14,37994,Grand Canyon,WAC,2253,Grand Canyon Lopes,Grand Canyon,Lopes,GCU,United Athletic Conference,30,exact
+2013-14,37982,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2013-14,37763,Hampton,MEAC,2261,Hampton Pirates,Hampton,Pirates,HAMP,Coastal Athletic Association,10,exact
+2013-14,37764,Hartford,America East,42,Hartford Hawks,Hartford,Hawks,HART,,,exact
+2013-14,37765,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2013-14,37766,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2013-14,38006,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2013-14,37767,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Coastal Athletic Association,10,exact
+2013-14,37768,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2013-14,37770,Houston,AAC,248,Houston Cougars,Houston,Cougars,HOU,Big 12 Conference,8,exact
+2013-14,37769,Houston Baptist,Southland,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,alias
+2013-14,37771,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2013-14,37999,IUPUI,Summit League,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,alias
+2013-14,37773,Idaho,WAC,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2013-14,37772,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2013-14,37775,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2013-14,37774,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2013-14,37778,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2013-14,37777,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2013-14,37780,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Conference,13,exact
+2013-14,37782,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2013-14,37781,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2013-14,37783,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2013-14,37785,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,Atlantic Sun Conference,46,exact
+2013-14,37784,Jacksonville St.,OVC,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,Conference USA,11,exact
+2013-14,37786,James Madison,CAA,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2013-14,37788,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2013-14,38000,Kansas City,WAC,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,47,exact
+2013-14,37787,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2013-14,37995,Kennesaw St.,ASUN,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,Conference USA,11,exact
+2013-14,37789,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2013-14,37790,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2013-14,37796,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2013-14,37803,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2013-14,37798,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2013-14,37791,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2013-14,37792,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2013-14,37793,Lamar University,Southland,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2013-14,37794,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2013-14,37795,Liberty,Big South,2335,Liberty Flames,Liberty,Flames,LIB,Conference USA,11,exact
+2013-14,38008,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,Atlantic Sun Conference,46,exact
+2013-14,37676,Little Rock,Sun Belt,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2013-14,37699,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2013-14,37797,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2013-14,37932,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2013-14,37799,Louisiana Tech,C-USA,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2013-14,37800,Louisville,AAC,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2013-14,37804,Loyola Chicago,MVC,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2013-14,37802,Loyola Maryland,Patriot,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2013-14,37805,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2013-14,37806,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Conference,13,exact
+2013-14,37807,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Conference,13,exact
+2013-14,37808,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2013-14,37809,Marshall,C-USA,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2013-14,37811,Maryland,ACC,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2013-14,37813,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2013-14,37814,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2013-14,37815,Memphis,AAC,235,Memphis Tigers,Memphis,Tigers,MEM,American Conference,62,exact
+2013-14,37816,Mercer,ASUN,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2013-14,37818,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2013-14,37817,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2013-14,37820,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2013-14,37819,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2013-14,37821,Middle Tenn.,C-USA,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2013-14,37984,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2013-14,37822,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2013-14,37823,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2013-14,37824,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2013-14,37826,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2013-14,37930,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2013-14,37827,Monmouth,MAAC,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Coastal Athletic Association,10,exact
+2013-14,37829,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2013-14,37828,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2013-14,37830,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2013-14,37831,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2013-14,37832,Mount St. Mary's,NEC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Conference,13,exact
+2013-14,37833,Murray St.,OVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2013-14,37851,N.C. A&T,MEAC,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Coastal Athletic Association,10,exact
+2013-14,37852,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2013-14,37853,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2013-14,37844,NJIT,-,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2013-14,37959,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2013-14,37839,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2013-14,37842,Nevada,Mountain West,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2013-14,37843,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2013-14,37846,New Mexico,Mountain West,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2013-14,37845,New Mexico St.,WAC,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Conference USA,11,exact
+2013-14,37847,New Orleans,Southland,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2013-14,37848,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Conference,13,exact
+2013-14,37849,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2013-14,37850,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2013-14,37835,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2013-14,37855,North Dakota,Big Sky,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,47,exact
+2013-14,37854,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,47,exact
+2013-14,38001,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,Atlantic Sun Conference,46,exact
+2013-14,37856,North Texas,C-USA,249,North Texas Mean Green,North Texas,Mean Green,UNT,American Conference,62,exact
+2013-14,37858,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Coastal Athletic Association,10,exact
+2013-14,37859,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2013-14,37860,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2013-14,37861,Northern Ill.,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2013-14,37863,Northern Ky.,ASUN,94,Northern Kentucky Norse,Northern Kentucky,Norse,NKU,Horizon League,45,exact
+2013-14,37865,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2013-14,37864,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2013-14,37866,Notre Dame,ACC,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2013-14,37867,Oakland,Horizon,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2013-14,37869,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2013-14,37868,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2013-14,37871,Oklahoma,Big 12,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Southeastern Conference,23,exact
+2013-14,37870,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2013-14,37872,Old Dominion,C-USA,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2013-14,37825,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2013-14,37840,Omaha,Summit League,2437,Omaha Mavericks,Omaha,Mavericks,OMA,Summit League,47,exact
+2013-14,37873,Oral Roberts,Southland,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,47,exact
+2013-14,37875,Oregon,Pac-12,2483,Oregon Ducks,Oregon,Ducks,ORE,Big Ten Conference,7,exact
+2013-14,37874,Oregon St.,Pac-12,204,Oregon State Beavers,Oregon State,Beavers,ORST,West Coast Conference,29,exact
+2013-14,37876,Pacific,WCC,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2013-14,37879,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2013-14,37878,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2013-14,37880,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2013-14,37881,Pittsburgh,ACC,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2013-14,37883,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2013-14,37882,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2013-14,37884,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2013-14,37996,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2013-14,37885,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2013-14,37886,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2013-14,37887,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2013-14,37779,Purdue Fort Wayne,Summit League,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2013-14,37888,Quinnipiac,MAAC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Conference,13,exact
+2013-14,37889,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2013-14,37890,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2013-14,37891,Rice,C-USA,242,Rice Owls,Rice,Owls,RICE,American Conference,62,exact
+2013-14,37892,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2013-14,37893,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Conference,13,exact
+2013-14,37894,Robert Morris,NEC,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2013-14,37895,Rutgers,AAC,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2013-14,37934,SFA,Southland,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Southland Conference,25,exact
+2013-14,37925,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2013-14,37926,SMU,AAC,2567,SMU Mustangs,SMU,Mustangs,SMU,Atlantic Coast Conference,2,exact
+2013-14,37701,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2013-14,37896,Sacred Heart,NEC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Metro Conference,13,exact
+2013-14,37899,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2013-14,37901,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2013-14,37902,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2013-14,37903,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2013-14,37904,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Conference,13,exact
+2013-14,37905,Sam Houston,Southland,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Conference USA,11,exact
+2013-14,37906,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2013-14,37908,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2013-14,37907,San Diego St.,Mountain West,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2013-14,37909,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2013-14,37910,San Jose St.,Mountain West,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2013-14,37911,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2013-14,37912,Savannah St.,MEAC,2542,Savannah State Tigers,Savannah State,Tigers,SAV,,,alias
+2013-14,37997,Seattle U,WAC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,United Athletic Conference,30,exact
+2013-14,37913,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2013-14,37914,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Conference,13,exact
+2013-14,37915,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2013-14,37917,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2013-14,37916,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2013-14,37919,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,47,exact
+2013-14,37918,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,47,exact
+2013-14,37920,South Fla.,AAC,58,South Florida Bulls,South Florida,Bulls,USF,American Conference,62,exact
+2013-14,37921,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2013-14,37922,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2013-14,37923,Southern California,Pac-12,30,USC Trojans,USC,Trojans,USC,Big Ten Conference,7,dict
+2013-14,37924,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2013-14,37927,Southern Miss.,C-USA,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2013-14,37928,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2013-14,37929,Southern Utah,Big Sky,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,United Athletic Conference,30,exact
+2013-14,37897,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2013-14,37898,St. Francis Brooklyn,NEC,2597,St. Francis Brooklyn Terriers,St. Francis Brooklyn,Terriers,SFNY,,,exact
+2013-14,37900,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2013-14,37933,Stanford,Pac-12,24,Stanford Cardinal,Stanford,Cardinal,STAN,Atlantic Coast Conference,2,exact
+2013-14,37935,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,Atlantic Sun Conference,46,exact
+2013-14,37936,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Coastal Athletic Association,10,exact
+2013-14,37937,Syracuse,ACC,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2013-14,37945,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2013-14,37938,Temple,AAC,218,Temple Owls,Temple,Owls,TEM,American Conference,62,exact
+2013-14,37942,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2013-14,37939,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2013-14,37940,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2013-14,37949,Texas,Big 12,251,Texas Longhorns,Texas,Longhorns,TEX,Southeastern Conference,23,exact
+2013-14,37944,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2013-14,37946,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2013-14,37931,Texas St.,Sun Belt,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2013-14,37947,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2013-14,37952,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2013-14,37953,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Coastal Athletic Association,10,exact
+2013-14,37954,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2013-14,37955,Tulane,C-USA,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Conference,62,exact
+2013-14,37956,Tulsa,C-USA,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Conference,62,exact
+2013-14,37667,UAB,C-USA,5,UAB Blazers,UAB,Blazers,UAB,American Conference,62,exact
+2013-14,37704,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2013-14,37705,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2013-14,37707,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2013-14,37702,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2013-14,37711,UCF,AAC,2116,UCF Knights,UCF,Knights,UCF,Big 12 Conference,8,exact
+2013-14,37706,UCLA,Pac-12,26,UCLA Bruins,UCLA,Bruins,UCLA,Big Ten Conference,7,exact
+2013-14,37722,UConn,AAC,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2013-14,37776,UIC,Horizon,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2013-14,38002,UIW,Southland,2916,Incarnate Word Cardinals,Incarnate Word,Cardinals,UIW,Southland Conference,25,exact
+2013-14,37857,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2013-14,37810,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2013-14,37812,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2013-14,37801,UMass Lowell,America East,2349,UMass Lowell River Hawks,UMass Lowell,River Hawks,UML,America East Conference,1,exact
+2013-14,37834,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2013-14,37837,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2013-14,37838,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Coastal Athletic Association,10,exact
+2013-14,37862,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2013-14,37841,UNLV,Mountain West,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2013-14,38004,USC Upstate,ASUN,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2013-14,37948,UT Arlington,Sun Belt,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,United Athletic Conference,30,exact
+2013-14,37943,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2013-14,37950,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2013-14,37877,UTRGV,WAC,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Southland Conference,25,dict
+2013-14,37951,UTSA,C-USA,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,American Conference,62,exact
+2013-14,37961,Utah,Pac-12,254,Utah Utes,Utah,Utes,UTAH,Big 12 Conference,8,exact
+2013-14,37960,Utah St.,Mountain West,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2013-14,38010,Utah Valley,WAC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,United Athletic Conference,30,exact
+2013-14,37966,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2013-14,37962,Valparaiso,Horizon,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2013-14,37963,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2013-14,37964,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2013-14,37965,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2013-14,37968,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2013-14,37967,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2013-14,37969,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2013-14,37970,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2013-14,37972,Washington,Pac-12,264,Washington Huskies,Washington,Huskies,WASH,Big Ten Conference,7,exact
+2013-14,37971,Washington St.,Pac-12,265,Washington State Cougars,Washington State,Cougars,WSU,West Coast Conference,29,exact
+2013-14,37973,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2013-14,37974,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2013-14,37975,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2013-14,37976,Western Ill.,Summit League,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Ohio Valley Conference,20,exact
+2013-14,37977,Western Ky.,Sun Belt,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2013-14,37978,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2013-14,37979,Wichita St.,MVC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Conference,62,exact
+2013-14,37980,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Coastal Athletic Association,10,exact
+2013-14,37981,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2013-14,37983,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2013-14,38003,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2013-14,37985,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2013-14,37986,Wyoming,Mountain West,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2013-14,37987,Xavier,Big East,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2013-14,37988,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2013-14,37989,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2014-15,16938,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2014-15,16593,Abilene Christian,Southland,2000,Abilene Christian Wildcats,Abilene Christian,Wildcats,ACU,United Athletic Conference,30,exact
+2014-15,16888,Air Force,Mountain West,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2014-15,16594,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2014-15,16597,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2014-15,16595,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2014-15,16596,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2014-15,16599,Albany (NY),America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,alias
+2014-15,16600,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2014-15,16601,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2014-15,16602,App State,Sun Belt,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2014-15,16604,Arizona,Pac-12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Big 12 Conference,8,exact
+2014-15,16603,Arizona St.,Pac-12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Big 12 Conference,8,exact
+2014-15,16929,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2014-15,16606,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2014-15,16605,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2014-15,16889,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2014-15,16608,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2014-15,16609,Austin Peay,OVC,2046,Austin Peay Governors,Austin Peay,Governors,APSU,Atlantic Sun Conference,46,exact
+2014-15,16620,BYU,WCC,252,BYU Cougars,BYU,Cougars,BYU,Big 12 Conference,8,exact
+2014-15,16610,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2014-15,16612,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2014-15,16936,Belmont,OVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2014-15,16613,Bethune-Cookman,MEAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2014-15,16614,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2014-15,16615,Boise St.,Mountain West,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2014-15,16616,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2014-15,16617,Boston U.,Patriot,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2014-15,16618,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2014-15,16619,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2014-15,16621,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2014-15,16622,Bryant,NEC,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2014-15,16623,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2014-15,16624,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2014-15,16625,Butler,Big East,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2014-15,16627,CSU Bakersfield,WAC,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2014-15,16631,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2014-15,16626,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2014-15,16629,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2014-15,16634,California,Pac-12,25,California Golden Bears,California,Golden Bears,CAL,Atlantic Coast Conference,2,exact
+2014-15,16639,Campbell,Big South,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Coastal Athletic Association,10,exact
+2014-15,16640,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Conference,13,exact
+2014-15,16921,Central Ark.,Southland,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,Atlantic Sun Conference,46,exact
+2014-15,16641,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2014-15,16643,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2014-15,16611,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2014-15,16767,Charlotte,C-USA,2429,Charlotte 49ers,Charlotte,49ers,CLT,American Conference,62,exact
+2014-15,16872,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2014-15,16644,Chicago St.,WAC,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Northeast Conference,19,exact
+2014-15,16645,Cincinnati,AAC,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,Big 12 Conference,8,exact
+2014-15,16646,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2014-15,16647,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2014-15,16648,Coastal Carolina,Big South,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2014-15,16922,Col. of Charleston,CAA,232,Charleston Cougars,Charleston,Cougars,COFC,Coastal Athletic Association,10,dict
+2014-15,16649,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2014-15,16651,Colorado,Pac-12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Big 12 Conference,8,exact
+2014-15,16650,Colorado St.,Mountain West,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2014-15,16652,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2014-15,16654,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2014-15,16655,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2014-15,16656,Creighton,Big East,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2014-15,16657,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2014-15,16658,Davidson,Atlantic 10,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2014-15,16659,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2014-15,16660,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2014-15,16662,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Coastal Athletic Association,10,exact
+2014-15,16661,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2014-15,16663,Denver,Summit League,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,47,exact
+2014-15,16664,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2014-15,16665,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2014-15,16666,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Coastal Athletic Association,10,exact
+2014-15,16667,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2014-15,16668,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2014-15,16670,ETSU,SoCon,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2014-15,16669,East Carolina,AAC,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Conference,62,exact
+2014-15,16671,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2014-15,16672,Eastern Ky.,OVC,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,Atlantic Sun Conference,46,exact
+2014-15,16673,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2014-15,16674,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2014-15,16923,Elon,CAA,2210,Elon Phoenix,Elon,Phoenix,ELON,Coastal Athletic Association,10,exact
+2014-15,16675,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2014-15,16940,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,Atlantic Sun Conference,46,exact
+2014-15,16680,FIU,C-USA,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2014-15,16676,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Conference,13,exact
+2014-15,16677,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2014-15,16679,Fla. Atlantic,C-USA,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,American Conference,62,exact
+2014-15,16682,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2014-15,16678,Florida A&M,MEAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2014-15,16681,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2014-15,16683,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2014-15,16628,Fresno St.,Mountain West,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2014-15,16684,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2014-15,16688,Ga. Southern,Sun Belt,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2014-15,16924,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2014-15,16685,George Mason,Atlantic 10,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2014-15,16686,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2014-15,16687,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2014-15,16691,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2014-15,16689,Georgia St.,Sun Belt,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2014-15,16690,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2014-15,16692,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2014-15,16693,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2014-15,16925,Grand Canyon,WAC,2253,Grand Canyon Lopes,Grand Canyon,Lopes,GCU,United Athletic Conference,30,exact
+2014-15,16913,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2014-15,16694,Hampton,MEAC,2261,Hampton Pirates,Hampton,Pirates,HAMP,Coastal Athletic Association,10,exact
+2014-15,16695,Hartford,America East,42,Hartford Hawks,Hartford,Hawks,HART,,,exact
+2014-15,16696,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2014-15,16697,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2014-15,16937,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2014-15,16698,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Coastal Athletic Association,10,exact
+2014-15,16699,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2014-15,16701,Houston,AAC,248,Houston Cougars,Houston,Cougars,HOU,Big 12 Conference,8,exact
+2014-15,16700,Houston Baptist,Southland,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,alias
+2014-15,16702,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2014-15,16930,IUPUI,Summit League,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,alias
+2014-15,16704,Idaho,Big Sky,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2014-15,16703,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2014-15,16706,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2014-15,16705,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2014-15,16709,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2014-15,16708,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2014-15,16711,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Conference,13,exact
+2014-15,16713,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2014-15,16712,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2014-15,16714,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2014-15,16716,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,Atlantic Sun Conference,46,exact
+2014-15,16715,Jacksonville St.,OVC,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,Conference USA,11,exact
+2014-15,16717,James Madison,CAA,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2014-15,16719,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2014-15,16931,Kansas City,WAC,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,47,exact
+2014-15,16718,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2014-15,16926,Kennesaw St.,ASUN,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,Conference USA,11,exact
+2014-15,16720,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2014-15,16721,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2014-15,16727,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2014-15,16734,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2014-15,16729,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2014-15,16722,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2014-15,16723,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2014-15,16724,Lamar University,Southland,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2014-15,16725,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2014-15,16726,Liberty,Big South,2335,Liberty Flames,Liberty,Flames,LIB,Conference USA,11,exact
+2014-15,16939,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,Atlantic Sun Conference,46,exact
+2014-15,16607,Little Rock,Sun Belt,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2014-15,16630,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2014-15,16728,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2014-15,16863,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2014-15,16730,Louisiana Tech,C-USA,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2014-15,16731,Louisville,ACC,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2014-15,16735,Loyola Chicago,MVC,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2014-15,16733,Loyola Maryland,Patriot,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2014-15,16736,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2014-15,16737,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Conference,13,exact
+2014-15,16738,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Conference,13,exact
+2014-15,16739,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2014-15,16740,Marshall,C-USA,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2014-15,16742,Maryland,Big Ten,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2014-15,16744,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2014-15,16745,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2014-15,16746,Memphis,AAC,235,Memphis Tigers,Memphis,Tigers,MEM,American Conference,62,exact
+2014-15,16747,Mercer,SoCon,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2014-15,16749,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2014-15,16748,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2014-15,16751,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2014-15,16750,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2014-15,16752,Middle Tenn.,C-USA,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2014-15,16915,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2014-15,16753,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2014-15,16754,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2014-15,16755,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2014-15,16757,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2014-15,16861,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2014-15,16758,Monmouth,MAAC,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Coastal Athletic Association,10,exact
+2014-15,16760,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2014-15,16759,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2014-15,16761,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2014-15,16762,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2014-15,16763,Mount St. Mary's,NEC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Conference,13,exact
+2014-15,16764,Murray St.,OVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2014-15,16782,N.C. A&T,MEAC,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Coastal Athletic Association,10,exact
+2014-15,16783,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2014-15,16784,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2014-15,16775,NJIT,-,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2014-15,16890,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2014-15,16770,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2014-15,16773,Nevada,Mountain West,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2014-15,16774,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2014-15,16777,New Mexico,Mountain West,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2014-15,16776,New Mexico St.,WAC,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Conference USA,11,exact
+2014-15,16778,New Orleans,Southland,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2014-15,16779,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Conference,13,exact
+2014-15,16780,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2014-15,16781,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2014-15,16766,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2014-15,16786,North Dakota,Big Sky,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,47,exact
+2014-15,16785,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,47,exact
+2014-15,16932,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,Atlantic Sun Conference,46,exact
+2014-15,16787,North Texas,C-USA,249,North Texas Mean Green,North Texas,Mean Green,UNT,American Conference,62,exact
+2014-15,16789,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Coastal Athletic Association,10,exact
+2014-15,16790,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2014-15,16791,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2014-15,16792,Northern Ill.,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2014-15,16794,Northern Ky.,ASUN,94,Northern Kentucky Norse,Northern Kentucky,Norse,NKU,Horizon League,45,exact
+2014-15,16796,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2014-15,16795,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2014-15,16797,Notre Dame,ACC,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2014-15,16798,Oakland,Horizon,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2014-15,16800,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2014-15,16799,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2014-15,16802,Oklahoma,Big 12,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Southeastern Conference,23,exact
+2014-15,16801,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2014-15,16803,Old Dominion,C-USA,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2014-15,16756,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2014-15,16771,Omaha,Summit League,2437,Omaha Mavericks,Omaha,Mavericks,OMA,Summit League,47,exact
+2014-15,16804,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,47,exact
+2014-15,16806,Oregon,Pac-12,2483,Oregon Ducks,Oregon,Ducks,ORE,Big Ten Conference,7,exact
+2014-15,16805,Oregon St.,Pac-12,204,Oregon State Beavers,Oregon State,Beavers,ORST,West Coast Conference,29,exact
+2014-15,16807,Pacific,WCC,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2014-15,16810,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2014-15,16809,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2014-15,16811,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2014-15,16812,Pittsburgh,ACC,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2014-15,16814,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2014-15,16813,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2014-15,16815,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2014-15,16927,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2014-15,16816,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2014-15,16817,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2014-15,16818,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2014-15,16710,Purdue Fort Wayne,Summit League,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2014-15,16819,Quinnipiac,MAAC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Conference,13,exact
+2014-15,16820,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2014-15,16821,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2014-15,16822,Rice,C-USA,242,Rice Owls,Rice,Owls,RICE,American Conference,62,exact
+2014-15,16823,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2014-15,16824,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Conference,13,exact
+2014-15,16825,Robert Morris,NEC,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2014-15,16826,Rutgers,Big Ten,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2014-15,16865,SFA,Southland,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Southland Conference,25,exact
+2014-15,16856,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2014-15,16857,SMU,AAC,2567,SMU Mustangs,SMU,Mustangs,SMU,Atlantic Coast Conference,2,exact
+2014-15,16632,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2014-15,16827,Sacred Heart,NEC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Metro Conference,13,exact
+2014-15,16830,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2014-15,16832,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2014-15,16833,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2014-15,16834,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2014-15,16835,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Conference,13,exact
+2014-15,16836,Sam Houston,Southland,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Conference USA,11,exact
+2014-15,16837,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2014-15,16839,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2014-15,16838,San Diego St.,Mountain West,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2014-15,16840,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2014-15,16841,San Jose St.,Mountain West,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2014-15,16842,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2014-15,16843,Savannah St.,MEAC,2542,Savannah State Tigers,Savannah State,Tigers,SAV,,,alias
+2014-15,16928,Seattle U,WAC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,United Athletic Conference,30,exact
+2014-15,16844,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2014-15,16845,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Conference,13,exact
+2014-15,16846,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2014-15,16848,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2014-15,16847,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2014-15,16850,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,47,exact
+2014-15,16849,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,47,exact
+2014-15,16851,South Fla.,AAC,58,South Florida Bulls,South Florida,Bulls,USF,American Conference,62,exact
+2014-15,16852,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2014-15,16853,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2014-15,16854,Southern California,Pac-12,30,USC Trojans,USC,Trojans,USC,Big Ten Conference,7,dict
+2014-15,16855,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2014-15,16858,Southern Miss.,C-USA,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2014-15,16859,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2014-15,16860,Southern Utah,Big Sky,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,United Athletic Conference,30,exact
+2014-15,16828,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2014-15,16829,St. Francis Brooklyn,NEC,2597,St. Francis Brooklyn Terriers,St. Francis Brooklyn,Terriers,SFNY,,,exact
+2014-15,16831,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2014-15,16864,Stanford,Pac-12,24,Stanford Cardinal,Stanford,Cardinal,STAN,Atlantic Coast Conference,2,exact
+2014-15,16866,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,Atlantic Sun Conference,46,exact
+2014-15,16867,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Coastal Athletic Association,10,exact
+2014-15,16868,Syracuse,ACC,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2014-15,16876,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2014-15,16869,Temple,AAC,218,Temple Owls,Temple,Owls,TEM,American Conference,62,exact
+2014-15,16873,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2014-15,16870,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2014-15,16871,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2014-15,16880,Texas,Big 12,251,Texas Longhorns,Texas,Longhorns,TEX,Southeastern Conference,23,exact
+2014-15,16875,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2014-15,16877,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2014-15,16862,Texas St.,Sun Belt,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2014-15,16878,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2014-15,16883,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2014-15,16884,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Coastal Athletic Association,10,exact
+2014-15,16885,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2014-15,16886,Tulane,AAC,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Conference,62,exact
+2014-15,16887,Tulsa,AAC,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Conference,62,exact
+2014-15,16598,UAB,C-USA,5,UAB Blazers,UAB,Blazers,UAB,American Conference,62,exact
+2014-15,16635,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2014-15,16636,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2014-15,16638,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2014-15,16633,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2014-15,16642,UCF,AAC,2116,UCF Knights,UCF,Knights,UCF,Big 12 Conference,8,exact
+2014-15,16637,UCLA,Pac-12,26,UCLA Bruins,UCLA,Bruins,UCLA,Big Ten Conference,7,exact
+2014-15,16653,UConn,AAC,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2014-15,16707,UIC,Horizon,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2014-15,16933,UIW,Southland,2916,Incarnate Word Cardinals,Incarnate Word,Cardinals,UIW,Southland Conference,25,exact
+2014-15,16788,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2014-15,16741,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2014-15,16743,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2014-15,16732,UMass Lowell,America East,2349,UMass Lowell River Hawks,UMass Lowell,River Hawks,UML,America East Conference,1,exact
+2014-15,16765,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2014-15,16768,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2014-15,16769,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Coastal Athletic Association,10,exact
+2014-15,16793,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2014-15,16772,UNLV,Mountain West,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2014-15,16935,USC Upstate,ASUN,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2014-15,16879,UT Arlington,Sun Belt,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,United Athletic Conference,30,exact
+2014-15,16874,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2014-15,16881,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2014-15,16808,UTRGV,WAC,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Southland Conference,25,dict
+2014-15,16882,UTSA,C-USA,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,American Conference,62,exact
+2014-15,16892,Utah,Pac-12,254,Utah Utes,Utah,Utes,UTAH,Big 12 Conference,8,exact
+2014-15,16891,Utah St.,Mountain West,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2014-15,16941,Utah Valley,WAC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,United Athletic Conference,30,exact
+2014-15,16897,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2014-15,16893,Valparaiso,Horizon,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2014-15,16894,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2014-15,16895,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2014-15,16896,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2014-15,16899,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2014-15,16898,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2014-15,16900,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2014-15,16901,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2014-15,16903,Washington,Pac-12,264,Washington Huskies,Washington,Huskies,WASH,Big Ten Conference,7,exact
+2014-15,16902,Washington St.,Pac-12,265,Washington State Cougars,Washington State,Cougars,WSU,West Coast Conference,29,exact
+2014-15,16904,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2014-15,16905,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2014-15,16906,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2014-15,16907,Western Ill.,Summit League,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Ohio Valley Conference,20,exact
+2014-15,16908,Western Ky.,C-USA,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2014-15,16909,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2014-15,16910,Wichita St.,MVC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Conference,62,exact
+2014-15,16911,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Coastal Athletic Association,10,exact
+2014-15,16912,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2014-15,16914,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2014-15,16934,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2014-15,16916,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2014-15,16917,Wyoming,Mountain West,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2014-15,16918,Xavier,Big East,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2014-15,16919,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2014-15,16920,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2015-16,23167,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2015-16,22822,Abilene Christian,Southland,2000,Abilene Christian Wildcats,Abilene Christian,Wildcats,ACU,United Athletic Conference,30,exact
+2015-16,23117,Air Force,Mountain West,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2015-16,22823,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2015-16,22826,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2015-16,22824,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2015-16,22825,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2015-16,22828,Albany (NY),America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,alias
+2015-16,22829,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2015-16,22830,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2015-16,22831,App State,Sun Belt,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2015-16,22833,Arizona,Pac-12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Big 12 Conference,8,exact
+2015-16,22832,Arizona St.,Pac-12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Big 12 Conference,8,exact
+2015-16,23158,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2015-16,22835,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2015-16,22834,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2015-16,23118,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2015-16,22837,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2015-16,22838,Austin Peay,OVC,2046,Austin Peay Governors,Austin Peay,Governors,APSU,Atlantic Sun Conference,46,exact
+2015-16,22849,BYU,WCC,252,BYU Cougars,BYU,Cougars,BYU,Big 12 Conference,8,exact
+2015-16,22839,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2015-16,22841,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2015-16,23165,Belmont,OVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2015-16,22842,Bethune-Cookman,MEAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2015-16,22843,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2015-16,22844,Boise St.,Mountain West,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2015-16,22845,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2015-16,22846,Boston U.,Patriot,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2015-16,22847,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2015-16,22848,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2015-16,22850,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2015-16,22851,Bryant,NEC,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2015-16,22852,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2015-16,22853,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2015-16,22854,Butler,Big East,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2015-16,22856,CSU Bakersfield,WAC,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2015-16,22860,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2015-16,22855,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2015-16,22858,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2015-16,22863,California,Pac-12,25,California Golden Bears,California,Golden Bears,CAL,Atlantic Coast Conference,2,exact
+2015-16,22868,Campbell,Big South,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Coastal Athletic Association,10,exact
+2015-16,22869,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Conference,13,exact
+2015-16,23150,Central Ark.,Southland,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,Atlantic Sun Conference,46,exact
+2015-16,22870,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2015-16,22872,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2015-16,22840,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2015-16,22996,Charlotte,C-USA,2429,Charlotte 49ers,Charlotte,49ers,CLT,American Conference,62,exact
+2015-16,23101,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2015-16,22873,Chicago St.,WAC,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Northeast Conference,19,exact
+2015-16,22874,Cincinnati,AAC,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,Big 12 Conference,8,exact
+2015-16,22875,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2015-16,22876,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2015-16,22877,Coastal Carolina,Big South,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2015-16,23151,Col. of Charleston,CAA,232,Charleston Cougars,Charleston,Cougars,COFC,Coastal Athletic Association,10,dict
+2015-16,22878,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2015-16,22880,Colorado,Pac-12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Big 12 Conference,8,exact
+2015-16,22879,Colorado St.,Mountain West,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2015-16,22881,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2015-16,22883,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2015-16,22884,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2015-16,22885,Creighton,Big East,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2015-16,22886,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2015-16,22887,Davidson,Atlantic 10,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2015-16,22888,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2015-16,22889,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2015-16,22891,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Coastal Athletic Association,10,exact
+2015-16,22890,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2015-16,22892,Denver,Summit League,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,47,exact
+2015-16,22893,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2015-16,22894,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2015-16,22895,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Coastal Athletic Association,10,exact
+2015-16,22896,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2015-16,22897,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2015-16,22899,ETSU,SoCon,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2015-16,22898,East Carolina,AAC,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Conference,62,exact
+2015-16,22900,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2015-16,22901,Eastern Ky.,OVC,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,Atlantic Sun Conference,46,exact
+2015-16,22902,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2015-16,22903,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2015-16,23152,Elon,CAA,2210,Elon Phoenix,Elon,Phoenix,ELON,Coastal Athletic Association,10,exact
+2015-16,22904,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2015-16,23169,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,Atlantic Sun Conference,46,exact
+2015-16,22909,FIU,C-USA,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2015-16,22905,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Conference,13,exact
+2015-16,22906,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2015-16,22908,Fla. Atlantic,C-USA,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,American Conference,62,exact
+2015-16,22911,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2015-16,22907,Florida A&M,MEAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2015-16,22910,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2015-16,22912,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2015-16,22857,Fresno St.,Mountain West,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2015-16,22913,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2015-16,22917,Ga. Southern,Sun Belt,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2015-16,23153,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2015-16,22914,George Mason,Atlantic 10,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2015-16,22915,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2015-16,22916,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2015-16,22920,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2015-16,22918,Georgia St.,Sun Belt,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2015-16,22919,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2015-16,22921,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2015-16,22922,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2015-16,23154,Grand Canyon,WAC,2253,Grand Canyon Lopes,Grand Canyon,Lopes,GCU,United Athletic Conference,30,exact
+2015-16,23142,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2015-16,22923,Hampton,MEAC,2261,Hampton Pirates,Hampton,Pirates,HAMP,Coastal Athletic Association,10,exact
+2015-16,22924,Hartford,America East,42,Hartford Hawks,Hartford,Hawks,HART,,,exact
+2015-16,22925,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2015-16,22926,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2015-16,23166,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2015-16,22927,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Coastal Athletic Association,10,exact
+2015-16,22928,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2015-16,22930,Houston,AAC,248,Houston Cougars,Houston,Cougars,HOU,Big 12 Conference,8,exact
+2015-16,22929,Houston Baptist,Southland,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,alias
+2015-16,22931,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2015-16,23159,IUPUI,Summit League,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,alias
+2015-16,22933,Idaho,Big Sky,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2015-16,22932,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2015-16,22935,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2015-16,22934,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2015-16,22938,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2015-16,22937,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2015-16,22940,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Conference,13,exact
+2015-16,22942,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2015-16,22941,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2015-16,22943,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2015-16,22945,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,Atlantic Sun Conference,46,exact
+2015-16,22944,Jacksonville St.,OVC,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,Conference USA,11,exact
+2015-16,22946,James Madison,CAA,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2015-16,22948,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2015-16,23160,Kansas City,WAC,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,47,exact
+2015-16,22947,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2015-16,23155,Kennesaw St.,ASUN,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,Conference USA,11,exact
+2015-16,22949,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2015-16,22950,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2015-16,22956,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2015-16,22963,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2015-16,22958,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2015-16,22951,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2015-16,22952,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2015-16,22953,Lamar University,Southland,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2015-16,22954,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2015-16,22955,Liberty,Big South,2335,Liberty Flames,Liberty,Flames,LIB,Conference USA,11,exact
+2015-16,23168,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,Atlantic Sun Conference,46,exact
+2015-16,22836,Little Rock,Sun Belt,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2015-16,22859,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2015-16,22957,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2015-16,23092,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2015-16,22959,Louisiana Tech,C-USA,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2015-16,22960,Louisville,ACC,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2015-16,22964,Loyola Chicago,MVC,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2015-16,22962,Loyola Maryland,Patriot,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2015-16,22965,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2015-16,22966,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Conference,13,exact
+2015-16,22967,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Conference,13,exact
+2015-16,22968,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2015-16,22969,Marshall,C-USA,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2015-16,22971,Maryland,Big Ten,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2015-16,22973,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2015-16,22974,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2015-16,22975,Memphis,AAC,235,Memphis Tigers,Memphis,Tigers,MEM,American Conference,62,exact
+2015-16,22976,Mercer,SoCon,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2015-16,22978,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2015-16,22977,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2015-16,22980,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2015-16,22979,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2015-16,22981,Middle Tenn.,C-USA,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2015-16,23144,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2015-16,22982,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2015-16,22983,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2015-16,22984,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2015-16,22986,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2015-16,23090,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2015-16,22987,Monmouth,MAAC,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Coastal Athletic Association,10,exact
+2015-16,22989,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2015-16,22988,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2015-16,22990,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2015-16,22991,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2015-16,22992,Mount St. Mary's,NEC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Conference,13,exact
+2015-16,22993,Murray St.,OVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2015-16,23011,N.C. A&T,MEAC,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Coastal Athletic Association,10,exact
+2015-16,23012,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2015-16,23013,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2015-16,23004,NJIT,ASUN,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2015-16,23119,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2015-16,22999,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2015-16,23002,Nevada,Mountain West,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2015-16,23003,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2015-16,23006,New Mexico,Mountain West,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2015-16,23005,New Mexico St.,WAC,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Conference USA,11,exact
+2015-16,23007,New Orleans,Southland,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2015-16,23008,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Conference,13,exact
+2015-16,23009,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2015-16,23010,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2015-16,22995,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2015-16,23015,North Dakota,Big Sky,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,47,exact
+2015-16,23014,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,47,exact
+2015-16,23161,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,Atlantic Sun Conference,46,exact
+2015-16,23016,North Texas,C-USA,249,North Texas Mean Green,North Texas,Mean Green,UNT,American Conference,62,exact
+2015-16,23018,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Coastal Athletic Association,10,exact
+2015-16,23019,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2015-16,23020,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2015-16,23021,Northern Ill.,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2015-16,23023,Northern Ky.,Horizon,94,Northern Kentucky Norse,Northern Kentucky,Norse,NKU,Horizon League,45,exact
+2015-16,23025,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2015-16,23024,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2015-16,23026,Notre Dame,ACC,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2015-16,23027,Oakland,Horizon,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2015-16,23029,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2015-16,23028,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2015-16,23031,Oklahoma,Big 12,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Southeastern Conference,23,exact
+2015-16,23030,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2015-16,23032,Old Dominion,C-USA,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2015-16,22985,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2015-16,23000,Omaha,Summit League,2437,Omaha Mavericks,Omaha,Mavericks,OMA,Summit League,47,exact
+2015-16,23033,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,47,exact
+2015-16,23035,Oregon,Pac-12,2483,Oregon Ducks,Oregon,Ducks,ORE,Big Ten Conference,7,exact
+2015-16,23034,Oregon St.,Pac-12,204,Oregon State Beavers,Oregon State,Beavers,ORST,West Coast Conference,29,exact
+2015-16,23036,Pacific,WCC,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2015-16,23039,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2015-16,23038,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2015-16,23040,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2015-16,23041,Pittsburgh,ACC,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2015-16,23043,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2015-16,23042,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2015-16,23044,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2015-16,23156,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2015-16,23045,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2015-16,23046,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2015-16,23047,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2015-16,22939,Purdue Fort Wayne,Summit League,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2015-16,23048,Quinnipiac,MAAC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Conference,13,exact
+2015-16,23049,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2015-16,23050,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2015-16,23051,Rice,C-USA,242,Rice Owls,Rice,Owls,RICE,American Conference,62,exact
+2015-16,23052,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2015-16,23053,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Conference,13,exact
+2015-16,23054,Robert Morris,NEC,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2015-16,23055,Rutgers,Big Ten,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2015-16,23094,SFA,Southland,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Southland Conference,25,exact
+2015-16,23085,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2015-16,23086,SMU,AAC,2567,SMU Mustangs,SMU,Mustangs,SMU,Atlantic Coast Conference,2,exact
+2015-16,22861,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2015-16,23056,Sacred Heart,NEC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Metro Conference,13,exact
+2015-16,23059,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2015-16,23061,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2015-16,23062,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2015-16,23063,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2015-16,23064,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Conference,13,exact
+2015-16,23065,Sam Houston,Southland,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Conference USA,11,exact
+2015-16,23066,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2015-16,23068,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2015-16,23067,San Diego St.,Mountain West,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2015-16,23069,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2015-16,23070,San Jose St.,Mountain West,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2015-16,23071,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2015-16,23072,Savannah St.,MEAC,2542,Savannah State Tigers,Savannah State,Tigers,SAV,,,alias
+2015-16,23157,Seattle U,WAC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,United Athletic Conference,30,exact
+2015-16,23073,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2015-16,23074,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Conference,13,exact
+2015-16,23075,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2015-16,23077,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2015-16,23076,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2015-16,23079,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,47,exact
+2015-16,23078,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,47,exact
+2015-16,23080,South Fla.,AAC,58,South Florida Bulls,South Florida,Bulls,USF,American Conference,62,exact
+2015-16,23081,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2015-16,23082,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2015-16,23083,Southern California,Pac-12,30,USC Trojans,USC,Trojans,USC,Big Ten Conference,7,dict
+2015-16,23084,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2015-16,23087,Southern Miss.,C-USA,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2015-16,23088,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2015-16,23089,Southern Utah,Big Sky,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,United Athletic Conference,30,exact
+2015-16,23057,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2015-16,23058,St. Francis Brooklyn,NEC,2597,St. Francis Brooklyn Terriers,St. Francis Brooklyn,Terriers,SFNY,,,exact
+2015-16,23060,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2015-16,23093,Stanford,Pac-12,24,Stanford Cardinal,Stanford,Cardinal,STAN,Atlantic Coast Conference,2,exact
+2015-16,23095,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,Atlantic Sun Conference,46,exact
+2015-16,23096,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Coastal Athletic Association,10,exact
+2015-16,23097,Syracuse,ACC,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2015-16,23105,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2015-16,23098,Temple,AAC,218,Temple Owls,Temple,Owls,TEM,American Conference,62,exact
+2015-16,23102,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2015-16,23099,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2015-16,23100,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2015-16,23109,Texas,Big 12,251,Texas Longhorns,Texas,Longhorns,TEX,Southeastern Conference,23,exact
+2015-16,23104,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2015-16,23106,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2015-16,23091,Texas St.,Sun Belt,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2015-16,23107,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2015-16,23112,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2015-16,23113,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Coastal Athletic Association,10,exact
+2015-16,23114,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2015-16,23115,Tulane,AAC,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Conference,62,exact
+2015-16,23116,Tulsa,AAC,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Conference,62,exact
+2015-16,22827,UAB,C-USA,5,UAB Blazers,UAB,Blazers,UAB,American Conference,62,exact
+2015-16,22864,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2015-16,22865,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2015-16,22867,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2015-16,22862,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2015-16,22871,UCF,AAC,2116,UCF Knights,UCF,Knights,UCF,Big 12 Conference,8,exact
+2015-16,22866,UCLA,Pac-12,26,UCLA Bruins,UCLA,Bruins,UCLA,Big Ten Conference,7,exact
+2015-16,22882,UConn,AAC,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2015-16,22936,UIC,Horizon,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2015-16,23162,UIW,Southland,2916,Incarnate Word Cardinals,Incarnate Word,Cardinals,UIW,Southland Conference,25,exact
+2015-16,23017,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2015-16,22970,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2015-16,22972,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2015-16,22961,UMass Lowell,America East,2349,UMass Lowell River Hawks,UMass Lowell,River Hawks,UML,America East Conference,1,exact
+2015-16,22994,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2015-16,22997,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2015-16,22998,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Coastal Athletic Association,10,exact
+2015-16,23022,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2015-16,23001,UNLV,Mountain West,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2015-16,23164,USC Upstate,ASUN,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2015-16,23108,UT Arlington,Sun Belt,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,United Athletic Conference,30,exact
+2015-16,23103,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2015-16,23110,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2015-16,23037,UTRGV,WAC,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Southland Conference,25,dict
+2015-16,23111,UTSA,C-USA,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,American Conference,62,exact
+2015-16,23121,Utah,Pac-12,254,Utah Utes,Utah,Utes,UTAH,Big 12 Conference,8,exact
+2015-16,23120,Utah St.,Mountain West,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2015-16,23170,Utah Valley,WAC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,United Athletic Conference,30,exact
+2015-16,23126,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2015-16,23122,Valparaiso,Horizon,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2015-16,23123,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2015-16,23124,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2015-16,23125,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2015-16,23128,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2015-16,23127,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2015-16,23129,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2015-16,23130,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2015-16,23132,Washington,Pac-12,264,Washington Huskies,Washington,Huskies,WASH,Big Ten Conference,7,exact
+2015-16,23131,Washington St.,Pac-12,265,Washington State Cougars,Washington State,Cougars,WSU,West Coast Conference,29,exact
+2015-16,23133,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2015-16,23134,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2015-16,23135,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2015-16,23136,Western Ill.,Summit League,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Ohio Valley Conference,20,exact
+2015-16,23137,Western Ky.,C-USA,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2015-16,23138,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2015-16,23139,Wichita St.,MVC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Conference,62,exact
+2015-16,23140,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Coastal Athletic Association,10,exact
+2015-16,23141,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2015-16,23143,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2015-16,23163,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2015-16,23145,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2015-16,23146,Wyoming,Mountain West,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2015-16,23147,Xavier,Big East,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2015-16,23148,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2015-16,23149,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2016-17,109740,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2016-17,109395,Abilene Christian,Southland,2000,Abilene Christian Wildcats,Abilene Christian,Wildcats,ACU,United Athletic Conference,30,exact
+2016-17,109690,Air Force,Mountain West,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2016-17,109396,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2016-17,109399,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2016-17,109397,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2016-17,109398,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2016-17,109401,Albany (NY),America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,alias
+2016-17,109402,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2016-17,109403,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2016-17,109404,App State,Sun Belt,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2016-17,109406,Arizona,Pac-12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Big 12 Conference,8,exact
+2016-17,109405,Arizona St.,Pac-12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Big 12 Conference,8,exact
+2016-17,109731,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2016-17,109408,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2016-17,109407,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2016-17,109691,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2016-17,109410,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2016-17,109411,Austin Peay,OVC,2046,Austin Peay Governors,Austin Peay,Governors,APSU,Atlantic Sun Conference,46,exact
+2016-17,109422,BYU,WCC,252,BYU Cougars,BYU,Cougars,BYU,Big 12 Conference,8,exact
+2016-17,109412,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2016-17,109414,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2016-17,109738,Belmont,OVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2016-17,109415,Bethune-Cookman,MEAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2016-17,109416,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2016-17,109417,Boise St.,Mountain West,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2016-17,109418,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2016-17,109419,Boston U.,Patriot,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2016-17,109420,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2016-17,109421,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2016-17,109423,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2016-17,109424,Bryant,NEC,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2016-17,109425,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2016-17,109426,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2016-17,109427,Butler,Big East,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2016-17,109429,CSU Bakersfield,WAC,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2016-17,109433,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2016-17,109428,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2016-17,109431,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2016-17,109436,California,Pac-12,25,California Golden Bears,California,Golden Bears,CAL,Atlantic Coast Conference,2,exact
+2016-17,109441,Campbell,Big South,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Coastal Athletic Association,10,exact
+2016-17,109442,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Conference,13,exact
+2016-17,109723,Central Ark.,Southland,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,Atlantic Sun Conference,46,exact
+2016-17,109443,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2016-17,109445,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2016-17,109413,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2016-17,109569,Charlotte,C-USA,2429,Charlotte 49ers,Charlotte,49ers,CLT,American Conference,62,exact
+2016-17,109674,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2016-17,109446,Chicago St.,WAC,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Northeast Conference,19,exact
+2016-17,109447,Cincinnati,AAC,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,Big 12 Conference,8,exact
+2016-17,109448,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2016-17,109449,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2016-17,109450,Coastal Carolina,Sun Belt,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2016-17,109724,Col. of Charleston,CAA,232,Charleston Cougars,Charleston,Cougars,COFC,Coastal Athletic Association,10,dict
+2016-17,109451,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2016-17,109453,Colorado,Pac-12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Big 12 Conference,8,exact
+2016-17,109452,Colorado St.,Mountain West,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2016-17,109454,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2016-17,109456,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2016-17,109457,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2016-17,109458,Creighton,Big East,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2016-17,109459,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2016-17,109460,Davidson,Atlantic 10,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2016-17,109461,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2016-17,109462,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2016-17,109464,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Coastal Athletic Association,10,exact
+2016-17,109463,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2016-17,109465,Denver,Summit League,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,47,exact
+2016-17,109466,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2016-17,109467,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2016-17,109468,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Coastal Athletic Association,10,exact
+2016-17,109469,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2016-17,109470,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2016-17,109472,ETSU,SoCon,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2016-17,109471,East Carolina,AAC,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Conference,62,exact
+2016-17,109473,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2016-17,109474,Eastern Ky.,OVC,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,Atlantic Sun Conference,46,exact
+2016-17,109475,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2016-17,109476,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2016-17,109725,Elon,CAA,2210,Elon Phoenix,Elon,Phoenix,ELON,Coastal Athletic Association,10,exact
+2016-17,109477,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2016-17,109742,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,Atlantic Sun Conference,46,exact
+2016-17,109482,FIU,C-USA,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2016-17,109478,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Conference,13,exact
+2016-17,109479,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2016-17,109481,Fla. Atlantic,C-USA,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,American Conference,62,exact
+2016-17,109484,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2016-17,109480,Florida A&M,MEAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2016-17,109483,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2016-17,109485,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2016-17,109430,Fresno St.,Mountain West,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2016-17,109486,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2016-17,109490,Ga. Southern,Sun Belt,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2016-17,109726,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2016-17,109487,George Mason,Atlantic 10,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2016-17,109488,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2016-17,109489,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2016-17,109493,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2016-17,109491,Georgia St.,Sun Belt,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2016-17,109492,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2016-17,109494,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2016-17,109495,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2016-17,109727,Grand Canyon,WAC,2253,Grand Canyon Lopes,Grand Canyon,Lopes,GCU,United Athletic Conference,30,exact
+2016-17,109715,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2016-17,109496,Hampton,MEAC,2261,Hampton Pirates,Hampton,Pirates,HAMP,Coastal Athletic Association,10,exact
+2016-17,109497,Hartford,America East,42,Hartford Hawks,Hartford,Hawks,HART,,,exact
+2016-17,109498,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2016-17,109499,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2016-17,109739,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2016-17,109500,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Coastal Athletic Association,10,exact
+2016-17,109501,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2016-17,109503,Houston,AAC,248,Houston Cougars,Houston,Cougars,HOU,Big 12 Conference,8,exact
+2016-17,109502,Houston Baptist,Southland,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,alias
+2016-17,109504,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2016-17,109732,IUPUI,Summit League,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,alias
+2016-17,109506,Idaho,Big Sky,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2016-17,109505,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2016-17,109508,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2016-17,109507,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2016-17,109511,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2016-17,109510,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2016-17,109513,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Conference,13,exact
+2016-17,109515,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2016-17,109514,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2016-17,109516,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2016-17,109518,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,Atlantic Sun Conference,46,exact
+2016-17,109517,Jacksonville St.,OVC,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,Conference USA,11,exact
+2016-17,109519,James Madison,CAA,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2016-17,109521,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2016-17,109733,Kansas City,WAC,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,47,exact
+2016-17,109520,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2016-17,109728,Kennesaw St.,ASUN,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,Conference USA,11,exact
+2016-17,109522,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2016-17,109523,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2016-17,109529,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2016-17,109536,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2016-17,109531,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2016-17,109524,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2016-17,109525,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2016-17,109526,Lamar University,Southland,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2016-17,109527,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2016-17,109528,Liberty,Big South,2335,Liberty Flames,Liberty,Flames,LIB,Conference USA,11,exact
+2016-17,109741,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,Atlantic Sun Conference,46,exact
+2016-17,109409,Little Rock,Sun Belt,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2016-17,109432,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2016-17,109530,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2016-17,109665,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2016-17,109532,Louisiana Tech,C-USA,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2016-17,109533,Louisville,ACC,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2016-17,109537,Loyola Chicago,MVC,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2016-17,109535,Loyola Maryland,Patriot,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2016-17,109538,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2016-17,109539,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Conference,13,exact
+2016-17,109540,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Conference,13,exact
+2016-17,109541,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2016-17,109542,Marshall,C-USA,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2016-17,109544,Maryland,Big Ten,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2016-17,109546,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2016-17,109547,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2016-17,109548,Memphis,AAC,235,Memphis Tigers,Memphis,Tigers,MEM,American Conference,62,exact
+2016-17,109549,Mercer,SoCon,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2016-17,109551,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2016-17,109550,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2016-17,109553,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2016-17,109552,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2016-17,109554,Middle Tenn.,C-USA,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2016-17,109717,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2016-17,109555,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2016-17,109556,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2016-17,109557,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2016-17,109559,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2016-17,109663,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2016-17,109560,Monmouth,MAAC,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Coastal Athletic Association,10,exact
+2016-17,109562,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2016-17,109561,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2016-17,109563,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2016-17,109564,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2016-17,109565,Mount St. Mary's,NEC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Conference,13,exact
+2016-17,109566,Murray St.,OVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2016-17,109584,N.C. A&T,MEAC,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Coastal Athletic Association,10,exact
+2016-17,109585,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2016-17,109586,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2016-17,109577,NJIT,ASUN,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2016-17,109692,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2016-17,109572,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2016-17,109575,Nevada,Mountain West,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2016-17,109576,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2016-17,109579,New Mexico,Mountain West,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2016-17,109578,New Mexico St.,WAC,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Conference USA,11,exact
+2016-17,109580,New Orleans,Southland,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2016-17,109581,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Conference,13,exact
+2016-17,109582,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2016-17,109583,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2016-17,109568,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2016-17,109588,North Dakota,Big Sky,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,47,exact
+2016-17,109587,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,47,exact
+2016-17,109734,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,Atlantic Sun Conference,46,exact
+2016-17,109589,North Texas,C-USA,249,North Texas Mean Green,North Texas,Mean Green,UNT,American Conference,62,exact
+2016-17,109591,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Coastal Athletic Association,10,exact
+2016-17,109592,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2016-17,109593,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2016-17,109594,Northern Ill.,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2016-17,109596,Northern Ky.,Horizon,94,Northern Kentucky Norse,Northern Kentucky,Norse,NKU,Horizon League,45,exact
+2016-17,109598,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2016-17,109597,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2016-17,109599,Notre Dame,ACC,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2016-17,109600,Oakland,Horizon,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2016-17,109602,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2016-17,109601,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2016-17,109604,Oklahoma,Big 12,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Southeastern Conference,23,exact
+2016-17,109603,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2016-17,109605,Old Dominion,C-USA,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2016-17,109558,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2016-17,109573,Omaha,Summit League,2437,Omaha Mavericks,Omaha,Mavericks,OMA,Summit League,47,exact
+2016-17,109606,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,47,exact
+2016-17,109608,Oregon,Pac-12,2483,Oregon Ducks,Oregon,Ducks,ORE,Big Ten Conference,7,exact
+2016-17,109607,Oregon St.,Pac-12,204,Oregon State Beavers,Oregon State,Beavers,ORST,West Coast Conference,29,exact
+2016-17,109609,Pacific,WCC,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2016-17,109612,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2016-17,109611,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2016-17,109613,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2016-17,109614,Pittsburgh,ACC,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2016-17,109616,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2016-17,109615,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2016-17,109617,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2016-17,109729,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2016-17,109618,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2016-17,109619,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2016-17,109620,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2016-17,109512,Purdue Fort Wayne,Summit League,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2016-17,109621,Quinnipiac,MAAC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Conference,13,exact
+2016-17,109622,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2016-17,109623,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2016-17,109624,Rice,C-USA,242,Rice Owls,Rice,Owls,RICE,American Conference,62,exact
+2016-17,109625,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2016-17,109626,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Conference,13,exact
+2016-17,109627,Robert Morris,NEC,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2016-17,109628,Rutgers,Big Ten,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2016-17,109667,SFA,Southland,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Southland Conference,25,exact
+2016-17,109658,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2016-17,109659,SMU,AAC,2567,SMU Mustangs,SMU,Mustangs,SMU,Atlantic Coast Conference,2,exact
+2016-17,109434,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2016-17,109629,Sacred Heart,NEC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Metro Conference,13,exact
+2016-17,109632,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2016-17,109634,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2016-17,109635,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2016-17,109636,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2016-17,109637,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Conference,13,exact
+2016-17,109638,Sam Houston,Southland,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Conference USA,11,exact
+2016-17,109639,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2016-17,109641,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2016-17,109640,San Diego St.,Mountain West,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2016-17,109642,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2016-17,109643,San Jose St.,Mountain West,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2016-17,109644,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2016-17,109645,Savannah St.,MEAC,2542,Savannah State Tigers,Savannah State,Tigers,SAV,,,alias
+2016-17,109730,Seattle U,WAC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,United Athletic Conference,30,exact
+2016-17,109646,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2016-17,109647,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Conference,13,exact
+2016-17,109648,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2016-17,109650,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2016-17,109649,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2016-17,109652,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,47,exact
+2016-17,109651,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,47,exact
+2016-17,109653,South Fla.,AAC,58,South Florida Bulls,South Florida,Bulls,USF,American Conference,62,exact
+2016-17,109654,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2016-17,109655,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2016-17,109656,Southern California,Pac-12,30,USC Trojans,USC,Trojans,USC,Big Ten Conference,7,dict
+2016-17,109657,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2016-17,109660,Southern Miss.,C-USA,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2016-17,109661,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2016-17,109662,Southern Utah,Big Sky,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,United Athletic Conference,30,exact
+2016-17,109630,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2016-17,109631,St. Francis Brooklyn,NEC,2597,St. Francis Brooklyn Terriers,St. Francis Brooklyn,Terriers,SFNY,,,exact
+2016-17,109633,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2016-17,109666,Stanford,Pac-12,24,Stanford Cardinal,Stanford,Cardinal,STAN,Atlantic Coast Conference,2,exact
+2016-17,109668,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,Atlantic Sun Conference,46,exact
+2016-17,109669,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Coastal Athletic Association,10,exact
+2016-17,109670,Syracuse,ACC,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2016-17,109678,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2016-17,109671,Temple,AAC,218,Temple Owls,Temple,Owls,TEM,American Conference,62,exact
+2016-17,109675,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2016-17,109672,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2016-17,109673,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2016-17,109682,Texas,Big 12,251,Texas Longhorns,Texas,Longhorns,TEX,Southeastern Conference,23,exact
+2016-17,109677,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2016-17,109679,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2016-17,109664,Texas St.,Sun Belt,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2016-17,109680,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2016-17,109685,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2016-17,109686,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Coastal Athletic Association,10,exact
+2016-17,109687,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2016-17,109688,Tulane,AAC,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Conference,62,exact
+2016-17,109689,Tulsa,AAC,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Conference,62,exact
+2016-17,109400,UAB,C-USA,5,UAB Blazers,UAB,Blazers,UAB,American Conference,62,exact
+2016-17,109437,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2016-17,109438,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2016-17,109440,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2016-17,109435,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2016-17,109444,UCF,AAC,2116,UCF Knights,UCF,Knights,UCF,Big 12 Conference,8,exact
+2016-17,109439,UCLA,Pac-12,26,UCLA Bruins,UCLA,Bruins,UCLA,Big Ten Conference,7,exact
+2016-17,109455,UConn,AAC,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2016-17,109509,UIC,Horizon,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2016-17,109735,UIW,Southland,2916,Incarnate Word Cardinals,Incarnate Word,Cardinals,UIW,Southland Conference,25,exact
+2016-17,109590,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2016-17,109543,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2016-17,109545,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2016-17,109534,UMass Lowell,America East,2349,UMass Lowell River Hawks,UMass Lowell,River Hawks,UML,America East Conference,1,exact
+2016-17,109567,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2016-17,109570,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2016-17,109571,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Coastal Athletic Association,10,exact
+2016-17,109595,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2016-17,109574,UNLV,Mountain West,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2016-17,109737,USC Upstate,ASUN,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2016-17,109681,UT Arlington,Sun Belt,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,United Athletic Conference,30,exact
+2016-17,109676,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2016-17,109683,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2016-17,109610,UTRGV,WAC,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Southland Conference,25,dict
+2016-17,109684,UTSA,C-USA,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,American Conference,62,exact
+2016-17,109694,Utah,Pac-12,254,Utah Utes,Utah,Utes,UTAH,Big 12 Conference,8,exact
+2016-17,109693,Utah St.,Mountain West,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2016-17,109743,Utah Valley,WAC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,United Athletic Conference,30,exact
+2016-17,109699,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2016-17,109695,Valparaiso,Horizon,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2016-17,109696,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2016-17,109697,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2016-17,109698,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2016-17,109701,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2016-17,109700,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2016-17,109702,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2016-17,109703,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2016-17,109705,Washington,Pac-12,264,Washington Huskies,Washington,Huskies,WASH,Big Ten Conference,7,exact
+2016-17,109704,Washington St.,Pac-12,265,Washington State Cougars,Washington State,Cougars,WSU,West Coast Conference,29,exact
+2016-17,109706,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2016-17,109707,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2016-17,109708,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2016-17,109709,Western Ill.,Summit League,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Ohio Valley Conference,20,exact
+2016-17,109710,Western Ky.,C-USA,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2016-17,109711,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2016-17,109712,Wichita St.,MVC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Conference,62,exact
+2016-17,109713,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Coastal Athletic Association,10,exact
+2016-17,109714,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2016-17,109716,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2016-17,109736,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2016-17,109718,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2016-17,109719,Wyoming,Mountain West,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2016-17,109720,Xavier,Big East,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2016-17,109721,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2016-17,109722,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2017-18,185571,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2017-18,185226,Abilene Christian,Southland,2000,Abilene Christian Wildcats,Abilene Christian,Wildcats,ACU,United Athletic Conference,30,exact
+2017-18,185521,Air Force,Mountain West,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2017-18,185227,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2017-18,185230,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2017-18,185228,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2017-18,185229,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2017-18,185232,Albany (NY),America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,alias
+2017-18,185233,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2017-18,185234,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2017-18,185235,App State,Sun Belt,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2017-18,185237,Arizona,Pac-12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Big 12 Conference,8,exact
+2017-18,185236,Arizona St.,Pac-12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Big 12 Conference,8,exact
+2017-18,185562,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2017-18,185239,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2017-18,185238,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2017-18,185522,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2017-18,185241,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2017-18,185242,Austin Peay,OVC,2046,Austin Peay Governors,Austin Peay,Governors,APSU,Atlantic Sun Conference,46,exact
+2017-18,185253,BYU,WCC,252,BYU Cougars,BYU,Cougars,BYU,Big 12 Conference,8,exact
+2017-18,185243,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2017-18,185245,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2017-18,185569,Belmont,OVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2017-18,185246,Bethune-Cookman,MEAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2017-18,185247,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2017-18,185248,Boise St.,Mountain West,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2017-18,185249,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2017-18,185250,Boston U.,Patriot,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2017-18,185251,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2017-18,185252,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2017-18,185254,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2017-18,185255,Bryant,NEC,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2017-18,185256,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2017-18,185257,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2017-18,185258,Butler,Big East,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2017-18,185260,CSU Bakersfield,WAC,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2017-18,185264,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2017-18,185259,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2017-18,185262,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2017-18,185267,California,Pac-12,25,California Golden Bears,California,Golden Bears,CAL,Atlantic Coast Conference,2,exact
+2017-18,185272,Campbell,Big South,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Coastal Athletic Association,10,exact
+2017-18,185273,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Conference,13,exact
+2017-18,185554,Central Ark.,Southland,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,Atlantic Sun Conference,46,exact
+2017-18,185274,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2017-18,185276,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2017-18,185244,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2017-18,185400,Charlotte,C-USA,2429,Charlotte 49ers,Charlotte,49ers,CLT,American Conference,62,exact
+2017-18,185505,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2017-18,185277,Chicago St.,WAC,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Northeast Conference,19,exact
+2017-18,185278,Cincinnati,AAC,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,Big 12 Conference,8,exact
+2017-18,185279,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2017-18,185280,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2017-18,185281,Coastal Carolina,Sun Belt,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2017-18,185555,Col. of Charleston,CAA,232,Charleston Cougars,Charleston,Cougars,COFC,Coastal Athletic Association,10,dict
+2017-18,185282,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2017-18,185284,Colorado,Pac-12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Big 12 Conference,8,exact
+2017-18,185283,Colorado St.,Mountain West,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2017-18,185285,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2017-18,185287,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2017-18,185288,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2017-18,185289,Creighton,Big East,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2017-18,185290,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2017-18,185291,Davidson,Atlantic 10,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2017-18,185292,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2017-18,185293,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2017-18,185295,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Coastal Athletic Association,10,exact
+2017-18,185294,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2017-18,185296,Denver,Summit League,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,47,exact
+2017-18,185297,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2017-18,185298,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2017-18,185299,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Coastal Athletic Association,10,exact
+2017-18,185300,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2017-18,185301,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2017-18,185303,ETSU,SoCon,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2017-18,185302,East Carolina,AAC,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Conference,62,exact
+2017-18,185304,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2017-18,185305,Eastern Ky.,OVC,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,Atlantic Sun Conference,46,exact
+2017-18,185306,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2017-18,185307,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2017-18,185556,Elon,CAA,2210,Elon Phoenix,Elon,Phoenix,ELON,Coastal Athletic Association,10,exact
+2017-18,185308,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2017-18,185573,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,Atlantic Sun Conference,46,exact
+2017-18,185313,FIU,C-USA,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2017-18,185309,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Conference,13,exact
+2017-18,185310,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2017-18,185312,Fla. Atlantic,C-USA,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,American Conference,62,exact
+2017-18,185315,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2017-18,185311,Florida A&M,MEAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2017-18,185314,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2017-18,185316,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2017-18,185261,Fresno St.,Mountain West,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2017-18,185317,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2017-18,185321,Ga. Southern,Sun Belt,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2017-18,185557,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2017-18,185318,George Mason,Atlantic 10,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2017-18,185319,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2017-18,185320,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2017-18,185324,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2017-18,185322,Georgia St.,Sun Belt,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2017-18,185323,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2017-18,185325,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2017-18,185326,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2017-18,185558,Grand Canyon,WAC,2253,Grand Canyon Lopes,Grand Canyon,Lopes,GCU,United Athletic Conference,30,exact
+2017-18,185546,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2017-18,185327,Hampton,MEAC,2261,Hampton Pirates,Hampton,Pirates,HAMP,Coastal Athletic Association,10,exact
+2017-18,185328,Hartford,America East,42,Hartford Hawks,Hartford,Hawks,HART,,,exact
+2017-18,185329,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2017-18,185330,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2017-18,185570,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2017-18,185331,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Coastal Athletic Association,10,exact
+2017-18,185332,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2017-18,185334,Houston,AAC,248,Houston Cougars,Houston,Cougars,HOU,Big 12 Conference,8,exact
+2017-18,185333,Houston Baptist,Southland,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,alias
+2017-18,185335,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2017-18,185563,IUPUI,Horizon,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,alias
+2017-18,185337,Idaho,Big Sky,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2017-18,185336,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2017-18,185339,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2017-18,185338,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2017-18,185342,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2017-18,185341,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2017-18,185344,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Conference,13,exact
+2017-18,185346,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2017-18,185345,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2017-18,185347,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2017-18,185349,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,Atlantic Sun Conference,46,exact
+2017-18,185348,Jacksonville St.,OVC,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,Conference USA,11,exact
+2017-18,185350,James Madison,CAA,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2017-18,185352,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2017-18,185564,Kansas City,WAC,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,47,exact
+2017-18,185351,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2017-18,185559,Kennesaw St.,ASUN,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,Conference USA,11,exact
+2017-18,185353,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2017-18,185354,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2017-18,185360,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2017-18,185367,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2017-18,185362,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2017-18,185355,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2017-18,185356,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2017-18,185357,Lamar University,Southland,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2017-18,185358,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2017-18,185359,Liberty,Big South,2335,Liberty Flames,Liberty,Flames,LIB,Conference USA,11,exact
+2017-18,185572,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,Atlantic Sun Conference,46,exact
+2017-18,185240,Little Rock,Sun Belt,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2017-18,185263,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2017-18,185361,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2017-18,185496,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2017-18,185363,Louisiana Tech,C-USA,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2017-18,185364,Louisville,ACC,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2017-18,185368,Loyola Chicago,MVC,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2017-18,185366,Loyola Maryland,Patriot,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2017-18,185369,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2017-18,185370,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Conference,13,exact
+2017-18,185371,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Conference,13,exact
+2017-18,185372,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2017-18,185373,Marshall,C-USA,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2017-18,185375,Maryland,Big Ten,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2017-18,185377,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2017-18,185378,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2017-18,185379,Memphis,AAC,235,Memphis Tigers,Memphis,Tigers,MEM,American Conference,62,exact
+2017-18,185380,Mercer,SoCon,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2017-18,185382,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2017-18,185381,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2017-18,185384,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2017-18,185383,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2017-18,185385,Middle Tenn.,C-USA,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2017-18,185548,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2017-18,185386,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2017-18,185387,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2017-18,185388,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2017-18,185390,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2017-18,185494,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2017-18,185391,Monmouth,MAAC,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Coastal Athletic Association,10,exact
+2017-18,185393,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2017-18,185392,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2017-18,185394,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2017-18,185395,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2017-18,185396,Mount St. Mary's,NEC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Conference,13,exact
+2017-18,185397,Murray St.,OVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2017-18,185415,N.C. A&T,MEAC,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Coastal Athletic Association,10,exact
+2017-18,185416,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2017-18,185417,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2017-18,185408,NJIT,ASUN,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2017-18,185523,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2017-18,185403,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2017-18,185406,Nevada,Mountain West,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2017-18,185407,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2017-18,185410,New Mexico,Mountain West,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2017-18,185409,New Mexico St.,WAC,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Conference USA,11,exact
+2017-18,185411,New Orleans,Southland,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2017-18,185412,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Conference,13,exact
+2017-18,185413,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2017-18,185414,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2017-18,185399,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2017-18,185419,North Dakota,Big Sky,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,47,exact
+2017-18,185418,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,47,exact
+2017-18,185565,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,Atlantic Sun Conference,46,exact
+2017-18,185420,North Texas,C-USA,249,North Texas Mean Green,North Texas,Mean Green,UNT,American Conference,62,exact
+2017-18,185422,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Coastal Athletic Association,10,exact
+2017-18,185423,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2017-18,185424,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2017-18,185425,Northern Ill.,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2017-18,185427,Northern Ky.,Horizon,94,Northern Kentucky Norse,Northern Kentucky,Norse,NKU,Horizon League,45,exact
+2017-18,185429,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2017-18,185428,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2017-18,185430,Notre Dame,ACC,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2017-18,185431,Oakland,Horizon,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2017-18,185433,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2017-18,185432,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2017-18,185435,Oklahoma,Big 12,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Southeastern Conference,23,exact
+2017-18,185434,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2017-18,185436,Old Dominion,C-USA,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2017-18,185389,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2017-18,185404,Omaha,Summit League,2437,Omaha Mavericks,Omaha,Mavericks,OMA,Summit League,47,exact
+2017-18,185437,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,47,exact
+2017-18,185439,Oregon,Pac-12,2483,Oregon Ducks,Oregon,Ducks,ORE,Big Ten Conference,7,exact
+2017-18,185438,Oregon St.,Pac-12,204,Oregon State Beavers,Oregon State,Beavers,ORST,West Coast Conference,29,exact
+2017-18,185440,Pacific,WCC,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2017-18,185443,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2017-18,185442,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2017-18,185444,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2017-18,185445,Pittsburgh,ACC,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2017-18,185447,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2017-18,185446,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2017-18,185448,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2017-18,185560,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2017-18,185449,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2017-18,185450,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2017-18,185451,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2017-18,185343,Purdue Fort Wayne,Summit League,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2017-18,185452,Quinnipiac,MAAC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Conference,13,exact
+2017-18,185453,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2017-18,185454,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2017-18,185455,Rice,C-USA,242,Rice Owls,Rice,Owls,RICE,American Conference,62,exact
+2017-18,185456,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2017-18,185457,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Conference,13,exact
+2017-18,185458,Robert Morris,NEC,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2017-18,185459,Rutgers,Big Ten,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2017-18,185498,SFA,Southland,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Southland Conference,25,exact
+2017-18,185489,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2017-18,185490,SMU,AAC,2567,SMU Mustangs,SMU,Mustangs,SMU,Atlantic Coast Conference,2,exact
+2017-18,185265,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2017-18,185460,Sacred Heart,NEC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Metro Conference,13,exact
+2017-18,185463,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2017-18,185465,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2017-18,185466,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2017-18,185467,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2017-18,185468,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Conference,13,exact
+2017-18,185469,Sam Houston,Southland,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Conference USA,11,exact
+2017-18,185470,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2017-18,185472,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2017-18,185471,San Diego St.,Mountain West,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2017-18,185473,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2017-18,185474,San Jose St.,Mountain West,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2017-18,185475,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2017-18,185476,Savannah St.,MEAC,2542,Savannah State Tigers,Savannah State,Tigers,SAV,,,alias
+2017-18,185561,Seattle U,WAC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,United Athletic Conference,30,exact
+2017-18,185477,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2017-18,185478,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Conference,13,exact
+2017-18,185479,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2017-18,185481,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2017-18,185480,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2017-18,185483,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,47,exact
+2017-18,185482,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,47,exact
+2017-18,185484,South Fla.,AAC,58,South Florida Bulls,South Florida,Bulls,USF,American Conference,62,exact
+2017-18,185485,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2017-18,185486,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2017-18,185487,Southern California,Pac-12,30,USC Trojans,USC,Trojans,USC,Big Ten Conference,7,dict
+2017-18,185488,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2017-18,185491,Southern Miss.,C-USA,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2017-18,185492,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2017-18,185493,Southern Utah,Big Sky,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,United Athletic Conference,30,exact
+2017-18,185461,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2017-18,185462,St. Francis Brooklyn,NEC,2597,St. Francis Brooklyn Terriers,St. Francis Brooklyn,Terriers,SFNY,,,exact
+2017-18,185464,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2017-18,185497,Stanford,Pac-12,24,Stanford Cardinal,Stanford,Cardinal,STAN,Atlantic Coast Conference,2,exact
+2017-18,185499,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,Atlantic Sun Conference,46,exact
+2017-18,185500,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Coastal Athletic Association,10,exact
+2017-18,185501,Syracuse,ACC,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2017-18,185509,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2017-18,185502,Temple,AAC,218,Temple Owls,Temple,Owls,TEM,American Conference,62,exact
+2017-18,185506,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2017-18,185503,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2017-18,185504,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2017-18,185513,Texas,Big 12,251,Texas Longhorns,Texas,Longhorns,TEX,Southeastern Conference,23,exact
+2017-18,185508,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2017-18,185510,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2017-18,185495,Texas St.,Sun Belt,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2017-18,185511,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2017-18,185516,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2017-18,185517,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Coastal Athletic Association,10,exact
+2017-18,185518,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2017-18,185519,Tulane,AAC,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Conference,62,exact
+2017-18,185520,Tulsa,AAC,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Conference,62,exact
+2017-18,185231,UAB,C-USA,5,UAB Blazers,UAB,Blazers,UAB,American Conference,62,exact
+2017-18,185268,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2017-18,185269,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2017-18,185271,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2017-18,185266,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2017-18,185275,UCF,AAC,2116,UCF Knights,UCF,Knights,UCF,Big 12 Conference,8,exact
+2017-18,185270,UCLA,Pac-12,26,UCLA Bruins,UCLA,Bruins,UCLA,Big Ten Conference,7,exact
+2017-18,185286,UConn,AAC,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2017-18,185340,UIC,Horizon,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2017-18,185566,UIW,Southland,2916,Incarnate Word Cardinals,Incarnate Word,Cardinals,UIW,Southland Conference,25,exact
+2017-18,185421,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2017-18,185374,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2017-18,185376,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2017-18,185365,UMass Lowell,America East,2349,UMass Lowell River Hawks,UMass Lowell,River Hawks,UML,America East Conference,1,exact
+2017-18,185398,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2017-18,185401,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2017-18,185402,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Coastal Athletic Association,10,exact
+2017-18,185426,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2017-18,185405,UNLV,Mountain West,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2017-18,185568,USC Upstate,ASUN,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2017-18,185512,UT Arlington,Sun Belt,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,United Athletic Conference,30,exact
+2017-18,185507,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2017-18,185514,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2017-18,185441,UTRGV,WAC,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Southland Conference,25,dict
+2017-18,185515,UTSA,C-USA,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,American Conference,62,exact
+2017-18,185525,Utah,Pac-12,254,Utah Utes,Utah,Utes,UTAH,Big 12 Conference,8,exact
+2017-18,185524,Utah St.,Mountain West,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2017-18,185574,Utah Valley,WAC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,United Athletic Conference,30,exact
+2017-18,185530,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2017-18,185526,Valparaiso,MVC,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2017-18,185527,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2017-18,185528,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2017-18,185529,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2017-18,185532,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2017-18,185531,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2017-18,185533,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2017-18,185534,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2017-18,185536,Washington,Pac-12,264,Washington Huskies,Washington,Huskies,WASH,Big Ten Conference,7,exact
+2017-18,185535,Washington St.,Pac-12,265,Washington State Cougars,Washington State,Cougars,WSU,West Coast Conference,29,exact
+2017-18,185537,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2017-18,185538,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2017-18,185539,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2017-18,185540,Western Ill.,Summit League,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Ohio Valley Conference,20,exact
+2017-18,185541,Western Ky.,C-USA,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2017-18,185542,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2017-18,185543,Wichita St.,AAC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Conference,62,exact
+2017-18,185544,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Coastal Athletic Association,10,exact
+2017-18,185545,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2017-18,185547,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2017-18,185567,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2017-18,185549,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2017-18,185550,Wyoming,Mountain West,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2017-18,185551,Xavier,Big East,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2017-18,185552,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2017-18,185553,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2018-19,451907,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2018-19,451562,Abilene Christian,Southland,2000,Abilene Christian Wildcats,Abilene Christian,Wildcats,ACU,United Athletic Conference,30,exact
+2018-19,451857,Air Force,Mountain West,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2018-19,451563,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2018-19,451566,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2018-19,451564,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2018-19,451565,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2018-19,451568,Albany (NY),America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,alias
+2018-19,451569,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2018-19,451570,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2018-19,451571,App State,Sun Belt,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2018-19,451573,Arizona,Pac-12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Big 12 Conference,8,exact
+2018-19,451572,Arizona St.,Pac-12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Big 12 Conference,8,exact
+2018-19,451898,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2018-19,451575,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2018-19,451574,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2018-19,451858,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2018-19,451577,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2018-19,451578,Austin Peay,OVC,2046,Austin Peay Governors,Austin Peay,Governors,APSU,Atlantic Sun Conference,46,exact
+2018-19,451589,BYU,WCC,252,BYU Cougars,BYU,Cougars,BYU,Big 12 Conference,8,exact
+2018-19,451579,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2018-19,451581,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2018-19,451905,Belmont,OVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2018-19,451582,Bethune-Cookman,MEAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2018-19,451583,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2018-19,451584,Boise St.,Mountain West,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2018-19,451585,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2018-19,451586,Boston U.,Patriot,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2018-19,451587,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2018-19,451588,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2018-19,451590,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2018-19,451591,Bryant,NEC,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2018-19,451592,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2018-19,451593,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2018-19,451594,Butler,Big East,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2018-19,451596,CSU Bakersfield,WAC,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2018-19,451600,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2018-19,451595,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2018-19,451598,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2018-19,451603,California,Pac-12,25,California Golden Bears,California,Golden Bears,CAL,Atlantic Coast Conference,2,exact
+2018-19,452194,California Baptist,WAC,2856,California Baptist Lancers,California Baptist,Lancers,CBU,United Athletic Conference,30,exact
+2018-19,451608,Campbell,Big South,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Coastal Athletic Association,10,exact
+2018-19,451609,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Conference,13,exact
+2018-19,451890,Central Ark.,Southland,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,Atlantic Sun Conference,46,exact
+2018-19,451610,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2018-19,451612,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2018-19,451580,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2018-19,451736,Charlotte,C-USA,2429,Charlotte 49ers,Charlotte,49ers,CLT,American Conference,62,exact
+2018-19,451841,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2018-19,451613,Chicago St.,WAC,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Northeast Conference,19,exact
+2018-19,451614,Cincinnati,AAC,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,Big 12 Conference,8,exact
+2018-19,451615,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2018-19,451616,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2018-19,451617,Coastal Carolina,Sun Belt,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2018-19,451891,Col. of Charleston,CAA,232,Charleston Cougars,Charleston,Cougars,COFC,Coastal Athletic Association,10,dict
+2018-19,451618,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2018-19,451620,Colorado,Pac-12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Big 12 Conference,8,exact
+2018-19,451619,Colorado St.,Mountain West,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2018-19,451621,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2018-19,451623,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2018-19,451624,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2018-19,451625,Creighton,Big East,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2018-19,451626,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2018-19,451627,Davidson,Atlantic 10,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2018-19,451628,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2018-19,451629,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2018-19,451631,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Coastal Athletic Association,10,exact
+2018-19,451630,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2018-19,451632,Denver,Summit League,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,47,exact
+2018-19,451633,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2018-19,451634,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2018-19,451635,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Coastal Athletic Association,10,exact
+2018-19,451636,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2018-19,451637,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2018-19,451639,ETSU,SoCon,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2018-19,451638,East Carolina,AAC,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Conference,62,exact
+2018-19,451640,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2018-19,451641,Eastern Ky.,OVC,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,Atlantic Sun Conference,46,exact
+2018-19,451642,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2018-19,451643,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2018-19,451892,Elon,CAA,2210,Elon Phoenix,Elon,Phoenix,ELON,Coastal Athletic Association,10,exact
+2018-19,451644,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2018-19,451909,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,Atlantic Sun Conference,46,exact
+2018-19,451649,FIU,C-USA,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2018-19,451645,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Conference,13,exact
+2018-19,451646,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2018-19,451648,Fla. Atlantic,C-USA,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,American Conference,62,exact
+2018-19,451651,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2018-19,451647,Florida A&M,MEAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2018-19,451650,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2018-19,451652,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2018-19,451597,Fresno St.,Mountain West,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2018-19,451653,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2018-19,451657,Ga. Southern,Sun Belt,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2018-19,451893,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2018-19,451654,George Mason,Atlantic 10,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2018-19,451655,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2018-19,451656,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2018-19,451660,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2018-19,451658,Georgia St.,Sun Belt,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2018-19,451659,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2018-19,451661,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2018-19,451662,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2018-19,451894,Grand Canyon,WAC,2253,Grand Canyon Lopes,Grand Canyon,Lopes,GCU,United Athletic Conference,30,exact
+2018-19,451882,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2018-19,451663,Hampton,Big South,2261,Hampton Pirates,Hampton,Pirates,HAMP,Coastal Athletic Association,10,exact
+2018-19,451664,Hartford,America East,42,Hartford Hawks,Hartford,Hawks,HART,,,exact
+2018-19,451665,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2018-19,451666,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2018-19,451906,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2018-19,451667,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Coastal Athletic Association,10,exact
+2018-19,451668,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2018-19,451670,Houston,AAC,248,Houston Cougars,Houston,Cougars,HOU,Big 12 Conference,8,exact
+2018-19,451669,Houston Baptist,Southland,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,alias
+2018-19,451671,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2018-19,451899,IUPUI,Horizon,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,alias
+2018-19,451673,Idaho,Big Sky,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2018-19,451672,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2018-19,451675,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2018-19,451674,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2018-19,451678,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2018-19,451677,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2018-19,451680,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Conference,13,exact
+2018-19,451682,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2018-19,451681,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2018-19,451683,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2018-19,451685,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,Atlantic Sun Conference,46,exact
+2018-19,451684,Jacksonville St.,OVC,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,Conference USA,11,exact
+2018-19,451686,James Madison,CAA,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2018-19,451688,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2018-19,451900,Kansas City,WAC,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,47,exact
+2018-19,451687,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2018-19,451895,Kennesaw St.,ASUN,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,Conference USA,11,exact
+2018-19,451689,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2018-19,451690,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2018-19,451696,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2018-19,451703,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2018-19,451698,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2018-19,451691,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2018-19,451692,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2018-19,451693,Lamar University,Southland,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2018-19,451694,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2018-19,451695,Liberty,ASUN,2335,Liberty Flames,Liberty,Flames,LIB,Conference USA,11,exact
+2018-19,451908,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,Atlantic Sun Conference,46,exact
+2018-19,451576,Little Rock,Sun Belt,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2018-19,451599,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2018-19,451697,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2018-19,451832,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2018-19,451699,Louisiana Tech,C-USA,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2018-19,451700,Louisville,ACC,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2018-19,451704,Loyola Chicago,MVC,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2018-19,451702,Loyola Maryland,Patriot,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2018-19,451705,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2018-19,451706,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Conference,13,exact
+2018-19,451707,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Conference,13,exact
+2018-19,451708,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2018-19,451709,Marshall,C-USA,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2018-19,451711,Maryland,Big Ten,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2018-19,451713,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2018-19,451714,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2018-19,451715,Memphis,AAC,235,Memphis Tigers,Memphis,Tigers,MEM,American Conference,62,exact
+2018-19,451716,Mercer,SoCon,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2018-19,451718,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2018-19,451717,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2018-19,451720,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2018-19,451719,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2018-19,451721,Middle Tenn.,C-USA,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2018-19,451884,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2018-19,451722,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2018-19,451723,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2018-19,451724,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2018-19,451726,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2018-19,451830,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2018-19,451727,Monmouth,MAAC,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Coastal Athletic Association,10,exact
+2018-19,451729,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2018-19,451728,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2018-19,451730,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2018-19,451731,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2018-19,451732,Mount St. Mary's,NEC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Conference,13,exact
+2018-19,451733,Murray St.,OVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2018-19,451751,N.C. A&T,MEAC,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Coastal Athletic Association,10,exact
+2018-19,451752,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2018-19,451753,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2018-19,451744,NJIT,ASUN,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2018-19,451859,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2018-19,451739,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2018-19,451742,Nevada,Mountain West,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2018-19,451743,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2018-19,451746,New Mexico,Mountain West,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2018-19,451745,New Mexico St.,WAC,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Conference USA,11,exact
+2018-19,451747,New Orleans,Southland,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2018-19,451748,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Conference,13,exact
+2018-19,451749,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2018-19,451750,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2018-19,452005,North Ala.,ASUN,2453,North Alabama Lions,North Alabama,Lions,UNA,Atlantic Sun Conference,46,exact
+2018-19,451735,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2018-19,451755,North Dakota,Summit League,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,47,exact
+2018-19,451754,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,47,exact
+2018-19,451901,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,Atlantic Sun Conference,46,exact
+2018-19,451756,North Texas,C-USA,249,North Texas Mean Green,North Texas,Mean Green,UNT,American Conference,62,exact
+2018-19,451758,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Coastal Athletic Association,10,exact
+2018-19,451759,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2018-19,451760,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2018-19,451761,Northern Ill.,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2018-19,451763,Northern Ky.,Horizon,94,Northern Kentucky Norse,Northern Kentucky,Norse,NKU,Horizon League,45,exact
+2018-19,451765,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2018-19,451764,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2018-19,451766,Notre Dame,ACC,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2018-19,451767,Oakland,Horizon,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2018-19,451769,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2018-19,451768,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2018-19,451771,Oklahoma,Big 12,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Southeastern Conference,23,exact
+2018-19,451770,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2018-19,451772,Old Dominion,C-USA,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2018-19,451725,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2018-19,451740,Omaha,Summit League,2437,Omaha Mavericks,Omaha,Mavericks,OMA,Summit League,47,exact
+2018-19,451773,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,47,exact
+2018-19,451775,Oregon,Pac-12,2483,Oregon Ducks,Oregon,Ducks,ORE,Big Ten Conference,7,exact
+2018-19,451774,Oregon St.,Pac-12,204,Oregon State Beavers,Oregon State,Beavers,ORST,West Coast Conference,29,exact
+2018-19,451776,Pacific,WCC,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2018-19,451779,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2018-19,451778,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2018-19,451780,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2018-19,451781,Pittsburgh,ACC,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2018-19,451783,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2018-19,451782,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2018-19,451784,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2018-19,451896,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2018-19,451785,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2018-19,451786,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2018-19,451787,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2018-19,451679,Purdue Fort Wayne,Summit League,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2018-19,451788,Quinnipiac,MAAC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Conference,13,exact
+2018-19,451789,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2018-19,451790,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2018-19,451791,Rice,C-USA,242,Rice Owls,Rice,Owls,RICE,American Conference,62,exact
+2018-19,451792,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2018-19,451793,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Conference,13,exact
+2018-19,451794,Robert Morris,NEC,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2018-19,451795,Rutgers,Big Ten,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2018-19,451834,SFA,Southland,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Southland Conference,25,exact
+2018-19,451825,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2018-19,451826,SMU,AAC,2567,SMU Mustangs,SMU,Mustangs,SMU,Atlantic Coast Conference,2,exact
+2018-19,451601,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2018-19,451796,Sacred Heart,NEC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Metro Conference,13,exact
+2018-19,451799,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2018-19,451801,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2018-19,451802,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2018-19,451803,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2018-19,451804,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Conference,13,exact
+2018-19,451805,Sam Houston,Southland,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Conference USA,11,exact
+2018-19,451806,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2018-19,451808,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2018-19,451807,San Diego St.,Mountain West,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2018-19,451809,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2018-19,451810,San Jose St.,Mountain West,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2018-19,451811,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2018-19,451812,Savannah St.,MEAC,2542,Savannah State Tigers,Savannah State,Tigers,SAV,,,alias
+2018-19,451897,Seattle U,WAC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,United Athletic Conference,30,exact
+2018-19,451813,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2018-19,451814,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Conference,13,exact
+2018-19,451815,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2018-19,451817,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2018-19,451816,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2018-19,451819,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,47,exact
+2018-19,451818,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,47,exact
+2018-19,451820,South Fla.,AAC,58,South Florida Bulls,South Florida,Bulls,USF,American Conference,62,exact
+2018-19,451821,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2018-19,451822,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2018-19,451823,Southern California,Pac-12,30,USC Trojans,USC,Trojans,USC,Big Ten Conference,7,dict
+2018-19,451824,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2018-19,451827,Southern Miss.,C-USA,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2018-19,451828,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2018-19,451829,Southern Utah,Big Sky,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,United Athletic Conference,30,exact
+2018-19,451797,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2018-19,451798,St. Francis Brooklyn,NEC,2597,St. Francis Brooklyn Terriers,St. Francis Brooklyn,Terriers,SFNY,,,exact
+2018-19,451800,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2018-19,451833,Stanford,Pac-12,24,Stanford Cardinal,Stanford,Cardinal,STAN,Atlantic Coast Conference,2,exact
+2018-19,451835,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,Atlantic Sun Conference,46,exact
+2018-19,451836,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Coastal Athletic Association,10,exact
+2018-19,451837,Syracuse,ACC,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2018-19,451845,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2018-19,451838,Temple,AAC,218,Temple Owls,Temple,Owls,TEM,American Conference,62,exact
+2018-19,451842,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2018-19,451839,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2018-19,451840,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2018-19,451849,Texas,Big 12,251,Texas Longhorns,Texas,Longhorns,TEX,Southeastern Conference,23,exact
+2018-19,451844,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2018-19,451846,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2018-19,451831,Texas St.,Sun Belt,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2018-19,451847,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2018-19,451852,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2018-19,451853,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Coastal Athletic Association,10,exact
+2018-19,451854,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2018-19,451855,Tulane,AAC,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Conference,62,exact
+2018-19,451856,Tulsa,AAC,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Conference,62,exact
+2018-19,451567,UAB,C-USA,5,UAB Blazers,UAB,Blazers,UAB,American Conference,62,exact
+2018-19,451604,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2018-19,451605,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2018-19,451607,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2018-19,451602,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2018-19,451611,UCF,AAC,2116,UCF Knights,UCF,Knights,UCF,Big 12 Conference,8,exact
+2018-19,451606,UCLA,Pac-12,26,UCLA Bruins,UCLA,Bruins,UCLA,Big Ten Conference,7,exact
+2018-19,451622,UConn,AAC,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2018-19,451676,UIC,Horizon,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2018-19,451902,UIW,Southland,2916,Incarnate Word Cardinals,Incarnate Word,Cardinals,UIW,Southland Conference,25,exact
+2018-19,451757,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2018-19,451710,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2018-19,451712,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2018-19,451701,UMass Lowell,America East,2349,UMass Lowell River Hawks,UMass Lowell,River Hawks,UML,America East Conference,1,exact
+2018-19,451734,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2018-19,451737,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2018-19,451738,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Coastal Athletic Association,10,exact
+2018-19,451762,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2018-19,451741,UNLV,Mountain West,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2018-19,451904,USC Upstate,Big South,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2018-19,451848,UT Arlington,Sun Belt,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,United Athletic Conference,30,exact
+2018-19,451843,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2018-19,451850,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2018-19,451777,UTRGV,WAC,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Southland Conference,25,dict
+2018-19,451851,UTSA,C-USA,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,American Conference,62,exact
+2018-19,451861,Utah,Pac-12,254,Utah Utes,Utah,Utes,UTAH,Big 12 Conference,8,exact
+2018-19,451860,Utah St.,Mountain West,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2018-19,451910,Utah Valley,WAC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,United Athletic Conference,30,exact
+2018-19,451866,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2018-19,451862,Valparaiso,MVC,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2018-19,451863,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2018-19,451864,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2018-19,451865,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2018-19,451868,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2018-19,451867,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2018-19,451869,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2018-19,451870,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2018-19,451872,Washington,Pac-12,264,Washington Huskies,Washington,Huskies,WASH,Big Ten Conference,7,exact
+2018-19,451871,Washington St.,Pac-12,265,Washington State Cougars,Washington State,Cougars,WSU,West Coast Conference,29,exact
+2018-19,451873,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2018-19,451874,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2018-19,451875,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2018-19,451876,Western Ill.,Summit League,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Ohio Valley Conference,20,exact
+2018-19,451877,Western Ky.,C-USA,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2018-19,451878,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2018-19,451879,Wichita St.,AAC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Conference,62,exact
+2018-19,451880,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Coastal Athletic Association,10,exact
+2018-19,451881,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2018-19,451883,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2018-19,451903,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2018-19,451885,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2018-19,451886,Wyoming,Mountain West,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2018-19,451887,Xavier,Big East,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2018-19,451888,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2018-19,451889,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2019-20,484452,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2019-20,483774,Abilene Christian,Southland,2000,Abilene Christian Wildcats,Abilene Christian,Wildcats,ACU,United Athletic Conference,30,exact
+2019-20,484359,Air Force,Mountain West,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2019-20,483776,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2019-20,483782,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2019-20,483778,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2019-20,483780,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2019-20,483786,Albany (NY),America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,alias
+2019-20,483788,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2019-20,483790,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2019-20,483792,App State,Sun Belt,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2019-20,483796,Arizona,Pac-12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Big 12 Conference,8,exact
+2019-20,483794,Arizona St.,Pac-12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Big 12 Conference,8,exact
+2019-20,484440,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2019-20,483800,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2019-20,483798,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2019-20,484360,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2019-20,483804,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2019-20,483806,Austin Peay,OVC,2046,Austin Peay Governors,Austin Peay,Governors,APSU,Atlantic Sun Conference,46,exact
+2019-20,483827,BYU,WCC,252,BYU Cougars,BYU,Cougars,BYU,Big 12 Conference,8,exact
+2019-20,483808,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2019-20,483811,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2019-20,484450,Belmont,OVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2019-20,483813,Bethune-Cookman,MEAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2019-20,483815,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2019-20,483817,Boise St.,Mountain West,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2019-20,483819,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2019-20,483821,Boston U.,Patriot,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2019-20,483823,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2019-20,483825,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2019-20,483829,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2019-20,483831,Bryant,NEC,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2019-20,483833,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2019-20,483835,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2019-20,483837,Butler,Big East,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2019-20,483841,CSU Bakersfield,WAC,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2019-20,483849,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2019-20,483839,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2019-20,483845,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2019-20,483854,California,Pac-12,25,California Golden Bears,California,Golden Bears,CAL,Atlantic Coast Conference,2,exact
+2019-20,483770,California Baptist,WAC,2856,California Baptist Lancers,California Baptist,Lancers,CBU,United Athletic Conference,30,exact
+2019-20,483873,Campbell,Big South,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Coastal Athletic Association,10,exact
+2019-20,483875,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Conference,13,exact
+2019-20,484424,Central Ark.,Southland,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,Atlantic Sun Conference,46,exact
+2019-20,483877,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2019-20,483881,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2019-20,483810,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2019-20,484115,Charlotte,C-USA,2429,Charlotte 49ers,Charlotte,49ers,CLT,American Conference,62,exact
+2019-20,484333,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2019-20,483883,Chicago St.,WAC,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Northeast Conference,19,exact
+2019-20,483885,Cincinnati,AAC,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,Big 12 Conference,8,exact
+2019-20,483887,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2019-20,483889,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2019-20,483891,Coastal Carolina,Sun Belt,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2019-20,484426,Col. of Charleston,CAA,232,Charleston Cougars,Charleston,Cougars,COFC,Coastal Athletic Association,10,dict
+2019-20,483893,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2019-20,483897,Colorado,Pac-12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Big 12 Conference,8,exact
+2019-20,483895,Colorado St.,Mountain West,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2019-20,483899,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2019-20,483902,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2019-20,483904,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2019-20,483906,Creighton,Big East,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2019-20,483908,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2019-20,483910,Davidson,Atlantic 10,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2019-20,483912,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2019-20,483914,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2019-20,483918,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Coastal Athletic Association,10,exact
+2019-20,483916,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2019-20,483920,Denver,Summit League,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,47,exact
+2019-20,483922,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2019-20,483923,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2019-20,483925,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Coastal Athletic Association,10,exact
+2019-20,483927,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2019-20,483929,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2019-20,483933,ETSU,SoCon,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2019-20,483931,East Carolina,AAC,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Conference,62,exact
+2019-20,483935,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2019-20,483937,Eastern Ky.,OVC,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,Atlantic Sun Conference,46,exact
+2019-20,483939,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2019-20,483941,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2019-20,484428,Elon,CAA,2210,Elon Phoenix,Elon,Phoenix,ELON,Coastal Athletic Association,10,exact
+2019-20,483943,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2019-20,484454,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,Atlantic Sun Conference,46,exact
+2019-20,483953,FIU,C-USA,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2019-20,483945,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Conference,13,exact
+2019-20,483947,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2019-20,483950,Fla. Atlantic,C-USA,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,American Conference,62,exact
+2019-20,483958,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2019-20,483948,Florida A&M,MEAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2019-20,483955,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2019-20,483959,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2019-20,483843,Fresno St.,Mountain West,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2019-20,483962,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2019-20,483970,Ga. Southern,Sun Belt,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2019-20,484430,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2019-20,483964,George Mason,Atlantic 10,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2019-20,483966,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2019-20,483968,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2019-20,483976,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2019-20,483972,Georgia St.,Sun Belt,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2019-20,483974,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2019-20,483978,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2019-20,483980,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2019-20,484431,Grand Canyon,WAC,2253,Grand Canyon Lopes,Grand Canyon,Lopes,GCU,United Athletic Conference,30,exact
+2019-20,484407,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2019-20,483982,Hampton,Big South,2261,Hampton Pirates,Hampton,Pirates,HAMP,Coastal Athletic Association,10,exact
+2019-20,483984,Hartford,America East,42,Hartford Hawks,Hartford,Hawks,HART,,,exact
+2019-20,483986,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2019-20,483988,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2019-20,484451,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2019-20,483990,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Coastal Athletic Association,10,exact
+2019-20,483992,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2019-20,483996,Houston,AAC,248,Houston Cougars,Houston,Cougars,HOU,Big 12 Conference,8,exact
+2019-20,483994,Houston Baptist,Southland,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,alias
+2019-20,483998,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2019-20,484442,IUPUI,Horizon,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,alias
+2019-20,484002,Idaho,Big Sky,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2019-20,484000,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2019-20,484006,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2019-20,484004,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2019-20,484012,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2019-20,484010,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2019-20,484015,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Conference,13,exact
+2019-20,484020,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2019-20,484018,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2019-20,484022,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2019-20,484026,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,Atlantic Sun Conference,46,exact
+2019-20,484024,Jacksonville St.,OVC,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,Conference USA,11,exact
+2019-20,484027,James Madison,CAA,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2019-20,484031,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2019-20,484444,Kansas City,WAC,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,47,exact
+2019-20,484029,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2019-20,484433,Kennesaw St.,ASUN,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,Conference USA,11,exact
+2019-20,484033,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2019-20,484035,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2019-20,484048,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2019-20,484061,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2019-20,484052,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2019-20,484037,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2019-20,484039,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2019-20,484041,Lamar University,Southland,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2019-20,484043,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2019-20,484046,Liberty,ASUN,2335,Liberty Flames,Liberty,Flames,LIB,Conference USA,11,exact
+2019-20,484453,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,Atlantic Sun Conference,46,exact
+2019-20,483802,Little Rock,Sun Belt,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2019-20,483847,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2019-20,484050,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2019-20,484314,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2019-20,484054,Louisiana Tech,C-USA,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2019-20,484056,Louisville,ACC,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2019-20,484063,Loyola Chicago,MVC,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2019-20,484060,Loyola Maryland,Patriot,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2019-20,484065,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2019-20,484067,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Conference,13,exact
+2019-20,484069,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Conference,13,exact
+2019-20,484071,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2019-20,484073,Marshall,C-USA,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2019-20,484075,Maryland,Big Ten,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2019-20,484077,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2019-20,484078,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2019-20,484079,Memphis,AAC,235,Memphis Tigers,Memphis,Tigers,MEM,American Conference,62,exact
+2019-20,484080,Mercer,SoCon,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2019-20,484794,Merrimack,NEC,2771,Merrimack Warriors,Merrimack,Warriors,MRMK,Metro Conference,13,exact
+2019-20,484082,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2019-20,484081,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2019-20,484084,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2019-20,484083,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2019-20,484086,Middle Tenn.,C-USA,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2019-20,484412,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2019-20,484088,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2019-20,484090,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2019-20,484091,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2019-20,484095,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2019-20,484310,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2019-20,484097,Monmouth,MAAC,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Coastal Athletic Association,10,exact
+2019-20,484101,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2019-20,484099,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2019-20,484103,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2019-20,484105,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2019-20,484107,Mount St. Mary's,NEC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Conference,13,exact
+2019-20,484109,Murray St.,OVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2019-20,484145,N.C. A&T,MEAC,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Coastal Athletic Association,10,exact
+2019-20,484148,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2019-20,484150,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2019-20,484131,NJIT,ASUN,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2019-20,484361,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2019-20,484121,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2019-20,484127,Nevada,Mountain West,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2019-20,484129,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2019-20,484135,New Mexico,Mountain West,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2019-20,484133,New Mexico St.,WAC,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Conference USA,11,exact
+2019-20,484136,New Orleans,Southland,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2019-20,484138,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Conference,13,exact
+2019-20,484141,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2019-20,484144,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2019-20,483772,North Ala.,ASUN,2453,North Alabama Lions,North Alabama,Lions,UNA,Atlantic Sun Conference,46,exact
+2019-20,484113,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2019-20,484154,North Dakota,Summit League,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,47,exact
+2019-20,484152,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,47,exact
+2019-20,484446,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,Atlantic Sun Conference,46,exact
+2019-20,484156,North Texas,C-USA,249,North Texas Mean Green,North Texas,Mean Green,UNT,American Conference,62,exact
+2019-20,484160,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Coastal Athletic Association,10,exact
+2019-20,484161,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2019-20,484163,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2019-20,484165,Northern Ill.,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2019-20,484169,Northern Ky.,Horizon,94,Northern Kentucky Norse,Northern Kentucky,Norse,NKU,Horizon League,45,exact
+2019-20,484173,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2019-20,484171,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2019-20,484175,Notre Dame,ACC,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2019-20,484177,Oakland,Horizon,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2019-20,484181,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2019-20,484179,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2019-20,484185,Oklahoma,Big 12,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Southeastern Conference,23,exact
+2019-20,484183,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2019-20,484187,Old Dominion,C-USA,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2019-20,484093,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2019-20,484123,Omaha,Summit League,2437,Omaha Mavericks,Omaha,Mavericks,OMA,Summit League,47,exact
+2019-20,484189,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,47,exact
+2019-20,484193,Oregon,Pac-12,2483,Oregon Ducks,Oregon,Ducks,ORE,Big Ten Conference,7,exact
+2019-20,484191,Oregon St.,Pac-12,204,Oregon State Beavers,Oregon State,Beavers,ORST,West Coast Conference,29,exact
+2019-20,484194,Pacific,WCC,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2019-20,484200,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2019-20,484198,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2019-20,484202,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2019-20,484204,Pittsburgh,ACC,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2019-20,484208,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2019-20,484206,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2019-20,484210,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2019-20,484435,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2019-20,484211,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2019-20,484213,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2019-20,484215,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2019-20,484014,Purdue Fort Wayne,Summit League,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2019-20,484217,Quinnipiac,MAAC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Conference,13,exact
+2019-20,484219,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2019-20,484221,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2019-20,484223,Rice,C-USA,242,Rice Owls,Rice,Owls,RICE,American Conference,62,exact
+2019-20,484225,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2019-20,484227,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Conference,13,exact
+2019-20,484238,Robert Morris,NEC,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2019-20,484240,Rutgers,Big Ten,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2019-20,484318,SFA,Southland,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Southland Conference,25,exact
+2019-20,484299,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2019-20,484302,SMU,AAC,2567,SMU Mustangs,SMU,Mustangs,SMU,Atlantic Coast Conference,2,exact
+2019-20,483850,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2019-20,484242,Sacred Heart,NEC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Metro Conference,13,exact
+2019-20,484248,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2019-20,484251,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2019-20,484253,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2019-20,484255,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2019-20,484257,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Conference,13,exact
+2019-20,484260,Sam Houston,Southland,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Conference USA,11,exact
+2019-20,484262,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2019-20,484266,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2019-20,484264,San Diego St.,Mountain West,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2019-20,484268,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2019-20,484270,San Jose St.,Mountain West,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2019-20,484272,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2019-20,484438,Seattle U,WAC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,United Athletic Conference,30,exact
+2019-20,484276,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2019-20,484278,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Conference,13,exact
+2019-20,484280,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2019-20,484284,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2019-20,484282,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2019-20,484288,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,47,exact
+2019-20,484286,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,47,exact
+2019-20,484290,South Fla.,AAC,58,South Florida Bulls,South Florida,Bulls,USF,American Conference,62,exact
+2019-20,484292,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2019-20,484294,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2019-20,484296,Southern California,Pac-12,30,USC Trojans,USC,Trojans,USC,Big Ten Conference,7,dict
+2019-20,484298,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2019-20,484304,Southern Miss.,C-USA,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2019-20,484306,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2019-20,484307,Southern Utah,Big Sky,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,United Athletic Conference,30,exact
+2019-20,484244,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2019-20,484246,St. Francis Brooklyn,NEC,2597,St. Francis Brooklyn Terriers,St. Francis Brooklyn,Terriers,SFNY,,,exact
+2019-20,484250,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2019-20,484316,Stanford,Pac-12,24,Stanford Cardinal,Stanford,Cardinal,STAN,Atlantic Coast Conference,2,exact
+2019-20,484320,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,Atlantic Sun Conference,46,exact
+2019-20,484322,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Coastal Athletic Association,10,exact
+2019-20,484325,Syracuse,ACC,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2019-20,484341,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2019-20,484327,Temple,AAC,218,Temple Owls,Temple,Owls,TEM,American Conference,62,exact
+2019-20,484335,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2019-20,484329,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2019-20,484331,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2019-20,484350,Texas,Big 12,251,Texas Longhorns,Texas,Longhorns,TEX,Southeastern Conference,23,exact
+2019-20,484339,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2019-20,484343,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2019-20,484312,Texas St.,Sun Belt,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2019-20,484345,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2019-20,484354,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2019-20,484355,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Coastal Athletic Association,10,exact
+2019-20,484356,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2019-20,484357,Tulane,AAC,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Conference,62,exact
+2019-20,484358,Tulsa,AAC,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Conference,62,exact
+2019-20,483784,UAB,C-USA,5,UAB Blazers,UAB,Blazers,UAB,American Conference,62,exact
+2019-20,483856,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2019-20,483858,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2019-20,483862,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2019-20,483852,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2019-20,483879,UCF,AAC,2116,UCF Knights,UCF,Knights,UCF,Big 12 Conference,8,exact
+2019-20,483860,UCLA,Pac-12,26,UCLA Bruins,UCLA,Bruins,UCLA,Big Ten Conference,7,exact
+2019-20,483901,UConn,AAC,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2019-20,484008,UIC,Horizon,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2019-20,484447,UIW,Southland,2916,Incarnate Word Cardinals,Incarnate Word,Cardinals,UIW,Southland Conference,25,exact
+2019-20,484158,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2019-20,484074,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2019-20,484076,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2019-20,484058,UMass Lowell,America East,2349,UMass Lowell River Hawks,UMass Lowell,River Hawks,UML,America East Conference,1,exact
+2019-20,484111,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2019-20,484117,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2019-20,484119,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Coastal Athletic Association,10,exact
+2019-20,484167,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2019-20,484125,UNLV,Mountain West,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2019-20,484449,USC Upstate,Big South,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2019-20,484347,UT Arlington,Sun Belt,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,United Athletic Conference,30,exact
+2019-20,484337,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2019-20,484352,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2019-20,484196,UTRGV,WAC,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Southland Conference,25,dict
+2019-20,484353,UTSA,C-USA,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,American Conference,62,exact
+2019-20,484366,Utah,Pac-12,254,Utah Utes,Utah,Utes,UTAH,Big 12 Conference,8,exact
+2019-20,484364,Utah St.,Mountain West,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2019-20,484456,Utah Valley,WAC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,United Athletic Conference,30,exact
+2019-20,484376,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2019-20,484368,Valparaiso,MVC,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2019-20,484370,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2019-20,484372,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2019-20,484374,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2019-20,484380,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2019-20,484378,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2019-20,484382,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2019-20,484384,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2019-20,484388,Washington,Pac-12,264,Washington Huskies,Washington,Huskies,WASH,Big Ten Conference,7,exact
+2019-20,484386,Washington St.,Pac-12,265,Washington State Cougars,Washington State,Cougars,WSU,West Coast Conference,29,exact
+2019-20,484390,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2019-20,484392,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2019-20,484394,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2019-20,484395,Western Ill.,Summit League,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Ohio Valley Conference,20,exact
+2019-20,484397,Western Ky.,C-USA,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2019-20,484399,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2019-20,484400,Wichita St.,AAC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Conference,62,exact
+2019-20,484401,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Coastal Athletic Association,10,exact
+2019-20,484405,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2019-20,484409,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2019-20,484448,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2019-20,484414,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2019-20,484416,Wyoming,Mountain West,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2019-20,484418,Xavier,Big East,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2019-20,484420,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2019-20,484422,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2020-21,506396,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2020-21,505812,Abilene Christian,Southland,2000,Abilene Christian Wildcats,Abilene Christian,Wildcats,ACU,United Athletic Conference,30,exact
+2020-21,506306,Air Force,Mountain West,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2020-21,505813,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2020-21,505816,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2020-21,505814,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2020-21,505815,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2020-21,505818,Albany (NY),America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,alias
+2020-21,505819,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2020-21,505820,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2020-21,505821,App State,Sun Belt,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2020-21,505823,Arizona,Pac-12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Big 12 Conference,8,exact
+2020-21,505822,Arizona St.,Pac-12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Big 12 Conference,8,exact
+2020-21,506367,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2020-21,505825,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2020-21,505824,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2020-21,506307,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2020-21,505827,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2020-21,505828,Austin Peay,OVC,2046,Austin Peay Governors,Austin Peay,Governors,APSU,Atlantic Sun Conference,46,exact
+2020-21,505859,BYU,WCC,252,BYU Cougars,BYU,Cougars,BYU,Big 12 Conference,8,exact
+2020-21,505829,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2020-21,505851,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2020-21,506807,Bellarmine,ASUN,91,Bellarmine Knights,Bellarmine,Knights,BELL,Atlantic Sun Conference,46,exact
+2020-21,506394,Belmont,OVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2020-21,505852,Bethune-Cookman,MEAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2020-21,505853,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2020-21,505854,Boise St.,Mountain West,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2020-21,505855,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2020-21,505856,Boston U.,Patriot,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2020-21,505857,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2020-21,505858,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2020-21,505860,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2020-21,505861,Bryant,NEC,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2020-21,505862,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2020-21,505863,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2020-21,505864,Butler,Big East,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2020-21,505866,CSU Bakersfield,Big West,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2020-21,505890,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2020-21,505865,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2020-21,505868,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2020-21,505893,California,Pac-12,25,California Golden Bears,California,Golden Bears,CAL,Atlantic Coast Conference,2,exact
+2020-21,505810,California Baptist,WAC,2856,California Baptist Lancers,California Baptist,Lancers,CBU,United Athletic Conference,30,exact
+2020-21,505898,Campbell,Big South,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Coastal Athletic Association,10,exact
+2020-21,505899,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Conference,13,exact
+2020-21,506359,Central Ark.,Southland,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,Atlantic Sun Conference,46,exact
+2020-21,505900,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2020-21,505902,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2020-21,505850,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2020-21,506106,Charlotte,C-USA,2429,Charlotte 49ers,Charlotte,49ers,CLT,American Conference,62,exact
+2020-21,506290,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2020-21,505903,Chicago St.,WAC,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Northeast Conference,19,exact
+2020-21,505904,Cincinnati,AAC,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,Big 12 Conference,8,exact
+2020-21,505905,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2020-21,505906,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2020-21,505907,Coastal Carolina,Sun Belt,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2020-21,506360,Col. of Charleston,CAA,232,Charleston Cougars,Charleston,Cougars,COFC,Coastal Athletic Association,10,dict
+2020-21,505908,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2020-21,505910,Colorado,Pac-12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Big 12 Conference,8,exact
+2020-21,505909,Colorado St.,Mountain West,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2020-21,505911,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2020-21,505913,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2020-21,505914,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2020-21,505915,Creighton,Big East,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2020-21,505916,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2020-21,505917,Davidson,Atlantic 10,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2020-21,505918,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2020-21,505919,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2020-21,505921,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Coastal Athletic Association,10,exact
+2020-21,505920,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2020-21,505922,Denver,Summit League,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,47,exact
+2020-21,505923,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2020-21,506731,Dixie St.,WAC,3101,Utah Tech Trailblazers,Utah Tech,Trailblazers,UTU,United Athletic Conference,30,alias
+2020-21,505924,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2020-21,505925,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Coastal Athletic Association,10,exact
+2020-21,505926,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2020-21,505927,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2020-21,505929,ETSU,SoCon,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2020-21,505928,East Carolina,AAC,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Conference,62,exact
+2020-21,505950,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2020-21,505951,Eastern Ky.,OVC,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,Atlantic Sun Conference,46,exact
+2020-21,505952,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2020-21,505953,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2020-21,506361,Elon,CAA,2210,Elon Phoenix,Elon,Phoenix,ELON,Coastal Athletic Association,10,exact
+2020-21,505954,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2020-21,506398,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,Atlantic Sun Conference,46,exact
+2020-21,505959,FIU,C-USA,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2020-21,505955,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Conference,13,exact
+2020-21,505956,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2020-21,505958,Fla. Atlantic,C-USA,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,American Conference,62,exact
+2020-21,505961,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2020-21,505957,Florida A&M,MEAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2020-21,505960,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2020-21,505962,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2020-21,505867,Fresno St.,Mountain West,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2020-21,505963,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2020-21,505967,Ga. Southern,Sun Belt,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2020-21,506362,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2020-21,505964,George Mason,Atlantic 10,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2020-21,505965,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2020-21,505966,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2020-21,505990,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2020-21,505968,Georgia St.,Sun Belt,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2020-21,505969,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2020-21,505991,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2020-21,505992,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2020-21,506363,Grand Canyon,WAC,2253,Grand Canyon Lopes,Grand Canyon,Lopes,GCU,United Athletic Conference,30,exact
+2020-21,506351,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2020-21,505993,Hampton,Big South,2261,Hampton Pirates,Hampton,Pirates,HAMP,Coastal Athletic Association,10,exact
+2020-21,505994,Hartford,America East,42,Hartford Hawks,Hartford,Hawks,HART,,,exact
+2020-21,505995,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2020-21,505996,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2020-21,506395,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2020-21,505997,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Coastal Athletic Association,10,exact
+2020-21,505998,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2020-21,506000,Houston,AAC,248,Houston Cougars,Houston,Cougars,HOU,Big 12 Conference,8,exact
+2020-21,505999,Houston Baptist,Southland,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,alias
+2020-21,506001,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2020-21,506368,IUPUI,Horizon,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,alias
+2020-21,506003,Idaho,Big Sky,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2020-21,506002,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2020-21,506005,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2020-21,506004,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2020-21,506008,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2020-21,506007,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2020-21,506010,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Conference,13,exact
+2020-21,506012,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2020-21,506011,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2020-21,506013,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2020-21,506015,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,Atlantic Sun Conference,46,exact
+2020-21,506014,Jacksonville St.,OVC,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,Conference USA,11,exact
+2020-21,506016,James Madison,CAA,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2020-21,506018,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2020-21,506369,Kansas City,Summit League,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,47,exact
+2020-21,506017,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2020-21,506364,Kennesaw St.,ASUN,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,Conference USA,11,exact
+2020-21,506019,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2020-21,506020,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2020-21,506026,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2020-21,506053,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2020-21,506028,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2020-21,506021,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2020-21,506022,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2020-21,506023,Lamar University,Southland,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2020-21,506024,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2020-21,506025,Liberty,ASUN,2335,Liberty Flames,Liberty,Flames,LIB,Conference USA,11,exact
+2020-21,506397,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,Atlantic Sun Conference,46,exact
+2020-21,505826,Little Rock,Sun Belt,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2020-21,505869,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2020-21,506027,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2020-21,506261,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2020-21,506029,Louisiana Tech,C-USA,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2020-21,506050,Louisville,ACC,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2020-21,506054,Loyola Chicago,MVC,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2020-21,506052,Loyola Maryland,Patriot,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2020-21,506055,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2020-21,506056,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Conference,13,exact
+2020-21,506057,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Conference,13,exact
+2020-21,506058,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2020-21,506059,Marshall,C-USA,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2020-21,506061,Maryland,Big Ten,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2020-21,506063,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2020-21,506064,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2020-21,506065,Memphis,AAC,235,Memphis Tigers,Memphis,Tigers,MEM,American Conference,62,exact
+2020-21,506066,Mercer,SoCon,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2020-21,506400,Merrimack,NEC,2771,Merrimack Warriors,Merrimack,Warriors,MRMK,Metro Conference,13,exact
+2020-21,506068,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2020-21,506067,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2020-21,506090,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2020-21,506069,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2020-21,506091,Middle Tenn.,C-USA,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2020-21,506353,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2020-21,506092,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2020-21,506093,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2020-21,506094,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2020-21,506096,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2020-21,506259,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2020-21,506097,Monmouth,MAAC,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Coastal Athletic Association,10,exact
+2020-21,506099,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2020-21,506098,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2020-21,506100,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2020-21,506101,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2020-21,506102,Mount St. Mary's,NEC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Conference,13,exact
+2020-21,506103,Murray St.,OVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2020-21,506141,N.C. A&T,MEAC,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Coastal Athletic Association,10,exact
+2020-21,506142,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2020-21,506143,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2020-21,506134,NJIT,America East,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2020-21,506308,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2020-21,506109,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2020-21,506132,Nevada,Mountain West,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2020-21,506133,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2020-21,506136,New Mexico,Mountain West,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2020-21,506135,New Mexico St.,WAC,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Conference USA,11,exact
+2020-21,506137,New Orleans,Southland,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2020-21,506138,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Conference,13,exact
+2020-21,506139,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2020-21,506140,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2020-21,505811,North Ala.,ASUN,2453,North Alabama Lions,North Alabama,Lions,UNA,Atlantic Sun Conference,46,exact
+2020-21,506105,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2020-21,506145,North Dakota,Summit League,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,47,exact
+2020-21,506144,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,47,exact
+2020-21,506390,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,Atlantic Sun Conference,46,exact
+2020-21,506146,North Texas,C-USA,249,North Texas Mean Green,North Texas,Mean Green,UNT,American Conference,62,exact
+2020-21,506148,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Coastal Athletic Association,10,exact
+2020-21,506149,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2020-21,506150,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2020-21,506151,Northern Ill.,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2020-21,506153,Northern Ky.,Horizon,94,Northern Kentucky Norse,Northern Kentucky,Norse,NKU,Horizon League,45,exact
+2020-21,506155,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2020-21,506154,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2020-21,506156,Notre Dame,ACC,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2020-21,506157,Oakland,Horizon,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2020-21,506159,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2020-21,506158,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2020-21,506161,Oklahoma,Big 12,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Southeastern Conference,23,exact
+2020-21,506160,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2020-21,506162,Old Dominion,C-USA,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2020-21,506095,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2020-21,506130,Omaha,Summit League,2437,Omaha Mavericks,Omaha,Mavericks,OMA,Summit League,47,exact
+2020-21,506163,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,47,exact
+2020-21,506165,Oregon,Pac-12,2483,Oregon Ducks,Oregon,Ducks,ORE,Big Ten Conference,7,exact
+2020-21,506164,Oregon St.,Pac-12,204,Oregon State Beavers,Oregon State,Beavers,ORST,West Coast Conference,29,exact
+2020-21,506166,Pacific,WCC,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2020-21,506169,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2020-21,506168,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2020-21,506190,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2020-21,506191,Pittsburgh,ACC,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2020-21,506193,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2020-21,506192,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2020-21,506194,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2020-21,506365,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2020-21,506195,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2020-21,506196,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2020-21,506197,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2020-21,506009,Purdue Fort Wayne,Horizon,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2020-21,506198,Quinnipiac,MAAC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Conference,13,exact
+2020-21,506199,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2020-21,506200,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2020-21,506201,Rice,C-USA,242,Rice Owls,Rice,Owls,RICE,American Conference,62,exact
+2020-21,506202,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2020-21,506203,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Conference,13,exact
+2020-21,506204,Robert Morris,Horizon,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2020-21,506205,Rutgers,Big Ten,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2020-21,506263,SFA,Southland,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Southland Conference,25,exact
+2020-21,506254,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2020-21,506255,SMU,AAC,2567,SMU Mustangs,SMU,Mustangs,SMU,Atlantic Coast Conference,2,exact
+2020-21,505891,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2020-21,506206,Sacred Heart,NEC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Metro Conference,13,exact
+2020-21,506209,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2020-21,506231,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2020-21,506232,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2020-21,506233,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2020-21,506234,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Conference,13,exact
+2020-21,506235,Sam Houston,Southland,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Conference USA,11,exact
+2020-21,506236,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2020-21,506238,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2020-21,506237,San Diego St.,Mountain West,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2020-21,506239,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2020-21,506240,San Jose St.,Mountain West,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2020-21,506241,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2020-21,506366,Seattle U,WAC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,United Athletic Conference,30,exact
+2020-21,506242,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2020-21,506243,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Conference,13,exact
+2020-21,506244,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2020-21,506246,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2020-21,506245,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2020-21,506248,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,47,exact
+2020-21,506247,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,47,exact
+2020-21,506249,South Fla.,AAC,58,South Florida Bulls,South Florida,Bulls,USF,American Conference,62,exact
+2020-21,506250,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2020-21,506251,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2020-21,506252,Southern California,Pac-12,30,USC Trojans,USC,Trojans,USC,Big Ten Conference,7,dict
+2020-21,506253,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2020-21,506256,Southern Miss.,C-USA,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2020-21,506257,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2020-21,506258,Southern Utah,Big Sky,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,United Athletic Conference,30,exact
+2020-21,506207,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2020-21,506208,St. Francis Brooklyn,NEC,2597,St. Francis Brooklyn Terriers,St. Francis Brooklyn,Terriers,SFNY,,,exact
+2020-21,506230,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2020-21,506262,Stanford,Pac-12,24,Stanford Cardinal,Stanford,Cardinal,STAN,Atlantic Coast Conference,2,exact
+2020-21,506264,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,Atlantic Sun Conference,46,exact
+2020-21,506265,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Coastal Athletic Association,10,exact
+2020-21,506266,Syracuse,ACC,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2020-21,506294,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2020-21,506573,Tarleton St.,WAC,2627,Tarleton State Texans,Tarleton State,Texans,TAR,United Athletic Conference,30,exact
+2020-21,506267,Temple,AAC,218,Temple Owls,Temple,Owls,TEM,American Conference,62,exact
+2020-21,506291,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2020-21,506268,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2020-21,506269,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2020-21,506298,Texas,Big 12,251,Texas Longhorns,Texas,Longhorns,TEX,Southeastern Conference,23,exact
+2020-21,506293,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2020-21,506295,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2020-21,506260,Texas St.,Sun Belt,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2020-21,506296,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2020-21,506301,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2020-21,506302,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Coastal Athletic Association,10,exact
+2020-21,506303,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2020-21,506304,Tulane,AAC,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Conference,62,exact
+2020-21,506305,Tulsa,AAC,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Conference,62,exact
+2020-21,505817,UAB,C-USA,5,UAB Blazers,UAB,Blazers,UAB,American Conference,62,exact
+2020-21,505894,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2020-21,505895,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2020-21,505897,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2020-21,506842,UC San Diego,Big West,28,UC San Diego Tritons,UC San Diego,Tritons,UCSD,Big West Conference,9,exact
+2020-21,505892,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2020-21,505901,UCF,AAC,2116,UCF Knights,UCF,Knights,UCF,Big 12 Conference,8,exact
+2020-21,505896,UCLA,Pac-12,26,UCLA Bruins,UCLA,Bruins,UCLA,Big Ten Conference,7,exact
+2020-21,505912,UConn,Big East,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2020-21,506006,UIC,Horizon,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2020-21,506391,UIW,Southland,2916,Incarnate Word Cardinals,Incarnate Word,Cardinals,UIW,Southland Conference,25,exact
+2020-21,506147,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2020-21,506060,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2020-21,506062,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2020-21,506051,UMass Lowell,America East,2349,UMass Lowell River Hawks,UMass Lowell,River Hawks,UML,America East Conference,1,exact
+2020-21,506104,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2020-21,506107,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2020-21,506108,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Coastal Athletic Association,10,exact
+2020-21,506152,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2020-21,506131,UNLV,Mountain West,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2020-21,506393,USC Upstate,Big South,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2020-21,506297,UT Arlington,Sun Belt,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,United Athletic Conference,30,exact
+2020-21,506292,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2020-21,506299,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2020-21,506167,UTRGV,WAC,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Southland Conference,25,dict
+2020-21,506300,UTSA,C-USA,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,American Conference,62,exact
+2020-21,506330,Utah,Pac-12,254,Utah Utes,Utah,Utes,UTAH,Big 12 Conference,8,exact
+2020-21,506309,Utah St.,Mountain West,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2020-21,506399,Utah Valley,WAC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,United Athletic Conference,30,exact
+2020-21,506335,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2020-21,506331,Valparaiso,MVC,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2020-21,506332,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2020-21,506333,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2020-21,506334,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2020-21,506337,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2020-21,506336,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2020-21,506338,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2020-21,506339,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2020-21,506341,Washington,Pac-12,264,Washington Huskies,Washington,Huskies,WASH,Big Ten Conference,7,exact
+2020-21,506340,Washington St.,Pac-12,265,Washington State Cougars,Washington State,Cougars,WSU,West Coast Conference,29,exact
+2020-21,506342,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2020-21,506343,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2020-21,506344,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2020-21,506345,Western Ill.,Summit League,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Ohio Valley Conference,20,exact
+2020-21,506346,Western Ky.,C-USA,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2020-21,506347,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2020-21,506348,Wichita St.,AAC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Conference,62,exact
+2020-21,506349,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Coastal Athletic Association,10,exact
+2020-21,506350,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2020-21,506352,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2020-21,506392,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2020-21,506354,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2020-21,506355,Wyoming,Mountain West,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2020-21,506356,Xavier,Big East,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2020-21,506357,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2020-21,506358,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2021-22,528811,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2021-22,527225,Abilene Christian,WAC,2000,Abilene Christian Wildcats,Abilene Christian,Wildcats,ACU,United Athletic Conference,30,exact
+2021-22,528761,Air Force,Mountain West,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2021-22,527226,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2021-22,527229,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2021-22,527227,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2021-22,527228,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2021-22,527231,Albany (NY),America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,alias
+2021-22,527232,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2021-22,527233,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2021-22,528474,App State,Sun Belt,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2021-22,528476,Arizona,Pac-12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Big 12 Conference,8,exact
+2021-22,528475,Arizona St.,Pac-12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Big 12 Conference,8,exact
+2021-22,528802,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2021-22,528478,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2021-22,528477,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2021-22,528762,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2021-22,528480,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2021-22,528481,Austin Peay,OVC,2046,Austin Peay Governors,Austin Peay,Governors,APSU,Atlantic Sun Conference,46,exact
+2021-22,528492,BYU,WCC,252,BYU Cougars,BYU,Cougars,BYU,Big 12 Conference,8,exact
+2021-22,528482,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2021-22,528484,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2021-22,528759,Bellarmine,ASUN,91,Bellarmine Knights,Bellarmine,Knights,BELL,Atlantic Sun Conference,46,exact
+2021-22,528809,Belmont,OVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2021-22,528485,Bethune-Cookman,SWAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2021-22,528486,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2021-22,528487,Boise St.,Mountain West,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2021-22,528488,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2021-22,528489,Boston U.,Patriot,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2021-22,528490,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2021-22,528491,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2021-22,528493,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2021-22,528494,Bryant,NEC,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2021-22,528495,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2021-22,528496,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2021-22,528497,Butler,Big East,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2021-22,528499,CSU Bakersfield,Big West,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2021-22,528503,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2021-22,528498,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2021-22,528501,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2021-22,528506,California,Pac-12,25,California Golden Bears,California,Golden Bears,CAL,Atlantic Coast Conference,2,exact
+2021-22,527223,California Baptist,WAC,2856,California Baptist Lancers,California Baptist,Lancers,CBU,United Athletic Conference,30,exact
+2021-22,528511,Campbell,Big South,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Coastal Athletic Association,10,exact
+2021-22,528512,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Conference,13,exact
+2021-22,528794,Central Ark.,ASUN,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,Atlantic Sun Conference,46,exact
+2021-22,528513,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2021-22,528515,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2021-22,528483,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2021-22,528639,Charlotte,C-USA,2429,Charlotte 49ers,Charlotte,49ers,CLT,American Conference,62,exact
+2021-22,528743,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2021-22,528516,Chicago St.,WAC,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Northeast Conference,19,exact
+2021-22,528517,Cincinnati,AAC,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,Big 12 Conference,8,exact
+2021-22,528518,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2021-22,528519,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2021-22,528520,Coastal Carolina,Sun Belt,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2021-22,528795,Col. of Charleston,CAA,232,Charleston Cougars,Charleston,Cougars,COFC,Coastal Athletic Association,10,dict
+2021-22,528521,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2021-22,528523,Colorado,Pac-12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Big 12 Conference,8,exact
+2021-22,528522,Colorado St.,Mountain West,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2021-22,528524,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2021-22,528526,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2021-22,528527,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2021-22,528528,Creighton,Big East,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2021-22,528529,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2021-22,528530,Davidson,Atlantic 10,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2021-22,528531,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2021-22,528532,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2021-22,528534,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Coastal Athletic Association,10,exact
+2021-22,528533,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2021-22,528535,Denver,Summit League,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,47,exact
+2021-22,528536,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2021-22,528758,Dixie St.,WAC,3101,Utah Tech Trailblazers,Utah Tech,Trailblazers,UTU,United Athletic Conference,30,alias
+2021-22,528537,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2021-22,528538,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Coastal Athletic Association,10,exact
+2021-22,528539,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2021-22,528540,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2021-22,528542,ETSU,SoCon,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2021-22,528541,East Carolina,AAC,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Conference,62,exact
+2021-22,528543,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2021-22,528544,Eastern Ky.,ASUN,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,Atlantic Sun Conference,46,exact
+2021-22,528545,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2021-22,528546,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2021-22,528796,Elon,CAA,2210,Elon Phoenix,Elon,Phoenix,ELON,Coastal Athletic Association,10,exact
+2021-22,528547,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2021-22,528813,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,Atlantic Sun Conference,46,exact
+2021-22,528552,FIU,C-USA,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2021-22,528548,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Conference,13,exact
+2021-22,528549,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2021-22,528551,Fla. Atlantic,C-USA,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,American Conference,62,exact
+2021-22,528554,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2021-22,528550,Florida A&M,SWAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2021-22,528553,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2021-22,528555,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2021-22,528500,Fresno St.,Mountain West,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2021-22,528556,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2021-22,528560,Ga. Southern,Sun Belt,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2021-22,528797,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2021-22,528557,George Mason,Atlantic 10,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2021-22,528558,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2021-22,528559,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2021-22,528563,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2021-22,528561,Georgia St.,Sun Belt,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2021-22,528562,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2021-22,528564,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2021-22,528565,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2021-22,528798,Grand Canyon,WAC,2253,Grand Canyon Lopes,Grand Canyon,Lopes,GCU,United Athletic Conference,30,exact
+2021-22,528786,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2021-22,528566,Hampton,Big South,2261,Hampton Pirates,Hampton,Pirates,HAMP,Coastal Athletic Association,10,exact
+2021-22,528567,Hartford,America East,42,Hartford Hawks,Hartford,Hawks,HART,,,exact
+2021-22,528568,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2021-22,528569,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2021-22,528810,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2021-22,528570,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Coastal Athletic Association,10,exact
+2021-22,528571,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2021-22,528573,Houston,AAC,248,Houston Cougars,Houston,Cougars,HOU,Big 12 Conference,8,exact
+2021-22,528572,Houston Baptist,Southland,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,alias
+2021-22,528574,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2021-22,528803,IUPUI,Horizon,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,alias
+2021-22,528576,Idaho,Big Sky,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2021-22,528575,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2021-22,528578,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2021-22,528577,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2021-22,528581,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2021-22,528580,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2021-22,528583,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Conference,13,exact
+2021-22,528585,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2021-22,528584,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2021-22,528586,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2021-22,528588,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,Atlantic Sun Conference,46,exact
+2021-22,528587,Jacksonville St.,ASUN,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,Conference USA,11,exact
+2021-22,528589,James Madison,CAA,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2021-22,528591,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2021-22,528804,Kansas City,Summit League,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,47,exact
+2021-22,528590,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2021-22,528799,Kennesaw St.,ASUN,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,Conference USA,11,exact
+2021-22,528592,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2021-22,528593,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2021-22,528599,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2021-22,528606,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2021-22,528601,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2021-22,528594,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2021-22,528595,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2021-22,528596,Lamar University,WAC,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2021-22,528597,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2021-22,528598,Liberty,ASUN,2335,Liberty Flames,Liberty,Flames,LIB,Conference USA,11,exact
+2021-22,528812,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,Atlantic Sun Conference,46,exact
+2021-22,528479,Little Rock,Sun Belt,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2021-22,528502,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2021-22,528600,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2021-22,528734,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2021-22,528602,Louisiana Tech,C-USA,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2021-22,528603,Louisville,ACC,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2021-22,528607,Loyola Chicago,MVC,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2021-22,528605,Loyola Maryland,Patriot,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2021-22,528608,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2021-22,528609,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Conference,13,exact
+2021-22,528610,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Conference,13,exact
+2021-22,528611,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2021-22,528612,Marshall,C-USA,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2021-22,528614,Maryland,Big Ten,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2021-22,528616,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2021-22,528617,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2021-22,528618,Memphis,AAC,235,Memphis Tigers,Memphis,Tigers,MEM,American Conference,62,exact
+2021-22,528619,Mercer,SoCon,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2021-22,528815,Merrimack,NEC,2771,Merrimack Warriors,Merrimack,Warriors,MRMK,Metro Conference,13,exact
+2021-22,528621,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2021-22,528620,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2021-22,528623,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2021-22,528622,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2021-22,528624,Middle Tenn.,C-USA,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2021-22,528788,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2021-22,528625,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2021-22,528626,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2021-22,528627,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2021-22,528629,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2021-22,528732,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2021-22,528630,Monmouth,MAAC,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Coastal Athletic Association,10,exact
+2021-22,528632,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2021-22,528631,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2021-22,528633,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2021-22,528634,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2021-22,528635,Mount St. Mary's,NEC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Conference,13,exact
+2021-22,528636,Murray St.,OVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2021-22,528654,N.C. A&T,Big South,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Coastal Athletic Association,10,exact
+2021-22,528655,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2021-22,528656,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2021-22,528647,NJIT,America East,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2021-22,528763,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2021-22,528642,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2021-22,528645,Nevada,Mountain West,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2021-22,528646,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2021-22,528649,New Mexico,Mountain West,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2021-22,528648,New Mexico St.,WAC,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Conference USA,11,exact
+2021-22,528650,New Orleans,Southland,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2021-22,528651,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Conference,13,exact
+2021-22,528652,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2021-22,528653,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2021-22,527224,North Ala.,ASUN,2453,North Alabama Lions,North Alabama,Lions,UNA,Atlantic Sun Conference,46,exact
+2021-22,528638,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2021-22,528658,North Dakota,Summit League,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,47,exact
+2021-22,528657,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,47,exact
+2021-22,528805,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,Atlantic Sun Conference,46,exact
+2021-22,528659,North Texas,C-USA,249,North Texas Mean Green,North Texas,Mean Green,UNT,American Conference,62,exact
+2021-22,528661,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Coastal Athletic Association,10,exact
+2021-22,528662,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2021-22,528663,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2021-22,528664,Northern Ill.,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2021-22,528666,Northern Ky.,Horizon,94,Northern Kentucky Norse,Northern Kentucky,Norse,NKU,Horizon League,45,exact
+2021-22,528668,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2021-22,528667,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2021-22,528669,Notre Dame,ACC,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2021-22,528670,Oakland,Horizon,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2021-22,528672,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2021-22,528671,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2021-22,528674,Oklahoma,Big 12,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Southeastern Conference,23,exact
+2021-22,528673,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2021-22,528675,Old Dominion,C-USA,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2021-22,528628,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2021-22,528643,Omaha,Summit League,2437,Omaha Mavericks,Omaha,Mavericks,OMA,Summit League,47,exact
+2021-22,528676,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,47,exact
+2021-22,528678,Oregon,Pac-12,2483,Oregon Ducks,Oregon,Ducks,ORE,Big Ten Conference,7,exact
+2021-22,528677,Oregon St.,Pac-12,204,Oregon State Beavers,Oregon State,Beavers,ORST,West Coast Conference,29,exact
+2021-22,528679,Pacific,WCC,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2021-22,528682,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2021-22,528681,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2021-22,528683,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2021-22,528684,Pittsburgh,ACC,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2021-22,528686,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2021-22,528685,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2021-22,528687,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2021-22,528800,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2021-22,528688,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2021-22,528689,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2021-22,528690,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2021-22,528582,Purdue Fort Wayne,Horizon,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2021-22,528691,Quinnipiac,MAAC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Conference,13,exact
+2021-22,528692,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2021-22,528693,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2021-22,528694,Rice,C-USA,242,Rice Owls,Rice,Owls,RICE,American Conference,62,exact
+2021-22,528695,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2021-22,528696,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Conference,13,exact
+2021-22,528697,Robert Morris,Horizon,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2021-22,528698,Rutgers,Big Ten,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2021-22,528736,SFA,WAC,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Southland Conference,25,exact
+2021-22,528727,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2021-22,528728,SMU,AAC,2567,SMU Mustangs,SMU,Mustangs,SMU,Atlantic Coast Conference,2,exact
+2021-22,528504,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2021-22,528699,Sacred Heart,NEC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Metro Conference,13,exact
+2021-22,528702,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2021-22,528704,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2021-22,528705,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2021-22,528706,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2021-22,528707,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Conference,13,exact
+2021-22,528708,Sam Houston,Southland,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Conference USA,11,exact
+2021-22,528709,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2021-22,528711,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2021-22,528710,San Diego St.,Mountain West,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2021-22,528712,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2021-22,528713,San Jose St.,Mountain West,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2021-22,528714,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2021-22,528801,Seattle U,WAC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,United Athletic Conference,30,exact
+2021-22,528715,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2021-22,528716,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Conference,13,exact
+2021-22,528717,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2021-22,528719,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2021-22,528718,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2021-22,528721,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,47,exact
+2021-22,528720,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,47,exact
+2021-22,528722,South Fla.,AAC,58,South Florida Bulls,South Florida,Bulls,USF,American Conference,62,exact
+2021-22,528723,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2021-22,528724,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2021-22,528725,Southern California,Pac-12,30,USC Trojans,USC,Trojans,USC,Big Ten Conference,7,dict
+2021-22,528726,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2021-22,528729,Southern Miss.,C-USA,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2021-22,528730,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2021-22,528731,Southern Utah,Big Sky,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,United Athletic Conference,30,exact
+2021-22,528700,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2021-22,528701,St. Francis Brooklyn,NEC,2597,St. Francis Brooklyn Terriers,St. Francis Brooklyn,Terriers,SFNY,,,exact
+2021-22,528703,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2021-22,529315,St. Thomas (MN),Summit League,2900,St. Thomas Tommies,St. Thomas,Tommies,STMN,Summit League,47,alias
+2021-22,528735,Stanford,Pac-12,24,Stanford Cardinal,Stanford,Cardinal,STAN,Atlantic Coast Conference,2,exact
+2021-22,528737,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,Atlantic Sun Conference,46,exact
+2021-22,528738,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Coastal Athletic Association,10,exact
+2021-22,528739,Syracuse,ACC,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2021-22,528747,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2021-22,527222,Tarleton St.,WAC,2627,Tarleton State Texans,Tarleton State,Texans,TAR,United Athletic Conference,30,exact
+2021-22,528740,Temple,AAC,218,Temple Owls,Temple,Owls,TEM,American Conference,62,exact
+2021-22,528744,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2021-22,528741,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2021-22,528742,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2021-22,528751,Texas,Big 12,251,Texas Longhorns,Texas,Longhorns,TEX,Southeastern Conference,23,exact
+2021-22,528746,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2021-22,528748,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2021-22,528733,Texas St.,Sun Belt,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2021-22,528749,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2021-22,528754,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2021-22,528755,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Coastal Athletic Association,10,exact
+2021-22,528756,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2021-22,528757,Tulane,AAC,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Conference,62,exact
+2021-22,528760,Tulsa,AAC,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Conference,62,exact
+2021-22,527230,UAB,C-USA,5,UAB Blazers,UAB,Blazers,UAB,American Conference,62,exact
+2021-22,528507,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2021-22,528508,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2021-22,528510,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2021-22,528816,UC San Diego,Big West,28,UC San Diego Tritons,UC San Diego,Tritons,UCSD,Big West Conference,9,exact
+2021-22,528505,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2021-22,528514,UCF,AAC,2116,UCF Knights,UCF,Knights,UCF,Big 12 Conference,8,exact
+2021-22,528509,UCLA,Pac-12,26,UCLA Bruins,UCLA,Bruins,UCLA,Big Ten Conference,7,exact
+2021-22,528525,UConn,Big East,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2021-22,528579,UIC,Horizon,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2021-22,528806,UIW,Southland,2916,Incarnate Word Cardinals,Incarnate Word,Cardinals,UIW,Southland Conference,25,exact
+2021-22,528660,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2021-22,528613,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2021-22,528615,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2021-22,528604,UMass Lowell,America East,2349,UMass Lowell River Hawks,UMass Lowell,River Hawks,UML,America East Conference,1,exact
+2021-22,528637,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2021-22,528640,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2021-22,528641,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Coastal Athletic Association,10,exact
+2021-22,528665,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2021-22,528644,UNLV,Mountain West,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2021-22,528808,USC Upstate,Big South,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2021-22,528750,UT Arlington,Sun Belt,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,United Athletic Conference,30,exact
+2021-22,528745,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2021-22,528752,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2021-22,528680,UTRGV,WAC,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Southland Conference,25,dict
+2021-22,528753,UTSA,C-USA,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,American Conference,62,exact
+2021-22,528765,Utah,Pac-12,254,Utah Utes,Utah,Utes,UTAH,Big 12 Conference,8,exact
+2021-22,528764,Utah St.,Mountain West,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2021-22,528814,Utah Valley,WAC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,United Athletic Conference,30,exact
+2021-22,528770,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2021-22,528766,Valparaiso,MVC,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2021-22,528767,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2021-22,528768,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2021-22,528769,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2021-22,528772,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2021-22,528771,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2021-22,528773,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2021-22,528774,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2021-22,528776,Washington,Pac-12,264,Washington Huskies,Washington,Huskies,WASH,Big Ten Conference,7,exact
+2021-22,528775,Washington St.,Pac-12,265,Washington State Cougars,Washington State,Cougars,WSU,West Coast Conference,29,exact
+2021-22,528777,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2021-22,528778,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2021-22,528779,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2021-22,528780,Western Ill.,Summit League,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Ohio Valley Conference,20,exact
+2021-22,528781,Western Ky.,C-USA,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2021-22,528782,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2021-22,528783,Wichita St.,AAC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Conference,62,exact
+2021-22,528784,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Coastal Athletic Association,10,exact
+2021-22,528785,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2021-22,528787,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2021-22,528807,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2021-22,528789,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2021-22,528790,Wyoming,Mountain West,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2021-22,528791,Xavier,Big East,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2021-22,528792,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2021-22,528793,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2022-23,542807,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2022-23,542059,Abilene Christian,WAC,2000,Abilene Christian Wildcats,Abilene Christian,Wildcats,ACU,United Athletic Conference,30,exact
+2022-23,542702,Air Force,Mountain West,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2022-23,542063,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2022-23,542069,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2022-23,542065,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2022-23,542067,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2022-23,542077,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2022-23,542079,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2022-23,542083,App State,Sun Belt,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2022-23,542088,Arizona,Pac-12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Big 12 Conference,8,exact
+2022-23,542084,Arizona St.,Pac-12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Big 12 Conference,8,exact
+2022-23,542789,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2022-23,542092,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2022-23,542090,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2022-23,542704,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2022-23,542097,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2022-23,542099,Austin Peay,ASUN,2046,Austin Peay Governors,Austin Peay,Governors,APSU,Atlantic Sun Conference,46,exact
+2022-23,542122,BYU,WCC,252,BYU Cougars,BYU,Cougars,BYU,Big 12 Conference,8,exact
+2022-23,542101,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2022-23,542105,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2022-23,542697,Bellarmine,ASUN,91,Bellarmine Knights,Bellarmine,Knights,BELL,Atlantic Sun Conference,46,exact
+2022-23,542803,Belmont,MVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2022-23,542107,Bethune-Cookman,SWAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2022-23,542109,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2022-23,542111,Boise St.,Mountain West,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2022-23,542114,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2022-23,542116,Boston U.,Patriot,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2022-23,542118,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2022-23,542120,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2022-23,542124,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2022-23,542126,Bryant,America East,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2022-23,542129,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2022-23,542131,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2022-23,542133,Butler,Big East,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2022-23,542139,CSU Bakersfield,Big West,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2022-23,542148,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2022-23,542135,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2022-23,542144,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2022-23,542153,California,Pac-12,25,California Golden Bears,California,Golden Bears,CAL,Atlantic Coast Conference,2,exact
+2022-23,542055,California Baptist,WAC,2856,California Baptist Lancers,California Baptist,Lancers,CBU,United Athletic Conference,30,exact
+2022-23,542164,Campbell,Big South,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Coastal Athletic Association,10,exact
+2022-23,542166,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Conference,13,exact
+2022-23,542772,Central Ark.,ASUN,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,Atlantic Sun Conference,46,exact
+2022-23,542168,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2022-23,542172,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2022-23,542103,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2022-23,542443,Charlotte,C-USA,2429,Charlotte 49ers,Charlotte,49ers,CLT,American Conference,62,exact
+2022-23,542665,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2022-23,542174,Chicago St.,Independent,2130,Chicago State Cougars,Chicago State,Cougars,CHST,Northeast Conference,19,exact
+2022-23,542176,Cincinnati,AAC,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,Big 12 Conference,8,exact
+2022-23,542178,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2022-23,542180,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2022-23,542182,Coastal Carolina,Sun Belt,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2022-23,542775,Col. of Charleston,CAA,232,Charleston Cougars,Charleston,Cougars,COFC,Coastal Athletic Association,10,dict
+2022-23,542184,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2022-23,542189,Colorado,Pac-12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Big 12 Conference,8,exact
+2022-23,542186,Colorado St.,Mountain West,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2022-23,542191,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2022-23,542197,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2022-23,542199,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2022-23,542201,Creighton,Big East,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2022-23,542203,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2022-23,542206,Davidson,Atlantic 10,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2022-23,542208,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2022-23,542212,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2022-23,542217,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Coastal Athletic Association,10,exact
+2022-23,542215,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2022-23,542218,Denver,Summit League,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,47,exact
+2022-23,542220,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2022-23,542221,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2022-23,542224,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Coastal Athletic Association,10,exact
+2022-23,542226,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2022-23,542228,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2022-23,542231,ETSU,SoCon,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2022-23,542229,East Carolina,AAC,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Conference,62,exact
+2022-23,542233,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2022-23,542238,Eastern Ky.,ASUN,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,Atlantic Sun Conference,46,exact
+2022-23,542241,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2022-23,542243,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2022-23,542777,Elon,CAA,2210,Elon Phoenix,Elon,Phoenix,ELON,Coastal Athletic Association,10,exact
+2022-23,542245,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2022-23,542812,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,Atlantic Sun Conference,46,exact
+2022-23,542256,FIU,C-USA,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2022-23,542247,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Conference,13,exact
+2022-23,542250,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2022-23,542254,Fla. Atlantic,C-USA,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,American Conference,62,exact
+2022-23,542261,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2022-23,542252,Florida A&M,SWAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2022-23,542258,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2022-23,542263,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2022-23,542142,Fresno St.,Mountain West,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2022-23,542265,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2022-23,542275,Ga. Southern,Sun Belt,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2022-23,542778,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2022-23,542267,George Mason,Atlantic 10,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2022-23,542270,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2022-23,542272,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2022-23,542280,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2022-23,542277,Georgia St.,Sun Belt,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2022-23,542279,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2022-23,542282,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2022-23,542284,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2022-23,542780,Grand Canyon,WAC,2253,Grand Canyon Lopes,Grand Canyon,Lopes,GCU,United Athletic Conference,30,exact
+2022-23,542755,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2022-23,542286,Hampton,CAA,2261,Hampton Pirates,Hampton,Pirates,HAMP,Coastal Athletic Association,10,exact
+2022-23,542288,Hartford,America East,42,Hartford Hawks,Hartford,Hawks,HART,,,exact
+2022-23,542291,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2022-23,542293,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2022-23,542805,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2022-23,542295,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Coastal Athletic Association,10,exact
+2022-23,542297,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2022-23,542302,Houston,AAC,248,Houston Cougars,Houston,Cougars,HOU,Big 12 Conference,8,exact
+2022-23,542300,Houston Christian,Southland,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,exact
+2022-23,542303,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2022-23,542790,IUPUI,Horizon,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,alias
+2022-23,542306,Idaho,Big Sky,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2022-23,542304,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2022-23,542310,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2022-23,542308,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2022-23,542315,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2022-23,542313,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2022-23,542320,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Conference,13,exact
+2022-23,542324,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2022-23,542322,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2022-23,542326,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2022-23,542330,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,Atlantic Sun Conference,46,exact
+2022-23,542328,Jacksonville St.,ASUN,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,Conference USA,11,exact
+2022-23,542332,James Madison,Sun Belt,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2022-23,542336,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2022-23,542792,Kansas City,Summit League,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,47,exact
+2022-23,542334,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2022-23,542782,Kennesaw St.,ASUN,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,Conference USA,11,exact
+2022-23,542338,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2022-23,542340,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2022-23,542353,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2022-23,542367,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2022-23,542358,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2022-23,542343,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2022-23,542345,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2022-23,542347,Lamar University,WAC,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2022-23,542348,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2022-23,542351,Liberty,ASUN,2335,Liberty Flames,Liberty,Flames,LIB,Conference USA,11,exact
+2022-23,543536,Lindenwood,OVC,2815,Lindenwood Lions,Lindenwood,Lions,LIN,Ohio Valley Conference,20,exact
+2022-23,542809,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,Atlantic Sun Conference,46,exact
+2022-23,542094,Little Rock,OVC,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2022-23,542146,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2022-23,542355,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2022-23,542647,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2022-23,542360,Louisiana Tech,C-USA,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2022-23,542362,Louisville,ACC,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2022-23,542369,Loyola Chicago,Atlantic 10,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2022-23,542365,Loyola Maryland,Patriot,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2022-23,542371,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2022-23,542373,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Conference,13,exact
+2022-23,542375,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Conference,13,exact
+2022-23,542378,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2022-23,542380,Marshall,Sun Belt,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2022-23,542384,Maryland,Big Ten,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2022-23,542389,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2022-23,542392,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2022-23,542394,Memphis,AAC,235,Memphis Tigers,Memphis,Tigers,MEM,American Conference,62,exact
+2022-23,542396,Mercer,SoCon,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2022-23,542817,Merrimack,NEC,2771,Merrimack Warriors,Merrimack,Warriors,MRMK,Metro Conference,13,exact
+2022-23,542401,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2022-23,542399,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2022-23,542405,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2022-23,542403,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2022-23,542408,Middle Tenn.,C-USA,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2022-23,542760,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2022-23,542409,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2022-23,542412,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2022-23,542415,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2022-23,542421,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2022-23,542643,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2022-23,542423,Monmouth,CAA,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Coastal Athletic Association,10,exact
+2022-23,542428,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2022-23,542426,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2022-23,542430,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2022-23,542432,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2022-23,542435,Mount St. Mary's,MAAC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Conference,13,exact
+2022-23,542437,Murray St.,MVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2022-23,542472,N.C. A&T,CAA,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Coastal Athletic Association,10,exact
+2022-23,542474,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2022-23,542476,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2022-23,542493,NIU,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2022-23,542459,NJIT,America East,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2022-23,542706,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2022-23,542450,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2022-23,542455,Nevada,Mountain West,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2022-23,542458,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2022-23,542463,New Mexico,Mountain West,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2022-23,542461,New Mexico St.,WAC,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Conference USA,11,exact
+2022-23,542464,New Orleans,Southland,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2022-23,542466,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Conference,13,exact
+2022-23,542468,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2022-23,542470,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2022-23,542057,North Ala.,ASUN,2453,North Alabama Lions,North Alabama,Lions,UNA,Atlantic Sun Conference,46,exact
+2022-23,542441,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2022-23,542480,North Dakota,Summit League,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,47,exact
+2022-23,542478,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,47,exact
+2022-23,542794,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,Atlantic Sun Conference,46,exact
+2022-23,542482,North Texas,C-USA,249,North Texas Mean Green,North Texas,Mean Green,UNT,American Conference,62,exact
+2022-23,542486,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Coastal Athletic Association,10,exact
+2022-23,542488,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2022-23,542490,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2022-23,542497,Northern Ky.,Horizon,94,Northern Kentucky Norse,Northern Kentucky,Norse,NKU,Horizon League,45,exact
+2022-23,542500,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2022-23,542498,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2022-23,542503,Notre Dame,ACC,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2022-23,542506,Oakland,Horizon,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2022-23,542510,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2022-23,542508,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2022-23,542514,Oklahoma,Big 12,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Southeastern Conference,23,exact
+2022-23,542512,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2022-23,542516,Old Dominion,Sun Belt,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2022-23,542418,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2022-23,542452,Omaha,Summit League,2437,Omaha Mavericks,Omaha,Mavericks,OMA,Summit League,47,exact
+2022-23,542518,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,47,exact
+2022-23,542522,Oregon,Pac-12,2483,Oregon Ducks,Oregon,Ducks,ORE,Big Ten Conference,7,exact
+2022-23,542520,Oregon St.,Pac-12,204,Oregon State Beavers,Oregon State,Beavers,ORST,West Coast Conference,29,exact
+2022-23,542525,Pacific,WCC,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2022-23,542531,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2022-23,542528,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2022-23,542533,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2022-23,542536,Pittsburgh,ACC,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2022-23,542540,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2022-23,542538,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2022-23,542543,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2022-23,542784,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2022-23,542546,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2022-23,542548,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2022-23,542551,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2022-23,542318,Purdue Fort Wayne,Horizon,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2022-23,543491,Queens (NC),ASUN,2511,Queens University Royals,Queens University,Royals,QUC,Atlantic Sun Conference,46,dict
+2022-23,542553,Quinnipiac,MAAC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Conference,13,exact
+2022-23,542555,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2022-23,542557,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2022-23,542559,Rice,C-USA,242,Rice Owls,Rice,Owls,RICE,American Conference,62,exact
+2022-23,542561,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2022-23,542562,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Conference,13,exact
+2022-23,542565,Robert Morris,Horizon,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2022-23,542567,Rutgers,Big Ten,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2022-23,542651,SFA,WAC,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Southland Conference,25,exact
+2022-23,542633,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2022-23,542634,SMU,AAC,2567,SMU Mustangs,SMU,Mustangs,SMU,Atlantic Coast Conference,2,exact
+2022-23,542149,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2022-23,542568,Sacred Heart,NEC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Metro Conference,13,exact
+2022-23,542574,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2022-23,542578,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2022-23,542580,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2022-23,542583,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2022-23,542585,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Conference,13,exact
+2022-23,542587,Sam Houston,Southland,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Conference USA,11,exact
+2022-23,542589,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2022-23,542593,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2022-23,542590,San Diego St.,Mountain West,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2022-23,542594,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2022-23,542596,San Jose St.,Mountain West,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2022-23,542599,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2022-23,542786,Seattle U,WAC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,United Athletic Conference,30,exact
+2022-23,542602,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2022-23,542604,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Conference,13,exact
+2022-23,542607,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2022-23,542612,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2022-23,542610,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2022-23,542618,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,47,exact
+2022-23,542615,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,47,exact
+2022-23,542621,South Fla.,AAC,58,South Florida Bulls,South Florida,Bulls,USF,American Conference,62,exact
+2022-23,542624,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2022-23,542626,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2022-23,542628,Southern California,Pac-12,30,USC Trojans,USC,Trojans,USC,Big Ten Conference,7,dict
+2022-23,542630,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2022-23,543608,Southern Ind.,OVC,88,Southern Indiana Screaming Eagles,Southern Indiana,Screaming Eagles,USI,Ohio Valley Conference,20,alias
+2022-23,542637,Southern Miss.,Sun Belt,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2022-23,542639,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2022-23,542641,Southern Utah,WAC,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,United Athletic Conference,30,exact
+2022-23,542570,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2022-23,542572,St. Francis Brooklyn,NEC,2597,St. Francis Brooklyn Terriers,St. Francis Brooklyn,Terriers,SFNY,,,exact
+2022-23,542576,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2022-23,542236,St. Thomas (MN),Summit League,2900,St. Thomas Tommies,St. Thomas,Tommies,STMN,Summit League,47,alias
+2022-23,542649,Stanford,Pac-12,24,Stanford Cardinal,Stanford,Cardinal,STAN,Atlantic Coast Conference,2,exact
+2022-23,542653,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,Atlantic Sun Conference,46,exact
+2022-23,543609,Stonehill,NEC,284,Stonehill Skyhawks,Stonehill,Skyhawks,STO,Northeast Conference,19,exact
+2022-23,542655,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Coastal Athletic Association,10,exact
+2022-23,542657,Syracuse,ACC,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2022-23,542672,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2022-23,542050,Tarleton St.,WAC,2627,Tarleton State Texans,Tarleton State,Texans,TAR,United Athletic Conference,30,exact
+2022-23,542659,Temple,AAC,218,Temple Owls,Temple,Owls,TEM,American Conference,62,exact
+2022-23,542666,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2022-23,542661,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2022-23,542663,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2022-23,543645,Tex. A&M-Commerce,Southland,2837,East Texas A&M Lions,East Texas A&M,Lions,ETAM,Southland Conference,25,alias
+2022-23,542680,Texas,Big 12,251,Texas Longhorns,Texas,Longhorns,TEX,Southeastern Conference,23,exact
+2022-23,542669,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2022-23,542674,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2022-23,542645,Texas St.,Sun Belt,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2022-23,542676,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2022-23,542686,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2022-23,542689,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Coastal Athletic Association,10,exact
+2022-23,542691,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2022-23,542692,Tulane,AAC,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Conference,62,exact
+2022-23,542699,Tulsa,AAC,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Conference,62,exact
+2022-23,542072,UAB,C-USA,5,UAB Blazers,UAB,Blazers,UAB,American Conference,62,exact
+2022-23,542075,UAlbany,America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,exact
+2022-23,542156,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2022-23,542158,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2022-23,542163,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2022-23,542819,UC San Diego,Big West,28,UC San Diego Tritons,UC San Diego,Tritons,UCSD,Big West Conference,9,exact
+2022-23,542151,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2022-23,542169,UCF,AAC,2116,UCF Knights,UCF,Knights,UCF,Big 12 Conference,8,exact
+2022-23,542160,UCLA,Pac-12,26,UCLA Bruins,UCLA,Bruins,UCLA,Big Ten Conference,7,exact
+2022-23,542194,UConn,Big East,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2022-23,542312,UIC,MVC,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2022-23,542796,UIW,Southland,2916,Incarnate Word Cardinals,Incarnate Word,Cardinals,UIW,Southland Conference,25,exact
+2022-23,542484,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2022-23,542382,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2022-23,542386,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2022-23,542364,UMass Lowell,America East,2349,UMass Lowell River Hawks,UMass Lowell,River Hawks,UML,America East Conference,1,exact
+2022-23,542439,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2022-23,542446,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2022-23,542448,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Coastal Athletic Association,10,exact
+2022-23,542495,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2022-23,542453,UNLV,Mountain West,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2022-23,542801,USC Upstate,Big South,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2022-23,542678,UT Arlington,WAC,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,United Athletic Conference,30,exact
+2022-23,542668,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2022-23,542683,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2022-23,542527,UTRGV,WAC,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Southland Conference,25,dict
+2022-23,542684,UTSA,C-USA,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,American Conference,62,exact
+2022-23,542710,Utah,Pac-12,254,Utah Utes,Utah,Utes,UTAH,Big 12 Conference,8,exact
+2022-23,542708,Utah St.,Mountain West,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2022-23,542695,Utah Tech,WAC,3101,Utah Tech Trailblazers,Utah Tech,Trailblazers,UTU,United Athletic Conference,30,exact
+2022-23,542814,Utah Valley,WAC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,United Athletic Conference,30,exact
+2022-23,542721,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2022-23,542712,Valparaiso,MVC,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2022-23,542715,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2022-23,542717,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2022-23,542719,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2022-23,542725,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2022-23,542723,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2022-23,542727,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2022-23,542729,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2022-23,542733,Washington,Pac-12,264,Washington Huskies,Washington,Huskies,WASH,Big Ten Conference,7,exact
+2022-23,542731,Washington St.,Pac-12,265,Washington State Cougars,Washington State,Cougars,WSU,West Coast Conference,29,exact
+2022-23,542736,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2022-23,542738,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2022-23,542740,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2022-23,542742,Western Ill.,Summit League,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Ohio Valley Conference,20,exact
+2022-23,542745,Western Ky.,C-USA,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2022-23,542747,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2022-23,542748,Wichita St.,AAC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Conference,62,exact
+2022-23,542750,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Coastal Athletic Association,10,exact
+2022-23,542752,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2022-23,542757,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2022-23,542799,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2022-23,542762,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2022-23,542764,Wyoming,Mountain West,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2022-23,542766,Xavier,Big East,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2022-23,542768,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2022-23,542770,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2023-24,560556,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2023-24,560574,Abilene Christian,WAC,2000,Abilene Christian Wildcats,Abilene Christian,Wildcats,ACU,United Athletic Conference,30,exact
+2023-24,561175,Air Force,MWC,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2023-24,560576,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2023-24,560582,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2023-24,560578,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2023-24,560580,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2023-24,560588,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2023-24,560590,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2023-24,560592,App State,Sun Belt,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2023-24,560595,Arizona,Pac-12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Big 12 Conference,8,exact
+2023-24,560594,Arizona St.,Pac-12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Big 12 Conference,8,exact
+2023-24,561256,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2023-24,560599,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2023-24,560597,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2023-24,561177,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2023-24,560603,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2023-24,560605,Austin Peay,ASUN,2046,Austin Peay Governors,Austin Peay,Governors,APSU,Atlantic Sun Conference,46,exact
+2023-24,560627,BYU,Big 12,252,BYU Cougars,BYU,Cougars,BYU,Big 12 Conference,8,exact
+2023-24,560607,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2023-24,560611,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2023-24,561171,Bellarmine,ASUN,91,Bellarmine Knights,Bellarmine,Knights,BELL,Atlantic Sun Conference,46,exact
+2023-24,560553,Belmont,MVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2023-24,560613,Bethune-Cookman,SWAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2023-24,560615,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2023-24,560617,Boise St.,MWC,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2023-24,560619,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2023-24,560621,Boston U.,Patriot,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2023-24,560623,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2023-24,560625,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2023-24,560629,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2023-24,560630,Bryant,America East,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2023-24,560634,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2023-24,560636,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2023-24,560638,Butler,Big East,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2023-24,560642,CSU Bakersfield,WAC,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2023-24,560650,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2023-24,560640,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2023-24,560645,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2023-24,560656,California,Pac-12,25,California Golden Bears,California,Golden Bears,CAL,Atlantic Coast Conference,2,exact
+2023-24,560570,California Baptist,WAC,2856,California Baptist Lancers,California Baptist,Lancers,CBU,United Athletic Conference,30,exact
+2023-24,560665,Campbell,CAA,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Coastal Athletic Association,10,exact
+2023-24,560668,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Conference,13,exact
+2023-24,561240,Central Ark.,ASUN,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,Atlantic Sun Conference,46,exact
+2023-24,560670,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2023-24,560673,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2023-24,560609,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2023-24,560928,Charlotte,AAC,2429,Charlotte 49ers,Charlotte,49ers,CLT,American Conference,62,exact
+2023-24,561140,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2023-24,560677,Cincinnati,Big 12,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,Big 12 Conference,8,exact
+2023-24,560679,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2023-24,560681,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2023-24,560684,Coastal Carolina,Sun Belt,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2023-24,561242,Col. of Charleston,CAA,232,Charleston Cougars,Charleston,Cougars,COFC,Coastal Athletic Association,10,dict
+2023-24,560686,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2023-24,560690,Colorado,Pac-12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Big 12 Conference,8,exact
+2023-24,560688,Colorado St.,MWC,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2023-24,560692,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2023-24,560697,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2023-24,560698,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2023-24,560701,Creighton,Big East,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2023-24,560703,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2023-24,560706,Davidson,Atlantic 10,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2023-24,560708,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2023-24,560710,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2023-24,560715,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Coastal Athletic Association,10,exact
+2023-24,560713,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2023-24,560717,Denver,Summit League,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,47,exact
+2023-24,560719,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2023-24,560720,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2023-24,560722,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Coastal Athletic Association,10,exact
+2023-24,560724,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2023-24,560725,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2023-24,560730,ETSU,SoCon,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2023-24,560728,East Carolina,AAC,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Conference,62,exact
+2023-24,560732,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2023-24,560737,Eastern Ky.,ASUN,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,Atlantic Sun Conference,46,exact
+2023-24,560739,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2023-24,560741,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2023-24,561244,Elon,CAA,2210,Elon Phoenix,Elon,Phoenix,ELON,Coastal Athletic Association,10,exact
+2023-24,560743,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2023-24,560561,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,Atlantic Sun Conference,46,exact
+2023-24,560753,FIU,C-USA,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2023-24,560745,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Conference,13,exact
+2023-24,560748,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2023-24,560751,Fla. Atlantic,AAC,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,American Conference,62,exact
+2023-24,560757,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2023-24,560749,Florida A&M,SWAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2023-24,560754,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2023-24,560759,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2023-24,560644,Fresno St.,MWC,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2023-24,560760,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2023-24,560768,Ga. Southern,Sun Belt,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2023-24,561246,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2023-24,560762,George Mason,Atlantic 10,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2023-24,560764,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2023-24,560766,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2023-24,560774,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2023-24,560770,Georgia St.,Sun Belt,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2023-24,560771,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2023-24,560776,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2023-24,560778,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2023-24,561248,Grand Canyon,WAC,2253,Grand Canyon Lopes,Grand Canyon,Lopes,GCU,United Athletic Conference,30,exact
+2023-24,561225,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2023-24,560779,Hampton,CAA,2261,Hampton Pirates,Hampton,Pirates,HAMP,Coastal Athletic Association,10,exact
+2023-24,560784,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2023-24,560786,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2023-24,560554,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2023-24,560788,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Coastal Athletic Association,10,exact
+2023-24,560790,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2023-24,560794,Houston,Big 12,248,Houston Cougars,Houston,Cougars,HOU,Big 12 Conference,8,exact
+2023-24,560793,Houston Christian,Southland,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,exact
+2023-24,560797,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2023-24,561257,IUPUI,Horizon,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,alias
+2023-24,560801,Idaho,Big Sky,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2023-24,560799,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2023-24,560805,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2023-24,560803,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2023-24,560811,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2023-24,560809,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2023-24,560814,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Conference,13,exact
+2023-24,560818,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2023-24,560816,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2023-24,560821,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2023-24,560825,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,Atlantic Sun Conference,46,exact
+2023-24,560823,Jacksonville St.,C-USA,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,Conference USA,11,exact
+2023-24,560827,James Madison,Sun Belt,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2023-24,560831,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2023-24,560547,Kansas City,WAC,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,47,exact
+2023-24,560829,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2023-24,561250,Kennesaw St.,ASUN,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,Conference USA,11,exact
+2023-24,560833,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2023-24,560835,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2023-24,560846,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2023-24,560860,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2023-24,560850,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2023-24,560837,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2023-24,560839,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2023-24,560841,Lamar University,WAC,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2023-24,561728,Le Moyne,NEC,2330,Le Moyne Dolphins,Le Moyne,Dolphins,LEM,Northeast Conference,19,exact
+2023-24,560842,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2023-24,560844,Liberty,C-USA,2335,Liberty Flames,Liberty,Flames,LIB,Conference USA,11,exact
+2023-24,561261,Lindenwood,OVC,2815,Lindenwood Lions,Lindenwood,Lions,LIN,Ohio Valley Conference,20,exact
+2023-24,560559,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,Atlantic Sun Conference,46,exact
+2023-24,560601,Little Rock,OVC,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2023-24,560648,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2023-24,560848,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2023-24,561120,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2023-24,560852,Louisiana Tech,C-USA,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2023-24,560854,Louisville,ACC,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2023-24,560862,Loyola Chicago,Atlantic 10,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2023-24,560858,Loyola Maryland,Patriot,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2023-24,560864,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2023-24,560866,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Conference,13,exact
+2023-24,560868,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Conference,13,exact
+2023-24,560870,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2023-24,560872,Marshall,Sun Belt,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2023-24,560876,Maryland,Big Ten,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2023-24,560880,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2023-24,560882,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2023-24,560884,Memphis,AAC,235,Memphis Tigers,Memphis,Tigers,MEM,American Conference,62,exact
+2023-24,560886,Mercer,SoCon,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2023-24,560564,Merrimack,NEC,2771,Merrimack Warriors,Merrimack,Warriors,MRMK,Metro Conference,13,exact
+2023-24,560890,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2023-24,560888,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2023-24,560896,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2023-24,560894,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2023-24,560898,Middle Tenn.,C-USA,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2023-24,561229,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2023-24,560900,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2023-24,560902,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2023-24,560904,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2023-24,560907,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2023-24,561116,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2023-24,560910,Monmouth,CAA,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Coastal Athletic Association,10,exact
+2023-24,560914,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2023-24,560912,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2023-24,560916,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2023-24,560918,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2023-24,560921,Mount St. Mary's,MAAC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Conference,13,exact
+2023-24,560923,Murray St.,MVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2023-24,560959,N.C. A&T,CAA,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Coastal Athletic Association,10,exact
+2023-24,560960,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2023-24,560962,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2023-24,560979,NIU,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2023-24,560944,NJIT,ASUN,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2023-24,561180,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2023-24,560934,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2023-24,560940,Nevada,MWC,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2023-24,560942,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2023-24,560948,New Mexico,MWC,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2023-24,560946,New Mexico St.,C-USA,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Conference USA,11,exact
+2023-24,560950,New Orleans,Southland,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2023-24,560952,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Conference,13,exact
+2023-24,560954,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2023-24,560957,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2023-24,560572,North Ala.,ASUN,2453,North Alabama Lions,North Alabama,Lions,UNA,Atlantic Sun Conference,46,exact
+2023-24,560927,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2023-24,560967,North Dakota,Summit League,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,47,exact
+2023-24,560965,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,47,exact
+2023-24,560548,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,Atlantic Sun Conference,46,exact
+2023-24,560969,North Texas,AAC,249,North Texas Mean Green,North Texas,Mean Green,UNT,American Conference,62,exact
+2023-24,560973,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Coastal Athletic Association,10,exact
+2023-24,560975,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2023-24,560977,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2023-24,560984,Northern Ky.,Horizon,94,Northern Kentucky Norse,Northern Kentucky,Norse,NKU,Horizon League,45,exact
+2023-24,560987,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2023-24,560986,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2023-24,560990,Notre Dame,ACC,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2023-24,560991,Oakland,Horizon,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2023-24,560996,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2023-24,560993,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2023-24,560999,Oklahoma,Big 12,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Southeastern Conference,23,exact
+2023-24,560997,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2023-24,561001,Old Dominion,Sun Belt,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2023-24,560906,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2023-24,560936,Omaha,Summit League,2437,Omaha Mavericks,Omaha,Mavericks,OMA,Summit League,47,exact
+2023-24,561003,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,47,exact
+2023-24,561007,Oregon,Pac-12,2483,Oregon Ducks,Oregon,Ducks,ORE,Big Ten Conference,7,exact
+2023-24,561005,Oregon St.,Pac-12,204,Oregon State Beavers,Oregon State,Beavers,ORST,West Coast Conference,29,exact
+2023-24,561009,Pacific,WCC,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2023-24,561015,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2023-24,561013,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2023-24,561017,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2023-24,561019,Pittsburgh,ACC,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2023-24,561023,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2023-24,561021,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2023-24,561025,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2023-24,561252,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2023-24,561027,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2023-24,561030,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2023-24,561032,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2023-24,560812,Purdue Fort Wayne,Summit League,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2023-24,561260,Queens (NC),ASUN,2511,Queens University Royals,Queens University,Royals,QUC,Atlantic Sun Conference,46,dict
+2023-24,561034,Quinnipiac,MAAC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Conference,13,exact
+2023-24,561037,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2023-24,561039,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2023-24,561041,Rice,AAC,242,Rice Owls,Rice,Owls,RICE,American Conference,62,exact
+2023-24,561043,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2023-24,561045,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Conference,13,exact
+2023-24,561046,Robert Morris,NEC,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2023-24,561048,Rutgers,Big Ten,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2023-24,561125,SFA,WAC,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Southland Conference,25,exact
+2023-24,561105,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2023-24,561107,SMU,AAC,2567,SMU Mustangs,SMU,Mustangs,SMU,Atlantic Coast Conference,2,exact
+2023-24,560652,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2023-24,561051,Sacred Heart,NEC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Metro Conference,13,exact
+2023-24,561057,Saint Francis (PA),NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,exact
+2023-24,561060,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2023-24,561062,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2023-24,561064,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2023-24,561065,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Conference,13,exact
+2023-24,561066,Sam Houston,C-USA,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Conference USA,11,exact
+2023-24,561068,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2023-24,561071,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2023-24,561070,San Diego St.,MWC,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2023-24,561073,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2023-24,561075,San Jose St.,MWC,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2023-24,561076,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2023-24,561254,Seattle U,WAC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,United Athletic Conference,30,exact
+2023-24,561079,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2023-24,561081,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Conference,13,exact
+2023-24,561083,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2023-24,561087,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2023-24,561085,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2023-24,561093,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,47,exact
+2023-24,561089,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,47,exact
+2023-24,561095,South Fla.,AAC,58,South Florida Bulls,South Florida,Bulls,USF,American Conference,62,exact
+2023-24,561097,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2023-24,561099,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2023-24,561101,Southern California,Pac-12,30,USC Trojans,USC,Trojans,USC,Big Ten Conference,7,dict
+2023-24,561103,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2023-24,561263,Southern Ind.,OVC,88,Southern Indiana Screaming Eagles,Southern Indiana,Screaming Eagles,USI,Ohio Valley Conference,20,alias
+2023-24,561109,Southern Miss.,Sun Belt,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2023-24,561111,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2023-24,561114,Southern Utah,WAC,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,United Athletic Conference,30,exact
+2023-24,561053,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2023-24,561058,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2023-24,560734,St. Thomas (MN),Summit League,2900,St. Thomas Tommies,St. Thomas,Tommies,STMN,Summit League,47,alias
+2023-24,561123,Stanford,Pac-12,24,Stanford Cardinal,Stanford,Cardinal,STAN,Atlantic Coast Conference,2,exact
+2023-24,561128,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,Atlantic Sun Conference,46,exact
+2023-24,561266,Stonehill,NEC,284,Stonehill Skyhawks,Stonehill,Skyhawks,STO,Northeast Conference,19,exact
+2023-24,561130,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Coastal Athletic Association,10,exact
+2023-24,561132,Syracuse,ACC,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2023-24,561148,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2023-24,560568,Tarleton St.,WAC,2627,Tarleton State Texans,Tarleton State,Texans,TAR,United Athletic Conference,30,exact
+2023-24,561135,Temple,AAC,218,Temple Owls,Temple,Owls,TEM,American Conference,62,exact
+2023-24,561142,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2023-24,561137,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2023-24,561138,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2023-24,561155,Texas,Big 12,251,Texas Longhorns,Texas,Longhorns,TEX,Southeastern Conference,23,exact
+2023-24,561146,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2023-24,561149,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2023-24,561118,Texas St.,Sun Belt,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2023-24,561151,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2023-24,561161,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2023-24,561163,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Coastal Athletic Association,10,exact
+2023-24,561165,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2023-24,561167,Tulane,AAC,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Conference,62,exact
+2023-24,561173,Tulsa,AAC,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Conference,62,exact
+2023-24,560584,UAB,AAC,5,UAB Blazers,UAB,Blazers,UAB,American Conference,62,exact
+2023-24,560586,UAlbany,America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,exact
+2023-24,560657,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2023-24,560660,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2023-24,560663,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2023-24,560566,UC San Diego,Big West,28,UC San Diego Tritons,UC San Diego,Tritons,UCSD,Big West Conference,9,exact
+2023-24,560653,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2023-24,560671,UCF,Big 12,2116,UCF Knights,UCF,Knights,UCF,Big 12 Conference,8,exact
+2023-24,560661,UCLA,Pac-12,26,UCLA Bruins,UCLA,Bruins,UCLA,Big Ten Conference,7,exact
+2023-24,560694,UConn,AAC,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2023-24,560807,UIC,MVC,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2023-24,560549,UIW,Southland,2916,Incarnate Word Cardinals,Incarnate Word,Cardinals,UIW,Southland Conference,25,exact
+2023-24,560971,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2023-24,560874,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2023-24,560878,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2023-24,560856,UMass Lowell,America East,2349,UMass Lowell River Hawks,UMass Lowell,River Hawks,UML,America East Conference,1,exact
+2023-24,560925,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2023-24,560930,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2023-24,560932,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Coastal Athletic Association,10,exact
+2023-24,560982,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2023-24,560938,UNLV,MWC,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2023-24,560551,USC Upstate,Big South,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2023-24,561153,UT Arlington,WAC,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,United Athletic Conference,30,exact
+2023-24,561144,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2023-24,561157,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2023-24,561011,UTRGV,WAC,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Southland Conference,25,dict
+2023-24,561159,UTSA,AAC,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,American Conference,62,exact
+2023-24,561183,Utah,Pac-12,254,Utah Utes,Utah,Utes,UTAH,Big 12 Conference,8,exact
+2023-24,561181,Utah St.,MWC,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2023-24,561169,Utah Tech,WAC,3101,Utah Tech Trailblazers,Utah Tech,Trailblazers,UTU,United Athletic Conference,30,exact
+2023-24,560563,Utah Valley,WAC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,United Athletic Conference,30,exact
+2023-24,561193,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2023-24,561185,Valparaiso,MVC,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2023-24,561187,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2023-24,561189,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2023-24,561191,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2023-24,561198,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2023-24,561196,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2023-24,561200,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2023-24,561201,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2023-24,561205,Washington,Pac-12,264,Washington Huskies,Washington,Huskies,WASH,Big Ten Conference,7,exact
+2023-24,561203,Washington St.,Pac-12,265,Washington State Cougars,Washington State,Cougars,WSU,West Coast Conference,29,exact
+2023-24,561207,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2023-24,561209,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2023-24,561211,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2023-24,561213,Western Ill.,OVC,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Ohio Valley Conference,20,exact
+2023-24,561215,Western Ky.,C-USA,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2023-24,561217,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2023-24,561219,Wichita St.,AAC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Conference,62,exact
+2023-24,561221,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Coastal Athletic Association,10,exact
+2023-24,561223,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2023-24,561227,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2023-24,560550,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2023-24,561231,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2023-24,561233,Wyoming,MWC,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2023-24,561234,Xavier,Big East,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2023-24,561236,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2023-24,561237,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2024-25,591979,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2024-25,591665,Abilene Christian,WAC,2000,Abilene Christian Wildcats,Abilene Christian,Wildcats,ACU,United Athletic Conference,30,exact
+2024-25,591934,Air Force,MWC,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2024-25,591666,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2024-25,591669,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2024-25,591667,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2024-25,591668,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2024-25,591672,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2024-25,591673,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2024-25,591674,App State,Sun Belt,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2024-25,591676,Arizona,Big 12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Big 12 Conference,8,exact
+2024-25,591675,Arizona St.,Big 12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Big 12 Conference,8,exact
+2024-25,591973,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2024-25,591678,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2024-25,591677,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2024-25,591935,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2024-25,591680,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2024-25,591681,Austin Peay,ASUN,2046,Austin Peay Governors,Austin Peay,Governors,APSU,Atlantic Sun Conference,46,exact
+2024-25,591692,BYU,Big 12,252,BYU Cougars,BYU,Cougars,BYU,Big 12 Conference,8,exact
+2024-25,591682,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2024-25,591684,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2024-25,591932,Bellarmine,ASUN,91,Bellarmine Knights,Bellarmine,Knights,BELL,Atlantic Sun Conference,46,exact
+2024-25,591657,Belmont,MVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2024-25,591685,Bethune-Cookman,SWAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2024-25,591686,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2024-25,591687,Boise St.,MWC,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2024-25,591688,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2024-25,591689,Boston U.,Patriot,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2024-25,591690,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2024-25,591691,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2024-25,591693,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2024-25,591694,Bryant,America East,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2024-25,591695,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2024-25,591696,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2024-25,591697,Butler,Big East,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2024-25,591699,CSU Bakersfield,WAC,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2024-25,591703,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2024-25,591698,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2024-25,591701,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2024-25,591706,California,ACC,25,California Golden Bears,California,Golden Bears,CAL,Atlantic Coast Conference,2,exact
+2024-25,591981,California Baptist,WAC,2856,California Baptist Lancers,California Baptist,Lancers,CBU,United Athletic Conference,30,exact
+2024-25,591710,Campbell,CAA,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Coastal Athletic Association,10,exact
+2024-25,591711,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Conference,13,exact
+2024-25,591966,Central Ark.,ASUN,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,Atlantic Sun Conference,46,exact
+2024-25,591712,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2024-25,591714,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2024-25,591683,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2024-25,591826,Charlotte,AAC,2429,Charlotte 49ers,Charlotte,49ers,CLT,American Conference,62,exact
+2024-25,592006,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2024-25,591716,Cincinnati,Big 12,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,Big 12 Conference,8,exact
+2024-25,591717,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2024-25,591718,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2024-25,591719,Coastal Carolina,Sun Belt,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2024-25,591967,Col. of Charleston,CAA,232,Charleston Cougars,Charleston,Cougars,COFC,Coastal Athletic Association,10,dict
+2024-25,591720,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2024-25,591722,Colorado,Big 12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Big 12 Conference,8,exact
+2024-25,591721,Colorado St.,MWC,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2024-25,591723,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2024-25,591724,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2024-25,591725,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2024-25,591726,Creighton,Big East,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2024-25,591727,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2024-25,591728,Davidson,Atlantic 10,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2024-25,591729,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2024-25,591730,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2024-25,591732,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Coastal Athletic Association,10,exact
+2024-25,591731,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2024-25,591733,Denver,Summit League,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,47,exact
+2024-25,591734,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2024-25,591984,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2024-25,591985,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Coastal Athletic Association,10,exact
+2024-25,591735,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2024-25,591736,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2024-25,591738,ETSU,SoCon,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2024-25,591737,East Carolina,AAC,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Conference,62,exact
+2024-25,591739,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2024-25,591741,Eastern Ky.,ASUN,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,Atlantic Sun Conference,46,exact
+2024-25,591742,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2024-25,591986,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2024-25,591968,Elon,CAA,2210,Elon Phoenix,Elon,Phoenix,ELON,Coastal Athletic Association,10,exact
+2024-25,591743,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2024-25,591980,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,Atlantic Sun Conference,46,exact
+2024-25,591747,FIU,C-USA,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2024-25,591987,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Conference,13,exact
+2024-25,591744,Fairleigh Dickinson,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2024-25,591746,Fla. Atlantic,AAC,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,American Conference,62,exact
+2024-25,591749,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2024-25,591745,Florida A&M,SWAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2024-25,591748,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2024-25,591750,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2024-25,591700,Fresno St.,MWC,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2024-25,591751,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2024-25,591755,Ga. Southern,Sun Belt,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2024-25,591969,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2024-25,591752,George Mason,Atlantic 10,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2024-25,591753,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2024-25,591754,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2024-25,591758,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2024-25,591756,Georgia St.,Sun Belt,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2024-25,591757,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2024-25,591759,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2024-25,591760,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2024-25,591970,Grand Canyon,WAC,2253,Grand Canyon Lopes,Grand Canyon,Lopes,GCU,United Athletic Conference,30,exact
+2024-25,592008,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2024-25,591761,Hampton,CAA,2261,Hampton Pirates,Hampton,Pirates,HAMP,Coastal Athletic Association,10,exact
+2024-25,591762,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2024-25,591763,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2024-25,591658,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2024-25,591764,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Coastal Athletic Association,10,exact
+2024-25,591988,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2024-25,591766,Houston,Big 12,248,Houston Cougars,Houston,Cougars,HOU,Big 12 Conference,8,exact
+2024-25,591765,Houston Christian,Southland,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,exact
+2024-25,591767,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2024-25,591974,IU Indy,Horizon,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,exact
+2024-25,591769,Idaho,Big Sky,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2024-25,591768,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2024-25,591771,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2024-25,591770,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2024-25,591774,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2024-25,591773,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2024-25,591776,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Conference,13,exact
+2024-25,591989,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2024-25,591777,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2024-25,591990,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2024-25,591779,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,Atlantic Sun Conference,46,exact
+2024-25,591778,Jacksonville St.,C-USA,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,Conference USA,11,exact
+2024-25,591780,James Madison,Sun Belt,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2024-25,591782,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2024-25,591652,Kansas City,WAC,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,47,exact
+2024-25,591781,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2024-25,591971,Kennesaw St.,C-USA,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,Conference USA,11,exact
+2024-25,591991,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2024-25,591783,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2024-25,591789,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2024-25,591796,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2024-25,591791,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2024-25,591784,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2024-25,591785,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2024-25,591786,Lamar University,WAC,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2024-25,591651,Le Moyne,NEC,2330,Le Moyne Dolphins,Le Moyne,Dolphins,LEM,Northeast Conference,19,exact
+2024-25,591787,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2024-25,591788,Liberty,C-USA,2335,Liberty Flames,Liberty,Flames,LIB,Conference USA,11,exact
+2024-25,591976,Lindenwood,OVC,2815,Lindenwood Lions,Lindenwood,Lions,LIN,Ohio Valley Conference,20,exact
+2024-25,591659,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,Atlantic Sun Conference,46,exact
+2024-25,591679,Little Rock,OVC,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2024-25,591702,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2024-25,591790,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2024-25,591909,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2024-25,591792,Louisiana Tech,C-USA,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2024-25,591793,Louisville,ACC,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2024-25,591797,Loyola Chicago,Atlantic 10,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2024-25,591795,Loyola Maryland,Patriot,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2024-25,591992,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2024-25,591798,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Conference,13,exact
+2024-25,591799,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Conference,13,exact
+2024-25,591800,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2024-25,591993,Marshall,Sun Belt,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2024-25,591802,Maryland,Big Ten,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2024-25,591804,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2024-25,591805,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2024-25,591806,Memphis,AAC,235,Memphis Tigers,Memphis,Tigers,MEM,American Conference,62,exact
+2024-25,591807,Mercer,SoCon,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2024-25,591661,Merrimack,MAAC,2771,Merrimack Warriors,Merrimack,Warriors,MRMK,Metro Conference,13,exact
+2024-25,591809,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2024-25,591808,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2024-25,591811,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2024-25,591810,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2024-25,591994,Middle Tenn.,C-USA,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2024-25,591960,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2024-25,591812,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2024-25,591813,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2024-25,591814,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2024-25,591816,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2024-25,591907,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2024-25,591817,Monmouth,CAA,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Coastal Athletic Association,10,exact
+2024-25,591819,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2024-25,591818,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2024-25,591820,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2024-25,591821,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2024-25,591822,Mount St. Mary's,MAAC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Conference,13,exact
+2024-25,591823,Murray St.,MVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2024-25,591839,N.C. A&T,CAA,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Coastal Athletic Association,10,exact
+2024-25,591840,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2024-25,591841,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2024-25,591849,NIU,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2024-25,591833,NJIT,ASUN,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2024-25,591936,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2024-25,591829,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2024-25,591831,Nevada,MWC,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2024-25,591832,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2024-25,591835,New Mexico,MWC,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2024-25,591834,New Mexico St.,C-USA,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Conference USA,11,exact
+2024-25,591836,New Orleans,Southland,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2024-25,591837,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Conference,13,exact
+2024-25,591838,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2024-25,591996,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2024-25,591664,North Ala.,ASUN,2453,North Alabama Lions,North Alabama,Lions,UNA,Atlantic Sun Conference,46,exact
+2024-25,591825,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2024-25,591843,North Dakota,Summit League,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,47,exact
+2024-25,591842,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,47,exact
+2024-25,591653,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,Atlantic Sun Conference,46,exact
+2024-25,591844,North Texas,AAC,249,North Texas Mean Green,North Texas,Mean Green,UNT,American Conference,62,exact
+2024-25,591846,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Coastal Athletic Association,10,exact
+2024-25,591847,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2024-25,591848,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2024-25,591851,Northern Ky.,Horizon,94,Northern Kentucky Norse,Northern Kentucky,Norse,NKU,Horizon League,45,exact
+2024-25,591853,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2024-25,591852,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2024-25,591997,Notre Dame,ACC,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2024-25,591854,Oakland,Horizon,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2024-25,591856,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2024-25,591855,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2024-25,591858,Oklahoma,SEC,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Southeastern Conference,23,exact
+2024-25,591857,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2024-25,591859,Old Dominion,Sun Belt,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2024-25,591815,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2024-25,591830,Omaha,Summit League,2437,Omaha Mavericks,Omaha,Mavericks,OMA,Summit League,47,exact
+2024-25,591860,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,47,exact
+2024-25,591862,Oregon,Big Ten,2483,Oregon Ducks,Oregon,Ducks,ORE,Big Ten Conference,7,exact
+2024-25,591861,Oregon St.,WCC,204,Oregon State Beavers,Oregon State,Beavers,ORST,West Coast Conference,29,exact
+2024-25,591863,Pacific,WCC,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2024-25,591866,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2024-25,591865,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2024-25,591867,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2024-25,591868,Pittsburgh,ACC,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2024-25,591998,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2024-25,591869,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2024-25,591870,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2024-25,592009,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2024-25,591999,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2024-25,591871,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2024-25,591872,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2024-25,591775,Purdue Fort Wayne,Summit League,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2024-25,591975,Queens (NC),ASUN,2511,Queens University Royals,Queens University,Royals,QUC,Atlantic Sun Conference,46,dict
+2024-25,591873,Quinnipiac,MAAC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Conference,13,exact
+2024-25,591874,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2024-25,591875,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2024-25,592000,Rice,AAC,242,Rice Owls,Rice,Owls,RICE,American Conference,62,exact
+2024-25,592001,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2024-25,591876,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Conference,13,exact
+2024-25,591877,Robert Morris,NEC,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2024-25,591878,Rutgers,Big Ten,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2024-25,591911,SFA,Southland,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Southland Conference,25,exact
+2024-25,591902,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2024-25,591903,SMU,ACC,2567,SMU Mustangs,SMU,Mustangs,SMU,Atlantic Coast Conference,2,exact
+2024-25,591704,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2024-25,592002,Sacred Heart,MAAC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Metro Conference,13,exact
+2024-25,591880,Saint Francis,NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,alias
+2024-25,591882,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2024-25,591883,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2024-25,591884,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2024-25,591885,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Conference,13,exact
+2024-25,591886,Sam Houston,C-USA,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Conference USA,11,exact
+2024-25,591887,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2024-25,591889,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2024-25,591888,San Diego St.,MWC,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2024-25,591890,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2024-25,591891,San Jose St.,MWC,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2024-25,591892,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2024-25,591972,Seattle U,WAC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,United Athletic Conference,30,exact
+2024-25,591893,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2024-25,591894,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Conference,13,exact
+2024-25,591895,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2024-25,592003,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2024-25,591896,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2024-25,591897,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,47,exact
+2024-25,592004,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,47,exact
+2024-25,591898,South Fla.,AAC,58,South Florida Bulls,South Florida,Bulls,USF,American Conference,62,exact
+2024-25,591899,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2024-25,591900,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2024-25,592005,Southern California,Big Ten,30,USC Trojans,USC,Trojans,USC,Big Ten Conference,7,dict
+2024-25,591901,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2024-25,592010,Southern Ind.,OVC,88,Southern Indiana Screaming Eagles,Southern Indiana,Screaming Eagles,USI,Ohio Valley Conference,20,alias
+2024-25,591904,Southern Miss.,Sun Belt,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2024-25,591905,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2024-25,591906,Southern Utah,WAC,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,United Athletic Conference,30,exact
+2024-25,591879,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2024-25,591881,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2024-25,591740,St. Thomas (MN),Summit League,2900,St. Thomas Tommies,St. Thomas,Tommies,STMN,Summit League,47,alias
+2024-25,591910,Stanford,ACC,24,Stanford Cardinal,Stanford,Cardinal,STAN,Atlantic Coast Conference,2,exact
+2024-25,591912,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,Atlantic Sun Conference,46,exact
+2024-25,591977,Stonehill,NEC,284,Stonehill Skyhawks,Stonehill,Skyhawks,STO,Northeast Conference,19,exact
+2024-25,591913,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Coastal Athletic Association,10,exact
+2024-25,591914,Syracuse,ACC,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2024-25,591921,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2024-25,591663,Tarleton St.,WAC,2627,Tarleton State Texans,Tarleton State,Texans,TAR,United Athletic Conference,30,exact
+2024-25,591915,Temple,AAC,218,Temple Owls,Temple,Owls,TEM,American Conference,62,exact
+2024-25,591918,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2024-25,591916,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2024-25,591917,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2024-25,592007,Texas,SEC,251,Texas Longhorns,Texas,Longhorns,TEX,Southeastern Conference,23,exact
+2024-25,591920,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2024-25,591922,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2024-25,591908,Texas St.,Sun Belt,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2024-25,591923,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2024-25,591927,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2024-25,591928,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Coastal Athletic Association,10,exact
+2024-25,591929,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2024-25,591930,Tulane,AAC,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Conference,62,exact
+2024-25,591933,Tulsa,AAC,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Conference,62,exact
+2024-25,591670,UAB,AAC,5,UAB Blazers,UAB,Blazers,UAB,American Conference,62,exact
+2024-25,591671,UAlbany,America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,exact
+2024-25,591707,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2024-25,591982,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2024-25,591709,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2024-25,591662,UC San Diego,Big West,28,UC San Diego Tritons,UC San Diego,Tritons,UCSD,Big West Conference,9,exact
+2024-25,591705,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2024-25,591713,UCF,Big 12,2116,UCF Knights,UCF,Knights,UCF,Big 12 Conference,8,exact
+2024-25,591708,UCLA,Big Ten,26,UCLA Bruins,UCLA,Bruins,UCLA,Big Ten Conference,7,exact
+2024-25,591983,UConn,AAC,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2024-25,591772,UIC,MVC,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2024-25,591654,UIW,Southland,2916,Incarnate Word Cardinals,Incarnate Word,Cardinals,UIW,Southland Conference,25,exact
+2024-25,591845,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2024-25,591801,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2024-25,591803,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2024-25,591794,UMass Lowell,America East,2349,UMass Lowell River Hawks,UMass Lowell,River Hawks,UML,America East Conference,1,exact
+2024-25,591824,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2024-25,591827,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2024-25,591828,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Coastal Athletic Association,10,exact
+2024-25,591850,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2024-25,591995,UNLV,MWC,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2024-25,591656,USC Upstate,Big South,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2024-25,591924,UT Arlington,WAC,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,United Athletic Conference,30,exact
+2024-25,591919,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2024-25,591925,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2024-25,591864,UTRGV,Southland,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Southland Conference,25,dict
+2024-25,591926,UTSA,AAC,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,American Conference,62,exact
+2024-25,591938,Utah,Big 12,254,Utah Utes,Utah,Utes,UTAH,Big 12 Conference,8,exact
+2024-25,591937,Utah St.,MWC,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2024-25,591931,Utah Tech,WAC,3101,Utah Tech Trailblazers,Utah Tech,Trailblazers,UTU,United Athletic Conference,30,exact
+2024-25,591660,Utah Valley,WAC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,United Athletic Conference,30,exact
+2024-25,591943,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2024-25,591939,Valparaiso,MVC,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2024-25,591940,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2024-25,591941,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2024-25,591942,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2024-25,591945,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2024-25,591944,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2024-25,591946,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2024-25,591947,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2024-25,591949,Washington,Big Ten,264,Washington Huskies,Washington,Huskies,WASH,Big Ten Conference,7,exact
+2024-25,591948,Washington St.,WCC,265,Washington State Cougars,Washington State,Cougars,WSU,West Coast Conference,29,exact
+2024-25,591950,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2024-25,592172,West Ga.,ASUN,2698,West Georgia Wolves,West Georgia,Wolves,WGA,Atlantic Sun Conference,46,exact
+2024-25,591951,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2024-25,591952,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2024-25,591953,Western Ill.,OVC,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Ohio Valley Conference,20,exact
+2024-25,591954,Western Ky.,C-USA,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2024-25,591955,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2024-25,591956,Wichita St.,AAC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Conference,62,exact
+2024-25,591957,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Coastal Athletic Association,10,exact
+2024-25,591958,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2024-25,591959,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2024-25,591655,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2024-25,591961,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2024-25,591962,Wyoming,MWC,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2024-25,591963,Xavier,Big East,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2024-25,591964,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2024-25,591965,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact
+2025-26,610016,A&M-Corpus Christi,Southland,357,Texas A&M-Corpus Christi Islanders,Texas A&M-Corpus Christi,Islanders,AMCC,Southland Conference,25,dict
+2025-26,610128,Abilene Christian,WAC,2000,Abilene Christian Wildcats,Abilene Christian,Wildcats,ACU,United Athletic Conference,30,exact
+2025-26,609930,Air Force,MWC,2005,Air Force Falcons,Air Force,Falcons,AF,Mountain West Conference,44,exact
+2025-26,610133,Akron,MAC,2006,Akron Zips,Akron,Zips,AKR,Mid-American Conference,14,exact
+2025-26,610143,Alabama,SEC,333,Alabama Crimson Tide,Alabama,Crimson Tide,ALA,Southeastern Conference,23,exact
+2025-26,610135,Alabama A&M,SWAC,2010,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,AAMU,Southwestern Athletic Conference,26,exact
+2025-26,610138,Alabama St.,SWAC,2011,Alabama State Hornets,Alabama State,Hornets,ALST,Southwestern Athletic Conference,26,exact
+2025-26,610153,Alcorn,SWAC,2016,Alcorn State Braves,Alcorn State,Braves,ALCN,Southwestern Athletic Conference,26,dict
+2025-26,610157,American,Patriot,44,American University Eagles,American University,Eagles,AMER,Patriot League,22,exact
+2025-26,610159,App State,Sun Belt,2026,App State Mountaineers,App State,Mountaineers,APP,Sun Belt Conference,27,exact
+2025-26,610166,Arizona,Big 12,12,Arizona Wildcats,Arizona,Wildcats,ARIZ,Big 12 Conference,8,exact
+2025-26,610162,Arizona St.,Big 12,9,Arizona State Sun Devils,Arizona State,Sun Devils,ASU,Big 12 Conference,8,exact
+2025-26,610005,Ark.-Pine Bluff,SWAC,2029,Arkansas-Pine Bluff Golden Lions,Arkansas-Pine Bluff,Golden Lions,UAPB,Southwestern Athletic Conference,26,dict
+2025-26,610171,Arkansas,SEC,8,Arkansas Razorbacks,Arkansas,Razorbacks,ARK,Southeastern Conference,23,exact
+2025-26,610169,Arkansas St.,Sun Belt,2032,Arkansas State Red Wolves,Arkansas State,Red Wolves,ARST,Sun Belt Conference,27,exact
+2025-26,609931,Army West Point,Patriot,349,Army Black Knights,Army,Black Knights,ARMY,Patriot League,22,dict
+2025-26,610176,Auburn,SEC,2,Auburn Tigers,Auburn,Tigers,AUB,Southeastern Conference,23,exact
+2025-26,610179,Austin Peay,ASUN,2046,Austin Peay Governors,Austin Peay,Governors,APSU,Atlantic Sun Conference,46,exact
+2025-26,610210,BYU,Big 12,252,BYU Cougars,BYU,Cougars,BYU,Big 12 Conference,8,exact
+2025-26,610182,Ball St.,MAC,2050,Ball State Cardinals,Ball State,Cardinals,BALL,Mid-American Conference,14,exact
+2025-26,610188,Baylor,Big 12,239,Baylor Bears,Baylor,Bears,BAY,Big 12 Conference,8,exact
+2025-26,609926,Bellarmine,ASUN,91,Bellarmine Knights,Bellarmine,Knights,BELL,Atlantic Sun Conference,46,exact
+2025-26,610105,Belmont,MVC,2057,Belmont Bruins,Belmont,Bruins,BEL,Missouri Valley Conference,18,exact
+2025-26,610190,Bethune-Cookman,SWAC,2065,Bethune-Cookman Wildcats,Bethune-Cookman,Wildcats,BCU,Southwestern Athletic Conference,26,exact
+2025-26,610193,Binghamton,America East,2066,Binghamton Bearcats,Binghamton,Bearcats,BING,America East Conference,1,exact
+2025-26,610195,Boise St.,MWC,68,Boise State Broncos,Boise State,Broncos,BOIS,Mountain West Conference,44,exact
+2025-26,610199,Boston College,ACC,103,Boston College Eagles,Boston College,Eagles,BC,Atlantic Coast Conference,2,exact
+2025-26,610202,Boston U.,Patriot,104,Boston University Terriers,Boston University,Terriers,BU,Patriot League,22,exact
+2025-26,610205,Bowling Green,MAC,189,Bowling Green Falcons,Bowling Green,Falcons,BGSU,Mid-American Conference,14,exact
+2025-26,610207,Bradley,MVC,71,Bradley Braves,Bradley,Braves,BRAD,Missouri Valley Conference,18,exact
+2025-26,610212,Brown,Ivy League,225,Brown Bears,Brown,Bears,BRWN,Ivy League,12,exact
+2025-26,610214,Bryant,America East,2803,Bryant Bulldogs,Bryant,Bulldogs,BRY,America East Conference,1,exact
+2025-26,610217,Bucknell,Patriot,2083,Bucknell Bison,Bucknell,Bison,BUCK,Patriot League,22,exact
+2025-26,610221,Buffalo,MAC,2084,Buffalo Bulls,Buffalo,Bulls,BUF,Mid-American Conference,14,exact
+2025-26,610224,Butler,Big East,2086,Butler Bulldogs,Butler,Bulldogs,BTLR,Big East Conference,4,exact
+2025-26,610230,CSU Bakersfield,WAC,2934,Cal State Bakersfield Roadrunners,Cal State Bakersfield,Roadrunners,CSUB,Big West Conference,9,alias
+2025-26,610240,CSUN,Big West,2463,Cal State Northridge Matadors,Cal State Northridge,Matadors,CSUN,Big West Conference,9,exact
+2025-26,610227,Cal Poly,Big West,13,Cal Poly Mustangs,Cal Poly,Mustangs,CP,Big West Conference,9,exact
+2025-26,610236,Cal St. Fullerton,Big West,2239,Cal State Fullerton Titans,Cal State Fullerton,Titans,CSUF,Big West Conference,9,exact
+2025-26,610248,California,ACC,25,California Golden Bears,California,Golden Bears,CAL,Atlantic Coast Conference,2,exact
+2025-26,610020,California Baptist,WAC,2856,California Baptist Lancers,California Baptist,Lancers,CBU,United Athletic Conference,30,exact
+2025-26,610259,Campbell,CAA,2097,Campbell Fighting Camels,Campbell,Fighting Camels,CAM,Coastal Athletic Association,10,exact
+2025-26,610262,Canisius,MAAC,2099,Canisius Golden Griffins,Canisius,Golden Griffins,CAN,Metro Conference,13,exact
+2025-26,609991,Central Ark.,ASUN,2110,Central Arkansas Bears,Central Arkansas,Bears,CARK,Atlantic Sun Conference,46,exact
+2025-26,610264,Central Conn. St.,NEC,2115,Central Connecticut Blue Devils,Central Connecticut,Blue Devils,CCSU,Northeast Conference,19,dict
+2025-26,610271,Central Mich.,MAC,2117,Central Michigan Chippewas,Central Michigan,Chippewas,CMU,Mid-American Conference,14,exact
+2025-26,610185,Charleston So.,Big South,2127,Charleston Southern Buccaneers,Charleston Southern,Buccaneers,CHSO,Big South Conference,6,exact
+2025-26,610578,Charlotte,AAC,2429,Charlotte 49ers,Charlotte,49ers,CLT,American Conference,62,exact
+2025-26,610073,Chattanooga,SoCon,236,Chattanooga Mocs,Chattanooga,Mocs,UTC,Southern Conference,24,exact
+2025-26,610276,Cincinnati,Big 12,2132,Cincinnati Bearcats,Cincinnati,Bearcats,CIN,Big 12 Conference,8,exact
+2025-26,610280,Clemson,ACC,228,Clemson Tigers,Clemson,Tigers,CLEM,Atlantic Coast Conference,2,exact
+2025-26,610282,Cleveland St.,Horizon,325,Cleveland State Vikings,Cleveland State,Vikings,CLE,Horizon League,45,exact
+2025-26,610287,Coastal Carolina,Sun Belt,324,Coastal Carolina Chanticleers,Coastal Carolina,Chanticleers,CCU,Sun Belt Conference,27,exact
+2025-26,609993,Col. of Charleston,CAA,232,Charleston Cougars,Charleston,Cougars,COFC,Coastal Athletic Association,10,dict
+2025-26,610291,Colgate,Patriot,2142,Colgate Raiders,Colgate,Raiders,COLG,Patriot League,22,exact
+2025-26,610298,Colorado,Big 12,38,Colorado Buffaloes,Colorado,Buffaloes,COLO,Big 12 Conference,8,exact
+2025-26,610294,Colorado St.,MWC,36,Colorado State Rams,Colorado State,Rams,CSU,Mountain West Conference,44,exact
+2025-26,610299,Columbia,Ivy League,171,Columbia Lions,Columbia,Lions,COLU,Ivy League,12,exact
+2025-26,610302,Coppin St.,MEAC,2154,Coppin State Eagles,Coppin State,Eagles,COPP,Mid-Eastern Athletic Conference,16,exact
+2025-26,610305,Cornell,Ivy League,172,Cornell Big Red,Cornell,Big Red,COR,Ivy League,12,exact
+2025-26,610308,Creighton,Big East,156,Creighton Bluejays,Creighton,Bluejays,CREI,Big East Conference,4,exact
+2025-26,610311,Dartmouth,Ivy League,159,Dartmouth Big Green,Dartmouth,Big Green,DART,Ivy League,12,exact
+2025-26,610314,Davidson,Atlantic 10,2166,Davidson Wildcats,Davidson,Wildcats,DAV,Atlantic 10 Conference,3,exact
+2025-26,610317,Dayton,Atlantic 10,2168,Dayton Flyers,Dayton,Flyers,DAY,Atlantic 10 Conference,3,exact
+2025-26,610320,DePaul,Big East,305,DePaul Blue Demons,DePaul,Blue Demons,DEP,Big East Conference,4,exact
+2025-26,610323,Delaware,CAA,48,Delaware Blue Hens,Delaware,Blue Hens,DEL,Coastal Athletic Association,10,exact
+2025-26,610321,Delaware St.,MEAC,2169,Delaware State Hornets,Delaware State,Hornets,DSU,Mid-Eastern Athletic Conference,16,exact
+2025-26,610325,Denver,Summit League,2172,Denver Pioneers,Denver,Pioneers,DEN,Summit League,47,exact
+2025-26,610329,Detroit Mercy,Horizon,2174,Detroit Mercy Titans,Detroit Mercy,Titans,DETM,Horizon League,45,exact
+2025-26,610027,Drake,MVC,2181,Drake Bulldogs,Drake,Bulldogs,DRKE,Missouri Valley Conference,18,exact
+2025-26,610028,Drexel,CAA,2182,Drexel Dragons,Drexel,Dragons,DREX,Coastal Athletic Association,10,exact
+2025-26,610331,Duke,ACC,150,Duke Blue Devils,Duke,Blue Devils,DUKE,Atlantic Coast Conference,2,exact
+2025-26,610334,Duquesne,Atlantic 10,2184,Duquesne Dukes,Duquesne,Dukes,DUQ,Atlantic 10 Conference,3,exact
+2025-26,610339,ETSU,SoCon,2193,East Tennessee State Buccaneers,East Tennessee State,Buccaneers,ETSU,Southern Conference,24,exact
+2025-26,610336,East Carolina,AAC,151,East Carolina Pirates,East Carolina,Pirates,ECU,American Conference,62,exact
+2025-26,610342,Eastern Ill.,OVC,2197,Eastern Illinois Panthers,Eastern Illinois,Panthers,EIU,Ohio Valley Conference,20,exact
+2025-26,610347,Eastern Ky.,ASUN,2198,Eastern Kentucky Colonels,Eastern Kentucky,Colonels,EKU,Atlantic Sun Conference,46,exact
+2025-26,610351,Eastern Mich.,MAC,2199,Eastern Michigan Eagles,Eastern Michigan,Eagles,EMU,Mid-American Conference,14,exact
+2025-26,610030,Eastern Wash.,Big Sky,331,Eastern Washington Eagles,Eastern Washington,Eagles,EWU,Big Sky Conference,5,exact
+2025-26,609995,Elon,CAA,2210,Elon Phoenix,Elon,Phoenix,ELON,Coastal Athletic Association,10,exact
+2025-26,610353,Evansville,MVC,339,Evansville Purple Aces,Evansville,Purple Aces,EVAN,Missouri Valley Conference,18,exact
+2025-26,610357,FDU,NEC,161,Fairleigh Dickinson Knights,Fairleigh Dickinson,Knights,FDU,Northeast Conference,19,exact
+2025-26,610018,FGCU,ASUN,526,Florida Gulf Coast Eagles,Florida Gulf Coast,Eagles,FGCU,Atlantic Sun Conference,46,exact
+2025-26,610366,FIU,C-USA,2229,Florida International Panthers,Florida International,Panthers,FIU,Conference USA,11,exact
+2025-26,610032,Fairfield,MAAC,2217,Fairfield Stags,Fairfield,Stags,FAIR,Metro Conference,13,exact
+2025-26,610363,Fla. Atlantic,AAC,2226,Florida Atlantic Owls,Florida Atlantic,Owls,FAU,American Conference,62,exact
+2025-26,610371,Florida,SEC,57,Florida Gators,Florida,Gators,FLA,Southeastern Conference,23,exact
+2025-26,610360,Florida A&M,SWAC,50,Florida A&M Rattlers,Florida A&M,Rattlers,FAMU,Southwestern Athletic Conference,26,exact
+2025-26,610368,Florida St.,ACC,52,Florida State Seminoles,Florida State,Seminoles,FSU,Atlantic Coast Conference,2,exact
+2025-26,610375,Fordham,Atlantic 10,2230,Fordham Rams,Fordham,Rams,FOR,Atlantic 10 Conference,3,exact
+2025-26,610233,Fresno St.,MWC,278,Fresno State Bulldogs,Fresno State,Bulldogs,FRES,Mountain West Conference,44,exact
+2025-26,610378,Furman,SoCon,231,Furman Paladins,Furman,Paladins,FUR,Southern Conference,24,exact
+2025-26,610391,Ga. Southern,Sun Belt,290,Georgia Southern Eagles,Georgia Southern,Eagles,GASO,Sun Belt Conference,27,exact
+2025-26,609997,Gardner-Webb,Big South,2241,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,GWEB,Big South Conference,6,exact
+2025-26,610381,George Mason,Atlantic 10,2244,George Mason Patriots,George Mason,Patriots,GMU,Atlantic 10 Conference,3,exact
+2025-26,610384,George Washington,Atlantic 10,45,George Washington Revolutionaries,George Washington,Revolutionaries,GW,Atlantic 10 Conference,3,exact
+2025-26,610388,Georgetown,Big East,46,Georgetown Hoyas,Georgetown,Hoyas,GTWN,Big East Conference,4,exact
+2025-26,610399,Georgia,SEC,61,Georgia Bulldogs,Georgia,Bulldogs,UGA,Southeastern Conference,23,exact
+2025-26,610394,Georgia St.,Sun Belt,2247,Georgia State Panthers,Georgia State,Panthers,GAST,Sun Belt Conference,27,exact
+2025-26,610396,Georgia Tech,ACC,59,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,GT,Atlantic Coast Conference,2,exact
+2025-26,610401,Gonzaga,WCC,2250,Gonzaga Bulldogs,Gonzaga,Bulldogs,GONZ,West Coast Conference,29,exact
+2025-26,610405,Grambling,SWAC,2755,Grambling Tigers,Grambling,Tigers,GRAM,Southwestern Athletic Conference,26,exact
+2025-26,609999,Grand Canyon,WAC,2253,Grand Canyon Lopes,Grand Canyon,Lopes,GCU,United Athletic Conference,30,exact
+2025-26,610079,Green Bay,Horizon,2739,Green Bay Phoenix,Green Bay,Phoenix,GB,Horizon League,45,exact
+2025-26,610407,Hampton,CAA,2261,Hampton Pirates,Hampton,Pirates,HAMP,Coastal Athletic Association,10,exact
+2025-26,610409,Harvard,Ivy League,108,Harvard Crimson,Harvard,Crimson,HARV,Ivy League,12,exact
+2025-26,610412,Hawaii,Big West,62,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,HAW,Big West Conference,9,dict
+2025-26,610108,High Point,Big South,2272,High Point Panthers,High Point,Panthers,HPU,Big South Conference,6,exact
+2025-26,610415,Hofstra,CAA,2275,Hofstra Pride,Hofstra,Pride,HOF,Coastal Athletic Association,10,exact
+2025-26,610034,Holy Cross,Patriot,107,Holy Cross Crusaders,Holy Cross,Crusaders,HC,Patriot League,22,exact
+2025-26,610421,Houston,Big 12,248,Houston Cougars,Houston,Cougars,HOU,Big 12 Conference,8,exact
+2025-26,610418,Houston Christian,Southland,2277,Houston Christian Huskies,Houston Christian,Huskies,HCU,Southland Conference,25,exact
+2025-26,610423,Howard,MEAC,47,Howard Bison,Howard,Bison,HOW,Mid-Eastern Athletic Conference,16,exact
+2025-26,610007,IU Indy,Horizon,85,IU Indianapolis Jaguars,IU Indianapolis,Jaguars,IUIN,Horizon League,45,exact
+2025-26,610428,Idaho,Big Sky,70,Idaho Vandals,Idaho,Vandals,IDHO,Big Sky Conference,5,exact
+2025-26,610425,Idaho St.,Big Sky,304,Idaho State Bengals,Idaho State,Bengals,IDST,Big Sky Conference,5,exact
+2025-26,610433,Illinois,Big Ten,356,Illinois Fighting Illini,Illinois,Fighting Illini,ILL,Big Ten Conference,7,exact
+2025-26,610430,Illinois St.,MVC,2287,Illinois State Redbirds,Illinois State,Redbirds,ILST,Missouri Valley Conference,18,exact
+2025-26,610439,Indiana,Big Ten,84,Indiana Hoosiers,Indiana,Hoosiers,IU,Big Ten Conference,7,exact
+2025-26,610437,Indiana St.,MVC,282,Indiana State Sycamores,Indiana State,Sycamores,INST,Missouri Valley Conference,18,exact
+2025-26,610443,Iona,MAAC,314,Iona Gaels,Iona,Gaels,IONA,Metro Conference,13,exact
+2025-26,610035,Iowa,Big Ten,2294,Iowa Hawkeyes,Iowa,Hawkeyes,IOWA,Big Ten Conference,7,exact
+2025-26,610445,Iowa St.,Big 12,66,Iowa State Cyclones,Iowa State,Cyclones,ISU,Big 12 Conference,8,exact
+2025-26,610037,Jackson St.,SWAC,2296,Jackson State Tigers,Jackson State,Tigers,JKST,Southwestern Athletic Conference,26,exact
+2025-26,610450,Jacksonville,ASUN,294,Jacksonville Dolphins,Jacksonville,Dolphins,JAX,Atlantic Sun Conference,46,exact
+2025-26,610448,Jacksonville St.,C-USA,55,Jacksonville State Gamecocks,Jacksonville State,Gamecocks,JXST,Conference USA,11,exact
+2025-26,610452,James Madison,Sun Belt,256,James Madison Dukes,James Madison,Dukes,JMU,Sun Belt Conference,27,exact
+2025-26,610455,Kansas,Big 12,2305,Kansas Jayhawks,Kansas,Jayhawks,KU,Big 12 Conference,8,exact
+2025-26,610090,Kansas City,WAC,140,Kansas City Roos,Kansas City,Roos,KC,Summit League,47,exact
+2025-26,610453,Kansas St.,Big 12,2306,Kansas State Wildcats,Kansas State,Wildcats,KSU,Big 12 Conference,8,exact
+2025-26,610001,Kennesaw St.,C-USA,338,Kennesaw State Owls,Kennesaw State,Owls,KENN,Conference USA,11,exact
+2025-26,610039,Kent St.,MAC,2309,Kent State Golden Flashes,Kent State,Golden Flashes,KENT,Mid-American Conference,14,exact
+2025-26,610457,Kentucky,SEC,96,Kentucky Wildcats,Kentucky,Wildcats,UK,Southeastern Conference,23,exact
+2025-26,610468,LIU,NEC,112358,Long Island University Sharks,Long Island University,Sharks,LIU,Northeast Conference,19,exact
+2025-26,610484,LMU (CA),WCC,2351,Loyola Marymount Lions,Loyola Marymount,Lions,LMU,West Coast Conference,29,dict
+2025-26,610471,LSU,SEC,99,LSU Tigers,LSU,Tigers,LSU,Southeastern Conference,23,exact
+2025-26,610459,La Salle,Atlantic 10,2325,La Salle Explorers,La Salle,Explorers,LAS,Atlantic 10 Conference,3,exact
+2025-26,610460,Lafayette,Patriot,322,Lafayette Leopards,Lafayette,Leopards,LAF,Patriot League,22,exact
+2025-26,610462,Lamar University,WAC,2320,Lamar Cardinals,Lamar,Cardinals,LAM,Southland Conference,25,dict
+2025-26,610087,Le Moyne,NEC,2330,Le Moyne Dolphins,Le Moyne,Dolphins,LEM,Northeast Conference,19,exact
+2025-26,610464,Lehigh,Patriot,2329,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,LEH,Patriot League,22,exact
+2025-26,610465,Liberty,C-USA,2335,Liberty Flames,Liberty,Flames,LIB,Conference USA,11,exact
+2025-26,610010,Lindenwood,OVC,2815,Lindenwood Lions,Lindenwood,Lions,LIN,Ohio Valley Conference,20,exact
+2025-26,610111,Lipscomb,ASUN,288,Lipscomb Bisons,Lipscomb,Bisons,LIP,Atlantic Sun Conference,46,exact
+2025-26,610174,Little Rock,OVC,2031,Little Rock Trojans,Little Rock,Trojans,LR,Ohio Valley Conference,20,exact
+2025-26,610239,Long Beach St.,Big West,299,Long Beach State Beach,Long Beach State,Beach,LBSU,Big West Conference,9,exact
+2025-26,610470,Longwood,Big South,2344,Longwood Lancers,Longwood,Lancers,LONG,Big South Conference,6,exact
+2025-26,609879,Louisiana,Sun Belt,309,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,UL,Sun Belt Conference,27,exact
+2025-26,610473,Louisiana Tech,C-USA,2348,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,LT,Conference USA,11,exact
+2025-26,610476,Louisville,ACC,97,Louisville Cardinals,Louisville,Cardinals,LOU,Atlantic Coast Conference,2,exact
+2025-26,610487,Loyola Chicago,Atlantic 10,2350,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,LUC,Atlantic 10 Conference,3,exact
+2025-26,610482,Loyola Maryland,Patriot,2352,Loyola Maryland Greyhounds,Loyola Maryland,Greyhounds,L-MD,Patriot League,22,exact
+2025-26,610041,Maine,America East,311,Maine Black Bears,Maine,Black Bears,ME,America East Conference,1,exact
+2025-26,610490,Manhattan,MAAC,2363,Manhattan Jaspers,Manhattan,Jaspers,MAN,Metro Conference,13,exact
+2025-26,610493,Marist,MAAC,2368,Marist Red Foxes,Marist,Red Foxes,MRST,Metro Conference,13,exact
+2025-26,610496,Marquette,Big East,269,Marquette Golden Eagles,Marquette,Golden Eagles,MARQ,Big East Conference,4,exact
+2025-26,610043,Marshall,Sun Belt,276,Marshall Thundering Herd,Marshall,Thundering Herd,MRSH,Sun Belt Conference,27,exact
+2025-26,610502,Maryland,Big Ten,120,Maryland Terrapins,Maryland,Terrapins,MD,Big Ten Conference,7,exact
+2025-26,610509,Massachusetts,Atlantic 10,113,Massachusetts Minutemen,Massachusetts,Minutemen,MASS,Atlantic 10 Conference,3,exact
+2025-26,610511,McNeese,Southland,2377,McNeese Cowboys,McNeese,Cowboys,MCN,Southland Conference,25,exact
+2025-26,610515,Memphis,AAC,235,Memphis Tigers,Memphis,Tigers,MEM,American Conference,62,exact
+2025-26,610518,Mercer,SoCon,2382,Mercer Bears,Mercer,Bears,MER,Southern Conference,24,exact
+2025-26,610117,Merrimack,MAAC,2771,Merrimack Warriors,Merrimack,Warriors,MRMK,Metro Conference,13,exact
+2025-26,610524,Miami (FL),ACC,2390,Miami Hurricanes,Miami,Hurricanes,MIA,Atlantic Coast Conference,2,dict
+2025-26,610521,Miami (OH),MAC,193,Miami (OH) RedHawks,Miami (OH),RedHawks,M-OH,Mid-American Conference,14,exact
+2025-26,610533,Michigan,Big Ten,130,Michigan Wolverines,Michigan,Wolverines,MICH,Big Ten Conference,7,exact
+2025-26,610529,Michigan St.,Big Ten,127,Michigan State Spartans,Michigan State,Spartans,MSU,Big Ten Conference,7,exact
+2025-26,610045,Middle Tenn.,C-USA,2393,Middle Tennessee Blue Raiders,Middle Tennessee,Blue Raiders,MTSU,Conference USA,11,exact
+2025-26,609980,Milwaukee,Horizon,270,Milwaukee Panthers,Milwaukee,Panthers,MILW,Horizon League,45,exact
+2025-26,610537,Minnesota,Big Ten,135,Minnesota Golden Gophers,Minnesota,Golden Gophers,MINN,Big Ten Conference,7,exact
+2025-26,610541,Mississippi St.,SEC,344,Mississippi State Bulldogs,Mississippi State,Bulldogs,MSST,Southeastern Conference,23,exact
+2025-26,610544,Mississippi Val.,SWAC,2400,Mississippi Valley State Delta Devils,Mississippi Valley State,Delta Devils,MVSU,Southwestern Athletic Conference,26,dict
+2025-26,610550,Missouri,SEC,142,Missouri Tigers,Missouri,Tigers,MIZ,Southeastern Conference,23,exact
+2025-26,609875,Missouri St.,MVC,2623,Missouri State Bears,Missouri State,Bears,MOST,Missouri Valley Conference,18,exact
+2025-26,610554,Monmouth,CAA,2405,Monmouth Hawks,Monmouth,Hawks,MONM,Coastal Athletic Association,10,exact
+2025-26,610560,Montana,Big Sky,149,Montana Grizzlies,Montana,Grizzlies,MONT,Big Sky Conference,5,exact
+2025-26,610556,Montana St.,Big Sky,147,Montana State Bobcats,Montana State,Bobcats,MTST,Big Sky Conference,5,exact
+2025-26,610562,Morehead St.,OVC,2413,Morehead State Eagles,Morehead State,Eagles,MORE,Ohio Valley Conference,20,exact
+2025-26,610566,Morgan St.,MEAC,2415,Morgan State Bears,Morgan State,Bears,MORG,Mid-Eastern Athletic Conference,16,exact
+2025-26,610569,Mount St. Mary's,MAAC,116,Mount St. Mary's Mountaineers,Mount St. Mary's,Mountaineers,MSM,Metro Conference,13,exact
+2025-26,610571,Murray St.,MVC,93,Murray State Racers,Murray State,Racers,MUR,Missouri Valley Conference,18,exact
+2025-26,610612,N.C. A&T,CAA,2448,North Carolina A&T Aggies,North Carolina A&T,Aggies,NCAT,Coastal Athletic Association,10,exact
+2025-26,610615,N.C. Central,MEAC,2428,North Carolina Central Eagles,North Carolina Central,Eagles,NCCU,Mid-Eastern Athletic Conference,16,exact
+2025-26,610618,NC State,ACC,152,NC State Wolfpack,NC State,Wolfpack,NCSU,Atlantic Coast Conference,2,exact
+2025-26,609755,NIU,MAC,2459,Northern Illinois Huskies,Northern Illinois,Huskies,NIU,Mid-American Conference,14,exact
+2025-26,610595,NJIT,ASUN,2885,NJIT Highlanders,NJIT,Highlanders,NJIT,America East Conference,1,exact
+2025-26,609933,Navy,Patriot,2426,Navy Midshipmen,Navy,Midshipmen,NAVY,Patriot League,22,exact
+2025-26,610587,Nebraska,Big Ten,158,Nebraska Cornhuskers,Nebraska,Cornhuskers,NEB,Big Ten Conference,7,exact
+2025-26,610590,Nevada,MWC,2440,Nevada Wolf Pack,Nevada,Wolf Pack,NEV,Mountain West Conference,44,exact
+2025-26,610592,New Hampshire,America East,160,New Hampshire Wildcats,New Hampshire,Wildcats,UNH,America East Conference,1,exact
+2025-26,610601,New Mexico,MWC,167,New Mexico Lobos,New Mexico,Lobos,UNM,Mountain West Conference,44,exact
+2025-26,610597,New Mexico St.,C-USA,166,New Mexico State Aggies,New Mexico State,Aggies,NMSU,Conference USA,11,exact
+2025-26,610604,New Orleans,Southland,2443,LSU New Orleans Privateers,LSU New Orleans,Privateers,NOLA,Southland Conference,25,exact
+2025-26,610607,Niagara,MAAC,315,Niagara Purple Eagles,Niagara,Purple Eagles,NIA,Metro Conference,13,exact
+2025-26,610609,Nicholls,Southland,2447,Nicholls Colonels,Nicholls,Colonels,NICH,Southland Conference,25,exact
+2025-26,610050,Norfolk St.,MEAC,2450,Norfolk State Spartans,Norfolk State,Spartans,NORF,Mid-Eastern Athletic Conference,16,exact
+2025-26,610125,North Ala.,ASUN,2453,North Alabama Lions,North Alabama,Lions,UNA,Atlantic Sun Conference,46,exact
+2025-26,610575,North Carolina,ACC,153,North Carolina Tar Heels,North Carolina,Tar Heels,UNC,Atlantic Coast Conference,2,exact
+2025-26,610624,North Dakota,Summit League,155,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,UND,Summit League,47,exact
+2025-26,610621,North Dakota St.,Summit League,2449,North Dakota State Bison,North Dakota State,Bison,NDSU,Summit League,47,exact
+2025-26,610093,North Florida,ASUN,2454,North Florida Ospreys,North Florida,Ospreys,UNF,Atlantic Sun Conference,46,exact
+2025-26,610626,North Texas,AAC,249,North Texas Mean Green,North Texas,Mean Green,UNT,American Conference,62,exact
+2025-26,610631,Northeastern,CAA,111,Northeastern Huskies,Northeastern,Huskies,NE,Coastal Athletic Association,10,exact
+2025-26,609751,Northern Ariz.,Big Sky,2464,Northern Arizona Lumberjacks,Northern Arizona,Lumberjacks,NAU,Big Sky Conference,5,exact
+2025-26,609754,Northern Colo.,Big Sky,2458,Northern Colorado Bears,Northern Colorado,Bears,UNCO,Big Sky Conference,5,exact
+2025-26,609760,Northern Ky.,Horizon,94,Northern Kentucky Norse,Northern Kentucky,Norse,NKU,Horizon League,45,exact
+2025-26,609763,Northwestern,Big Ten,77,Northwestern Wildcats,Northwestern,Wildcats,NU,Big Ten Conference,7,exact
+2025-26,609761,Northwestern St.,Southland,2466,Northwestern State Demons,Northwestern State,Demons,NWST,Southland Conference,25,exact
+2025-26,610052,Notre Dame,ACC,87,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,ND,Atlantic Coast Conference,2,exact
+2025-26,609766,Oakland,Horizon,2473,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,OAK,Horizon League,45,exact
+2025-26,609770,Ohio,MAC,195,Ohio Bobcats,Ohio,Bobcats,OHIO,Mid-American Conference,14,exact
+2025-26,609768,Ohio St.,Big Ten,194,Ohio State Buckeyes,Ohio State,Buckeyes,OSU,Big Ten Conference,7,exact
+2025-26,609774,Oklahoma,SEC,201,Oklahoma Sooners,Oklahoma,Sooners,OU,Southeastern Conference,23,exact
+2025-26,609772,Oklahoma St.,Big 12,197,Oklahoma State Cowboys,Oklahoma State,Cowboys,OKST,Big 12 Conference,8,exact
+2025-26,609776,Old Dominion,Sun Belt,295,Old Dominion Monarchs,Old Dominion,Monarchs,ODU,Sun Belt Conference,27,exact
+2025-26,610547,Ole Miss,SEC,145,Ole Miss Rebels,Ole Miss,Rebels,MISS,Southeastern Conference,23,exact
+2025-26,610589,Omaha,Summit League,2437,Omaha Mavericks,Omaha,Mavericks,OMA,Summit League,47,exact
+2025-26,609778,Oral Roberts,Summit League,198,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,ORU,Summit League,47,exact
+2025-26,609782,Oregon,Big Ten,2483,Oregon Ducks,Oregon,Ducks,ORE,Big Ten Conference,7,exact
+2025-26,609780,Oregon St.,WCC,204,Oregon State Beavers,Oregon State,Beavers,ORST,West Coast Conference,29,exact
+2025-26,609784,Pacific,WCC,279,Pacific Tigers,Pacific,Tigers,PAC,West Coast Conference,29,exact
+2025-26,609791,Penn,Ivy League,219,Pennsylvania Quakers,Pennsylvania,Quakers,PENN,Ivy League,12,exact
+2025-26,609789,Penn St.,Big Ten,213,Penn State Nittany Lions,Penn State,Nittany Lions,PSU,Big Ten Conference,7,exact
+2025-26,609794,Pepperdine,WCC,2492,Pepperdine Waves,Pepperdine,Waves,PEPP,West Coast Conference,29,exact
+2025-26,609795,Pittsburgh,ACC,221,Pittsburgh Panthers,Pittsburgh,Panthers,PITT,Atlantic Coast Conference,2,exact
+2025-26,610054,Portland,WCC,2501,Portland Pilots,Portland,Pilots,PORT,West Coast Conference,29,exact
+2025-26,609798,Portland St.,Big Sky,2502,Portland State Vikings,Portland State,Vikings,PRST,Big Sky Conference,5,exact
+2025-26,609800,Prairie View,SWAC,2504,Prairie View A&M Panthers,Prairie View A&M,Panthers,PV,Southwestern Athletic Conference,26,exact
+2025-26,610082,Presbyterian,Big South,2506,Presbyterian Blue Hose,Presbyterian,Blue Hose,PRES,Big South Conference,6,exact
+2025-26,610056,Princeton,Ivy League,163,Princeton Tigers,Princeton,Tigers,PRIN,Ivy League,12,exact
+2025-26,609802,Providence,Big East,2507,Providence Friars,Providence,Friars,PROV,Big East Conference,4,exact
+2025-26,609804,Purdue,Big Ten,2509,Purdue Boilermakers,Purdue,Boilermakers,PUR,Big Ten Conference,7,exact
+2025-26,610441,Purdue Fort Wayne,Summit League,2870,Purdue Fort Wayne Mastodons,Purdue Fort Wayne,Mastodons,PFW,Horizon League,45,exact
+2025-26,610009,Queens (NC),ASUN,2511,Queens University Royals,Queens University,Royals,QUC,Atlantic Sun Conference,46,dict
+2025-26,609806,Quinnipiac,MAAC,2514,Quinnipiac Bobcats,Quinnipiac,Bobcats,QUIN,Metro Conference,13,exact
+2025-26,609809,Radford,Big South,2515,Radford Highlanders,Radford,Highlanders,RAD,Big South Conference,6,exact
+2025-26,609811,Rhode Island,Atlantic 10,227,Rhode Island Rams,Rhode Island,Rams,URI,Atlantic 10 Conference,3,exact
+2025-26,610059,Rice,AAC,242,Rice Owls,Rice,Owls,RICE,American Conference,62,exact
+2025-26,610060,Richmond,Atlantic 10,257,Richmond Spiders,Richmond,Spiders,RICH,Atlantic 10 Conference,3,exact
+2025-26,609814,Rider,MAAC,2520,Rider Broncs,Rider,Broncs,RID,Metro Conference,13,exact
+2025-26,609816,Robert Morris,NEC,2523,Robert Morris Colonials,Robert Morris,Colonials,RMU,Horizon League,45,exact
+2025-26,609818,Rutgers,Big Ten,164,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,RUTG,Big Ten Conference,7,exact
+2025-26,609884,SFA,Southland,2617,Stephen F. Austin Lumberjacks,Stephen F. Austin,Lumberjacks,SFA,Southland Conference,25,exact
+2025-26,609865,SIUE,OVC,2565,SIU Edwardsville Cougars,SIU Edwardsville,Cougars,SIUE,Ohio Valley Conference,20,exact
+2025-26,609867,SMU,ACC,2567,SMU Mustangs,SMU,Mustangs,SMU,Atlantic Coast Conference,2,exact
+2025-26,610243,Sacramento St.,Big Sky,16,Sacramento State Hornets,Sacramento State,Hornets,SAC,Big Sky Conference,5,exact
+2025-26,610063,Sacred Heart,MAAC,2529,Sacred Heart Pioneers,Sacred Heart,Pioneers,SHU,Metro Conference,13,exact
+2025-26,609823,Saint Francis,NEC,2598,St. Francis (PA) Red Flash,St. Francis (PA),Red Flash,SFPA,Northeast Conference,19,alias
+2025-26,609827,Saint Joseph's,Atlantic 10,2603,Saint Joseph's Hawks,Saint Joseph's,Hawks,JOES,Atlantic 10 Conference,3,exact
+2025-26,609829,Saint Louis,Atlantic 10,139,Saint Louis Billikens,Saint Louis,Billikens,SLU,Atlantic 10 Conference,3,exact
+2025-26,609831,Saint Mary's (CA),WCC,2608,Saint Mary's Gaels,Saint Mary's,Gaels,SMC,West Coast Conference,29,dict
+2025-26,609833,Saint Peter's,MAAC,2612,Saint Peter's Peacocks,Saint Peter's,Peacocks,SPU,Metro Conference,13,exact
+2025-26,609835,Sam Houston,C-USA,2534,Sam Houston Bearkats,Sam Houston,Bearkats,SHSU,Conference USA,11,exact
+2025-26,609837,Samford,SoCon,2535,Samford Bulldogs,Samford,Bulldogs,SAM,Southern Conference,24,exact
+2025-26,609842,San Diego,WCC,301,San Diego Toreros,San Diego,Toreros,USD,West Coast Conference,29,exact
+2025-26,609839,San Diego St.,MWC,21,San Diego State Aztecs,San Diego State,Aztecs,SDSU,Mountain West Conference,44,exact
+2025-26,609844,San Francisco,WCC,2539,San Francisco Dons,San Francisco,Dons,SF,West Coast Conference,29,exact
+2025-26,609846,San Jose St.,MWC,23,San José State Spartans,San José State,Spartans,SJSU,Mountain West Conference,44,dict
+2025-26,609847,Santa Clara,WCC,2541,Santa Clara Broncos,Santa Clara,Broncos,SCU,West Coast Conference,29,exact
+2025-26,610003,Seattle U,WAC,2547,Seattle U Redhawks,Seattle U,Redhawks,SEA,United Athletic Conference,30,exact
+2025-26,609849,Seton Hall,Big East,2550,Seton Hall Pirates,Seton Hall,Pirates,HALL,Big East Conference,4,exact
+2025-26,609852,Siena,MAAC,2561,Siena Saints,Siena,Saints,SIE,Metro Conference,13,exact
+2025-26,609853,South Alabama,Sun Belt,6,South Alabama Jaguars,South Alabama,Jaguars,USA,Sun Belt Conference,27,exact
+2025-26,610065,South Carolina,SEC,2579,South Carolina Gamecocks,South Carolina,Gamecocks,SC,Southeastern Conference,23,exact
+2025-26,609855,South Carolina St.,MEAC,2569,South Carolina State Bulldogs,South Carolina State,Bulldogs,SCST,Mid-Eastern Athletic Conference,16,exact
+2025-26,609857,South Dakota,Summit League,233,South Dakota Coyotes,South Dakota,Coyotes,SDAK,Summit League,47,exact
+2025-26,610067,South Dakota St.,Summit League,2571,South Dakota State Jackrabbits,South Dakota State,Jackrabbits,SDST,Summit League,47,exact
+2025-26,609858,South Fla.,AAC,58,South Florida Bulls,South Florida,Bulls,USF,American Conference,62,exact
+2025-26,609860,Southeast Mo. St.,OVC,2546,Southeast Missouri State Redhawks,Southeast Missouri State,Redhawks,SEMO,Ohio Valley Conference,20,exact
+2025-26,609862,Southeastern La.,Southland,2545,SE Louisiana Lions,SE Louisiana,Lions,SELA,Southland Conference,25,dict
+2025-26,610071,Southern California,Big Ten,30,USC Trojans,USC,Trojans,USC,Big Ten Conference,7,dict
+2025-26,609863,Southern Ill.,MVC,79,Southern Illinois Salukis,Southern Illinois,Salukis,SIU,Missouri Valley Conference,18,exact
+2025-26,610084,Southern Ind.,OVC,88,Southern Indiana Screaming Eagles,Southern Indiana,Screaming Eagles,USI,Ohio Valley Conference,20,alias
+2025-26,609869,Southern Miss.,Sun Belt,2572,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,USM,Sun Belt Conference,27,dict
+2025-26,609872,Southern U.,SWAC,2582,Southern Jaguars,Southern,Jaguars,SOU,Southwestern Athletic Conference,26,dict
+2025-26,609873,Southern Utah,WAC,253,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,SUU,United Athletic Conference,30,exact
+2025-26,609820,St. Bonaventure,Atlantic 10,179,St. Bonaventure Bonnies,St. Bonaventure,Bonnies,SBU,Atlantic 10 Conference,3,exact
+2025-26,609825,St. John's (NY),Big East,2599,St. John's Red Storm,St. John's,Red Storm,SJU,Big East Conference,4,dict
+2025-26,610343,St. Thomas (MN),Summit League,2900,St. Thomas Tommies,St. Thomas,Tommies,STMN,Summit League,47,alias
+2025-26,609881,Stanford,ACC,24,Stanford Cardinal,Stanford,Cardinal,STAN,Atlantic Coast Conference,2,exact
+2025-26,609886,Stetson,ASUN,56,Stetson Hatters,Stetson,Hatters,STET,Atlantic Sun Conference,46,exact
+2025-26,610012,Stonehill,NEC,284,Stonehill Skyhawks,Stonehill,Skyhawks,STO,Northeast Conference,19,exact
+2025-26,609888,Stony Brook,America East,2619,Stony Brook Seawolves,Stony Brook,Seawolves,STBK,Coastal Athletic Association,10,exact
+2025-26,609890,Syracuse,ACC,183,Syracuse Orange,Syracuse,Orange,SYR,Atlantic Coast Conference,2,exact
+2025-26,609904,TCU,Big 12,2628,TCU Horned Frogs,TCU,Horned Frogs,TCU,Big 12 Conference,8,exact
+2025-26,610122,Tarleton St.,WAC,2627,Tarleton State Texans,Tarleton State,Texans,TAR,United Athletic Conference,30,exact
+2025-26,609892,Temple,AAC,218,Temple Owls,Temple,Owls,TEM,American Conference,62,exact
+2025-26,609898,Tennessee,SEC,2633,Tennessee Volunteers,Tennessee,Volunteers,TENN,Southeastern Conference,23,exact
+2025-26,609894,Tennessee St.,OVC,2634,Tennessee State Tigers,Tennessee State,Tigers,TNST,Ohio Valley Conference,20,exact
+2025-26,609896,Tennessee Tech,OVC,2635,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,TNTC,Ohio Valley Conference,20,exact
+2025-26,610076,Texas,SEC,251,Texas Longhorns,Texas,Longhorns,TEX,Southeastern Conference,23,exact
+2025-26,609902,Texas A&M,SEC,245,Texas A&M Aggies,Texas A&M,Aggies,TA&M,Southeastern Conference,23,exact
+2025-26,609906,Texas Southern,SWAC,2640,Texas Southern Tigers,Texas Southern,Tigers,TXSO,Southwestern Athletic Conference,26,exact
+2025-26,609877,Texas St.,Sun Belt,326,Texas State Bobcats,Texas State,Bobcats,TXST,Sun Belt Conference,27,exact
+2025-26,609908,Texas Tech,Big 12,2641,Texas Tech Red Raiders,Texas Tech,Red Raiders,TTU,Big 12 Conference,8,exact
+2025-26,609916,Toledo,MAC,2649,Toledo Rockets,Toledo,Rockets,TOL,Mid-American Conference,14,exact
+2025-26,609918,Towson,CAA,119,Towson Tigers,Towson,Tigers,TOW,Coastal Athletic Association,10,exact
+2025-26,609920,Troy,Sun Belt,2653,Troy Trojans,Troy,Trojans,TROY,Sun Belt Conference,27,exact
+2025-26,609922,Tulane,AAC,2655,Tulane Green Wave,Tulane,Green Wave,TULN,American Conference,62,exact
+2025-26,609928,Tulsa,AAC,202,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,TLSA,American Conference,62,exact
+2025-26,610147,UAB,AAC,5,UAB Blazers,UAB,Blazers,UAB,American Conference,62,exact
+2025-26,610149,UAlbany,America East,399,UAlbany Great Danes,UAlbany,Great Danes,UALB,America East Conference,1,exact
+2025-26,610251,UC Davis,Big West,302,UC Davis Aggies,UC Davis,Aggies,UCD,Big West Conference,9,exact
+2025-26,610022,UC Irvine,Big West,300,UC Irvine Anteaters,UC Irvine,Anteaters,UCI,Big West Conference,9,exact
+2025-26,610257,UC Riverside,Big West,27,UC Riverside Highlanders,UC Riverside,Highlanders,UCR,Big West Conference,9,exact
+2025-26,610119,UC San Diego,Big West,28,UC San Diego Tritons,UC San Diego,Tritons,UCSD,Big West Conference,9,exact
+2025-26,610246,UC Santa Barbara,Big West,2540,UC Santa Barbara Gauchos,UC Santa Barbara,Gauchos,UCSB,Big West Conference,9,exact
+2025-26,610268,UCF,Big 12,2116,UCF Knights,UCF,Knights,UCF,Big 12 Conference,8,exact
+2025-26,610254,UCLA,Big Ten,26,UCLA Bruins,UCLA,Bruins,UCLA,Big Ten Conference,7,exact
+2025-26,610024,UConn,AAC,41,UConn Huskies,UConn,Huskies,CONN,Big East Conference,4,exact
+2025-26,610435,UIC,MVC,82,UIC Flames,UIC,Flames,UIC,Missouri Valley Conference,18,exact
+2025-26,610096,UIW,Southland,2916,Incarnate Word Cardinals,Incarnate Word,Cardinals,UIW,Southland Conference,25,exact
+2025-26,610629,ULM,Sun Belt,2433,UL Monroe Warhawks,UL Monroe,Warhawks,ULM,Sun Belt Conference,27,exact
+2025-26,610499,UMBC,America East,2378,UMBC Retrievers,UMBC,Retrievers,UMBC,America East Conference,1,exact
+2025-26,610507,UMES,MEAC,2379,Maryland Eastern Shore Hawks,Maryland Eastern Shore,Hawks,UMES,Mid-Eastern Athletic Conference,16,exact
+2025-26,610479,UMass Lowell,America East,2349,UMass Lowell River Hawks,UMass Lowell,River Hawks,UML,America East Conference,1,exact
+2025-26,610573,UNC Asheville,Big South,2427,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNCA,Big South Conference,6,exact
+2025-26,610581,UNC Greensboro,SoCon,2430,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNCG,Southern Conference,24,exact
+2025-26,610585,UNCW,CAA,350,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNCW,Coastal Athletic Association,10,exact
+2025-26,609757,UNI,MVC,2460,Northern Iowa Panthers,Northern Iowa,Panthers,UNI,Missouri Valley Conference,18,exact
+2025-26,610048,UNLV,MWC,2439,UNLV Rebels,UNLV,Rebels,UNLV,Mountain West Conference,44,exact
+2025-26,610102,USC Upstate,Big South,2908,South Carolina Upstate Spartans,South Carolina Upstate,Spartans,UPST,Big South Conference,6,dict
+2025-26,609910,UT Arlington,WAC,250,UT Arlington Mavericks,UT Arlington,Mavericks,UTA,United Athletic Conference,30,exact
+2025-26,609900,UT Martin,OVC,2630,UT Martin Skyhawks,UT Martin,Skyhawks,UTM,Ohio Valley Conference,20,exact
+2025-26,609912,UTEP,C-USA,2638,UTEP Miners,UTEP,Miners,UTEP,Conference USA,11,exact
+2025-26,609787,UTRGV,Southland,292,UT Rio Grande Valley Vaqueros,UT Rio Grande Valley,Vaqueros,RGV,Southland Conference,25,dict
+2025-26,609914,UTSA,AAC,2636,UTSA Roadrunners,UTSA,Roadrunners,UTSA,American Conference,62,exact
+2025-26,609937,Utah,Big 12,254,Utah Utes,Utah,Utes,UTAH,Big 12 Conference,8,exact
+2025-26,609935,Utah St.,MWC,328,Utah State Aggies,Utah State,Aggies,USU,Mountain West Conference,44,exact
+2025-26,609924,Utah Tech,WAC,3101,Utah Tech Trailblazers,Utah Tech,Trailblazers,UTU,United Athletic Conference,30,exact
+2025-26,610114,Utah Valley,WAC,3084,Utah Valley Wolverines,Utah Valley,Wolverines,UVU,United Athletic Conference,30,exact
+2025-26,609948,VCU,Atlantic 10,2670,VCU Rams,VCU,Rams,VCU,Atlantic 10 Conference,3,exact
+2025-26,609939,Valparaiso,MVC,2674,Valparaiso Beacons,Valparaiso,Beacons,VAL,Missouri Valley Conference,18,exact
+2025-26,609942,Vanderbilt,SEC,238,Vanderbilt Commodores,Vanderbilt,Commodores,VAN,Southeastern Conference,23,exact
+2025-26,609944,Vermont,America East,261,Vermont Catamounts,Vermont,Catamounts,UVM,America East Conference,1,exact
+2025-26,609946,Villanova,Big East,222,Villanova Wildcats,Villanova,Wildcats,VILL,Big East Conference,4,exact
+2025-26,609953,Virginia,ACC,258,Virginia Cavaliers,Virginia,Cavaliers,UVA,Atlantic Coast Conference,2,exact
+2025-26,609951,Virginia Tech,ACC,259,Virginia Tech Hokies,Virginia Tech,Hokies,VT,Atlantic Coast Conference,2,exact
+2025-26,609955,Wagner,NEC,2681,Wagner Seahawks,Wagner,Seahawks,WAG,Northeast Conference,19,exact
+2025-26,609956,Wake Forest,ACC,154,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,WAKE,Atlantic Coast Conference,2,exact
+2025-26,609960,Washington,Big Ten,264,Washington Huskies,Washington,Huskies,WASH,Big Ten Conference,7,exact
+2025-26,609958,Washington St.,WCC,265,Washington State Cougars,Washington State,Cougars,WSU,West Coast Conference,29,exact
+2025-26,609962,Weber St.,Big Sky,2692,Weber State Wildcats,Weber State,Wildcats,WEB,Big Sky Conference,5,exact
+2025-26,610634,West Ga.,ASUN,2698,West Georgia Wolves,West Georgia,Wolves,WGA,Atlantic Sun Conference,46,exact
+2025-26,609963,West Virginia,Big 12,277,West Virginia Mountaineers,West Virginia,Mountaineers,WVU,Big 12 Conference,8,exact
+2025-26,609965,Western Caro.,SoCon,2717,Western Carolina Catamounts,Western Carolina,Catamounts,WCU,Southern Conference,24,exact
+2025-26,609967,Western Ill.,OVC,2710,Western Illinois Leathernecks,Western Illinois,Leathernecks,WIU,Ohio Valley Conference,20,exact
+2025-26,609969,Western Ky.,C-USA,98,Western Kentucky Hilltoppers,Western Kentucky,Hilltoppers,WKU,Conference USA,11,exact
+2025-26,609971,Western Mich.,MAC,2711,Western Michigan Broncos,Western Michigan,Broncos,WMU,Mid-American Conference,14,exact
+2025-26,609973,Wichita St.,AAC,2724,Wichita State Shockers,Wichita State,Shockers,WICH,American Conference,62,exact
+2025-26,609975,William & Mary,CAA,2729,William & Mary Tribe,William & Mary,Tribe,W&M,Coastal Athletic Association,10,exact
+2025-26,609977,Winthrop,Big South,2737,Winthrop Eagles,Winthrop,Eagles,WIN,Big South Conference,6,exact
+2025-26,609979,Wisconsin,Big Ten,275,Wisconsin Badgers,Wisconsin,Badgers,WIS,Big Ten Conference,7,exact
+2025-26,610099,Wofford,SoCon,2747,Wofford Terriers,Wofford,Terriers,WOF,Southern Conference,24,exact
+2025-26,609982,Wright St.,Horizon,2750,Wright State Raiders,Wright State,Raiders,WRST,Horizon League,45,exact
+2025-26,609984,Wyoming,MWC,2751,Wyoming Cowboys,Wyoming,Cowboys,WYO,Mountain West Conference,44,exact
+2025-26,609986,Xavier,Big East,2752,Xavier Musketeers,Xavier,Musketeers,XAV,Big East Conference,4,exact
+2025-26,609987,Yale,Ivy League,43,Yale Bulldogs,Yale,Bulldogs,YALE,Ivy League,12,exact
+2025-26,609989,Youngstown St.,Horizon,2754,Youngstown State Penguins,Youngstown State,Penguins,YSU,Horizon League,45,exact

--- a/sportsdataverse/wbb/wbb_espn_ext.py
+++ b/sportsdataverse/wbb/wbb_espn_ext.py
@@ -1663,6 +1663,7 @@ def espn_wbb_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1679,6 +1680,7 @@ def espn_wbb_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1692,7 +1694,9 @@ def espn_wbb_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/basketball/leagues/womens-college-basketball/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/sportsdataverse/wbb/wbb_ncaa_espn_crosswalk.py
+++ b/sportsdataverse/wbb/wbb_ncaa_espn_crosswalk.py
@@ -1,0 +1,13 @@
+"""Women's-basketball re-export of the NCAA <-> ESPN team-id crosswalk.
+
+The loader is league-parameterized and lives in
+:mod:`sportsdataverse.mbb.mbb_ncaa_espn_crosswalk`; importing it from
+``sportsdataverse.wbb`` is purely a namespace convenience. Pass
+``league="wbb"`` to read the women's table.
+"""
+
+from __future__ import annotations
+
+from sportsdataverse.mbb.mbb_ncaa_espn_crosswalk import ncaa_espn_team_crosswalk
+
+__all__ = ["ncaa_espn_team_crosswalk"]

--- a/sportsdataverse/wnba/wnba_espn_ext.py
+++ b/sportsdataverse/wnba/wnba_espn_ext.py
@@ -1622,6 +1622,7 @@ def espn_wnba_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1638,6 +1639,7 @@ def espn_wnba_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1651,7 +1653,9 @@ def espn_wnba_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/tests/mbb/test_ncaa_espn_team_crosswalk.py
+++ b/tests/mbb/test_ncaa_espn_team_crosswalk.py
@@ -1,0 +1,145 @@
+"""Contract tests for the bundled stats.ncaa.org <-> ESPN team-id crosswalk.
+
+Covers both leagues from one file because the loader is league-parameterized
+and the alias table is shared.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from sportsdataverse.mbb import ncaa_espn_team_crosswalk, ncaa_mbb_team_ids
+from sportsdataverse.wbb import ncaa_wbb_team_ids
+
+LEAGUES = ("mbb", "wbb")
+ALIAS_CSV = Path(__file__).resolve().parents[2] / "tools" / "crosswalk" / "alias_ncaa_espn.csv"
+
+#: Observed floors, NOT aspirational: the build currently resolves 100% of every
+#: season in both leagues. Held a little under that so a single upstream rename
+#: is a warning shot rather than an instant red, but high enough that a broken
+#: normalizer or a stale ESPN reference table fails immediately.
+RECENT_FLOOR = 0.97
+OVERALL_FLOOR = 0.95
+RECENT_SEASONS = ("2023-24", "2024-25", "2025-26")
+
+
+@pytest.fixture(scope="module", params=LEAGUES)
+def league(request) -> str:
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def crosswalks() -> "dict[str, pl.DataFrame]":
+    return {lg: ncaa_espn_team_crosswalk(league=lg) for lg in LEAGUES}
+
+
+def test_rejects_unknown_league():
+    with pytest.raises(ValueError, match="league must be one of"):
+        ncaa_espn_team_crosswalk(league="nba")
+
+
+def test_id_dtypes(crosswalks, league):
+    df = crosswalks[league]
+    assert df.schema["ncaa_team_id"] == pl.Int64
+    assert df.schema["espn_team_id"] == pl.Utf8, "ESPN ids are Utf8 everywhere else in sdv-py"
+    assert df.schema["espn_conference_id"] == pl.Utf8
+    assert df.schema["season"] == pl.Utf8
+
+
+def test_pandas_round_trip(league):
+    assert ncaa_espn_team_crosswalk(league=league, return_as_pandas=True).shape[1] == 12
+
+
+def test_no_team_is_dropped(crosswalks, league):
+    """Every (season, team) in the source id table survives into the crosswalk."""
+    source = ncaa_mbb_team_ids() if league == "mbb" else ncaa_wbb_team_ids()
+    df = crosswalks[league]
+    assert df.height == source.height
+    assert set(zip(df["season"], df["ncaa_team_id"])) == set(zip(source["season"], source["id"]))
+
+
+def test_no_duplicate_ncaa_key(crosswalks, league):
+    df = crosswalks[league]
+    dupes = df.group_by("season", "ncaa_team_id").agg(pl.len()).filter(pl.col("len") > 1)
+    assert dupes.height == 0, dupes.to_dicts()
+
+
+def test_no_espn_id_shared_by_two_teams_in_a_season(crosswalks, league):
+    """An ESPN id must identify at most one NCAA program per season."""
+    collisions = (
+        crosswalks[league]
+        .filter(pl.col("espn_team_id").is_not_null())
+        .group_by("season", "espn_team_id")
+        .agg(pl.col("ncaa_team").unique().alias("ncaa_teams"))
+        .filter(pl.col("ncaa_teams").list.len() > 1)
+    )
+    assert collisions.height == 0, collisions.to_dicts()
+
+
+def test_match_method_is_consistent_with_the_id(crosswalks, league):
+    df = crosswalks[league]
+    assert set(df["match_method"].unique()) <= {"exact", "dict", "alias", "unmatched"}
+    assert df.filter((pl.col("match_method") == "unmatched") & pl.col("espn_team_id").is_not_null()).height == 0
+    assert df.filter((pl.col("match_method") != "unmatched") & pl.col("espn_team_id").is_null()).height == 0
+
+
+def test_recent_season_match_rate_floor(crosswalks, league):
+    df = crosswalks[league]
+    for season in RECENT_SEASONS:
+        rows = df.filter(pl.col("season") == season)
+        assert rows.height > 300, f"{league} {season} looks truncated"
+        rate = rows.filter(pl.col("espn_team_id").is_not_null()).height / rows.height
+        assert rate >= RECENT_FLOOR, f"{league} {season} match rate {rate:.3%} < {RECENT_FLOOR:.0%}"
+
+
+def test_every_season_clears_the_overall_floor(crosswalks, league):
+    rates = (
+        crosswalks[league]
+        .group_by("season")
+        .agg((pl.col("espn_team_id").is_not_null().sum() / pl.len()).alias("rate"))
+        .filter(pl.col("rate") < OVERALL_FLOOR)
+    )
+    assert rates.height == 0, rates.sort("season").to_dicts()
+
+
+def test_espn_columns_are_populated_when_matched(crosswalks, league):
+    """A matched row carries ESPN identity, not just an id."""
+    matched = crosswalks[league].filter(pl.col("espn_team_id").is_not_null())
+    for col in ("espn_display_name", "espn_location", "espn_mascot"):
+        assert matched[col].null_count() == 0, col
+
+
+def test_alias_table_has_no_unused_rows(crosswalks):
+    """Every hand-curated alias must still be earning its keep in some league."""
+    alias = pl.read_csv(ALIAS_CSV, schema_overrides={"espn_team_id": pl.Utf8})
+    used = set()
+    for df in crosswalks.values():
+        used |= set(df.filter(pl.col("match_method") == "alias")["ncaa_team"].unique())
+    unused = sorted(set(alias["ncaa_team"]) - used)
+    assert not unused, f"alias rows matched nothing: {unused}"
+
+
+def test_alias_table_is_unambiguous():
+    alias = pl.read_csv(ALIAS_CSV, schema_overrides={"espn_team_id": pl.Utf8})
+    assert alias["ncaa_team"].n_unique() == alias.height
+    assert alias["espn_team_id"].null_count() == 0
+    assert alias["note"].null_count() == 0, "every alias needs a written justification"
+
+
+def test_known_hard_cases(crosswalks):
+    """Spot-checks for the traps: Saint-vs-State, renames, AP abbreviations."""
+    mbb = crosswalks["mbb"].filter(pl.col("season") == "2025-26")
+    lookup = dict(zip(mbb["ncaa_team"], mbb["espn_team_id"]))
+    expected = {
+        "Ohio St.": "194",  # trailing "St." is State
+        "St. John's (NY)": "2599",  # leading "St." is Saint
+        "Saint Mary's (CA)": "2608",
+        "Saint Francis": "2598",  # NCAA dropped the (PA) qualifier
+        "CSU Bakersfield": "2934",  # Cal State Bakersfield
+        "Queens (NC)": "2511",
+        "Southern Ind.": "88",
+    }
+    assert {k: lookup.get(k) for k in expected} == expected

--- a/tools/codegen/_generated/bundesliga_espn_ext.py
+++ b/tools/codegen/_generated/bundesliga_espn_ext.py
@@ -1627,6 +1627,7 @@ def espn_bundesliga_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1643,6 +1644,7 @@ def espn_bundesliga_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1656,7 +1658,9 @@ def espn_bundesliga_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/soccer/leagues/ger.1/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/tools/codegen/_generated/cfb_espn_ext.py
+++ b/tools/codegen/_generated/cfb_espn_ext.py
@@ -1666,6 +1666,7 @@ def espn_cfb_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1682,6 +1683,7 @@ def espn_cfb_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1695,7 +1697,9 @@ def espn_cfb_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/tools/codegen/_generated/cfl_espn_ext.py
+++ b/tools/codegen/_generated/cfl_espn_ext.py
@@ -1623,6 +1623,7 @@ def espn_cfl_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1639,6 +1640,7 @@ def espn_cfl_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1652,7 +1654,9 @@ def espn_cfl_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/football/leagues/cfl/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/tools/codegen/_generated/college_baseball_espn_ext.py
+++ b/tools/codegen/_generated/college_baseball_espn_ext.py
@@ -1664,6 +1664,7 @@ def espn_college_baseball_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1680,6 +1681,7 @@ def espn_college_baseball_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1693,7 +1695,9 @@ def espn_college_baseball_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/baseball/leagues/college-baseball/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/tools/codegen/_generated/college_softball_espn_ext.py
+++ b/tools/codegen/_generated/college_softball_espn_ext.py
@@ -1664,6 +1664,7 @@ def espn_college_softball_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1680,6 +1681,7 @@ def espn_college_softball_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1693,7 +1695,9 @@ def espn_college_softball_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/baseball/leagues/college-softball/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/tools/codegen/_generated/cricket_espn_ext.py
+++ b/tools/codegen/_generated/cricket_espn_ext.py
@@ -1665,6 +1665,7 @@ def espn_cricket_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1681,6 +1682,7 @@ def espn_cricket_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1694,7 +1696,9 @@ def espn_cricket_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/cricket/leagues/{league}/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/tools/codegen/_generated/epl_espn_ext.py
+++ b/tools/codegen/_generated/epl_espn_ext.py
@@ -1627,6 +1627,7 @@ def espn_epl_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1643,6 +1644,7 @@ def espn_epl_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1656,7 +1658,9 @@ def espn_epl_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/soccer/leagues/eng.1/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/tools/codegen/_generated/laliga_espn_ext.py
+++ b/tools/codegen/_generated/laliga_espn_ext.py
@@ -1627,6 +1627,7 @@ def espn_laliga_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1643,6 +1644,7 @@ def espn_laliga_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1656,7 +1658,9 @@ def espn_laliga_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/soccer/leagues/esp.1/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/tools/codegen/_generated/ligamx_espn_ext.py
+++ b/tools/codegen/_generated/ligamx_espn_ext.py
@@ -1627,6 +1627,7 @@ def espn_ligamx_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1643,6 +1644,7 @@ def espn_ligamx_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1656,7 +1658,9 @@ def espn_ligamx_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/soccer/leagues/mex.1/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/tools/codegen/_generated/ligue1_espn_ext.py
+++ b/tools/codegen/_generated/ligue1_espn_ext.py
@@ -1627,6 +1627,7 @@ def espn_ligue1_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1643,6 +1644,7 @@ def espn_ligue1_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1656,7 +1658,9 @@ def espn_ligue1_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/soccer/leagues/fra.1/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/tools/codegen/_generated/mbb_espn_ext.py
+++ b/tools/codegen/_generated/mbb_espn_ext.py
@@ -1664,6 +1664,7 @@ def espn_mbb_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1680,6 +1681,7 @@ def espn_mbb_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1693,7 +1695,9 @@ def espn_mbb_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/basketball/leagues/mens-college-basketball/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/tools/codegen/_generated/mch_espn_ext.py
+++ b/tools/codegen/_generated/mch_espn_ext.py
@@ -1664,6 +1664,7 @@ def espn_mch_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1680,6 +1681,7 @@ def espn_mch_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1693,7 +1695,9 @@ def espn_mch_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/hockey/leagues/mens-college-hockey/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/tools/codegen/_generated/mlb_espn_ext.py
+++ b/tools/codegen/_generated/mlb_espn_ext.py
@@ -1624,6 +1624,7 @@ def espn_mlb_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1640,6 +1641,7 @@ def espn_mlb_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1653,7 +1655,9 @@ def espn_mlb_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/baseball/leagues/mlb/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/tools/codegen/_generated/mls_espn_ext.py
+++ b/tools/codegen/_generated/mls_espn_ext.py
@@ -1627,6 +1627,7 @@ def espn_mls_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1643,6 +1644,7 @@ def espn_mls_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1656,7 +1658,9 @@ def espn_mls_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/soccer/leagues/usa.1/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/tools/codegen/_generated/nba_espn_ext.py
+++ b/tools/codegen/_generated/nba_espn_ext.py
@@ -1623,6 +1623,7 @@ def espn_nba_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1639,6 +1640,7 @@ def espn_nba_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1652,7 +1654,9 @@ def espn_nba_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/basketball/leagues/nba/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/tools/codegen/_generated/nfl_espn_ext.py
+++ b/tools/codegen/_generated/nfl_espn_ext.py
@@ -1625,6 +1625,7 @@ def espn_nfl_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1641,6 +1642,7 @@ def espn_nfl_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1654,7 +1656,9 @@ def espn_nfl_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/football/leagues/nfl/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/tools/codegen/_generated/nhl_espn_ext.py
+++ b/tools/codegen/_generated/nhl_espn_ext.py
@@ -1623,6 +1623,7 @@ def espn_nhl_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1639,6 +1640,7 @@ def espn_nhl_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1652,7 +1654,9 @@ def espn_nhl_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/hockey/leagues/nhl/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/tools/codegen/_generated/nwsl_espn_ext.py
+++ b/tools/codegen/_generated/nwsl_espn_ext.py
@@ -1627,6 +1627,7 @@ def espn_nwsl_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1643,6 +1644,7 @@ def espn_nwsl_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1656,7 +1658,9 @@ def espn_nwsl_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/soccer/leagues/usa.nwsl/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/tools/codegen/_generated/seriea_espn_ext.py
+++ b/tools/codegen/_generated/seriea_espn_ext.py
@@ -1627,6 +1627,7 @@ def espn_seriea_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1643,6 +1644,7 @@ def espn_seriea_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1656,7 +1658,9 @@ def espn_seriea_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/soccer/leagues/ita.1/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/tools/codegen/_generated/soccer_espn_ext.py
+++ b/tools/codegen/_generated/soccer_espn_ext.py
@@ -1666,6 +1666,7 @@ def espn_soccer_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1682,6 +1683,7 @@ def espn_soccer_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1695,7 +1697,9 @@ def espn_soccer_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/soccer/leagues/{league}/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/tools/codegen/_generated/ucl_espn_ext.py
+++ b/tools/codegen/_generated/ucl_espn_ext.py
@@ -1627,6 +1627,7 @@ def espn_ucl_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1643,6 +1644,7 @@ def espn_ucl_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1656,7 +1658,9 @@ def espn_ucl_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/soccer/leagues/uefa.champions/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/tools/codegen/_generated/uel_espn_ext.py
+++ b/tools/codegen/_generated/uel_espn_ext.py
@@ -1627,6 +1627,7 @@ def espn_uel_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1643,6 +1644,7 @@ def espn_uel_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1656,7 +1658,9 @@ def espn_uel_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/soccer/leagues/uefa.europa/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/tools/codegen/_generated/ufl_espn_ext.py
+++ b/tools/codegen/_generated/ufl_espn_ext.py
@@ -1623,6 +1623,7 @@ def espn_ufl_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1639,6 +1640,7 @@ def espn_ufl_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1652,7 +1654,9 @@ def espn_ufl_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/football/leagues/ufl/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/tools/codegen/_generated/wbb_espn_ext.py
+++ b/tools/codegen/_generated/wbb_espn_ext.py
@@ -1663,6 +1663,7 @@ def espn_wbb_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1679,6 +1680,7 @@ def espn_wbb_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1692,7 +1694,9 @@ def espn_wbb_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/basketball/leagues/womens-college-basketball/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/tools/codegen/_generated/wc_espn_ext.py
+++ b/tools/codegen/_generated/wc_espn_ext.py
@@ -1627,6 +1627,7 @@ def espn_wc_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1643,6 +1644,7 @@ def espn_wc_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1656,7 +1658,9 @@ def espn_wc_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/soccer/leagues/fifa.world/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/tools/codegen/_generated/wch_espn_ext.py
+++ b/tools/codegen/_generated/wch_espn_ext.py
@@ -1664,6 +1664,7 @@ def espn_wch_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1680,6 +1681,7 @@ def espn_wch_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1693,7 +1695,9 @@ def espn_wch_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/hockey/leagues/womens-college-hockey/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/tools/codegen/_generated/wnba_espn_ext.py
+++ b/tools/codegen/_generated/wnba_espn_ext.py
@@ -1622,6 +1622,7 @@ def espn_wnba_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1638,6 +1639,7 @@ def espn_wnba_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1651,7 +1653,9 @@ def espn_wnba_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/basketball/leagues/wnba/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/tools/codegen/_generated/wwc_espn_ext.py
+++ b/tools/codegen/_generated/wwc_espn_ext.py
@@ -1627,6 +1627,7 @@ def espn_wwc_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1643,6 +1644,7 @@ def espn_wwc_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1656,7 +1658,9 @@ def espn_wwc_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/soccer/leagues/fifa.wwc/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/tools/codegen/_generated/xfl_espn_ext.py
+++ b/tools/codegen/_generated/xfl_espn_ext.py
@@ -1623,6 +1623,7 @@ def espn_xfl_season_group_children(
     season: Union[int, str],
     season_type: Union[int, str],
     group_id: Union[int, str],
+    limit: Optional[int] = 500,
     *,
     return_parsed: bool = True,
     return_as_pandas: bool = False,
@@ -1639,6 +1640,7 @@ def espn_xfl_season_group_children(
         season: season path parameter.
         season_type: season_type path parameter.
         group_id: group_id path parameter.
+        limit: limit query parameter.
         return_parsed: parse the payload through parse_items -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
 
@@ -1652,7 +1654,9 @@ def espn_xfl_season_group_children(
     """
     raw = _get(
         f"https://sports.core.api.espn.com/v2/sports/football/leagues/xfl/seasons/{season}/types/{season_type}/groups/{group_id}/children",
-        params={},
+        params={
+            "limit": limit,
+        },
         **kwargs,
     )
     if return_parsed:

--- a/tools/codegen/endpoints/espn_core_v2.yaml
+++ b/tools/codegen/endpoints/espn_core_v2.yaml
@@ -121,6 +121,16 @@ endpoints:
   - name: group_id
     type: int|str
     required: true
+  # ESPN pages this collection at 25 by default, so without an explicit limit
+  # the wrapper silently returned page 1 only -- 25 of 31 women's D-I
+  # conferences, leaving 76 ESPN teams with a null conference. Mirrors the
+  # limit block its sibling season_group_teams already declares. scope is
+  # universal, so this one entry fixes every league's wrapper.
+  extra_params:
+  - name: limit
+    query_key: limit
+    type: int
+    default: 500
   parser: parse_items
   example_args:
     season: 2024

--- a/tools/crosswalk/README.md
+++ b/tools/crosswalk/README.md
@@ -1,0 +1,63 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [NCAA <-> ESPN basketball team-id crosswalk — build inputs](#ncaa---espn-basketball-team-id-crosswalk--build-inputs)
+  - [Rebuild](#rebuild)
+  - [Files](#files)
+    - [Why the ESPN pool is a union of three sources](#why-the-espn-pool-is-a-union-of-three-sources)
+  - [Match rate](#match-rate)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# NCAA <-> ESPN basketball team-id crosswalk — build inputs
+
+Everything here is a **build input** for
+`build_ncaa_espn_crosswalk.py`. It is not shipped in the wheel; the two
+generated outputs are:
+
+- `sportsdataverse/mbb/data/ncaa_espn_team_crosswalk_mbb.csv`
+- `sportsdataverse/wbb/data/ncaa_espn_team_crosswalk_wbb.csv`
+
+read at runtime by `ncaa_espn_team_crosswalk(league=...)`.
+
+## Rebuild
+
+```sh
+uv run python tools/crosswalk/build_ncaa_espn_crosswalk.py            # offline
+uv run python tools/crosswalk/build_ncaa_espn_crosswalk.py --capture  # refresh inputs (network)
+```
+
+The default mode is fully offline and deterministic. Run `--capture` only when
+ESPN gains/renames a program or a conference realigns, then re-run the default
+mode and review the diff.
+
+## Files
+
+| File | Provenance |
+|---|---|
+| `espn_mbb_teams.csv` | Captured 2026-08-01. Union of ESPN Site-API `mens-college-basketball/teams?groups=50`, the same women's list, hoopR's committed `data-raw/espn_mbb_teams.csv` (2023 snapshot), and per-id lookups for alias targets. Conference columns from hoopR. |
+| `espn_wbb_teams.csv` | Same union; conference columns from ESPN Core v2 `seasons/2025/types/2/groups/50/children` -> `groups/{id}/teams`. |
+| `dict_hoopR_ncaa_espn.csv` | `NCAA`/`ESPN`/`ESPN_PBP` columns of hoopR's hand-curated `data-raw/dict_hoopR.csv` (367 rows, `year` 2023). The primary bridge. |
+| `alias_ncaa_espn.csv` | Hand-curated, league-independent. One row per NCAA name the normalizer + dictionary cannot resolve; every row carries a written justification and was verified individually against ESPN's per-team endpoint. |
+
+### Why the ESPN pool is a union of three sources
+
+- ESPN team ids are **school-level** — one id shared by the men's and women's
+  programs — so either league's list backfills the other.
+- The two Site-API D-I lists **disagree**: the men's list is missing
+  Lindenwood, Queens University and Southern Indiana; the women's list has them.
+- Both live lists **forget programs that left D-I** (Hartford, both St.
+  Francises); hoopR's 2023 snapshot still carries them.
+- Programs that left before 2023 (Savannah State, Centenary, Winston-Salem
+  State) are in no bulk list at all, but their per-team endpoint still
+  resolves — `--capture` rebuilds those rows from the alias table's ids.
+
+## Match rate
+
+100% of every season in both leagues (2009-10 .. 2025-26) as of the last
+build. `match_method` records how each row was resolved: `exact` (~92%),
+`dict` (~6%), `alias` (~1%). There is no fuzzy matching — a fuzzy candidate
+must be verified by hand and written into `alias_ncaa_espn.csv`.
+
+Contract tests: `tests/mbb/test_ncaa_espn_team_crosswalk.py`.

--- a/tools/crosswalk/alias_ncaa_espn.csv
+++ b/tools/crosswalk/alias_ncaa_espn.csv
@@ -1,0 +1,14 @@
+ncaa_team,espn_team_id,note
+Albany (NY),399,ESPN brands it UAlbany; NCAA keeps the (NY) disambiguator
+CSU Bakersfield,2934,NCAA abbreviates Cal State; ESPN spells it out
+Centenary (LA),2113,left D-I after 2010-11; absent from both live team lists
+Dixie St.,3101,renamed Utah Tech in 2022; ESPN carries the new name on the old id
+Houston Baptist,2277,renamed Houston Christian in 2022
+IUPUI,85,split/rebranded IU Indianapolis in 2024; same ESPN id
+LIU Brooklyn,112358,LIU Brooklyn + LIU Post merged into Long Island University in 2019
+Saint Francis,2598,NCAA dropped the (PA) qualifier for 2024-25; ESPN id unchanged
+Savannah St.,2542,reclassified to D-II after 2018-19; absent from both live team lists
+Southern Ind.,88,NCAA abbreviates Indiana
+St. Thomas (MN),2900,ESPN drops the (MN); no other D-I St. Thomas
+Tex. A&M-Commerce,2837,renamed East Texas A&M in 2025; same ESPN id
+Winston-Salem,2736,Winston-Salem State; D-I only through 2009-10

--- a/tools/crosswalk/build_ncaa_espn_crosswalk.py
+++ b/tools/crosswalk/build_ncaa_espn_crosswalk.py
@@ -1,0 +1,409 @@
+"""Build the stats.ncaa.org <-> ESPN basketball team-id crosswalk.
+
+Two modes:
+
+``--capture``
+    Hit ESPN once and refresh the committed reference tables
+    (``espn_mbb_teams.csv`` / ``espn_wbb_teams.csv`` in this directory).
+    Requires network; run rarely (new D-I members, conference realignment).
+
+default
+    Fully offline. Reads the committed reference tables, the hoopR
+    cross-provider name dictionary, and the hand-curated alias tables, then
+    writes ``sportsdataverse/{mbb,wbb}/data/ncaa_espn_team_crosswalk_{mbb,wbb}.csv``
+    and prints the per-season match-rate report.
+
+Match order (first hit wins, and a candidate is only accepted when it resolves
+to exactly ONE ESPN team):
+
+1. ``exact``  -- normalized NCAA name against the ESPN candidate keys.
+2. ``dict``   -- normalized NCAA name -> hoopR ``dict_hoopR`` ``NCAA`` row ->
+   its ``ESPN`` / ``ESPN_PBP`` spellings -> ESPN candidate keys.
+3. ``alias``  -- the hand-curated ``alias_{league}.csv`` (ncaa_team ->
+   espn_team_id), for AP abbreviations and post-2023 renames/promotions the
+   dictionary predates.
+
+Anything left over is emitted with a null ``espn_team_id`` and
+``match_method="unmatched"`` -- rows are never dropped. There is deliberately
+NO fuzzy matching: a fuzzy candidate must be verified by hand and written into
+the alias table, so the build stays deterministic and reviewable.
+
+Usage::
+
+    uv run python tools/crosswalk/build_ncaa_espn_crosswalk.py
+    uv run python tools/crosswalk/build_ncaa_espn_crosswalk.py --capture
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from typing import Dict, List, Optional, Set
+
+import polars as pl
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parents[1]
+HOOPR_DICT = HERE / "dict_hoopR_ncaa_espn.csv"
+ALIAS = HERE / "alias_ncaa_espn.csv"
+_SITE_TEAM = "https://site.api.espn.com/apis/site/v2/sports/basketball/mens-college-basketball/teams"
+
+#: AP-style abbreviations stats.ncaa.org uses that ESPN spells out. Derived
+#: empirically from the unmatched residue, not guessed -- every entry below
+#: retired at least one real miss.
+_ABBREV: Dict[str, str] = {
+    "st.": "state",
+    "u.": "university",
+    "univ.": "university",
+    "ala.": "alabama",
+    "ark.": "arkansas",
+    "ariz.": "arizona",
+    "caro.": "carolina",
+    "colo.": "colorado",
+    "conn.": "connecticut",
+    "fla.": "florida",
+    "ga.": "georgia",
+    "ill.": "illinois",
+    "ind.": "indiana",
+    "ky.": "kentucky",
+    "la.": "louisiana",
+    "md.": "maryland",
+    "mass.": "massachusetts",
+    "mich.": "michigan",
+    "minn.": "minnesota",
+    "miss.": "mississippi",
+    "mo.": "missouri",
+    "n.c.": "north carolina",
+    "n.d.": "north dakota",
+    "n.j.": "new jersey",
+    "n.m.": "new mexico",
+    "n.y.": "new york",
+    "neb.": "nebraska",
+    "okla.": "oklahoma",
+    "ore.": "oregon",
+    "pa.": "pennsylvania",
+    "s.c.": "south carolina",
+    "s.d.": "south dakota",
+    "tenn.": "tennessee",
+    "tex.": "texas",
+    "va.": "virginia",
+    "vt.": "vermont",
+    "w.va.": "west virginia",
+    "wash.": "washington",
+    "wis.": "wisconsin",
+}
+
+#: A LEADING "St. " is Saint (St. John's, St. Mary's, St. Bonaventure); a
+#: trailing/medial "St." is State (Ohio St., Central Conn. St.). Handled before
+#: the token pass so the ``st. -> state`` entry above can't clobber it.
+_LEADING_SAINT = re.compile(r"^st\.\s+")
+_NON_ALNUM = re.compile(r"[^a-z0-9]+")
+
+
+def normalize(name: Optional[str]) -> str:
+    """Contract an NCAA/ESPN school name to a comparable key.
+
+    Expands AP abbreviations, folds case, drops punctuation. ``""`` for null.
+    """
+    if not name:
+        return ""
+    text = _LEADING_SAINT.sub("saint ", name.lower().strip())
+    text = " ".join(_ABBREV.get(tok, tok) for tok in text.split())
+    text = text.replace("&", " and ")
+    return _NON_ALNUM.sub(" ", text).strip()
+
+
+# --------------------------------------------------------------------------
+# capture
+# --------------------------------------------------------------------------
+
+_ESPN_OUT_COLS = [
+    "team_id",
+    "location",
+    "display_name",
+    "short_name",
+    "mascot",
+    "nickname",
+    "abbreviation",
+    "conference_id",
+    "conference_name",
+]
+
+_HOOPR_TEAMS = Path("C:/Users/saiem/Documents/GitHub-Data/sdv-dev/hoopR-dev/hoopR/data-raw/espn_mbb_teams.csv")
+_HOOPR_DICT_SRC = Path("C:/Users/saiem/Documents/GitHub-Data/sdv-dev/hoopR-dev/hoopR/data-raw/dict_hoopR.csv")
+
+
+def _site_teams(league: str) -> pl.DataFrame:
+    """Live ESPN Site-API team table, renamed to the reference-table shape."""
+    if league == "mbb":
+        from sportsdataverse.mbb import espn_mbb_teams as fetch
+    else:
+        from sportsdataverse.wbb import espn_wbb_teams as fetch
+
+    df = fetch()
+    return df.select(
+        pl.col("team_id").cast(pl.Utf8).alias("team_id"),
+        pl.col("team_location").alias("location"),
+        pl.col("team_display_name").alias("display_name"),
+        pl.col("team_short_display_name").alias("short_name"),
+        pl.col("team_name").alias("mascot"),
+        pl.col("team_nickname").alias("nickname"),
+        pl.col("team_abbreviation").alias("abbreviation"),
+    )
+
+
+def _hoopr_teams() -> pl.DataFrame:
+    """hoopR's committed ESPN MBB table -- the only source of conference cols."""
+    df = pl.read_csv(_HOOPR_TEAMS, null_values=["NA"], infer_schema_length=10000)
+    return df.select(
+        pl.col("team_id").cast(pl.Utf8).alias("team_id"),
+        pl.col("team").alias("location"),
+        pl.col("display_name"),
+        pl.col("short_name"),
+        pl.col("mascot"),
+        pl.col("nickname"),
+        pl.col("abbreviation"),
+        pl.col("conference_id").cast(pl.Utf8).alias("conference_id"),
+        pl.col("conference_name"),
+    )
+
+
+def _wbb_conferences() -> pl.DataFrame:
+    """Women's conference membership from the ESPN Core v2 groups tree.
+
+    The Site-API ``groups=`` filter is a no-op for women's basketball (it
+    returns all 362 teams whatever you pass), so conference affiliation has to
+    come from Core v2 ``seasons/{yr}/types/2/groups/{id}/teams``.
+    """
+    from sportsdataverse.dl_utils import download
+    from sportsdataverse.wbb import espn_wbb_season_group, espn_wbb_season_group_teams
+
+    season, season_type, division_i = 2025, 2, 50
+    core = (
+        f"https://sports.core.api.espn.com/v2/sports/basketball/leagues/womens-college-basketball"
+        f"/seasons/{season}/types/{season_type}/groups/{division_i}/children"
+    )
+
+    def _ref_ids(refs: List[str]) -> List[str]:
+        out = [str(r).split("?")[0].rstrip("/").rsplit("/", 1)[-1] for r in refs]
+        return [i for i in out if i.isdigit()]
+
+    def _ids(df: pl.DataFrame) -> List[str]:
+        return _ref_ids(df.get_column("$ref").to_list() if "$ref" in df.columns else [])
+
+    # NOTE: espn_wbb_season_group_children() hardcodes params={} so it returns
+    # only the first page (25 of 31 conferences). Go through the shared HTTP
+    # chokepoint directly until that wrapper grows a ``limit``.
+    children = download(url=core, params={"limit": 100}).json().get("items", [])
+
+    rows: List[Dict[str, str]] = []
+    for gid in _ref_ids([c.get("$ref", "") for c in children]):
+        meta = espn_wbb_season_group(season=season, season_type=season_type, group_id=gid)
+        cname = meta.get_column("name")[0] if meta.height else ""
+        teams = espn_wbb_season_group_teams(season=season, season_type=season_type, group_id=gid)
+        for tid in _ids(teams):
+            rows.append({"team_id": tid, "conference_id": gid, "conference_name": cname or ""})
+    return pl.DataFrame(rows, schema={"team_id": pl.Utf8, "conference_id": pl.Utf8, "conference_name": pl.Utf8}).unique(
+        subset=["team_id"], keep="first"
+    )
+
+
+def _alias_only_teams(columns: List[str]) -> pl.DataFrame:
+    """ESPN rows for alias targets neither live list nor hoopR carries.
+
+    Defunct / reclassified programs (Savannah State, Centenary, Winston-Salem
+    State) are gone from every bulk team list but their per-team endpoint still
+    resolves, so the alias table's ids are enough to rebuild the row.
+    """
+    import requests
+
+    alias = pl.read_csv(ALIAS, schema_overrides={"espn_team_id": pl.Utf8})
+    rows: List[Dict[str, Optional[str]]] = []
+    for team_id in alias.get_column("espn_team_id").unique().to_list():
+        resp = requests.get(f"{_SITE_TEAM}/{team_id}", timeout=30)
+        resp.raise_for_status()
+        team = resp.json().get("team", {})
+        rows.append(
+            {
+                "team_id": str(team.get("id")),
+                "location": team.get("location"),
+                "display_name": team.get("displayName"),
+                "short_name": team.get("shortDisplayName"),
+                "mascot": team.get("name"),
+                "nickname": team.get("nickname"),
+                "abbreviation": team.get("abbreviation"),
+            }
+        )
+    return pl.DataFrame(rows, schema={c: pl.Utf8 for c in columns}).select(columns)
+
+
+def capture() -> None:
+    """Refresh the committed ESPN reference tables + the trimmed hoopR dict.
+
+    ESPN team ids are school-level -- one id per school, shared by its men's
+    and women's programs -- so the reference pool is the UNION of three
+    sources, first one wins per id:
+
+    * live men's Site-API team list,
+    * live women's Site-API team list (the two D-I lists disagree: the men's
+      one is missing Lindenwood / Queens / Southern Indiana, the women's one
+      has them),
+    * hoopR's committed 2023 snapshot, which still carries the programs ESPN
+      has since dropped from D-I (Hartford, both St. Francises).
+
+    Only the conference columns are league-specific.
+    """
+    hoopr = _hoopr_teams()
+    site = _site_teams("mbb")
+    pool = (
+        site.vstack(_site_teams("wbb"))
+        .vstack(hoopr.select(site.columns))
+        .vstack(_alias_only_teams(list(site.columns)))
+        .unique(subset=["team_id"], keep="first", maintain_order=True)
+    )
+
+    for league, conference in (
+        ("mbb", hoopr.select("team_id", "conference_id", "conference_name")),
+        ("wbb", _wbb_conferences()),
+    ):
+        table = pool.join(conference, on="team_id", how="left").select(_ESPN_OUT_COLS).sort("team_id")
+        table.write_csv(HERE / f"espn_{league}_teams.csv")
+        print(f"espn_{league}_teams.csv: {table.height} rows")
+
+    dct = pl.read_csv(_HOOPR_DICT_SRC, null_values=["NA"], infer_schema_length=10000)
+    dct.select("NCAA", "ESPN", "ESPN_PBP").drop_nulls("NCAA").unique(maintain_order=True).write_csv(HOOPR_DICT)
+    print(f"dict_hoopR_ncaa_espn.csv: {dct.height} rows")
+
+
+# --------------------------------------------------------------------------
+# build
+# --------------------------------------------------------------------------
+
+
+def _espn_index(espn: pl.DataFrame) -> Dict[str, Set[str]]:
+    """normalized-name -> {espn team_id}. Ambiguous keys keep every id."""
+    index: Dict[str, Set[str]] = {}
+    for row in espn.iter_rows(named=True):
+        keys = {normalize(row[c]) for c in ("location", "display_name", "short_name", "nickname", "abbreviation")}
+        display, mascot = row["display_name"], row["mascot"]
+        if display and mascot and display.endswith(mascot):
+            keys.add(normalize(display[: -len(mascot)]))
+        for key in keys - {""}:
+            index.setdefault(key, set()).add(row["team_id"])
+    return index
+
+
+def _dict_bridge() -> Dict[str, Set[str]]:
+    """normalized NCAA name -> {ESPN spellings} from hoopR's name dictionary."""
+    dct = pl.read_csv(HOOPR_DICT, null_values=["NA"], infer_schema_length=10000)
+    bridge: Dict[str, Set[str]] = {}
+    for row in dct.iter_rows(named=True):
+        spellings = {v for v in (row["ESPN"], row["ESPN_PBP"]) if v}
+        if row["NCAA"] and spellings:
+            bridge.setdefault(normalize(row["NCAA"]), set()).update(spellings)
+    return bridge
+
+
+def build(league: str) -> pl.DataFrame:
+    """Season-keyed crosswalk for *league*; unmatched rows kept with nulls."""
+    from sportsdataverse.mbb.mbb_ncaa_team_ids import _ncaa_bb_team_ids
+
+    ncaa = _ncaa_bb_team_ids(league)
+    espn = pl.read_csv(
+        HERE / f"espn_{league}_teams.csv", schema_overrides={"team_id": pl.Utf8, "conference_id": pl.Utf8}
+    )
+    alias_df = pl.read_csv(ALIAS, schema_overrides={"espn_team_id": pl.Utf8})
+    alias = dict(zip(alias_df.get_column("ncaa_team").to_list(), alias_df.get_column("espn_team_id").to_list()))
+
+    index = _espn_index(espn)
+    bridge = _dict_bridge()
+    espn_by_id = {r["team_id"]: r for r in espn.iter_rows(named=True)}
+
+    def resolve(team: str) -> "tuple[Optional[str], str]":
+        if team in alias:
+            return alias[team], "alias"
+        key = normalize(team)
+        hit = index.get(key, set())
+        if len(hit) == 1:
+            return next(iter(hit)), "exact"
+        ids: Set[str] = set()
+        for spelling in bridge.get(key, set()):
+            ids |= index.get(normalize(spelling), set())
+        if len(ids) == 1:
+            return next(iter(ids)), "dict"
+        return None, "ambiguous" if (hit or ids) else "unmatched"
+
+    resolved = {team: resolve(team) for team in ncaa.get_column("team").unique().to_list()}
+    espn_ids = [resolved[t][0] for t in ncaa.get_column("team")]
+    methods = [resolved[t][1] for t in ncaa.get_column("team")]
+
+    def col(field: str) -> List[Optional[str]]:
+        return [espn_by_id[i][field] if i is not None else None for i in espn_ids]
+
+    return ncaa.select(
+        pl.col("season"),
+        pl.col("id").cast(pl.Int64).alias("ncaa_team_id"),
+        pl.col("team").alias("ncaa_team"),
+        pl.col("conference").alias("ncaa_conference"),
+        pl.Series("espn_team_id", espn_ids, dtype=pl.Utf8),
+        pl.Series("espn_display_name", col("display_name"), dtype=pl.Utf8),
+        pl.Series("espn_location", col("location"), dtype=pl.Utf8),
+        pl.Series("espn_mascot", col("mascot"), dtype=pl.Utf8),
+        pl.Series("espn_abbreviation", col("abbreviation"), dtype=pl.Utf8),
+        pl.Series("espn_conference_name", col("conference_name"), dtype=pl.Utf8),
+        pl.Series("espn_conference_id", col("conference_id"), dtype=pl.Utf8),
+        pl.Series("match_method", methods, dtype=pl.Utf8),
+    ).sort("season", "ncaa_team")
+
+
+def report(league: str, df: pl.DataFrame) -> None:
+    """Per-season match rates + the unmatched residue."""
+    per_season = (
+        df.group_by("season")
+        .agg(
+            pl.len().alias("n"),
+            (pl.col("espn_team_id").is_not_null()).sum().alias("matched"),
+            (pl.col("match_method") == "exact").sum().alias("exact"),
+            (pl.col("match_method") == "dict").sum().alias("dict"),
+            (pl.col("match_method") == "alias").sum().alias("alias"),
+        )
+        .with_columns((pl.col("matched") / pl.col("n") * 100).round(2).alias("pct"))
+        .sort("season")
+    )
+    print(f"\n=== {league.upper()} ===")
+    for row in per_season.iter_rows(named=True):
+        print(
+            f"  {row['season']}  n={row['n']:3d}  matched={row['matched']:3d} ({row['pct']:6.2f}%)"
+            f"  exact={row['exact']:3d} dict={row['dict']:2d} alias={row['alias']:2d}"
+        )
+    residue = (
+        df.filter(pl.col("espn_team_id").is_null())
+        .group_by("ncaa_team")
+        .agg(pl.col("season").min().alias("first"), pl.col("season").max().alias("last"), pl.len().alias("seasons"))
+        .sort("seasons", descending=True)
+    )
+    print(f"  unmatched distinct teams: {residue.height}")
+    for row in residue.iter_rows(named=True):
+        print(f"    {row['ncaa_team']:<28} {row['seasons']:2d} seasons  {row['first']}..{row['last']}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--capture", action="store_true", help="refresh the ESPN reference tables from the network")
+    args = parser.parse_args()
+
+    if args.capture:
+        capture()
+        return
+
+    for league in ("mbb", "wbb"):
+        df = build(league)
+        out = ROOT / "sportsdataverse" / league / "data" / f"ncaa_espn_team_crosswalk_{league}.csv"
+        df.write_csv(out)
+        report(league, df)
+        print(f"  -> {out.relative_to(ROOT)} ({df.height} rows)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/crosswalk/dict_hoopR_ncaa_espn.csv
+++ b/tools/crosswalk/dict_hoopR_ncaa_espn.csv
@@ -1,0 +1,364 @@
+NCAA,ESPN,ESPN_PBP
+Abilene Christian,Abil Christian,Abilene Christian
+Air Force,Air Force,Air Force
+Akron,Akron,Akron
+Alabama,Alabama,Alabama
+Alabama A&M,Alabama A&M,Alabama A&M
+Alabama St.,Alabama State,Alabama State
+UAlbany,Albany,Albany
+Alcorn,Alcorn State,Alcorn State
+American,American,American
+App State,Appalachian St,Appalachian State
+Arizona,Arizona,Arizona
+Arizona St.,Arizona State,Arizona State
+Arkansas,Arkansas,Arkansas
+Ark.-Pine Bluff,AR-Pine Bluff,Arkansas-Pine Bluff
+Arkansas St.,Arkansas State,Arkansas St
+Army West Point,Army,Army
+Auburn,Auburn,Auburn
+Austin Peay,Austin Peay,Austin Peay
+BYU,BYU,BYU
+Ball St.,Ball State,Ball State
+Baylor,Baylor,Baylor
+Bellarmine,Bellarmine,Bellarmine
+Belmont,Belmont,Belmont
+Bethune-Cookman,Bethune-Cookman,Bethune-Cookman
+Binghamton,Binghamton,Binghamton
+Boise St.,Boise State,Boise State
+Boston College,Boston College,Boston College
+Boston U.,Boston U,Boston University
+Bowling Green,Bowling Green,Bowling Green
+Bradley,Bradley,Bradley
+Brown,Brown,Brown
+Bryant,Bryant,Bryant
+Bucknell,Bucknell,Bucknell
+Buffalo,Buffalo,Buffalo
+Butler,Butler,Butler
+California Baptist,Cal Baptist,Cal Baptist
+Cal Poly,Cal Poly,Cal Poly
+CSU Bakersfield,CSU Bakersfield,CSU Bakersfield
+Cal St. Fullerton,CSU Fullerton,CS Fullerton
+CSUN,CSU Northridge,CSU Northridge
+California,Cal,California
+Campbell,Campbell,Campbell
+Canisius,Canisius,Canisius
+Central Ark.,Cent Arkansas,Central Arkansas
+Central Conn. St.,Cent Conn St,Central Connecticut
+Central Mich.,Cent Michigan,Central Michigan
+Col. of Charleston,Charleston,Charleston
+Charleston So.,Charleston So,Charleston Southern
+Charlotte,Charlotte,Charlotte
+Chattanooga,Chattanooga,Chattanooga
+Chicago St.,Chicago State,Chicago State
+Cincinnati,Cincinnati,Cincinnati
+Clemson,Clemson,Clemson
+Cleveland St.,Cleveland State,Cleveland State
+Coastal Carolina,C. Carolina,Coastal Carolina
+Colgate,Colgate,Colgate
+Colorado,Colorado,Colorado
+Colorado St.,Colorado State,Colorado State
+Columbia,Columbia,Columbia
+UConn,UConn,Connecticut
+Coppin St.,Coppin State,Coppin State
+Cornell,Cornell,Cornell
+Creighton,Creighton,Creighton
+Dartmouth,Dartmouth,Dartmouth
+Davidson,Davidson,Davidson
+Dayton,Dayton,Dayton
+DePaul,DePaul,DePaul
+Delaware,Delaware,Delaware
+Delaware St.,Delaware State,Delaware State
+Denver,Denver,Denver
+Detroit Mercy,Detroit Mercy,Detroit Mercy
+Drake,Drake,Drake
+Drexel,Drexel,Drexel
+Duke,Duke,Duke
+Duquesne,Duquesne,Duquesne
+East Carolina,ECU,East Carolina
+ETSU,ETSU,East Tennessee State
+Eastern Ill.,E Illinois,Eastern Illinois
+Eastern Ky.,E Kentucky,Eastern Kentucky
+Eastern Mich.,E Michigan,Eastern Michigan
+Eastern Wash.,E Washington,Eastern Washington
+Elon,Elon,Elon
+Evansville,Evansville,Evansville
+FIU,FIU,Florida International
+Fairfield,Fairfield,Fairfield
+Fairleigh Dickinson,Fair Dickinson,Fairleigh Dickinson
+Florida,Florida,Florida
+Florida A&M,Florida A&M,Florida A&M
+Fla. Atlantic,FAU,Florida Atlantic
+FGCU,FGCU,Florida Gulf Coast
+Florida St.,Florida State,Florida State
+Fordham,Fordham,Fordham
+Fresno St.,Fresno State,Fresno State
+Furman,Furman,Furman
+Gardner-Webb,Gardner-Webb,Gardner-Webb
+George Mason,George Mason,George Mason
+George Washington,G Washington,George Washington
+Georgetown,Georgetown,Georgetown
+Georgia,Georgia,Georgia
+Ga. Southern,Ga Southern,Georgia Southern
+Georgia St.,Georgia State,Georgia St
+Georgia Tech,Georgia Tech,Georgia Tech
+Gonzaga,Gonzaga,Gonzaga
+Grambling,Grambling,Grambling
+Grand Canyon,Grand Canyon,Grand Canyon
+Green Bay,Green Bay,Green Bay
+Hampton,Hampton,Hampton
+Hartford,Hartford,Hartford
+Harvard,Harvard,Harvard
+Hawaii,Hawai'i,Hawai'i
+High Point,High Point,High Point
+Hofstra,Hofstra,Hofstra
+Holy Cross,Holy Cross,Holy Cross
+Houston,Houston,Houston
+Houston Christian,Houston Baptist,Houston Baptist
+Howard,Howard,Howard
+IUPUI,IUPUI,IUPUI
+Idaho,Idaho,Idaho
+Idaho St.,Idaho State,Idaho State
+Illinois,Illinois,Illinois
+UIC,UIC,UIC
+Illinois St.,Illinois State,Illinois State
+UIW,Incarnate Word,Incarnate Word
+Indiana,Indiana,Indiana
+Indiana St.,Indiana State,Indiana State
+Iona,Iona,Iona
+Iowa,Iowa,Iowa
+Iowa St.,Iowa State,Iowa State
+Jackson St.,Jackson State,Jackson State
+Jacksonville,Jacksonville,Jacksonville
+Jacksonville St.,Jacksonville St,Jacksonville State
+James Madison,JMU,James Madison
+Kansas,Kansas,Kansas
+Kansas St.,Kansas State,Kansas State
+Kennesaw St.,Kennesaw State,Kennesaw State
+Kent St.,Kent State,Kent State
+Kentucky,Kentucky,Kentucky
+LIU,LIU,Long Island University
+LSU,LSU,LSU
+La Salle,La Salle,La Salle
+Lafayette,Lafayette,Lafayette
+Lamar University,Lamar,Lamar
+Lehigh,Lehigh,Lehigh
+Liberty,Liberty,Liberty
+Lindenwood,Lindenwood,Lindenwood
+Lipscomb,Lipscomb,Lipscomb
+Little Rock,Little Rock,Arkansas-Little Rock
+Long Beach St.,Long Beach State,Long Beach State
+Longwood,Longwood,Longwood
+Louisiana,Louisiana,Louisiana
+ULM,UL Monroe,Ul Monroe
+Louisiana Tech,LA Tech,Louisiana Tech
+Louisville,Louisville,Louisville
+Loyola Chicago,Loyola-Chicago,Loyola Chicago
+Loyola Maryland,Loyola (MD),Loyola (MD)
+LMU (CA),Loyola Mary,Loyola Marymount
+Maine,Maine,Maine
+Manhattan,Manhattan,Manhattan
+Marist,Marist,Marist
+Marquette,Marquette,Marquette
+Marshall,Marshall,Marshall
+Maryland,Maryland,Maryland
+UMES,MD-E Shore,Maryland-Eastern Shore
+Massachusetts,UMass,Massachusetts
+McNeese,Mcneese,Mcneese St
+Memphis,Memphis,Memphis
+Mercer,Mercer,Mercer
+Merrimack,Merrimack,Merrimack
+Miami (FL),Miami,Miami
+Miami (OH),Miami (OH),Miami (OH)
+Michigan,Michigan,Michigan
+Michigan St.,Michigan State,Michigan State
+Middle Tenn.,Mid Tennessee,Middle Tennessee
+Milwaukee,Milwaukee,Milwaukee
+Minnesota,Minnesota,Minnesota
+Ole Miss,Ole Miss,Ole Miss
+Mississippi St.,Miss St,Mississippi State
+Mississippi Val.,Miss Valley St,Mississippi Valley State
+Missouri,Missouri,Missouri
+Missouri St.,Missouri State,Missouri State
+Monmouth,Monmouth,Monmouth
+Montana,Montana,Montana
+Montana St.,Montana State,Montana State
+Morehead St.,Morehead State,Morehead State
+Morgan St.,Morgan State,Morgan State
+Mount St. Mary's,Mt St Mary's,Mt. St. Mary'S
+Murray St.,Murray State,Murray State
+NC State,NC State,NC State
+NJIT,NJIT,NJIT
+Navy,Navy,Navy
+Nebraska,Nebraska,Nebraska
+Omaha,Omaha,Omaha
+Nevada,Nevada,Nevada
+New Hampshire,UNH,New Hampshire
+New Mexico,New Mexico,New Mexico
+New Mexico St.,New Mexico St,New Mexico State
+New Orleans,New Orleans,New Orleans
+Niagara,Niagara,Niagara
+Nicholls,Nicholls,Nicholls
+Norfolk St.,Norfolk State,Norfolk State
+North Ala.,North Alabama,North Alabama
+North Carolina,UNC,North Carolina
+N.C. A&T,NC A&T,North Carolina A&T
+N.C. Central,NC Central,North Carolina Central
+North Dakota,North Dakota,North Dakota
+North Dakota St.,North Dakota St,North Dakota State
+North Florida,North Florida,North Florida
+North Texas,North Texas,North Texas
+Northeastern,Northeastern,Northeastern
+Northern Ariz.,N Arizona,Northern Arizona
+Northern Colo.,N Colorado,Northern Colorado
+NIU,N Illinois,Northern Illinois
+UNI,Northern Iowa,Northern Iowa
+Northern Ky.,N Kentucky,Northern Kentucky
+Northwestern,Northwestern,Northwestern
+Northwestern St.,Northwestern St,Northwestern State
+Notre Dame,Notre Dame,Notre Dame
+Oakland,Oakland,Oakland
+Ohio,Ohio,Ohio
+Ohio St.,Ohio State,Ohio State
+Oklahoma,Oklahoma,Oklahoma
+Oklahoma St.,Oklahoma State,Oklahoma State
+Old Dominion,Old Dominion,Old Dominion
+Oral Roberts,Oral Roberts,Oral Roberts
+Oregon,Oregon,Oregon
+Oregon St.,Oregon State,Oregon State
+Pacific,Pacific,Pacific
+Penn,Penn,Pennsylvania
+Penn St.,Penn State,Penn State
+Pepperdine,Pepperdine,Pepperdine
+Pittsburgh,Pitt,Pittsburgh
+Portland,Portland,Portland
+Portland St.,Portland State,Portland State
+Prairie View,PV A&M,Prairie View A&M
+Presbyterian,Presbyterian,Presbyterian College
+Princeton,Princeton,Princeton
+Providence,Providence,Providence
+Purdue,Purdue,Purdue
+Purdue Fort Wayne,Fort Wayne,Purdue Fort Wayne
+Queens (NC),Queens University,Queens University
+Quinnipiac,Quinnipiac,Quinnipiac
+Radford,Radford,Radford
+Rhode Island,URI,Rhode Island
+Rice,Rice,Rice
+Richmond,Richmond,Richmond
+Rider,Rider,Rider
+Robert Morris,Robert Morris,Robert Morris
+Rutgers,Rutgers,Rutgers
+SIUE,SIUE,SIU Edwardsville
+SMU,SMU,SMU
+Sacramento St.,Sacramento St,Sacramento State
+Sacred Heart,Sacred Heart,Sacred Heart
+Saint Joseph's,Saint Joe's,Saint Joseph's
+Saint Louis,Saint Louis,Saint Louis
+Saint Mary's (CA),Saint Mary's,Saint Mary's
+Saint Peter's,St Peter's,Saint Peter's
+Sam Houston,Sam Houston,Sam Houston State
+Samford,Samford,Samford
+San Diego,San Diego,San Diego
+San Diego St.,San Diego State,San Diego State
+San Francisco,San Francisco,San Francisco
+San Jose St.,San Jose State,San José State
+Santa Clara,Santa Clara,Santa Clara
+Seattle U,Seattle,Seattle U
+Seton Hall,Seton Hall,Seton Hall
+Siena,Siena,Siena
+South Alabama,South Alabama,South Alabama
+South Carolina,South Carolina,South Carolina
+South Carolina St.,S Carolina St,South Carolina State
+South Dakota,South Dakota,South Dakota
+South Dakota St.,South Dakota St,South Dakota State
+South Fla.,USF,South Florida
+Southeast Mo. St.,SE Missouri St,Southeast Missouri State
+Southeastern La.,SE Louisiana,SE Louisiana
+Southern U.,Southern,Southern
+Southern Ill.,S Illinois,Southern Illinois
+Southern Ind.,Southern Indiana,Southern Indiana
+Southern Miss.,Southern Miss,Southern Miss
+Southern Utah,Southern Utah,Southern Utah
+St. Bonaventure,St Bonaventure,St. Bonaventure
+St. Francis Brooklyn,St Francis (BKN),St. Francis (BKN)
+Saint Francis (PA),St Francis (PA),St. Francis (PA)
+St. John's (NY),St John's,St. John's
+St. Thomas (MN),St. Thomas - Minnesota,St. Thomas - Minnesota
+Stanford,Stanford,Stanford
+SFA,SF Austin,Stephen F. Austin
+Stetson,Stetson,Stetson
+Stonehill,Stonehill,Stonehill
+Stony Brook,Stony Brook,Stony Brook
+Syracuse,Syracuse,Syracuse
+TCU,TCU,TCU
+Tarleton St.,Tarleton,Tarleton
+Temple,Temple,Temple
+Tennessee,Tennessee,Tennessee
+UT Martin,UT Martin,UT Martin
+Tennessee St.,Tennessee St,Tennessee State
+Tennessee Tech,Tenn Tech,Tennessee Tech
+Texas,Texas,Texas
+Texas A&M,Texas A&M,Texas A&M
+Tex. A&M-Commerce,Texas A&M-Commerce,Texas A&M-Commerce
+A&M-Corpus Christi,Texas A&M-CC,Texas A&M-CC
+Texas Southern,Texas Southern,Texas Southern
+Texas St.,Texas State,Texas State
+Texas Tech,Texas Tech,Texas Tech
+The Citadel,The Citadel,The Citadel
+Toledo,Toledo,Toledo
+Towson,Towson,Towson
+Troy,Troy,Troy
+Tulane,Tulane,Tulane
+Tulsa,Tulsa,Tulsa
+UAB,UAB,UAB
+UC Davis,UC Davis,UC Davis
+UC Irvine,UC Irvine,UC Irvine
+UC Riverside,UC Riverside,UC Riverside
+UC San Diego,UC San Diego,UC San Diego
+UC Santa Barbara,UCSB,UC Santa Barbara
+UCF,UCF,UCF
+UCLA,UCLA,UCLA
+UMBC,UMBC,UMBC
+Kansas City,UMKC,UM Kansas City
+UMass Lowell,UMass Lowell,UMass Lowell
+UNC Asheville,UNC Asheville,UNC Asheville
+UNC Greensboro,UNCG,UNC Greensboro
+UNCW,UNC Wilmington,UNC Wilmington
+UNLV,UNLV,UNLV
+Southern California,USC,USC
+USC Upstate,USC Upstate,South Carolina Upstate
+UT Arlington,UT Arlington,UT Arlington
+UTRGV,UT Rio Grande,UT Rio Grande Valley
+UTEP,UTEP,UTEP
+UTSA,UTSA,UT San Antonio
+Utah,Utah,Utah
+Utah St.,Utah State,Utah State
+Utah Tech,Utah Tech,Utah Tech
+Utah Valley,Utah Valley,Utah Valley
+VCU,VCU,VCU
+VMI,VMI,VMI
+Valparaiso,Valparaiso,Valparaiso
+Vanderbilt,Vanderbilt,Vanderbilt
+Vermont,Vermont,Vermont
+Villanova,Villanova,Villanova
+Virginia,UVA,Virginia
+Virginia Tech,Virginia Tech,Virginia Tech
+Wagner,Wagner,Wagner
+Wake Forest,Wake Forest,Wake Forest
+Washington,Washington,Washington
+Washington St.,Washington St,Washington State
+Weber St.,Weber State,Weber State
+West Virginia,West Virginia,West Virginia
+Western Caro.,W Carolina,Western Carolina
+Western Ill.,W Illinois,Western Illinois
+Western Ky.,W Kentucky,Western Kentucky
+Western Mich.,W Michigan,Western Michigan
+Wichita St.,Wichita State,Wichita State
+William & Mary,William & Mary,William & Mary
+Winthrop,Winthrop,Winthrop
+Wisconsin,Wisconsin,Wisconsin
+Wofford,Wofford,Wofford
+Wright St.,Wright State,Wright State
+Wyoming,Wyoming,Wyoming
+Xavier,Xavier,Xavier
+Yale,Yale,Yale
+Youngstown St.,Youngstown St,Youngstown State

--- a/tools/crosswalk/espn_mbb_teams.csv
+++ b/tools/crosswalk/espn_mbb_teams.csv
@@ -1,0 +1,372 @@
+team_id,location,display_name,short_name,mascot,nickname,abbreviation,conference_id,conference_name
+103,Boston College,Boston College Eagles,Boston College,Eagles,Boston College,BC,2,Atlantic Coast Conference
+104,Boston University,Boston University Terriers,Boston U,Terriers,Boston U,BU,22,Patriot League
+107,Holy Cross,Holy Cross Crusaders,Holy Cross,Crusaders,Holy Cross,HC,22,Patriot League
+108,Harvard,Harvard Crimson,Harvard,Crimson,Harvard,HARV,12,Ivy League
+111,Northeastern,Northeastern Huskies,Northeastern,Huskies,Northeastern,NE,10,Colonial Athletic Association
+112358,Long Island University,Long Island University Sharks,Long Island,Sharks,Long Island,LIU,19,Northeast Conference
+113,Massachusetts,Massachusetts Minutemen,UMass,Minutemen,UMass,MASS,3,Atlantic 10 Conference
+116,Mount St. Mary's,Mount St. Mary's Mountaineers,Mount St Marys,Mountaineers,Mount St Marys,MSM,13,Metro Atlantic Athletic Conference
+119,Towson,Towson Tigers,Towson,Tigers,Towson,TOW,10,Colonial Athletic Association
+12,Arizona,Arizona Wildcats,Arizona,Wildcats,Arizona,ARIZ,21,Pac-12 Conference
+120,Maryland,Maryland Terrapins,Maryland,Terrapins,Maryland,MD,7,Big Ten Conference
+127,Michigan State,Michigan State Spartans,Michigan St,Spartans,Michigan St,MSU,7,Big Ten Conference
+13,Cal Poly,Cal Poly Mustangs,Cal Poly,Mustangs,Cal Poly,CP,9,Big West Conference
+130,Michigan,Michigan Wolverines,Michigan,Wolverines,Michigan,MICH,7,Big Ten Conference
+135,Minnesota,Minnesota Golden Gophers,Minnesota,Golden Gophers,Minnesota,MINN,7,Big Ten Conference
+139,Saint Louis,Saint Louis Billikens,Saint Louis,Billikens,Saint Louis,SLU,3,Atlantic 10 Conference
+140,Kansas City,Kansas City Roos,Kansas City,Roos,Kansas City,KC,49,Summit League
+142,Missouri,Missouri Tigers,Missouri,Tigers,Missouri,MIZ,23,Southeastern Conference
+145,Ole Miss,Ole Miss Rebels,Ole Miss,Rebels,Ole Miss,MISS,23,Southeastern Conference
+147,Montana State,Montana State Bobcats,Montana St,Bobcats,Montana St,MTST,5,Big Sky Conference
+149,Montana,Montana Grizzlies,Montana,Grizzlies,Montana,MONT,5,Big Sky Conference
+150,Duke,Duke Blue Devils,Duke,Blue Devils,Duke,DUKE,2,Atlantic Coast Conference
+151,East Carolina,East Carolina Pirates,East Carolina,Pirates,East Carolina,ECU,62,American Athletic Conference
+152,NC State,NC State Wolfpack,NC State,Wolfpack,NC State,NCSU,2,Atlantic Coast Conference
+153,North Carolina,North Carolina Tar Heels,North Carolina,Tar Heels,North Carolina,UNC,2,Atlantic Coast Conference
+154,Wake Forest,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,Wake Forest,WAKE,2,Atlantic Coast Conference
+155,North Dakota,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,North Dakota,UND,49,Summit League
+156,Creighton,Creighton Bluejays,Creighton,Bluejays,Creighton,CREI,4,Big East Conference
+158,Nebraska,Nebraska Cornhuskers,Nebraska,Cornhuskers,Nebraska,NEB,7,Big Ten Conference
+159,Dartmouth,Dartmouth Big Green,Dartmouth,Big Green,Dartmouth,DART,12,Ivy League
+16,Sacramento State,Sacramento State Hornets,Sacramento St,Hornets,Sacramento St,SAC,5,Big Sky Conference
+160,New Hampshire,New Hampshire Wildcats,New Hampshire,Wildcats,New Hampshire,UNH,1,America East Conference
+161,Fairleigh Dickinson,Fairleigh Dickinson Knights,FDU,Knights,FDU,FDU,19,Northeast Conference
+163,Princeton,Princeton Tigers,Princeton,Tigers,Princeton,PRIN,12,Ivy League
+164,Rutgers,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,Rutgers,RUTG,7,Big Ten Conference
+166,New Mexico State,New Mexico State Aggies,New Mexico St,Aggies,New Mexico St,NMSU,30,Western Athletic Conference
+167,New Mexico,New Mexico Lobos,New Mexico,Lobos,New Mexico,UNM,44,Mountain West Conference
+171,Columbia,Columbia Lions,Columbia,Lions,Columbia,COLU,12,Ivy League
+172,Cornell,Cornell Big Red,Cornell,Big Red,Cornell,COR,12,Ivy League
+179,St. Bonaventure,St. Bonaventure Bonnies,St Bonaventure,Bonnies,St Bonaventure,SBU,3,Atlantic 10 Conference
+183,Syracuse,Syracuse Orange,Syracuse,Orange,Syracuse,SYR,2,Atlantic Coast Conference
+189,Bowling Green,Bowling Green Falcons,Bowling Green,Falcons,Bowling Green,BGSU,14,Mid-American Conference
+193,Miami (OH),Miami (OH) RedHawks,Miami OH,RedHawks,Miami OH,M-OH,14,Mid-American Conference
+194,Ohio State,Ohio State Buckeyes,Ohio State,Buckeyes,Ohio State,OSU,7,Big Ten Conference
+195,Ohio,Ohio Bobcats,Ohio,Bobcats,Ohio,OHIO,14,Mid-American Conference
+197,Oklahoma State,Oklahoma State Cowboys,Oklahoma St,Cowboys,Oklahoma St,OKST,8,Big 12 Conference
+198,Oral Roberts,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,Oral Roberts,ORU,49,Summit League
+2,Auburn,Auburn Tigers,Auburn,Tigers,Auburn,AUB,23,Southeastern Conference
+2000,Abilene Christian,Abilene Christian Wildcats,Abilene Chrstn,Wildcats,Abilene Chrstn,ACU,30,Western Athletic Conference
+2005,Air Force,Air Force Falcons,Air Force,Falcons,Air Force,AF,44,Mountain West Conference
+2006,Akron,Akron Zips,Akron,Zips,Akron,AKR,14,Mid-American Conference
+201,Oklahoma,Oklahoma Sooners,Oklahoma,Sooners,Oklahoma,OU,8,Big 12 Conference
+2010,Alabama A&M,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,Alabama A&M,AAMU,26,Southwestern Athletic Conference
+2011,Alabama State,Alabama State Hornets,Alabama St,Hornets,Alabama St,ALST,26,Southwestern Athletic Conference
+2016,Alcorn State,Alcorn State Braves,Alcorn St,Braves,Alcorn St,ALCN,26,Southwestern Athletic Conference
+202,Tulsa,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,Tulsa,TLSA,62,American Athletic Conference
+2026,App State,App State Mountaineers,App State,Mountaineers,App State,APP,27,Sun Belt Conference
+2029,Arkansas-Pine Bluff,Arkansas-Pine Bluff Golden Lions,AR-Pine Bluff,Golden Lions,AR-Pine Bluff,UAPB,26,Southwestern Athletic Conference
+2031,Little Rock,Little Rock Trojans,Little Rock,Trojans,Little Rock,LR,20,Ohio Valley Conference
+2032,Arkansas State,Arkansas State Red Wolves,Arkansas St,Red Wolves,Arkansas St,ARST,27,Sun Belt Conference
+204,Oregon State,Oregon State Beavers,Oregon St,Beavers,Oregon St,ORST,21,Pac-12 Conference
+2046,Austin Peay,Austin Peay Governors,Austin Peay,Governors,Austin Peay,APSU,46,ASUN Conference
+2050,Ball State,Ball State Cardinals,Ball State,Cardinals,Ball State,BALL,14,Mid-American Conference
+2057,Belmont,Belmont Bruins,Belmont,Bruins,Belmont,BEL,18,Missouri Valley Conference
+2065,Bethune-Cookman,Bethune-Cookman Wildcats,Bethune,Wildcats,Bethune,BCU,26,Southwestern Athletic Conference
+2066,Binghamton,Binghamton Bearcats,Binghamton,Bearcats,Binghamton,BING,1,America East Conference
+2083,Bucknell,Bucknell Bison,Bucknell,Bison,Bucknell,BUCK,22,Patriot League
+2084,Buffalo,Buffalo Bulls,Buffalo,Bulls,Buffalo,BUF,14,Mid-American Conference
+2086,Butler,Butler Bulldogs,Butler,Bulldogs,Butler,BTLR,4,Big East Conference
+2097,Campbell,Campbell Fighting Camels,Campbell,Fighting Camels,Campbell,CAM,6,Big South Conference
+2099,Canisius,Canisius Golden Griffins,Canisius,Golden Griffins,Canisius,CAN,13,Metro Atlantic Athletic Conference
+21,San Diego State,San Diego State Aztecs,San Diego St,Aztecs,San Diego St,SDSU,44,Mountain West Conference
+2110,Central Arkansas,Central Arkansas Bears,C Arkansas,Bears,C Arkansas,CARK,46,ASUN Conference
+2113,Centenary (LA),Centenary (LA) Gentlemen,Centenary (LA),Gentlemen,Centenary (LA),CTLA,,
+2115,Central Connecticut,Central Connecticut Blue Devils,C Connecticut,Blue Devils,C Connecticut,CCSU,19,Northeast Conference
+2116,UCF,UCF Knights,UCF,Knights,UCF,UCF,62,American Athletic Conference
+2117,Central Michigan,Central Michigan Chippewas,C Michigan,Chippewas,C Michigan,CMU,14,Mid-American Conference
+2127,Charleston Southern,Charleston Southern Buccaneers,Charleston So,Buccaneers,Charleston So,CHSO,6,Big South Conference
+213,Penn State,Penn State Nittany Lions,Penn State,Nittany Lions,Penn State,PSU,7,Big Ten Conference
+2130,Chicago State,Chicago State Cougars,Chicago St,Cougars,Chicago St,CHST,43,Division I Independents
+2132,Cincinnati,Cincinnati Bearcats,Cincinnati,Bearcats,Cincinnati,CIN,62,American Athletic Conference
+2142,Colgate,Colgate Raiders,Colgate,Raiders,Colgate,COLG,22,Patriot League
+2154,Coppin State,Coppin State Eagles,Coppin St,Eagles,Coppin St,COPP,16,Mid-Eastern Athletic Conference
+2166,Davidson,Davidson Wildcats,Davidson,Wildcats,Davidson,DAV,3,Atlantic 10 Conference
+2168,Dayton,Dayton Flyers,Dayton,Flyers,Dayton,DAY,3,Atlantic 10 Conference
+2169,Delaware State,Delaware State Hornets,Delaware St,Hornets,Delaware St,DSU,16,Mid-Eastern Athletic Conference
+2172,Denver,Denver Pioneers,Denver,Pioneers,Denver,DEN,49,Summit League
+2174,Detroit Mercy,Detroit Mercy Titans,Detroit Mercy,Titans,Detroit Mercy,DETM,45,Horizon League
+218,Temple,Temple Owls,Temple,Owls,Temple,TEM,62,American Athletic Conference
+2181,Drake,Drake Bulldogs,Drake,Bulldogs,Drake,DRKE,18,Missouri Valley Conference
+2182,Drexel,Drexel Dragons,Drexel,Dragons,Drexel,DREX,10,Colonial Athletic Association
+2184,Duquesne,Duquesne Dukes,Duquesne,Dukes,Duquesne,DUQ,3,Atlantic 10 Conference
+219,Pennsylvania,Pennsylvania Quakers,Penn,Quakers,Penn,PENN,12,Ivy League
+2193,East Tennessee State,East Tennessee State Buccaneers,ETSU,Buccaneers,ETSU,ETSU,24,Southern Conference
+2197,Eastern Illinois,Eastern Illinois Panthers,E Illinois,Panthers,E Illinois,EIU,20,Ohio Valley Conference
+2198,Eastern Kentucky,Eastern Kentucky Colonels,E Kentucky,Colonels,E Kentucky,EKU,46,ASUN Conference
+2199,Eastern Michigan,Eastern Michigan Eagles,E Michigan,Eagles,E Michigan,EMU,14,Mid-American Conference
+221,Pittsburgh,Pittsburgh Panthers,Pitt,Panthers,Pitt,PITT,2,Atlantic Coast Conference
+2210,Elon,Elon Phoenix,Elon,Phoenix,Elon,ELON,10,Colonial Athletic Association
+2217,Fairfield,Fairfield Stags,Fairfield,Stags,Fairfield,FAIR,13,Metro Atlantic Athletic Conference
+222,Villanova,Villanova Wildcats,Villanova,Wildcats,Villanova,VILL,4,Big East Conference
+2226,Florida Atlantic,Florida Atlantic Owls,FAU,Owls,FAU,FAU,11,Conference USA
+2229,Florida International,Florida International Panthers,FIU,Panthers,FIU,FIU,11,Conference USA
+2230,Fordham,Fordham Rams,Fordham,Rams,Fordham,FOR,3,Atlantic 10 Conference
+2239,Cal State Fullerton,Cal State Fullerton Titans,Fullerton,Titans,Fullerton,CSUF,9,Big West Conference
+2241,Gardner-Webb,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,Gardner-Webb,GWEB,6,Big South Conference
+2244,George Mason,George Mason Patriots,George Mason,Patriots,George Mason,GMU,3,Atlantic 10 Conference
+2247,Georgia State,Georgia State Panthers,Georgia St,Panthers,Georgia St,GAST,27,Sun Belt Conference
+225,Brown,Brown Bears,Brown,Bears,Brown,BRWN,12,Ivy League
+2250,Gonzaga,Gonzaga Bulldogs,Gonzaga,Bulldogs,Gonzaga,GONZ,29,West Coast Conference
+2253,Grand Canyon,Grand Canyon Lopes,Grand Canyon,Lopes,Grand Canyon,GCU,30,Western Athletic Conference
+2261,Hampton,Hampton Pirates,Hampton,Pirates,Hampton,HAMP,10,Colonial Athletic Association
+227,Rhode Island,Rhode Island Rams,Rhode Island,Rams,Rhode Island,URI,3,Atlantic 10 Conference
+2272,High Point,High Point Panthers,High Point,Panthers,High Point,HPU,6,Big South Conference
+2275,Hofstra,Hofstra Pride,Hofstra,Pride,Hofstra,HOF,10,Colonial Athletic Association
+2277,Houston Christian,Houston Christian Huskies,Hou Christian,Huskies,Hou Christian,HCU,25,Southland Conference
+228,Clemson,Clemson Tigers,Clemson,Tigers,Clemson,CLEM,2,Atlantic Coast Conference
+2287,Illinois State,Illinois State Redbirds,Illinois St,Redbirds,Illinois St,ILST,18,Missouri Valley Conference
+2294,Iowa,Iowa Hawkeyes,Iowa,Hawkeyes,Iowa,IOWA,7,Big Ten Conference
+2296,Jackson State,Jackson State Tigers,Jackson St,Tigers,Jackson St,JKST,26,Southwestern Athletic Conference
+23,San José State,San José State Spartans,San José St,Spartans,San José St,SJSU,44,Mountain West Conference
+2305,Kansas,Kansas Jayhawks,Kansas,Jayhawks,Kansas,KU,8,Big 12 Conference
+2306,Kansas State,Kansas State Wildcats,Kansas St,Wildcats,Kansas St,KSU,8,Big 12 Conference
+2309,Kent State,Kent State Golden Flashes,Kent State,Golden Flashes,Kent State,KENT,14,Mid-American Conference
+231,Furman,Furman Paladins,Furman,Paladins,Furman,FUR,24,Southern Conference
+232,Charleston,Charleston Cougars,Charleston,Cougars,Charleston,COFC,10,Colonial Athletic Association
+2320,Lamar,Lamar Cardinals,Lamar,Cardinals,Lamar,LAM,25,Southland Conference
+2325,La Salle,La Salle Explorers,La Salle,Explorers,La Salle,LAS,3,Atlantic 10 Conference
+2329,Lehigh,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,Lehigh,LEH,22,Patriot League
+233,South Dakota,South Dakota Coyotes,South Dakota,Coyotes,South Dakota,SDAK,49,Summit League
+2330,Le Moyne,Le Moyne Dolphins,Le Moyne,Dolphins,Le Moyne,LEM,,
+2335,Liberty,Liberty Flames,Liberty,Flames,Liberty,LIB,46,ASUN Conference
+2344,Longwood,Longwood Lancers,Longwood,Lancers,Longwood,LONG,6,Big South Conference
+2348,Louisiana Tech,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,Louisiana Tech,LT,11,Conference USA
+2349,UMass Lowell,UMass Lowell River Hawks,UMass Lowell,River Hawks,UMass Lowell,UML,1,America East Conference
+235,Memphis,Memphis Tigers,Memphis,Tigers,Memphis,MEM,62,American Athletic Conference
+2350,Loyola Chicago,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,Loyola Chicago,LUC,3,Atlantic 10 Conference
+2351,Loyola Marymount,Loyola Marymount Lions,LMU,Lions,LMU,LMU,29,West Coast Conference
+2352,Loyola Maryland,Loyola Maryland Greyhounds,Loyola MD,Greyhounds,Loyola MD,L-MD,22,Patriot League
+236,Chattanooga,Chattanooga Mocs,Chattanooga,Mocs,Chattanooga,UTC,24,Southern Conference
+2363,Manhattan,Manhattan Jaspers,Manhattan,Jaspers,Manhattan,MAN,13,Metro Atlantic Athletic Conference
+2368,Marist,Marist Red Foxes,Marist,Red Foxes,Marist,MRST,13,Metro Atlantic Athletic Conference
+2377,McNeese,McNeese Cowboys,McNeese,Cowboys,McNeese,MCN,25,Southland Conference
+2378,UMBC,UMBC Retrievers,UMBC,Retrievers,UMBC,UMBC,1,America East Conference
+2379,Maryland Eastern Shore,Maryland Eastern Shore Hawks,MD Eastern,Hawks,MD Eastern,UMES,16,Mid-Eastern Athletic Conference
+238,Vanderbilt,Vanderbilt Commodores,Vanderbilt,Commodores,Vanderbilt,VAN,23,Southeastern Conference
+2382,Mercer,Mercer Bears,Mercer,Bears,Mercer,MER,24,Southern Conference
+2385,Mercyhurst,Mercyhurst Lakers,Mercyhurst,Lakers,Mercyhurst,MERC,,
+239,Baylor,Baylor Bears,Baylor,Bears,Baylor,BAY,8,Big 12 Conference
+2390,Miami,Miami Hurricanes,Miami,Hurricanes,Miami,MIA,2,Atlantic Coast Conference
+2393,Middle Tennessee,Middle Tennessee Blue Raiders,MTSU,Blue Raiders,MTSU,MTSU,11,Conference USA
+24,Stanford,Stanford Cardinal,Stanford,Cardinal,Stanford,STAN,21,Pac-12 Conference
+2400,Mississippi Valley State,Mississippi Valley State Delta Devils,Miss Valley St,Delta Devils,Miss Valley St,MVSU,26,Southwestern Athletic Conference
+2405,Monmouth,Monmouth Hawks,Monmouth,Hawks,Monmouth,MONM,10,Colonial Athletic Association
+2413,Morehead State,Morehead State Eagles,Morehead St,Eagles,Morehead St,MORE,20,Ohio Valley Conference
+2415,Morgan State,Morgan State Bears,Morgan St,Bears,Morgan St,MORG,16,Mid-Eastern Athletic Conference
+242,Rice,Rice Owls,Rice,Owls,Rice,RICE,11,Conference USA
+2426,Navy,Navy Midshipmen,Navy,Midshipmen,Navy,NAVY,22,Patriot League
+2427,UNC Asheville,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNC Asheville,UNCA,6,Big South Conference
+2428,North Carolina Central,North Carolina Central Eagles,NC Central,Eagles,NC Central,NCCU,16,Mid-Eastern Athletic Conference
+2429,Charlotte,Charlotte 49ers,Charlotte,49ers,Charlotte,CLT,11,Conference USA
+2430,UNC Greensboro,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNC Greensboro,UNCG,24,Southern Conference
+2433,UL Monroe,UL Monroe Warhawks,UL Monroe,Warhawks,UL Monroe,ULM,27,Sun Belt Conference
+2437,Omaha,Omaha Mavericks,Omaha,Mavericks,Omaha,OMA,49,Summit League
+2439,UNLV,UNLV Rebels,UNLV,Rebels,UNLV,UNLV,44,Mountain West Conference
+2440,Nevada,Nevada Wolf Pack,Nevada,Wolf Pack,Nevada,NEV,44,Mountain West Conference
+2441,New Haven,New Haven Chargers,New Haven,Chargers,New Haven,NHVN,,
+2443,LSU New Orleans,LSU New Orleans Privateers,New Orleans,Privateers,New Orleans,NOLA,25,Southland Conference
+2447,Nicholls,Nicholls Colonels,Nicholls,Colonels,Nicholls,NICH,25,Southland Conference
+2448,North Carolina A&T,North Carolina A&T Aggies,NC A&T,Aggies,NC A&T,NCAT,10,Colonial Athletic Association
+2449,North Dakota State,North Dakota State Bison,N Dakota St,Bison,N Dakota St,NDSU,49,Summit League
+245,Texas A&M,Texas A&M Aggies,Texas A&M,Aggies,Texas A&M,TA&M,23,Southeastern Conference
+2450,Norfolk State,Norfolk State Spartans,Norfolk St,Spartans,Norfolk St,NORF,16,Mid-Eastern Athletic Conference
+2453,North Alabama,North Alabama Lions,North Alabama,Lions,North Alabama,UNA,46,ASUN Conference
+2454,North Florida,North Florida Ospreys,North Florida,Ospreys,North Florida,UNF,46,ASUN Conference
+2458,Northern Colorado,Northern Colorado Bears,N Colorado,Bears,N Colorado,UNCO,5,Big Sky Conference
+2459,Northern Illinois,Northern Illinois Huskies,N Illinois,Huskies,N Illinois,NIU,14,Mid-American Conference
+2460,Northern Iowa,Northern Iowa Panthers,Northern Iowa,Panthers,Northern Iowa,UNI,18,Missouri Valley Conference
+2463,Cal State Northridge,Cal State Northridge Matadors,CSU Northridge,Matadors,CSU Northridge,CSUN,9,Big West Conference
+2464,Northern Arizona,Northern Arizona Lumberjacks,N Arizona,Lumberjacks,N Arizona,NAU,5,Big Sky Conference
+2466,Northwestern State,Northwestern State Demons,N'Western St,Demons,N'Western St,NWST,25,Southland Conference
+2473,Oakland,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,Oakland,OAK,45,Horizon League
+248,Houston,Houston Cougars,Houston,Cougars,Houston,HOU,62,American Athletic Conference
+2483,Oregon,Oregon Ducks,Oregon,Ducks,Oregon,ORE,21,Pac-12 Conference
+249,North Texas,North Texas Mean Green,North Texas,Mean Green,North Texas,UNT,11,Conference USA
+2492,Pepperdine,Pepperdine Waves,Pepperdine,Waves,Pepperdine,PEPP,29,West Coast Conference
+25,California,California Golden Bears,California,Golden Bears,California,CAL,21,Pac-12 Conference
+250,UT Arlington,UT Arlington Mavericks,UT Arlington,Mavericks,UT Arlington,UTA,30,Western Athletic Conference
+2501,Portland,Portland Pilots,Portland,Pilots,Portland,PORT,29,West Coast Conference
+2502,Portland State,Portland State Vikings,Portland St,Vikings,Portland St,PRST,5,Big Sky Conference
+2504,Prairie View A&M,Prairie View A&M Panthers,Prairie View,Panthers,Prairie View,PV,26,Southwestern Athletic Conference
+2506,Presbyterian,Presbyterian Blue Hose,Presbyterian,Blue Hose,Presbyterian,PRES,6,Big South Conference
+2507,Providence,Providence Friars,Providence,Friars,Providence,PROV,4,Big East Conference
+2509,Purdue,Purdue Boilermakers,Purdue,Boilermakers,Purdue,PUR,7,Big Ten Conference
+251,Texas,Texas Longhorns,Texas,Longhorns,Texas,TEX,8,Big 12 Conference
+2511,Queens University,Queens University Royals,Queens,Royals,Queens,QUC,,
+2514,Quinnipiac,Quinnipiac Bobcats,Quinnipiac,Bobcats,Quinnipiac,QUIN,13,Metro Atlantic Athletic Conference
+2515,Radford,Radford Highlanders,Radford,Highlanders,Radford,RAD,6,Big South Conference
+252,BYU,BYU Cougars,BYU,Cougars,BYU,BYU,29,West Coast Conference
+2520,Rider,Rider Broncs,Rider,Broncs,Rider,RID,13,Metro Atlantic Athletic Conference
+2523,Robert Morris,Robert Morris Colonials,Robert Morris,Colonials,Robert Morris,RMU,45,Horizon League
+2529,Sacred Heart,Sacred Heart Pioneers,Sacred Heart,Pioneers,Sacred Heart,SHU,19,Northeast Conference
+253,Southern Utah,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,Southern Utah,SUU,30,Western Athletic Conference
+2534,Sam Houston,Sam Houston Bearkats,Sam Houston,Bearkats,Sam Houston,SHSU,30,Western Athletic Conference
+2535,Samford,Samford Bulldogs,Samford,Bulldogs,Samford,SAM,24,Southern Conference
+2539,San Francisco,San Francisco Dons,San Francisco,Dons,San Francisco,SF,29,West Coast Conference
+254,Utah,Utah Utes,Utah,Utes,Utah,UTAH,21,Pac-12 Conference
+2540,UC Santa Barbara,UC Santa Barbara Gauchos,Santa Barbara,Gauchos,Santa Barbara,UCSB,9,Big West Conference
+2541,Santa Clara,Santa Clara Broncos,Santa Clara,Broncos,Santa Clara,SCU,29,West Coast Conference
+2542,Savannah State,Savannah State Tigers,Savannah St,Tigers,Savannah St,SAV,,
+2545,SE Louisiana,SE Louisiana Lions,SE Louisiana,Lions,SE Louisiana,SELA,25,Southland Conference
+2546,Southeast Missouri State,Southeast Missouri State Redhawks,SE Missouri,Redhawks,SE Missouri,SEMO,20,Ohio Valley Conference
+2547,Seattle U,Seattle U Redhawks,Seattle U,Redhawks,Seattle U,SEA,30,Western Athletic Conference
+2550,Seton Hall,Seton Hall Pirates,Seton Hall,Pirates,Seton Hall,HALL,4,Big East Conference
+256,James Madison,James Madison Dukes,James Madison,Dukes,James Madison,JMU,27,Sun Belt Conference
+2561,Siena,Siena Saints,Siena,Saints,Siena,SIE,13,Metro Atlantic Athletic Conference
+2565,SIU Edwardsville,SIU Edwardsville Cougars,SIUE,Cougars,SIUE,SIUE,20,Ohio Valley Conference
+2567,SMU,SMU Mustangs,SMU,Mustangs,SMU,SMU,62,American Athletic Conference
+2569,South Carolina State,South Carolina State Bulldogs,SC State,Bulldogs,SC State,SCST,16,Mid-Eastern Athletic Conference
+257,Richmond,Richmond Spiders,Richmond,Spiders,Richmond,RICH,3,Atlantic 10 Conference
+2571,South Dakota State,South Dakota State Jackrabbits,S Dakota St,Jackrabbits,S Dakota St,SDST,49,Summit League
+2572,Southern Miss,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,Southern Miss,USM,27,Sun Belt Conference
+2579,South Carolina,South Carolina Gamecocks,South Carolina,Gamecocks,South Carolina,SC,23,Southeastern Conference
+258,Virginia,Virginia Cavaliers,Virginia,Cavaliers,Virginia,UVA,2,Atlantic Coast Conference
+2582,Southern,Southern Jaguars,Southern,Jaguars,Southern,SOU,26,Southwestern Athletic Conference
+259,Virginia Tech,Virginia Tech Hokies,Virginia Tech,Hokies,Virginia Tech,VT,2,Atlantic Coast Conference
+2597,St. Francis Brooklyn,St. Francis Brooklyn Terriers,St Francis BK,Terriers,St Francis BK,SFNY,19,Northeast Conference
+2598,St. Francis (PA),St. Francis (PA) Red Flash,St Francis PA,Red Flash,St Francis PA,SFPA,19,Northeast Conference
+2599,St. John's,St. John's Red Storm,St John's,Red Storm,St John's,SJU,4,Big East Conference
+26,UCLA,UCLA Bruins,UCLA,Bruins,UCLA,UCLA,21,Pac-12 Conference
+2603,Saint Joseph's,Saint Joseph's Hawks,Saint Joseph's,Hawks,Saint Joseph's,JOES,3,Atlantic 10 Conference
+2608,Saint Mary's,Saint Mary's Gaels,Saint Mary's,Gaels,Saint Mary's,SMC,29,West Coast Conference
+261,Vermont,Vermont Catamounts,Vermont,Catamounts,Vermont,UVM,1,America East Conference
+2612,Saint Peter's,Saint Peter's Peacocks,Saint Peter's,Peacocks,Saint Peter's,SPU,13,Metro Atlantic Athletic Conference
+2617,Stephen F. Austin,Stephen F. Austin Lumberjacks,SF Austin,Lumberjacks,SF Austin,SFA,30,Western Athletic Conference
+2619,Stony Brook,Stony Brook Seawolves,Stony Brook,Seawolves,Stony Brook,STBK,10,Colonial Athletic Association
+2623,Missouri State,Missouri State Bears,Missouri St,Bears,Missouri St,MOST,18,Missouri Valley Conference
+2627,Tarleton State,Tarleton State Texans,Tarleton St,Texans,Tarleton St,TAR,30,Western Athletic Conference
+2628,TCU,TCU Horned Frogs,TCU,Horned Frogs,TCU,TCU,8,Big 12 Conference
+2630,UT Martin,UT Martin Skyhawks,UT Martin,Skyhawks,UT Martin,UTM,20,Ohio Valley Conference
+2633,Tennessee,Tennessee Volunteers,Tennessee,Volunteers,Tennessee,TENN,23,Southeastern Conference
+2634,Tennessee State,Tennessee State Tigers,Tennessee St,Tigers,Tennessee St,TNST,20,Ohio Valley Conference
+2635,Tennessee Tech,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,Tennessee Tech,TNTC,20,Ohio Valley Conference
+2636,UTSA,UTSA Roadrunners,UTSA,Roadrunners,UTSA,UTSA,11,Conference USA
+2638,UTEP,UTEP Miners,UTEP,Miners,UTEP,UTEP,11,Conference USA
+264,Washington,Washington Huskies,Washington,Huskies,Washington,WASH,21,Pac-12 Conference
+2640,Texas Southern,Texas Southern Tigers,Texas Southern,Tigers,Texas Southern,TXSO,26,Southwestern Athletic Conference
+2641,Texas Tech,Texas Tech Red Raiders,Texas Tech,Red Raiders,Texas Tech,TTU,8,Big 12 Conference
+2643,The Citadel,The Citadel Bulldogs,The Citadel,Bulldogs,The Citadel,CIT,24,Southern Conference
+2649,Toledo,Toledo Rockets,Toledo,Rockets,Toledo,TOL,14,Mid-American Conference
+265,Washington State,Washington State Cougars,Washington St,Cougars,Washington St,WSU,21,Pac-12 Conference
+2653,Troy,Troy Trojans,Troy,Trojans,Troy,TROY,27,Sun Belt Conference
+2655,Tulane,Tulane Green Wave,Tulane,Green Wave,Tulane,TULN,62,American Athletic Conference
+2670,VCU,VCU Rams,VCU,Rams,VCU,VCU,3,Atlantic 10 Conference
+2674,Valparaiso,Valparaiso Beacons,Valparaiso,Beacons,Valparaiso,VAL,18,Missouri Valley Conference
+2678,VMI,VMI Keydets,VMI,Keydets,VMI,VMI,24,Southern Conference
+2681,Wagner,Wagner Seahawks,Wagner,Seahawks,Wagner,WAG,19,Northeast Conference
+269,Marquette,Marquette Golden Eagles,Marquette,Golden Eagles,Marquette,MARQ,4,Big East Conference
+2692,Weber State,Weber State Wildcats,Weber St,Wildcats,Weber St,WEB,5,Big Sky Conference
+2697,West Florida,West Florida Argonauts,West Florida,Argonauts,West Florida,WFL,,
+2698,West Georgia,West Georgia Wolves,West Georgia,Wolves,West Georgia,WGA,,
+27,UC Riverside,UC Riverside Highlanders,UC Riverside,Highlanders,UC Riverside,UCR,9,Big West Conference
+270,Milwaukee,Milwaukee Panthers,Milwaukee,Panthers,Milwaukee,MILW,45,Horizon League
+2710,Western Illinois,Western Illinois Leathernecks,W Illinois,Leathernecks,W Illinois,WIU,49,Summit League
+2711,Western Michigan,Western Michigan Broncos,W Michigan,Broncos,W Michigan,WMU,14,Mid-American Conference
+2717,Western Carolina,Western Carolina Catamounts,W Carolina,Catamounts,W Carolina,WCU,24,Southern Conference
+2724,Wichita State,Wichita State Shockers,Wichita St,Shockers,Wichita St,WICH,62,American Athletic Conference
+2729,William & Mary,William & Mary Tribe,William & Mary,Tribe,William & Mary,W&M,10,Colonial Athletic Association
+2736,Winston-Salem State,Winston-Salem State Rams,Winston-Salem,Rams,Winston-Salem,WSSU,,
+2737,Winthrop,Winthrop Eagles,Winthrop,Eagles,Winthrop,WIN,6,Big South Conference
+2739,Green Bay,Green Bay Phoenix,Green Bay,Phoenix,Green Bay,GB,45,Horizon League
+2747,Wofford,Wofford Terriers,Wofford,Terriers,Wofford,WOF,24,Southern Conference
+275,Wisconsin,Wisconsin Badgers,Wisconsin,Badgers,Wisconsin,WIS,7,Big Ten Conference
+2750,Wright State,Wright State Raiders,Wright St,Raiders,Wright St,WRST,45,Horizon League
+2751,Wyoming,Wyoming Cowboys,Wyoming,Cowboys,Wyoming,WYO,44,Mountain West Conference
+2752,Xavier,Xavier Musketeers,Xavier,Musketeers,Xavier,XAV,4,Big East Conference
+2754,Youngstown State,Youngstown State Penguins,Youngstown St,Penguins,Youngstown St,YSU,45,Horizon League
+2755,Grambling,Grambling Tigers,Grambling,Tigers,Grambling,GRAM,26,Southwestern Athletic Conference
+276,Marshall,Marshall Thundering Herd,Marshall,Thundering Herd,Marshall,MRSH,27,Sun Belt Conference
+277,West Virginia,West Virginia Mountaineers,West Virginia,Mountaineers,West Virginia,WVU,8,Big 12 Conference
+2771,Merrimack,Merrimack Warriors,Merrimack,Warriors,Merrimack,MRMK,19,Northeast Conference
+278,Fresno State,Fresno State Bulldogs,Fresno St,Bulldogs,Fresno St,FRES,44,Mountain West Conference
+279,Pacific,Pacific Tigers,Pacific,Tigers,Pacific,PAC,29,West Coast Conference
+28,UC San Diego,UC San Diego Tritons,UC San Diego,Tritons,UC San Diego,UCSD,9,Big West Conference
+2803,Bryant,Bryant Bulldogs,Bryant,Bulldogs,Bryant,BRY,1,America East Conference
+2815,Lindenwood,Lindenwood Lions,Lindenwood,Lions,Lindenwood,LIN,,
+282,Indiana State,Indiana State Sycamores,Indiana St,Sycamores,Indiana St,INST,18,Missouri Valley Conference
+2837,East Texas A&M,East Texas A&M Lions,E Texas A&M,Lions,E Texas A&M,ETAM,25,Southland Conference
+284,Stonehill,Stonehill Skyhawks,Stonehill,Skyhawks,Stonehill,STO,19,Northeast Conference
+2856,California Baptist,California Baptist Lancers,CA Baptist,Lancers,CA Baptist,CBU,30,Western Athletic Conference
+2870,Purdue Fort Wayne,Purdue Fort Wayne Mastodons,Purdue FW,Mastodons,Purdue FW,PFW,45,Horizon League
+288,Lipscomb,Lipscomb Bisons,Lipscomb,Bisons,Lipscomb,LIP,46,ASUN Conference
+2885,NJIT,NJIT Highlanders,NJIT,Highlanders,NJIT,NJIT,1,America East Conference
+290,Georgia Southern,Georgia Southern Eagles,GA Southern,Eagles,GA Southern,GASO,27,Sun Belt Conference
+2900,St. Thomas,St. Thomas Tommies,St Thomas (MN),Tommies,St Thomas (MN),STMN,49,Summit League
+2908,South Carolina Upstate,South Carolina Upstate Spartans,SC Upstate,Spartans,SC Upstate,UPST,6,Big South Conference
+2916,Incarnate Word,Incarnate Word Cardinals,Incarnate Word,Cardinals,Incarnate Word,UIW,25,Southland Conference
+292,UT Rio Grande Valley,UT Rio Grande Valley Vaqueros,UT Rio Grande,Vaqueros,UT Rio Grande,RGV,30,Western Athletic Conference
+2934,Cal State Bakersfield,Cal State Bakersfield Roadrunners,Bakersfield,Roadrunners,Bakersfield,CSUB,9,Big West Conference
+294,Jacksonville,Jacksonville Dolphins,Jacksonville,Dolphins,Jacksonville,JAX,46,ASUN Conference
+295,Old Dominion,Old Dominion Monarchs,Old Dominion,Monarchs,Old Dominion,ODU,27,Sun Belt Conference
+299,Long Beach State,Long Beach State Beach,Long Beach St,Beach,Long Beach St,LBSU,9,Big West Conference
+30,USC,USC Trojans,USC,Trojans,USC,USC,21,Pac-12 Conference
+300,UC Irvine,UC Irvine Anteaters,UC Irvine,Anteaters,UC Irvine,UCI,9,Big West Conference
+301,San Diego,San Diego Toreros,San Diego,Toreros,San Diego,USD,29,West Coast Conference
+302,UC Davis,UC Davis Aggies,UC Davis,Aggies,UC Davis,UCD,9,Big West Conference
+304,Idaho State,Idaho State Bengals,Idaho St,Bengals,Idaho St,IDST,5,Big Sky Conference
+305,DePaul,DePaul Blue Demons,DePaul,Blue Demons,DePaul,DEP,4,Big East Conference
+3084,Utah Valley,Utah Valley Wolverines,Utah Valley,Wolverines,Utah Valley,UVU,30,Western Athletic Conference
+309,Louisiana,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,Louisiana,UL,27,Sun Belt Conference
+3101,Utah Tech,Utah Tech Trailblazers,Utah Tech,Trailblazers,Utah Tech,UTU,30,Western Athletic Conference
+311,Maine,Maine Black Bears,Maine,Black Bears,Maine,ME,1,America East Conference
+314,Iona,Iona Gaels,Iona,Gaels,Iona,IONA,13,Metro Atlantic Athletic Conference
+315,Niagara,Niagara Purple Eagles,Niagara,Purple Eagles,Niagara,NIA,13,Metro Atlantic Athletic Conference
+322,Lafayette,Lafayette Leopards,Lafayette,Leopards,Lafayette,LAF,22,Patriot League
+324,Coastal Carolina,Coastal Carolina Chanticleers,Coastal,Chanticleers,Coastal,CCU,27,Sun Belt Conference
+325,Cleveland State,Cleveland State Vikings,Cleveland St,Vikings,Cleveland St,CLE,45,Horizon League
+326,Texas State,Texas State Bobcats,Texas St,Bobcats,Texas St,TXST,27,Sun Belt Conference
+328,Utah State,Utah State Aggies,Utah State,Aggies,Utah State,USU,44,Mountain West Conference
+331,Eastern Washington,Eastern Washington Eagles,E Washington,Eagles,E Washington,EWU,5,Big Sky Conference
+333,Alabama,Alabama Crimson Tide,Alabama,Crimson Tide,Alabama,ALA,23,Southeastern Conference
+338,Kennesaw State,Kennesaw State Owls,Kennesaw St,Owls,Kennesaw St,KENN,46,ASUN Conference
+339,Evansville,Evansville Purple Aces,Evansville,Purple Aces,Evansville,EVAN,18,Missouri Valley Conference
+344,Mississippi State,Mississippi State Bulldogs,Mississippi St,Bulldogs,Mississippi St,MSST,23,Southeastern Conference
+349,Army,Army Black Knights,Army,Black Knights,Army,ARMY,22,Patriot League
+350,UNC Wilmington,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNC Wilmington,UNCW,10,Colonial Athletic Association
+356,Illinois,Illinois Fighting Illini,Illinois,Fighting Illini,Illinois,ILL,7,Big Ten Conference
+357,Texas A&M-Corpus Christi,Texas A&M-Corpus Christi Islanders,Texas A&M-CC,Islanders,Texas A&M-CC,AMCC,25,Southland Conference
+36,Colorado State,Colorado State Rams,Colorado St,Rams,Colorado St,CSU,44,Mountain West Conference
+38,Colorado,Colorado Buffaloes,Colorado,Buffaloes,Colorado,COLO,21,Pac-12 Conference
+399,UAlbany,UAlbany Great Danes,UAlbany,Great Danes,UAlbany,UALB,1,America East Conference
+41,UConn,UConn Huskies,UConn,Huskies,UConn,CONN,4,Big East Conference
+42,Hartford,Hartford Hawks,Hartford,Hawks,Hartford,HART,43,Division I Independents
+43,Yale,Yale Bulldogs,Yale,Bulldogs,Yale,YALE,12,Ivy League
+44,American University,American University Eagles,American,Eagles,American,AMER,22,Patriot League
+45,George Washington,George Washington Revolutionaries,G Washington,Revolutionaries,G Washington,GW,3,Atlantic 10 Conference
+46,Georgetown,Georgetown Hoyas,Georgetown,Hoyas,Georgetown,GTWN,4,Big East Conference
+47,Howard,Howard Bison,Howard,Bison,Howard,HOW,16,Mid-Eastern Athletic Conference
+48,Delaware,Delaware Blue Hens,Delaware,Blue Hens,Delaware,DEL,10,Colonial Athletic Association
+5,UAB,UAB Blazers,UAB,Blazers,UAB,UAB,11,Conference USA
+50,Florida A&M,Florida A&M Rattlers,Florida A&M,Rattlers,Florida A&M,FAMU,26,Southwestern Athletic Conference
+52,Florida State,Florida State Seminoles,Florida St,Seminoles,Florida St,FSU,2,Atlantic Coast Conference
+526,Florida Gulf Coast,Florida Gulf Coast Eagles,FGCU,Eagles,FGCU,FGCU,46,ASUN Conference
+55,Jacksonville State,Jacksonville State Gamecocks,Jax State,Gamecocks,Jax State,JXST,46,ASUN Conference
+56,Stetson,Stetson Hatters,Stetson,Hatters,Stetson,STET,46,ASUN Conference
+57,Florida,Florida Gators,Florida,Gators,Florida,FLA,23,Southeastern Conference
+58,South Florida,South Florida Bulls,South Florida,Bulls,South Florida,USF,62,American Athletic Conference
+59,Georgia Tech,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,Georgia Tech,GT,2,Atlantic Coast Conference
+6,South Alabama,South Alabama Jaguars,South Alabama,Jaguars,South Alabama,USA,27,Sun Belt Conference
+61,Georgia,Georgia Bulldogs,Georgia,Bulldogs,Georgia,UGA,23,Southeastern Conference
+62,Hawai'i,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,Hawai'i,HAW,9,Big West Conference
+66,Iowa State,Iowa State Cyclones,Iowa State,Cyclones,Iowa State,ISU,8,Big 12 Conference
+68,Boise State,Boise State Broncos,Boise St,Broncos,Boise St,BOIS,44,Mountain West Conference
+70,Idaho,Idaho Vandals,Idaho,Vandals,Idaho,IDHO,5,Big Sky Conference
+71,Bradley,Bradley Braves,Bradley,Braves,Bradley,BRAD,18,Missouri Valley Conference
+77,Northwestern,Northwestern Wildcats,Northwestern,Wildcats,Northwestern,NU,7,Big Ten Conference
+79,Southern Illinois,Southern Illinois Salukis,S Illinois,Salukis,S Illinois,SIU,18,Missouri Valley Conference
+8,Arkansas,Arkansas Razorbacks,Arkansas,Razorbacks,Arkansas,ARK,23,Southeastern Conference
+82,UIC,UIC Flames,UIC,Flames,UIC,UIC,18,Missouri Valley Conference
+84,Indiana,Indiana Hoosiers,Indiana,Hoosiers,Indiana,IU,7,Big Ten Conference
+85,IU Indianapolis,IU Indianapolis Jaguars,IU Indy,Jaguars,IU Indy,IUIN,45,Horizon League
+87,Notre Dame,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,Notre Dame,ND,2,Atlantic Coast Conference
+88,Southern Indiana,Southern Indiana Screaming Eagles,So Indiana,Screaming Eagles,So Indiana,USI,,
+9,Arizona State,Arizona State Sun Devils,Arizona St,Sun Devils,Arizona St,ASU,21,Pac-12 Conference
+91,Bellarmine,Bellarmine Knights,Bellarmine,Knights,Bellarmine,BELL,46,ASUN Conference
+93,Murray State,Murray State Racers,Murray St,Racers,Murray St,MUR,18,Missouri Valley Conference
+94,Northern Kentucky,Northern Kentucky Norse,N Kentucky,Norse,N Kentucky,NKU,45,Horizon League
+96,Kentucky,Kentucky Wildcats,Kentucky,Wildcats,Kentucky,UK,23,Southeastern Conference
+97,Louisville,Louisville Cardinals,Louisville,Cardinals,Louisville,LOU,2,Atlantic Coast Conference
+98,Western Kentucky,Western Kentucky Hilltoppers,Western KY,Hilltoppers,Western KY,WKU,11,Conference USA
+99,LSU,LSU Tigers,LSU,Tigers,LSU,LSU,23,Southeastern Conference

--- a/tools/crosswalk/espn_wbb_teams.csv
+++ b/tools/crosswalk/espn_wbb_teams.csv
@@ -1,0 +1,372 @@
+team_id,location,display_name,short_name,mascot,nickname,abbreviation,conference_id,conference_name
+103,Boston College,Boston College Eagles,Boston College,Eagles,Boston College,BC,2,Atlantic Coast Conference
+104,Boston University,Boston University Terriers,Boston U,Terriers,Boston U,BU,22,Patriot League
+107,Holy Cross,Holy Cross Crusaders,Holy Cross,Crusaders,Holy Cross,HC,22,Patriot League
+108,Harvard,Harvard Crimson,Harvard,Crimson,Harvard,HARV,12,Ivy League
+111,Northeastern,Northeastern Huskies,Northeastern,Huskies,Northeastern,NE,10,Coastal Athletic Association
+112358,Long Island University,Long Island University Sharks,Long Island,Sharks,Long Island,LIU,19,Northeast Conference
+113,Massachusetts,Massachusetts Minutemen,UMass,Minutemen,UMass,MASS,3,Atlantic 10 Conference
+116,Mount St. Mary's,Mount St. Mary's Mountaineers,Mount St Marys,Mountaineers,Mount St Marys,MSM,13,Metro Conference
+119,Towson,Towson Tigers,Towson,Tigers,Towson,TOW,10,Coastal Athletic Association
+12,Arizona,Arizona Wildcats,Arizona,Wildcats,Arizona,ARIZ,8,Big 12 Conference
+120,Maryland,Maryland Terrapins,Maryland,Terrapins,Maryland,MD,7,Big Ten Conference
+127,Michigan State,Michigan State Spartans,Michigan St,Spartans,Michigan St,MSU,7,Big Ten Conference
+13,Cal Poly,Cal Poly Mustangs,Cal Poly,Mustangs,Cal Poly,CP,9,Big West Conference
+130,Michigan,Michigan Wolverines,Michigan,Wolverines,Michigan,MICH,7,Big Ten Conference
+135,Minnesota,Minnesota Golden Gophers,Minnesota,Golden Gophers,Minnesota,MINN,7,Big Ten Conference
+139,Saint Louis,Saint Louis Billikens,Saint Louis,Billikens,Saint Louis,SLU,3,Atlantic 10 Conference
+140,Kansas City,Kansas City Roos,Kansas City,Roos,Kansas City,KC,47,Summit League
+142,Missouri,Missouri Tigers,Missouri,Tigers,Missouri,MIZ,23,Southeastern Conference
+145,Ole Miss,Ole Miss Rebels,Ole Miss,Rebels,Ole Miss,MISS,23,Southeastern Conference
+147,Montana State,Montana State Bobcats,Montana St,Bobcats,Montana St,MTST,5,Big Sky Conference
+149,Montana,Montana Grizzlies,Montana,Grizzlies,Montana,MONT,5,Big Sky Conference
+150,Duke,Duke Blue Devils,Duke,Blue Devils,Duke,DUKE,2,Atlantic Coast Conference
+151,East Carolina,East Carolina Pirates,East Carolina,Pirates,East Carolina,ECU,62,American Conference
+152,NC State,NC State Wolfpack,NC State,Wolfpack,NC State,NCSU,2,Atlantic Coast Conference
+153,North Carolina,North Carolina Tar Heels,North Carolina,Tar Heels,North Carolina,UNC,2,Atlantic Coast Conference
+154,Wake Forest,Wake Forest Demon Deacons,Wake Forest,Demon Deacons,Wake Forest,WAKE,2,Atlantic Coast Conference
+155,North Dakota,North Dakota Fighting Hawks,North Dakota,Fighting Hawks,North Dakota,UND,47,Summit League
+156,Creighton,Creighton Bluejays,Creighton,Bluejays,Creighton,CREI,4,Big East Conference
+158,Nebraska,Nebraska Cornhuskers,Nebraska,Cornhuskers,Nebraska,NEB,7,Big Ten Conference
+159,Dartmouth,Dartmouth Big Green,Dartmouth,Big Green,Dartmouth,DART,12,Ivy League
+16,Sacramento State,Sacramento State Hornets,Sacramento St,Hornets,Sacramento St,SAC,5,Big Sky Conference
+160,New Hampshire,New Hampshire Wildcats,New Hampshire,Wildcats,New Hampshire,UNH,1,America East Conference
+161,Fairleigh Dickinson,Fairleigh Dickinson Knights,FDU,Knights,FDU,FDU,19,Northeast Conference
+163,Princeton,Princeton Tigers,Princeton,Tigers,Princeton,PRIN,12,Ivy League
+164,Rutgers,Rutgers Scarlet Knights,Rutgers,Scarlet Knights,Rutgers,RUTG,7,Big Ten Conference
+166,New Mexico State,New Mexico State Aggies,New Mexico St,Aggies,New Mexico St,NMSU,11,Conference USA
+167,New Mexico,New Mexico Lobos,New Mexico,Lobos,New Mexico,UNM,44,Mountain West Conference
+171,Columbia,Columbia Lions,Columbia,Lions,Columbia,COLU,12,Ivy League
+172,Cornell,Cornell Big Red,Cornell,Big Red,Cornell,COR,12,Ivy League
+179,St. Bonaventure,St. Bonaventure Bonnies,St Bonaventure,Bonnies,St Bonaventure,SBU,3,Atlantic 10 Conference
+183,Syracuse,Syracuse Orange,Syracuse,Orange,Syracuse,SYR,2,Atlantic Coast Conference
+189,Bowling Green,Bowling Green Falcons,Bowling Green,Falcons,Bowling Green,BGSU,14,Mid-American Conference
+193,Miami (OH),Miami (OH) RedHawks,Miami OH,RedHawks,Miami OH,M-OH,14,Mid-American Conference
+194,Ohio State,Ohio State Buckeyes,Ohio State,Buckeyes,Ohio State,OSU,7,Big Ten Conference
+195,Ohio,Ohio Bobcats,Ohio,Bobcats,Ohio,OHIO,14,Mid-American Conference
+197,Oklahoma State,Oklahoma State Cowboys,Oklahoma St,Cowboys,Oklahoma St,OKST,8,Big 12 Conference
+198,Oral Roberts,Oral Roberts Golden Eagles,Oral Roberts,Golden Eagles,Oral Roberts,ORU,47,Summit League
+2,Auburn,Auburn Tigers,Auburn,Tigers,Auburn,AUB,23,Southeastern Conference
+2000,Abilene Christian,Abilene Christian Wildcats,Abilene Chrstn,Wildcats,Abilene Chrstn,ACU,30,United Athletic Conference
+2005,Air Force,Air Force Falcons,Air Force,Falcons,Air Force,AF,44,Mountain West Conference
+2006,Akron,Akron Zips,Akron,Zips,Akron,AKR,14,Mid-American Conference
+201,Oklahoma,Oklahoma Sooners,Oklahoma,Sooners,Oklahoma,OU,23,Southeastern Conference
+2010,Alabama A&M,Alabama A&M Bulldogs,Alabama A&M,Bulldogs,Alabama A&M,AAMU,26,Southwestern Athletic Conference
+2011,Alabama State,Alabama State Hornets,Alabama St,Hornets,Alabama St,ALST,26,Southwestern Athletic Conference
+2016,Alcorn State,Alcorn State Braves,Alcorn St,Braves,Alcorn St,ALCN,26,Southwestern Athletic Conference
+202,Tulsa,Tulsa Golden Hurricane,Tulsa,Golden Hurricane,Tulsa,TLSA,62,American Conference
+2026,App State,App State Mountaineers,App State,Mountaineers,App State,APP,27,Sun Belt Conference
+2029,Arkansas-Pine Bluff,Arkansas-Pine Bluff Golden Lions,AR-Pine Bluff,Golden Lions,AR-Pine Bluff,UAPB,26,Southwestern Athletic Conference
+2031,Little Rock,Little Rock Trojans,Little Rock,Trojans,Little Rock,LR,20,Ohio Valley Conference
+2032,Arkansas State,Arkansas State Red Wolves,Arkansas St,Red Wolves,Arkansas St,ARST,27,Sun Belt Conference
+204,Oregon State,Oregon State Beavers,Oregon St,Beavers,Oregon St,ORST,29,West Coast Conference
+2046,Austin Peay,Austin Peay Governors,Austin Peay,Governors,Austin Peay,APSU,46,Atlantic Sun Conference
+2050,Ball State,Ball State Cardinals,Ball State,Cardinals,Ball State,BALL,14,Mid-American Conference
+2057,Belmont,Belmont Bruins,Belmont,Bruins,Belmont,BEL,18,Missouri Valley Conference
+2065,Bethune-Cookman,Bethune-Cookman Wildcats,Bethune,Wildcats,Bethune,BCU,26,Southwestern Athletic Conference
+2066,Binghamton,Binghamton Bearcats,Binghamton,Bearcats,Binghamton,BING,1,America East Conference
+2083,Bucknell,Bucknell Bison,Bucknell,Bison,Bucknell,BUCK,22,Patriot League
+2084,Buffalo,Buffalo Bulls,Buffalo,Bulls,Buffalo,BUF,14,Mid-American Conference
+2086,Butler,Butler Bulldogs,Butler,Bulldogs,Butler,BTLR,4,Big East Conference
+2097,Campbell,Campbell Fighting Camels,Campbell,Fighting Camels,Campbell,CAM,10,Coastal Athletic Association
+2099,Canisius,Canisius Golden Griffins,Canisius,Golden Griffins,Canisius,CAN,13,Metro Conference
+21,San Diego State,San Diego State Aztecs,San Diego St,Aztecs,San Diego St,SDSU,44,Mountain West Conference
+2110,Central Arkansas,Central Arkansas Bears,C Arkansas,Bears,C Arkansas,CARK,46,Atlantic Sun Conference
+2113,Centenary (LA),Centenary (LA) Gentlemen,Centenary (LA),Gentlemen,Centenary (LA),CTLA,,
+2115,Central Connecticut,Central Connecticut Blue Devils,C Connecticut,Blue Devils,C Connecticut,CCSU,19,Northeast Conference
+2116,UCF,UCF Knights,UCF,Knights,UCF,UCF,8,Big 12 Conference
+2117,Central Michigan,Central Michigan Chippewas,C Michigan,Chippewas,C Michigan,CMU,14,Mid-American Conference
+2127,Charleston Southern,Charleston Southern Buccaneers,Charleston So,Buccaneers,Charleston So,CHSO,6,Big South Conference
+213,Penn State,Penn State Nittany Lions,Penn State,Nittany Lions,Penn State,PSU,7,Big Ten Conference
+2130,Chicago State,Chicago State Cougars,Chicago St,Cougars,Chicago St,CHST,19,Northeast Conference
+2132,Cincinnati,Cincinnati Bearcats,Cincinnati,Bearcats,Cincinnati,CIN,8,Big 12 Conference
+2142,Colgate,Colgate Raiders,Colgate,Raiders,Colgate,COLG,22,Patriot League
+2154,Coppin State,Coppin State Eagles,Coppin St,Eagles,Coppin St,COPP,16,Mid-Eastern Athletic Conference
+2166,Davidson,Davidson Wildcats,Davidson,Wildcats,Davidson,DAV,3,Atlantic 10 Conference
+2168,Dayton,Dayton Flyers,Dayton,Flyers,Dayton,DAY,3,Atlantic 10 Conference
+2169,Delaware State,Delaware State Hornets,Delaware St,Hornets,Delaware St,DSU,16,Mid-Eastern Athletic Conference
+2172,Denver,Denver Pioneers,Denver,Pioneers,Denver,DEN,47,Summit League
+2174,Detroit Mercy,Detroit Mercy Titans,Detroit Mercy,Titans,Detroit Mercy,DETM,45,Horizon League
+218,Temple,Temple Owls,Temple,Owls,Temple,TEM,62,American Conference
+2181,Drake,Drake Bulldogs,Drake,Bulldogs,Drake,DRKE,18,Missouri Valley Conference
+2182,Drexel,Drexel Dragons,Drexel,Dragons,Drexel,DREX,10,Coastal Athletic Association
+2184,Duquesne,Duquesne Dukes,Duquesne,Dukes,Duquesne,DUQ,3,Atlantic 10 Conference
+219,Pennsylvania,Pennsylvania Quakers,Penn,Quakers,Penn,PENN,12,Ivy League
+2193,East Tennessee State,East Tennessee State Buccaneers,ETSU,Buccaneers,ETSU,ETSU,24,Southern Conference
+2197,Eastern Illinois,Eastern Illinois Panthers,E Illinois,Panthers,E Illinois,EIU,20,Ohio Valley Conference
+2198,Eastern Kentucky,Eastern Kentucky Colonels,E Kentucky,Colonels,E Kentucky,EKU,46,Atlantic Sun Conference
+2199,Eastern Michigan,Eastern Michigan Eagles,E Michigan,Eagles,E Michigan,EMU,14,Mid-American Conference
+221,Pittsburgh,Pittsburgh Panthers,Pitt,Panthers,Pitt,PITT,2,Atlantic Coast Conference
+2210,Elon,Elon Phoenix,Elon,Phoenix,Elon,ELON,10,Coastal Athletic Association
+2217,Fairfield,Fairfield Stags,Fairfield,Stags,Fairfield,FAIR,13,Metro Conference
+222,Villanova,Villanova Wildcats,Villanova,Wildcats,Villanova,VILL,4,Big East Conference
+2226,Florida Atlantic,Florida Atlantic Owls,FAU,Owls,FAU,FAU,62,American Conference
+2229,Florida International,Florida International Panthers,FIU,Panthers,FIU,FIU,11,Conference USA
+2230,Fordham,Fordham Rams,Fordham,Rams,Fordham,FOR,3,Atlantic 10 Conference
+2239,Cal State Fullerton,Cal State Fullerton Titans,Fullerton,Titans,Fullerton,CSUF,9,Big West Conference
+2241,Gardner-Webb,Gardner-Webb Runnin' Bulldogs,Gardner-Webb,Runnin' Bulldogs,Gardner-Webb,GWEB,6,Big South Conference
+2244,George Mason,George Mason Patriots,George Mason,Patriots,George Mason,GMU,3,Atlantic 10 Conference
+2247,Georgia State,Georgia State Panthers,Georgia St,Panthers,Georgia St,GAST,27,Sun Belt Conference
+225,Brown,Brown Bears,Brown,Bears,Brown,BRWN,12,Ivy League
+2250,Gonzaga,Gonzaga Bulldogs,Gonzaga,Bulldogs,Gonzaga,GONZ,29,West Coast Conference
+2253,Grand Canyon,Grand Canyon Lopes,Grand Canyon,Lopes,Grand Canyon,GCU,30,United Athletic Conference
+2261,Hampton,Hampton Pirates,Hampton,Pirates,Hampton,HAMP,10,Coastal Athletic Association
+227,Rhode Island,Rhode Island Rams,Rhode Island,Rams,Rhode Island,URI,3,Atlantic 10 Conference
+2272,High Point,High Point Panthers,High Point,Panthers,High Point,HPU,6,Big South Conference
+2275,Hofstra,Hofstra Pride,Hofstra,Pride,Hofstra,HOF,10,Coastal Athletic Association
+2277,Houston Christian,Houston Christian Huskies,Hou Christian,Huskies,Hou Christian,HCU,25,Southland Conference
+228,Clemson,Clemson Tigers,Clemson,Tigers,Clemson,CLEM,2,Atlantic Coast Conference
+2287,Illinois State,Illinois State Redbirds,Illinois St,Redbirds,Illinois St,ILST,18,Missouri Valley Conference
+2294,Iowa,Iowa Hawkeyes,Iowa,Hawkeyes,Iowa,IOWA,7,Big Ten Conference
+2296,Jackson State,Jackson State Tigers,Jackson St,Tigers,Jackson St,JKST,26,Southwestern Athletic Conference
+23,San José State,San José State Spartans,San José St,Spartans,San José St,SJSU,44,Mountain West Conference
+2305,Kansas,Kansas Jayhawks,Kansas,Jayhawks,Kansas,KU,8,Big 12 Conference
+2306,Kansas State,Kansas State Wildcats,Kansas St,Wildcats,Kansas St,KSU,8,Big 12 Conference
+2309,Kent State,Kent State Golden Flashes,Kent State,Golden Flashes,Kent State,KENT,14,Mid-American Conference
+231,Furman,Furman Paladins,Furman,Paladins,Furman,FUR,24,Southern Conference
+232,Charleston,Charleston Cougars,Charleston,Cougars,Charleston,COFC,10,Coastal Athletic Association
+2320,Lamar,Lamar Cardinals,Lamar,Cardinals,Lamar,LAM,25,Southland Conference
+2325,La Salle,La Salle Explorers,La Salle,Explorers,La Salle,LAS,3,Atlantic 10 Conference
+2329,Lehigh,Lehigh Mountain Hawks,Lehigh,Mountain Hawks,Lehigh,LEH,22,Patriot League
+233,South Dakota,South Dakota Coyotes,South Dakota,Coyotes,South Dakota,SDAK,47,Summit League
+2330,Le Moyne,Le Moyne Dolphins,Le Moyne,Dolphins,Le Moyne,LEM,19,Northeast Conference
+2335,Liberty,Liberty Flames,Liberty,Flames,Liberty,LIB,11,Conference USA
+2344,Longwood,Longwood Lancers,Longwood,Lancers,Longwood,LONG,6,Big South Conference
+2348,Louisiana Tech,Louisiana Tech Bulldogs,Louisiana Tech,Bulldogs,Louisiana Tech,LT,11,Conference USA
+2349,UMass Lowell,UMass Lowell River Hawks,UMass Lowell,River Hawks,UMass Lowell,UML,1,America East Conference
+235,Memphis,Memphis Tigers,Memphis,Tigers,Memphis,MEM,62,American Conference
+2350,Loyola Chicago,Loyola Chicago Ramblers,Loyola Chicago,Ramblers,Loyola Chicago,LUC,3,Atlantic 10 Conference
+2351,Loyola Marymount,Loyola Marymount Lions,LMU,Lions,LMU,LMU,29,West Coast Conference
+2352,Loyola Maryland,Loyola Maryland Greyhounds,Loyola MD,Greyhounds,Loyola MD,L-MD,22,Patriot League
+236,Chattanooga,Chattanooga Mocs,Chattanooga,Mocs,Chattanooga,UTC,24,Southern Conference
+2363,Manhattan,Manhattan Jaspers,Manhattan,Jaspers,Manhattan,MAN,13,Metro Conference
+2368,Marist,Marist Red Foxes,Marist,Red Foxes,Marist,MRST,13,Metro Conference
+2377,McNeese,McNeese Cowboys,McNeese,Cowboys,McNeese,MCN,25,Southland Conference
+2378,UMBC,UMBC Retrievers,UMBC,Retrievers,UMBC,UMBC,1,America East Conference
+2379,Maryland Eastern Shore,Maryland Eastern Shore Hawks,MD Eastern,Hawks,MD Eastern,UMES,16,Mid-Eastern Athletic Conference
+238,Vanderbilt,Vanderbilt Commodores,Vanderbilt,Commodores,Vanderbilt,VAN,23,Southeastern Conference
+2382,Mercer,Mercer Bears,Mercer,Bears,Mercer,MER,24,Southern Conference
+2385,Mercyhurst,Mercyhurst Lakers,Mercyhurst,Lakers,Mercyhurst,MERC,19,Northeast Conference
+239,Baylor,Baylor Bears,Baylor,Bears,Baylor,BAY,8,Big 12 Conference
+2390,Miami,Miami Hurricanes,Miami,Hurricanes,Miami,MIA,2,Atlantic Coast Conference
+2393,Middle Tennessee,Middle Tennessee Blue Raiders,MTSU,Blue Raiders,MTSU,MTSU,11,Conference USA
+24,Stanford,Stanford Cardinal,Stanford,Cardinal,Stanford,STAN,2,Atlantic Coast Conference
+2400,Mississippi Valley State,Mississippi Valley State Delta Devils,Miss Valley St,Delta Devils,Miss Valley St,MVSU,26,Southwestern Athletic Conference
+2405,Monmouth,Monmouth Hawks,Monmouth,Hawks,Monmouth,MONM,10,Coastal Athletic Association
+2413,Morehead State,Morehead State Eagles,Morehead St,Eagles,Morehead St,MORE,20,Ohio Valley Conference
+2415,Morgan State,Morgan State Bears,Morgan St,Bears,Morgan St,MORG,16,Mid-Eastern Athletic Conference
+242,Rice,Rice Owls,Rice,Owls,Rice,RICE,62,American Conference
+2426,Navy,Navy Midshipmen,Navy,Midshipmen,Navy,NAVY,22,Patriot League
+2427,UNC Asheville,UNC Asheville Bulldogs,UNC Asheville,Bulldogs,UNC Asheville,UNCA,6,Big South Conference
+2428,North Carolina Central,North Carolina Central Eagles,NC Central,Eagles,NC Central,NCCU,16,Mid-Eastern Athletic Conference
+2429,Charlotte,Charlotte 49ers,Charlotte,49ers,Charlotte,CLT,62,American Conference
+2430,UNC Greensboro,UNC Greensboro Spartans,UNC Greensboro,Spartans,UNC Greensboro,UNCG,24,Southern Conference
+2433,UL Monroe,UL Monroe Warhawks,UL Monroe,Warhawks,UL Monroe,ULM,27,Sun Belt Conference
+2437,Omaha,Omaha Mavericks,Omaha,Mavericks,Omaha,OMA,47,Summit League
+2439,UNLV,UNLV Rebels,UNLV,Rebels,UNLV,UNLV,44,Mountain West Conference
+2440,Nevada,Nevada Wolf Pack,Nevada,Wolf Pack,Nevada,NEV,44,Mountain West Conference
+2441,New Haven,New Haven Chargers,New Haven,Chargers,New Haven,NHVN,,
+2443,LSU New Orleans,LSU New Orleans Privateers,New Orleans,Privateers,New Orleans,NOLA,25,Southland Conference
+2447,Nicholls,Nicholls Colonels,Nicholls,Colonels,Nicholls,NICH,25,Southland Conference
+2448,North Carolina A&T,North Carolina A&T Aggies,NC A&T,Aggies,NC A&T,NCAT,10,Coastal Athletic Association
+2449,North Dakota State,North Dakota State Bison,N Dakota St,Bison,N Dakota St,NDSU,47,Summit League
+245,Texas A&M,Texas A&M Aggies,Texas A&M,Aggies,Texas A&M,TA&M,23,Southeastern Conference
+2450,Norfolk State,Norfolk State Spartans,Norfolk St,Spartans,Norfolk St,NORF,16,Mid-Eastern Athletic Conference
+2453,North Alabama,North Alabama Lions,North Alabama,Lions,North Alabama,UNA,46,Atlantic Sun Conference
+2454,North Florida,North Florida Ospreys,North Florida,Ospreys,North Florida,UNF,46,Atlantic Sun Conference
+2458,Northern Colorado,Northern Colorado Bears,N Colorado,Bears,N Colorado,UNCO,5,Big Sky Conference
+2459,Northern Illinois,Northern Illinois Huskies,N Illinois,Huskies,N Illinois,NIU,14,Mid-American Conference
+2460,Northern Iowa,Northern Iowa Panthers,Northern Iowa,Panthers,Northern Iowa,UNI,18,Missouri Valley Conference
+2463,Cal State Northridge,Cal State Northridge Matadors,CSU Northridge,Matadors,CSU Northridge,CSUN,9,Big West Conference
+2464,Northern Arizona,Northern Arizona Lumberjacks,N Arizona,Lumberjacks,N Arizona,NAU,5,Big Sky Conference
+2466,Northwestern State,Northwestern State Demons,N'Western St,Demons,N'Western St,NWST,25,Southland Conference
+2473,Oakland,Oakland Golden Grizzlies,Oakland,Golden Grizzlies,Oakland,OAK,45,Horizon League
+248,Houston,Houston Cougars,Houston,Cougars,Houston,HOU,8,Big 12 Conference
+2483,Oregon,Oregon Ducks,Oregon,Ducks,Oregon,ORE,7,Big Ten Conference
+249,North Texas,North Texas Mean Green,North Texas,Mean Green,North Texas,UNT,62,American Conference
+2492,Pepperdine,Pepperdine Waves,Pepperdine,Waves,Pepperdine,PEPP,29,West Coast Conference
+25,California,California Golden Bears,California,Golden Bears,California,CAL,2,Atlantic Coast Conference
+250,UT Arlington,UT Arlington Mavericks,UT Arlington,Mavericks,UT Arlington,UTA,30,United Athletic Conference
+2501,Portland,Portland Pilots,Portland,Pilots,Portland,PORT,29,West Coast Conference
+2502,Portland State,Portland State Vikings,Portland St,Vikings,Portland St,PRST,5,Big Sky Conference
+2504,Prairie View A&M,Prairie View A&M Panthers,Prairie View,Panthers,Prairie View,PV,26,Southwestern Athletic Conference
+2506,Presbyterian,Presbyterian Blue Hose,Presbyterian,Blue Hose,Presbyterian,PRES,6,Big South Conference
+2507,Providence,Providence Friars,Providence,Friars,Providence,PROV,4,Big East Conference
+2509,Purdue,Purdue Boilermakers,Purdue,Boilermakers,Purdue,PUR,7,Big Ten Conference
+251,Texas,Texas Longhorns,Texas,Longhorns,Texas,TEX,23,Southeastern Conference
+2511,Queens University,Queens University Royals,Queens,Royals,Queens,QUC,46,Atlantic Sun Conference
+2514,Quinnipiac,Quinnipiac Bobcats,Quinnipiac,Bobcats,Quinnipiac,QUIN,13,Metro Conference
+2515,Radford,Radford Highlanders,Radford,Highlanders,Radford,RAD,6,Big South Conference
+252,BYU,BYU Cougars,BYU,Cougars,BYU,BYU,8,Big 12 Conference
+2520,Rider,Rider Broncs,Rider,Broncs,Rider,RID,13,Metro Conference
+2523,Robert Morris,Robert Morris Colonials,Robert Morris,Colonials,Robert Morris,RMU,45,Horizon League
+2529,Sacred Heart,Sacred Heart Pioneers,Sacred Heart,Pioneers,Sacred Heart,SHU,13,Metro Conference
+253,Southern Utah,Southern Utah Thunderbirds,Southern Utah,Thunderbirds,Southern Utah,SUU,30,United Athletic Conference
+2534,Sam Houston,Sam Houston Bearkats,Sam Houston,Bearkats,Sam Houston,SHSU,11,Conference USA
+2535,Samford,Samford Bulldogs,Samford,Bulldogs,Samford,SAM,24,Southern Conference
+2539,San Francisco,San Francisco Dons,San Francisco,Dons,San Francisco,SF,29,West Coast Conference
+254,Utah,Utah Utes,Utah,Utes,Utah,UTAH,8,Big 12 Conference
+2540,UC Santa Barbara,UC Santa Barbara Gauchos,Santa Barbara,Gauchos,Santa Barbara,UCSB,9,Big West Conference
+2541,Santa Clara,Santa Clara Broncos,Santa Clara,Broncos,Santa Clara,SCU,29,West Coast Conference
+2542,Savannah State,Savannah State Tigers,Savannah St,Tigers,Savannah St,SAV,,
+2545,SE Louisiana,SE Louisiana Lions,SE Louisiana,Lions,SE Louisiana,SELA,25,Southland Conference
+2546,Southeast Missouri State,Southeast Missouri State Redhawks,SE Missouri,Redhawks,SE Missouri,SEMO,20,Ohio Valley Conference
+2547,Seattle U,Seattle U Redhawks,Seattle U,Redhawks,Seattle U,SEA,30,United Athletic Conference
+2550,Seton Hall,Seton Hall Pirates,Seton Hall,Pirates,Seton Hall,HALL,4,Big East Conference
+256,James Madison,James Madison Dukes,James Madison,Dukes,James Madison,JMU,27,Sun Belt Conference
+2561,Siena,Siena Saints,Siena,Saints,Siena,SIE,13,Metro Conference
+2565,SIU Edwardsville,SIU Edwardsville Cougars,SIUE,Cougars,SIUE,SIUE,20,Ohio Valley Conference
+2567,SMU,SMU Mustangs,SMU,Mustangs,SMU,SMU,2,Atlantic Coast Conference
+2569,South Carolina State,South Carolina State Bulldogs,SC State,Bulldogs,SC State,SCST,16,Mid-Eastern Athletic Conference
+257,Richmond,Richmond Spiders,Richmond,Spiders,Richmond,RICH,3,Atlantic 10 Conference
+2571,South Dakota State,South Dakota State Jackrabbits,S Dakota St,Jackrabbits,S Dakota St,SDST,47,Summit League
+2572,Southern Miss,Southern Miss Golden Eagles,Southern Miss,Golden Eagles,Southern Miss,USM,27,Sun Belt Conference
+2579,South Carolina,South Carolina Gamecocks,South Carolina,Gamecocks,South Carolina,SC,23,Southeastern Conference
+258,Virginia,Virginia Cavaliers,Virginia,Cavaliers,Virginia,UVA,2,Atlantic Coast Conference
+2582,Southern,Southern Jaguars,Southern,Jaguars,Southern,SOU,26,Southwestern Athletic Conference
+259,Virginia Tech,Virginia Tech Hokies,Virginia Tech,Hokies,Virginia Tech,VT,2,Atlantic Coast Conference
+2597,St. Francis Brooklyn,St. Francis Brooklyn Terriers,St Francis BK,Terriers,St Francis BK,SFNY,,
+2598,St. Francis (PA),St. Francis (PA) Red Flash,St Francis PA,Red Flash,St Francis PA,SFPA,19,Northeast Conference
+2599,St. John's,St. John's Red Storm,St John's,Red Storm,St John's,SJU,4,Big East Conference
+26,UCLA,UCLA Bruins,UCLA,Bruins,UCLA,UCLA,7,Big Ten Conference
+2603,Saint Joseph's,Saint Joseph's Hawks,Saint Joseph's,Hawks,Saint Joseph's,JOES,3,Atlantic 10 Conference
+2608,Saint Mary's,Saint Mary's Gaels,Saint Mary's,Gaels,Saint Mary's,SMC,29,West Coast Conference
+261,Vermont,Vermont Catamounts,Vermont,Catamounts,Vermont,UVM,1,America East Conference
+2612,Saint Peter's,Saint Peter's Peacocks,Saint Peter's,Peacocks,Saint Peter's,SPU,13,Metro Conference
+2617,Stephen F. Austin,Stephen F. Austin Lumberjacks,SF Austin,Lumberjacks,SF Austin,SFA,25,Southland Conference
+2619,Stony Brook,Stony Brook Seawolves,Stony Brook,Seawolves,Stony Brook,STBK,10,Coastal Athletic Association
+2623,Missouri State,Missouri State Bears,Missouri St,Bears,Missouri St,MOST,18,Missouri Valley Conference
+2627,Tarleton State,Tarleton State Texans,Tarleton St,Texans,Tarleton St,TAR,30,United Athletic Conference
+2628,TCU,TCU Horned Frogs,TCU,Horned Frogs,TCU,TCU,8,Big 12 Conference
+2630,UT Martin,UT Martin Skyhawks,UT Martin,Skyhawks,UT Martin,UTM,20,Ohio Valley Conference
+2633,Tennessee,Tennessee Volunteers,Tennessee,Volunteers,Tennessee,TENN,23,Southeastern Conference
+2634,Tennessee State,Tennessee State Tigers,Tennessee St,Tigers,Tennessee St,TNST,20,Ohio Valley Conference
+2635,Tennessee Tech,Tennessee Tech Golden Eagles,Tennessee Tech,Golden Eagles,Tennessee Tech,TNTC,20,Ohio Valley Conference
+2636,UTSA,UTSA Roadrunners,UTSA,Roadrunners,UTSA,UTSA,62,American Conference
+2638,UTEP,UTEP Miners,UTEP,Miners,UTEP,UTEP,11,Conference USA
+264,Washington,Washington Huskies,Washington,Huskies,Washington,WASH,7,Big Ten Conference
+2640,Texas Southern,Texas Southern Tigers,Texas Southern,Tigers,Texas Southern,TXSO,26,Southwestern Athletic Conference
+2641,Texas Tech,Texas Tech Red Raiders,Texas Tech,Red Raiders,Texas Tech,TTU,8,Big 12 Conference
+2643,The Citadel,The Citadel Bulldogs,The Citadel,Bulldogs,The Citadel,CIT,,
+2649,Toledo,Toledo Rockets,Toledo,Rockets,Toledo,TOL,14,Mid-American Conference
+265,Washington State,Washington State Cougars,Washington St,Cougars,Washington St,WSU,29,West Coast Conference
+2653,Troy,Troy Trojans,Troy,Trojans,Troy,TROY,27,Sun Belt Conference
+2655,Tulane,Tulane Green Wave,Tulane,Green Wave,Tulane,TULN,62,American Conference
+2670,VCU,VCU Rams,VCU,Rams,VCU,VCU,3,Atlantic 10 Conference
+2674,Valparaiso,Valparaiso Beacons,Valparaiso,Beacons,Valparaiso,VAL,18,Missouri Valley Conference
+2678,VMI,VMI Keydets,VMI,Keydets,VMI,VMI,,
+2681,Wagner,Wagner Seahawks,Wagner,Seahawks,Wagner,WAG,19,Northeast Conference
+269,Marquette,Marquette Golden Eagles,Marquette,Golden Eagles,Marquette,MARQ,4,Big East Conference
+2692,Weber State,Weber State Wildcats,Weber St,Wildcats,Weber St,WEB,5,Big Sky Conference
+2697,West Florida,West Florida Argonauts,West Florida,Argonauts,West Florida,WFL,,
+2698,West Georgia,West Georgia Wolves,West Georgia,Wolves,West Georgia,WGA,46,Atlantic Sun Conference
+27,UC Riverside,UC Riverside Highlanders,UC Riverside,Highlanders,UC Riverside,UCR,9,Big West Conference
+270,Milwaukee,Milwaukee Panthers,Milwaukee,Panthers,Milwaukee,MILW,45,Horizon League
+2710,Western Illinois,Western Illinois Leathernecks,W Illinois,Leathernecks,W Illinois,WIU,20,Ohio Valley Conference
+2711,Western Michigan,Western Michigan Broncos,W Michigan,Broncos,W Michigan,WMU,14,Mid-American Conference
+2717,Western Carolina,Western Carolina Catamounts,W Carolina,Catamounts,W Carolina,WCU,24,Southern Conference
+2724,Wichita State,Wichita State Shockers,Wichita St,Shockers,Wichita St,WICH,62,American Conference
+2729,William & Mary,William & Mary Tribe,William & Mary,Tribe,William & Mary,W&M,10,Coastal Athletic Association
+2736,Winston-Salem State,Winston-Salem State Rams,Winston-Salem,Rams,Winston-Salem,WSSU,,
+2737,Winthrop,Winthrop Eagles,Winthrop,Eagles,Winthrop,WIN,6,Big South Conference
+2739,Green Bay,Green Bay Phoenix,Green Bay,Phoenix,Green Bay,GB,45,Horizon League
+2747,Wofford,Wofford Terriers,Wofford,Terriers,Wofford,WOF,24,Southern Conference
+275,Wisconsin,Wisconsin Badgers,Wisconsin,Badgers,Wisconsin,WIS,7,Big Ten Conference
+2750,Wright State,Wright State Raiders,Wright St,Raiders,Wright St,WRST,45,Horizon League
+2751,Wyoming,Wyoming Cowboys,Wyoming,Cowboys,Wyoming,WYO,44,Mountain West Conference
+2752,Xavier,Xavier Musketeers,Xavier,Musketeers,Xavier,XAV,4,Big East Conference
+2754,Youngstown State,Youngstown State Penguins,Youngstown St,Penguins,Youngstown St,YSU,45,Horizon League
+2755,Grambling,Grambling Tigers,Grambling,Tigers,Grambling,GRAM,26,Southwestern Athletic Conference
+276,Marshall,Marshall Thundering Herd,Marshall,Thundering Herd,Marshall,MRSH,27,Sun Belt Conference
+277,West Virginia,West Virginia Mountaineers,West Virginia,Mountaineers,West Virginia,WVU,8,Big 12 Conference
+2771,Merrimack,Merrimack Warriors,Merrimack,Warriors,Merrimack,MRMK,13,Metro Conference
+278,Fresno State,Fresno State Bulldogs,Fresno St,Bulldogs,Fresno St,FRES,44,Mountain West Conference
+279,Pacific,Pacific Tigers,Pacific,Tigers,Pacific,PAC,29,West Coast Conference
+28,UC San Diego,UC San Diego Tritons,UC San Diego,Tritons,UC San Diego,UCSD,9,Big West Conference
+2803,Bryant,Bryant Bulldogs,Bryant,Bulldogs,Bryant,BRY,1,America East Conference
+2815,Lindenwood,Lindenwood Lions,Lindenwood,Lions,Lindenwood,LIN,20,Ohio Valley Conference
+282,Indiana State,Indiana State Sycamores,Indiana St,Sycamores,Indiana St,INST,18,Missouri Valley Conference
+2837,East Texas A&M,East Texas A&M Lions,E Texas A&M,Lions,E Texas A&M,ETAM,25,Southland Conference
+284,Stonehill,Stonehill Skyhawks,Stonehill,Skyhawks,Stonehill,STO,19,Northeast Conference
+2856,California Baptist,California Baptist Lancers,CA Baptist,Lancers,CA Baptist,CBU,30,United Athletic Conference
+2870,Purdue Fort Wayne,Purdue Fort Wayne Mastodons,Purdue FW,Mastodons,Purdue FW,PFW,45,Horizon League
+288,Lipscomb,Lipscomb Bisons,Lipscomb,Bisons,Lipscomb,LIP,46,Atlantic Sun Conference
+2885,NJIT,NJIT Highlanders,NJIT,Highlanders,NJIT,NJIT,1,America East Conference
+290,Georgia Southern,Georgia Southern Eagles,GA Southern,Eagles,GA Southern,GASO,27,Sun Belt Conference
+2900,St. Thomas,St. Thomas Tommies,St Thomas (MN),Tommies,St Thomas (MN),STMN,47,Summit League
+2908,South Carolina Upstate,South Carolina Upstate Spartans,SC Upstate,Spartans,SC Upstate,UPST,6,Big South Conference
+2916,Incarnate Word,Incarnate Word Cardinals,Incarnate Word,Cardinals,Incarnate Word,UIW,25,Southland Conference
+292,UT Rio Grande Valley,UT Rio Grande Valley Vaqueros,UT Rio Grande,Vaqueros,UT Rio Grande,RGV,25,Southland Conference
+2934,Cal State Bakersfield,Cal State Bakersfield Roadrunners,Bakersfield,Roadrunners,Bakersfield,CSUB,9,Big West Conference
+294,Jacksonville,Jacksonville Dolphins,Jacksonville,Dolphins,Jacksonville,JAX,46,Atlantic Sun Conference
+295,Old Dominion,Old Dominion Monarchs,Old Dominion,Monarchs,Old Dominion,ODU,27,Sun Belt Conference
+299,Long Beach State,Long Beach State Beach,Long Beach St,Beach,Long Beach St,LBSU,9,Big West Conference
+30,USC,USC Trojans,USC,Trojans,USC,USC,7,Big Ten Conference
+300,UC Irvine,UC Irvine Anteaters,UC Irvine,Anteaters,UC Irvine,UCI,9,Big West Conference
+301,San Diego,San Diego Toreros,San Diego,Toreros,San Diego,USD,29,West Coast Conference
+302,UC Davis,UC Davis Aggies,UC Davis,Aggies,UC Davis,UCD,9,Big West Conference
+304,Idaho State,Idaho State Bengals,Idaho St,Bengals,Idaho St,IDST,5,Big Sky Conference
+305,DePaul,DePaul Blue Demons,DePaul,Blue Demons,DePaul,DEP,4,Big East Conference
+3084,Utah Valley,Utah Valley Wolverines,Utah Valley,Wolverines,Utah Valley,UVU,30,United Athletic Conference
+309,Louisiana,Louisiana Ragin' Cajuns,Louisiana,Ragin' Cajuns,Louisiana,UL,27,Sun Belt Conference
+3101,Utah Tech,Utah Tech Trailblazers,Utah Tech,Trailblazers,Utah Tech,UTU,30,United Athletic Conference
+311,Maine,Maine Black Bears,Maine,Black Bears,Maine,ME,1,America East Conference
+314,Iona,Iona Gaels,Iona,Gaels,Iona,IONA,13,Metro Conference
+315,Niagara,Niagara Purple Eagles,Niagara,Purple Eagles,Niagara,NIA,13,Metro Conference
+322,Lafayette,Lafayette Leopards,Lafayette,Leopards,Lafayette,LAF,22,Patriot League
+324,Coastal Carolina,Coastal Carolina Chanticleers,Coastal,Chanticleers,Coastal,CCU,27,Sun Belt Conference
+325,Cleveland State,Cleveland State Vikings,Cleveland St,Vikings,Cleveland St,CLE,45,Horizon League
+326,Texas State,Texas State Bobcats,Texas St,Bobcats,Texas St,TXST,27,Sun Belt Conference
+328,Utah State,Utah State Aggies,Utah State,Aggies,Utah State,USU,44,Mountain West Conference
+331,Eastern Washington,Eastern Washington Eagles,E Washington,Eagles,E Washington,EWU,5,Big Sky Conference
+333,Alabama,Alabama Crimson Tide,Alabama,Crimson Tide,Alabama,ALA,23,Southeastern Conference
+338,Kennesaw State,Kennesaw State Owls,Kennesaw St,Owls,Kennesaw St,KENN,11,Conference USA
+339,Evansville,Evansville Purple Aces,Evansville,Purple Aces,Evansville,EVAN,18,Missouri Valley Conference
+344,Mississippi State,Mississippi State Bulldogs,Mississippi St,Bulldogs,Mississippi St,MSST,23,Southeastern Conference
+349,Army,Army Black Knights,Army,Black Knights,Army,ARMY,22,Patriot League
+350,UNC Wilmington,UNC Wilmington Seahawks,UNC Wilmington,Seahawks,UNC Wilmington,UNCW,10,Coastal Athletic Association
+356,Illinois,Illinois Fighting Illini,Illinois,Fighting Illini,Illinois,ILL,7,Big Ten Conference
+357,Texas A&M-Corpus Christi,Texas A&M-Corpus Christi Islanders,Texas A&M-CC,Islanders,Texas A&M-CC,AMCC,25,Southland Conference
+36,Colorado State,Colorado State Rams,Colorado St,Rams,Colorado St,CSU,44,Mountain West Conference
+38,Colorado,Colorado Buffaloes,Colorado,Buffaloes,Colorado,COLO,8,Big 12 Conference
+399,UAlbany,UAlbany Great Danes,UAlbany,Great Danes,UAlbany,UALB,1,America East Conference
+41,UConn,UConn Huskies,UConn,Huskies,UConn,CONN,4,Big East Conference
+42,Hartford,Hartford Hawks,Hartford,Hawks,Hartford,HART,,
+43,Yale,Yale Bulldogs,Yale,Bulldogs,Yale,YALE,12,Ivy League
+44,American University,American University Eagles,American,Eagles,American,AMER,22,Patriot League
+45,George Washington,George Washington Revolutionaries,G Washington,Revolutionaries,G Washington,GW,3,Atlantic 10 Conference
+46,Georgetown,Georgetown Hoyas,Georgetown,Hoyas,Georgetown,GTWN,4,Big East Conference
+47,Howard,Howard Bison,Howard,Bison,Howard,HOW,16,Mid-Eastern Athletic Conference
+48,Delaware,Delaware Blue Hens,Delaware,Blue Hens,Delaware,DEL,10,Coastal Athletic Association
+5,UAB,UAB Blazers,UAB,Blazers,UAB,UAB,62,American Conference
+50,Florida A&M,Florida A&M Rattlers,Florida A&M,Rattlers,Florida A&M,FAMU,26,Southwestern Athletic Conference
+52,Florida State,Florida State Seminoles,Florida St,Seminoles,Florida St,FSU,2,Atlantic Coast Conference
+526,Florida Gulf Coast,Florida Gulf Coast Eagles,FGCU,Eagles,FGCU,FGCU,46,Atlantic Sun Conference
+55,Jacksonville State,Jacksonville State Gamecocks,Jax State,Gamecocks,Jax State,JXST,11,Conference USA
+56,Stetson,Stetson Hatters,Stetson,Hatters,Stetson,STET,46,Atlantic Sun Conference
+57,Florida,Florida Gators,Florida,Gators,Florida,FLA,23,Southeastern Conference
+58,South Florida,South Florida Bulls,South Florida,Bulls,South Florida,USF,62,American Conference
+59,Georgia Tech,Georgia Tech Yellow Jackets,Georgia Tech,Yellow Jackets,Georgia Tech,GT,2,Atlantic Coast Conference
+6,South Alabama,South Alabama Jaguars,South Alabama,Jaguars,South Alabama,USA,27,Sun Belt Conference
+61,Georgia,Georgia Bulldogs,Georgia,Bulldogs,Georgia,UGA,23,Southeastern Conference
+62,Hawai'i,Hawai'i Rainbow Warriors,Hawai'i,Rainbow Warriors,Hawai'i,HAW,9,Big West Conference
+66,Iowa State,Iowa State Cyclones,Iowa State,Cyclones,Iowa State,ISU,8,Big 12 Conference
+68,Boise State,Boise State Broncos,Boise St,Broncos,Boise St,BOIS,44,Mountain West Conference
+70,Idaho,Idaho Vandals,Idaho,Vandals,Idaho,IDHO,5,Big Sky Conference
+71,Bradley,Bradley Braves,Bradley,Braves,Bradley,BRAD,18,Missouri Valley Conference
+77,Northwestern,Northwestern Wildcats,Northwestern,Wildcats,Northwestern,NU,7,Big Ten Conference
+79,Southern Illinois,Southern Illinois Salukis,S Illinois,Salukis,S Illinois,SIU,18,Missouri Valley Conference
+8,Arkansas,Arkansas Razorbacks,Arkansas,Razorbacks,Arkansas,ARK,23,Southeastern Conference
+82,UIC,UIC Flames,UIC,Flames,UIC,UIC,18,Missouri Valley Conference
+84,Indiana,Indiana Hoosiers,Indiana,Hoosiers,Indiana,IU,7,Big Ten Conference
+85,IU Indianapolis,IU Indianapolis Jaguars,IU Indy,Jaguars,IU Indy,IUIN,45,Horizon League
+87,Notre Dame,Notre Dame Fighting Irish,Notre Dame,Fighting Irish,Notre Dame,ND,2,Atlantic Coast Conference
+88,Southern Indiana,Southern Indiana Screaming Eagles,So Indiana,Screaming Eagles,So Indiana,USI,20,Ohio Valley Conference
+9,Arizona State,Arizona State Sun Devils,Arizona St,Sun Devils,Arizona St,ASU,8,Big 12 Conference
+91,Bellarmine,Bellarmine Knights,Bellarmine,Knights,Bellarmine,BELL,46,Atlantic Sun Conference
+93,Murray State,Murray State Racers,Murray St,Racers,Murray St,MUR,18,Missouri Valley Conference
+94,Northern Kentucky,Northern Kentucky Norse,N Kentucky,Norse,N Kentucky,NKU,45,Horizon League
+96,Kentucky,Kentucky Wildcats,Kentucky,Wildcats,Kentucky,UK,23,Southeastern Conference
+97,Louisville,Louisville Cardinals,Louisville,Cardinals,Louisville,LOU,2,Atlantic Coast Conference
+98,Western Kentucky,Western Kentucky Hilltoppers,Western KY,Hilltoppers,Western KY,WKU,11,Conference USA
+99,LSU,LSU Tigers,LSU,Tigers,LSU,LSU,23,Southeastern Conference


### PR DESCRIPTION
Two related changes: a bundled stats.ncaa.org <-> ESPN team-id crosswalk for both basketball leagues, and the ESPN pagination bug that building it uncovered.

## 1. NCAA <-> ESPN team-id crosswalk

Season-keyed (NCAA team ids change every season; ESPN ids are stable and **school-level**, shared by the men's and women's programs).

| League | Rows | Seasons | exact | dict | alias | unmatched |
|---|---|---|---|---|---|---|
| MBB | 6006 | 2009-10..2025-26 | 5604 | 344 | 58 | **0** |
| WBB | 5972 | 2009-10..2025-26 | 5543 | 344 | 85 | **0** |

**100% match on all 17 seasons in both leagues**, up from a 79.5% naive-normalizer baseline. No team is dropped and no row carries a null `espn_team_id`.

Three deterministic passes, **no fuzzy matching at build time or runtime** (fuzzy candidates were promoted into an explicit alias table, each verified individually):
1. **Contracting normalizer** — AP abbreviation expansion, each entry derived from a real miss. The load-bearing subtlety: a *leading* `St.` is Saint, a *trailing* `St.` is State — so `St. John's (NY)`->2599, `Saint Mary's (CA)`->2608, `Ohio St.`->194 all resolve correctly.
2. **hoopR `dict_hoopR.csv` bridge** — the hand-curated cross-provider name dictionary (`NCAA`->`ESPN` columns), trimmed and committed.
3. **Hand-curated alias table** for the residue (recent renames/new D-I members the dictionary predates: `FDU`, `IU Indy`, `East Texas A&M`, `Le Moyne`, `Lindenwood`).

Worth recording: **ESPN's two D-I team lists disagree** — the men's list omits Lindenwood, Queens and Southern Indiana while the women's has them. Unioning the two retired 5 residue names on its own.

## 2. `season_group_children` returned page 1 only

The endpoint yields a paginated `{items: [...]}` collection but declared no `limit`, so ESPN's default page size of 25 silently truncated it. For women's D-I that meant **25 of 33 conferences**, leaving 76 ESPN teams with a null conference — the crosswalk build had to work around it before this fix.

`scope: universal`, so the single YAML entry fixes **every league's wrapper**, not just the women's one. Default 500 matches the sibling `season_group_teams`.

Verified live: `espn_wbb_season_group_children(2024, 2, 50)` now returns **33** conferences, and exactly **25** when `limit=25` is forced.

## Verification
- **1,258 passed** (`tests/mbb` + `tests/wbb` + universal parsers); **126 codegen tests** pass
- 22 new crosswalk tests: match-rate floors (set *under* the observed 100% so an upstream rename warns rather than instantly reds), no duplicate `(season, ncaa_team_id)`, no ESPN id shared by two NCAA teams in a season, row-set equality against `ncaa_{lg}_team_ids()` (nothing dropped), id dtypes, `match_method`<->null consistency, no unused alias rows, and hard-case spot checks
- ruff, mypy (new module added to the ratchet), and `generate.py --check` (exit 0, checked explicitly) all clean

## Downstream
Merging unblocks the ESPN columns in the new `teams` datasets in `ncaa-mbb-hoops-raw` / `ncaa-wbb-hoops-raw`, which currently emit typed nulls via an optional-import fallback; `scripts/run_datasets.sh --season <yr>` backfills them with no code change.

## Summary by Sourcery

Add a bundled season-keyed NCAA-to-ESPN team-id crosswalk for men’s and women’s college basketball and fix ESPN season_group_children pagination across all leagues by introducing an explicit limit parameter.

New Features:
- Expose ncaa_espn_team_crosswalk for both MBB and WBB, backed by bundled crosswalk CSVs and documented in the additional reference pages.
- Provide a league-parameterized crosswalk loader for MBB and a convenience re-export for WBB to join stats.ncaa.org team ids to ESPN team ids offline.
- Introduce a crosswalk build toolchain with committed ESPN team reference tables, a trimmed hoopR name dictionary, and an alias table to deterministically regenerate the crosswalks.

Bug Fixes:
- Ensure espn_*_season_group_children endpoints request all pages by adding a limit query parameter (default 500) in the shared codegen config and all generated and hand-written wrappers, preventing silent truncation of conference lists.

Enhancements:
- Refactor bundled CSV access into a shared _league_data_bytes helper used by NCAA team id and crosswalk loaders.
- Export ncaa_espn_team_crosswalk through the parsed MBB and WBB namespaces to make it available in the high-level API.

Documentation:
- Document ncaa_espn_team_crosswalk in the MBB and WBB additional reference, including parameters, returned columns, and usage examples.
- Update ESPN core API reference docs for every league to describe the new limit parameter on season_group_children.
- Add a README under tools/crosswalk explaining the crosswalk build inputs, rebuild process, and match-rate characteristics.

Tests:
- Add crosswalk contract tests validating id types, uniqueness, match-rate floors, alias usage, and known hard-name cases across both MBB and WBB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional result limits to season-group child requests across supported sports, defaulting to up to 500 items.
  * Added NCAA-to-ESPN team crosswalks for men’s and women’s college basketball, including unmatched-team details and pandas output support.
* **Documentation**
  * Documented the new request limit and basketball crosswalk functionality.
  * Updated documented basketball function counts.
* **Tests**
  * Added comprehensive validation for crosswalk schemas, matching quality, conversions, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->