### PR TITLE
feat(scrape): shared stats.nba.com/wnba.com sweep engine — Phase 1 lift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
+- [Unreleased](#unreleased)
+  - [New — `sportsdataverse.scrape.stats`: shared stats.nba.com / stats.wnba.com sweep engine (Phase 1)](#new--sportsdataversescrapestats-shared-statsnbacom--statswnbacom-sweep-engine-phase-1)
 - [0.0.74 Release: August 2, 2026](#0074-release-august-2-2026)
   - [CFB — the ridge opponent adjustment was a no-op (BREAKING rating change)](#cfb--the-ridge-opponent-adjustment-was-a-no-op-breaking-rating-change)
   - [CFB — ESPN's `-1` end-of-play yardline sentinel corrupted 2016 week 2](#cfb--espns--1-end-of-play-yardline-sentinel-corrupted-2016-week-2)
@@ -214,6 +216,32 @@
 - [0.0.5 Release: October 20, 2021](#005-release-october-20-2021)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Unreleased
+
+### New — `sportsdataverse.scrape.stats`: shared stats.nba.com / stats.wnba.com sweep engine (Phase 1)
+
+The scraping machinery that was copy-pasted between `hoopR-nba-stats-raw` and
+`wehoop-wnba-stats-raw` (and had drifted to byte-identical-or-nearly — 0–6 diff
+lines per file) now has one library home, per the 2026-08-02 pipeline audit's
+shared-engine decision:
+
+- `scrape/stats/proxy.py` — round-robin ProxyBonanza pool with quarantine +
+  outcome classification (`transport_err`/`blocked`/`blank` quarantine;
+  `server_err`/`notfound` never count against a proxy).
+- `scrape/stats/session_transport.py` — thread-local sticky-session
+  `curl_cffi` transport (Chrome impersonation; the hosts TLS/JA3-block plain
+  `requests` with a silent hang), in-session retry of the cheap `server_err`
+  class only.
+- `scrape/stats/observability.py` — sweep bookkeeping (endpoint outcome
+  ledger, degradation windows, progress heartbeat).
+
+Deliberately **not** re-exported at the top-level `sportsdataverse` namespace —
+this is producer-pipeline tooling, not the tidy-data API. The `-raw` twins
+migrate to these imports next (deleting their local copies); league-specific
+endpoint sets / season formats stay repo-side until Phase 2's `LeagueConfig`.
+All three modules are typed (mypy ratchet) and covered by the ported offline
+observability suite plus a proxy-classifier truth table (23 tests).
 
 ## 0.0.74 Release: August 2, 2026
 

--- a/docs/src/pages/CHANGELOG.md
+++ b/docs/src/pages/CHANGELOG.md
@@ -2,6 +2,8 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
+- [Unreleased](#unreleased)
+  - [New — `sportsdataverse.scrape.stats`: shared stats.nba.com / stats.wnba.com sweep engine (Phase 1)](#new--sportsdataversescrapestats-shared-statsnbacom--statswnbacom-sweep-engine-phase-1)
 - [0.0.74 Release: August 2, 2026](#0074-release-august-2-2026)
   - [CFB — the ridge opponent adjustment was a no-op (BREAKING rating change)](#cfb--the-ridge-opponent-adjustment-was-a-no-op-breaking-rating-change)
   - [CFB — ESPN's `-1` end-of-play yardline sentinel corrupted 2016 week 2](#cfb--espns--1-end-of-play-yardline-sentinel-corrupted-2016-week-2)
@@ -214,6 +216,32 @@
 - [0.0.5 Release: October 20, 2021](#005-release-october-20-2021)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Unreleased
+
+### New — `sportsdataverse.scrape.stats`: shared stats.nba.com / stats.wnba.com sweep engine (Phase 1)
+
+The scraping machinery that was copy-pasted between `hoopR-nba-stats-raw` and
+`wehoop-wnba-stats-raw` (and had drifted to byte-identical-or-nearly — 0–6 diff
+lines per file) now has one library home, per the 2026-08-02 pipeline audit's
+shared-engine decision:
+
+- `scrape/stats/proxy.py` — round-robin ProxyBonanza pool with quarantine +
+  outcome classification (`transport_err`/`blocked`/`blank` quarantine;
+  `server_err`/`notfound` never count against a proxy).
+- `scrape/stats/session_transport.py` — thread-local sticky-session
+  `curl_cffi` transport (Chrome impersonation; the hosts TLS/JA3-block plain
+  `requests` with a silent hang), in-session retry of the cheap `server_err`
+  class only.
+- `scrape/stats/observability.py` — sweep bookkeeping (endpoint outcome
+  ledger, degradation windows, progress heartbeat).
+
+Deliberately **not** re-exported at the top-level `sportsdataverse` namespace —
+this is producer-pipeline tooling, not the tidy-data API. The `-raw` twins
+migrate to these imports next (deleting their local copies); league-specific
+endpoint sets / season formats stay repo-side until Phase 2's `LeagueConfig`.
+All three modules are typed (mypy ratchet) and covered by the ported offline
+observability suite plus a proxy-classifier truth table (23 tests).
 
 ## 0.0.74 Release: August 2, 2026
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -640,4 +640,9 @@ files = [
     "sportsdataverse/wnba/wnba_player_core.py",
     "sportsdataverse/wbb/wbb_player_core.py",
     "sportsdataverse/schemas/__init__.py",
+    "sportsdataverse/scrape/__init__.py",
+    "sportsdataverse/scrape/stats/__init__.py",
+    "sportsdataverse/scrape/stats/proxy.py",
+    "sportsdataverse/scrape/stats/session_transport.py",
+    "sportsdataverse/scrape/stats/observability.py",
 ]

--- a/sportsdataverse/scrape/__init__.py
+++ b/sportsdataverse/scrape/__init__.py
@@ -1,0 +1,12 @@
+"""Shared scrape-engine primitives for the SDV ``-raw`` producer repos.
+
+This subpackage is the library home for scraping machinery that was previously
+copy-pasted between producer repos (the 2026-08-02 pipeline audit's twin-repo
+finding). It is **operational tooling for the data-producer pipelines**, not
+part of the tidy-data API surface — nothing here is re-exported at the
+top-level ``sportsdataverse`` namespace.
+
+Families:
+    * ``sportsdataverse.scrape.stats`` — stats.nba.com / stats.wnba.com sweep
+      engine (proxy pool, sticky-session transport, sweep observability).
+"""

--- a/sportsdataverse/scrape/stats/__init__.py
+++ b/sportsdataverse/scrape/stats/__init__.py
@@ -1,0 +1,22 @@
+"""stats.nba.com / stats.wnba.com sweep engine (shared by the stats-raw twins).
+
+Lifted verbatim (Phase 1 of the shared-engine extraction) from
+``hoopR-nba-stats-raw`` / ``wehoop-wnba-stats-raw``, where these modules had
+drifted to byte-identical-or-nearly (0–6 diff lines each):
+
+    * :mod:`~sportsdataverse.scrape.stats.proxy` — round-robin ProxyBonanza
+      pool with quarantine + outcome classification.
+    * :mod:`~sportsdataverse.scrape.stats.session_transport` — thread-local
+      sticky-session ``curl_cffi`` transport (Chrome impersonation; the hosts
+      TLS/JA3-block plain ``requests`` with a silent hang).
+    * :mod:`~sportsdataverse.scrape.stats.observability` — sweep bookkeeping
+      (endpoint outcome ledger, degradation windows, progress heartbeat).
+
+Import the modules directly (``from sportsdataverse.scrape.stats import
+observability``); there are deliberately no wildcard re-exports here —
+``proxy`` and ``observability`` each define their own ``classify`` for
+different layers, and flattening them would shadow one.
+
+League-specific behavior (endpoint sets, season formats, store roots) stays in
+the consuming ``-raw`` repos; Phase 2 moves it behind a ``LeagueConfig``.
+"""

--- a/sportsdataverse/scrape/stats/observability.py
+++ b/sportsdataverse/scrape/stats/observability.py
@@ -1,0 +1,276 @@
+"""Sweep observability: heartbeat, miss categorisation, proxy health, degradation alerts.
+
+A multi-hour sweep that only logs at season boundaries is silent for 30-60 minutes
+at a stretch, reports one opaque "misses" number, and gives no view of the proxy
+pool at all. That makes three different situations look identical: working
+normally, blocked by a throttled pool, and hung.
+
+Four pieces, all additive:
+
+:class:`Progress`
+    Periodic per-game heartbeat with rate and ETA, so a stall is visible within a
+    minute instead of at the next season boundary.
+
+:func:`classify`
+    Buckets a failed fetch into ``endpoint_absent`` / ``timeout`` / ``throttled`` /
+    ``error``. The first is the important one: most early-season "misses" are
+    endpoints that did not exist yet, which is expected and permanent -- not a
+    failure, and not worth retrying on the next run.
+
+:class:`ProxyHealth`
+    Per-proxy outcome counters with quarantine. The scraper picks the proxy for
+    every call, so this needs nothing from sdv-py: the caller already knows which
+    IP it used.
+
+:class:`Degradation`
+    Escalates to a loud warning when the real-error rate spikes or the healthy pool
+    shrinks past a floor, so a multi-hour run against a dead pool announces itself
+    rather than quietly burning the budget.
+
+Everything here is pure bookkeeping over outcomes the caller reports -- no HTTP, no
+globals -- so it is all testable offline.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import Counter, defaultdict
+from collections.abc import Callable
+
+# -- outcome vocabulary --------------------------------------------------------
+
+OK = "ok"
+#: Upstream has no data for this (endpoint, season) -- expected, permanent.
+ENDPOINT_ABSENT = "endpoint_absent"
+TIMEOUT = "timeout"
+#: Rate-limited / blocked: the pool's problem, not the data's.
+THROTTLED = "throttled"
+ERROR = "error"
+
+#: Categories that mean "do not bother trying this again".
+PERMANENT = frozenset({ENDPOINT_ABSENT})
+
+_TIMEOUT_HINTS = ("timeout", "timed out", "read timeout", "connecttimeout")
+_THROTTLE_HINTS = (
+    "429",
+    "too many requests",
+    "rate limit",
+    "forbidden",
+    "403",
+    "blocked",
+)
+_ABSENT_HINTS = ("no data", "empty", "not found", "404")
+
+
+def classify(exc: BaseException | None, payload: object = None) -> str:
+    """Bucket one fetch outcome.
+
+    An empty payload is treated as ``endpoint_absent`` rather than an error:
+    stats.com answers 200-with-nothing for an endpoint that has no data in a given
+    season, which is the single largest source of "misses" in early seasons.
+    """
+    if exc is None:
+        if payload is None or (isinstance(payload, (dict, list)) and not payload):
+            return ENDPOINT_ABSENT
+        return OK
+    text = f"{type(exc).__name__}: {exc}".lower()
+    if any(h in text for h in _TIMEOUT_HINTS):
+        return TIMEOUT
+    if any(h in text for h in _THROTTLE_HINTS):
+        return THROTTLED
+    if any(h in text for h in _ABSENT_HINTS):
+        return ENDPOINT_ABSENT
+    return ERROR
+
+
+class Progress:
+    """Heartbeat for a per-game pass."""
+
+    def __init__(
+        self,
+        total: int,
+        label: str,
+        log: Callable[[str], None],
+        interval_s: float = 60.0,
+        now: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.total = total
+        self.label = label
+        self._log = log
+        self.interval_s = interval_s
+        self._now = now
+        self._start = now()
+        self._last = self._start
+        self.done = 0
+        self.payloads = 0
+
+    def advance(self, payloads: int = 0) -> None:
+        """Record one finished game, emitting a heartbeat when due."""
+        self.done += 1
+        self.payloads += payloads
+        now = self._now()
+        if now - self._last < self.interval_s and self.done < self.total:
+            return
+        self._last = now
+        self._log(self.render(now))
+
+    def render(self, now: float | None = None) -> str:
+        now = self._now() if now is None else now
+        elapsed = max(now - self._start, 1e-9)
+        rate = self.done / elapsed
+        remaining = self.total - self.done
+        eta = remaining / rate if rate > 0 else 0.0
+        return (
+            f"{self.label}: {self.done}/{self.total} games · {self.payloads} payloads"
+            f" · {rate * 60:.0f} games/min · ETA {_human(eta)}"
+        )
+
+
+def _human(seconds: float) -> str:
+    seconds = int(max(seconds, 0))
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m"
+    return f"{seconds // 3600}h{(seconds % 3600) // 60:02d}m"
+
+
+class MissLedger:
+    """Counts fetch outcomes, overall and per endpoint."""
+
+    def __init__(self) -> None:
+        self.totals: Counter[str] = Counter()
+        self.by_endpoint: dict[str, Counter[str]] = defaultdict(Counter)
+
+    def record(self, endpoint: str, outcome: str) -> None:
+        self.totals[outcome] += 1
+        self.by_endpoint[endpoint][outcome] += 1
+
+    @property
+    def real_failures(self) -> int:
+        """Misses that are actually wrong -- absent endpoints are not."""
+        return sum(v for k, v in self.totals.items() if k not in (OK, ENDPOINT_ABSENT))
+
+    def snapshot(self) -> Counter:
+        """Copy of the current totals, for diffing one season against the run."""
+        return Counter(self.totals)
+
+    def since(self, mark: Counter) -> str:
+        """Outcome breakdown accumulated since ``mark`` -- i.e. this season only.
+
+        The ledger spans the whole run, so reporting its totals under a per-season
+        heading silently invites mis-attribution: a season's numbers look like the
+        run's. Callers mark at season start and report the delta.
+        """
+        delta = {k: self.totals[k] - mark.get(k, 0) for k in self.totals}
+        parts = [f"{k}={v}" for k, v in sorted(delta.items()) if v]
+        return " ".join(parts) if parts else "no fetches"
+
+    def real_failures_since(self, mark: Counter) -> int:
+        return sum(self.totals[k] - mark.get(k, 0) for k in self.totals if k not in (OK, ENDPOINT_ABSENT))
+
+    def summary(self) -> str:
+        if not self.totals:
+            return "no fetches"
+        parts = [f"{k}={v}" for k, v in sorted(self.totals.items()) if v]
+        return " ".join(parts)
+
+    def worst_endpoints(self, limit: int = 3) -> str:
+        """Endpoints with the most real failures, for pointing at a culprit."""
+        ranked = sorted(
+            (
+                (sum(v for k, v in c.items() if k not in (OK, ENDPOINT_ABSENT)), ep)
+                for ep, c in self.by_endpoint.items()
+            ),
+            reverse=True,
+        )
+        hits = [f"{ep}={n}" for n, ep in ranked[:limit] if n]
+        return ", ".join(hits) if hits else "none"
+
+
+class ProxyHealth:
+    """Per-proxy outcome counters with quarantine of consistently-failing IPs."""
+
+    def __init__(self, pool_size: int, consecutive_fail_limit: int = 20) -> None:
+        self.pool_size = pool_size
+        self.limit = consecutive_fail_limit
+        self.ok: Counter[str] = Counter()
+        self.bad: Counter[str] = Counter()
+        self.consecutive: Counter[str] = Counter()
+        self.quarantined: set[str] = set()
+
+    def record(self, proxy: str | None, outcome: str) -> None:
+        if not proxy:
+            return
+        # An absent endpoint says nothing about the proxy -- counting it would
+        # quarantine healthy IPs during early seasons, which are mostly absences.
+        if outcome == ENDPOINT_ABSENT:
+            return
+        if outcome == OK:
+            self.ok[proxy] += 1
+            self.consecutive[proxy] = 0
+            return
+        self.bad[proxy] += 1
+        self.consecutive[proxy] += 1
+        if self.consecutive[proxy] >= self.limit:
+            self.quarantined.add(proxy)
+
+    def healthy(self) -> int:
+        return self.pool_size - len(self.quarantined)
+
+    def is_quarantined(self, proxy: str | None) -> bool:
+        return bool(proxy) and proxy in self.quarantined
+
+    def summary(self) -> str:
+        degraded = sum(1 for p, n in self.bad.items() if n and p not in self.quarantined)
+        return (
+            f"proxies: {self.healthy()}/{self.pool_size} healthy"
+            f" · {degraded} degraded · {len(self.quarantined)} quarantined"
+        )
+
+
+class Degradation:
+    """Escalates when the sweep looks like it is fighting the pool, not the data."""
+
+    def __init__(
+        self,
+        proxies: ProxyHealth,
+        ledger: MissLedger,
+        log: Callable[[str], None],
+        min_healthy_fraction: float = 0.5,
+        max_failure_rate: float = 0.25,
+        min_sample: int = 50,
+    ) -> None:
+        self.proxies = proxies
+        self.ledger = ledger
+        self._log = log
+        self.min_healthy_fraction = min_healthy_fraction
+        self.max_failure_rate = max_failure_rate
+        self.min_sample = min_sample
+        self._warned: set[str] = set()
+
+    def failure_rate(self) -> float:
+        attempted = sum(v for k, v in self.ledger.totals.items() if k != ENDPOINT_ABSENT)
+        return self.ledger.real_failures / attempted if attempted else 0.0
+
+    def check(self) -> None:
+        """Warn once per condition, so a bad run is loud but not spammy."""
+        if self.proxies.pool_size:
+            fraction = self.proxies.healthy() / self.proxies.pool_size
+            if fraction < self.min_healthy_fraction and "pool" not in self._warned:
+                self._warned.add("pool")
+                self._log(
+                    f"WARNING: proxy pool degraded -- {self.proxies.healthy()}"
+                    f"/{self.proxies.pool_size} healthy. The sweep will keep running but"
+                    " is likely burning budget against blocked IPs."
+                )
+        attempted = sum(v for k, v in self.ledger.totals.items() if k != ENDPOINT_ABSENT)
+        if attempted >= self.min_sample:
+            rate = self.failure_rate()
+            if rate > self.max_failure_rate and "rate" not in self._warned:
+                self._warned.add("rate")
+                self._log(
+                    f"WARNING: {rate:.0%} of attempted fetches are failing"
+                    f" ({self.ledger.summary()}); worst: {self.ledger.worst_endpoints()}."
+                    " Expected-absent endpoints are excluded, so this is real."
+                )

--- a/sportsdataverse/scrape/stats/proxy.py
+++ b/sportsdataverse/scrape/stats/proxy.py
@@ -1,0 +1,348 @@
+"""Round-robin ProxyBonanza proxy pool for the shared stats.nba.com / stats.wnba.com request budget.
+
+Port of the R side's ``R/utils.R::get_proxy_ips`` / ``next_proxy``. Credentials
+(``PROXY_ENDPOINT`` / ``PROXY_KEY`` / ``PROXY_PKG``) are read from the process
+environment at call time -- never hardcoded, never logged in cleartext (use
+:func:`redact` before putting a proxy URL in a log line or error message).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import threading
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Optional
+
+
+def classify(status: Optional[int], text: str, error: Optional[str]) -> str:
+    """Bucket a fetch outcome for health/observability.
+
+    - ``transport_err``: the request raised (timeout / connection / proxy dead).
+    - ``blocked``: HTTP 403 / 429 — the IP was rate-limited / blocked.
+    - ``server_err``: HTTP 5xx — the request REACHED the stats host and the server
+      erred (e.g. gamerotation 500s on pre-tracking games). The proxy is fine, so
+      this is NOT a proxy-health signal and never quarantines.
+    - ``notfound``: HTTP 400 / 404 — endpoint genuinely absent (expected for old
+      seasons; benign).
+    - ``blank``: HTTP 200 with an empty body (mild throttle signal).
+    - ``ok``: HTTP 200 with a body.
+
+    Only ``transport_err`` / ``blocked`` / ``blank`` are quarantine-worthy (the
+    proxy or the IP is the problem). ``server_err`` and ``notfound`` never count
+    against a proxy.
+    """
+    if error is not None:
+        return "transport_err"
+    if status == 200:
+        return "ok" if (text or "").strip() else "blank"
+    if status in (400, 404):
+        return "notfound"
+    if status is not None and 500 <= status < 600:
+        return "server_err"
+    return "blocked"
+
+
+_QUARANTINE_CATS = ("transport_err", "blocked", "blank")
+_ERROR_CATS = (
+    "transport_err",
+    "blocked",
+    "blank",
+    "server_err",
+)  # non-benign, worth logging
+
+
+class ProxyHealth:
+    """Thread-safe per-proxy + global fetch-outcome registry.
+
+    Drives three things: per-proxy quarantine (consecutive bad outcomes), the
+    heartbeat's health summary, and the degradation WARN. Keyed by the redacted
+    ``host:port`` so credentials never enter the counters or a log line.
+    """
+
+    _CAT_KEYS = ("ok", "blank", "notfound", "blocked", "server_err", "transport_err")
+
+    def __init__(
+        self,
+        quarantine_fails: int = 5,
+        quarantine_secs: float = 120.0,
+        error_log: Optional[str] = None,
+    ):
+        self._lock = threading.Lock()
+        self._per: dict[str, dict[str, Any]] = {}
+        self.quarantine_fails = quarantine_fails
+        # Quarantine is a COOLDOWN, not a death sentence: a proxy that trips the
+        # consecutive-fault threshold is benched for quarantine_secs then retried,
+        # so a transient block storm can't sideline good IPs forever.
+        self.quarantine_secs = quarantine_secs
+        self.cat: dict[str, int] = {k: 0 for k in self._CAT_KEYS}
+        # Aggregate outcomes by endpoint too, so "which requests error and why"
+        # is answerable: endpoint -> {category: count}.
+        self.endpoint_cat: dict[str, dict[str, int]] = {}
+        # Optional append-only JSONL of every non-ok outcome (the queryable
+        # by-endpoint/type/resource drill-down). One line: ts, endpoint,
+        # resource (game_id/season), status, cat, latency, proxy.
+        self._elog = None
+        if error_log:
+            try:
+                self._elog = open(error_log, "a", encoding="utf-8")  # noqa: SIM115
+            except OSError:
+                self._elog = None
+
+    def record(
+        self,
+        proxy_url: Optional[str],
+        category: str,
+        latency_ms: float = 0.0,
+        endpoint: str = "?",
+        resource: str = "",
+        status: Optional[int] = None,
+        params: Optional[dict[str, Any]] = None,
+        session_id: Optional[int] = None,
+        session_req: Optional[int] = None,
+    ) -> None:
+        key = redact(proxy_url) if proxy_url else "direct"
+        with self._lock:
+            self.cat[category] = self.cat.get(category, 0) + 1
+            ec = self.endpoint_cat.setdefault(endpoint, {k: 0 for k in self._CAT_KEYS})
+            ec[category] = ec.get(category, 0) + 1
+            d = self._per.setdefault(
+                key,
+                {
+                    "req": 0,
+                    "consec_err": 0,
+                    "quar_until": 0.0,
+                    "lat_ms": 0.0,
+                    "ok": 0,
+                    "blank": 0,
+                    "notfound": 0,
+                    "blocked": 0,
+                    "server_err": 0,
+                    "transport_err": 0,
+                },
+            )
+            d["req"] += 1
+            d[category] = d.get(category, 0) + 1
+            d["lat_ms"] = latency_ms
+            if category in _QUARANTINE_CATS:
+                d["consec_err"] += 1
+                if d["consec_err"] >= self.quarantine_fails:  # (re-)bench for a cooldown
+                    d["quar_until"] = time.monotonic() + self.quarantine_secs
+            else:  # ok / notfound / server_err: the proxy delivered, so rehabilitate it
+                d["consec_err"] = 0
+                d["quar_until"] = 0.0
+            if self._elog is not None and category in _ERROR_CATS:
+                entry = {
+                    "ts": round(time.time(), 3),
+                    "endpoint": endpoint,
+                    "resource": resource,
+                    "status": status,
+                    "cat": category,
+                    "lat_ms": round(latency_ms, 1),
+                    "proxy": key,
+                }
+                # Full request params make same-endpoint/different-variant errors
+                # individually distinguishable (e.g. leaguedashteamshotlocations's
+                # 28 param variants). session_id + session_req pinpoint WHICH
+                # session and WHICH request-in-the-sequence failed (throttle-after-N).
+                if params:
+                    entry["params"] = params
+                if session_id is not None:
+                    entry["session_id"] = session_id
+                if session_req is not None:
+                    entry["session_req"] = session_req
+                self._elog.write(json.dumps(entry) + "\n")
+                self._elog.flush()
+
+    def is_quarantined(self, proxy_url: Optional[str]) -> bool:
+        key = redact(proxy_url) if proxy_url else "direct"
+        with self._lock:
+            d = self._per.get(key)
+            return bool(d and d["quar_until"] > time.monotonic())
+
+    def reset_quarantine(self) -> None:
+        with self._lock:
+            for d in self._per.values():
+                d["consec_err"] = 0
+                d["quar_until"] = 0.0
+
+    def snapshot(self) -> dict:
+        with self._lock:
+            healthy = degraded = quar = 0
+            worst = []
+            now = time.monotonic()
+            for k, d in self._per.items():
+                if d["quar_until"] > now:
+                    quar += 1
+                    worst.append((k, d["consec_err"]))
+                elif d["consec_err"] >= 2:
+                    degraded += 1
+                    worst.append((k, d["consec_err"]))
+                else:
+                    healthy += 1
+            worst.sort(key=lambda x: -x[1])
+            return {
+                "cat": dict(self.cat),
+                "healthy": healthy,
+                "degraded": degraded,
+                "quar": quar,
+                "used": len(self._per),
+                "worst": worst[:3],
+            }
+
+    def endpoint_summary(self, min_errors: int = 1) -> list[tuple]:
+        """(endpoint, err_total, {cat: count}) for every endpoint with >=
+        min_errors non-benign outcomes, worst first. Feeds the season/final
+        breakdown and answers 'which requests error, and how'."""
+        with self._lock:
+            rows = []
+            for ep, ec in self.endpoint_cat.items():
+                errs = sum(ec.get(c, 0) for c in _ERROR_CATS)
+                if errs >= min_errors:
+                    rows.append((ep, errs, dict(ec)))
+            rows.sort(key=lambda r: -r[1])
+            return rows
+
+    def top_error_endpoints(self, n: int = 3) -> str:
+        """Compact 'gamerotation(5xx682) hustle(b88)' fragment for the heartbeat."""
+        frag = []
+        for ep, _errs, ec in self.endpoint_summary()[:n]:
+            parts = []
+            if ec.get("transport_err"):
+                parts.append(f"t{ec['transport_err']}")
+            if ec.get("blocked"):
+                parts.append(f"b{ec['blocked']}")
+            if ec.get("server_err"):
+                parts.append(f"5xx{ec['server_err']}")
+            if ec.get("blank"):
+                parts.append(f"z{ec['blank']}")
+            frag.append(f"{ep}({' '.join(parts)})")
+        return " ".join(frag) or "none"
+
+    def close(self) -> None:
+        if self._elog is not None:
+            try:
+                self._elog.close()
+            except OSError:
+                pass
+
+
+def load_proxies() -> list[dict[str, Any]]:
+    """Fetch the configured ProxyBonanza proxy list.
+
+    Reads ``PROXY_ENDPOINT`` / ``PROXY_KEY`` / ``PROXY_PKG`` from the process
+    environment at call time. GETs ``{PROXY_ENDPOINT}/{PROXY_PKG}.json`` with
+    an ``Authorization: {PROXY_KEY}`` header, mirroring the R
+    ``get_proxy_ips()`` response shape (``data.login`` / ``data.password`` /
+    ``data.ippacks[].ip`` / ``data.ippacks[].port_http``, broadcast into one
+    dict per IP pack). Never raises: returns ``[]`` if any of the three env
+    vars is unset, the request fails, or the payload doesn't match the
+    expected shape.
+
+    Returns:
+        A list of dicts with ``ip`` / ``port`` / ``login`` / ``password``
+        keys (consumable by :class:`RoundRobin`), or ``[]`` when
+        unconfigured / unreachable.
+    """
+    endpoint = os.environ.get("PROXY_ENDPOINT")
+    key = os.environ.get("PROXY_KEY")
+    pkg = os.environ.get("PROXY_PKG")
+    if not endpoint or not key or not pkg:
+        return []
+
+    url = f"{endpoint.rstrip('/')}/{pkg}.json"
+    req = urllib.request.Request(url, headers={"Authorization": key})
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:  # noqa: S310 - fixed https proxy-vendor endpoint
+            payload = json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, ValueError):
+        return []
+
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(data, dict):
+        return []
+    ippacks = data.get("ippacks")
+    if not isinstance(ippacks, list):
+        return []
+    login = data.get("login")
+    password = data.get("password")
+    return [
+        {
+            "ip": pack["ip"],
+            "port": pack["port_http"],
+            "login": login,
+            "password": password,
+        }
+        for pack in ippacks
+        if isinstance(pack, dict) and pack.get("ip") and pack.get("port_http")
+    ]
+
+
+class RoundRobin:
+    """Random-start round-robin proxy rotation.
+
+    Mirrors ``next_proxy()``: shuffles a fixed visiting order once (spreads
+    load evenly across IPs instead of ``select_proxy()``'s sampling with
+    replacement) and walks it forever.
+
+    Args:
+        proxies: List of proxy dicts (``ip`` / ``port`` / ``login`` /
+            ``password``), e.g. from :func:`load_proxies`.
+    """
+
+    def __init__(self, proxies: list[dict[str, Any]], health: "Optional[ProxyHealth]" = None):
+        self._proxies = list(proxies)
+        self._order = list(range(len(self._proxies)))
+        random.shuffle(self._order)
+        self._pos = 0
+        self._health = health
+        self._lock = threading.Lock()  # 14 workers call next() concurrently
+
+    def _url_at(self, idx: int) -> str:
+        p = self._proxies[self._order[idx % len(self._order)]]
+        return f"http://{p['login']}:{p['password']}@{p['ip']}:{p['port']}"
+
+    def next(self) -> Optional[str]:
+        """Return the next non-quarantined proxy URL, or ``None`` if the pool is empty.
+
+        Skips proxies the health tracker has quarantined (too many consecutive
+        timeouts / blocks). If every proxy is quarantined, clears the quarantine
+        and hands one back anyway rather than stalling the sweep.
+        """
+        if not self._proxies:
+            return None
+        with self._lock:
+            n = len(self._order)
+            for _ in range(n):
+                url = self._url_at(self._pos)
+                self._pos += 1
+                if self._health is None or not self._health.is_quarantined(url):
+                    return url
+            # whole pool quarantined — reset and fall back so work never stalls
+            if self._health is not None:
+                self._health.reset_quarantine()
+            url = self._url_at(self._pos)
+            self._pos += 1
+            return url
+
+
+def redact(url: str) -> str:
+    """Strip ``login:password@`` userinfo from a proxy URL for safe logging.
+
+    Args:
+        url: A proxy URL, e.g. ``"http://user:pass@1.2.3.4:8000"``.
+
+    Returns:
+        The URL with credentials removed (``"scheme://host:port"``). Returns
+        the input unchanged if there is no ``@`` to strip.
+    """
+    scheme_sep = url.find("://")
+    if scheme_sep == -1 or "@" not in url:
+        return url
+    scheme = url[: scheme_sep + 3]
+    rest = url[scheme_sep + 3 :]
+    _, _, hostport = rest.partition("@")
+    return f"{scheme}{hostport}"

--- a/sportsdataverse/scrape/stats/proxy.py
+++ b/sportsdataverse/scrape/stats/proxy.py
@@ -6,8 +6,7 @@ environment at call time -- never hardcoded, never logged in cleartext (use
 :func:`redact` before putting a proxy URL in a log line or error message).
 """
 
-from __future__ import annotations
-
+import io
 import json
 import os
 import random
@@ -70,7 +69,7 @@ class ProxyHealth:
         quarantine_fails: int = 5,
         quarantine_secs: float = 120.0,
         error_log: Optional[str] = None,
-    ):
+    ) -> None:
         self._lock = threading.Lock()
         self._per: dict[str, dict[str, Any]] = {}
         self.quarantine_fails = quarantine_fails
@@ -85,7 +84,7 @@ class ProxyHealth:
         # Optional append-only JSONL of every non-ok outcome (the queryable
         # by-endpoint/type/resource drill-down). One line: ts, endpoint,
         # resource (game_id/season), status, cat, latency, proxy.
-        self._elog = None
+        self._elog: Optional[io.TextIOBase] = None
         if error_log:
             try:
                 self._elog = open(error_log, "a", encoding="utf-8")  # noqa: SIM115
@@ -252,13 +251,15 @@ def load_proxies() -> list[dict[str, Any]]:
     pkg = os.environ.get("PROXY_PKG")
     if not endpoint or not key or not pkg:
         return []
+    if not endpoint.lower().startswith(("http://", "https://")):
+        return []  # refuse file:// / ftp:// etc. -- keeps the S310 suppression honest
 
     url = f"{endpoint.rstrip('/')}/{pkg}.json"
     req = urllib.request.Request(url, headers={"Authorization": key})
     try:
         with urllib.request.urlopen(req, timeout=15) as resp:  # noqa: S310 - fixed https proxy-vendor endpoint
             payload = json.loads(resp.read().decode("utf-8"))
-    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, ValueError):
+    except (OSError, json.JSONDecodeError, ValueError):
         return []
 
     data = payload.get("data") if isinstance(payload, dict) else None
@@ -344,5 +345,5 @@ def redact(url: str) -> str:
         return url
     scheme = url[: scheme_sep + 3]
     rest = url[scheme_sep + 3 :]
-    _, _, hostport = rest.partition("@")
+    _, _, hostport = rest.rpartition("@")
     return f"{scheme}{hostport}"

--- a/sportsdataverse/scrape/stats/session_transport.py
+++ b/sportsdataverse/scrape/stats/session_transport.py
@@ -1,0 +1,160 @@
+"""Thread-local sticky-session curl_cffi transport for stats.nba.com / stats.wnba.com sweeps.
+
+More prudent than rotating the proxy on every request: each worker thread keeps a
+persistent ``curl_cffi.Session`` (keep-alive) bound to ONE proxy, so the TLS/JA3
+handshake is paid once and reused across a burst of requests — faster, and a
+coherent per-IP session reads as more legitimate than per-request IP hopping. A
+rotation policy bounds per-IP exposure and self-heals:
+
+    * rotate after SESSION_MAX_REQUESTS requests (default 120),
+    * or SESSION_MAX_SECS seconds (default 300),
+    * or immediately on a proxy fault (timeout / connection / 403 / 429),
+
+and it never binds a quarantined proxy (it draws from the same quarantine-aware
+``RoundRobin``). Injected via the wrapper ``transport=`` hook, so sdv-py is
+unchanged. Every fetch is recorded to ``ProxyHealth`` with its endpoint + full
+params + status + latency + proxy + session id + session request number, so
+same-endpoint/different-param requests are individually distinguishable in the
+error log.
+
+Transient server-side 500s (the stats hosts intermittently 500 an individual
+historical game/endpoint even though the data exists) are retried in-session on
+the SAME proxy up to SESSION_SERVER_ERR_RETRIES (default 2) — the IP is healthy,
+so rebinding would be wasteful. Timeouts / blocks are NOT retried here: they stay
+single-shot and rotate, preserving the fast-on-faults contract.
+"""
+
+from __future__ import annotations
+
+import itertools
+import os
+import threading
+import time
+from typing import Optional
+
+from .proxy import ProxyHealth, RoundRobin, classify
+
+_ROTATE_ON = ("transport_err", "blocked")  # proxy/IP faults -> rebind the session
+
+
+class SessionTransport:
+    def __init__(
+        self,
+        rr: RoundRobin,
+        health: ProxyHealth,
+        max_requests: int = 120,
+        max_secs: float = 300.0,
+    ) -> None:
+        self.rr = rr
+        self.health = health
+        self.max_requests = int(os.environ.get("SESSION_MAX_REQUESTS", str(max_requests)))
+        self.max_secs = float(os.environ.get("SESSION_MAX_SECS", str(max_secs)))
+        self.timeout = float(os.environ.get("SDV_PY_NBA_STATS_TIMEOUT", "30"))
+        # the stats hosts 500 intermittently on individual historical games even
+        # though the data exists (measured: the same game/endpoint recovers on an
+        # immediate re-request). Retry the CHEAP server_err class in-session;
+        # timeouts/blocks stay single-shot (the fast-on-faults contract).
+        self.server_err_retries = int(os.environ.get("SESSION_SERVER_ERR_RETRIES", "2"))
+        self._tls = threading.local()
+        self._ids = itertools.count(1)
+        self._id_lock = threading.Lock()
+
+    def _next_id(self) -> int:
+        with self._id_lock:
+            return next(self._ids)
+
+    def _bind(self, st: threading.local) -> None:
+        """(Re)bind this worker to a fresh Session on a new (non-quarantined) proxy."""
+        from curl_cffi import requests as creq
+
+        old = getattr(st, "sess", None)
+        if old is not None:
+            try:
+                old.close()
+            except Exception:  # noqa: BLE001 - a close failure must not stall the sweep
+                pass
+        st.proxy = self.rr.next()
+        st.sess = creq.Session(impersonate="chrome")  # one JA3 handshake, then reuse
+        if st.proxy:
+            st.sess.proxies = {"http": st.proxy, "https": st.proxy}
+        st.n = 0
+        st.t0 = time.monotonic()
+        st.sid = self._next_id()
+
+    def __call__(self, url: str, params: dict, headers: dict, proxy_url: Optional[str]) -> tuple:
+        st = self._tls
+        if (
+            getattr(st, "sess", None) is None
+            or st.n >= self.max_requests
+            or (time.monotonic() - st.t0) >= self.max_secs
+        ):
+            self._bind(st)
+
+        endpoint = url.rsplit("/stats/", 1)[-1].split("?")[0] if "/stats/" in url else url
+        resource = str((params or {}).get("GameID") or (params or {}).get("Season") or "")
+        st_req = st.n + 1  # ordinal of this request within the current session
+        t0 = time.monotonic()
+        try:
+            r = st.sess.get(url, params=params, headers=headers, timeout=self.timeout)
+            status, text = r.status_code, r.text
+        except Exception:
+            lat = (time.monotonic() - t0) * 1000
+            self.health.record(
+                st.proxy,
+                "transport_err",
+                lat,
+                endpoint=endpoint,
+                resource=resource,
+                status=None,
+                params=params,
+                session_id=st.sid,
+                session_req=st_req,
+            )
+            self._bind(st)  # a dead/slow proxy: drop the session and move on
+            raise  # preserve the "timeout propagates" contract for the miss count
+
+        st.n += 1
+        lat = (time.monotonic() - t0) * 1000
+        cat = classify(status, text, None)
+        # Recover transient server-side 500s on the SAME proxy (the IP is fine, the
+        # server erred). Only the final outcome is recorded, so a recovered 500 logs
+        # nothing and a persistent one logs a single server_err.
+        tries = 0
+        while cat == "server_err" and tries < self.server_err_retries:
+            tries += 1
+            st.n += 1
+            t0 = time.monotonic()
+            try:
+                r = st.sess.get(url, params=params, headers=headers, timeout=self.timeout)
+                status, text = r.status_code, r.text
+            except Exception:
+                lat = (time.monotonic() - t0) * 1000
+                self.health.record(
+                    st.proxy,
+                    "transport_err",
+                    lat,
+                    endpoint=endpoint,
+                    resource=resource,
+                    status=None,
+                    params=params,
+                    session_id=st.sid,
+                    session_req=st_req,
+                )
+                self._bind(st)
+                raise
+            lat = (time.monotonic() - t0) * 1000
+            cat = classify(status, text, None)
+        self.health.record(
+            st.proxy,
+            cat,
+            lat,
+            endpoint=endpoint,
+            resource=resource,
+            status=status,
+            params=params,
+            session_id=st.sid,
+            session_req=st_req,
+        )
+        if cat in _ROTATE_ON:  # the IP was throttled/blocked -> rebind to a fresh one
+            self._bind(st)
+        return status, text

--- a/sportsdataverse/scrape/stats/session_transport.py
+++ b/sportsdataverse/scrape/stats/session_transport.py
@@ -24,8 +24,6 @@ so rebinding would be wasteful. Timeouts / blocks are NOT retried here: they sta
 single-shot and rotate, preserving the fast-on-faults contract.
 """
 
-from __future__ import annotations
-
 import itertools
 import os
 import threading
@@ -82,6 +80,9 @@ class SessionTransport:
         st.sid = self._next_id()
 
     def __call__(self, url: str, params: dict, headers: dict, proxy_url: Optional[str]) -> tuple:
+        # ``proxy_url`` is the shared wrapper-transport hook signature; this
+        # transport OWNS proxy selection (round-robin + quarantine) and
+        # deliberately ignores an explicit proxy.
         st = self._tls
         if (
             getattr(st, "sess", None) is None
@@ -110,7 +111,10 @@ class SessionTransport:
                 session_id=st.sid,
                 session_req=st_req,
             )
-            self._bind(st)  # a dead/slow proxy: drop the session and move on
+            try:
+                self._bind(st)  # a dead/slow proxy: drop the session and move on
+            except Exception:  # noqa: BLE001 - must not mask the original transport error
+                st.sess = None  # rebind lazily on the next call instead
             raise  # preserve the "timeout propagates" contract for the miss count
 
         st.n += 1
@@ -123,6 +127,7 @@ class SessionTransport:
         while cat == "server_err" and tries < self.server_err_retries:
             tries += 1
             st.n += 1
+            st_req = st.n  # the retry's ordinal -- keep throttle-after-N analysis honest
             t0 = time.monotonic()
             try:
                 r = st.sess.get(url, params=params, headers=headers, timeout=self.timeout)
@@ -140,7 +145,10 @@ class SessionTransport:
                     session_id=st.sid,
                     session_req=st_req,
                 )
-                self._bind(st)
+                try:
+                    self._bind(st)
+                except Exception:  # noqa: BLE001 - must not mask the original transport error
+                    st.sess = None
                 raise
             lat = (time.monotonic() - t0) * 1000
             cat = classify(status, text, None)

--- a/tests/scrape/test_scrape_stats_observability.py
+++ b/tests/scrape/test_scrape_stats_observability.py
@@ -1,0 +1,201 @@
+"""Tests for sweep observability. All pure bookkeeping -- no HTTP, no sleeping."""
+
+from __future__ import annotations
+
+from sportsdataverse.scrape.stats.observability import (
+    ENDPOINT_ABSENT,
+    ERROR,
+    OK,
+    THROTTLED,
+    TIMEOUT,
+    Degradation,
+    MissLedger,
+    Progress,
+    ProxyHealth,
+    classify,
+)
+
+
+class Clock:
+    def __init__(self) -> None:
+        self.t = 0.0
+
+    def __call__(self) -> float:
+        return self.t
+
+
+# -- classify ------------------------------------------------------------------
+
+
+def test_empty_payload_is_an_absent_endpoint_not_an_error() -> None:
+    """The largest source of early-season misses: 200 with nothing in it."""
+    assert classify(None, {}) == ENDPOINT_ABSENT
+    assert classify(None, []) == ENDPOINT_ABSENT
+    assert classify(None, None) == ENDPOINT_ABSENT
+    assert classify(None, {"resultSets": [1]}) == OK
+
+
+def test_timeouts_and_throttles_are_distinguished() -> None:
+    assert classify(TimeoutError("read timeout")) == TIMEOUT
+    assert classify(RuntimeError("HTTP 429 Too Many Requests")) == THROTTLED
+    assert classify(RuntimeError("403 Forbidden")) == THROTTLED
+    assert classify(ValueError("something else entirely")) == ERROR
+
+
+def test_absent_hints_in_an_exception_still_read_as_absent() -> None:
+    assert classify(RuntimeError("404 not found")) == ENDPOINT_ABSENT
+
+
+# -- progress ------------------------------------------------------------------
+
+
+def test_heartbeat_fires_on_interval_not_every_game() -> None:
+    lines: list[str] = []
+    clock = Clock()
+    p = Progress(100, "1997", lines.append, interval_s=60, now=clock)
+    for _ in range(10):
+        clock.t += 1
+        p.advance(3)
+    assert lines == [], "should not log before the interval elapses"
+    clock.t += 60
+    p.advance(3)
+    assert len(lines) == 1
+    assert "11/100 games" in lines[0] and "payloads" in lines[0]
+
+
+def test_final_game_always_reports() -> None:
+    lines: list[str] = []
+    clock = Clock()
+    p = Progress(2, "x", lines.append, interval_s=9999, now=clock)
+    p.advance()
+    p.advance()
+    assert len(lines) == 1 and "2/2" in lines[0]
+
+
+def test_render_includes_rate_and_eta() -> None:
+    clock = Clock()
+    p = Progress(120, "s", lambda _m: None, interval_s=9999, now=clock)
+    for _ in range(60):
+        clock.t += 1
+        p.done += 1
+    out = p.render()
+    assert "games/min" in out and "ETA" in out
+
+
+# -- ledger --------------------------------------------------------------------
+
+
+def test_absent_endpoints_are_not_real_failures() -> None:
+    led = MissLedger()
+    for _ in range(9):
+        led.record("boxscoreadvancedv3", ENDPOINT_ABSENT)
+    led.record("playbyplayv3", TIMEOUT)
+    assert led.real_failures == 1
+    assert "endpoint_absent=9" in led.summary()
+
+
+def test_worst_endpoints_points_at_the_culprit() -> None:
+    led = MissLedger()
+    for _ in range(5):
+        led.record("gamerotation", ERROR)
+    led.record("playbyplayv3", ERROR)
+    led.record("boxscoremiscv3", ENDPOINT_ABSENT)
+    worst = led.worst_endpoints()
+    assert worst.startswith("gamerotation=5")
+    assert "boxscoremiscv3" not in worst, "absent endpoints are not culprits"
+
+
+# -- proxy health --------------------------------------------------------------
+
+
+def test_absent_endpoints_never_count_against_a_proxy() -> None:
+    """Early seasons are mostly absences; counting them would quarantine the pool."""
+    ph = ProxyHealth(pool_size=5, consecutive_fail_limit=3)
+    for _ in range(50):
+        ph.record("p1", ENDPOINT_ABSENT)
+    assert ph.healthy() == 5 and not ph.quarantined
+
+
+def test_consecutive_failures_quarantine_and_success_resets() -> None:
+    ph = ProxyHealth(pool_size=5, consecutive_fail_limit=3)
+    for _ in range(2):
+        ph.record("p1", TIMEOUT)
+    ph.record("p1", OK)  # resets the streak
+    for _ in range(2):
+        ph.record("p1", TIMEOUT)
+    assert not ph.is_quarantined("p1")
+    ph.record("p1", TIMEOUT)
+    assert ph.is_quarantined("p1") and ph.healthy() == 4
+
+
+def test_summary_counts_degraded_separately_from_quarantined() -> None:
+    ph = ProxyHealth(pool_size=3, consecutive_fail_limit=2)
+    ph.record("p1", TIMEOUT)  # degraded, not out
+    ph.record("p2", TIMEOUT)
+    ph.record("p2", TIMEOUT)  # quarantined
+    s = ph.summary()
+    assert "2/3 healthy" in s and "1 degraded" in s and "1 quarantined" in s
+
+
+# -- degradation ---------------------------------------------------------------
+
+
+def test_warns_once_when_the_pool_collapses() -> None:
+    lines: list[str] = []
+    ph = ProxyHealth(pool_size=4, consecutive_fail_limit=1)
+    deg = Degradation(ph, MissLedger(), lines.append)
+    for p in ("a", "b", "c"):
+        ph.record(p, TIMEOUT)
+    deg.check()
+    deg.check()
+    assert len(lines) == 1 and "pool degraded" in lines[0]
+
+
+def test_failure_rate_excludes_absent_endpoints() -> None:
+    """Otherwise every early season would trip the alarm."""
+    led = MissLedger()
+    for _ in range(500):
+        led.record("boxscoreusagev3", ENDPOINT_ABSENT)
+    for _ in range(60):
+        led.record("playbyplayv3", OK)
+    deg = Degradation(ProxyHealth(10), led, lambda _m: None)
+    assert deg.failure_rate() == 0.0
+
+
+def test_warns_when_real_failures_spike() -> None:
+    lines: list[str] = []
+    led = MissLedger()
+    for _ in range(40):
+        led.record("playbyplayv3", OK)
+    for _ in range(30):
+        led.record("playbyplayv3", TIMEOUT)
+    deg = Degradation(ProxyHealth(10), led, lines.append)
+    deg.check()
+    assert len(lines) == 1 and "failing" in lines[0]
+
+
+def test_no_warning_below_the_sample_floor() -> None:
+    lines: list[str] = []
+    led = MissLedger()
+    led.record("x", ERROR)
+    Degradation(ProxyHealth(10), led, lines.append).check()
+    assert lines == [], "one bad call must not raise an alarm"
+
+
+def test_since_reports_one_season_not_the_whole_run() -> None:
+    """The ledger spans the run; a per-season line must not print run totals."""
+    led = MissLedger()
+    for _ in range(81):
+        led.record("gamerotation", TIMEOUT)
+    mark = led.snapshot()
+    for _ in range(209):
+        led.record("gamerotation", TIMEOUT)
+    assert "timeout=209" in led.since(mark), "must report the season, not 290"
+    assert led.real_failures_since(mark) == 209
+    assert led.real_failures == 290, "the run total is still available"
+
+
+def test_since_on_an_unchanged_ledger_is_empty() -> None:
+    led = MissLedger()
+    led.record("x", OK)
+    assert led.since(led.snapshot()) == "no fetches"

--- a/tests/scrape/test_scrape_stats_proxy.py
+++ b/tests/scrape/test_scrape_stats_proxy.py
@@ -43,3 +43,5 @@ def test_redact_strips_credentials() -> None:
     out = redact("http://user:secret@1.2.3.4:8080")
     assert "secret" not in out
     assert "1.2.3.4" in out
+    # RFC 3986: userinfo ends at the LAST @ -- a password containing @ must not leak
+    assert redact("http://user:p@ss@1.2.3.4:8080") == "http://1.2.3.4:8080"

--- a/tests/scrape/test_scrape_stats_proxy.py
+++ b/tests/scrape/test_scrape_stats_proxy.py
@@ -1,0 +1,45 @@
+"""Truth-table tests for the proxy-layer outcome classifier.
+
+Pure bookkeeping — no HTTP. The categories are the quarantine contract: only
+``transport_err`` / ``blocked`` / ``blank`` may count against a proxy;
+``server_err`` and ``notfound`` reached the host and must never quarantine.
+"""
+
+from __future__ import annotations
+
+from sportsdataverse.scrape.stats.proxy import _QUARANTINE_CATS, classify, redact
+
+
+def test_error_wins_over_status() -> None:
+    assert classify(None, "", "timed out") == "transport_err"
+    assert classify(200, "body", "conn reset") == "transport_err"
+
+
+def test_ok_requires_a_body() -> None:
+    assert classify(200, '{"resultSets": []}', None) == "ok"
+    assert classify(200, "", None) == "blank"
+    assert classify(200, "   \n", None) == "blank"
+
+
+def test_notfound_is_400_and_404() -> None:
+    assert classify(400, "", None) == "notfound"
+    assert classify(404, "nope", None) == "notfound"
+
+
+def test_server_err_is_5xx_and_never_quarantines() -> None:
+    for status in (500, 502, 503, 599):
+        assert classify(status, "", None) == "server_err"
+    assert "server_err" not in _QUARANTINE_CATS
+    assert "notfound" not in _QUARANTINE_CATS
+
+
+def test_everything_else_is_blocked() -> None:
+    assert classify(403, "", None) == "blocked"
+    assert classify(429, "", None) == "blocked"
+    assert classify(None, "", None) == "blocked"
+
+
+def test_redact_strips_credentials() -> None:
+    out = redact("http://user:secret@1.2.3.4:8080")
+    assert "secret" not in out
+    assert "1.2.3.4" in out


### PR DESCRIPTION
Phase 1 of the shared stats-raw engine decided in the 2026-08-02 pipeline audit (option B: engine lives in sdv-py). Lifts the pure-shared band — the three modules that had drifted to byte-identical-or-nearly between `hoopR-nba-stats-raw` and `wehoop-wnba-stats-raw` (0/4/6 diff lines, all cosmetic host-name mentions) — into one library home:

- `sportsdataverse/scrape/stats/proxy.py` — round-robin ProxyBonanza pool, quarantine + outcome classification
- `sportsdataverse/scrape/stats/session_transport.py` — thread-local sticky-session curl_cffi transport (Chrome impersonation), in-session retry of the cheap `server_err` class only
- `sportsdataverse/scrape/stats/observability.py` — sweep bookkeeping (outcome ledger, degradation windows, heartbeat)

Deliberately NOT re-exported at the top-level namespace — producer-pipeline tooling, not the tidy-data API. No wildcard re-exports inside the subpackage either (`proxy` and `observability` each define a layer-specific `classify`).

**Faithfulness:** modules lifted verbatim from the NBA twin (canonical side); only changes are league-neutral docstrings, the package-relative import, two type annotations (`rr: RoundRobin, health: ProxyHealth`, `st: threading.local`), and sdv-py's ruff format.

**Verification:** 23 offline tests green (the twins' 17-test observability suite ported + a new proxy-classifier truth table incl. the never-quarantine contract for `server_err`/`notfound`); mypy ratchet green (346 files) with all five new files appended; ruff lint + format clean; codegen drift untouched.

**Next (separate PRs):** the twins swap to these imports and delete their local copies (git-SHA pin until the next PyPI release); Phase 2 unifies the league-flavored band (`endpoints`/`season_capture`/`scrape_raw_json`, ~700 real drift lines) behind a `LeagueConfig`.

## Summary by Sourcery

Introduce a shared scrape engine subpackage for stats.nba.com and stats.wnba.com, consolidating proxy handling, session transport, and sweep observability logic for use by producer pipelines.

New Features:
- Add sportsdataverse.scrape and sportsdataverse.scrape.stats subpackages to host shared scraping machinery for NBA and WNBA stats sweeps.
- Provide a proxy management module with round-robin rotation, health tracking, and outcome classification for the shared stats request budget.
- Provide a sticky-session curl_cffi-based transport module with proxy-aware session rotation and selective in-session retries for server-side errors.
- Provide an observability module for sweep progress heartbeat, outcome categorization, proxy health monitoring, and degradation alerts.

Build:
- Include the new scrape packages and modules in the pyproject.toml tracked files list so they are part of the distribution.

Documentation:
- Document the new shared stats scrape engine and its modules in the main CHANGELOG and docs CHANGELOG, including its intended usage and non-exported status from the top-level namespace.

Tests:
- Add offline tests covering observability bookkeeping (progress, miss ledger, proxy health, degradation) and proxy classifier behavior and redaction to validate the new shared scrape engine components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared stats-scraping engine for NBA and WNBA data collection.
  * Added proxy pooling, health monitoring, quarantine handling, session reuse, and selective retries.
  * Added progress tracking, endpoint outcome classification, failure summaries, and degradation warnings.
  * Added documentation for the new scraping capabilities and their current scope.

* **Tests**
  * Added offline coverage for proxy behavior, credential redaction, observability, retries, and failure tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->