### PR TITLE
fix(nba): sort stats query params alphabetically before sending

### DIFF
--- a/sportsdataverse/nba/nba_stats_runtime.py
+++ b/sportsdataverse/nba/nba_stats_runtime.py
@@ -149,6 +149,12 @@ def _get(
     clean: dict = {k: v for k, v in (params or {}).items() if v is not None}
     if "GameID" in clean:
         clean["GameID"] = str(clean["GameID"]).zfill(10)
+    # nba_api sorts query parameters alphabetically before sending -- their
+    # source carries the comment "for some reason this matters for some
+    # requests". Dict insertion order survives all the way through curl_cffi's
+    # query string, so match that canonical order. Free insurance against the
+    # order-sensitive endpoints; a no-op for everything else.
+    clean = dict(sorted(clean.items()))
 
     if path.startswith("http://") or path.startswith("https://"):
         url = path


### PR DESCRIPTION
nba_api sorts query parameters by key before every request — their source carries the comment *"for some reason this matters for some requests"* (`library/http.py`). Our generated wrappers send params in YAML declaration order, which survives through curl_cffi's query string.

This matches the canonical alphabetical order in `_get`. Free insurance against the order-sensitive endpoints; a byte-level no-op for everything else. The WNBA runtime shim delegates to the same `_get`, so both hosts get it.

Verified with an injected transport that the sent order is sorted; 41 nba stats tests green, ruff clean.

Part of the stats-API best-practice pass documented in `sdv-internal-refs/nba/API_NOTES.md` §7.

## Summary by Sourcery

Bug Fixes:
- Ensure NBA stats runtime sends query parameters in a deterministic alphabetical order to prevent failures on endpoints that depend on parameter ordering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when processing requests by sorting query parameters before they are sent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->