### PR TITLE
docs(codegen): sport-scoped description fallback (closes #320)

### DIFF
--- a/docs/docs/cfb/reference/additional.md
+++ b/docs/docs/cfb/reference/additional.md
@@ -40,7 +40,7 @@ A single-row wide DataFrame (polars by default). When `raw=True` returns the raw
 |---|---|---|
 | `season` | integer | Season (4-digit year). |
 | `season_type` | character | ESPN season type (2 = regular, 3 = postseason). |
-| `total` | logical | Total. |
+| `total` | logical | The sum of each team's score in the game. Equals h_score + v_score. Is NA for games which haven't yet been played. Convenient for evaluating over/under total bets. |
 | `athlete_id` | integer | ESPN athlete id. |
 | `athlete_uid` | character | ESPN athlete UID (universal identifier). |
 | `athlete_guid` | character | ESPN athlete GUID. |
@@ -54,7 +54,7 @@ A single-row wide DataFrame (polars by default). When `raw=True` returns the raw
 | `display_weight` | character | Human-readable weight (e.g. `205 lbs`). |
 | `height` | double | Listed height (inches). |
 | `display_height` | character | Human-readable height (e.g. `6' 1"`). |
-| `age` | integer | Player age (in years). |
+| `age` | integer | Age as of last pipeline build, rounded to one decimal. Pipeline is built on a weekly basis. |
 | `date_of_birth` | character | Player date of birth (if published). |
 | `jersey` | character | Jersey number. |
 | `slug` | character | URL slug for the team. |
@@ -63,7 +63,7 @@ A single-row wide DataFrame (polars by default). When `raw=True` returns the raw
 | `position_name` | character | Position name (e.g. `Quarterback`); `position_detail = TRUE` only. |
 | `position_display_name` | character | Human-readable position name; `position_detail = TRUE` only. |
 | `position_abbreviation` | character | Position abbreviation (e.g. `QB`); `position_detail = TRUE` only. |
-| `college_name` | character | College name. |
+| `college_name` | character | Official college (usually the last one attended) |
 | `status_id` | integer | ESPN commitment status id. |
 | `status_name` | character | Status-type key (e.g. `STATUS_FINAL`). |
 | `general_fumbles` | double | Total number of fumbles committed by the player across all offensive and special-teams plays. |

--- a/docs/docs/cfb/reference/loaders.md
+++ b/docs/docs/cfb/reference/loaders.md
@@ -1041,12 +1041,12 @@ Release: [espn_cfb_game_rosters](https://github.com/sportsdataverse/sportsdatave
 | `game_id` | Int64 | ESPN game identifier. |
 | `season` | Int64 | Season (4-digit year). |
 | `week` | Int64 | Game week of the season. |
-| `age` | Float64 | Player age (in years). |
+| `age` | Float64 | Age as of last pipeline build, rounded to one decimal. Pipeline is built on a weekly basis. |
 | `date_of_birth` | String | Player date of birth (if published). |
 | `citizenship` | String | Citizenship. |
 | `draft_display_text` | String | Draft display text. |
-| `draft_round` | Float64 | Round of the draft selection. |
-| `draft_year` | Float64 | Draft year (4-digit). |
+| `draft_round` | Float64 | Round that player was drafted in |
+| `draft_year` | Float64 | Year that player was drafted |
 | `draft_selection` | Float64 | Draft selection. |
 | `draft_team_href` | String | API link to the team that drafted the player. Sparse: absent entirely from the 2023 and 2024 assets and populated on only a small share of 2025 rows. |
 
@@ -1546,7 +1546,7 @@ Release: [espn_cfb_adv_specialists](https://github.com/sportsdataverse/sportsdat
 |---|---|---|
 | `pos_team_id` | Int64 | ESPN team id of the team on offense. Present for every season 2004+. |
 | `pos_team` | String | Team name in possession at the start of the play (offense, kickoff-aware). |
-| `player_name` | String | Player name. |
+| `player_name` | String | Full name of player |
 | `field_goals` | Int64 | Number of field-goal attempts. |
 | `field_goals_yards` | Int64 | Sum of the field-goal attempt distances parsed out of the play text; it stays at zero when no distance could be parsed from the narrative. |
 | `punts` | Int64 | Punts attempted. |

--- a/docs/docs/cfb/reference/on3.md
+++ b/docs/docs/cfb/reference/on3.md
@@ -67,7 +67,7 @@ GET /rdb/v1/coaches/{personKey}/profile
 | col_name | type | description |
 |---|---|---|
 | `salary` | numeric | Total cap-counting salary for the season ($). |
-| `age` | integer | Player age (in years). |
+| `age` | integer | Age as of last pipeline build, rounded to one decimal. Pipeline is built on a weekly basis. |
 | `high_school_name` | character | Recruit high-school name. |
 | `home_town_name` | character |  |
 | `description` | character | ESPN's description of the stat. |
@@ -392,7 +392,7 @@ GET /rdb/v1/draft-organization-rank
 | `five_stars` | integer |  |
 | `four_stars` | integer |  |
 | `three_stars` | integer | Whether three stars data is available. |
-| `total` | integer | Total. |
+| `total` | integer | The sum of each team's score in the game. Equals h_score + v_score. Is NA for games which haven't yet been played. Convenient for evaluating over/under total bets. |
 | `percent_drafted` | numeric |  |
 | `draft_rate` | numeric |  |
 
@@ -432,7 +432,7 @@ GET /rdb/v1/draft-pick-organization-rank
 | `second_round` | integer |  |
 | `third_round` | integer |  |
 | `fourth_through_seventh_round` | integer |  |
-| `total` | integer | Total. |
+| `total` | integer | The sum of each team's score in the game. Equals h_score + v_score. Is NA for games which haven't yet been played. Convenient for evaluating over/under total bets. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -484,7 +484,7 @@ GET /rdb/v1/drafts
 | `overall_pick` | integer | Overall pick number in the draft. |
 | `person` | character |  |
 | `position` | character | Athlete position. |
-| `age` | numeric | Player age (in years). |
+| `age` | numeric | Age as of last pipeline build, rounded to one decimal. Pipeline is built on a weekly basis. |
 | `rating` | character | Overall SP+ rating (Bill Connelly methodology, in points per game). |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -524,7 +524,7 @@ GET /rdb/v1/drafts-by-stars
 | `four_stars` | integer |  |
 | `three_stars` | integer | Whether three stars data is available. |
 | `zero_stars` | integer |  |
-| `total` | integer | Total. |
+| `total` | integer | The sum of each team's score in the game. Equals h_score + v_score. Is NA for games which haven't yet been played. Convenient for evaluating over/under total bets. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -610,7 +610,7 @@ GET /rdb/v1/drafts/{orgKey}/players
 | `overall_pick` | integer | Overall pick number in the draft. |
 | `person` | character |  |
 | `position` | character | Athlete position. |
-| `age` | numeric | Player age (in years). |
+| `age` | numeric | Age as of last pipeline build, rounded to one decimal. Pipeline is built on a weekly basis. |
 | `rating` | character | Overall SP+ rating (Bill Connelly methodology, in points per game). |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -1042,7 +1042,7 @@ GET /rdb/v1/organizations/{organizationKey}/draft-count-by-stars
 | `four_stars` | integer |  |
 | `three_stars` | integer | Whether three stars data is available. |
 | `zero_stars` | integer |  |
-| `total` | integer | Total. |
+| `total` | integer | The sum of each team's score in the game. Equals h_score + v_score. Is NA for games which haven't yet been played. Convenient for evaluating over/under total bets. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1080,7 +1080,7 @@ GET /rdb/v1/organizations/{organizationKey}/draft-count-by-year
 | `four_stars` | integer |  |
 | `three_stars` | integer | Whether three stars data is available. |
 | `zero_stars` | integer |  |
-| `total` | integer | Total. |
+| `total` | integer | The sum of each team's score in the game. Equals h_score + v_score. Is NA for games which haven't yet been played. Convenient for evaluating over/under total bets. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -1164,7 +1164,7 @@ GET /rdb/v1/organizations/{organizationKey}/drafted-players
 | `overall_pick` | integer | Overall pick number in the draft. |
 | `person` | character |  |
 | `position` | character | Athlete position. |
-| `age` | numeric | Player age (in years). |
+| `age` | numeric | Age as of last pipeline build, rounded to one decimal. Pipeline is built on a weekly basis. |
 | `rating` | character | Overall SP+ rating (Bill Connelly methodology, in points per game). |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -2021,7 +2021,7 @@ GET /rdb/v1/player/{playerKey}/organizations/{orgKey}
 | `exp_min` | integer |  |
 | `exp_max` | integer |  |
 | `year` | character | Four-digit season year (e.g. 2019). |
-| `age` | integer | Player age (in years). |
+| `age` | integer | Age as of last pipeline build, rounded to one decimal. Pipeline is built on a weekly basis. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -2120,7 +2120,7 @@ GET /rdb/v1/player/{personKey}/profile
 | `weight` | integer | Listed weight (lbs). |
 | `class_year` | integer |  |
 | `degree` | character |  |
-| `age` | integer | Player age (in years). |
+| `age` | integer | Age as of last pipeline build, rounded to one decimal. Pipeline is built on a weekly basis. |
 | `default_sport` | character |  |
 | `sports` | character |  |
 | `description` | character | ESPN's description of the stat. |
@@ -2140,7 +2140,7 @@ GET /rdb/v1/player/{personKey}/profile
 | `visibility` | character |  |
 | `tier` | character |  |
 | `review_status` | character |  |
-| `jersey_number` | character | Jersey number. |
+| `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
 | `badge` | character |  |
 | `ncaa_id` | character |  |
 | `managed_by_user` | logical |  |
@@ -2241,7 +2241,7 @@ GET /rdb/v1/player/verified
 | `weight` | integer | Listed weight (lbs). |
 | `class_year` | integer |  |
 | `degree` | character |  |
-| `age` | integer | Player age (in years). |
+| `age` | integer | Age as of last pipeline build, rounded to one decimal. Pipeline is built on a weekly basis. |
 | `default_sport` | character |  |
 | `sports` | character |  |
 | `description` | character | ESPN's description of the stat. |
@@ -2261,7 +2261,7 @@ GET /rdb/v1/player/verified
 | `visibility` | character |  |
 | `tier` | character |  |
 | `review_status` | character |  |
-| `jersey_number` | character | Jersey number. |
+| `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
 | `badge` | character |  |
 | `ncaa_id` | character |  |
 | `managed_by_user` | logical |  |

--- a/docs/docs/cfb/reference/sports247_site_pages.md
+++ b/docs/docs/cfb/reference/sports247_site_pages.md
@@ -28,7 +28,7 @@ Coach identity detail.
 | `first_name` | character | Athlete first name. |
 | `last_name` | character | Athlete last name. |
 | `full_name` | character | Venue full name (e.g. `Tenney Stadium`). |
-| `birthdate` | character | Date of birth. |
+| `birthdate` | character | Birthdate |
 | `hometown` | integer | Prospect hometown. |
 | `alma_mater` | integer |  |
 | `cbs_key` | character |  |
@@ -166,7 +166,7 @@ Single CoachRanking row.
 | `scout_rating` | character |  |
 | `composite_rating` | character | Composite class rating for the coach's haul. |
 | `commits` | character | Number of commits in the position group. |
-| `total` | character | Total. |
+| `total` | character | The sum of each team's score in the game. Equals h_score + v_score. Is NA for games which haven't yet been played. Convenient for evaluating over/under total bets. |
 | `composite_total` | character |  |
 | `five_stars` | character |  |
 | `scout_five_stars` | character |  |
@@ -233,7 +233,7 @@ Coach's recruiting-ranking history (one row per Ranking snapshot).
 | `scout_rating` | character |  |
 | `composite_rating` | character | Composite class rating for the coach's haul. |
 | `commits` | character | Number of commits in the position group. |
-| `total` | character | Total. |
+| `total` | character | The sum of each team's score in the game. Equals h_score + v_score. Is NA for games which haven't yet been played. Convenient for evaluating over/under total bets. |
 | `composite_total` | character |  |
 | `five_stars` | character |  |
 | `scout_five_stars` | character |  |
@@ -507,8 +507,8 @@ Pro-draft picks embed for a league/year/round.
 | `pick` | character | Pick number within the round. |
 | `overall_pick` | character | Overall selection number in the draft. |
 | `player` | integer | Player name. |
-| `player_first_name` | character | Participant first name. |
-| `player_last_name` | character | Participant last name. |
+| `player_first_name` | character | Player's first name |
+| `player_last_name` | character | Player's last name |
 | `college_team` | integer | College team name. |
 | `college_team_name` | character |  |
 | `position_abbreviation` | character | Player's position at draft. |
@@ -636,7 +636,7 @@ Player detail (identity + primary-sport rating/ranks).
 | `weight` | numeric | Listed weight (lbs). |
 | `bio` | character |  |
 | `scout_evaluation` | character |  |
-| `birthdate` | character | Date of birth. |
+| `birthdate` | character | Birthdate |
 | `modified_user` | character |  |
 | `modified_date` | character |  |
 | `cbs_key` | integer | Cross-reference key into the CBS Sports id space. |
@@ -979,7 +979,7 @@ Player name search.
 | `weight` | numeric | Listed weight (lbs). |
 | `bio` | character |  |
 | `scout_evaluation` | character |  |
-| `birthdate` | character | Date of birth. |
+| `birthdate` | character | Birthdate |
 | `modified_user` | character |  |
 | `modified_date` | character |  |
 | `cbs_key` | integer | Cross-reference key into the CBS Sports id space. |
@@ -1763,8 +1763,8 @@ Recruit class rankings for a season (rich per-recruit rows with inlined Player).
 | `recruit_interest_count` | integer | Number of tracked school interests. |
 | `recruit_interests_url` | character | Site URL to the recruit's interest timeline. |
 | `player_key` | integer | Primary key of this entity (the id used in its `.json` route). |
-| `player_first_name` | character | Participant first name. |
-| `player_last_name` | character | Participant last name. |
+| `player_first_name` | character | Player's first name |
+| `player_last_name` | character | Player's last name |
 | `player_full_name` | character | Player full name. |
 | `player_height` | character | Participant height (e.g. "6' 5\""). |
 | `player_weight` | numeric | Participant weight in pounds. |

--- a/docs/docs/mbb/reference/loaders.md
+++ b/docs/docs/mbb/reference/loaders.md
@@ -439,7 +439,7 @@ Release: [espn_mens_college_basketball_standings](https://github.com/sportsdatav
 | `team_alternate_color` | String | Team alternate color (hex without leading '#'). |
 | `team_logo` | String | Team logo image URL. |
 | `stat_name` | String | Stat key. |
-| `stat_display_name` | String | Stat display name (from `displayNames`). |
+| `stat_display_name` | String | Stat display name. |
 | `stat_short_display_name` | String | Short human-readable stat name. |
 | `stat_description` | String | ESPN's longer-form label for the standings statistic, which can differ from stat_display_name (streak is described as Current Streak and playoffSeed as Playoff Seed). |
 | `stat_abbreviation` | String | Short code ESPN prints for the standings statistic in a table header, such as W, L, PCT, GB or STRK; it diverges from stat_short_display_name for playoff seed and the home and conference record rows. |
@@ -469,7 +469,7 @@ Release: [espn_mens_college_basketball_player_season_stats](https://github.com/s
 | `category` | String | Category label. |
 | `stat_label` | String | Human-readable label of the statistic (e.g. 'At bats'). |
 | `stat_name` | String | Stat key. |
-| `stat_display_name` | String | Stat display name (from `displayNames`). |
+| `stat_display_name` | String | Stat display name. |
 | `stat_description` | String | ESPN's prose glossary definition of the statistic named in stat_name, for example defining assists as a pass to a teammate that leads directly to a field goal. |
 | `display_value` | String | Display-formatted value. |
 | `value` | Float64 | Numeric or string value field. |
@@ -567,7 +567,7 @@ Release: [espn_mens_college_basketball_game_rosters](https://github.com/sportsda
 | `athlete_first_name` | String | Player first name; `athlete_detail = TRUE` only. |
 | `athlete_last_name` | String | Athlete last name. |
 | `athlete_jersey` | String | Athlete jersey number. |
-| `athlete_position` | String | Player position name; `athlete_detail = TRUE` only. |
+| `athlete_position` | String | Athlete position. |
 | `athlete_headshot` | String | URL of the player's ESPN headshot image, whose filename is the athlete_id (verified equal for all 190,365 non-null rows in 2025); null when ESPN publishes no photo for that player. |
 | `starter` | Boolean | TRUE if the player was in the starting lineup; FALSE otherwise. |
 | `did_not_play` | Boolean | TRUE if the player did not appear in the game. |
@@ -598,7 +598,7 @@ Release: [espn_mens_college_basketball_team_season_stats](https://github.com/spo
 | `category` | String | Category label. |
 | `stat_label` | String | Human-readable label of the statistic (e.g. 'At bats'). |
 | `stat_name` | String | Stat key. |
-| `stat_display_name` | String | Stat display name (from `displayNames`). |
+| `stat_display_name` | String | Stat display name. |
 | `stat_description` | String | ESPN's prose glossary definition of the statistic named in stat_name, for example defining field goal percentage as the ratio of field goals made to field goals attempted. |
 | `display_value` | String | Display-formatted value. |
 | `value` | Float64 | Numeric or string value field. |

--- a/docs/docs/nba/reference/loaders.md
+++ b/docs/docs/nba/reference/loaders.md
@@ -379,7 +379,7 @@ Release: [espn_nba_game_rosters](https://github.com/sportsdataverse/sportsdatave
 | `athlete_first_name` | String | Player first name; `athlete_detail = TRUE` only. |
 | `athlete_last_name` | String | Athlete last name. |
 | `athlete_jersey` | String | Athlete jersey number. |
-| `athlete_position` | String | Player position name; `athlete_detail = TRUE` only. |
+| `athlete_position` | String | Athlete position. |
 | `athlete_headshot` | String | URL of the player's headshot image. |
 | `starter` | Boolean | TRUE if the player was in the starting lineup; FALSE otherwise. |
 | `did_not_play` | Boolean | TRUE if the player did not appear in the game. |
@@ -466,7 +466,7 @@ Release: [espn_nba_standings](https://github.com/sportsdataverse/sportsdataverse
 | `team_alternate_color` | String | Team alternate color (hex without leading '#'). |
 | `team_logo` | String | Team logo image URL. |
 | `stat_name` | String | Stat key. |
-| `stat_display_name` | String | Stat display name (from `displayNames`). |
+| `stat_display_name` | String | Stat display name. |
 | `stat_short_display_name` | String | Short human-readable stat name. |
 | `stat_description` | String | ESPN's prose gloss for the standings statistic on this row; for the clincher stat it is not a fixed label but the team's actual status text, such as Clinched Playoff Berth or Eliminated From Playoff. |
 | `stat_abbreviation` | String | ESPN's short code for the standings statistic, such as PCT, GB or OPP PPG; it is null for the four record-style splits (Home, Road, vs. Conf., vs. Div.), which ship no abbreviation. |
@@ -496,7 +496,7 @@ Release: [espn_nba_player_season_stats](https://github.com/sportsdataverse/sport
 | `category` | String | Category label. |
 | `stat_label` | String | Human-readable label of the statistic (e.g. 'At bats'). |
 | `stat_name` | String | Stat key. |
-| `stat_display_name` | String | Stat display name (from `displayNames`). |
+| `stat_display_name` | String | Stat display name. |
 | `stat_description` | String | ESPN's prose definition of the statistic on this row, for example the ratio of field goals made to field goals attempted; for the paired Made-Attempted stats it is the two definitions joined with a hyphen. |
 | `display_value` | String | Display-formatted value. |
 | `value` | Float64 | Numeric or string value field. |
@@ -524,7 +524,7 @@ Release: [espn_nba_team_season_stats](https://github.com/sportsdataverse/sportsd
 | `category` | String | Category label. |
 | `stat_label` | String | Human-readable label of the statistic (e.g. 'At bats'). |
 | `stat_name` | String | Stat key. |
-| `stat_display_name` | String | Stat display name (from `displayNames`). |
+| `stat_display_name` | String | Stat display name. |
 | `stat_description` | String | ESPN's prose definition of the team statistic on this row, for example the average number of assists a team records per turnover. |
 | `display_value` | String | Display-formatted value. |
 | `value` | Float64 | Numeric or string value field. |
@@ -544,7 +544,7 @@ Release: [espn_nba_draft](https://github.com/sportsdataverse/sportsdataverse-dat
 | `round` | Int32 | Tournament / playoff round. |
 | `round_display_name` | String | ESPN's display label for the draft round a pick belongs to, read from the round object's displayName; the NBA payload supplies no round metadata, so this is null for every released season 2003 through 2025. |
 | `pick` | Int32 | Pick number within the round. |
-| `overall_pick` | Int32 | Overall pick number in the draft. |
+| `overall_pick` | Int32 | Overall pick. |
 | `pick_traded` | String | ESPN's traded flag for the pick, carried through as a string rather than a boolean; every released NBA row reads FALSE, so it does not currently identify traded picks. |
 | `pick_notes` | String | Free-text note ESPN can attach to a pick, read from the pick's notes or note field; the NBA draft payload never populates it, so it is null across all released seasons. |
 | `athlete_id` | Int32 | Unique athlete identifier (ESPN). |
@@ -1420,13 +1420,13 @@ Release: [nba_stats_rosters](https://github.com/sportsdataverse/sportsdataverse-
 | `player` | String | Player name. |
 | `nickname` | String | Team or athlete nickname. |
 | `player_slug` | String | URL-safe player identifier. |
-| `num` | String | Inning number. |
+| `num` | String | Jersey number worn by the player. |
 | `position` | String | Listed roster position (G, F, C, etc.). |
 | `height` | String | Player height (string e.g. '6-2' or inches). |
 | `weight` | String | Player weight in pounds. |
 | `birth_date` | String | Date of birth (YYYY-MM-DD). |
 | `age` | Float64 | Player age (in years). |
-| `exp` | String | Exp. |
+| `exp` | String | Years of NBA playing experience entering the season ('R' = rookie). |
 | `school` | String | Player school / pre-draft team. |
 | `player_id` | Int64 | Unique player identifier. |
 | `how_acquired` | String |  |

--- a/docs/docs/nba/reference/nba_stats.md
+++ b/docs/docs/nba/reference/nba_stats.md
@@ -6436,7 +6436,7 @@ GET /stats/shotchartdetail
 | `seconds_remaining` | character | Seconds remaining in the period. |
 | `event_type` | character | Event / play type code (V2 PBP). |
 | `action_type` | character | Action type label (e.g. 'Made Shot', 'Substitution'). |
-| `shot_type` | character | Type of shot taken (e.g. wrist, snap, backhand). |
+| `shot_type` | character | Shot type label (e.g. 'Jump Shot', 'Layup'). |
 | `shot_zone_basic` | character | Shot zone (e.g. 'Restricted Area', 'Mid-Range', 'Above the Break 3'). |
 | `shot_zone_area` | character | Shot zone area ('Left Side', 'Right Side', 'Center'). |
 | `shot_zone_range` | character | Shot zone range ('Less Than 8 ft.', '8-16 ft.', '16-24 ft.', etc.). |
@@ -6545,7 +6545,7 @@ GET /stats/shotchartlineupdetail
 | `seconds_remaining` | character | Seconds remaining in the period. |
 | `event_type` | character | Event / play type code (V2 PBP). |
 | `action_type` | character | Action type label (e.g. 'Made Shot', 'Substitution'). |
-| `shot_type` | character | Type of shot taken (e.g. wrist, snap, backhand). |
+| `shot_type` | character | Shot type label (e.g. 'Jump Shot', 'Layup'). |
 | `shot_zone_basic` | character | Shot zone (e.g. 'Restricted Area', 'Mid-Range', 'Above the Break 3'). |
 | `shot_zone_area` | character | Shot zone area ('Left Side', 'Right Side', 'Center'). |
 | `shot_zone_range` | character | Shot zone range ('Less Than 8 ft.', '8-16 ft.', '16-24 ft.', etc.). |

--- a/docs/docs/nfl/reference/additional.md
+++ b/docs/docs/nfl/reference/additional.md
@@ -28,26 +28,26 @@ Polars dataframe of game roster data with columns: 'athlete_id', 'athlete_uid', 
 
 | col_name | type | description |
 |---|---|---|
-| `athlete_id` | integer | Unique athlete identifier (ESPN). |
+| `athlete_id` | integer | ESPN athlete id. |
 | `athlete_uid` | character | ESPN athlete UID (universal identifier). |
 | `athlete_guid` | character | ESPN athlete GUID. |
 | `athlete_type` | character | Athlete type / class. |
 | `first_name` | character | First name of player |
 | `last_name` | character | Last name of player |
 | `full_name` | character | Full name as per NFL.com |
-| `athlete_display_name` | character | Athlete display name (full). |
+| `athlete_display_name` | character | Player display name; `athlete_detail = TRUE` only. |
 | `short_name` | character | Player short name (i.e. "F.Last") |
 | `weight` | double | Official weight, in pounds |
-| `display_weight` | character | Player weight in display format (e.g. '180 lbs'). |
+| `display_weight` | character | Human-readable weight (e.g. `205 lbs`). |
 | `height` | double | Official height, in inches |
-| `display_height` | character | Player height in display format (e.g. '6-2'). |
+| `display_height` | character | Human-readable height (e.g. `6' 1"`). |
 | `age` | integer | Age as of last pipeline build, rounded to one decimal. Pipeline is built on a weekly basis. |
-| `date_of_birth` | character | Date of birth (YYYY-MM-DD). |
+| `date_of_birth` | character | Player date of birth (if published). |
 | `debut_year` | integer | Year of professional debut. |
-| `slug` | character | URL-safe identifier. |
-| `jersey` | character | Jersey number worn by the player. |
+| `slug` | character | URL slug for the team. |
+| `jersey` | character | Jersey number. |
 | `linked` | logical | TRUE if the record is linked to a related entity. |
-| `active` | logical | TRUE if the row represents an active record (player / team / season). |
+| `active` | logical | `TRUE` if the player was active for the game. |
 | `alternate_ids_sdr` | character | Alternate ids sdr. |
 | `birth_place_city` | character | Birth place city. |
 | `birth_place_state` | character | Birth place state. |
@@ -56,7 +56,7 @@ Polars dataframe of game roster data with columns: 'athlete_id', 'athlete_uid', 
 | `headshot_alt` | character | Alternative-text label for the headshot. |
 | `projections_href` | character | ESPN API hyperlink reference URL for the player's statistical projection resource. |
 | `contracts_href` | character | ESPN API hyperlink reference URL for the full list of the player's historical contract records. |
-| `experience_years` | integer | Experience years. |
+| `experience_years` | integer | Years of experience. |
 | `college_athlete_href` | character | ESPN API hyperlink reference URL for the athlete's college profile resource. |
 | `contract_href` | character | ESPN API hyperlink reference URL for the player's full contract resource. |
 | `contract_option_type` | integer | Contract option type. |
@@ -67,8 +67,8 @@ Polars dataframe of game roster data with columns: 'athlete_id', 'athlete_uid', 
 | `contract_season_href` | character | ESPN API hyperlink reference URL for the specific season-level contract detail resource. |
 | `contract_team_href` | character | ESPN API hyperlink reference URL for the team associated with the player's contract. |
 | `contract_active` | logical | Contract active. |
-| `status_id` | character | Status identifier. |
-| `status_name` | character | Status label. |
+| `status_id` | character | ESPN commitment status id. |
+| `status_name` | character | Status-type key (e.g. `STATUS_FINAL`). |
 | `status_type` | character | Status type. |
 | `status_abbreviation` | character | Status abbreviation. |
 | `contract_salary_remaining` | integer | Contract salary remaining. |
@@ -81,34 +81,34 @@ Polars dataframe of game roster data with columns: 'athlete_id', 'athlete_uid', 
 | `hand_type` | character | Hand type. |
 | `hand_abbreviation` | character | Hand abbreviation. |
 | `hand_display_value` | character | Hand display value. |
-| `starter` | logical | TRUE if the player was in the starting lineup; FALSE otherwise. |
+| `starter` | logical | `TRUE` if the athlete started the game. |
 | `jersey_right` | character | Secondary or alternate jersey number display string used by ESPN (e.g., for special-game uniforms). |
-| `valid` | logical | Valid. |
-| `did_not_play` | logical | TRUE if the player did not appear in the game. |
+| `valid` | logical | `TRUE` if the roster entry is flagged valid by ESPN. |
+| `did_not_play` | logical | `TRUE` if the athlete did not play. |
 | `display_name` | character | Full name of player |
 | `athlete_href` | character | ESPN API hyperlink reference URL for the athlete resource. |
 | `position_href` | character | ESPN API hyperlink reference URL for the player's positional classification resource. |
 | `statistics_href` | character | ESPN API hyperlink reference URL for the player's career statistics resource. |
-| `team_id` | integer | Unique team identifier. |
-| `order` | integer | Display order within the result set. |
-| `home_away` | character | Game venue label ('home' or 'away'). |
-| `winner` | logical | Winner. |
+| `team_id` | integer | ESPN team id. |
+| `order` | integer | Team order within the competition (0 = first). |
+| `home_away` | character | `home` or `away`. |
+| `winner` | logical | `TRUE` if this team won the game. |
 | `team_guid` | character | ESPN team GUID. |
 | `team_uid` | character | ESPN universal team identifier (UID format 's:40~l:...~t:...'). |
-| `team_slug` | character | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
-| `team_location` | character | Team city or location string. |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
-| `team_nickname` | character | Team nickname. |
-| `team_abbreviation` | character | Short team abbreviation (e.g. 'LAS'). |
-| `team_display_name` | character | Full team display name. |
-| `team_short_display_name` | character | Short team display name (e.g. 'Aces'). |
-| `team_color` | character | Team primary color (hex without leading '#'). |
-| `team_alternate_color` | character | Team alternate color (hex without leading '#'). |
+| `team_slug` | character | Team slug for the stat row. |
+| `team_location` | character | Team location / school name; `team_detail = TRUE` only. |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
+| `team_nickname` | character | Team nickname label; `team_detail = TRUE` only. |
+| `team_abbreviation` | character | Team abbreviation; `team_detail = TRUE` only. |
+| `team_display_name` | character | Full team display name; `team_detail = TRUE` only. |
+| `team_short_display_name` | character | Short team display name; `team_detail = TRUE` only. |
+| `team_color` | character | Primary team color; `team_detail = TRUE` only. |
+| `team_alternate_color` | character | Alternate team color; `team_detail = TRUE` only. |
 | `is_active` | logical | Active contract |
-| `is_all_star` | logical | Is all star. |
+| `is_all_star` | logical | Whether the team is an all-star team. |
 | `team_alternate_ids_sdr` | character | SportsDataverse SDR alternate identifier for the team, used for cross-source joins. |
-| `logo_href` | character | Team or league logo URL. |
-| `logo_dark_href` | character | Logo URL for dark backgrounds. |
+| `logo_href` | character | URL of the default team logo. |
+| `logo_dark_href` | character | URL of the dark-variant team logo. |
 | `game_id` | integer | Ten digit identifier for NFL game. |
 
 **Example**
@@ -156,7 +156,7 @@ A single-row wide DataFrame (polars by default). When `raw=True` returns the raw
 | `season` | integer | 4 digit number indicating to which season(s) the specified timeframe belongs to. |
 | `season_type` | character | REG or POST indicating if the timeframe belongs to regular or post season. |
 | `total` | logical | The sum of each team's score in the game. Equals h_score + v_score. Is NA for games which haven't yet been played. Convenient for evaluating over/under total bets. |
-| `athlete_id` | integer | Unique athlete identifier (ESPN). |
+| `athlete_id` | integer | ESPN athlete id. |
 | `athlete_uid` | character | ESPN athlete UID (universal identifier). |
 | `athlete_guid` | character | ESPN athlete GUID. |
 | `athlete_type` | character | Athlete type / class. |
@@ -166,21 +166,21 @@ A single-row wide DataFrame (polars by default). When `raw=True` returns the raw
 | `display_name` | character | Full name of player |
 | `short_name` | character | Player short name (i.e. "F.Last") |
 | `weight` | double | Official weight, in pounds |
-| `display_weight` | character | Player weight in display format (e.g. '180 lbs'). |
+| `display_weight` | character | Human-readable weight (e.g. `205 lbs`). |
 | `height` | double | Official height, in inches |
-| `display_height` | character | Player height in display format (e.g. '6-2'). |
+| `display_height` | character | Human-readable height (e.g. `6' 1"`). |
 | `age` | integer | Age as of last pipeline build, rounded to one decimal. Pipeline is built on a weekly basis. |
-| `date_of_birth` | character | Date of birth (YYYY-MM-DD). |
-| `jersey` | character | Jersey number worn by the player. |
-| `slug` | character | URL-safe identifier. |
-| `active` | logical | TRUE if the row represents an active record (player / team / season). |
-| `position_id` | integer | Unique position identifier. |
-| `position_name` | character | Listed roster position ('Guard', 'Forward', 'Center'). |
-| `position_display_name` | character | Position display name. |
-| `position_abbreviation` | character | Position abbreviation ('G' / 'F' / 'C'). |
+| `date_of_birth` | character | Player date of birth (if published). |
+| `jersey` | character | Jersey number. |
+| `slug` | character | URL slug for the team. |
+| `active` | logical | `TRUE` if the player was active for the game. |
+| `position_id` | integer | ESPN position id. |
+| `position_name` | character | Position name (e.g. `Quarterback`); `position_detail = TRUE` only. |
+| `position_display_name` | character | Human-readable position name; `position_detail = TRUE` only. |
+| `position_abbreviation` | character | Position abbreviation (e.g. `QB`); `position_detail = TRUE` only. |
 | `college_name` | character | Official college (usually the last one attended) |
-| `status_id` | integer | Status identifier. |
-| `status_name` | character | Status label. |
+| `status_id` | integer | ESPN commitment status id. |
+| `status_name` | character | Status-type key (e.g. `STATUS_FINAL`). |
 | `general_fumbles` | double | Total number of times the player fumbled the ball regardless of who recovered it. |
 | `general_fumbles_lost` | double | Number of fumbles by the player that were subsequently recovered by the opposing team. |
 | `general_fumbles_forced` | double | Number of fumbles the player forced from opposing ball carriers. |
@@ -339,17 +339,17 @@ A single-row wide DataFrame (polars by default). When `raw=True` returns the raw
 | `scoring_two_point_rec_convs` | double | Number of successful two-point conversion receptions caught by the player. |
 | `scoring_two_point_rush_convs` | double | Number of successful two-point conversion rushes scored by the player. |
 | `scoring_one_pt_safeties_made` | double | Number of one-point safeties recorded, scored when the defense stops an offense that is attempting a two-point conversion in their own end zone. |
-| `team_id` | integer | Unique team identifier. |
+| `team_id` | integer | ESPN team id. |
 | `team_uid` | character | ESPN universal team identifier (UID format 's:40~l:...~t:...'). |
 | `team_guid` | character | ESPN team GUID. |
-| `team_slug` | character | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
-| `team_location` | character | Team city or location string. |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
-| `team_abbreviation` | character | Short team abbreviation (e.g. 'LAS'). |
-| `team_display_name` | character | Full team display name. |
-| `team_short_display_name` | character | Short team display name (e.g. 'Aces'). |
-| `team_color` | character | Team primary color (hex without leading '#'). |
-| `team_alternate_color` | character | Team alternate color (hex without leading '#'). |
+| `team_slug` | character | Team slug for the stat row. |
+| `team_location` | character | Team location / school name; `team_detail = TRUE` only. |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
+| `team_abbreviation` | character | Team abbreviation; `team_detail = TRUE` only. |
+| `team_display_name` | character | Full team display name; `team_detail = TRUE` only. |
+| `team_short_display_name` | character | Short team display name; `team_detail = TRUE` only. |
+| `team_color` | character | Primary team color; `team_detail = TRUE` only. |
+| `team_alternate_color` | character | Alternate team color; `team_detail = TRUE` only. |
 | `team_is_active` | logical | TRUE if the team is currently active. |
 | `team_logo_href` | character | Default team logo URL; `team_detail = TRUE` only. |
 
@@ -383,24 +383,24 @@ Polars dataframe containing schedule dates for the requested season. Returns Non
 | col_name | type | description |
 |---|---|---|
 | `id` | character | ID of the player in the 'name' column. |
-| `uid` | character | ESPN UID string. |
-| `date` | character | Date in YYYY-MM-DD format. |
-| `attendance` | integer | Reported attendance. |
+| `uid` | character | ESPN global unique identifier. |
+| `date` | character | Date of the poll release. |
+| `attendance` | integer | Reported attendance at the game. |
 | `time_valid` | logical | Whether the start time is confirmed. |
-| `neutral_site` | logical | Neutral site. |
+| `neutral_site` | logical | TRUE/FALSE flag for if the game took place at a neutral site. |
 | `conference_competition` | logical | Conference competition. |
 | `play_by_play_available` | logical | Whether play-by-play data is available. |
 | `recent` | logical | Whether the game is recent. |
-| `start_date` | character | Start date (YYYY-MM-DD). |
-| `broadcast` | character | Broadcast information string. |
+| `start_date` | character | Season start timestamp (ISO 8601, UTC). |
+| `broadcast` | character | Broadcast network short name. |
 | `highlights` | character | Game highlight urls. |
 | `notes_type` | character | Notes type. |
 | `notes_headline` | character | Notes headline. |
 | `broadcast_market` | character | Broadcast market label (e.g. 'national', 'home'). |
 | `broadcast_name` | character | Broadcast name. |
-| `type_id` | character | Type identifier (numeric). |
-| `type_abbreviation` | character | Play type abbreviation. |
-| `venue_id` | character | Unique venue identifier. |
+| `type_id` | character | Play-type id. |
+| `type_abbreviation` | character | Play-type abbreviation (e.g. `RUSH`, `TD`). |
+| `venue_id` | character | Referencing venue id. |
 | `venue_full_name` | character | Venue full name. |
 | `venue_address_city` | character | Venue address city. |
 | `venue_address_state` | character | Venue address state / region. |
@@ -418,7 +418,7 @@ Polars dataframe containing schedule dates for the requested season. Returns Non
 | `status_type_short_detail` | character | Status type short detail. |
 | `status_is_tbd_flex` | logical | Boolean flag indicating whether the game's broadcast slot is designated as a flex/TBD window. |
 | `format_regulation_periods` | integer | Format regulation periods. |
-| `home_id` | character | Unique identifier for home. |
+| `home_id` | character | Home team referencing id. |
 | `home_uid` | character | Home team's uid. |
 | `home_location` | character | Home team's location. |
 | `home_name` | character | Home team display name. |
@@ -434,7 +434,7 @@ Polars dataframe containing schedule dates for the requested season. Returns Non
 | `home_current_rank` | integer | Current AP or ESPN power ranking of the home team at the time of the game. |
 | `home_linescores` | list | Comma-separated or serialized quarter-by-quarter score totals for the home team. |
 | `home_records` | character | Serialized win-loss-tie record(s) for the home team (e.g., overall, home, away, conference). |
-| `away_id` | character | Unique identifier for away. |
+| `away_id` | character | Away team referencing id. |
 | `away_uid` | character | Away team's uid. |
 | `away_location` | character | Away team's location. |
 | `away_name` | character | Away team display name. |
@@ -555,7 +555,7 @@ Polars dataframe containing historical contracts available.
 | `player_page` | character | Player's OverTheCap url |
 | `otc_id` | integer | Over the Cap ID for player |
 | `gsis_id` | character | Game Stats and Info Service ID: the primary ID for play-by-play data. |
-| `date_of_birth` | character | Date of birth (YYYY-MM-DD). |
+| `date_of_birth` | character | Player date of birth (if published). |
 | `height` | character | Official height, in inches |
 | `weight` | character | Official weight, in pounds |
 | `college` | character | Official college (usually the last one attended) |
@@ -1340,7 +1340,7 @@ Polars dataframe containing historical contracts available.
 | `player_page` | character | Player's OverTheCap url |
 | `otc_id` | integer | Over the Cap ID for player |
 | `gsis_id` | character | Game Stats and Info Service ID: the primary ID for play-by-play data. |
-| `date_of_birth` | character | Date of birth (YYYY-MM-DD). |
+| `date_of_birth` | character | Player date of birth (if published). |
 | `height` | character | Official height, in inches |
 | `weight` | character | Official weight, in pounds |
 | `college` | character | Official college (usually the last one attended) |
@@ -3040,12 +3040,12 @@ Polars dataframe containing teams available.
 | col_name | type | description |
 |---|---|---|
 | `team_abbr` | character | Official team abbreveation |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
-| `team_id` | integer | Unique team identifier. |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
+| `team_id` | integer | ESPN team id. |
 | `team_nick` | character | Team nickname (e.g., 'Chiefs', 'Eagles', 'Patriots') without the city or state prefix. |
 | `team_conf` | character | Conference affiliation of the team (e.g., 'AFC' or 'NFC'). |
 | `team_division` | character | Division affiliation of the team (e.g., 'AFC North', 'NFC West'). |
-| `team_color` | character | Team primary color (hex without leading '#'). |
+| `team_color` | character | Primary team color; `team_detail = TRUE` only. |
 | `team_color2` | character | Secondary brand color for the team in hexadecimal format (e.g., '#FFB612'). |
 | `team_color3` | character | Tertiary brand color for the team in hexadecimal format, used in alternate uniforms or accents. |
 | `team_color4` | character | Quaternary brand color for the team in hexadecimal format, part of the team's full brand palette. |
@@ -3846,12 +3846,12 @@ Polars dataframe containing teams available.
 | col_name | type | description |
 |---|---|---|
 | `team_abbr` | character | Official team abbreveation |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
-| `team_id` | integer | Unique team identifier. |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
+| `team_id` | integer | ESPN team id. |
 | `team_nick` | character | Team nickname or mascot name (e.g., 'Chiefs', 'Patriots'). |
 | `team_conf` | character | Conference the team belongs to (e.g., 'AFC', 'NFC'). |
 | `team_division` | character | Division within the conference the team belongs to (e.g., 'AFC East'). |
-| `team_color` | character | Team primary color (hex without leading '#'). |
+| `team_color` | character | Primary team color; `team_detail = TRUE` only. |
 | `team_color2` | character | Secondary brand color for the team, expressed as a hex color code. |
 | `team_color3` | character | Tertiary brand color for the team, expressed as a hex color code. |
 | `team_color4` | character | Quaternary brand color for the team, expressed as a hex color code. |
@@ -5389,19 +5389,19 @@ Polars dataframe containing teams for the requested league. This function caches
 
 | col_name | type | description |
 |---|---|---|
-| `team_abbreviation` | character | Short team abbreviation (e.g. 'LAS'). |
-| `team_alternate_color` | character | Team alternate color (hex without leading '#'). |
-| `team_color` | character | Team primary color (hex without leading '#'). |
-| `team_display_name` | character | Full team display name. |
-| `team_id` | character | Unique team identifier. |
+| `team_abbreviation` | character | Team abbreviation; `team_detail = TRUE` only. |
+| `team_alternate_color` | character | Alternate team color; `team_detail = TRUE` only. |
+| `team_color` | character | Primary team color; `team_detail = TRUE` only. |
+| `team_display_name` | character | Full team display name; `team_detail = TRUE` only. |
+| `team_id` | character | ESPN team id. |
 | `team_is_active` | logical | TRUE if the team is currently active. |
 | `team_is_all_star` | logical | TRUE if the row represents an All-Star team. |
-| `team_location` | character | Team city or location string. |
+| `team_location` | character | Team location / school name; `team_detail = TRUE` only. |
 | `team_logos` | integer | Team logo metadata. |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
-| `team_nickname` | character | Team nickname. |
-| `team_short_display_name` | character | Short team display name (e.g. 'Aces'). |
-| `team_slug` | character | URL-safe team identifier (e.g. 'lasvegas-aces' / 'aces'). |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
+| `team_nickname` | character | Team nickname label; `team_detail = TRUE` only. |
+| `team_short_display_name` | character | Short team display name; `team_detail = TRUE` only. |
+| `team_slug` | character | Team slug for the stat row. |
 | `team_uid` | character | ESPN universal team identifier (UID format 's:40~l:...~t:...'). |
 
 **Example**
@@ -6514,7 +6514,7 @@ A polars (or pandas) `DataFrame`, one row per team.
 | `teamType` | character | Classification of the team type within the NFL system (e.g., 'NFL' for active franchises). |
 | `ticketPhoneNumber` | character | Phone number for ticket sales inquiries for this team. |
 | `yearFound` | integer | Year the franchise was founded. |
-| `conference_id` | character | Conference identifier. |
+| `conference_id` | character | Referencing conference id. |
 | `conference_abbr` | character | Conference abbreviation. |
 | `conference_fullName` | character | Full name of the conference the team belongs to (e.g., 'American Football Conference'). |
 | `division_id` | character | Division MLBAM ID. |
@@ -6622,7 +6622,7 @@ A polars (or pandas) `DataFrame`, one row per chart in the page.
 | `teamId` | character | Unique numeric identifier for the player's team in the NFL NGS/Shield data system. |
 | `timestamp` | integer | Response timestamp (ISO 8601). |
 | `touchdowns` | integer | Total number of touchdowns scored or thrown by the player featured on the NGS microsite chart. |
-| `type` | character | Record type / category. |
+| `type` | character | Record-type category (e.g. `total`, `home`, `road`). |
 | `week` | integer | Season week. |
 | `extraLargeImg` | character | URL to the extra-large player image asset used on the NFL NGS microsite chart display. |
 | `playerNameSlug` | character | URL-safe slug version of the player's name used in NGS microsite routing (e.g., 'patrick-mahomes'). |
@@ -7871,14 +7871,14 @@ A polars (or pandas) `DataFrame`, one row per game.
 |---|---|---|
 | `id` | character | ID of the player in the 'name' column. |
 | `category` | character | Broader category of player positions |
-| `date` | character | Date in YYYY-MM-DD format. |
+| `date` | character | Date of the poll release. |
 | `time` | character | Time at start of play provided in string format as minutes:seconds remaining in the quarter. |
 | `gameType` | character | Game type identifier (3 for playoffs). |
 | `international` | logical | Boolean flag indicating whether this game is designated as an international (outside the United States) game. |
 | `neutralSite` | logical | Whether the game is at a neutral site. |
 | `season` | integer | 4 digit number indicating to which season(s) the specified timeframe belongs to. |
 | `seasonType` | character | Phase of the season in which this game takes place (e.g., 'REG', 'POST', 'PRE'). |
-| `status` | character | Status label. |
+| `status` | character | Game status (e.g. "scheduled", "in_progress", "completed"). |
 | `week` | integer | Season week. |
 | `weekType` | character | Classification of the week type within the season (e.g., 'REG', 'WC', 'DIV', 'CONF', 'SB'). |
 | `externalIds` | character | Serialized list of external system identifiers (e.g., partner IDs, league IDs) mapped to this game. |
@@ -7898,9 +7898,9 @@ A polars (or pandas) `DataFrame`, one row per game.
 | `broadcastInfo_streamingNetworks` | character | Serialized list of streaming platforms (e.g., Peacock, Amazon Prime Video) carrying the game. |
 | `broadcastInfo_territory` | character | Geographic territory or market designation for which this broadcast record applies. |
 | `broadcastInfo_audioNetworks` | character | Serialized list of radio networks carrying the game's audio broadcast. |
-| `venue_id` | character | Unique venue identifier. |
-| `venue_name` | character | Venue name. |
-| `venue_city` | character | Venue city. |
+| `venue_id` | character | Referencing venue id. |
+| `venue_name` | character | Full name of the franchise's venue. |
+| `venue_city` | character | City where the venue is located. |
 | `venue_country` | character | Country name or ISO code indicating where the game's venue is located. |
 
 **Example**

--- a/docs/docs/nfl/reference/pff_core.md
+++ b/docs/docs/nfl/reference/pff_core.md
@@ -35,7 +35,7 @@ Facet report /defense/run (By Position leaderboard; add franchiseId for By Team,
 | `draft_season` | numeric |  |
 | `eligible_season` | numeric |  |
 | `forced_fumbles` | numeric |  |
-| `franchise_id` | numeric | ESPN franchise identifier. |
+| `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
 | `grades_coverage_defense` | numeric |  |
 | `grades_defense` | numeric |  |
 | `grades_defense_penalty` | numeric |  |
@@ -56,7 +56,7 @@ Facet report /defense/run (By Position leaderboard; add franchiseId for By Team,
 | `stops` | numeric |  |
 | `tackles` | numeric | Team tackles. |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -94,7 +94,7 @@ Facet report /field_goal/summary (By Position leaderboard; add franchiseId for B
 | `pat_percent` | numeric |  |
 | `draft_season` | numeric |  |
 | `forty_made` | numeric |  |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
 | `fifty_percent` | numeric |  |
 | `total_made` | numeric |  |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
@@ -120,7 +120,7 @@ Facet report /field_goal/summary (By Position leaderboard; add franchiseId for B
 | `twenty_percent` | numeric |  |
 | `forty_percent` | numeric |  |
 | `player` | character | Player name |
-| `franchise_id` | numeric | ESPN franchise identifier. |
+| `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
 | `fifty_made` | numeric |  |
 | `thirty_made` | numeric |  |
 | `player_id` | numeric | Player ID (aka GSIS ID) as defined by nflreadr::load_rosters |
@@ -162,7 +162,7 @@ Facet report /defense/coverage (By Position leaderboard; add franchiseId for By 
 | `draft_season` | numeric |  |
 | `missed_tackles` | numeric |  |
 | `catch_rate` | numeric |  |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
 | `tackles` | numeric | Team tackles. |
 | `coverage_percent` | numeric |  |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
@@ -191,7 +191,7 @@ Facet report /defense/coverage (By Position leaderboard; add franchiseId for By 
 | `yards_per_reception` | numeric |  |
 | `grades_defense_penalty` | numeric |  |
 | `player` | character | Player name |
-| `franchise_id` | numeric | ESPN franchise identifier. |
+| `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
 | `yards_after_catch` | numeric | Numeric value for distance in yards perpendicular to the yard line where the receiver made the reception to where the play ended. |
 | `avg_depth_of_target` | numeric |  |
 | `pass_break_ups` | numeric |  |
@@ -244,7 +244,7 @@ Facet report /kickoff/summary (By Position leaderboard; add franchiseId for By T
 | `draft_season` | numeric |  |
 | `eligible_season` | numeric |  |
 | `fair_catches` | numeric |  |
-| `franchise_id` | numeric | ESPN franchise identifier. |
+| `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
 | `grades_kickoff_kicker` | numeric |  |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
 | `kicked_yards` | numeric |  |
@@ -258,7 +258,7 @@ Facet report /kickoff/summary (By Position leaderboard; add franchiseId for By T
 | `position` | character | Primary position as reported by NFL.com |
 | `return_yards` | numeric | Yards gained by the return team. Returns may occur on any of: interception, fumble, kickoff, punt, or blocked kicks. |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
 | `total_hangtime` | numeric |  |
 | `touchbacks` | numeric |  |
 
@@ -300,7 +300,7 @@ Facet report /offense/blocking (By Position leaderboard; add franchiseId for By 
 | `non_spike_pass_block_percentage` | numeric |  |
 | `draft_season` | numeric |  |
 | `snap_counts_rg` | numeric |  |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
 | `snap_counts_ce` | numeric |  |
 | `hits_allowed` | numeric |  |
@@ -324,7 +324,7 @@ Facet report /offense/blocking (By Position leaderboard; add franchiseId for By 
 | `non_spike_pass_block` | numeric |  |
 | `snap_counts_lt` | numeric |  |
 | `player` | character | Player name |
-| `franchise_id` | numeric | ESPN franchise identifier. |
+| `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
 | `snap_counts_pass_block` | numeric |  |
 | `pass_block_percent` | numeric |  |
 | `snap_counts_lg` | numeric |  |
@@ -519,7 +519,7 @@ Facet report /passing/allowed_pressure (By Position leaderboard; add franchiseId
 | `draft_season` | numeric |  |
 | `pressures_lt` | numeric |  |
 | `pressures_rg` | numeric |  |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
 | `lt_percent` | numeric |  |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
 | `hits_allowed` | numeric |  |
@@ -546,7 +546,7 @@ Facet report /passing/allowed_pressure (By Position leaderboard; add franchiseId
 | `lg_percent` | numeric |  |
 | `player` | character | Player name |
 | `rt_percent` | numeric |  |
-| `franchise_id` | numeric | ESPN franchise identifier. |
+| `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
 | `other_percent` | numeric |  |
 | `pressures_off` | numeric |  |
 | `rg_percent` | numeric |  |
@@ -588,7 +588,7 @@ Facet report /defense/pass_rush (By Position leaderboard; add franchiseId for By
 | `draft_season` | numeric |  |
 | `true_pass_set_prp` | numeric |  |
 | `true_pass_set_hurries` | numeric |  |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
 | `prp` | numeric |  |
 | `true_pass_set_sacks` | numeric |  |
 | `pass_rush_win_rate` | numeric |  |
@@ -616,7 +616,7 @@ Facet report /defense/pass_rush (By Position leaderboard; add franchiseId for By
 | `true_pass_set_grades_pass_rush_defense` | numeric |  |
 | `true_pass_set_batted_passes` | numeric |  |
 | `player` | character | Player name |
-| `franchise_id` | numeric | ESPN franchise identifier. |
+| `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
 | `pass_rush_percent` | numeric |  |
 | `true_pass_set_pass_rush_opp` | numeric |  |
 | `true_pass_set_pass_rush_percent` | numeric |  |
@@ -688,7 +688,7 @@ Facet report /passing/concept (By Position leaderboard; add franchiseId for By T
 | `screen_spikes` | numeric |  |
 | `pa_first_downs` | numeric |  |
 | `pa_big_time_throws` | numeric |  |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
 | `pa_spikes` | numeric |  |
 | `pa_sack_percent` | numeric |  |
 | `screen_dropbacks_percent` | numeric |  |
@@ -800,7 +800,7 @@ Facet report /passing/concept (By Position leaderboard; add franchiseId for By T
 | `player` | character | Player name |
 | `pa_drops` | numeric |  |
 | `pa_btt_rate` | numeric |  |
-| `franchise_id` | numeric | ESPN franchise identifier. |
+| `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
 | `screen_big_time_throws` | numeric |  |
 | `screen_aimed_passes` | numeric |  |
 | `npa_touchdowns` | numeric |  |
@@ -911,7 +911,7 @@ Facet report /defense/coverage_scheme (By Position leaderboard; add franchiseId 
 | `draft_season` | numeric |  |
 | `zone_coverage_snaps_per_target` | numeric |  |
 | `man_yards_per_reception` | numeric |  |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
 | `man_snap_counts_coverage` | numeric |  |
 | `man_tackles` | numeric |  |
@@ -954,7 +954,7 @@ Facet report /defense/coverage_scheme (By Position leaderboard; add franchiseId 
 | `zone_avg_depth_of_target` | numeric |  |
 | `man_snap_counts_coverage_percent` | numeric |  |
 | `player` | character | Player name |
-| `franchise_id` | numeric | ESPN franchise identifier. |
+| `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
 | `zone_forced_incompletes` | numeric |  |
 | `man_forced_incompletion_rate` | numeric |  |
 | `zone_targets` | numeric |  |
@@ -1155,7 +1155,7 @@ Facet report /passing/detail (By Position leaderboard; add franchiseId for By Te
 | `left_behind_los_btt_rate` | numeric |  |
 | `right_behind_los_btt_rate` | numeric |  |
 | `pa_big_time_throws` | numeric |  |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
 | `short_touchdowns` | numeric |  |
 | `pa_spikes` | numeric |  |
 | `center_medium_drops` | numeric |  |
@@ -1758,7 +1758,7 @@ Facet report /passing/detail (By Position leaderboard; add franchiseId for By Te
 | `right_medium_drop_rate` | numeric |  |
 | `blitz_passing_snaps` | numeric |  |
 | `center_medium_big_time_throws` | numeric |  |
-| `franchise_id` | numeric | ESPN franchise identifier. |
+| `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
 | `left_short_completion_percent` | numeric |  |
 | `screen_big_time_throws` | numeric |  |
 | `left_short_drop_rate` | numeric |  |
@@ -1989,7 +1989,7 @@ Facet report /offense/run_blocking (By Position leaderboard; add franchiseId for
 | `declined_penalties` | numeric |  |
 | `draft_season` | numeric |  |
 | `eligible_season` | numeric |  |
-| `franchise_id` | numeric | ESPN franchise identifier. |
+| `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
 | `gap_grades_run_block` | numeric |  |
 | `gap_run_block_percent` | numeric |  |
 | `gap_snap_counts_run_block` | numeric |  |
@@ -2006,7 +2006,7 @@ Facet report /offense/run_blocking (By Position leaderboard; add franchiseId for
 | `snap_counts_run_block` | numeric |  |
 | `snap_counts_run_play` | numeric |  |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
 | `zone_grades_run_block` | numeric |  |
 | `zone_run_block_percent` | numeric |  |
 | `zone_snap_counts_run_block` | numeric |  |
@@ -2052,7 +2052,7 @@ Facet report /offense/pass_blocking (By Position leaderboard; add franchiseId fo
 | `pbe` | numeric |  |
 | `non_spike_pass_block_percentage` | numeric |  |
 | `draft_season` | numeric |  |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
 | `hits_allowed` | numeric |  |
 | `true_pass_set_non_spike_pass_block` | numeric |  |
@@ -2075,7 +2075,7 @@ Facet report /offense/pass_blocking (By Position leaderboard; add franchiseId fo
 | `true_pass_set_snap_counts_pass_block` | numeric |  |
 | `player` | character | Player name |
 | `true_pass_set_sacks_allowed` | numeric |  |
-| `franchise_id` | numeric | ESPN franchise identifier. |
+| `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
 | `snap_counts_pass_block` | numeric |  |
 | `pass_block_percent` | numeric |  |
 | `player_id` | numeric | Player ID (aka GSIS ID) as defined by nflreadr::load_rosters |
@@ -2198,7 +2198,7 @@ Facet report /punting/summary (By Position leaderboard; add franchiseId for By T
 | `draft_season` | numeric |  |
 | `percent_returned` | numeric |  |
 | `fair_catches` | numeric |  |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
 | `player_game_count` | numeric |  |
 | `eligible_season` | numeric |  |
@@ -2220,7 +2220,7 @@ Facet report /punting/summary (By Position leaderboard; add franchiseId for By T
 | `blocks` | numeric | Total blocks. |
 | `average_yards_per_attempt` | numeric |  |
 | `player` | character | Player name |
-| `franchise_id` | numeric | ESPN franchise identifier. |
+| `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
 | `grades_punter` | numeric |  |
 | `return_yards` | numeric | Yards gained by the return team. Returns may occur on any of: interception, fumble, kickoff, punt, or blocked kicks. |
 | `downeds` | numeric |  |
@@ -2344,7 +2344,7 @@ Facet report /passing/depth (By Position leaderboard; add franchiseId for By Tea
 | `center_behind_los_completion_percent` | numeric |  |
 | `left_behind_los_btt_rate` | numeric |  |
 | `right_behind_los_btt_rate` | numeric |  |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
 | `short_touchdowns` | numeric |  |
 | `center_medium_drops` | numeric |  |
 | `left_behind_los_aimed_passes` | numeric |  |
@@ -2726,7 +2726,7 @@ Facet report /passing/depth (By Position leaderboard; add franchiseId for By Tea
 | `right_medium_yards` | numeric |  |
 | `right_medium_drop_rate` | numeric |  |
 | `center_medium_big_time_throws` | numeric |  |
-| `franchise_id` | numeric | ESPN franchise identifier. |
+| `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
 | `left_short_completion_percent` | numeric |  |
 | `left_short_drop_rate` | numeric |  |
 | `left_behind_los_scrambles` | numeric |  |
@@ -2880,7 +2880,7 @@ Facet report /passing/pressure (By Position leaderboard; add franchiseId for By 
 | `pressure_aimed_passes` | numeric |  |
 | `blitz_sacks` | numeric |  |
 | `no_pressure_interceptions` | numeric |  |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
 | `pressure_epa` | numeric |  |
 | `blitz_completions` | numeric |  |
 | `blitz_attempts` | numeric |  |
@@ -2998,7 +2998,7 @@ Facet report /passing/pressure (By Position leaderboard; add franchiseId for By 
 | `no_pressure_turnover_worthy_plays` | numeric |  |
 | `pressure_first_downs` | numeric |  |
 | `blitz_passing_snaps` | numeric |  |
-| `franchise_id` | numeric | ESPN franchise identifier. |
+| `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
 | `no_pressure_twp_rate` | numeric |  |
 | `no_blitz_sacks` | numeric |  |
 | `no_blitz_grades_pass_route` | numeric |  |
@@ -3183,7 +3183,7 @@ Facet report /return/summary (By Position leaderboard; add franchiseId for By Te
 | `declined_penalties` | numeric |  |
 | `draft_season` | numeric |  |
 | `eligible_season` | numeric |  |
-| `franchise_id` | numeric | ESPN franchise identifier. |
+| `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
 | `grades_kick_return` | numeric |  |
 | `grades_return` | numeric |  |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
@@ -3207,7 +3207,7 @@ Facet report /return/summary (By Position leaderboard; add franchiseId for By Te
 | `punt_yards` | numeric |  |
 | `punt_ypa` | numeric |  |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
 | `total_attempts` | numeric |  |
 | `grades_punt_return` | numeric |  |
 
@@ -3246,13 +3246,13 @@ Facet report /rushing/direction (By Position leaderboard; add franchiseId for By
 | `directions` | list |  |
 | `draft_season` | numeric |  |
 | `eligible_season` | numeric |  |
-| `franchise_id` | numeric | ESPN franchise identifier. |
+| `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
 | `player` | character | Player name |
 | `player_id` | numeric | Player ID (aka GSIS ID) as defined by nflreadr::load_rosters |
 | `position` | character | Primary position as reported by NFL.com |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
 | `total_attempts` | numeric |  |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
@@ -3406,7 +3406,7 @@ Facet report /signature/defense/slot_coverage (By Position leaderboard; add fran
 | `coverage_snaps_per_target` | numeric |  |
 | `draft_season` | numeric |  |
 | `eligible_season` | numeric |  |
-| `franchise_id` | numeric | ESPN franchise identifier. |
+| `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
 | `interceptions` | numeric | The number of interceptions thrown. |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
 | `player` | character | Player name |
@@ -3417,7 +3417,7 @@ Facet report /signature/defense/slot_coverage (By Position leaderboard; add fran
 | `receptions` | numeric | The number of pass receptions. Lateral receptions officially don't count as reception. |
 | `targets` | numeric | The number of pass plays where the player was the targeted receiver. |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
 | `touchdowns` | numeric |  |
 | `yards` | numeric | The number of receiving yards |
 | `yards_after_catch` | numeric | Numeric value for distance in yards perpendicular to the yard line where the receiver made the reception to where the play ended. |
@@ -3456,7 +3456,7 @@ Facet report /signature/pass-blocking/efficiency/line (By Position leaderboard; 
 | col_name | type | description |
 |---|---|---|
 | `attempts` | numeric | The number of pass attempts as defined by the NFL. |
-| `franchise_id` | numeric | ESPN franchise identifier. |
+| `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
 | `hits_allowed` | numeric |  |
 | `hurries_allowed` | numeric |  |
 | `pass_snaps` | numeric |  |
@@ -3465,7 +3465,7 @@ Facet report /signature/pass-blocking/efficiency/line (By Position leaderboard; 
 | `pressures_allowed` | numeric |  |
 | `sacks_allowed` | numeric | Opponent sacks. |
 | `season_id` | numeric | Unique season identifier. |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -3505,7 +3505,7 @@ Facet report /signature/defense/outside_pass_rush (By Position leaderboard; add 
 | `draft_season` | numeric |  |
 | `pass_snaps` | numeric |  |
 | `lhs_hurries` | numeric |  |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
 | `prp` | numeric |  |
 | `tackles` | numeric | Team tackles. |
 | `rhs_pressures` | numeric |  |
@@ -3534,7 +3534,7 @@ Facet report /signature/defense/outside_pass_rush (By Position leaderboard; add 
 | `misses` | numeric |  |
 | `player` | character | Player name |
 | `rhs_sacks` | numeric |  |
-| `franchise_id` | numeric | ESPN franchise identifier. |
+| `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
 | `pass_rush_percent` | numeric |  |
 | `rhs_hurries` | numeric |  |
 | `rhs_assists` | numeric |  |
@@ -3589,7 +3589,7 @@ Facet report /receiving/scheme (By Position leaderboard; add franchiseId for By 
 | `zone_positive_epa_percent` | numeric |  |
 | `man_targets_percent` | numeric |  |
 | `man_yards_per_reception` | numeric |  |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
 | `man_drop_rate` | numeric |  |
 | `zone_grades_pass_route` | numeric |  |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
@@ -3638,7 +3638,7 @@ Facet report /receiving/scheme (By Position leaderboard; add franchiseId for By 
 | `zone_yards_after_catch_per_reception` | numeric |  |
 | `zone_avg_depth_of_target` | numeric |  |
 | `player` | character | Player name |
-| `franchise_id` | numeric | ESPN franchise identifier. |
+| `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
 | `zone_contested_targets` | numeric |  |
 | `zone_contested_receptions` | numeric |  |
 | `man_contested_receptions` | numeric |  |
@@ -3700,7 +3700,7 @@ Facet report /signature/passing/time_in_pocket (By Position leaderboard; add fra
 | `less_aimed_passes` | numeric |  |
 | `more_dropbacks_percent` | numeric |  |
 | `less_positive_epa_percent` | numeric |  |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
 | `avg_ttt_scrambles` | numeric |  |
 | `more_yards` | numeric |  |
 | `more_accuracy_percent` | numeric |  |
@@ -3760,7 +3760,7 @@ Facet report /signature/passing/time_in_pocket (By Position leaderboard; add fra
 | `more_drops` | numeric |  |
 | `player` | character | Player name |
 | `more_touchdowns` | numeric |  |
-| `franchise_id` | numeric | ESPN franchise identifier. |
+| `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
 | `more_drop_rate` | numeric |  |
 | `less_twp_rate` | numeric |  |
 | `more_grades_offense` | numeric |  |
@@ -3840,7 +3840,7 @@ Facet report /receiving/concept (By Position leaderboard; add franchiseId for By
 | `screen_yprr` | numeric |  |
 | `draft_season` | numeric |  |
 | `slot_routes` | numeric |  |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
 | `screen_grades_hands_drop` | numeric |  |
 | `jersey_number` | character | Jersey number. Often useful for joins by name/team/jersey. |
 | `screen_contested_catch_rate` | numeric |  |
@@ -3892,7 +3892,7 @@ Facet report /receiving/concept (By Position leaderboard; add franchiseId for By
 | `player` | character | Player name |
 | `slot_epa` | numeric |  |
 | `slot_drop_rate` | numeric |  |
-| `franchise_id` | numeric | ESPN franchise identifier. |
+| `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
 | `slot_touchdowns` | numeric |  |
 | `slot_yards_after_catch_per_reception` | numeric |  |
 | `screen_receptions` | numeric |  |
@@ -3944,7 +3944,7 @@ Facet report /special/summary (By Position leaderboard; add franchiseId for By T
 | `declined_penalties` | numeric |  |
 | `draft_season` | numeric |  |
 | `eligible_season` | numeric |  |
-| `franchise_id` | numeric | ESPN franchise identifier. |
+| `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
 | `grades_fgep_kicker` | numeric |  |
 | `grades_kickoff_kicker` | numeric |  |
 | `grades_misc_st` | numeric |  |
@@ -3964,7 +3964,7 @@ Facet report /special/summary (By Position leaderboard; add franchiseId for By T
 | `snap_counts_punt_return` | numeric |  |
 | `tackles` | numeric | Team tackles. |
 | `team` | character | NFL team. Uses official abbreviations as per NFL.com |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
 | `grades_fgep_defense` | numeric |  |
 | `grades_fgep_offense` | numeric |  |
 | `grades_long_snap` | numeric |  |
@@ -4081,7 +4081,7 @@ Facet report /receiving/depth (By Position leaderboard; add franchiseId for By T
 | `deep_yards_after_catch_per_reception` | numeric |  |
 | `center_deep_contested_receptions` | numeric |  |
 | `center_short_pass_blocks` | numeric |  |
-| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_name` | character | Team nickname; `team_detail = TRUE` only. |
 | `deep_pass_block_rate` | numeric |  |
 | `short_touchdowns` | numeric |  |
 | `center_medium_drops` | numeric |  |
@@ -4429,7 +4429,7 @@ Facet report /receiving/depth (By Position leaderboard; add franchiseId for By T
 | `medium_grades_hands_drop` | numeric |  |
 | `right_deep_pass_blocks` | numeric |  |
 | `medium_contested_catch_rate` | numeric |  |
-| `franchise_id` | numeric | ESPN franchise identifier. |
+| `franchise_id` | numeric | ESPN franchise id (parsed from `franchise_ref`). |
 | `center_behind_los_caught_percent` | numeric |  |
 | `right_behind_los_caught_percent` | numeric |  |
 | `short_pass_plays` | numeric |  |
@@ -4773,14 +4773,14 @@ Leagues + seasons + week groups (bootstrap)
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `abbreviation` | character | Short abbreviation. |
+| `abbreviation` | character | Metric abbreviation. |
 | `default_season` | numeric |  |
 | `default_week` | numeric |  |
 | `default_week_group` | character |  |
 | `id` | numeric | ID of the player in the 'name' column. |
 | `name` | character | Name, as reported by MFL but reordered into FirstName LastName instead of Last, First |
 | `seasons` | list | NBA seasons played. |
-| `slug` | character | URL-safe identifier. |
+| `slug` | character | URL slug for the team. |
 | `week_groups` | list |  |
 | `weeks` | list |  |
 
@@ -4815,7 +4815,7 @@ Teams / franchise groups + games for a league-season
 | `heirarchy` | list |  |
 | `id` | numeric | ID of the player in the 'name' column. |
 | `name` | character | Name, as reported by MFL but reordered into FirstName LastName instead of Last, First |
-| `slug` | character | URL-safe identifier. |
+| `slug` | character | URL slug for the team. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 
@@ -4861,12 +4861,12 @@ Team overview table (By Team landing)
 | `grades_run_block` | numeric |  |
 | `grades_run_defense` | numeric |  |
 | `grades_tackle` | numeric |  |
-| `losses` | numeric | Total losses. |
+| `losses` | numeric | Losses against the spread in the split. |
 | `name` | character | Name, as reported by MFL but reordered into FirstName LastName instead of Last, First |
 | `points_allowed` | numeric | Points for the opponent. |
 | `points_scored` | numeric |  |
 | `ties` | numeric | Number of ties in the series. |
-| `wins` | numeric | Total wins. |
+| `wins` | numeric | Wins against the spread in the split. |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
 

--- a/docs/docs/nfl/reference/site.md
+++ b/docs/docs/nfl/reference/site.md
@@ -29,7 +29,7 @@ ESPN endpoint.
 | col_name | type | description |
 |---|---|---|
 | `game_id` | character | ESPN event id. |
-| `uid` | character | ESPN UID string. |
+| `uid` | character | ESPN global unique identifier. |
 | `date` | character | Match start timestamp (ISO 8601, UTC). |
 | `name` | character | Full event name (e.g. 'Team A at Team B'). |
 | `short_name` | character | Abbreviated event name (e.g. 'TA @ TB'). |
@@ -48,15 +48,15 @@ ESPN endpoint.
 | `status_period` | integer | Current period. |
 | `neutral_site` | logical | Whether the match is played at a neutral venue. |
 | `conference_competition` | logical | Conference competition. |
-| `attendance` | integer | Reported attendance. |
-| `venue_id` | character | Unique venue identifier. |
+| `attendance` | integer | Reported attendance at the game. |
+| `venue_id` | character | Referencing venue id. |
 | `venue_full_name` | character | Venue full name. |
-| `venue_city` | character | Venue city. |
-| `venue_state` | character | Venue state / region. |
+| `venue_city` | character | City where the venue is located. |
+| `venue_state` | character | State (or province/country) where the venue is located. |
 | `venue_indoor` | logical | Whether the home venue is indoors. |
-| `broadcast` | character | Broadcast information string. |
+| `broadcast` | character | Broadcast network short name. |
 | `note` | character | Injury status and description. |
-| `home_id` | character | Unique identifier for home. |
+| `home_id` | character | Home team referencing id. |
 | `home_name` | character | Home team display name. |
 | `home_abbreviation` | character | Home team's abbreviation. |
 | `home_display_name` | character | Home team display name. |
@@ -67,7 +67,7 @@ ESPN endpoint.
 | `home_score` | character | Home team's score. For cricket, the innings string (e.g. '161/5 (18/20 ov, target 156)'). |
 | `home_winner` | logical | Whether the home team won. |
 | `home_rank` | character | Home team rank (if ranked). |
-| `away_id` | character | Unique identifier for away. |
+| `away_id` | character | Away team referencing id. |
 | `away_name` | character | Away team display name. |
 | `away_abbreviation` | character | Away team's abbreviation. |
 | `away_display_name` | character | Away team display name. |
@@ -277,7 +277,7 @@ ESPN endpoint.
 | `ties` | character | Number of ties in the series. |
 | `win_percent` | character | Win percent. |
 | `wins` | character | Wins. |
-| `overall` | character | Overall pick number. |
+| `overall` | character | Overall draft pick number. |
 
 **format**
 
@@ -380,7 +380,7 @@ ESPN endpoint.
 | `team_name` | character | Full display name of the team. |
 | `team_abbreviation` | character | Team abbreviation. |
 | `team_display_name` | character | Team display name. |
-| `team_short_display_name` | character | Short team display name (e.g. 'Aces'). |
+| `team_short_display_name` | character | Short team display name; `team_detail = TRUE` only. |
 | `team_logos` | character | Team logos. |
 | `start_period_type` | character | Period type at the start of the drive (e.g. `quarter`). |
 | `start_period_number` | integer | Period or quarter number in which the drive or sequence began. |
@@ -415,7 +415,7 @@ ESPN endpoint.
 | `is_turnover` | logical | `TRUE` if the play was a turnover. |
 | `type_id` | character | Type id. |
 | `type_text` | character | Type text. |
-| `type_abbreviation` | character | Play type abbreviation. |
+| `type_abbreviation` | character | Play-type abbreviation (e.g. `RUSH`, `TD`). |
 | `period_number` | integer | Period number. |
 | `clock_display_value` | character | Clock display value. |
 | `start_down` | integer | Down at the start of the play. |
@@ -452,7 +452,7 @@ ESPN endpoint.
 | `home_score` | integer | Home score. |
 | `type_id` | character | Type id. |
 | `type_text` | character | Type text. |
-| `type_abbreviation` | character | Play type abbreviation. |
+| `type_abbreviation` | character | Play-type abbreviation (e.g. `RUSH`, `TD`). |
 | `period_number` | integer | Period number. |
 | `clock_value` | double | Clock value in seconds. |
 | `clock_display_value` | character | Clock display value. |

--- a/docs/docs/wbb/reference/additional.md
+++ b/docs/docs/wbb/reference/additional.md
@@ -394,11 +394,11 @@ Polars dataframe containing schedule dates for the requested season. Returns Non
 | `uid` | character | ESPN UID string. |
 | `date` | character | Date in YYYY-MM-DD format. |
 | `attendance` | integer | Reported attendance. |
-| `time_valid` | logical | Whether the start time is confirmed. |
+| `time_valid` | logical | Time valid. |
 | `neutral_site` | logical | Neutral site. |
 | `conference_competition` | logical | Conference competition. |
 | `play_by_play_available` | logical | Whether play-by-play data is available. |
-| `recent` | logical | Whether the game is recent. |
+| `recent` | logical | Recent. |
 | `tournament_id` | integer | ESPN tournament identifier. |
 | `start_date` | character | Start date (YYYY-MM-DD). |
 | `broadcast` | character | Broadcast information string. |
@@ -413,14 +413,14 @@ Polars dataframe containing schedule dates for the requested season. Returns Non
 | `venue_full_name` | character | Venue full name. |
 | `venue_address_city` | character | Venue address city. |
 | `venue_address_state` | character | Venue address state / region. |
-| `venue_indoor` | logical | Whether the home venue is indoors. |
-| `status_clock` | double | Game clock in seconds. |
+| `venue_indoor` | logical | TRUE if the venue is indoors. |
+| `status_clock` | double | Status clock. |
 | `status_display_clock` | character | Status display clock. |
-| `status_period` | integer | Current period. |
+| `status_period` | integer | Status period. |
 | `status_type_id` | character | Unique identifier for status type. |
 | `status_type_name` | character | Status type name. |
-| `status_type_state` | character | Status state (pre/in/post). |
-| `status_type_completed` | logical | Whether the game is complete. |
+| `status_type_state` | character | Status type state. |
+| `status_type_completed` | logical | Status type completed. |
 | `status_type_description` | character | Status type description. |
 | `status_type_detail` | character | Status type detail. |
 | `status_type_short_detail` | character | Status type short detail. |
@@ -428,36 +428,36 @@ Polars dataframe containing schedule dates for the requested season. Returns Non
 | `home_id` | character | Unique identifier for home. |
 | `home_uid` | character | Home team's uid. |
 | `home_location` | character | Home team's location. |
-| `home_name` | character | Home team display name. |
+| `home_name` | character | Home name. |
 | `home_abbreviation` | character | Home team's abbreviation. |
-| `home_display_name` | character | Home team display name. |
+| `home_display_name` | character | Home display name. |
 | `home_short_display_name` | character | Home short display name. |
-| `home_color` | character | Home team primary color hex. |
+| `home_color` | character | Color code (hex) for home. |
 | `home_alternate_color` | character | Color code (hex) for home alternate. |
 | `home_is_active` | logical | Home team's is active. |
 | `home_venue_id` | character | Unique identifier for home venue. |
 | `home_logo` | character | Home team logo URL. |
 | `home_conference_id` | character | Unique identifier for home conference. |
 | `home_score` | character | Home team score at the time of the play. |
-| `home_winner` | logical | Whether the home team won. |
+| `home_winner` | logical | Home team's winner. |
 | `home_current_rank` | integer | Current AP/coaches poll ranking of the home team at the time of the game. |
 | `home_linescores` | list | Points scored by the home team in each period or half of the game. |
 | `home_records` | character | Win-loss record string for the home team at the time of the game. |
 | `away_id` | character | Unique identifier for away. |
 | `away_uid` | character | Away team's uid. |
 | `away_location` | character | Away team's location. |
-| `away_name` | character | Away team display name. |
+| `away_name` | character | Away name. |
 | `away_abbreviation` | character | Away team's abbreviation. |
-| `away_display_name` | character | Away team display name. |
+| `away_display_name` | character | Away display name. |
 | `away_short_display_name` | character | Away short display name. |
-| `away_color` | character | Away team primary color hex. |
+| `away_color` | character | Color code (hex) for away. |
 | `away_alternate_color` | character | Color code (hex) for away alternate. |
 | `away_is_active` | logical | Away team's is active. |
 | `away_venue_id` | character | Unique identifier for away venue. |
 | `away_logo` | character | Away team logo URL. |
 | `away_conference_id` | character | Unique identifier for away conference. |
 | `away_score` | character | Away team score at the time of the play. |
-| `away_winner` | logical | Whether the away team won. |
+| `away_winner` | logical | Away team's winner. |
 | `away_current_rank` | integer | Current AP/coaches poll ranking of the away team at the time of the game. |
 | `away_linescores` | list | Points scored by the away team in each period or half of the game. |
 | `away_records` | character | Win-loss record string for the away team at the time of the game. |

--- a/docs/docs/wbb/reference/loaders.md
+++ b/docs/docs/wbb/reference/loaders.md
@@ -187,11 +187,11 @@ Release: [espn_womens_college_basketball_schedules](https://github.com/sportsdat
 | `uid` | String | ESPN UID string. |
 | `date` | String | Date in YYYY-MM-DD format. |
 | `attendance` | Float64 | Reported attendance. |
-| `time_valid` | Boolean | Whether the start time is confirmed. |
+| `time_valid` | Boolean | Time valid. |
 | `neutral_site` | Boolean | Neutral site. |
 | `conference_competition` | Boolean | Conference competition. |
 | `play_by_play_available` | Boolean | Whether play-by-play data is available. |
-| `recent` | Boolean | Whether the game is recent. |
+| `recent` | Boolean | Recent. |
 | `start_date` | String | Start date (YYYY-MM-DD). |
 | `broadcast` | String | Broadcast information string. |
 | `highlights` | String | Game highlight urls. |
@@ -205,14 +205,14 @@ Release: [espn_womens_college_basketball_schedules](https://github.com/sportsdat
 | `venue_full_name` | String | Venue full name. |
 | `venue_address_city` | String | Venue address city. |
 | `venue_address_state` | String | Venue address state / region. |
-| `venue_indoor` | Boolean | Whether the home venue is indoors. |
-| `status_clock` | Float64 | Game clock in seconds. |
+| `venue_indoor` | Boolean | TRUE if the venue is indoors. |
+| `status_clock` | Float64 | Status clock. |
 | `status_display_clock` | String | Status display clock. |
-| `status_period` | Float64 | Current period. |
+| `status_period` | Float64 | Status period. |
 | `status_type_id` | Int32 | Unique identifier for status type. |
 | `status_type_name` | String | Status type name. |
-| `status_type_state` | String | Status state (pre/in/post). |
-| `status_type_completed` | Boolean | Whether the game is complete. |
+| `status_type_state` | String | Status type state. |
+| `status_type_completed` | Boolean | Status type completed. |
 | `status_type_description` | String | Status type description. |
 | `status_type_detail` | String | Status type detail. |
 | `status_type_short_detail` | String | Status type short detail. |
@@ -220,36 +220,36 @@ Release: [espn_womens_college_basketball_schedules](https://github.com/sportsdat
 | `home_id` | Int32 | Unique identifier for home. |
 | `home_uid` | String | Home team's uid. |
 | `home_location` | String | Home team's location. |
-| `home_name` | String | Home team display name. |
+| `home_name` | String | Home name. |
 | `home_abbreviation` | String | Home team's abbreviation. |
-| `home_display_name` | String | Home team display name. |
+| `home_display_name` | String | Home display name. |
 | `home_short_display_name` | String | Home short display name. |
-| `home_color` | String | Home team primary color hex. |
+| `home_color` | String | Color code (hex) for home. |
 | `home_alternate_color` | String | Color code (hex) for home alternate. |
 | `home_is_active` | Boolean | Home team's is active. |
 | `home_venue_id` | Int32 | Unique identifier for home venue. |
 | `home_logo` | String | Home team logo URL. |
 | `home_conference_id` | Int32 | Unique identifier for home conference. |
 | `home_score` | Int32 | Home team score at the time of the play. |
-| `home_winner` | Boolean | Whether the home team won. |
+| `home_winner` | Boolean | Home team's winner. |
 | `home_current_rank` | Float64 |  |
 | `home_linescores` | String |  |
 | `home_records` | String |  |
 | `away_id` | Int32 | Unique identifier for away. |
 | `away_uid` | String | Away team's uid. |
 | `away_location` | String | Away team's location. |
-| `away_name` | String | Away team display name. |
+| `away_name` | String | Away name. |
 | `away_abbreviation` | String | Away team's abbreviation. |
-| `away_display_name` | String | Away team display name. |
+| `away_display_name` | String | Away display name. |
 | `away_short_display_name` | String | Away short display name. |
-| `away_color` | String | Away team primary color hex. |
+| `away_color` | String | Color code (hex) for away. |
 | `away_alternate_color` | String | Color code (hex) for away alternate. |
 | `away_is_active` | Boolean | Away team's is active. |
 | `away_venue_id` | Int32 | Unique identifier for away venue. |
 | `away_logo` | String | Away team logo URL. |
 | `away_conference_id` | Int32 | Unique identifier for away conference. |
 | `away_score` | Int32 | Away team score at the time of the play. |
-| `away_winner` | Boolean | Whether the away team won. |
+| `away_winner` | Boolean | Away team's winner. |
 | `away_current_rank` | Float64 |  |
 | `away_linescores` | String |  |
 | `away_records` | String |  |
@@ -267,8 +267,8 @@ Release: [espn_womens_college_basketball_schedules](https://github.com/sportsdat
 | `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') | Game start date/time (ISO 8601). |
 | `game_date` | Date | Game date (YYYY-MM-DD). |
 | `PBP` | Boolean | Whether play-by-play data is available. |
-| `team_box` | Boolean | Whether team box score data is available. |
-| `player_box` | Boolean | Whether player box score data is available. |
+| `team_box` | Boolean | Team box. |
+| `player_box` | Boolean | Player box. |
 
 ```python
 load_wbb_schedule(seasons=2024)

--- a/docs/docs/wbb/reference/site.md
+++ b/docs/docs/wbb/reference/site.md
@@ -38,14 +38,14 @@ ESPN endpoint.
 | `season_slug` | character | Season slug. |
 | `status_type_id` | character | Unique identifier for status type. |
 | `status_type_name` | character | Status type name. |
-| `status_type_state` | character | Status state (pre/in/post). |
-| `status_type_completed` | logical | Whether the game is complete. |
+| `status_type_state` | character | Status type state. |
+| `status_type_completed` | logical | Status type completed. |
 | `status_type_description` | character | Status type description. |
 | `status_type_detail` | character | Status type detail. |
 | `status_type_short_detail` | character | Status type short detail. |
-| `status_clock` | double | Game clock in seconds. |
+| `status_clock` | double | Status clock. |
 | `status_display_clock` | character | Status display clock. |
-| `status_period` | integer | Current period. |
+| `status_period` | integer | Status period. |
 | `neutral_site` | logical | Whether the match is played at a neutral venue. |
 | `conference_competition` | logical | Conference competition. |
 | `attendance` | integer | Reported attendance. |
@@ -53,30 +53,30 @@ ESPN endpoint.
 | `venue_full_name` | character | Venue full name. |
 | `venue_city` | character | Venue city. |
 | `venue_state` | character | Venue state / region. |
-| `venue_indoor` | logical | Whether the home venue is indoors. |
+| `venue_indoor` | logical | TRUE if the venue is indoors. |
 | `broadcast` | character | Broadcast information string. |
 | `note` | character | Injury status and description. |
 | `home_id` | character | Unique identifier for home. |
-| `home_name` | character | Home team display name. |
+| `home_name` | character | Home name. |
 | `home_abbreviation` | character | Home team's abbreviation. |
-| `home_display_name` | character | Home team display name. |
+| `home_display_name` | character | Home display name. |
 | `home_location` | character | Home team's location. |
-| `home_color` | character | Home team primary color hex. |
+| `home_color` | character | Color code (hex) for home. |
 | `home_alternate_color` | character | Color code (hex) for home alternate. |
 | `home_logo` | character | Home team logo URL. |
 | `home_score` | character | Home team's score. For cricket, the innings string (e.g. '161/5 (18/20 ov, target 156)'). |
-| `home_winner` | logical | Whether the home team won. |
+| `home_winner` | logical | Home team's winner. |
 | `home_rank` | integer | Home team rank (if ranked). |
 | `away_id` | character | Unique identifier for away. |
-| `away_name` | character | Away team display name. |
+| `away_name` | character | Away name. |
 | `away_abbreviation` | character | Away team's abbreviation. |
-| `away_display_name` | character | Away team display name. |
+| `away_display_name` | character | Away display name. |
 | `away_location` | character | Away team's location. |
-| `away_color` | character | Away team primary color hex. |
+| `away_color` | character | Color code (hex) for away. |
 | `away_alternate_color` | character | Color code (hex) for away alternate. |
 | `away_logo` | character | Away team logo URL. |
 | `away_score` | character | Away team's score. For cricket, the innings string. |
-| `away_winner` | logical | Whether the away team won. |
+| `away_winner` | logical | Away team's winner. |
 | `away_rank` | integer | Away team rank (if ranked). |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.

--- a/docs/docs/wnba/reference/additional.md
+++ b/docs/docs/wnba/reference/additional.md
@@ -263,11 +263,11 @@ Polars dataframe containing schedule dates for the requested season. Returns Non
 | `uid` | character | ESPN UID string. |
 | `date` | character | Date in YYYY-MM-DD format. |
 | `attendance` | integer | Reported attendance. |
-| `time_valid` | logical | Whether the start time is confirmed. |
+| `time_valid` | logical | Time valid. |
 | `neutral_site` | logical | Neutral site. |
 | `conference_competition` | logical | Conference competition. |
 | `play_by_play_available` | logical | Whether play-by-play data is available. |
-| `recent` | logical | Whether the game is recent. |
+| `recent` | logical | Recent. |
 | `start_date` | character | Start date (YYYY-MM-DD). |
 | `broadcast` | character | Broadcast information string. |
 | `highlights` | integer | Game highlight urls. |
@@ -281,14 +281,14 @@ Polars dataframe containing schedule dates for the requested season. Returns Non
 | `venue_full_name` | character | Venue full name. |
 | `venue_address_city` | character | Venue address city. |
 | `venue_address_state` | character | Venue address state / region. |
-| `venue_indoor` | logical | Whether the home venue is indoors. |
-| `status_clock` | double | Game clock in seconds. |
+| `venue_indoor` | logical | TRUE if the venue is indoors. |
+| `status_clock` | double | Status clock. |
 | `status_display_clock` | character | Status display clock. |
-| `status_period` | integer | Current period. |
+| `status_period` | integer | Status period. |
 | `status_type_id` | character | Unique identifier for status type. |
 | `status_type_name` | character | Status type name. |
-| `status_type_state` | character | Status state (pre/in/post). |
-| `status_type_completed` | logical | Whether the game is complete. |
+| `status_type_state` | character | Status type state. |
+| `status_type_completed` | logical | Status type completed. |
 | `status_type_description` | character | Status type description. |
 | `status_type_detail` | character | Status type detail. |
 | `status_type_short_detail` | character | Status type short detail. |
@@ -296,33 +296,33 @@ Polars dataframe containing schedule dates for the requested season. Returns Non
 | `home_id` | character | Unique identifier for home. |
 | `home_uid` | character | Home team's uid. |
 | `home_location` | character | Home team's location. |
-| `home_name` | character | Home team display name. |
+| `home_name` | character | Home name. |
 | `home_abbreviation` | character | Home team's abbreviation. |
-| `home_display_name` | character | Home team display name. |
+| `home_display_name` | character | Home display name. |
 | `home_short_display_name` | character | Home short display name. |
-| `home_color` | character | Home team primary color hex. |
+| `home_color` | character | Color code (hex) for home. |
 | `home_alternate_color` | character | Color code (hex) for home alternate. |
 | `home_is_active` | logical | Home team's is active. |
 | `home_venue_id` | character | Unique identifier for home venue. |
 | `home_logo` | character | Home team logo URL. |
 | `home_score` | character | Home team score at the time of the play. |
-| `home_winner` | logical | Whether the home team won. |
+| `home_winner` | logical | Home team's winner. |
 | `home_linescores` | list | Period-by-period point totals for the home team, stored as a list of integer scores. |
 | `home_records` | character | Win-loss record strings for the home team across relevant splits (e.g., overall, home/away, conference). |
 | `away_id` | character | Unique identifier for away. |
 | `away_uid` | character | Away team's uid. |
 | `away_location` | character | Away team's location. |
-| `away_name` | character | Away team display name. |
+| `away_name` | character | Away name. |
 | `away_abbreviation` | character | Away team's abbreviation. |
-| `away_display_name` | character | Away team display name. |
+| `away_display_name` | character | Away display name. |
 | `away_short_display_name` | character | Away short display name. |
-| `away_color` | character | Away team primary color hex. |
+| `away_color` | character | Color code (hex) for away. |
 | `away_alternate_color` | character | Color code (hex) for away alternate. |
 | `away_is_active` | logical | Away team's is active. |
 | `away_venue_id` | character | Unique identifier for away venue. |
 | `away_logo` | character | Away team logo URL. |
 | `away_score` | character | Away team score at the time of the play. |
-| `away_winner` | logical | Whether the away team won. |
+| `away_winner` | logical | Away team's winner. |
 | `away_linescores` | list | Period-by-period point totals for the away team, stored as a list of integer scores. |
 | `away_records` | character | Win-loss record strings for the away team across relevant splits (e.g., overall, home/away, conference). |
 | `game_id` | integer | Unique game identifier. |

--- a/docs/docs/wnba/reference/loaders.md
+++ b/docs/docs/wnba/reference/loaders.md
@@ -202,11 +202,11 @@ Release: [espn_wnba_schedules](https://github.com/sportsdataverse/sportsdatavers
 | `uid` | String | ESPN UID string. |
 | `date` | String | Date in YYYY-MM-DD format. |
 | `attendance` | Float64 | Reported attendance. |
-| `time_valid` | Boolean | Whether the start time is confirmed. |
+| `time_valid` | Boolean | Time valid. |
 | `neutral_site` | Boolean | Neutral site. |
 | `conference_competition` | Boolean | Conference competition. |
 | `play_by_play_available` | Boolean | Whether play-by-play data is available. |
-| `recent` | Boolean | Whether the game is recent. |
+| `recent` | Boolean | Recent. |
 | `start_date` | String | Start date (YYYY-MM-DD). |
 | `broadcast` | String | Broadcast information string. |
 | `highlights` | String | Game highlight urls. |
@@ -220,14 +220,14 @@ Release: [espn_wnba_schedules](https://github.com/sportsdataverse/sportsdatavers
 | `venue_full_name` | String | Venue full name. |
 | `venue_address_city` | String | Venue address city. |
 | `venue_address_state` | String | Venue address state / region. |
-| `venue_indoor` | Boolean | Whether the home venue is indoors. |
-| `status_clock` | Float64 | Game clock in seconds. |
+| `venue_indoor` | Boolean | TRUE if the venue is indoors. |
+| `status_clock` | Float64 | Status clock. |
 | `status_display_clock` | String | Status display clock. |
-| `status_period` | Float64 | Current period. |
+| `status_period` | Float64 | Status period. |
 | `status_type_id` | Int32 | Unique identifier for status type. |
 | `status_type_name` | String | Status type name. |
-| `status_type_state` | String | Status state (pre/in/post). |
-| `status_type_completed` | Boolean | Whether the game is complete. |
+| `status_type_state` | String | Status type state. |
+| `status_type_completed` | Boolean | Status type completed. |
 | `status_type_description` | String | Status type description. |
 | `status_type_detail` | String | Status type detail. |
 | `status_type_short_detail` | String | Status type short detail. |
@@ -235,33 +235,33 @@ Release: [espn_wnba_schedules](https://github.com/sportsdataverse/sportsdatavers
 | `home_id` | Int32 | Unique identifier for home. |
 | `home_uid` | String | Home team's uid. |
 | `home_location` | String | Home team's location. |
-| `home_name` | String | Home team display name. |
+| `home_name` | String | Home name. |
 | `home_abbreviation` | String | Home team's abbreviation. |
-| `home_display_name` | String | Home team display name. |
+| `home_display_name` | String | Home display name. |
 | `home_short_display_name` | String | Home short display name. |
-| `home_color` | String | Home team primary color hex. |
+| `home_color` | String | Color code (hex) for home. |
 | `home_alternate_color` | String | Color code (hex) for home alternate. |
 | `home_is_active` | Boolean | Home team's is active. |
 | `home_venue_id` | Int32 | Unique identifier for home venue. |
 | `home_logo` | String | Home team logo URL. |
 | `home_score` | Int32 | Home team score at the time of the play. |
-| `home_winner` | Boolean | Whether the home team won. |
+| `home_winner` | Boolean | Home team's winner. |
 | `home_linescores` | String |  |
 | `home_records` | String |  |
 | `away_id` | Int32 | Unique identifier for away. |
 | `away_uid` | String | Away team's uid. |
 | `away_location` | String | Away team's location. |
-| `away_name` | String | Away team display name. |
+| `away_name` | String | Away name. |
 | `away_abbreviation` | String | Away team's abbreviation. |
-| `away_display_name` | String | Away team display name. |
+| `away_display_name` | String | Away display name. |
 | `away_short_display_name` | String | Away short display name. |
-| `away_color` | String | Away team primary color hex. |
+| `away_color` | String | Color code (hex) for away. |
 | `away_alternate_color` | String | Color code (hex) for away alternate. |
 | `away_is_active` | Boolean | Away team's is active. |
 | `away_venue_id` | Int32 | Unique identifier for away venue. |
 | `away_logo` | String | Away team logo URL. |
 | `away_score` | Int32 | Away team score at the time of the play. |
-| `away_winner` | Boolean | Whether the away team won. |
+| `away_winner` | Boolean | Away team's winner. |
 | `away_linescores` | String |  |
 | `away_records` | String |  |
 | `game_id` | Int32 | Unique game identifier. |
@@ -273,8 +273,8 @@ Release: [espn_wnba_schedules](https://github.com/sportsdataverse/sportsdatavers
 | `game_date_time` | Datetime(time_unit='us', time_zone='America/New_York') | Game start date/time (ISO 8601). |
 | `game_date` | Date | Game date (YYYY-MM-DD). |
 | `PBP` | Boolean | Whether play-by-play data is available. |
-| `team_box` | Boolean | Whether team box score data is available. |
-| `player_box` | Boolean | Whether player box score data is available. |
+| `team_box` | Boolean | Team box. |
+| `player_box` | Boolean | Player box. |
 
 ```python
 load_wnba_schedule(seasons=2024)
@@ -1039,13 +1039,13 @@ Release: [wnba_stats_rosters](https://github.com/sportsdataverse/sportsdataverse
 | `player` | String | Player name. |
 | `nickname` | String | Team or athlete nickname. |
 | `player_slug` | String | URL-safe player identifier. |
-| `num` | String | Inning number. |
+| `num` | String | Jersey number worn by the player. |
 | `position` | String | Listed roster position (G, F, C, etc.). |
 | `height` | String | Player height (string e.g. '6-2' or inches). |
 | `weight` | String | Player weight in pounds. |
 | `birth_date` | String | Date of birth (YYYY-MM-DD). |
 | `age` | Float64 | Player age (in years). |
-| `exp` | String | Years of MLB service experience. |
+| `exp` | String | Years of WNBA playing experience entering the season ('R' = rookie). |
 | `school` | String | Player's school / college (when distinct from 'college'). |
 | `player_id` | Int64 | Unique player identifier. |
 | `how_acquired` | String | How the team acquired the player (draft, trade, free agency). |

--- a/docs/docs/wnba/reference/site.md
+++ b/docs/docs/wnba/reference/site.md
@@ -38,14 +38,14 @@ ESPN endpoint.
 | `season_slug` | character | Season slug. |
 | `status_type_id` | character | Unique identifier for status type. |
 | `status_type_name` | character | Status type name. |
-| `status_type_state` | character | Status state (pre/in/post). |
-| `status_type_completed` | logical | Whether the game is complete. |
+| `status_type_state` | character | Status type state. |
+| `status_type_completed` | logical | Status type completed. |
 | `status_type_description` | character | Status type description. |
 | `status_type_detail` | character | Status type detail. |
 | `status_type_short_detail` | character | Status type short detail. |
-| `status_clock` | double | Game clock in seconds. |
+| `status_clock` | double | Status clock. |
 | `status_display_clock` | character | Status display clock. |
-| `status_period` | integer | Current period. |
+| `status_period` | integer | Status period. |
 | `neutral_site` | logical | Whether the match is played at a neutral venue. |
 | `conference_competition` | logical | Conference competition. |
 | `attendance` | integer | Reported attendance. |
@@ -53,30 +53,30 @@ ESPN endpoint.
 | `venue_full_name` | character | Venue full name. |
 | `venue_city` | character | Venue city. |
 | `venue_state` | character | Venue state / region. |
-| `venue_indoor` | logical | Whether the home venue is indoors. |
+| `venue_indoor` | logical | TRUE if the venue is indoors. |
 | `broadcast` | character | Broadcast information string. |
 | `note` | character | Injury status and description. |
 | `home_id` | character | Unique identifier for home. |
-| `home_name` | character | Home team display name. |
+| `home_name` | character | Home name. |
 | `home_abbreviation` | character | Home team's abbreviation. |
-| `home_display_name` | character | Home team display name. |
+| `home_display_name` | character | Home display name. |
 | `home_location` | character | Home team's location. |
-| `home_color` | character | Home team primary color hex. |
+| `home_color` | character | Color code (hex) for home. |
 | `home_alternate_color` | character | Color code (hex) for home alternate. |
 | `home_logo` | character | Home team logo URL. |
 | `home_score` | character | Home team's score. For cricket, the innings string (e.g. '161/5 (18/20 ov, target 156)'). |
-| `home_winner` | logical | Whether the home team won. |
+| `home_winner` | logical | Home team's winner. |
 | `home_rank` | character | Home team rank (if ranked). |
 | `away_id` | character | Unique identifier for away. |
-| `away_name` | character | Away team display name. |
+| `away_name` | character | Away name. |
 | `away_abbreviation` | character | Away team's abbreviation. |
-| `away_display_name` | character | Away team display name. |
+| `away_display_name` | character | Away display name. |
 | `away_location` | character | Away team's location. |
-| `away_color` | character | Away team primary color hex. |
+| `away_color` | character | Color code (hex) for away. |
 | `away_alternate_color` | character | Color code (hex) for away alternate. |
 | `away_logo` | character | Away team logo URL. |
 | `away_score` | character | Away team's score. For cricket, the innings string. |
-| `away_winner` | logical | Whether the away team won. |
+| `away_winner` | logical | Away team's winner. |
 | `away_rank` | character | Away team rank (if ranked). |
 
 **`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.

--- a/docs/docs/wnba/reference/wnba_stats.md
+++ b/docs/docs/wnba/reference/wnba_stats.md
@@ -257,7 +257,7 @@ GET /stats/boxscoreadvancedv3
 | `possessions` | numeric | Possessions used. |
 | `reboundpercentage` | numeric |  |
 | `teamcity` | character | Teamcity. |
-| `teamid` | integer | FanGraphs team ID. |
+| `teamid` | integer | Teamid. |
 | `teamname` | character | Teamname. |
 | `teamslug` | character |  |
 | `teamtricode` | character |  |
@@ -317,7 +317,7 @@ GET /stats/boxscoredefensivev2
 | `steals` | integer | Total steals. |
 | `switcheson` | integer | NBA or WNBA Stats value for switcheson in the boxscoredefensivev2 result set. |
 | `teamcity` | character | Teamcity. |
-| `teamid` | integer | FanGraphs team ID. |
+| `teamid` | integer | Teamid. |
 | `teamname` | character | Teamname. |
 | `teamslug` | character | URL slug for teamslug used by NBA or WNBA Stats pages. |
 | `teamtricode` | character | Three-letter team code used by NBA or WNBA Stats schedule and scoreboard feeds. |
@@ -372,7 +372,7 @@ GET /stats/boxscorefourfactorsv3
 | `playerslug` | character |  |
 | `position` | character | Listed roster position (G, F, C, etc.). |
 | `teamcity` | character | Teamcity. |
-| `teamid` | integer | FanGraphs team ID. |
+| `teamid` | integer | Teamid. |
 | `teamname` | character | Teamname. |
 | `teamslug` | character |  |
 | `teamtricode` | character |  |
@@ -415,7 +415,7 @@ GET /stats/boxscorematchupsv3
 | `playerslug` | character | URL slug for the player on NBA or WNBA Stats pages. |
 | `position` | character | Listed roster position (G, F, C, etc.). |
 | `teamcity` | character | Teamcity. |
-| `teamid` | integer | FanGraphs team ID. |
+| `teamid` | integer | Teamid. |
 | `teamname` | character | Teamname. |
 | `teamslug` | character | URL slug for teamslug used by NBA or WNBA Stats pages. |
 | `teamtricode` | character | Three-letter team code used by NBA or WNBA Stats schedule and scoreboard feeds. |
@@ -475,7 +475,7 @@ GET /stats/boxscoremiscv3
 | `pointssecondchance` | integer |  |
 | `position` | character | Listed roster position (G, F, C, etc.). |
 | `teamcity` | character | Teamcity. |
-| `teamid` | integer | FanGraphs team ID. |
+| `teamid` | integer | Teamid. |
 | `teamname` | character | Teamname. |
 | `teamslug` | character |  |
 | `teamtricode` | character |  |
@@ -534,7 +534,7 @@ GET /stats/boxscoreplayertrackv3
 | `secondaryassists` | integer | Passing or assist metric for secondaryassists in the requested NBA or WNBA Stats split. |
 | `speed` | numeric | Speed. |
 | `teamcity` | character | Teamcity. |
-| `teamid` | integer | FanGraphs team ID. |
+| `teamid` | integer | Teamid. |
 | `teamname` | character | Teamname. |
 | `teamslug` | character | URL slug for teamslug used by NBA or WNBA Stats pages. |
 | `teamtricode` | character | Three-letter team code used by NBA or WNBA Stats schedule and scoreboard feeds. |
@@ -601,7 +601,7 @@ GET /stats/boxscorescoringv3
 | `playerslug` | character |  |
 | `position` | character | Listed roster position (G, F, C, etc.). |
 | `teamcity` | character | Teamcity. |
-| `teamid` | integer | FanGraphs team ID. |
+| `teamid` | integer | Teamid. |
 | `teamname` | character | Teamname. |
 | `teamslug` | character |  |
 | `teamtricode` | character |  |
@@ -753,7 +753,7 @@ GET /stats/boxscoretraditionalv3
 | `starters_turnovers` | integer |  |
 | `steals` | integer | Total steals. |
 | `teamcity` | character | Teamcity. |
-| `teamid` | integer | FanGraphs team ID. |
+| `teamid` | integer | Teamid. |
 | `teamname` | character | Teamname. |
 | `teamslug` | character |  |
 | `teamtricode` | character |  |
@@ -822,7 +822,7 @@ GET /stats/boxscoreusagev3
 | `playerslug` | character |  |
 | `position` | character | Listed roster position (G, F, C, etc.). |
 | `teamcity` | character | Teamcity. |
-| `teamid` | integer | FanGraphs team ID. |
+| `teamid` | integer | Teamid. |
 | `teamname` | character | Teamname. |
 | `teamslug` | character |  |
 | `teamtricode` | character |  |
@@ -1002,7 +1002,7 @@ GET /stats/commonteamroster
 **`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
 | col_name | type | description |
 |---|---|---|
-| `teamid` | integer | FanGraphs team ID. |
+| `teamid` | integer | Teamid. |
 | `season` | character | Season identifier (4-digit year or 'YYYY-YY' string). |
 | `leagueid` | character |  |
 | `player` | character | Player name. |
@@ -1014,7 +1014,7 @@ GET /stats/commonteamroster
 | `weight` | character | Player weight in pounds. |
 | `birth_date` | character | Date of birth (YYYY-MM-DD). |
 | `age` | numeric | Player age (in years). |
-| `exp` | character | Years of MLB service experience. |
+| `exp` | character | Exp. |
 | `school` | character | Player's school / college (when distinct from 'college'). |
 | `player_id` | integer | Unique player identifier. |
 | `how_acquired` | character |  |
@@ -2421,7 +2421,7 @@ GET /stats/leaguedashptdefend
 | `player_position` | character | Position of the player accordinng to NGS |
 | `age` | numeric | Player age (in years). |
 | `gp` | integer | Games played. |
-| `g` | integer | Goals (skaters). |
+| `g` | integer | Games played. |
 | `freq` | numeric | NBA or WNBA Stats value for freq in the leaguedashptdefend result set. |
 | `d_fgm` | numeric | Shooting metric for d fgm in the requested NBA or WNBA Stats split. |
 | `d_fga` | numeric | Shooting metric for d fga in the requested NBA or WNBA Stats split. |
@@ -3286,7 +3286,7 @@ GET /stats/leaguestandingsv3
 |---|---|---|
 | `leagueid` | character | League identifier used in compact NBA Stats schedule and scoreboard result sets. |
 | `seasonid` | character | Stats API identifier for seasonid associated with this NBA or WNBA Stats row. |
-| `teamid` | integer | FanGraphs team ID. |
+| `teamid` | integer | Teamid. |
 | `teamcity` | character | Teamcity. |
 | `teamname` | character | Teamname. |
 | `teamslug` | character | URL slug for teamslug used by NBA or WNBA Stats pages. |
@@ -3307,7 +3307,7 @@ GET /stats/leaguestandingsv3
 | `l10` | character | L10. |
 | `last10home` | character | NBA or WNBA Stats value for last10home in the leaguestandingsv3 result set. |
 | `last10road` | character | NBA or WNBA Stats value for last10road in the leaguestandingsv3 result set. |
-| `ot` | character | Overtime results. |
+| `ot` | character | Ot. |
 | `threeptsorless` | character | Scoring or score-margin metric for threeptsorless in the requested NBA or WNBA Stats split. |
 | `tenptsormore` | character | Scoring or score-margin metric for tenptsormore in the requested NBA or WNBA Stats split. |
 | `longhomestreak` | integer | NBA or WNBA Stats value for longhomestreak in the leaguestandingsv3 result set. |
@@ -3425,7 +3425,7 @@ GET /stats/playbyplayv3
 | `shotresult` | character | Result of the shot attempt, such as made or missed. |
 | `shotvalue` | integer | Point value of the shot attempt, usually two or three points. |
 | `subtype` | character | Secondary play subtype reported by NBA or WNBA Stats. |
-| `teamid` | integer | FanGraphs team ID. |
+| `teamid` | integer | Teamid. |
 | `teamtricode` | character | Three-letter code for the team associated with the play event. |
 | `videoavailable` | integer | Flag indicating whether video is available for the play or game row. |
 | `xlegacy` | integer | Legacy NBA Stats x-coordinate for shot-location play events. |
@@ -4529,7 +4529,7 @@ GET /stats/playerdashptshotdefend
 |---|---|---|
 | `matchupid` | integer | Stats API identifier for matchupid associated with this NBA or WNBA Stats row. |
 | `gp` | integer | Games played. |
-| `g` | integer | Goals (skaters). |
+| `g` | integer | Games played. |
 | `defense_category` | character | NBA or WNBA Stats value for defense category in the playerdashptshotdefend result set. |
 | `freq` | numeric | NBA or WNBA Stats value for freq in the playerdashptshotdefend result set. |
 | `d_fgm` | numeric | Shooting metric for d fgm in the requested NBA or WNBA Stats split. |

--- a/tools/codegen/generate.py
+++ b/tools/codegen/generate.py
@@ -248,6 +248,30 @@ def _r_col_descs() -> dict:
     return yaml.safe_load(_R_DICT_FILE.read_text(encoding="utf-8")) or {}
 
 
+#: Sport family per R package — lets the fallback prefer SAME-SPORT text over
+#: the cross-sport ``_merged`` union (which put "Inning number" on jersey-number
+#: columns and NFL career text on basketball turnovers).
+_PACKAGE_SPORT = {
+    "hoopR": "basketball",
+    "wehoop": "basketball",
+    "cfbfastR": "football",
+    "nflreadr": "football",
+    "fastRhockey": "hockey",
+    "baseballr": "baseball",
+}
+
+
+@functools.lru_cache(maxsize=None)
+def _sport_merged(sport: str) -> dict:
+    """Union of the sport's package dicts (first package listed wins a tie)."""
+    out: dict = {}
+    for pkg, sp in _PACKAGE_SPORT.items():
+        if sp == sport:
+            for col, desc in (_r_col_descs().get(pkg) or {}).items():
+                out.setdefault(col, desc)
+    return out
+
+
 @functools.lru_cache(maxsize=None)
 def _r_pkg_dict(league: str | None) -> dict:
     """The per-league lookup dict: the league's R package map (cached per league).
@@ -287,10 +311,17 @@ def _r_col_desc(league: str | None, col: str) -> str:
     val = _r_pkg_dict(league).get(col)
     if val:
         return _fix_desc_typos(val)
-    # The cross-package ``_merged`` union CAN put another sport's phrasing on a
-    # column the league dict misses; known collisions are overridden in
-    # manual_column_descriptions.yaml (which wins over this fill) rather than
-    # dropping the fallback — blanket-blanking regressed ~800 described cells.
+    # Prefer SAME-SPORT sibling packages before the cross-sport ``_merged``
+    # union (wehoop text for an nba column beats nflreadr's). ``_merged`` stays
+    # as the last resort — dropping it blanked ~800 described cells and trips
+    # the residual ratchet; remaining wrong-sport fills are overridden in
+    # manual_column_descriptions.yaml as they are found (it wins over this).
+    pkg = _LEAGUE_R_PACKAGE.get(league or "")
+    sport = _PACKAGE_SPORT.get(pkg or "")
+    if sport:
+        val = _sport_merged(sport).get(col)
+        if val:
+            return _fix_desc_typos(val)
     return _fix_desc_typos(_r_col_descs().get("_merged", {}).get(col, "") or "")
 
 

--- a/tools/codegen/manual_column_descriptions.yaml
+++ b/tools/codegen/manual_column_descriptions.yaml
@@ -5512,6 +5512,8 @@ load_wnba_stats_draft:
   draft_type: 'CONSTANT in the published asset: every row reads ''Draft'', so it does not currently distinguish the main draft
     from any other selection event.'
 load_wnba_stats_rosters:
+  num: Jersey number worn by the player.
+  exp: Years of WNBA playing experience entering the season ('R' = rookie).
   how_acquired: How the team acquired the player (draft, trade, free agency).
 load_cfb_fpi_weekly:
   accomplishment: Reflects chance that an average Top 25 team would have team's record or better, given the schedule. On a
@@ -5621,6 +5623,9 @@ load_nfl_depth_charts:
   depth_team: Depth rank of the player at their position, stored as a string ('1' = starter, '2' = backup, etc.).
   elias_id: Elias Sports Bureau player identifier used for official NFL record-keeping and statistics attribution.
   formation: Offensive or defensive formation label (e.g., 'Base 3-4', 'Nickel') associated with this depth chart grouping.
+load_nba_stats_rosters:
+  num: Jersey number worn by the player.
+  exp: Years of NBA playing experience entering the season ('R' = rookie).
 load_nfl_espn_qbr:
   epa_total: Total expected points added across the quarterback's plays (ESPN QBR EPA component).
   exp_sack: QBR points contribution adjustment from expected sacks.


### PR DESCRIPTION
Implements the systemic fix #320 was held open for: a **same-sport fallback tier** between the league package dict and the cross-sport `_merged` union (`hoopR`/`wehoop` text beats `nflreadr` on basketball columns). `_merged` remains the last resort so nothing described goes blank — the residual ratchet holds (18/18 codegen description/id tests green).

Also fixes the confirmed collision instances from the #318 review via manual overrides: rosters `num` ("Inning number" → jersey number) and `exp` (MLB service → W/NBA experience) for both stats schemas. The `to` boxscore instance was already cured by the newest-first re-capture (column no longer exists).

Closes #320.

## Summary by Sourcery

Introduce sport-aware description fallback in code generation and correct several misaligned stat and roster column descriptions across NFL, NBA, WNBA, CFB, and related documentation.

Enhancements:
- Add a sport-family mapping to prefer same-sport column description fallbacks before using the cross-sport merged dictionary in codegen.

Documentation:
- Clarify and align numerous column descriptions for roster, schedule, standings, stats, and site reference tables across NFL, NBA, WNBA, CFB, and college basketball documentation, including fixing incorrect meanings for jersey and experience fields.
- Document manual overrides for known column description collisions in NBA and WNBA stats rosters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified and standardized field descriptions across college, professional, and women’s sports reference documentation.
  * Corrected inaccurate terminology for jersey numbers, experience, shot types, player names, team identifiers, standings, and game statistics.
  * Added details about calculated totals, rounding, timing, availability, and field-specific meanings.
* **Improvements**
  * Improved generated column descriptions by prioritizing sport-specific definitions.
  * Added NBA and WNBA roster descriptions for jersey numbers and player experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->