### PR TITLE
feat(scrape): LeagueConfig-parameterized capture layer — Phase 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Unreleased](#unreleased)
+  - [`sportsdataverse.scrape.stats` — league-parameterized capture layer (Phase 2)](#sportsdataversescrapestats--league-parameterized-capture-layer-phase-2)
   - [Docs — offline full-text search on the documentation site](#docs--offline-full-text-search-on-the-documentation-site)
   - [CI — docs site builds on GitHub Actions and publishes to `gh-pages`](#ci--docs-site-builds-on-github-actions-and-publishes-to-gh-pages)
   - [New — `sportsdataverse.scrape.stats`: shared stats.nba.com / stats.wnba.com sweep engine (Phase 1)](#new--sportsdataversescrapestats-shared-statsnbacom--statswnbacom-sweep-engine-phase-1)
@@ -220,6 +221,34 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Unreleased
+
+### `sportsdataverse.scrape.stats` — league-parameterized capture layer (Phase 2)
+
+Phase 1 gave the stats-raw twins one transport/proxy/observability engine; this
+moves the *capture planning* behind a `LeagueConfig` so the two `-raw` repos
+stop carrying near-duplicate copies of it (the remaining ~700 drift lines):
+
+- `league_config.py` — frozen `NBA` / `WNBA` identity (LeagueID, wrapper
+  module and prefix, store env var and subdir), resolvable by `by_league_id()`.
+- `endpoints.py` — the signature-derived capture registry. Season-string
+  spelling is now league-keyed: the NBA's two-year span (`"2023-24"`, without
+  which several endpoints silently return zero rows) vs the WNBA's bare
+  calendar year.
+- `season_capture.py` — atomic, resumable season-level captures with the
+  contentless-payload guard (an unparseable `{}` is never persisted, because
+  resume is `path.exists()` and one empty write is permanent).
+- `periods.py` — league- and era-aware per-period window math: NBA 12-minute
+  quarters, WNBA two 20-minute halves through 2005 and four 10-minute quarters
+  from 2006. Regulation totals 2400s in *both* WNBA eras, so only the period
+  boundaries reveal a mix-up; a regression test pins the NBA path to
+  `nba_lineups._period_start_range`, the function that reads these captures
+  back.
+- `refill.py` — the empty-`{}` repair pass, driven by a `LeagueConfig` instead
+  of per-repo constants.
+
+Resolving the wrapper module from the config fixed a latent crash: the WNBA
+repo's own refill shim imported `sportsdataverse.nba.wnba_stats`, which does
+not exist, so a real (non-`--check`) refill run raised `ModuleNotFoundError`.
 
 ### Docs — offline full-text search on the documentation site
 

--- a/docs/src/pages/CHANGELOG.md
+++ b/docs/src/pages/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Unreleased](#unreleased)
+  - [`sportsdataverse.scrape.stats` — league-parameterized capture layer (Phase 2)](#sportsdataversescrapestats--league-parameterized-capture-layer-phase-2)
   - [Docs — offline full-text search on the documentation site](#docs--offline-full-text-search-on-the-documentation-site)
   - [CI — docs site builds on GitHub Actions and publishes to `gh-pages`](#ci--docs-site-builds-on-github-actions-and-publishes-to-gh-pages)
   - [New — `sportsdataverse.scrape.stats`: shared stats.nba.com / stats.wnba.com sweep engine (Phase 1)](#new--sportsdataversescrapestats-shared-statsnbacom--statswnbacom-sweep-engine-phase-1)
@@ -220,6 +221,34 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Unreleased
+
+### `sportsdataverse.scrape.stats` — league-parameterized capture layer (Phase 2)
+
+Phase 1 gave the stats-raw twins one transport/proxy/observability engine; this
+moves the *capture planning* behind a `LeagueConfig` so the two `-raw` repos
+stop carrying near-duplicate copies of it (the remaining ~700 drift lines):
+
+- `league_config.py` — frozen `NBA` / `WNBA` identity (LeagueID, wrapper
+  module and prefix, store env var and subdir), resolvable by `by_league_id()`.
+- `endpoints.py` — the signature-derived capture registry. Season-string
+  spelling is now league-keyed: the NBA's two-year span (`"2023-24"`, without
+  which several endpoints silently return zero rows) vs the WNBA's bare
+  calendar year.
+- `season_capture.py` — atomic, resumable season-level captures with the
+  contentless-payload guard (an unparseable `{}` is never persisted, because
+  resume is `path.exists()` and one empty write is permanent).
+- `periods.py` — league- and era-aware per-period window math: NBA 12-minute
+  quarters, WNBA two 20-minute halves through 2005 and four 10-minute quarters
+  from 2006. Regulation totals 2400s in *both* WNBA eras, so only the period
+  boundaries reveal a mix-up; a regression test pins the NBA path to
+  `nba_lineups._period_start_range`, the function that reads these captures
+  back.
+- `refill.py` — the empty-`{}` repair pass, driven by a `LeagueConfig` instead
+  of per-repo constants.
+
+Resolving the wrapper module from the config fixed a latent crash: the WNBA
+repo's own refill shim imported `sportsdataverse.nba.wnba_stats`, which does
+not exist, so a real (non-`--check`) refill run raised `ModuleNotFoundError`.
 
 ### Docs — offline full-text search on the documentation site
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -645,4 +645,9 @@ files = [
     "sportsdataverse/scrape/stats/proxy.py",
     "sportsdataverse/scrape/stats/session_transport.py",
     "sportsdataverse/scrape/stats/observability.py",
+    "sportsdataverse/scrape/stats/league_config.py",
+    "sportsdataverse/scrape/stats/periods.py",
+    "sportsdataverse/scrape/stats/endpoints.py",
+    "sportsdataverse/scrape/stats/season_capture.py",
+    "sportsdataverse/scrape/stats/refill.py",
 ]

--- a/sportsdataverse/scrape/stats/__init__.py
+++ b/sportsdataverse/scrape/stats/__init__.py
@@ -17,6 +17,20 @@ observability``); there are deliberately no wildcard re-exports here —
 ``proxy`` and ``observability`` each define their own ``classify`` for
 different layers, and flattening them would shadow one.
 
-League-specific behavior (endpoint sets, season formats, store roots) stays in
-the consuming ``-raw`` repos; Phase 2 moves it behind a ``LeagueConfig``.
+Phase 2 added the league-parameterized capture layer:
+
+    * :mod:`~sportsdataverse.scrape.stats.league_config` — frozen per-league
+      identity (:data:`~sportsdataverse.scrape.stats.league_config.NBA` /
+      :data:`~sportsdataverse.scrape.stats.league_config.WNBA`).
+    * :mod:`~sportsdataverse.scrape.stats.endpoints` — signature-derived capture
+      registry; season-string spelling (NBA span ``"2023-24"`` vs WNBA bare
+      year) keys off ``league_id``.
+    * :mod:`~sportsdataverse.scrape.stats.season_capture` — atomic, resumable
+      season-level captures (validity-guarded writes).
+    * :mod:`~sportsdataverse.scrape.stats.periods` — league- and era-aware
+      per-period window math (NBA 12-min quarters; WNBA halves→quarters 2006).
+    * :mod:`~sportsdataverse.scrape.stats.refill` — repair pass for the
+      empty-``{}`` payload incident class, driven by a ``LeagueConfig``.
+
+The owning ``-raw`` repos keep only thin league-binding shims + drivers.
 """

--- a/sportsdataverse/scrape/stats/endpoints.py
+++ b/sportsdataverse/scrape/stats/endpoints.py
@@ -1,0 +1,358 @@
+"""Declarative capture registry for the stats.{nba,wnba}.com surface.
+
+One module drives both leagues and both raw repos; only ``league_id`` differs.
+
+Rather than hand-maintaining ~90 endpoint entries and their parameter matrices,
+the matrix for each endpoint is **derived from its own signature**: an endpoint
+that accepts a ``season_type*`` parameter gets swept over season types, one that
+accepts ``measure_type*`` over measure types, and so on. A new endpoint appearing
+upstream is therefore captured at the right granularity with no edit here, and an
+endpoint that drops a parameter stops being swept over it instead of 400-ing.
+
+Granularity choices, made for reuse rather than for any one current consumer:
+
+* **Game endpoints** are captured whole-game, one payload per game per endpoint.
+  Anything narrower (period, range) is a strict subset that can be re-requested,
+  and the per-period capture already exists separately for lineup grounding.
+* **Season endpoints** are captured at ``Totals`` *and* ``PerGame``. Totals is the
+  information-dense form -- PerGame, Per36 and Per100 are all derivable from it --
+  but the currently published datasets are PerGame, and deriving them would
+  introduce rounding differences against what consumers already read. Season-level
+  calls are cheap enough (tens per season, against thousands per season of games)
+  that capturing both removes the question entirely.
+* Every call pins ``season`` and ``league_id`` explicitly rather than relying on
+  upstream defaults, which are undocumented and free to drift.
+
+Capturing a superset is deliberate: a payload already on disk costs nothing to
+reshape later, while a payload never captured means re-sweeping a decade.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Iterator
+from typing import Any, Callable
+
+LEAGUE_NBA = "00"
+LEAGUE_WNBA = "10"
+
+SEASON_TYPES = ("Regular Season", "Playoffs")
+#: Every measure type the API defines. "Four Factors" was missing from this
+#: tuple, so it was never captured for ANY endpoint -- a whole measure type
+#: absent from the archive rather than merely mis-parameterised.
+MEASURE_TYPES = (
+    "Base",
+    "Advanced",
+    "Misc",
+    "Four Factors",
+    "Scoring",
+    "Usage",
+    "Defense",
+    "Opponent",
+)
+
+#: Measure-type values each parameter actually accepts, keyed by the parameter's
+#: OWN name. Sweeping all of MEASURE_TYPES over every ``measure_type*`` parameter
+#: is what produced most of this archive's empty payloads: the endpoint accepts
+#: the parameter, but the API answers an unsupported value with a body that does
+#: not parse, and that `{}` was persisted and never retried.
+#:
+#: Measured live (2026-08-01), not taken from documentation:
+#:   measure_type_simple            Base/Opponent only -> the other 6 were 5/7
+#:                                  of every shot-locations capture (71.4% empty,
+#:                                  identical in NBA and WNBA)
+#:   measure_type_detailed_defense  everything except Usage -> 1/7 (14.3% empty,
+#:                                  again identical across both leagues)
+#: An unlisted parameter falls back to the full tuple.
+MEASURE_TYPE_DOMAINS: dict[str, tuple[str, ...]] = {
+    "measure_type_simple": ("Base", "Opponent"),
+    "measure_type_detailed_defense": MEASURE_TYPES,
+    # The PLAYER-side domain. Four Factors / Opponent answer {} on
+    # playergamelogs (calm re-probe 2026-08-02) -- they are team-level
+    # concepts, exactly mirroring Usage being player-only. teamgamelogs
+    # shares this parameter NAME but not this domain; its override below
+    # carries Four Factors + Opponent instead of Usage.
+    "measure_type_player_game_logs_nullable": (
+        "Base",
+        "Advanced",
+        "Misc",
+        "Scoring",
+        "Usage",
+    ),
+}
+
+#: Per-ENDPOINT narrowing, applied on top of the parameter default above.
+#:
+#: The domain is not purely a property of the parameter. leaguedashteamstats and
+#: leaguedashplayerstats both take `measure_type_detailed_defense`, but only the
+#: team one rejects Usage -- so keying solely by parameter name silently dropped
+#: Usage from leaguedashlineups / leaguedashplayerclutch / leaguedashplayerstats
+#: / leaguedashteamclutch / leaguelineupviz, all of which do support it.
+#:
+#: Derived by scanning the committed archive: a measure that is empty in EVERY
+#: captured season is unsupported; one populated in any season is supported.
+#: That is a far larger and more stable sample than live probing, which throttles
+#: and returns inconsistent negatives.
+ENDPOINT_MEASURE_TYPES: dict[str, tuple[str, ...]] = {
+    "leaguedashteamstats": tuple(m for m in MEASURE_TYPES if m != "Usage"),
+    # Measured live 2026-08-02 (both leagues): Four Factors and Opponent each
+    # return full seasons (NBA 2,460 rows, WNBA 480), so the earlier
+    # Base/Advanced/Misc/Scoring tuple -- derived by scanning an archive
+    # captured under the poisoned TeamID default -- was two measures short.
+    # Usage stays out: {} on teamgamelogs in both leagues even with valid
+    # params (usage is a player concept; the team FF/Opponent measures are
+    # the mirror image, {} on playergamelogs).
+    "teamgamelogs": ("Base", "Advanced", "Four Factors", "Misc", "Scoring", "Opponent"),
+}
+
+
+def measure_types_for(fn_name: str, param: str, default: tuple[str, ...]) -> tuple[str, ...]:
+    """Values to sweep for ``param`` on the endpoint behind ``fn_name``.
+
+    Endpoint override beats parameter default beats the caller's full list.
+
+    ``fn_name`` is the wrapper's full name (``nba_stats_leaguedashteamstats``),
+    matched by SUFFIX. Splitting on the first underscore would be wrong -- the
+    league prefix itself contains one -- and this function has no access to the
+    prefix ``discover()`` used.
+    """
+    # Guard the axis. _SWEEPS also carries season_type and per_mode, and an
+    # endpoint override applied to those would set season_type_all_star="Base"
+    # and per_mode_detailed="Misc" -- silently turning one endpoint's matrix
+    # into the cube of its measure types.
+    if not param.startswith("measure_type"):
+        return default
+    for endpoint, values in ENDPOINT_MEASURE_TYPES.items():
+        if fn_name == endpoint or fn_name.endswith(f"_{endpoint}"):
+            return values
+    return MEASURE_TYPE_DOMAINS.get(param, default)
+
+
+#: Season / league parameters, most-specific first. Matched by EXACT name from
+#: this list rather than by prefix: prefix-matching "season" would also hit
+#: ``season_segment_nullable`` and ``season_type_*``. The previous code tested
+#: only the bare ``season``, so endpoints that spell it ``season_nullable``
+#: (playergamelogs, teamgamelogs) were called with NO season filter at all --
+#: the API answered nothing and 100% of those captures were empty in both
+#: leagues.
+_SEASON_PARAMS = ("season", "season_nullable", "season_year", "season_all_time")
+_LEAGUE_PARAMS = ("league_id", "league_id_nullable")
+
+PER_MODES = ("Totals", "PerGame")
+
+#: Sub-dimension axes. These endpoints take a REQUIRED extra axis; before
+#: 2026-08-02 the sweep left each at its wrapper default, so the archive held
+#: one slice of a much larger surface: synergyplaytypes = Isolation/Offensive
+#: only (1 of 22), leaguedashptstats = Drives only (1 of 12), leaguedashptdefend
+#: = Overall only (1 of 6). Values from nba_api parameters.py (PtMeasureType /
+#: DefenseCategory / PlayType classes) -- the API's own domain model.
+PT_MEASURE_TYPES = (
+    "SpeedDistance",
+    "Rebounding",
+    "Possessions",
+    "CatchShoot",
+    "PullUpShot",
+    "Defense",
+    "Drives",
+    "Passing",
+    "ElbowTouch",
+    "PostTouch",
+    "PaintTouch",
+    "Efficiency",
+)
+DEFENSE_CATEGORIES = (
+    "Overall",
+    "3 Pointers",
+    "2 Pointers",
+    "Less Than 6Ft",
+    "Less Than 10Ft",
+    "Greater Than 15Ft",
+)
+#: Synergy spellings are the API's own: PRBallHandler / PRRollman, and
+#: putbacks are "OffRebound".
+PLAY_TYPES = (
+    "Transition",
+    "Isolation",
+    "PRBallHandler",
+    "PRRollman",
+    "Postup",
+    "Spotup",
+    "Handoff",
+    "Cut",
+    "OffScreen",
+    "OffRebound",
+    "Misc",
+)
+TYPE_GROUPINGS = ("Offensive", "Defensive")
+
+#: Season-level endpoints that must never be swept per-season.
+#: scoreboardv3 is DATE-keyed (GameDate=YYYY-MM-DD); sweeping it per season
+#: captured the wrapper's fixed default date over and over -- one junk file per
+#: season. Its content (the day's games) is fully covered by the per-game
+#: endpoints. Excluded in discover(), the single registry gate.
+#: shotchartlineupdetail is LINEUP-keyed: it requires a GroupID (a 5-man
+#: lineup id) and the roxygen-mined default pinned one specific lineup, so
+#: every "season" capture was one lineup's shots. A season sweep cannot
+#: enumerate lineups; per-lineup capture is an entity-iteration design.
+EXCLUDED_SEASON_ENDPOINTS = frozenset({"scoreboardv3", "shotchartlineupdetail"})
+
+#: Lineups are five-player units; the endpoint also accepts 2-4 but the published
+#: datasets are 5-man and the smaller units are a much larger combinatorial space.
+LINEUP_GROUP_QUANTITY = 5
+
+#: Parameter-name prefix -> the values to sweep it over. Prefix-matched because the
+#: same concept is spelled differently per endpoint (``season_type_all_star``,
+#: ``season_type_playoffs``, ``season_type_nullable``).
+_SWEEPS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("season_type", SEASON_TYPES),
+    ("measure_type", MEASURE_TYPES),
+    ("pt_measure_type", PT_MEASURE_TYPES),
+    ("defense_category", DEFENSE_CATEGORIES),
+    ("play_type", PLAY_TYPES),
+    ("type_grouping", TYPE_GROUPINGS),
+    ("per_mode", PER_MODES),
+)
+
+#: Parameters pinned to a single value when the endpoint accepts them.
+_PINS: tuple[tuple[str, Any], ...] = (("group_quantity", LINEUP_GROUP_QUANTITY),)
+
+#: Season parameters that want the NBA's two-year span string ("2023-24").
+#: NBA ONLY: the WNBA plays inside one calendar year and its API takes the
+#: bare year (measured on the WNBA sweep; a span string is not the WNBA's
+#: spelling). The span decision is keyed off ``league_id`` in
+#: :func:`season_variants`.
+#:
+#: `season_year` is deliberately absent: on the draftcombine* endpoints the
+#: probed shape is a bare draft year ("2019" -> 77 rows, 2026-08-02; the span
+#: is ALSO accepted, but bare is what hoopR sends and what the archive holds).
+#: `season_all_time` (draftcombinestats' spelling) IS spanned -- "2019-20"
+#: returned 77 rows on the same probe; the sweep had never sent it a season at
+#: all because the name wasn't in _SEASON_PARAMS, so the endpoint was
+#: misdiagnosed as parameter-broken.
+_SPAN_SEASON_PARAMS = ("season", "season_nullable", "season_all_time")
+
+
+def season_string(season: int) -> str:
+    """The NBA's own spelling of a season: 2023 -> "2023-24", 1999 -> "1999-00"."""
+    return f"{season}-{str(season + 1)[-2:]}"
+
+
+def _params(fn: Callable[..., Any]) -> set[str]:
+    try:
+        return set(inspect.signature(fn).parameters)
+    except (TypeError, ValueError):
+        return set()
+
+
+def _match(params: set[str], prefix: str) -> str | None:
+    """The endpoint's own spelling of a swept parameter, if it accepts one."""
+    for name in sorted(params):
+        if name.startswith(prefix):
+            return name
+    return None
+
+
+def slug(value: Any) -> str:
+    """Filename-safe parameter value (``Regular Season`` -> ``regular-season``)."""
+    return str(value).lower().replace(" ", "-").replace("_", "-")
+
+
+def discover(module: Any, prefix: str) -> tuple[list[str], list[str]]:
+    """``(game_endpoints, season_endpoints)`` exposed by a league's stats module.
+
+    Team- and player-keyed endpoints are excluded: they are addressed by an id this
+    sweep does not enumerate, and are a separate (much larger) capture decision.
+    """
+    game: list[str] = []
+    season: list[str] = []
+    for name in sorted(dir(module)):
+        if not name.startswith(f"{prefix}_"):
+            continue
+        fn = getattr(module, name)
+        if not callable(fn):
+            continue
+        params = _params(fn)
+        if not params:
+            continue
+        short = name[len(prefix) + 1 :]
+        if short in EXCLUDED_SEASON_ENDPOINTS:
+            continue
+        if "game_id" in params:
+            game.append(short)
+        elif "team_id" in params or "player_id" in params:
+            continue
+        else:
+            season.append(short)
+    return game, season
+
+
+def season_variants(fn: Callable[..., Any], season: int, league_id: str) -> Iterator[tuple[str | None, dict[str, Any]]]:
+    """Yield ``(variant_slug, kwargs)`` for every capture of one season endpoint.
+
+    The slug is built only from the parameters this endpoint actually sweeps, so
+    an endpoint gaining an unrelated parameter later cannot rename existing
+    captures, and two endpoints never collide on a filename.
+    """
+    params = _params(fn)
+    base: dict[str, Any] = {}
+    season_param = next((p for p in _SEASON_PARAMS if p in params), None)
+    if season_param:
+        # A BARE year silently returns zero rows on several endpoints while
+        # others tolerate it, so the sweep looked healthy while
+        # leagueleaders / leaguedashptstats / leaguedashptdefend /
+        # leaguedashteamptshot / leaguedashplayerptshot / leaguedashoppptshot
+        # captured a valid envelope with no data, every season, for years.
+        #
+        # Measured: leagueleaders 0 -> 240 rows, leaguedashptstats 0 -> 572,
+        # leaguedashptdefend 0 -> 569 once the span string is sent.
+        #
+        # Tolerant endpoints are unaffected: "2023" and "2023-24" return
+        # byte-identical rows (checked against leaguedashteamstats), so the
+        # API already reads a bare year as the START year. This only makes
+        # that explicit.
+        base[season_param] = (
+            season_string(season) if league_id == LEAGUE_NBA and season_param in _SPAN_SEASON_PARAMS else str(season)
+        )
+    league_param = next((p for p in _LEAGUE_PARAMS if p in params), None)
+    if league_param:
+        base[league_param] = league_id
+    for pin, value in _PINS:
+        name = _match(params, pin)
+        if name:
+            base[name] = value
+
+    # Expand the cartesian product of whichever sweeps this endpoint supports.
+    # Each axis is narrowed to the values its OWN parameter accepts, so the
+    # sweep stops issuing calls the API cannot answer.
+    axes: list[tuple[str, tuple[str, ...]]] = []
+    for prefix, values in _SWEEPS:
+        name = _match(params, prefix)
+        if name:
+            axes.append((name, measure_types_for(fn.__name__, name, values)))
+
+    if not axes:
+        yield None, base
+        return
+
+    def walk(i: int, acc: dict[str, Any], parts: list[str]) -> Iterator[tuple[str, dict[str, Any]]]:
+        if i == len(axes):
+            yield "_".join(parts), {**base, **acc}
+            return
+        name, values = axes[i]
+        for value in values:
+            yield from walk(i + 1, {**acc, name: value}, [*parts, slug(value)])
+
+    yield from walk(0, {}, [])
+
+
+def plan_counts(module: Any, prefix: str, league_id: str, season: int = 2025) -> dict[str, int]:
+    """Per-season call counts, for sizing a sweep before running one."""
+    game, season_eps = discover(module, prefix)
+    n_season = sum(
+        len(list(season_variants(getattr(module, f"{prefix}_{ep}"), season, league_id))) for ep in season_eps
+    )
+    return {
+        "game_endpoints": len(game),
+        "season_endpoints": len(season_eps),
+        "season_calls_per_season": n_season,
+    }

--- a/sportsdataverse/scrape/stats/league_config.py
+++ b/sportsdataverse/scrape/stats/league_config.py
@@ -1,0 +1,67 @@
+"""League identity for the stats.nba.com / stats.wnba.com sweep engine.
+
+One frozen config per league carries the identity facts the engine cannot
+derive: which wrapper module serves the league, the ``LeagueID`` the API
+expects, and where the owning ``-raw`` repo keeps its store. Everything
+behavioral (season-string spelling, period time math) lives in
+:mod:`~sportsdataverse.scrape.stats.endpoints` and
+:mod:`~sportsdataverse.scrape.stats.periods`, keyed off ``league_id`` — the
+same key the capture planners already thread through every call.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LeagueConfig:
+    """Identity facts for one league's raw-store sweep.
+
+    Attributes:
+        key: Short league slug (``"nba"`` / ``"wnba"``).
+        league_id: The stats API's ``LeagueID`` (``"00"`` NBA, ``"10"`` WNBA).
+        stats_module: Import path of the sdv-py wrapper module whose
+            ``{stats_prefix}_<endpoint>`` callables the sweep drives.
+        stats_prefix: Wrapper-name prefix (``nba_stats`` / ``wnba_stats``).
+        repo: Owning ``-raw`` repository name (log/error messages only).
+        store_env: Environment variable that overrides the raw-store root.
+        store_subdir: Store path components under the owning repo's root.
+    """
+
+    key: str
+    league_id: str
+    stats_module: str
+    stats_prefix: str
+    repo: str
+    store_env: str
+    store_subdir: tuple[str, ...]
+
+
+NBA = LeagueConfig(
+    key="nba",
+    league_id="00",
+    stats_module="sportsdataverse.nba.nba_stats",
+    stats_prefix="nba_stats",
+    repo="hoopR-nba-stats-raw",
+    store_env="SDV_PY_NBA_RAW_JSON_DIR",
+    store_subdir=("nba_stats", "json"),
+)
+
+WNBA = LeagueConfig(
+    key="wnba",
+    league_id="10",
+    # wehoop-wnba-stats-raw's pre-migration refill_empty.py imported the
+    # nonexistent `sportsdataverse.nba.wnba_stats` — a latent crash on its
+    # non-check path that the config test here caught. This is the real module.
+    stats_module="sportsdataverse.wnba.wnba_stats",
+    stats_prefix="wnba_stats",
+    repo="wehoop-wnba-stats-raw",
+    store_env="SDV_PY_WNBA_RAW_JSON_DIR",
+    store_subdir=("wnba_stats", "json"),
+)
+
+_BY_LEAGUE_ID = {c.league_id: c for c in (NBA, WNBA)}
+
+
+def by_league_id(league_id: str) -> LeagueConfig:
+    """The config for a stats ``LeagueID`` (raises ``KeyError`` on unknown)."""
+    return _BY_LEAGUE_ID[league_id]

--- a/sportsdataverse/scrape/stats/periods.py
+++ b/sportsdataverse/scrape/stats/periods.py
@@ -1,0 +1,114 @@
+"""Per-period boxscore windows — league- and era-aware time math.
+
+``boxscoretraditionalv3`` accepts a ``RangeType=2`` request window; asking for
+the one-second window at a period's opening tick returns exactly the players on
+court when that period began. Those captures let a downstream builder
+reconstruct on-court lineups from period starts + substitutions instead of
+inferring them from play-by-play alone.
+
+**The window is league- AND season-specific**, which is why every function here
+takes an explicit ``league_id`` (and refuses to default the season):
+
+* NBA (``"00"``): four 12-minute quarters for the whole span the stores cover.
+* WNBA (``"10"``): two 20-minute halves through 2005, four 10-minute quarters
+  from 2006 (confirmed from captured play-by-play: every season 1997-2005 has a
+  modal max period of 2 opening at ``PT20M00.00S``; 2006 onward is 4 periods at
+  ``PT10M00.00S``). Regulation is 2400s in both eras, so a regulation-total
+  check cannot catch a mix-up — the *period boundaries* differ by ten minutes,
+  and a wrong window returns a well-formed boxscore for the wrong moment rather
+  than an error.
+
+Overtime is 5 minutes in both leagues and both eras.
+
+Game-id season decoding also differs: an NBA season spans two calendar years,
+so the store's directory is the id's start year **plus one**; the WNBA plays
+inside one calendar year.
+
+A regression test pins the NBA math to
+``sportsdataverse.nba.nba_lineups._period_start_range`` (the same function the
+possession engine uses when it reads these payloads back), so the capture
+window cannot drift from what the reader expects.
+"""
+
+#: ``RangeType=2`` selects an explicit Start/EndRange window (pbpstats convention).
+QUARTER_BOX_RANGE_TYPE = "2"
+
+#: One-second opening window, in tenths — same width sdv-py and pbpstats use.
+WINDOW_WIDTH_TENTHS = 10
+
+#: Guard against a malformed payload driving an unbounded fetch loop.
+MAX_PERIODS = 12
+
+#: Overtime is 5 minutes in both leagues and both eras.
+OT_PERIOD_SECONDS = 300
+
+#: ``league_id -> ((from_season, periods, seconds_per_period), ...)`` newest era
+#: first. The first entry whose ``from_season`` the season reaches wins.
+_REGULATION_ERAS: dict[str, tuple[tuple[int, int, int], ...]] = {
+    "00": ((0, 4, 720),),
+    "10": ((2006, 4, 600), (0, 2, 1200)),
+}
+
+#: Season-directory year relative to the game id's two-digit start year: an NBA
+#: season spans two calendar years (store keys the END year); a WNBA season is
+#: one calendar year.
+_GAME_ID_YEAR_OFFSET = {"00": 1, "10": 0}
+
+
+def regulation_shape(season: int, league_id: str) -> tuple[int, int]:
+    """``(periods, seconds_per_period)`` for ``season``'s regulation format."""
+    for from_season, periods, secs in _REGULATION_ERAS[league_id]:
+        if season >= from_season:
+            return periods, secs
+    raise ValueError(f"no regulation era covers season {season}")
+
+
+def period_elapsed_seconds(period: int, season: int, league_id: str) -> int:
+    """Game seconds elapsed when ``period`` (1-indexed) opens in ``season``.
+
+    ``season`` is required rather than defaulted: the WNBA halves/quarters split
+    makes a silent default wrong for a third of that league's history.
+    """
+    periods, per_period = regulation_shape(season, league_id)
+    if period <= periods:
+        return (period - 1) * per_period
+    return periods * per_period + (period - periods - 1) * OT_PERIOD_SECONDS
+
+
+def period_start_range(period: int, season: int, league_id: str) -> tuple[str, str]:
+    """``(StartRange, EndRange)`` in tenths of a second at ``period``'s opening tick."""
+    start = period_elapsed_seconds(period, season, league_id) * 10
+    return str(start), str(start + WINDOW_WIDTH_TENTHS)
+
+
+def periods_in_game(pbp_payload: object) -> int:
+    """Highest period number in a captured ``playbyplayv3`` payload (0 if unknown).
+
+    Reading it off the stored play-by-play means overtime is discovered for
+    free — a fixed regulation-period fetch would truncate every OT game, and
+    probing for it would spend a request per game.
+    """
+    if not isinstance(pbp_payload, dict):
+        return 0
+    actions = (pbp_payload.get("game") or {}).get("actions") or []
+    best = 0
+    for action in actions:
+        if isinstance(action, dict):
+            try:
+                best = max(best, int(action.get("period") or 0))
+            except (TypeError, ValueError):
+                continue
+    return min(best, MAX_PERIODS)
+
+
+def season_of(game_id: str, league_id: str) -> int:
+    """Season directory year encoded in a 10-digit stats game id.
+
+    Digits 3-4 are the season's two-digit start year (``>= 90`` is 19xx). NBA
+    ``0020500469`` -> 2006 (season spans two years; the store keys the END
+    year); WNBA ``1022600071`` -> 2026 (single calendar year).
+    """
+    gid = str(game_id).zfill(10)
+    yy = int(gid[3:5])
+    start = 1900 + yy if yy >= 90 else 2000 + yy
+    return start + _GAME_ID_YEAR_OFFSET[league_id]

--- a/sportsdataverse/scrape/stats/refill.py
+++ b/sportsdataverse/scrape/stats/refill.py
@@ -1,0 +1,187 @@
+"""Refill season-level payloads that were persisted as empty ``{}``.
+
+Why this exists
+---------------
+``season_capture.write_payload`` originally had no guard, and resume is
+``path.exists()`` -- presence, not content. So a failed fetch that returned
+``{}`` was written to disk and every later sweep counted it "present", never
+refetched it, and reported the season complete. A backfill no-ops.
+hoopR-nba-stats-raw reached 3,347 such files and wehoop-wnba-stats-raw 3,872
+before the guard landed.
+
+The guard now refuses to persist a contentless payload, but it cannot undo the
+files already on disk: they still exist, so they are still skipped. This module
+deletes them and refetches exactly those ``(endpoint, season, variant)`` tuples.
+
+Safety
+------
+* Only files whose size is <= 2 bytes are touched. That is exactly ``{}`` /
+  ``[]``. It is NOT "small": a valid 201-byte envelope whose entity list is
+  legitimately empty must survive.
+* The deleted files are tracked in git in the owning repo, so
+  ``git checkout -- <store>/`` restores them if a run goes wrong.
+* Nothing is deleted until its replacement is about to be fetched, and a fetch
+  that comes back empty leaves NO file -- so a partial run is resumable and
+  never worse than where it started.
+
+Usage (from an owning ``-raw`` repo's ``python/refill_empty.py`` shim)
+----------------------------------------------------------------------
+    python python/refill_empty.py --check          # census only, no network
+    python python/refill_empty.py                  # refill everything
+    python python/refill_empty.py 2015:2026        # season range
+    python python/refill_empty.py --endpoint matchupsrollup
+"""
+
+import argparse
+import datetime
+import importlib
+import os
+from collections import defaultdict
+from pathlib import Path
+from typing import Optional
+
+from .league_config import LeagueConfig
+from .proxy import ProxyHealth, RoundRobin, load_proxies
+from .season_capture import payload_path, plan_season, write_payload
+from .session_transport import SessionTransport
+
+#: A payload this small cannot hold an envelope; anything larger is real.
+CONTENTLESS_MAX_BYTES = 2
+
+
+def _log(msg: str) -> None:
+    print(f"[{datetime.datetime.now():%Y-%m-%d %H:%M:%S}] {msg}", flush=True)
+
+
+def store_root(cfg: LeagueConfig, default_root: Path) -> Path:
+    """Same resolution the sweep uses, so both agree on where payloads live."""
+    return Path(os.environ.get(cfg.store_env) or default_root)
+
+
+def find_empty(root: Path) -> "dict[int, set[tuple[str, Optional[str]]]]":
+    """``season -> {(endpoint, variant)}`` for every contentless payload on disk."""
+    out: dict[int, set[tuple[str, Optional[str]]]] = defaultdict(set)
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if not d.startswith(".")]
+        for fn in filenames:
+            if not fn.endswith(".json"):
+                continue
+            fp = Path(dirpath) / fn
+            try:
+                if fp.stat().st_size > CONTENTLESS_MAX_BYTES:
+                    continue
+            except OSError:
+                continue
+            rel = fp.relative_to(root).parts
+            # <endpoint>/<season>/<variant>.json  or  <endpoint>/<season>.json
+            if len(rel) == 3:
+                endpoint, season, variant = rel[0], rel[1], rel[2][: -len(".json")]
+            elif len(rel) == 2:
+                endpoint, season, variant = rel[0], rel[1][: -len(".json")], None
+            else:
+                continue
+            if season.isdigit():
+                out[int(season)].add((endpoint, variant))
+    return out
+
+
+def main(cfg: LeagueConfig, argv: "Optional[list[str]]" = None, *, default_root: Path) -> int:
+    """Run the refill for one league. Returns a process exit code.
+
+    ``default_root`` is the owning repo's on-disk store location (the shim
+    passes it, since only the repo knows where it lives); ``cfg.store_env``
+    overrides it, exactly as the sweep resolves the root.
+    """
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("seasons", nargs="?", default=None, help="START:END (default: all found)")
+    ap.add_argument("--check", action="store_true", help="census only; no deletes, no network")
+    ap.add_argument("--endpoint", default=None, help="restrict to one endpoint")
+    ap.add_argument(
+        "--allow-direct",
+        action="store_true",
+        help="run without proxies (serial, residential IP only -- hangs on datacenter IPs)",
+    )
+    args = ap.parse_args(argv)
+
+    root = store_root(cfg, default_root)
+    _log(f"scanning {root} for contentless payloads")
+    empty = find_empty(root)
+    if args.seasons:
+        lo, _, hi = args.seasons.partition(":")
+        lo_i, hi_i = int(lo), int(hi or lo)
+        empty = {s: v for s, v in empty.items() if lo_i <= s <= hi_i}
+    if args.endpoint:
+        empty = {s: {(e, v) for e, v in pairs if e == args.endpoint} for s, pairs in empty.items()}
+        empty = {s: p for s, p in empty.items() if p}
+
+    per_endpoint: dict[str, int] = defaultdict(int)
+    for pairs in empty.values():
+        for endpoint, _v in pairs:
+            per_endpoint[endpoint] += 1
+    total = sum(per_endpoint.values())
+
+    _log(f"{total} contentless payloads across {len(empty)} seasons")
+    for endpoint, n in sorted(per_endpoint.items(), key=lambda kv: -kv[1]):
+        _log(f"  {n:>6}  {endpoint}")
+    if args.check or not total:
+        return 0
+
+    stats = importlib.import_module(cfg.stats_module)
+
+    health = ProxyHealth(error_log=os.environ.get("STATS_ERROR_LOG", "logs/errors.jsonl"))
+    pool = load_proxies()
+    timeout = os.environ.get("SDV_PY_NBA_STATS_TIMEOUT", "30")
+    transport: Optional[SessionTransport]
+    if pool:
+        _log(f"proxy pool: {len(pool)} entries | timeout={timeout}s")
+        transport = SessionTransport(RoundRobin(pool, health=health), health)
+    elif args.allow_direct:
+        # Serial + residential only. The live probe that proved these payloads
+        # are recoverable ran this way, so it is supported -- but never silently.
+        _log(f"no proxy pool; --allow-direct given, going direct | timeout={timeout}s")
+        transport = None
+    else:
+        # Same contract as the main sweep: un-proxied stats-host calls HANG
+        # rather than fail, so a missing pool must stop the run, not degrade it.
+        _log(
+            "ERROR: no proxies. PROXY_ENDPOINT / PROXY_KEY / PROXY_PKG live in"
+            " ~/.Renviron, which Python does not read -- export them (the wrapper"
+            " scripts/refill_empty_payloads.sh does) or pass --allow-direct."
+        )
+        return 1
+
+    def fetch(endpoint: str, kwargs: dict) -> object:
+        fn = getattr(stats, f"{cfg.stats_prefix}_{endpoint}")
+        if transport is None:
+            return fn(return_parsed=False, **kwargs)
+        return fn(return_parsed=False, transport=transport, **kwargs)
+
+    refilled = still_empty = failed = 0
+    for season in sorted(empty):
+        wanted = empty[season]
+        # Reuse the sweep's own plan so kwargs are built exactly as a normal
+        # capture builds them -- no second, drifting copy of the matrix.
+        for endpoint, variant, kwargs in plan_season(season, stats, cfg.stats_prefix, cfg.league_id):
+            if (endpoint, variant) not in wanted:
+                continue
+            path = payload_path(root, endpoint, season, variant)
+            try:
+                payload = fetch(endpoint, kwargs)
+            except Exception as exc:  # noqa: BLE001 - one gap must not kill the refill
+                _log(f"{season} {endpoint}[{variant}]: FAILED {exc}")
+                failed += 1
+                continue
+            # Delete only now, with a replacement in hand.
+            path.unlink(missing_ok=True)
+            if write_payload(path, payload):
+                refilled += 1
+                _log(f"{season} {endpoint}[{variant}]: refilled")
+            else:
+                still_empty += 1
+                _log(f"{season} {endpoint}[{variant}]: STILL EMPTY (left absent for retry)")
+
+    _log(f"refill complete: {refilled} refilled | {still_empty} still empty | {failed} failed")
+    for ep, errs, ec in health.endpoint_summary():
+        _log(f"  {ep}: {errs} faults {ec}")
+    health.close()
+    return 0

--- a/sportsdataverse/scrape/stats/season_capture.py
+++ b/sportsdataverse/scrape/stats/season_capture.py
@@ -1,0 +1,249 @@
+"""Season-level (non per-game) captures for the raw store.
+
+``scrape_raw_json.py`` fills the per-game half of the store through sdv-py's
+read-through cache, which keys on ``game_id``. Season-level endpoints are keyed on
+*(season, parameters)* instead and cannot use that store, so they land here under
+
+    {endpoint}/{season}/{variant}.json     (parameterized)
+    {endpoint}/{season}.json               (no variants)
+
+Which endpoints, and which parameter matrix each one gets, comes from
+:mod:`endpoints` -- derived from the endpoints' own signatures rather than a
+hand-maintained list, so a new upstream endpoint is captured without an edit here.
+
+Writes are atomic (tmp + rename) and idempotent: an existing payload is skipped
+without parsing, so a sweep is resumable after Ctrl-C.
+
+Rate discipline: every fetch shares the ProxyBonanza rotation and the single
+stats.{nba,wnba}.com budget with the per-game sweep. These are fetched
+**sequentially** -- a few hundred calls per season against thousands of games --
+so there is nothing to gain from parallelising them.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Callable, Iterator
+from pathlib import Path
+from typing import Any
+
+from .endpoints import discover, season_variants, slug
+
+__all__ = [
+    "capture_season",
+    "game_ids_from_gamelog",
+    "payload_path",
+    "plan_season",
+    "slug",
+    "write_payload",
+]
+
+
+def payload_path(root: str | Path, endpoint: str, season: int, variant: str | None = None) -> Path:
+    """Where a season-level capture lives. ``variant=None`` means unparameterized."""
+    base = Path(root) / endpoint
+    return base / str(season) / f"{variant}.json" if variant else base / f"{season}.json"
+
+
+def is_contentless(payload: Any) -> bool:
+    """True when ``payload`` carries nothing and must not be persisted.
+
+    The stats hosts never answer with an empty body: an endpoint with no rows
+    still returns the full envelope with ``rowSet: []``. A bare ``{}`` therefore
+    means the getter could not parse a response -- a failed fetch, not "no data".
+
+    That distinction is load-bearing because resume is ``path.exists()``, i.e.
+    presence rather than content. One empty write is permanent: every later
+    sweep counts the file present, never refetches, and reports the season
+    complete, so a backfill no-ops. 3,347 files in hoopR-nba-stats-raw and
+    3,872 in wehoop-wnba-stats-raw reached that state before this guard.
+
+    Deliberately narrow -- ``{"resultSets": []}`` and a v3 payload whose entity
+    list is empty are REAL answers and are persisted.
+    """
+    return payload is None or not isinstance(payload, (dict, list)) or len(payload) == 0
+
+
+def write_payload(path: Path, payload: Any) -> bool:
+    """Persist ``payload`` atomically. Returns False (writing nothing) if it is
+    contentless.
+
+    Atomic so a killed sweep never leaves half a file; guarded so a failed fetch
+    never becomes a permanent gap.
+    """
+    if is_contentless(payload):
+        return False
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.partial")
+    try:
+        tmp.write_text(json.dumps(payload), encoding="utf-8")
+        os.replace(tmp, path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+    return True
+
+
+def _result_tables(payload: Any) -> list[dict]:
+    """Every ``{name, headers, rowSet}`` table in a stats-host payload.
+
+    The envelope is not uniform, and iterating ``payload["resultSets"]`` blindly
+    is wrong for two of its shapes:
+
+    * ``resultSets`` as a LIST of tables -- the common case.
+    * ``resultSets`` as a single DICT (the shot-locations family). Iterating
+      that yields its KEYS, so the caller ends up calling ``.get()`` on a
+      string and raises AttributeError.
+    * ``resultSet`` SINGULAR, holding one table as a dict (leagueleaders,
+      *estimatedmetrics) -- invisible to anything looking only at the plural.
+
+    Returns an empty list for the v3 ``{<entity>, meta}`` payloads, which carry
+    no result tables at all.
+    """
+    if not isinstance(payload, dict):
+        return []
+    tables: list[dict] = []
+    for key in ("resultSets", "resultSet"):
+        value = payload.get(key)
+        if isinstance(value, dict):
+            tables.append(value)
+        elif isinstance(value, list):
+            tables.extend(t for t in value if isinstance(t, dict))
+    return tables
+
+
+def _ids_from(payload: Any, column: str) -> list[str]:
+    """Distinct values of ``column`` across every result table in ``payload``."""
+    out: set[str] = set()
+    for rs in _result_tables(payload):
+        # The grouped family's headers are column-GROUP dicts, not name
+        # strings; str() on a dict cannot match a column name, so those tables
+        # are skipped rather than mis-indexed.
+        headers = [str(h).upper() for h in rs.get("headers") or []]
+        if column not in headers:
+            continue
+        idx = headers.index(column)
+        for row in rs.get("rowSet") or []:
+            if isinstance(row, list) and idx < len(row) and row[idx] is not None:
+                out.add(str(row[idx]))
+    return sorted(out)
+
+
+def game_ids_from_gamelog(payload: Any) -> list[str]:
+    """Zero-padded game ids from a raw ``leaguegamelog`` payload.
+
+    Lets the per-game sweep enumerate from the persisted capture instead of making
+    its own call for the same thing.
+    """
+    return [g.zfill(10) for g in _ids_from(payload, "GAME_ID")]
+
+
+def plan_season(
+    season: int, module: Any, prefix: str, league_id: str
+) -> Iterator[tuple[str, str | None, dict[str, Any]]]:
+    """Yield ``(endpoint, variant, kwargs)`` for every season-level capture.
+
+    ``commonteamroster`` is absent: it is team-keyed, so :func:`capture_season`
+    schedules it separately once team ids are known.
+    """
+    _game, season_endpoints = discover(module, prefix)
+    for endpoint in season_endpoints:
+        fn = getattr(module, f"{prefix}_{endpoint}")
+        for variant, kwargs in season_variants(fn, season, league_id):
+            yield endpoint, variant, kwargs
+
+
+def capture_season(
+    season: int,
+    root: str | Path,
+    fetch: Callable[[str, dict[str, Any]], Any],
+    module: Any,
+    prefix: str,
+    league_id: str,
+    log: Callable[[str], None] = lambda _m: None,
+    skip_endpoints: frozenset[str] | set[str] = frozenset(),
+) -> tuple[int, int, int]:
+    """Fetch every season-level payload for ``season``. Returns (written, skipped, failed).
+
+    ``fetch(endpoint, kwargs)`` performs one call and returns the raw payload; the
+    caller supplies it so proxy rotation and transport stay in the scraper and this
+    module stays offline-testable.
+
+    ``skip_endpoints`` names season-level endpoints to omit entirely -- parked
+    endpoints, and anything below its season floor.
+    """
+    written = skipped = failed = 0
+    team_source: Any = None
+
+    def _is_team_source(endpoint: str, kwargs: dict[str, Any]) -> bool:
+        """The one team-stats capture whose rows enumerate the league's teams.
+
+        Matched on kwargs, not on the variant slug: the slug is composed from the
+        axis order in ``endpoints._SWEEPS``, so reordering those axes would silently
+        stop this from ever matching and no team rosters would be captured.
+        """
+        if endpoint != "leaguedashteamstats":
+            return False
+        return all(
+            any(k.startswith(p) and v == want for k, v in kwargs.items())
+            for p, want in (
+                ("season_type", "Regular Season"),
+                ("measure_type", "Base"),
+                ("per_mode", "Totals"),
+            )
+        )
+
+    for endpoint, variant, kwargs in plan_season(season, module, prefix, league_id):
+        if endpoint in skip_endpoints:  # parked, or below its season floor
+            continue
+        path = payload_path(root, endpoint, season, variant)
+        is_team_source = _is_team_source(endpoint, kwargs)
+        if path.exists():
+            skipped += 1
+            if is_team_source:
+                try:
+                    team_source = json.loads(path.read_text(encoding="utf-8"))
+                except json.JSONDecodeError:
+                    team_source = None
+            continue
+        try:
+            payload = fetch(endpoint, kwargs)
+        except Exception as exc:  # noqa: BLE001 - one endpoint gap must not kill the season
+            log(f"season {season} {endpoint}[{variant}]: {exc}")
+            failed += 1
+            continue
+        if not write_payload(path, payload):
+            # Counted as a failure, not a write: leaving no file is what lets the
+            # next sweep retry it.
+            log(f"season {season} {endpoint}[{variant}]: empty payload, not persisted")
+            failed += 1
+            continue
+        written += 1
+        if is_team_source:
+            team_source = payload
+
+    # commonteamroster is per (season, team); team ids come from the team-stats
+    # capture above rather than a second index call.
+    if hasattr(module, f"{prefix}_commonteamroster"):
+        for team_id in _ids_from(team_source, "TEAM_ID"):
+            path = payload_path(root, "commonteamroster", season, team_id)
+            if path.exists():
+                skipped += 1
+                continue
+            try:
+                payload = fetch(
+                    "commonteamroster",
+                    {"season": str(season), "team_id": team_id, "league_id": league_id},
+                )
+            except Exception as exc:  # noqa: BLE001
+                log(f"season {season} commonteamroster[{team_id}]: {exc}")
+                failed += 1
+                continue
+            if not write_payload(path, payload):
+                log(f"season {season} commonteamroster[{team_id}]: empty payload, not persisted")
+                failed += 1
+                continue
+            written += 1
+
+    return written, skipped, failed

--- a/tests/scrape/test_scrape_stats_league.py
+++ b/tests/scrape/test_scrape_stats_league.py
@@ -1,0 +1,155 @@
+"""League-parameterization tests for the Phase 2 capture layer.
+
+The heavyweight behavioral suites stay in the owning -raw repos (they exercise
+their own league's behavior against this engine); these tests pin the
+league-varying seams: season-string spelling, period time math, id decoding,
+and the refill census. All offline.
+"""
+
+import importlib
+import json
+
+import pytest
+
+from sportsdataverse.nba.nba_lineups import _QUARTER_BOX_RANGE_TYPE, _period_start_range
+from sportsdataverse.scrape.stats import league_config, periods, refill
+from sportsdataverse.scrape.stats.endpoints import (
+    measure_types_for,
+    season_string,
+    season_variants,
+)
+
+# -- league_config -------------------------------------------------------------
+
+
+def test_configs_are_consistent_and_resolvable() -> None:
+    for cfg in (league_config.NBA, league_config.WNBA):
+        assert league_config.by_league_id(cfg.league_id) is cfg
+        mod = importlib.import_module(cfg.stats_module)
+        fns = [n for n in dir(mod) if n.startswith(f"{cfg.stats_prefix}_")]
+        assert len(fns) > 50, f"{cfg.stats_module} exposes {len(fns)} wrappers"
+
+
+def test_unknown_league_id_raises() -> None:
+    with pytest.raises(KeyError):
+        league_config.by_league_id("99")
+
+
+# -- endpoints: span vs bare season spelling -----------------------------------
+
+
+def _fake_endpoint_span(season: str = "", league_id: str = "") -> None: ...
+def _fake_endpoint_year(season_year: str = "", league_id: str = "") -> None: ...
+
+
+def test_nba_spans_the_season_string_wnba_stays_bare() -> None:
+    """The load-bearing league difference: a bare year silently returns zero
+    rows on several NBA endpoints, while the WNBA API takes the bare year."""
+    (_v_nba,) = list(season_variants(_fake_endpoint_span, 2023, "00"))
+    assert _v_nba[1]["season"] == "2023-24"
+    (_v_wnba,) = list(season_variants(_fake_endpoint_span, 2023, "10"))
+    assert _v_wnba[1]["season"] == "2023"
+
+
+def test_season_year_is_bare_in_both_leagues() -> None:
+    """`season_year` (draftcombine spelling) takes the bare draft year even on
+    the NBA side — it is deliberately absent from _SPAN_SEASON_PARAMS."""
+    for league_id in ("00", "10"):
+        (variant,) = list(season_variants(_fake_endpoint_year, 2019, league_id))
+        assert variant[1]["season_year"] == "2019"
+
+
+def test_season_string_spelling() -> None:
+    assert season_string(2023) == "2023-24"
+    assert season_string(1999) == "1999-00"
+
+
+def test_measure_override_never_touches_other_axes() -> None:
+    default = ("Regular Season", "Playoffs")
+    got = measure_types_for("nba_stats_leaguedashteamstats", "season_type_all_star", default)
+    assert got == default
+
+
+# -- periods: league- and era-aware window math --------------------------------
+
+
+def test_nba_window_matches_the_possession_engine_reader() -> None:
+    """Drift-guard: the capture window must equal what nba_lineups computes when
+    it reads these payloads back. Pinned for regulation + deep OT."""
+    assert periods.QUARTER_BOX_RANGE_TYPE == _QUARTER_BOX_RANGE_TYPE
+    for period in range(1, 13):
+        assert periods.period_start_range(period, 2024, "00") == _period_start_range(period)
+
+
+def test_wnba_halves_era_boundaries() -> None:
+    # Through 2005: two 20-minute halves. Period 2 opens at 1200s, OT at 2400s.
+    assert periods.regulation_shape(2005, "10") == (2, 1200)
+    assert periods.period_elapsed_seconds(2, 2005, "10") == 1200
+    assert periods.period_elapsed_seconds(3, 2005, "10") == 2400  # OT1
+    assert periods.period_elapsed_seconds(4, 2005, "10") == 2700  # OT2
+
+
+def test_wnba_quarters_era_boundaries() -> None:
+    # From 2006: four 10-minute quarters. Period 2 opens at 600s, OT at 2400s.
+    assert periods.regulation_shape(2006, "10") == (4, 600)
+    assert periods.period_elapsed_seconds(2, 2006, "10") == 600
+    assert periods.period_elapsed_seconds(5, 2006, "10") == 2400  # OT1
+    assert periods.period_elapsed_seconds(6, 2006, "10") == 2700  # OT2
+
+
+def test_wnba_regulation_total_is_constant_across_the_format_change() -> None:
+    """2400s regulation in BOTH eras — the trap: a total check cannot catch a
+    mixed-up era, only the period boundaries can."""
+    for season in (2005, 2006):
+        p, s = periods.regulation_shape(season, "10")
+        assert p * s == 2400
+
+
+def test_period_start_range_is_a_one_second_window() -> None:
+    start, end = periods.period_start_range(2, 2006, "10")
+    assert (start, end) == ("6000", "6010")
+
+
+def test_season_of_league_offsets() -> None:
+    assert periods.season_of("0020500469", "00") == 2006  # NBA: END year
+    assert periods.season_of("1022600071", "10") == 2026  # WNBA: calendar year
+    assert periods.season_of("0029900012", "00") == 2000  # 19xx pivot
+
+
+def test_periods_in_game_reads_pbp_and_clamps() -> None:
+    pbp = {"game": {"actions": [{"period": 1}, {"period": 4}, {"period": "5"}]}}
+    assert periods.periods_in_game(pbp) == 5
+    assert periods.periods_in_game({"game": {"actions": [{"period": 99}]}}) == periods.MAX_PERIODS
+    assert periods.periods_in_game(None) == 0
+    assert periods.periods_in_game({"game": {}}) == 0
+
+
+# -- refill: census + root resolution (offline) --------------------------------
+
+
+def test_find_empty_maps_the_store_layout(tmp_path) -> None:
+    (tmp_path / "leagueleaders" / "1996").mkdir(parents=True)
+    (tmp_path / "leagueleaders" / "1996" / "playoffs_pergame.json").write_text("{}")
+    (tmp_path / "drafthistory").mkdir()
+    (tmp_path / "drafthistory" / "2001.json").write_text("{}")
+    ok = tmp_path / "leagueleaders" / "1996" / "regular-season_totals.json"
+    ok.write_text(json.dumps({"resultSets": []}))  # a REAL empty answer — must survive
+    empty = refill.find_empty(tmp_path)
+    assert empty[1996] == {("leagueleaders", "playoffs_pergame")}
+    assert empty[2001] == {("drafthistory", None)}
+
+
+def test_store_root_env_override(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv(league_config.NBA.store_env, str(tmp_path))
+    assert refill.store_root(league_config.NBA, tmp_path / "unused") == tmp_path
+    monkeypatch.delenv(league_config.NBA.store_env)
+    assert refill.store_root(league_config.NBA, tmp_path / "d") == tmp_path / "d"
+
+
+def test_refill_check_mode_is_offline(tmp_path, capsys) -> None:
+    (tmp_path / "leagueleaders" / "1996").mkdir(parents=True)
+    (tmp_path / "leagueleaders" / "1996" / "playoffs_pergame.json").write_text("{}")
+    rc = refill.main(league_config.NBA, ["--check"], default_root=tmp_path)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "1 contentless payloads" in out


### PR DESCRIPTION
Phase 2 of the shared stats-raw engine (Phase 1: #325). Moves *capture planning* behind a `LeagueConfig` so `hoopR-nba-stats-raw` and `wehoop-wnba-stats-raw` stop carrying near-duplicate copies of it — the ~700 real drift lines the audit measured.

## What lands

- **`league_config.py`** — frozen `NBA` / `WNBA` identity: LeagueID, wrapper module + prefix, store env var and subdir. `by_league_id()` resolves it.
- **`endpoints.py`** — the signature-derived capture registry (unchanged behavior), with the one genuine league difference now keyed off `league_id`: NBA sends the two-year span `"2023-24"` (without which several endpoints silently return zero rows), WNBA sends the bare calendar year.
- **`season_capture.py`** — atomic, resumable season-level captures + the contentless-payload guard.
- **`periods.py`** — league- AND era-aware per-period window math. NBA: 12-minute quarters. WNBA: two 20-minute halves through 2005, four 10-minute quarters from 2006. Regulation is 2400s in *both* WNBA eras, so a totals check cannot catch a mix-up — only the period boundaries can.
- **`refill.py`** — the empty-`{}` repair pass, driven by a `LeagueConfig` instead of per-repo constants.

## Bug found by unification

Resolving the wrapper module from the config fixed a latent crash: the WNBA repo's own refill shim imported `sportsdataverse.nba.wnba_stats`, **which does not exist** — a `ModuleNotFoundError` on every real (non-`--check`) refill run. The config test caught it immediately. That is the third real bug this extraction has surfaced (after #325's py3.9 `socket.timeout` and the stale retry ordinal).

## Verification

- 39 offline tests green (16 new Phase 2 cases: span-vs-bare season spelling per league, both WNBA eras + the 2400s-constant trap, OT boundaries, game-id season offsets, refill census/root resolution, `--check` offline path).
- **Drift-guard**: `test_nba_window_matches_the_possession_engine_reader` pins `periods.period_start_range` to `nba_lineups._period_start_range` for periods 1-12 — the capture window cannot drift from what the possession engine expects when it reads these payloads back.
- Full mypy ratchet green (351 files) with all five modules appended; ruff lint + format clean.

## Next

Twin-migration PRs: both repos delete their `endpoints.py` / `season_capture.py` / `period_capture.py` / `refill_empty.py` bodies and keep thin league-binding shims + drivers.

## Summary by Sourcery

Introduce a league-parameterized capture layer shared between NBA and WNBA stats-raw repos, centralizing capture planning and fixing latent issues in the refill workflow.

New Features:
- Add LeagueConfig definitions for NBA and WNBA to centralize league identity and raw-store configuration.
- Add a shared endpoints registry that derives season-level capture matrices from endpoint signatures and keys league-specific season string spelling off league_id.
- Add a season_capture module to perform atomic, resumable season-level captures with guards against persisting contentless payloads.
- Add a periods module implementing league- and era-aware per-period window math and season decoding for stats game IDs.
- Add a refill module that scans for and refills contentless season-level payloads using the shared capture plan.

Bug Fixes:
- Fix the WNBA refill shim to resolve the correct stats wrapper module, preventing ModuleNotFoundError during real refill runs.
- Stop capturing unsupported measure-type combinations and mis-specified season parameters that previously produced empty or malformed payloads.

Enhancements:
- Update the scrape.stats package __init__ docstring to describe the new league-parameterized capture layer modules and their roles.
- Extend pyproject configuration to include the new capture-planning and refill modules in type checking and packaging.

Documentation:
- Document the Phase 2 league-parameterized capture layer and its components in both the main and docs changelogs.

Tests:
- Add offline tests covering league config resolution, season-string spelling differences, period window math across NBA and WNBA eras, game-id season decoding, empty-payload detection and census, and refill offline behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared NBA and WNBA statistics capture support with league-specific endpoint, season, and timing configurations.
  * Added resumable season captures with atomic persistence and protection against empty payloads.
  * Added tools to identify and refill incomplete captures, with filtering and check-only modes.
  * Added historical period handling for NBA and WNBA seasons, including older WNBA formats.

* **Bug Fixes**
  * Fixed WNBA refill resolution to support reliable repairs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->