### PR TITLE
docs(cfb): describe the FPI loader columns from ESPN's own field text

### DIFF
--- a/docs/docs/cfb/reference/loaders.md
+++ b/docs/docs/cfb/reference/loaders.md
@@ -965,52 +965,52 @@ Release: [cfb_fpi_weekly](https://github.com/sportsdataverse/sportsdataverse-dat
 | `week` | Int64 | Game week of the season. |
 | `team_id` | Int64 | ESPN team id. |
 | `last_updated` | String | Timestamp ESPN last refreshed the power index. |
-| `run_date_time_key` | Int64 |  |
-| `snapshot_out_of_sequence` | Boolean |  |
-| `fpi` | Float64 | ESPN Football Power Index rating (projected scoring margin vs. average team). |
-| `fpirank` | Float64 |  |
-| `projectedw` | Float64 |  |
-| `projectedl` | Float64 |  |
-| `projectedt` | Null |  |
-| `projectedwpctrank` | Float64 |  |
-| `probwinout` | Float64 |  |
-| `probwinconf` | Float64 |  |
-| `sosremainingrank` | Float64 |  |
-| `accomplishment` | Float64 |  |
-| `accomplishmentrank` | Float64 |  |
-| `adjwins` | Float64 |  |
-| `adjlosses` | Float64 |  |
-| `adjwinpctrank` | Float64 |  |
-| `gamecontrol` | Float64 |  |
-| `gamecontrolrank` | Float64 |  |
-| `adjavgingamewp` | Float64 |  |
-| `adjavgingamewprank` | Float64 |  |
-| `avgingamewp` | Float64 |  |
-| `avgingamewprank` | Float64 |  |
-| `avgsosrank` | Float64 |  |
-| `topsosrank` | Float64 |  |
-| `epaoffense` | Float64 |  |
-| `epadefense` | Float64 |  |
-| `epaspecialteams` | Float64 |  |
-| `probwindiv` | Float64 |  |
-| `probmakeplayoffs` | Float64 |  |
-| `probmaketitlegame` | Float64 |  |
-| `numwins` | Float64 |  |
-| `numlosses` | Float64 |  |
-| `numties` | Float64 |  |
-| `probwintitle` | Float64 |  |
-| `rankchange7days` | Float64 |  |
-| `prob6wins` | Float64 |  |
-| `rank` | Float64 | Position of the school within the poll for the given week (1 = top-ranked). |
-| `offefficiency` | Float64 |  |
-| `offefficiencyrank` | Float64 |  |
-| `defefficiency` | Float64 |  |
-| `defefficiencyrank` | Float64 |  |
-| `stefficiency` | Float64 |  |
-| `stefficiencyrank` | Float64 |  |
-| `totefficiency` | Float64 |  |
-| `totefficiencyrank` | Float64 |  |
-| `snapshot_is_contemporaneous` | Boolean |  |
+| `run_date_time_key` | Int64 | ESPN's run key for the snapshot, as an integer timestamp (e.g. 20241021040000). This is the AS-OF date the snapshot represents, which is not the same as last_updated (when ESPN computed it); the gap between the two is what snapshot_is_contemporaneous flags. |
+| `snapshot_out_of_sequence` | Boolean | True when this snapshot was computed AFTER one belonging to a later week of the same season type -- so it cannot be read as an as-of-that-week rating. Almost always the week-1 slot, which ESPN overwrites with a late-season computation (2024 week 1 is stamped 2024-12-15). Filter these out for any point-in-time or backtest use. |
+| `fpi` | Float64 | Football Power Index that measures team's true strength on net points scale; expected point margin vs average opponent on neutral field. |
+| `fpirank` | Float64 | ESPN's FPI rank field. Agrees with rank on 99.4% of rows; on the ~0.6% where they differ it is stale -- it never matches the rank implied by the published fpi, while rank always does. Prefer rank. |
+| `projectedw` | Float64 | Projected overall W-L, accounting for results to date and FPI-based projections for remaining scheduled games (and potential conference championship games). May not sum to a whole number because of differing number of games played in each simulation. |
+| `projectedl` | Float64 | Projected overall Losses, accounting for results to date and FPI-based projections for remaining scheduled games (including potential conference championship games). May not sum to a whole number because of differing number of games played in each simulation. |
+| `projectedt` | Null | Projected ties. Always null -- college football abolished ties in 1996, and ESPN emits the key beside projectedw/projectedl without ever populating it. Retained so the column set matches the upstream payload. |
+| `projectedwpctrank` | Float64 | Rank among FBS teams by projected win percentage. ESPN publishes the rank without the underlying percentage; derive it from projectedw and projectedl. |
+| `probwinout` | Float64 | Percent of season simulations in which team won all remaining scheduled games as well as conference championship game (if applicable). |
+| `probwinconf` | Float64 | Percent of season simulations in which team won its conference, incorporating chance of getting to and winning conference championship game (if applicable). Accounts for shared conference titles in conferences that allow them. |
+| `sosremainingrank` | Float64 | Rank among all FBS teams of remaining schedule strength, from perspective of an average FBS team. |
+| `accomplishment` | Float64 | Reflects chance that an average Top 25 team would have team's record or better, given the schedule. On a 0 to 100 scale, where 100 is best. |
+| `accomplishmentrank` | Float64 | Strength of Record rank. Reflects chance that an average Top 25 team would have team's record or better, given the schedule. |
+| `adjwins` | Float64 | Team's Wins adjusted for chance an average FBS team would have team's record or better, given the schedule. |
+| `adjlosses` | Float64 | Team's Losses adjusted for chance an average FBS team would have team's record or better, given the schedule. |
+| `adjwinpctrank` | Float64 | Rank among FBS teams by adjusted win percentage. ESPN publishes the rank without the underlying percentage; derive it from adjwins and adjlosses. 0 is an unranked placeholder, not a rank -- it appears where the underlying value is null. |
+| `gamecontrol` | Float64 | Reflects chance that an average Top 25 team would control games from start to end the way this team did, given the schedule. On a 0 to 100 scale, where 100 is best. |
+| `gamecontrolrank` | Float64 | Game Control rank. Reflects chance that an average Top 25 team would control games from start to end the way this team did, given the schedule. |
+| `adjavgingamewp` | Float64 | Team's average in-game win probability adjusted for chance that an average FBS team would control games from start to end the way this team did, given the schedule. |
+| `adjavgingamewprank` | Float64 | Rank among FBS teams by adjavgingamewp (average in-game win probability adjusted for opponent). Null for most pre-2019 snapshots. 0 is an unranked placeholder, not a rank. |
+| `avgingamewp` | Float64 | Team's average in-game win probability across all plays of all games played, not adjusted for site or opponent. |
+| `avgingamewprank` | Float64 | Team's average in-game win probability rank adjusted for chance that an average FBS team would control games from start to end the way this team did, given the schedule. |
+| `avgsosrank` | Float64 | Rank among all FBS teams of games already played schedule strength, from perspective of an average Top 25 team. |
+| `topsosrank` | Float64 | Rank among all FBS teams of games already played schedule strength, from perspective of an top FBS team. |
+| `epaoffense` | Float64 | Offensive component of FPI. Offensive contribution to expected point margin vs average opponent on neutral field. |
+| `epadefense` | Float64 | Defensive component of FPI. Defensive contribution to expected point margin vs average opponent on neutral field. |
+| `epaspecialteams` | Float64 | Special teams component of FPI. Special teams contribution to expected point margin vs average opponent on neutral field. |
+| `probwindiv` | Float64 | Percent of season simulations in which team won its conference division, for those conferences that have divisions. |
+| `probmakeplayoffs` | Float64 | Chance to make the CFB Playoff, according to the Playoff Predictor. |
+| `probmaketitlegame` | Float64 | Chance to make the CFB Playoff National Championship game, according to the Playoff Predictor. |
+| `numwins` | Float64 | Actual wins to date at the time of the snapshot. Distinct from projectedw (full-season projection) and adjwins (opponent-adjusted). |
+| `numlosses` | Float64 | Actual losses to date at the time of the snapshot. Distinct from projectedl (full-season projection) and adjlosses (opponent-adjusted). |
+| `numties` | Float64 | Actual ties to date. Never nonzero -- college football abolished ties in 1996; the column is null or 0 in every published row. |
+| `probwintitle` | Float64 | Chance to win the CFB Playoff National Championship, according to the Playoff Predictor. |
+| `rankchange7days` | Float64 | FPI Rank change from previous week. |
+| `prob6wins` | Float64 | Percent of season simulations in which a team won at least 6 games (typically bowl-eligible). |
+| `rank` | Float64 | FPI rank among FBS teams for this snapshot (1 = best). Prefer this over fpirank: the two agree on 99.4% of rows, and on the ~0.6% where they differ, rank is always the one consistent with the published fpi value. |
+| `offefficiency` | Float64 | Offensive efficiency on 0-100 scale; based on offense's contribution to scoring margin on per-play basis, adjusted for strength of opposing defenses faced. |
+| `offefficiencyrank` | Float64 | Team's offensive efficiency rank among all FBS teams. |
+| `defefficiency` | Float64 | Defensive efficiency on 0-100 scale; based on defense's contribution to scoring margin on per-play basis, adjusted for strength of opposing offenses faced. |
+| `defefficiencyrank` | Float64 | Team's defensive efficiency rank among all FBS teams. |
+| `stefficiency` | Float64 | Special teams efficiency on 0-100 scale; based on special teams' contribution to scoring margin on per-play basis, adjusted for strength of opposing special teams faced. |
+| `stefficiencyrank` | Float64 | Team's special teams efficiency rank among all FBS teams. |
+| `totefficiency` | Float64 | Net efficiency on 0-100 scale; incorporates offense, defense and special teams efficiencies into a single schedule-adjusted measure of per-play efficiency. |
+| `totefficiencyrank` | Float64 | Team's overall efficiency rank among all FBS teams. |
+| `snapshot_is_contemporaneous` | Boolean | True when the snapshot was computed inside its own season's window (August of the season year through February of the next), i.e. it is a live weekly run rather than a retrospective backfill. False for every row before 2015, which ESPN computed in one pass afterwards. A retrospective row is a reconstruction, not an as-of-week rating. |
 
 ```python
 load_cfb_fpi_weekly(seasons=2024)
@@ -1026,10 +1026,10 @@ Release: [espn_cfb_power_index](https://github.com/sportsdataverse/sportsdataver
 | `season` | Int64 | Season (4-digit year). |
 | `game_id` | Int64 | ESPN game identifier. |
 | `team_id` | Int64 | ESPN team id. |
-| `teampredptdiff` | Float64 |  |
-| `gameprojection` | Float64 |  |
-| `matchupquality` | Float64 |  |
-| `teamadjgamescore` | Float64 |  |
+| `teampredptdiff` | Float64 | Expected margin of victory for the FPI favorite. |
+| `gameprojection` | Float64 | Team's predicted win percentage in this game at time of given BPI run. |
+| `matchupquality` | Float64 | A measure of projected competitiveness and excitement in the game, using a 0 to 100 scale, with 100 as the most exciting. |
+| `teamadjgamescore` | Float64 | A measure of how well a team performed compared to their expected performance and the expected performance of a typical top 25 team. |
 
 ```python
 load_cfb_power_index(seasons=2024)

--- a/tools/codegen/gen_fpi_descriptions.py
+++ b/tools/codegen/gen_fpi_descriptions.py
@@ -127,7 +127,18 @@ def _get(url: str) -> dict[str, Any]:
 
 
 def espn_descriptions() -> dict[str, str]:
-    """Field name -> ESPN's own description, from both FPI payloads."""
+    """Collect ESPN's own FPI field descriptions from both payloads.
+
+    Returns:
+        Field name -> description, punctuation-normalized. Keys are ESPN's raw
+        field names (``gamecontrol``, ``epaoffense``, ...), which are already the
+        published column names, so the result can be looked up by column
+        directly. Merged across the weekly table and the per-event matchup entry;
+        neither payload alone covers every column.
+
+    Network errors and malformed JSON are left to propagate: this is a build
+    script, and a half-fetched vocabulary would silently emit a partial file.
+    """
     out: dict[str, str] = {}
 
     def take(name: Any, desc: Any) -> None:
@@ -150,6 +161,13 @@ def espn_descriptions() -> dict[str, str]:
 
 
 def main() -> int:
+    """Write the intermediate yaml the merge helper consumes.
+
+    Returns 0 always. Columns this file does not cover are not an error -- shared
+    keys are described once in codegen's cross-loader vocabulary, and the
+    coverage ratchet in ``extract_residual_columns`` is what decides whether
+    anything is genuinely undescribed.
+    """
     from tools.codegen.generate import _loader_schemas
 
     descriptions = {**espn_descriptions(), **_AUTHORED}

--- a/tools/codegen/gen_fpi_descriptions.py
+++ b/tools/codegen/gen_fpi_descriptions.py
@@ -1,0 +1,193 @@
+"""Compose returns-table descriptions for the two ESPN FPI loaders.
+
+ESPN ships a ``description`` alongside every FPI field in its own payloads, so
+the bulk of this file is not authored text -- it is ESPN's text, fetched and
+attached to the matching column. That is deliberate: a composed description
+invented here would drift from what the provider actually means by
+``gamecontrol`` or ``accomplishment``.
+
+Two payloads are needed because the two loaders come from different endpoints:
+
+  * the weekly team table  -> ``predictives`` / ``efficiencies`` field blocks
+  * the per-game matchup   -> the event powerindex entry's ``stats`` block
+
+The handful of columns ESPN does NOT describe are authored below, each one
+grounded in an observed property of the published data rather than a guess.
+
+Run:  uv run python tools/codegen/gen_fpi_descriptions.py
+Then: uv run python tools/codegen/merge_column_descriptions.py <out.yaml>
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import urllib.request
+from typing import Any
+
+import yaml
+
+CORE = "https://sports.core.api.espn.com/v2/sports/football/leagues/college-football"
+_UA = {"User-Agent": "Mozilla/5.0 (compatible; sportsdataverse/codegen)"}
+
+# A season/week known to carry a fully-populated FPI table, and a game known to
+# have matchup FPI. Pinned rather than "current" so a re-run is reproducible.
+_WEEK_URL = f"{CORE}/seasons/2024/types/2/weeks/8/powerindex?limit=5"
+_GAME_URL = f"{CORE}/events/401628319/competitions/401628319/powerindex?limit=10"
+
+# Columns ESPN ships no description for. Every one of these is grounded in a
+# checked property of the published data, noted in the text where it matters to
+# a consumer -- an undocumented sentinel or an always-null column is exactly the
+# kind of thing a returns table exists to warn about.
+_AUTHORED: dict[str, str] = {
+    # Rank-only fields: ESPN publishes the rank but not the underlying
+    # percentage (there is no `adjwinpct` / `projectedwpct` column). adjwins and
+    # adjlosses ARE published, so the adjusted percentage is derivable.
+    "adjwinpctrank": (
+        "Rank among FBS teams by adjusted win percentage. ESPN publishes the rank "
+        "without the underlying percentage; derive it from adjwins and adjlosses. "
+        "0 is an unranked placeholder, not a rank -- it appears where the "
+        "underlying value is null."
+    ),
+    "projectedwpctrank": (
+        "Rank among FBS teams by projected win percentage. ESPN publishes the rank "
+        "without the underlying percentage; derive it from projectedw and projectedl."
+    ),
+    "adjavgingamewprank": (
+        "Rank among FBS teams by adjavgingamewp (average in-game win probability "
+        "adjusted for opponent). Null for most pre-2019 snapshots. 0 is an "
+        "unranked placeholder, not a rank."
+    ),
+    # Vestigial: college football abolished ties in 1996. ESPN still emits the
+    # key beside projectedw / projectedl but never a value -- null in all
+    # 23,641 published rows, hence the Null dtype.
+    "projectedt": (
+        "Projected ties. Always null -- college football abolished ties in 1996, "
+        "and ESPN emits the key beside projectedw/projectedl without ever "
+        "populating it. Retained so the column set matches the upstream payload."
+    ),
+    # ESPN's own text for these is degenerate -- "Won Games.", "Rank." -- and the
+    # returns-table quality gate rejects a description that only restates the
+    # column name. Replaced with text that says which of the several similar
+    # columns this one actually is, which is the real question a reader has here.
+    "numwins": (
+        "Actual wins to date at the time of the snapshot. Distinct from projectedw "
+        "(full-season projection) and adjwins (opponent-adjusted)."
+    ),
+    "numlosses": (
+        "Actual losses to date at the time of the snapshot. Distinct from projectedl "
+        "(full-season projection) and adjlosses (opponent-adjusted)."
+    ),
+    "numties": (
+        "Actual ties to date. Never nonzero -- college football abolished ties in "
+        "1996; the column is null or 0 in every published row."
+    ),
+    # Verified against the data rather than assumed: across 2015-2025 the two rank
+    # columns disagree on 140 of 23,591 rows, and in every one of those `rank`
+    # equals the rank implied by the published fpi while `fpirank` equals it in
+    # none. So `rank` is the trustworthy one and the caveat belongs on both.
+    "rank": (
+        "FPI rank among FBS teams for this snapshot (1 = best). Prefer this over "
+        "fpirank: the two agree on 99.4% of rows, and on the ~0.6% where they "
+        "differ, rank is always the one consistent with the published fpi value."
+    ),
+    "fpirank": (
+        "ESPN's FPI rank field. Agrees with rank on 99.4% of rows; on the ~0.6% "
+        "where they differ it is stale -- it never matches the rank implied by the "
+        "published fpi, while rank always does. Prefer rank."
+    ),
+    # Producer-side columns (not ESPN fields).
+    "run_date_time_key": (
+        "ESPN's run key for the snapshot, as an integer timestamp "
+        "(e.g. 20241021040000). This is the AS-OF date the snapshot represents, "
+        "which is not the same as last_updated (when ESPN computed it); the gap "
+        "between the two is what snapshot_is_contemporaneous flags."
+    ),
+    "snapshot_out_of_sequence": (
+        "True when this snapshot was computed AFTER one belonging to a later week "
+        "of the same season type -- so it cannot be read as an as-of-that-week "
+        "rating. Almost always the week-1 slot, which ESPN overwrites with a "
+        "late-season computation (2024 week 1 is stamped 2024-12-15). Filter these "
+        "out for any point-in-time or backtest use."
+    ),
+    "snapshot_is_contemporaneous": (
+        "True when the snapshot was computed inside its own season's window "
+        "(August of the season year through February of the next), i.e. it is a "
+        "live weekly run rather than a retrospective backfill. False for every "
+        "row before 2015, which ESPN computed in one pass afterwards. A "
+        "retrospective row is a reconstruction, not an as-of-week rating."
+    ),
+}
+
+
+def _get(url: str) -> dict[str, Any]:
+    req = urllib.request.Request(url, headers=_UA)
+    with urllib.request.urlopen(req, timeout=45) as r:
+        return json.load(r)
+
+
+def espn_descriptions() -> dict[str, str]:
+    """Field name -> ESPN's own description, from both FPI payloads."""
+    out: dict[str, str] = {}
+
+    def take(name: Any, desc: Any) -> None:
+        if name and desc:
+            out[str(name)] = str(desc).strip().rstrip(".") + "."
+
+    item = (_get(_WEEK_URL).get("items") or [{}])[0]
+    for block in ("predictives", "efficiencies"):
+        for f in item.get(block) or []:
+            take(f.get("name"), f.get("description"))
+
+    for entry in _get(_GAME_URL).get("items") or []:
+        ref = entry.get("$ref") or ""
+        # Only follow ESPN's own refs, and over https.
+        if ref.startswith(("http://sports.core.api.espn.com/", "https://sports.core.api.espn.com/")):
+            entry = _get(ref.replace("http://", "https://", 1))
+        for s in entry.get("stats") or []:
+            take(s.get("name"), s.get("description"))
+    return out
+
+
+def main() -> int:
+    from tools.codegen.generate import _loader_schemas
+
+    descriptions = {**espn_descriptions(), **_AUTHORED}
+    schemas = _loader_schemas()
+
+    # Drive off the DECLARED schema, never off the current deferred list: the
+    # deferred list shrinks as entries land, so a generator keyed on it stops
+    # reproducing its own output and is no longer idempotent.
+    out: dict[str, dict[str, str]] = {}
+    missing: list[str] = []
+    for fn in ("load_cfb_fpi_weekly", "load_cfb_power_index"):
+        cols = schemas.get(fn) or []
+        block = {}
+        for c in cols:
+            name = c["name"] if isinstance(c, dict) else c
+            if name in descriptions:
+                block[name] = descriptions[name]
+            else:
+                missing.append(f"{fn}.{name}")
+        if block:
+            out[fn] = block
+
+    dest = pathlib.Path("tools/codegen/_fpi_descriptions.yaml")
+    dest.write_text(
+        yaml.safe_dump(out, sort_keys=True, allow_unicode=True, width=100),
+        encoding="utf-8",
+    )
+    total = sum(len(v) for v in out.values())
+    print(f"wrote {dest}: {total} descriptions across {len(out)} loaders")
+    if missing:
+        # Not a failure. Shared keys (season / week / team_id / game_id ...) are
+        # described once in codegen's cross-loader vocabulary rather than
+        # per-loader, so they are correctly absent here -- the coverage ratchet
+        # in extract_residual_columns is what decides whether anything is
+        # genuinely undescribed.
+        print(f"not covered here (expected for shared keys): {sorted(missing)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/codegen/manual_column_descriptions.yaml
+++ b/tools/codegen/manual_column_descriptions.yaml
@@ -2846,7 +2846,6 @@ load_cfb_player_box:
   yardsPerPuntReturn: Yards gained per punt return.
   yardsPerReception: Yards gained per reception.
   yardsPerRushAttempt: Yards gained per rushing attempt.
-load_cfb_power_index:
 load_cfb_ratings:
   adj_def_epa: Opponent-adjusted EPA per play allowed, netted the same way as the offensive rating, so lower is better because
     it measures EPA surrendered.
@@ -5551,6 +5550,94 @@ load_wnba_stats_rosters:
   how_acquired: How the team acquired the player (draft, trade, free agency).
   season_2: Season label in the league's second display form.
   team_id_lookup: Team id used to join the row back to the team tables.
+load_cfb_fpi_weekly:
+  accomplishment: Reflects chance that an average Top 25 team would have team's record or better, given the schedule. On a
+    0 to 100 scale, where 100 is best.
+  accomplishmentrank: Strength of Record rank. Reflects chance that an average Top 25 team would have team's record or better,
+    given the schedule.
+  adjavgingamewp: Team's average in-game win probability adjusted for chance that an average FBS team would control games
+    from start to end the way this team did, given the schedule.
+  adjavgingamewprank: Rank among FBS teams by adjavgingamewp (average in-game win probability adjusted for opponent). Null
+    for most pre-2019 snapshots. 0 is an unranked placeholder, not a rank.
+  adjlosses: Team's Losses adjusted for chance an average FBS team would have team's record or better, given the schedule.
+  adjwinpctrank: Rank among FBS teams by adjusted win percentage. ESPN publishes the rank without the underlying percentage;
+    derive it from adjwins and adjlosses. 0 is an unranked placeholder, not a rank -- it appears where the underlying value
+    is null.
+  adjwins: Team's Wins adjusted for chance an average FBS team would have team's record or better, given the schedule.
+  avgingamewp: Team's average in-game win probability across all plays of all games played, not adjusted for site or opponent.
+  avgingamewprank: Team's average in-game win probability rank adjusted for chance that an average FBS team would control
+    games from start to end the way this team did, given the schedule.
+  avgsosrank: Rank among all FBS teams of games already played schedule strength, from perspective of an average Top 25 team.
+  defefficiency: Defensive efficiency on 0-100 scale; based on defense's contribution to scoring margin on per-play basis,
+    adjusted for strength of opposing offenses faced.
+  defefficiencyrank: Team's defensive efficiency rank among all FBS teams.
+  epadefense: Defensive component of FPI. Defensive contribution to expected point margin vs average opponent on neutral field.
+  epaoffense: Offensive component of FPI. Offensive contribution to expected point margin vs average opponent on neutral field.
+  epaspecialteams: Special teams component of FPI. Special teams contribution to expected point margin vs average opponent
+    on neutral field.
+  fpi: Football Power Index that measures team's true strength on net points scale; expected point margin vs average opponent
+    on neutral field.
+  fpirank: ESPN's FPI rank field. Agrees with rank on 99.4% of rows; on the ~0.6% where they differ it is stale -- it never
+    matches the rank implied by the published fpi, while rank always does. Prefer rank.
+  gamecontrol: Reflects chance that an average Top 25 team would control games from start to end the way this team did, given
+    the schedule. On a 0 to 100 scale, where 100 is best.
+  gamecontrolrank: Game Control rank. Reflects chance that an average Top 25 team would control games from start to end the
+    way this team did, given the schedule.
+  numlosses: Actual losses to date at the time of the snapshot. Distinct from projectedl (full-season projection) and adjlosses
+    (opponent-adjusted).
+  numties: Actual ties to date. Never nonzero -- college football abolished ties in 1996; the column is null or 0 in every
+    published row.
+  numwins: Actual wins to date at the time of the snapshot. Distinct from projectedw (full-season projection) and adjwins
+    (opponent-adjusted).
+  offefficiency: Offensive efficiency on 0-100 scale; based on offense's contribution to scoring margin on per-play basis,
+    adjusted for strength of opposing defenses faced.
+  offefficiencyrank: Team's offensive efficiency rank among all FBS teams.
+  prob6wins: Percent of season simulations in which a team won at least 6 games (typically bowl-eligible).
+  probmakeplayoffs: Chance to make the CFB Playoff, according to the Playoff Predictor.
+  probmaketitlegame: Chance to make the CFB Playoff National Championship game, according to the Playoff Predictor.
+  probwinconf: Percent of season simulations in which team won its conference, incorporating chance of getting to and winning
+    conference championship game (if applicable). Accounts for shared conference titles in conferences that allow them.
+  probwindiv: Percent of season simulations in which team won its conference division, for those conferences that have divisions.
+  probwinout: Percent of season simulations in which team won all remaining scheduled games as well as conference championship
+    game (if applicable).
+  probwintitle: Chance to win the CFB Playoff National Championship, according to the Playoff Predictor.
+  projectedl: Projected overall Losses, accounting for results to date and FPI-based projections for remaining scheduled games
+    (including potential conference championship games). May not sum to a whole number because of differing number of games
+    played in each simulation.
+  projectedt: Projected ties. Always null -- college football abolished ties in 1996, and ESPN emits the key beside projectedw/projectedl
+    without ever populating it. Retained so the column set matches the upstream payload.
+  projectedw: Projected overall W-L, accounting for results to date and FPI-based projections for remaining scheduled games
+    (and potential conference championship games). May not sum to a whole number because of differing number of games played
+    in each simulation.
+  projectedwpctrank: Rank among FBS teams by projected win percentage. ESPN publishes the rank without the underlying percentage;
+    derive it from projectedw and projectedl.
+  rank: 'FPI rank among FBS teams for this snapshot (1 = best). Prefer this over fpirank: the two agree on 99.4% of rows,
+    and on the ~0.6% where they differ, rank is always the one consistent with the published fpi value.'
+  rankchange7days: FPI Rank change from previous week.
+  run_date_time_key: ESPN's run key for the snapshot, as an integer timestamp (e.g. 20241021040000). This is the AS-OF date
+    the snapshot represents, which is not the same as last_updated (when ESPN computed it); the gap between the two is what
+    snapshot_is_contemporaneous flags.
+  snapshot_is_contemporaneous: True when the snapshot was computed inside its own season's window (August of the season year
+    through February of the next), i.e. it is a live weekly run rather than a retrospective backfill. False for every row
+    before 2015, which ESPN computed in one pass afterwards. A retrospective row is a reconstruction, not an as-of-week rating.
+  snapshot_out_of_sequence: True when this snapshot was computed AFTER one belonging to a later week of the same season type
+    -- so it cannot be read as an as-of-that-week rating. Almost always the week-1 slot, which ESPN overwrites with a late-season
+    computation (2024 week 1 is stamped 2024-12-15). Filter these out for any point-in-time or backtest use.
+  sosremainingrank: Rank among all FBS teams of remaining schedule strength, from perspective of an average FBS team.
+  stefficiency: Special teams efficiency on 0-100 scale; based on special teams' contribution to scoring margin on per-play
+    basis, adjusted for strength of opposing special teams faced.
+  stefficiencyrank: Team's special teams efficiency rank among all FBS teams.
+  topsosrank: Rank among all FBS teams of games already played schedule strength, from perspective of an top FBS team.
+  totefficiency: Net efficiency on 0-100 scale; incorporates offense, defense and special teams efficiencies into a single
+    schedule-adjusted measure of per-play efficiency.
+  totefficiencyrank: Team's overall efficiency rank among all FBS teams.
+load_cfb_power_index:
+  gameprojection: Team's predicted win percentage in this game at time of given BPI run.
+  matchupquality: A measure of projected competitiveness and excitement in the game, using a 0 to 100 scale, with 100 as the
+    most exciting.
+  teamadjgamescore: A measure of how well a team performed compared to their expected performance and the expected performance
+    of a typical top 25 team.
+  teampredptdiff: Expected margin of victory for the FPI favorite.
 load_contracts:
   cols: Placeholder column retained in the contracts loader output schema; contains no meaningful data in this context.
 load_depth_charts:

--- a/tools/codegen/merge_column_descriptions.py
+++ b/tools/codegen/merge_column_descriptions.py
@@ -21,7 +21,10 @@ p = pathlib.Path("tools/codegen/manual_column_descriptions.yaml")
 cur = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
 added = 0
 for k, cols in new.items():
-    have = cur.get(k, {})
+    # `or {}` not `.get(k, {})`: a loader can be present in the yaml with an
+    # EMPTY block, which yaml parses to None. The two-arg default only covers a
+    # missing key, so the None case fell through and crashed on `c not in have`.
+    have = cur.get(k) or {}
     for c, d in cols.items():
         if c not in have:
             have[c] = d


### PR DESCRIPTION
The two FPI loaders added in #316 brought **48 columns with no returns-table description**, taking the coverage ratchet back off zero. This closes it.

## Most of the text is ESPN's, not mine

ESPN ships a `description` beside every FPI field in its own payloads. The generator fetches both — the weekly table's `predictives`/`efficiencies` blocks and the per-event `stats` block — and attaches ESPN's wording to the matching column. That covers **43 of 48**. Writing my own prose for `gamecontrol` or `accomplishment` would only drift from what the provider means by them.

## The rest are authored, each grounded in the published data

| column | what the data shows |
|---|---|
| `projectedt` | **null in all 23,641 rows** — ESPN emits the key beside `projectedw`/`projectedl` but never a value. Ties were abolished in 1996. Hence the `Null` dtype. |
| `adjwinpctrank`, `projectedwpctrank` | ranks whose underlying percentage ESPN **does not publish** (there is no `adjwinpct` column). `0` is an unranked placeholder, not a rank — it appears where the underlying value is null. |
| `run_date_time_key` | the **as-of** date, which is not `last_updated` (**when computed**). The gap between them is the retrospection. |
| `snapshot_out_of_sequence` / `_is_contemporaneous` | the two point-in-time traps, documented where a consumer meets them rather than only in a module docstring. |

## Four of ESPN's own descriptions are filler

`"Won Games."`, `"Lost Games."`, `"Tied Games."`, `"Rank."` — the `test_no_filler_descriptions` gate rejects a description that only restates the column name, and it was right to. Replaced with text that answers the actual question here, which is *which* of several similar columns this one is: `numwins` is the **actual** record, not `projectedw` (projection) and not `adjwins` (opponent-adjusted).

## The rank caveat is measured, not asserted

I nearly wrote "`fpirank` looks stale" off one 2015 row. Instead I derived the rank implied by the published `fpi` within each snapshot and compared:

```
disagreeing rows: 140 of 23,591 (0.6%)
  rank    matches derived: 140
  fpirank matches derived:   0
agreeing rows that match derived: 23,451 of 23,451
```

So `rank` is authoritative and `fpirank` is stale on exactly those rows. Both columns now say to prefer `rank`.

## Drive-by fix in the merge helper

`cur.get(k, {})` returned `None` for a loader present in the yaml with an **empty block** — the two-arg default only covers a *missing key*, not a *null value*, and YAML parses an empty block to `None`. It crashed the merge.

Worth noting how it hid: the crash was invisible through `cmd 2>&1 | tail`, because a pipeline's exit code is `tail`'s, not the failing command's — so the `&&` chain marched on and the next step 'succeeded' against unmerged input. Caught by checking the ratchet count, not the exit code.

## Verification

- ratchet: `residual = 0`, `loader deferred = 0` (was 48)
- rendered: **51** and **7** rows, **0 blank** — confirmed by parsing the built page, after a first probe that matched the wrong heading format and cheerfully reported "0 blank" because it had found nothing at all
- generator is idempotent: re-run merges `+0`
- `tests/codegen/test_manual_descriptions.py` 6 passed; ruff clean; `generate.py --check` current

## Summary by Sourcery

Document ESPN FPI loader columns using provider-sourced descriptions and a small set of authored explanations, and fix the column-description merge helper to handle empty YAML blocks safely.

Bug Fixes:
- Correct the merge_column_descriptions helper to treat null YAML loader blocks as empty mappings, preventing crashes when merging new descriptions.

Enhancements:
- Introduce a dedicated generator script that pulls FPI field descriptions from ESPN APIs, augments them with authored caveats, and emits a reusable YAML for manual column descriptions.

Documentation:
- Add full, user-facing descriptions for all columns in the cfb_fpi_weekly and espn_cfb_power_index loaders, clarifying semantics, rank behavior, and point-in-time caveats.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded college football FPI loader documentation with descriptions for metrics, rankings, projections, probabilities, schedule strength, efficiency, and snapshot metadata.
  * Added definitions for power index game projections, matchup quality, adjusted game scores, and predicted point differentials.
  * Clarified field meanings, snapshot timing, and result ordering for easier interpretation.

* **Chores**
  * Improved automated generation and merging of column descriptions, including support for empty metadata entries and more consistent coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->