### PR TITLE
feat(scrape): shared stats.ncaa.org hoops sweep engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Unreleased](#unreleased)
+  - [New — `sportsdataverse.scrape.ncaa`: shared stats.ncaa.org hoops sweep engine](#new--sportsdataversescrapencaa-shared-statsncaaorg-hoops-sweep-engine)
   - [`sportsdataverse.scrape.stats` — league-parameterized capture layer (Phase 2)](#sportsdataversescrapestats--league-parameterized-capture-layer-phase-2)
   - [Docs — offline full-text search on the documentation site](#docs--offline-full-text-search-on-the-documentation-site)
   - [CI — docs site builds on GitHub Actions and publishes to `gh-pages`](#ci--docs-site-builds-on-github-actions-and-publishes-to-gh-pages)
@@ -221,6 +222,39 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Unreleased
+
+### New — `sportsdataverse.scrape.ncaa`: shared stats.ncaa.org hoops sweep engine
+
+`ncaa-mbb-hoops-raw` and `ncaa-wbb-hoops-raw` were the same pipeline twice:
+27 shared files, ~4,000 LOC of production code, and only ~90 lines of real
+difference between them — the rest maintained by hand-porting each fix from one
+repo to the other. That stack now has one home:
+
+- `scrape/ncaa/discover.py` — team/season crosswalk → contest ids → the season
+  `schedule_master`.
+- `scrape/ncaa/capture.py` — the 3-page bundle per contest: sharded,
+  disk-is-checkpoint, ban-aware.
+- `scrape/ncaa/parse.py` — bundle → pbp / shots / lineups frames.
+- `scrape/ncaa/rosters.py`, `datasets.py`, `identity.py`,
+  `espn_game_xwalk.py`, `bundle.py`, `canary.py`.
+- `scrape/ncaa/league_config.py` — `MBB` / `WBB` identity.
+
+**`league` is a required keyword on every public entry point**, deliberately.
+The capture stack is league-agnostic (stats.ncaa.org serves one contest-id
+namespace, and sdv-py's NCAA parsers already select the period model and
+three-point arc by league), so a league is only ever a token threaded through
+calls — and a shared engine that *defaults* one is how a women's run silently
+reads men's data. That was not hypothetical: the men's repo's capture CLI
+hardcoded both the schedule-master path and the capture league to `"mbb"` and
+had no `--league` flag at all, so it could not be pointed at the other league.
+A source-level test guards the literal from creeping back, since the failure it
+causes is silent — a well-formed capture written to the wrong league's tree.
+
+Not re-exported at the top-level `sportsdataverse` namespace: this is
+producer-pipeline tooling, not the tidy-data API. The two `-raw` repos keep a
+thin league-binding shim per module, their launchers (which carry real
+per-league pacing), and their test suites — those suites are the engine's
+parity harness and stay repo-side.
 
 ### `sportsdataverse.scrape.stats` — league-parameterized capture layer (Phase 2)
 

--- a/docs/src/pages/CHANGELOG.md
+++ b/docs/src/pages/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Unreleased](#unreleased)
+  - [New — `sportsdataverse.scrape.ncaa`: shared stats.ncaa.org hoops sweep engine](#new--sportsdataversescrapencaa-shared-statsncaaorg-hoops-sweep-engine)
   - [`sportsdataverse.scrape.stats` — league-parameterized capture layer (Phase 2)](#sportsdataversescrapestats--league-parameterized-capture-layer-phase-2)
   - [Docs — offline full-text search on the documentation site](#docs--offline-full-text-search-on-the-documentation-site)
   - [CI — docs site builds on GitHub Actions and publishes to `gh-pages`](#ci--docs-site-builds-on-github-actions-and-publishes-to-gh-pages)
@@ -221,6 +222,39 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Unreleased
+
+### New — `sportsdataverse.scrape.ncaa`: shared stats.ncaa.org hoops sweep engine
+
+`ncaa-mbb-hoops-raw` and `ncaa-wbb-hoops-raw` were the same pipeline twice:
+27 shared files, ~4,000 LOC of production code, and only ~90 lines of real
+difference between them — the rest maintained by hand-porting each fix from one
+repo to the other. That stack now has one home:
+
+- `scrape/ncaa/discover.py` — team/season crosswalk → contest ids → the season
+  `schedule_master`.
+- `scrape/ncaa/capture.py` — the 3-page bundle per contest: sharded,
+  disk-is-checkpoint, ban-aware.
+- `scrape/ncaa/parse.py` — bundle → pbp / shots / lineups frames.
+- `scrape/ncaa/rosters.py`, `datasets.py`, `identity.py`,
+  `espn_game_xwalk.py`, `bundle.py`, `canary.py`.
+- `scrape/ncaa/league_config.py` — `MBB` / `WBB` identity.
+
+**`league` is a required keyword on every public entry point**, deliberately.
+The capture stack is league-agnostic (stats.ncaa.org serves one contest-id
+namespace, and sdv-py's NCAA parsers already select the period model and
+three-point arc by league), so a league is only ever a token threaded through
+calls — and a shared engine that *defaults* one is how a women's run silently
+reads men's data. That was not hypothetical: the men's repo's capture CLI
+hardcoded both the schedule-master path and the capture league to `"mbb"` and
+had no `--league` flag at all, so it could not be pointed at the other league.
+A source-level test guards the literal from creeping back, since the failure it
+causes is silent — a well-formed capture written to the wrong league's tree.
+
+Not re-exported at the top-level `sportsdataverse` namespace: this is
+producer-pipeline tooling, not the tidy-data API. The two `-raw` repos keep a
+thin league-binding shim per module, their launchers (which carry real
+per-league pacing), and their test suites — those suites are the engine's
+parity harness and stay repo-side.
 
 ### `sportsdataverse.scrape.stats` — league-parameterized capture layer (Phase 2)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -650,4 +650,12 @@ files = [
     "sportsdataverse/scrape/stats/endpoints.py",
     "sportsdataverse/scrape/stats/season_capture.py",
     "sportsdataverse/scrape/stats/refill.py",
+    "sportsdataverse/scrape/ncaa/__init__.py",
+    "sportsdataverse/scrape/ncaa/league_config.py",
+    "sportsdataverse/scrape/ncaa/bundle.py",
+    "sportsdataverse/scrape/ncaa/espn_game_xwalk.py",
+    "sportsdataverse/scrape/ncaa/rosters.py",
+    "sportsdataverse/scrape/ncaa/discover.py",
+    "sportsdataverse/scrape/ncaa/capture.py",
+    "sportsdataverse/scrape/ncaa/parse.py",
 ]

--- a/sportsdataverse/scrape/ncaa/__init__.py
+++ b/sportsdataverse/scrape/ncaa/__init__.py
@@ -1,0 +1,30 @@
+"""stats.ncaa.org college-basketball sweep engine (shared by the NCAA hoops twins).
+
+Lifted from ``ncaa-mbb-hoops-raw`` / ``ncaa-wbb-hoops-raw``, whose ``python/``
+trees had diverged by only ~90 lines across ~4,000 LOC of production code — the
+two repos were the same pipeline twice, ported by hand.
+
+Stages, in run order:
+
+    * :mod:`~sportsdataverse.scrape.ncaa.discover` — team/season crosswalk →
+      contest ids → the season ``schedule_master``.
+    * :mod:`~sportsdataverse.scrape.ncaa.capture` — the 3-page bundle per
+      contest, sharded, disk-is-checkpoint, ban-aware.
+    * :mod:`~sportsdataverse.scrape.ncaa.parse` — bundle → pbp / shots /
+      lineups frames (period model + three-point arc selected by league).
+    * :mod:`~sportsdataverse.scrape.ncaa.rosters` — per-team roster pages.
+    * :mod:`~sportsdataverse.scrape.ncaa.datasets` — season aggregates + the
+      tree writers.
+    * :mod:`~sportsdataverse.scrape.ncaa.identity` /
+      :mod:`~sportsdataverse.scrape.ncaa.espn_game_xwalk` — id enrichment and
+      the ESPN crosswalk.
+    * :mod:`~sportsdataverse.scrape.ncaa.bundle` — bundle read/write +
+      ``is_captured`` (the real resume check).
+    * :mod:`~sportsdataverse.scrape.ncaa.canary` — pre-flight transport probe.
+
+``league`` is a **required keyword** on every public entry point; see
+:mod:`~sportsdataverse.scrape.ncaa.league_config` for why defaulting it is
+unsafe. Each ``-raw`` repo keeps a thin shim that binds its league, plus its
+launchers and its test suite (the suites are the parity harness for this
+engine and deliberately stay repo-side).
+"""

--- a/sportsdataverse/scrape/ncaa/bundle.py
+++ b/sportsdataverse/scrape/ncaa/bundle.py
@@ -1,0 +1,77 @@
+"""Raw-bundle read/write helpers for captured NCAA game pages.
+
+Each captured contest is stored as one gzip-compressed JSON file at
+``root/{league}/raw/{season}/{contest_id}.json.gz`` containing the raw
+``play_by_play`` / ``box_score`` / ``individual_stats`` payloads plus their
+source URLs and capture timestamp.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+__all__ = ["bundle_path", "write_bundle", "read_bundle", "is_captured"]
+
+
+def bundle_path(root: str | Path, league: str, season: str, contest_id: str) -> Path:
+    """Return the on-disk path for a captured contest bundle."""
+    return Path(root) / league / "raw" / season / f"{contest_id}.json.gz"
+
+
+def write_bundle(
+    root: str | Path,
+    league: str,
+    season: str,
+    contest_id: str,
+    pages: dict[str, Any],
+    urls: dict[str, Any],
+    captured_at: str,
+) -> Path:
+    """Gzip-write the contract bundle for a contest, atomically.
+
+    Args:
+        root: Root directory of the raw data tree.
+        league: League slug (e.g. ``"mbb"``).
+        season: Season label, used verbatim in the path (e.g. ``"2025-26"``).
+        contest_id: Contest identifier as a string (never cast to int).
+        pages: Dict with keys ``play_by_play``, ``box_score``, ``individual_stats``.
+        urls: Dict of source URLs matching ``pages`` keys.
+        captured_at: ISO-8601 capture timestamp (caller-supplied).
+
+    Returns:
+        The path the bundle was written to.
+    """
+    path = bundle_path(root, league, season, contest_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    bundle = {
+        "contest_id": contest_id,
+        "league": league,
+        "season": season,
+        "captured_at": captured_at,
+        "urls": urls,
+        "pages": pages,
+    }
+    payload = json.dumps(bundle).encode("utf-8")
+
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    with gzip.open(tmp_path, "wb") as f:
+        f.write(payload)
+    os.replace(tmp_path, path)
+
+    return path
+
+
+def read_bundle(path: str | Path) -> dict[str, Any]:
+    """Gunzip and parse a contest bundle written by :func:`write_bundle`."""
+    with gzip.open(path, "rb") as f:
+        return json.loads(f.read().decode("utf-8"))
+
+
+def is_captured(root: str | Path, league: str, season: str, contest_id: str) -> bool:
+    """Return True if a bundle already exists for this contest."""
+    return bundle_path(root, league, season, contest_id).exists()

--- a/sportsdataverse/scrape/ncaa/canary.py
+++ b/sportsdataverse/scrape/ncaa/canary.py
@@ -1,0 +1,532 @@
+"""Vendor-agnostic proxy canary for stats.ncaa.org bm-verify.
+
+Runs the SAME small MBB probe (default 10 known-good contests x 2 game-detail
+pages) through every proxy vendor listed in a TOML config, scoring each fetch
+with the PRODUCTION classifier from :mod:`sportsdataverse.mbb.mbb_ncaa_fetch`
+(``_ban_check`` / ``_is_challenge`` / the 1 KB size floor). A "clean" here is a
+"clean" in the real backfill, so the winner is chosen on measured bm-verify
+solve rate -- not on a vendor's marketing.
+
+Why this exists: the ProxyBonanza pool was ASN-confirmed **datacenter**
+(QuickPacket / Hivelocity / ReliableSite), which is exactly what Akamai
+bm-verify + IP reputation defeats. Before spending on a residential/ISP/mobile
+or managed-unblocker vendor, prove one actually solves the challenge on this
+host. See ``docs/SCRAPING_NOTES.md``.
+
+Two adapter classes, both reusing the existing :class:`NcaaFetcher` (so the
+probe's fetch path == production's):
+
+* ``proxy_browser``   -- raw residential/ISP/mobile proxies + the Playwright
+  new-headless solver (NetNut, Decodo, mobile). ``NcaaFetcher.with_browser``.
+* ``unblocker_zyte``  -- Zyte API (``api.zyte.com``): URL in, solved HTML out.
+* ``unblocker_proxy`` -- a managed-unblocker PROXY endpoint that returns solved
+  HTML for a plain GET (Bright Data Web Unlocker, Oxylabs Web Unblocker).
+
+Config: copy ``canary_vendors.toml.example`` -> ``canary_vendors.toml`` (gitignored)
+and fill in whichever trial creds you have. Vendors with placeholder/empty creds
+are skipped with a note, so you can add trials one at a time.
+
+Run via ``scripts/run_canary.sh`` (wires PYTHONPATH + the venv python).
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import statistics
+import sys
+import tempfile
+import time
+import tomllib
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Callable, Optional
+from urllib.parse import urlsplit
+
+from sportsdataverse.mbb.mbb_ncaa_fetch import (
+    _MIN_CONTENT_BYTES,
+    _RAW_FETCH_JS,
+    NcaaFetchConfig,
+    NcaaFetcher,
+    _ban_check,
+    _browser_response_unsolved,
+    _is_challenge,
+)
+
+# Known-good captured MBB contests (present in mbb/json/) -- valid games, so any
+# non-clean result is unambiguously a vendor/challenge failure, not a bad id.
+DEFAULT_CONTEST_IDS = [
+    "6388769",
+    "6388905",
+    "6388907",
+    "6388965",
+    "6388997",
+    "6389038",
+    "6389078",
+    "6389091",
+    "6389095",
+    "6389099",
+]
+
+# Two bm-verify-gated game-detail pages per game (the ones curl_cffi can't clear).
+PAGES = ("play_by_play", "individual_stats")
+
+# Substrings that mark a config value as an unfilled placeholder -> skip vendor.
+_PLACEHOLDERS = (
+    "your_",
+    "user:pass",
+    "customer-xxx",
+    "xxxxxx",
+    "<",
+    "changeme",
+    "example",
+)
+
+CLEAN, STUB, CHALLENGE, BAN, TIMEOUT, ERROR = (
+    "clean",
+    "stub",
+    "challenge",
+    "ban",
+    "timeout",
+    "error",
+)
+_CATS = (CLEAN, STUB, CHALLENGE, BAN, TIMEOUT, ERROR)
+
+
+def classify(text: str) -> str:
+    """Classify a returned body the way production does -- ban > challenge > size floor.
+
+    Order is load-bearing: a ban page can be small, and the markerless XHR stub
+    (15-411 B observed) is only caught by the size floor, so it must come last.
+    """
+    if _ban_check(text) != "clean":
+        return BAN
+    if _is_challenge(text):
+        return CHALLENGE
+    if len(text) < _MIN_CONTENT_BYTES:
+        return STUB
+    return CLEAN
+
+
+def classify_error(exc: Exception) -> str:
+    """Bucket a fetch exception (NcaaFetcher raises loudly on ban/unsolved)."""
+    msg = str(exc).lower()
+    if "every proxy" in msg or "banned" in msg or "403" in msg:
+        return BAN
+    if "bm-verify" in msg or "challenge" in msg:
+        return CHALLENGE
+    if "timeout" in msg or "timed out" in msg:
+        return TIMEOUT
+    return ERROR
+
+
+def _has_placeholder(value: str) -> bool:
+    low = value.lower()
+    return not value.strip() or any(p in low for p in _PLACEHOLDERS)
+
+
+def _vendor_ready(vendor: dict) -> Optional[str]:
+    """Return a skip-reason string if the vendor's creds are unfilled, else None."""
+    vtype = vendor.get("type", "")
+    if vtype in ("proxy_browser", "proxy_patchright"):
+        proxies = vendor.get("proxies") or []
+        if not proxies or any(_has_placeholder(p) for p in proxies):
+            return "no proxies configured (placeholder/empty)"
+    elif vtype == "unblocker_zyte":
+        if _has_placeholder(vendor.get("api_key", "")):
+            return "no api_key configured (placeholder/empty)"
+    elif vtype == "unblocker_proxy":
+        if _has_placeholder(vendor.get("proxy", "")):
+            return "no proxy endpoint configured (placeholder/empty)"
+    elif vtype == "managed_cdp":
+        if _has_placeholder(vendor.get("cdp_url", "")):
+            return "no cdp_url configured (placeholder/empty)"
+    else:
+        return f"unknown vendor type {vtype!r}"
+    return None
+
+
+# Real Chrome UA -- MUST override the browser's default, which leaks
+# "HeadlessChrome" in new-headless mode. That leak is the single tell that made
+# earlier patchright runs fail; with it fixed the solve clears bm-verify (proven
+# live 2026-07-16: 200 + 135 KB real PBP on the first attempt).
+_REAL_CHROME_UA = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36"
+)
+
+
+class _PatchrightTransport:
+    """Local anti-detect (patchright) Chromium solver, proxy-bound like production.
+
+    Drives **patchright** (a drop-in Playwright fork that closes the
+    ``Runtime.enable`` CDP leak + ``navigator.webdriver`` tells) in **new-headless**
+    mode (``--headless=new`` -> real GPU/ANGLE, not SwiftShader) with a **real
+    Chrome UA** (no ``HeadlessChrome`` leak). This exact combination clears
+    stats.ncaa.org bm-verify from a US residential IP where vanilla Playwright and
+    a leaky-UA patchright both failed. Requires a host with a real GPU.
+    """
+
+    def __init__(
+        self,
+        *,
+        challenge_wait_ms: int = 8000,
+        nav_timeout_ms: int = 45000,  # residential + multi-round-trip solve needs headroom
+        solve_attempts: int = 3,
+        user_agent: str = _REAL_CHROME_UA,
+    ) -> None:
+        self.user_agent = user_agent
+        self.challenge_wait_ms = challenge_wait_ms
+        self.nav_timeout_ms = nav_timeout_ms
+        self.solve_attempts = max(1, solve_attempts)
+        self._pw: Any = None
+        self._ctx: Any = None
+        self._page: Any = None
+        self._current_proxy: Optional[str] = None
+
+    def _ensure(self, proxies: "dict[str, str]") -> None:
+        proxy = proxies.get("http") or proxies.get("https") or None
+        if self._page is not None:
+            if proxy == self._current_proxy:
+                return
+            self.close()  # proxy rotated -> relaunch (context is proxy-bound at launch)
+        import atexit
+
+        from patchright.sync_api import sync_playwright
+
+        self._pw = sync_playwright().start()
+        udd = tempfile.mkdtemp(prefix="patchright_udd_")
+        launch: "dict[str, Any]" = {
+            "user_data_dir": udd,
+            # new-headless (real GPU/ANGLE) + real Chrome UA -- the config that
+            # actually clears bm-verify. headless=False + --headless=new is the
+            # Playwright idiom for new-headless.
+            "headless": False,
+            "args": ["--headless=new"],
+            "user_agent": self.user_agent,
+            "no_viewport": True,
+        }
+        if proxy:
+            parts = urlsplit(proxy)
+            username = parts.username
+            if username and "-session-" in username:
+                # Sticky-session vendors (Decodo) pin the egress IP to the
+                # session id in the username. Re-mint it on every LAUNCH so a
+                # relaunch after a failed solve lands on a fresh IP -- an aged
+                # session (~70min ceiling) stops clearing bm-verify, and
+                # retrying it on the same IP fails forever.
+                import re as _re
+                import uuid as _uuid
+
+                username = _re.sub(r"(-session-)\w+", rf"\g<1>{_uuid.uuid4().hex[:12]}", username)
+            launch["proxy"] = {
+                "server": f"{parts.scheme}://{parts.hostname}:{parts.port}",
+                **({"username": username} if username else {}),
+                **({"password": parts.password} if parts.password else {}),
+            }
+        self._ctx = self._pw.chromium.launch_persistent_context(**launch)
+        self._page = self._ctx.pages[0] if self._ctx.pages else self._ctx.new_page()
+        self._current_proxy = proxy
+        atexit.register(self.close)
+
+    def __call__(self, url: str, proxies: "dict[str, str]", headers: "dict[str, str]") -> "tuple[int, str]":
+        self._ensure(proxies)
+        # Navigate ONCE (this triggers + solves the challenge), then poll the raw
+        # in-page fetch until _abck is minted -- the proven pattern. Re-navigating
+        # per attempt through a slow residential proxy is what timed the solve out.
+        self._page.goto(url, wait_until="domcontentloaded", timeout=self.nav_timeout_ms)
+        status, text = 0, ""
+        for _ in range(self.solve_attempts):
+            self._page.wait_for_timeout(self.challenge_wait_ms)
+            result = self._page.evaluate(_RAW_FETCH_JS, url)
+            status, text = int(result["status"]), str(result["text"])
+            if not _browser_response_unsolved(text):
+                return status, text
+        # Retire the (likely aged-out) session so the caller's retry relaunches
+        # on a freshly-minted sticky id instead of re-failing the same IP.
+        self.close()
+        raise RuntimeError(
+            f"patchright: bm-verify not passed after {self.solve_attempts} attempts ({len(text)}-byte body)"
+        )
+
+    def close(self) -> None:
+        for obj, meth in ((self._ctx, "close"), (self._pw, "stop")):
+            try:
+                if obj is not None:
+                    getattr(obj, meth)()
+            except Exception:  # noqa: BLE001 - best-effort teardown
+                pass
+        self._pw = self._ctx = self._page = None
+        self._current_proxy = None
+
+    def __enter__(self) -> "_PatchrightTransport":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+
+class _ManagedCdpTransport:
+    """Drive a MANAGED remote browser over CDP (Bright Data Scraping Browser,
+    Browserbase, Zyte browser). The provider owns the hardened fingerprint,
+    residential egress, and Akamai solve; Playwright only steers it. Same shape
+    as sdv-py's ncaa.fetch.ManagedBrowserTransport, kept self-contained here so
+    the canary doesn't depend on that (currently uncommitted) module.
+    """
+
+    def __init__(
+        self,
+        endpoint_url: str,
+        *,
+        challenge_wait_ms: int = 8000,
+        nav_timeout_ms: int = 120000,
+        solve_attempts: int = 2,
+    ) -> None:
+        self._endpoint = endpoint_url
+        self.challenge_wait_ms = challenge_wait_ms
+        self.nav_timeout_ms = nav_timeout_ms
+        self.solve_attempts = max(1, solve_attempts)
+        self._pw: Any = None
+        self._browser: Any = None
+        self._page: Any = None
+
+    def _ensure(self) -> None:
+        if self._page is not None:
+            return
+        from playwright.sync_api import sync_playwright
+
+        self._pw = sync_playwright().start()
+        self._browser = self._pw.chromium.connect_over_cdp(self._endpoint, timeout=self.nav_timeout_ms)
+        self._page = self._browser.new_page()
+
+    def __call__(self, url: str, proxies: "dict[str, str]", headers: "dict[str, str]") -> "tuple[int, str]":
+        self._ensure()
+        status, text = 0, ""
+        for _ in range(self.solve_attempts):
+            self._page.goto(url, wait_until="domcontentloaded", timeout=self.nav_timeout_ms)
+            self._page.wait_for_timeout(self.challenge_wait_ms)
+            result = self._page.evaluate(_RAW_FETCH_JS, url)
+            status, text = int(result["status"]), str(result["text"])
+            if not _browser_response_unsolved(text):
+                return status, text
+        raise RuntimeError(
+            f"managed_cdp: bm-verify not passed after {self.solve_attempts} attempts ({len(text)}-byte body)"
+        )
+
+    def close(self) -> None:
+        for obj, meth in ((self._browser, "close"), (self._pw, "stop")):
+            try:
+                if obj is not None:
+                    getattr(obj, meth)()
+            except Exception:  # noqa: BLE001 - best-effort teardown
+                pass
+        self._pw = self._browser = self._page = None
+
+    def __enter__(self) -> "_ManagedCdpTransport":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+
+def _make_zyte_transport(api_key: str, render: str) -> Callable[..., "tuple[int, str]"]:
+    import requests
+
+    def _t(url: str, proxies: dict, headers: dict) -> "tuple[int, str]":
+        key = "browserHtml" if render == "browserHtml" else "httpResponseBody"
+        r = requests.post(
+            "https://api.zyte.com/v1/extract",
+            auth=(api_key, ""),
+            json={"url": url, key: True},
+            timeout=120,
+        )
+        if r.status_code != 200:
+            return r.status_code, r.text
+        data = r.json()
+        status = int(data.get("statusCode") or 200)
+        if "browserHtml" in data:
+            return status, str(data["browserHtml"])
+        body = data.get("httpResponseBody")
+        return (status, base64.b64decode(body).decode("utf-8", "replace")) if body else (status, "")
+
+    return _t
+
+
+def _make_unblocker_proxy_transport(proxy: str) -> Callable[..., "tuple[int, str]"]:
+    # Bright Data Web Unlocker / Oxylabs Web Unblocker: plain GET through their
+    # proxy endpoint returns already-solved HTML. verify=False because these MITM
+    # TLS (their CA isn't in the trust store); the "auth" is the proxy creds.
+    import curl_cffi
+
+    def _t(url: str, proxies: dict, headers: dict) -> "tuple[int, str]":
+        r = curl_cffi.get(
+            url,
+            headers=headers,
+            proxies={"http": proxy, "https": proxy},
+            timeout=120,
+            impersonate="chrome",
+            verify=False,
+        )
+        return r.status_code, r.text
+
+    return _t
+
+
+def build_fetcher(vendor: dict, cache_dir: Path) -> NcaaFetcher:
+    """Construct the right NcaaFetcher for a vendor (all context-managed)."""
+    vtype = vendor["type"]
+    if vtype == "proxy_browser":
+        cfg = NcaaFetchConfig(cache_dir=cache_dir)
+        # nav_timeout_ms lower than the prod default so a dead/typo'd proxy host
+        # fails a game in ~20s instead of ~40s; a real IP resolves well under it.
+        return NcaaFetcher.with_browser(cfg, proxy_pool=list(vendor["proxies"]), nav_timeout_ms=20000)
+    if vtype == "proxy_patchright":
+        cfg = NcaaFetchConfig(cache_dir=cache_dir, transport=_PatchrightTransport())  # type: ignore[arg-type]
+        return NcaaFetcher(cfg, proxy_pool=list(vendor["proxies"]))
+    if vtype == "managed_cdp":
+        cfg = NcaaFetchConfig(cache_dir=cache_dir, transport=_ManagedCdpTransport(vendor["cdp_url"]))  # type: ignore[arg-type]
+        return NcaaFetcher(cfg, proxy_pool=None)
+    if vtype == "unblocker_zyte":
+        transport = _make_zyte_transport(vendor["api_key"], vendor.get("render", "browserHtml"))
+    elif vtype == "unblocker_proxy":
+        transport = _make_unblocker_proxy_transport(vendor["proxy"])
+    else:  # pragma: no cover - guarded by _vendor_ready
+        raise ValueError(f"unknown vendor type {vtype!r}")
+    cfg = NcaaFetchConfig(cache_dir=cache_dir, transport=transport)  # type: ignore[arg-type]
+    return NcaaFetcher(cfg, proxy_pool=None)
+
+
+def _fetch_page(fetcher: NcaaFetcher, cid: str, page: str) -> str:
+    if page == "play_by_play":
+        return fetcher.fetch_game_pbp(cid, force=True)
+    return fetcher.fetch_game_individual_stats(cid, force=True)
+
+
+def probe_vendor(vendor: dict, contest_ids: list[str], delay: float) -> list[dict]:
+    """Run one vendor over all contests x pages. Returns per-fetch result rows."""
+    rows: list[dict] = []
+    cache_dir = Path(tempfile.mkdtemp(prefix=f"ncaa_canary_{vendor['name']}_"))
+    with build_fetcher(vendor, cache_dir) as fetcher:
+        for game_idx, cid in enumerate(contest_ids, 1):
+            for page in PAGES:
+                t0 = time.monotonic()
+                try:
+                    text = _fetch_page(fetcher, cid, page)
+                    cat, nbytes = classify(text), len(text)
+                except Exception as exc:  # noqa: BLE001 - a probe records failures, never aborts
+                    cat, nbytes = classify_error(exc), 0
+                rows.append(
+                    {
+                        "cid": cid,
+                        "page": page,
+                        "cat": cat,
+                        "bytes": nbytes,
+                        "sec": round(time.monotonic() - t0, 1),
+                        "game_idx": game_idx,
+                    }
+                )
+                print(
+                    f"    [{vendor['name']}] game {game_idx:>2}/{len(contest_ids)} "
+                    f"{page:<16} {cat:<9} {nbytes:>7}B {rows[-1]['sec']:>5}s",
+                    flush=True,
+                )
+                if delay:
+                    time.sleep(delay)
+    return rows
+
+
+def scorecard(vendor: dict, rows: list[dict], n_games: int) -> str:
+    """Aggregate a vendor's rows into a markdown scorecard section."""
+    counts = {c: sum(1 for r in rows if r["cat"] == c) for c in _CATS}
+    total = len(rows)
+    clean_pct = 100 * counts[CLEAN] / total if total else 0.0
+    # A game is clean only if BOTH its pages are clean (production needs both).
+    by_game: dict[str, list[str]] = {}
+    for r in rows:
+        by_game.setdefault(r["cid"], []).append(r["cat"])
+    clean_games = sum(1 for cats in by_game.values() if all(c == CLEAN for c in cats))
+    # First non-clean fetch's game index = IP-lifetime signal.
+    first_fail = next((r["game_idx"] for r in rows if r["cat"] != CLEAN), None)
+    clean_bytes = [r["bytes"] for r in rows if r["cat"] == CLEAN]
+    med_bytes = int(statistics.median(clean_bytes)) if clean_bytes else 0
+    verdict = "PASS" if clean_games >= 0.9 * n_games else "FAIL"
+
+    lines = [
+        f"### {vendor['name']}  ({vendor['type']}) -- **{verdict}**",
+        "",
+        f"- clean pages: **{counts[CLEAN]}/{total}** ({clean_pct:.0f}%)",
+        f"- clean games (both pages): **{clean_games}/{n_games}**",
+        f"- first failure at game #: {first_fail if first_fail else 'none'}",
+        f"- median clean page size: {med_bytes:,} B",
+        "- breakdown: " + ", ".join(f"{c}={counts[c]}" for c in _CATS if counts[c]),
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--config", default="canary_vendors.toml", help="TOML vendor config")
+    ap.add_argument("--games", type=int, default=0, help="limit to first N contests (0=all)")
+    ap.add_argument("--delay", type=float, default=1.0, help="seconds between fetches (be gentle)")
+    ap.add_argument("--out", default="canary_out", help="output directory for the scorecard")
+    args = ap.parse_args(argv)
+
+    cfg_path = Path(args.config)
+    if not cfg_path.exists():
+        print(
+            f"config not found: {cfg_path}\ncopy canary_vendors.toml.example -> {cfg_path} and fill in trial creds.",
+            file=sys.stderr,
+        )
+        return 2
+    conf = tomllib.loads(cfg_path.read_text(encoding="utf-8"))
+    contest_ids = [str(c) for c in conf.get("contest_ids", DEFAULT_CONTEST_IDS)]
+    if args.games:
+        contest_ids = contest_ids[: args.games]
+    vendors = conf.get("vendor", [])
+    if not vendors:
+        print("no [[vendor]] entries in config.", file=sys.stderr)
+        return 2
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_file = out_dir / f"canary_{stamp}.md"
+    header = (
+        f"# NCAA proxy canary -- {stamp}\n\n"
+        f"{len(contest_ids)} MBB contests x {len(PAGES)} pages "
+        f"(play_by_play + individual_stats). PASS = >=90% clean games.\n\n"
+    )
+    out_file.write_text(header, encoding="utf-8")
+    print(header)
+
+    summary: list[str] = []
+    for vendor in vendors:
+        name = vendor.get("name", "?")
+        skip = _vendor_ready(vendor)
+        if skip:
+            note = f"### {name}  ({vendor.get('type', '?')}) -- SKIPPED: {skip}\n\n"
+            out_file.write_text(out_file.read_text(encoding="utf-8") + note, encoding="utf-8")
+            print(f"  {name}: SKIPPED ({skip})", flush=True)
+            summary.append(f"{name}: skipped")
+            continue
+        print(f"  probing {name} ({vendor['type']}) ...", flush=True)
+        try:
+            rows = probe_vendor(vendor, contest_ids, args.delay)
+            section = scorecard(vendor, rows, len(contest_ids))
+        except Exception as exc:  # noqa: BLE001 - one bad vendor must not sink the run
+            section = f"### {name}  ({vendor['type']}) -- ERROR building/running: {exc}\n\n"
+        # Append incrementally so a later hang never loses earlier results.
+        out_file.write_text(out_file.read_text(encoding="utf-8") + section + "\n", encoding="utf-8")
+        first_line = section.splitlines()[0].replace("### ", "")
+        print(f"  -> {first_line}", flush=True)
+        summary.append(first_line)
+
+    print("\n=== canary summary ===")
+    for s in summary:
+        print(f"  {s}")
+    print(f"\nfull scorecard -> {out_file}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sportsdataverse/scrape/ncaa/capture.py
+++ b/sportsdataverse/scrape/ncaa/capture.py
@@ -1,0 +1,380 @@
+"""Per-contest game-page capture loop (3-page bundle write).
+
+For each contest_id not already captured (:func:`ncaa_bundle.is_captured`),
+fetches the play-by-play / box-score / individual-stats pages through one
+shared browser-transport :class:`NcaaFetcher` session, validates each page
+cleared the Akamai challenge (large enough + enough ``<tr>`` rows), and
+writes the 3-page bundle via :func:`ncaa_bundle.write_bundle`.
+
+Single-threaded by design: Playwright's sync API is not thread-safe, so one
+browser session drives contests serially. Throughput scales by running
+separate launcher PROCESSES over disjoint shards -- see :func:`shard`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Union
+
+from .bundle import is_captured, write_bundle
+
+logger = logging.getLogger(__name__)
+
+PAGE_KEYS = ("play_by_play", "box_score", "individual_stats")
+_MIN_BYTES = 20000
+# ponytail: 30, not the round-number 50 -- the committed real-capture
+# fixtures show box_score is a small fixed-structure team-stats table
+# (~41 <tr> on every one of the 8 games, independent of score), while
+# pbp/individual_stats run into the hundreds. 30 stays well clear of a
+# genuine shell (0 rows) with margin below the observed real floor.
+_MIN_ROWS = 30
+_TR_RE = re.compile(r"<tr[\s>]", re.IGNORECASE)
+
+# A sustained "challenge not cleared" run means the browser session has been
+# SOFT-banned: every further request yields nothing AND digs the ban deeper.
+# The 2026-07-13 backfill proved it -- 1262 consecutive failures across a full
+# hour (zero bundles written) before stats.ncaa.org escalated to a hard 403.
+# Stop at the first sign instead; the caller cools down and resumes.
+DEFAULT_MAX_CONSECUTIVE_FAILURES = 25
+
+FetchPagesFn = Callable[[Any, str], Dict[str, str]]
+
+__all__ = ["capture_contests", "shard", "DEFAULT_MAX_CONSECUTIVE_FAILURES"]
+
+
+def _is_clean(html: str) -> bool:
+    """A page cleared the challenge iff it's large and table-populated."""
+    return len(html) > _MIN_BYTES and len(_TR_RE.findall(html)) > _MIN_ROWS
+
+
+def _default_fetch_pages_fn() -> FetchPagesFn:
+    def fetch(fetcher: Any, contest_id: str) -> Dict[str, str]:
+        return {
+            "play_by_play": fetcher.fetch_game_pbp(contest_id, force=True),
+            "box_score": fetcher.fetch_game_box(contest_id, force=True),
+            "individual_stats": fetcher.fetch_game_individual_stats(contest_id, force=True),
+        }
+
+    return fetch
+
+
+def _page_urls(contest_id: str) -> Dict[str, str]:
+    base = f"https://stats.ncaa.org/contests/{contest_id}"
+    return {
+        "play_by_play": f"{base}/play_by_play",
+        "box_score": f"{base}/box_score",
+        "individual_stats": f"{base}/individual_stats",
+    }
+
+
+def shard(contest_ids: "List[str]", i: int, n: int) -> "List[str]":
+    """Split a sorted contest_id list into disjoint shard *i* of *n*.
+
+    Launcher parallelism model: start N separate processes, each running
+    one :class:`NcaaFetcher` session over ``shard(ids, i, n)`` for its
+    ``i``. Never share a browser across threads.
+    """
+    return [c for k, c in enumerate(sorted(contest_ids)) if k % n == i]
+
+
+def capture_contests(
+    contest_ids: "List[str]",
+    season: int,
+    *,
+    league: str,
+    root: Union[str, Path],
+    fetch_pages_fn: Optional[FetchPagesFn] = None,
+    fetcher: Any = None,
+    max_contests: Optional[int] = None,
+    max_consecutive_failures: int = DEFAULT_MAX_CONSECUTIVE_FAILURES,
+) -> "Dict[str, int]":
+    """Capture the 3-page bundle for each contest_id not already captured.
+
+    Args:
+        contest_ids: Contest ids to capture (kept as str throughout).
+        season: Ending-year season int, stamped on the bundle as ``str(season)``.
+        league: League slug (``"mbb"`` / ``"wbb"``).
+        root: Root directory of the raw data tree (passed to
+            :func:`ncaa_bundle.write_bundle` / :func:`ncaa_bundle.is_captured`).
+        fetch_pages_fn: ``(fetcher, contest_id) -> {"play_by_play":html,
+            "box_score":html, "individual_stats":html}``. Defaults to one
+            shared :class:`NcaaFetcher.with_browser` session calling
+            ``fetch_game_pbp/box/individual_stats(id, force=True)``. Inject
+            a fake for offline tests -- the *fetcher* arg is unused by the
+            default path's caller in that case and may be ``None``.
+        fetcher: Pre-built fetcher session (e.g. from :func:`_vendor_fetcher`,
+            the canary-vendor transports -- Decodo sticky residential +
+            patchright). ``None`` (default) builds the sdv-py
+            ``NcaaFetcher.with_browser()`` env-configured session. Ownership
+            transfers: this function closes the fetcher it used on exit.
+        max_contests: Stop CLEANLY after this many NEW bundles are written
+            (chunked backfill -- the browser session degrades past roughly
+            2000 bundles / ~2h, so capture a chunk, cool down, resume).
+            ``None`` (default) = unlimited.
+        max_consecutive_failures: Hard-stop after this many consecutive
+            challenge-not-cleared contests (soft-ban guard, see
+            :data:`DEFAULT_MAX_CONSECUTIVE_FAILURES`). The counter resets on
+            every successful capture, so isolated bad games never trip it.
+            ``0`` disables the guard.
+
+    Returns:
+        Counts: ``{"captured": int, "skipped": int, "failed": int}``.
+
+    Raises:
+        SystemExit: A fetch raised ``RuntimeError`` (NcaaFetcher's
+            ban-suspect / exhausted-proxy sentinel), OR
+            *max_consecutive_failures* consecutive challenges failed to clear
+            (soft-ban) -- either way the whole run stops immediately rather
+            than continuing to the next contest. Both are resumable: re-run
+            after a cooldown and already-captured contests are skipped.
+    """
+    season_str = str(season)
+    counts = {"captured": 0, "skipped": 0, "failed": 0}
+    consecutive_failures = 0
+
+    fetch_fn = fetch_pages_fn if fetch_pages_fn is not None else _default_fetch_pages_fn()
+
+    # An injected *fetcher* (e.g. a canary-vendor transport from
+    # :func:`_vendor_fetcher`) takes precedence; ownership transfers here either
+    # way -- the ``finally`` below closes whichever fetcher this loop used.
+    if fetcher is None and fetch_pages_fn is None:
+        from sportsdataverse.mbb.mbb_ncaa_fetch import NcaaFetcher
+
+        fetcher = NcaaFetcher.with_browser()
+
+    try:
+        for contest_id in contest_ids:
+            if is_captured(root, league, season_str, contest_id):
+                counts["skipped"] += 1
+                continue
+
+            try:
+                pages = fetch_fn(fetcher, contest_id)
+            except RuntimeError as exc:
+                logger.error(
+                    "BAN-SUSPECT: hard-stopping capture at contest_id=%s: %s",
+                    contest_id,
+                    exc,
+                )
+                raise SystemExit(f"BAN-SUSPECT: capture halted at contest_id={contest_id}: {exc}") from exc
+
+            if not all(_is_clean(pages.get(key, "")) for key in PAGE_KEYS):
+                logger.warning(
+                    "challenge not cleared for contest_id=%s -- bundle not written",
+                    contest_id,
+                )
+                counts["failed"] += 1
+                consecutive_failures += 1
+                if max_consecutive_failures and consecutive_failures >= max_consecutive_failures:
+                    msg = (
+                        f"SOFT-BAN: capture halted after {consecutive_failures} consecutive "
+                        f"challenge failures (last contest_id={contest_id}); the browser session "
+                        f"is no longer clearing bm-verify. Cool down, then re-run to resume."
+                    )
+                    logger.error("%s", msg)
+                    raise SystemExit(msg)
+                continue
+
+            write_bundle(
+                root,
+                league,
+                season_str,
+                contest_id,
+                pages={key: pages[key] for key in PAGE_KEYS},
+                urls=_page_urls(contest_id),
+                captured_at=datetime.now(timezone.utc).isoformat(),
+            )
+            counts["captured"] += 1
+            consecutive_failures = 0  # a clear page proves the session is healthy
+
+            if max_contests is not None and counts["captured"] >= max_contests:
+                logger.info(
+                    "chunk complete: %d new bundles captured (--max-contests) -- stopping cleanly; re-run to continue",
+                    counts["captured"],
+                )
+                break
+    finally:
+        if fetcher is not None:
+            closer = getattr(fetcher, "__exit__", None)
+            if callable(closer):
+                closer(None, None, None)
+
+    return counts
+
+
+def _vendor_fetcher(
+    vendor_name: str,
+    root: "Union[str, Path]",
+    *,
+    shard_i: int = 0,
+    shard_n: int = 1,
+) -> Any:
+    """Build an ``NcaaFetcher`` from a ``canary_vendors.toml`` entry.
+
+    Reuses :func:`ncaa_canary.build_fetcher`, so any canary-proven transport
+    (``proxy_patchright`` = Decodo US sticky residential + patchright is the
+    2026-07-16 PASS) drives production capture with zero new transport code.
+
+    The sticky-session id in each proxy URL is re-minted per run
+    (``-session-cap<epoch>``): a restart never re-enters a possibly
+    soft-banned session's IP, at the cost of one cold bm-verify solve.
+    """
+    import re as _re
+    import time
+    import tomllib
+
+    from .canary import _vendor_ready, build_fetcher
+
+    cfg_path = Path(root) / "canary_vendors.toml"
+    if not cfg_path.exists():
+        raise SystemExit(f"--vendor requires {cfg_path} (copy from canary_vendors.toml.example)")
+    with open(cfg_path, "rb") as f:
+        doc = tomllib.load(f)
+    vendors = {v.get("name"): dict(v) for v in doc.get("vendor", [])}
+    if vendor_name not in vendors:
+        raise SystemExit(f"vendor {vendor_name!r} not in {cfg_path} (have: {sorted(vendors)})")
+    vendor = vendors[vendor_name]
+    reason = _vendor_ready(vendor)
+    if reason is not None:
+        raise SystemExit(f"vendor {vendor_name!r} not ready: {reason}")
+
+    if vendor.get("proxies"):
+        stamp = f"cap{int(time.time())}w{shard_i}"
+        vendor["proxies"] = [_re.sub(r"-session-\w+", f"-session-{stamp}", p) for p in vendor["proxies"]]
+        if shard_n > 1:
+            # Parallel workers each start the rotation at a different offset so
+            # they ride DISJOINT sticky ports (all starting at index 0 would
+            # pile every worker onto one IP -- the burst pattern that bans).
+            k = (shard_i * len(vendor["proxies"])) // shard_n
+            vendor["proxies"] = vendor["proxies"][k:] + vendor["proxies"][:k]
+        logger.info(
+            "vendor %s: %d prox(y/ies), sticky session re-minted -> session-%s",
+            vendor_name,
+            len(vendor["proxies"]),
+            stamp,
+        )
+
+    cache_dir = Path(root) / ".ncaa_fetch_cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return build_fetcher(vendor, cache_dir)
+
+
+def _env_int(name: str, default: Optional[int]) -> Optional[int]:
+    """Env override for an int knob; an unparseable value falls back to *default*."""
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("ignoring invalid %s=%r (want an int)", name, raw)
+        return default
+
+
+def _parse_shard(spec: str) -> "tuple[int, int]":
+    """``"i/N"`` -> ``(i, N)``. Defaults to ``0/1`` (no sharding)."""
+    i_str, _, n_str = spec.partition("/")
+    i, n = int(i_str), int(n_str or "1")
+    if n < 1 or not (0 <= i < n):
+        raise ValueError(f"invalid --shard {spec!r}; expected 'i/N' with 0<=i<N")
+    return i, n
+
+
+def _select_pending(master_path: Union[str, Path], season: int) -> "List[str]":
+    """Contest ids not yet captured for *season* (dtype-matched Utf8 season key).
+
+    Split out of :func:`_main` so the season filter is unit-testable. The
+    master holds EVERY backfilled season's rows, so filtering on ``captured``
+    alone returns other seasons' ids too -- and because
+    :func:`ncaa_bundle.is_captured` looks under ``raw/{THIS run's season}/``,
+    a foreign id always reads as un-captured and gets re-fetched into the
+    wrong partition. Contest ids sort ascending by season, so the damage only
+    starts once a worker exhausts its own season's slice mid-chunk -- which is
+    why this stayed invisible through the 2025 and 2026 backfills.
+    """
+    import polars as pl
+
+    master = pl.read_parquet(master_path)
+    return (
+        master.filter((pl.col("captured") == False) & (pl.col("season") == str(season)))  # noqa: E712
+        .get_column("contest_id")
+        .to_list()
+    )
+
+
+def _main(default_league: str) -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Capture the 3-page bundle for a season's not-yet-captured contests.")
+    parser.add_argument("--league", default=default_league, help="League slug: 'mbb' or 'wbb'.")
+    parser.add_argument(
+        "--season",
+        type=int,
+        required=True,
+        help="Ending year of the season, e.g. 2026.",
+    )
+    parser.add_argument(
+        "--root",
+        default=str(Path(__file__).resolve().parents[1]),
+        help="Root of the raw data tree (default: repo root).",
+    )
+    parser.add_argument(
+        "--shard",
+        default="0/1",
+        help="This process's shard as 'i/N' (default: 0/1, no sharding).",
+    )
+    parser.add_argument(
+        "--vendor",
+        default=os.environ.get("NCAA_VENDOR") or None,
+        help=(
+            "canary_vendors.toml vendor name to use as the capture transport "
+            "(e.g. 'decodo_patchright'). Default: env NCAA_VENDOR, else the "
+            "sdv-py env-configured NcaaFetcher (ProxyBonanza)."
+        ),
+    )
+    parser.add_argument(
+        "--max-contests",
+        type=int,
+        default=_env_int("NCAA_MAX_CONTESTS", None),
+        help=(
+            "Stop cleanly after N NEW bundles -- chunked backfill (env NCAA_MAX_CONTESTS). "
+            "The browser session degrades past roughly 2000 bundles / ~2h, so capture a "
+            "chunk, cool down, then re-run. Default: unlimited."
+        ),
+    )
+    parser.add_argument(
+        "--max-consecutive-failures",
+        type=int,
+        default=_env_int("NCAA_MAX_CONSECUTIVE_FAILURES", DEFAULT_MAX_CONSECUTIVE_FAILURES),
+        help=(
+            "Hard-stop after N consecutive challenge-not-cleared contests -- the soft-ban "
+            "guard (env NCAA_MAX_CONSECUTIVE_FAILURES; 0 disables). "
+            f"Default: {DEFAULT_MAX_CONSECUTIVE_FAILURES}."
+        ),
+    )
+    args = parser.parse_args()
+    i, n = _parse_shard(args.shard)
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    master_path = Path(args.root) / args.league / "schedule_master.parquet"
+    pending = _select_pending(master_path, args.season)
+    my_ids = shard(pending, i, n)
+    print(f"pending={len(pending)} shard={i}/{n} assigned={len(my_ids)}")
+    if args.vendor:
+        print(f"transport: canary vendor {args.vendor!r}")
+
+    counts = capture_contests(
+        my_ids,
+        args.season,
+        league=args.league,
+        root=args.root,
+        fetcher=_vendor_fetcher(args.vendor, args.root, shard_i=i, shard_n=n) if args.vendor else None,
+        max_contests=args.max_contests,
+        max_consecutive_failures=args.max_consecutive_failures,
+    )
+    print(f"captured={counts['captured']} skipped={counts['skipped']} failed={counts['failed']}")

--- a/sportsdataverse/scrape/ncaa/datasets.py
+++ b/sportsdataverse/scrape/ncaa/datasets.py
@@ -1,0 +1,698 @@
+"""Committed dataset trees: schedules, teams, rosters (html + json + parquet).
+
+**Zero extra HTTP.** Every page these trees are built from is already fetched by
+an existing stage, and this module only owns the persist/enrich/aggregate side:
+
+- ``schedules`` piggybacks on :mod:`ncaa_discover`'s team-page sweep, which
+  fetches ``teams/{team_id}`` for every team in the season and (before this
+  module) parsed out the contest ids and threw the HTML away.
+- ``rosters`` piggybacks on :mod:`ncaa_rosters`' sweep of
+  ``teams/{team_id}/roster``.
+- ``teams`` needs no fetch at all -- it is the bundled sdv-py ``(team, season)
+  -> id`` crosswalk, reshaped.
+
+Layout (``{lg}`` = ``mbb``/``wbb``, ``{season}`` = ending year, e.g. 2026)::
+
+    {lg}/schedules/html/{season}/{team_id}.html   <- per-team source page
+    {lg}/schedules/json/{season}/{team_id}.json   <- per-team parsed schedule
+    {lg}/schedules/parquet/{season}.parquet       <- ONE compiled season dataset
+    {lg}/rosters/html/{season}/{team_id}.html     <- per-team source page
+    {lg}/rosters/json/{season}/{team_id}.json     <- per-team parsed roster
+    {lg}/rosters/parquet/{season}.parquet         <- ONE compiled season dataset
+    {lg}/teams/{html,json,parquet}/{season}.*     <- one file per season
+
+**html + json are per team; parquet is the compiled season dataset.** There is
+no per-team parquet and no json aggregate -- the season view is parquet-only,
+exactly one file per season per kind, so the tree never accumulates hundreds of
+tiny parquet fragments.
+
+**The committed HTML is the durable checkpoint.** Both sweeps skip a team whose
+HTML already exists and re-derive its json from it offline, so a re-run never
+re-fetches a page this repo already holds, and a parser fix can be re-applied to
+every season with :func:`rebuild_missing` -- no network.
+
+**Shard safety.** Per-team html/json are disjoint per shard, so ``--shard i/N``
+workers never collide. The season parquet is NOT built by the shards (each sees
+only its slice, and concurrent writers would race one file into a truncated
+mess); it is compiled by a separate non-sharded pass over the per-team json --
+:func:`build_season_aggregate`, driven by ``scripts/run_datasets.sh``.
+
+Every frame carries BOTH machine ids and human-readable names: schedules carry
+``team``/``opponent`` next to ``team_id``/``opponent_id``, rosters carry
+``clean_name`` (properly-cased display name) and ``player`` (the ALL-CAPS
+``FIRST.LAST`` key the play-by-play stream uses) next to ``player_id``.
+
+**These three trees are where the ESPN identity lives.** All of them are
+reference data, so each carries the ESPN team id off the same
+``ncaa_espn_team_crosswalk`` row -- schedules for BOTH sides
+(``espn_team_id`` / ``opponent_espn_team_id``), rosters for the roster's team,
+``teams`` for the team plus ESPN's display name and mascot. The per-game
+families deliberately do NOT: they carry ``ncaa_team_id`` and join here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html as _html
+import importlib
+import json
+import logging
+from functools import lru_cache
+from pathlib import Path
+from typing import Callable, Dict, List, Optional, Union
+
+import polars as pl
+
+from sportsdataverse.mbb.mbb_ncaa_schedule import parse_ncaa_bb_team_roster, parse_ncaa_bb_team_schedule
+from sportsdataverse.mbb.mbb_ncaa_team_ids import ncaa_mbb_team_ids
+from sportsdataverse.wbb.wbb_ncaa_team_ids import ncaa_wbb_team_ids
+
+logger = logging.getLogger(__name__)
+
+#: This repo's league token -- the only line that differs from the MBB sibling.
+# NOTE: the per-repo league token lives in each -raw repo's shim, not here --
+# a shared engine that defaults to one league is how a wbb run silently
+# reads mbb data (see capture.py's pre-extraction hardcode).
+
+#: league -> bundled ``(team, season) -> id`` crosswalk getter. Two entries, and
+#: the leaf module owns it so ncaa_discover/ncaa_rosters can import it without a
+#: cycle. ponytail: a dict, not a plugin registry.
+TEAM_ID_CROSSWALKS: Dict[str, Callable[[], pl.DataFrame]] = {
+    "mbb": ncaa_mbb_team_ids,
+    "wbb": ncaa_wbb_team_ids,
+}
+
+#: The bundled crosswalk is scoped to the Division-I ``season_divisions`` id
+#: (that is the only division the scoreboard sweep in ``refresh_ncaa_team_ids``
+#: walks), so every row here is D-I by construction. Stamped as a column rather
+#: than left implicit so a future D-II/D-III tree can union in without a schema
+#: change.
+DIVISION = "I"
+
+_KINDS = ("schedules", "rosters", "teams")
+_EXT = {"html": "html", "json": "json", "parquet": "parquet"}
+
+
+def _is_per_team(kind: str, fmt: str) -> bool:
+    """``html``/``json`` are per team; ``parquet`` is the compiled season file.
+
+    ``teams`` is one row per team but one FILE per season in every format, so it
+    is never per-team on disk.
+    """
+    if kind not in _KINDS:
+        raise ValueError(f"unrecognized kind={kind!r}; expected one of {list(_KINDS)}")
+    return kind != "teams" and fmt != "parquet"
+
+
+SCHEDULE_COLUMNS: List[str] = [
+    "season",
+    "league",
+    "team_id",
+    "team",
+    "espn_team_id",
+    "contest_id",
+    "game_date",
+    "home",
+    "home_score",
+    "away",
+    "away_score",
+    "opponent",
+    "opponent_id",
+    "opponent_espn_team_id",
+    "is_neutral",
+    "detail",
+    "attendance",
+]
+
+ROSTER_COLUMNS: List[str] = [
+    "season",
+    "league",
+    "team_id",
+    "team",
+    "espn_team_id",
+    "player_id",
+    "clean_name",
+    "player",
+    "jersey",
+    "class",
+    "position",
+    "height",
+    "ht_inches",
+    "hometown",
+    "high_school",
+    "gp",
+    "gs",
+]
+
+TEAMS_COLUMNS: List[str] = [
+    "season",
+    "season_ncaa",
+    "league",
+    "ncaa_team_id",
+    "team",
+    "conference",
+    "division",
+    "espn_team_id",
+    "espn_display_name",
+    "espn_mascot",
+]
+
+#: ESPN identifiers are filled from sdv-py's ``ncaa_espn_team_crosswalk``, which
+#: may not be published yet; absent it, these ship as all-null Utf8 columns.
+_ESPN_COLUMNS: List[str] = ["espn_team_id", "espn_display_name", "espn_mascot"]
+#: That loader's join keys: ``ncaa_team_id`` is Int64 (ours is Utf8 -- cast at
+#: the boundary) and ``season`` is the NCAA ``"YYYY-YY"`` form, so it joins to
+#: our ``season_ncaa``, NOT to our ending-year ``season``.
+_ESPN_ID_COLUMN = "ncaa_team_id"
+_ESPN_SEASON_COLUMN = "season"
+
+__all__ = [
+    "DIVISION",
+    "ROSTER_COLUMNS",
+    "SCHEDULE_COLUMNS",
+    "TEAMS_COLUMNS",
+    "TEAM_ID_CROSSWALKS",
+    "build_season_aggregate",
+    "build_teams",
+    "dataset_path",
+    "persist_roster",
+    "persist_schedule",
+    "read_html",
+    "rebuild_missing",
+    "season_ncaa",
+    "season_teams",
+]
+
+
+def season_ncaa(season: int) -> str:
+    """Ending-year int -> crosswalk ``"YYYY-YY"`` (2026 -> ``"2025-26"``)."""
+    return f"{season - 1}-{str(season)[-2:]}"
+
+
+def dataset_path(
+    root: Union[str, Path],
+    league: str,
+    kind: str,
+    fmt: str,
+    season: int,
+    team_id: Optional[Union[int, str]] = None,
+) -> Path:
+    """Canonical path for one dataset artifact.
+
+    Args:
+        root: Repo root (the data tree lives at ``{root}/{league}/``).
+        league: ``"mbb"`` or ``"wbb"``.
+        kind: ``"schedules"``, ``"rosters"``, or ``"teams"``.
+        fmt: ``"html"``, ``"json"``, or ``"parquet"``.
+        season: Ending year, e.g. ``2026``.
+        team_id: Required for per-team artifacts (``html``/``json`` of
+            ``schedules``/``rosters``); ignored for the compiled season
+            ``parquet`` and for ``teams`` in every format.
+
+    Returns:
+        The absolute path. Parent directories are NOT created.
+    """
+    base = Path(root) / league / kind / fmt
+    ext = _EXT[fmt]
+    if not _is_per_team(kind, fmt):
+        return base / f"{season}.{ext}"
+    if team_id is None:
+        raise ValueError(f"{kind}/{fmt} is per-team; team_id is required")
+    return base / str(season) / f"{team_id}.{ext}"
+
+
+def read_html(root: Union[str, Path], league: str, kind: str, season: int, team_id: Union[int, str]) -> Optional[str]:
+    """The committed HTML for one team, or ``None`` when it was never captured.
+
+    The sweeps call this BEFORE fetching: a hit means the page is already in the
+    repo and the network round trip is skipped entirely.
+    """
+    path = dataset_path(root, league, kind, "html", season, team_id)
+    if not path.is_file():
+        return None
+    return path.read_text(encoding="utf-8")
+
+
+def season_teams(league: str, season: int) -> pl.DataFrame:
+    """The season's D-I teams from the bundled crosswalk.
+
+    Returns:
+        ``season`` (Utf8 ending year), ``season_ncaa`` (``"YYYY-YY"``),
+        ``league``, ``ncaa_team_id`` (Utf8 -- NCAA ids stay strings),
+        ``team``, ``conference``, ``division``.
+
+    Raises:
+        ValueError: *league* is unknown, or the crosswalk has no rows for
+            *season* (a season-format drift, raised rather than silently
+            returning an empty, complete-looking team list).
+    """
+    try:
+        crosswalk_fn = TEAM_ID_CROSSWALKS[league]
+    except KeyError:
+        raise ValueError(f"unrecognized league={league!r}; expected one of {sorted(TEAM_ID_CROSSWALKS)}") from None
+    season_str = season_ncaa(season)
+    rows = crosswalk_fn().filter(pl.col("season") == season_str)
+    if rows.height == 0:
+        raise ValueError(f"no {league!r} crosswalk teams for season={season} ({season_str})")
+    return rows.select(
+        pl.lit(str(season)).alias("season"),
+        pl.col("season").alias("season_ncaa"),
+        pl.lit(league).alias("league"),
+        # Int64 -> Utf8 straight off the integer id: never via Float64, which
+        # would stringify as "609554.0" and break every downstream join.
+        pl.col("id").cast(pl.Int64).cast(pl.Utf8).alias("ncaa_team_id"),
+        pl.col("team"),
+        pl.col("conference"),
+        pl.lit(DIVISION).alias("division"),
+    ).sort("ncaa_team_id")
+
+
+@lru_cache(maxsize=8)
+def _teams_with_espn(league: str, season: int) -> pl.DataFrame:
+    """:func:`season_teams` plus the ESPN identifier columns.
+
+    The one source of team identity for all three trees, so schedules, rosters
+    and ``teams`` can never disagree about a team's ESPN id. Cached because the
+    schedules/rosters sweeps ask for the same season once per team -- tests that
+    monkeypatch :func:`_espn_crosswalk` must call ``cache_clear()``.
+    """
+    return _with_espn(season_teams(league, season), league, season)
+
+
+def _team_identity(league: str, season: int, team_id: Union[int, str]) -> Dict[str, Optional[str]]:
+    """``{"team": name, "espn_team_id": id}`` for one team; nulls when unknown."""
+    teams = _teams_with_espn(league, season)
+    hit = teams.filter(pl.col("ncaa_team_id") == str(team_id))
+    if hit.height == 0:
+        return {"team": None, "espn_team_id": None}
+    return {"team": hit.get_column("team")[0], "espn_team_id": hit.get_column("espn_team_id")[0]}
+
+
+def _empty(columns: List[str], schema: Dict[str, pl.DataType]) -> pl.DataFrame:
+    return pl.DataFrame(schema={c: schema.get(c, pl.Utf8) for c in columns})
+
+
+_SCHEDULE_TYPES: Dict[str, pl.DataType] = {
+    "home_score": pl.Int64,
+    "away_score": pl.Int64,
+    "attendance": pl.Int64,
+    "is_neutral": pl.Boolean,
+}
+_ROSTER_TYPES: Dict[str, pl.DataType] = {"ht_inches": pl.Int64}
+
+
+def _conform(df: pl.DataFrame, columns: List[str], types: Dict[str, pl.DataType]) -> pl.DataFrame:
+    """Project onto the documented column set and pin every dtype.
+
+    A source frame can legitimately be missing a column (a season whose roster
+    table omits ``GS``, or a legacy payload whose ``ht_inches`` was all-null and
+    inferred as Null) -- those become typed nulls rather than a schema that
+    diverges per team and blows up the ``_season`` concatenation.
+    """
+    have = set(df.columns)
+    return df.select(
+        [pl.col(c) if c in have else pl.lit(None, dtype=types.get(c, pl.Utf8)).alias(c) for c in columns]
+    ).cast(types)  # type: ignore[arg-type]
+
+
+def _enrich_schedule(df: pl.DataFrame, team_id: Union[int, str], season: int, league: str) -> pl.DataFrame:
+    """Stamp identity columns and derive ``opponent`` / ``opponent_id``.
+
+    ``parse_ncaa_bb_team_schedule`` already emits both sides by NAME (``home`` /
+    ``away``); the swept team is whichever side matches its own crosswalk name,
+    so the opponent is the other one. ``opponent_id`` comes from an exact join
+    against the same season's crosswalk -- the ids the parser matched names
+    against in the first place. No fuzzy matching, deliberately: an unmatched
+    opponent (a non-D-I exhibition foe) stays null rather than guessing.
+
+    BOTH sides also carry the ESPN team id (``espn_team_id`` for the swept team,
+    ``opponent_espn_team_id`` for the other), off the same crosswalk row -- so a
+    schedule joins to ESPN without a second lookup. An opponent with no
+    crosswalk row keeps its name and gets nulls for both ids.
+    """
+    teams = _teams_with_espn(league, season)
+    tid = str(team_id)
+    identity = _team_identity(league, season, tid)
+    team_name = identity["team"]
+    if team_name is None:
+        logger.warning(
+            "team_id=%s is not in the %s %s crosswalk; team/opponent names will be null", tid, season, league
+        )
+
+    if df.height == 0:
+        return _empty(SCHEDULE_COLUMNS, _SCHEDULE_TYPES)
+
+    out = df.rename({"game_id": "contest_id"}).with_columns(
+        pl.lit(str(season)).alias("season"),
+        pl.lit(league).alias("league"),
+        pl.lit(tid).alias("team_id"),
+        pl.lit(team_name, dtype=pl.Utf8).alias("team"),
+        pl.lit(identity["espn_team_id"], dtype=pl.Utf8).alias("espn_team_id"),
+    )
+    # box_id is the identical value the parser assigns to game_id (one shared
+    # positional fill), so it is dropped rather than shipped as a duplicate.
+    opponent = (
+        pl.when(pl.col("home") == pl.col("team"))
+        .then(pl.col("away"))
+        .when(pl.col("away") == pl.col("team"))
+        .then(pl.col("home"))
+        .otherwise(None)
+    )
+    out = out.with_columns(opponent.alias("opponent")).join(
+        teams.select(
+            pl.col("team").alias("opponent"),
+            pl.col("ncaa_team_id").alias("opponent_id"),
+            pl.col("espn_team_id").alias("opponent_espn_team_id"),
+        ),
+        on="opponent",
+        how="left",
+    )
+    return _conform(out, SCHEDULE_COLUMNS, _SCHEDULE_TYPES)
+
+
+def _enrich_roster(df: pl.DataFrame, team_id: Union[int, str], season: int, league: str) -> pl.DataFrame:
+    """Stamp identity columns onto a parsed roster frame.
+
+    The parser's ``name`` column is byte-identical to ``clean_name``; only
+    ``clean_name`` is kept. ``player`` (ALL-CAPS ``FIRST.LAST``) is the key the
+    play-by-play stream uses, ``clean_name`` the properly-cased display form --
+    both ship, which is the whole point of the roster tree.
+
+    The team's ESPN id rides along too -- a roster is reference data, so the
+    ESPN identity belongs on it (unlike the per-game families, which carry the
+    NCAA id only and join ``teams`` for ESPN).
+    """
+    tid = str(team_id)
+    identity = _team_identity(league, season, tid)
+
+    if df.height == 0:
+        return _empty(ROSTER_COLUMNS, _ROSTER_TYPES)
+
+    stamped = df.with_columns(
+        pl.lit(str(season)).alias("season"),
+        pl.lit(league).alias("league"),
+        pl.lit(tid).alias("team_id"),
+        pl.lit(identity["team"], dtype=pl.Utf8).alias("team"),
+        pl.lit(identity["espn_team_id"], dtype=pl.Utf8).alias("espn_team_id"),
+    )
+    return _conform(stamped, ROSTER_COLUMNS, _ROSTER_TYPES)
+
+
+def _write_json(df: pl.DataFrame, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(df.write_json(), encoding="utf-8")
+
+
+def _write_parquet(df: pl.DataFrame, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.write_parquet(path)
+
+
+def _persist(
+    kind: str,
+    df: pl.DataFrame,
+    raw_html: Optional[str],
+    team_id: Union[int, str],
+    season: int,
+    league: str,
+    root: Union[str, Path],
+    overwrite: bool,
+) -> pl.DataFrame:
+    html_path = dataset_path(root, league, kind, "html", season, team_id)
+    if raw_html is not None and (overwrite or not html_path.exists()):
+        html_path.parent.mkdir(parents=True, exist_ok=True)
+        html_path.write_text(raw_html, encoding="utf-8")
+    json_path = dataset_path(root, league, kind, "json", season, team_id)
+    if overwrite or not json_path.exists():
+        _write_json(df, json_path)
+    # No per-team parquet: the season parquet is compiled from these json files
+    # by the non-sharded build_season_aggregate pass.
+    return df
+
+
+def persist_schedule(
+    raw_html: str,
+    team_id: Union[int, str],
+    season: int,
+    *,
+    league: str,
+    root: Union[str, Path],
+    overwrite: bool = False,
+) -> pl.DataFrame:
+    """Parse one team-page HTML and write html + json + parquet.
+
+    Called from :func:`ncaa_discover.discover_season` with the HTML it already
+    fetched, and from :func:`rebuild_missing` with HTML already on disk. Writing
+    is idempotent -- an existing artifact is left alone unless *overwrite*.
+    """
+    df = _enrich_schedule(parse_ncaa_bb_team_schedule(raw_html, int(team_id), league=league), team_id, season, league)
+    return _persist("schedules", df, raw_html, team_id, season, league, root, overwrite)
+
+
+def persist_roster(
+    raw_html: str,
+    team_id: Union[int, str],
+    season: int,
+    *,
+    league: str,
+    root: Union[str, Path],
+    overwrite: bool = False,
+) -> pl.DataFrame:
+    """Parse one roster-page HTML and write html + json + parquet."""
+    df = _enrich_roster(parse_ncaa_bb_team_roster(raw_html, int(team_id)), team_id, season, league)
+    return _persist("rosters", df, raw_html, team_id, season, league, root, overwrite)
+
+
+_PERSISTERS = {"schedules": persist_schedule, "rosters": persist_roster}
+
+
+def _backfill_rosters_from_legacy(season: int, league: str, root: Union[str, Path], overwrite: bool) -> int:
+    """Seed the rosters tree from the pre-existing ``team_rosters/`` JSON.
+
+    ``ncaa_rosters`` has always written ``{lg}/team_rosters/{season}/{team_id}.
+    json``, whose ``players`` array is exactly the parser's output. Seasons
+    already captured that way get their per-team json here WITHOUT a re-fetch
+    (and so feed the season parquet) -- only ``html`` is unavailable for them,
+    because that payload never kept the page.
+    """
+    legacy_dir = Path(root) / league / "team_rosters" / str(season)
+    if not legacy_dir.is_dir():
+        return 0
+    count = 0
+    for legacy in sorted(legacy_dir.glob("*.json")):
+        team_id = legacy.stem
+        json_path = dataset_path(root, league, "rosters", "json", season, team_id)
+        if not overwrite and json_path.exists():
+            continue
+        players = json.loads(legacy.read_text(encoding="utf-8")).get("players") or []
+        parsed = pl.DataFrame(players) if players else _empty(ROSTER_COLUMNS, _ROSTER_TYPES)
+        df = _enrich_roster(parsed, team_id, season, league)
+        _persist("rosters", df, None, team_id, season, league, root, overwrite)
+        count += 1
+    if count:
+        logger.info("backfilled %d rosters for season=%s from team_rosters/ (no html available)", count, season)
+    return count
+
+
+def rebuild_missing(kind: str, season: int, *, league: str, root: Union[str, Path], overwrite: bool = False) -> int:
+    """Re-derive the per-team json from committed HTML. Fully offline.
+
+    Every page this repo holds can be re-parsed without the network, so a parser
+    fix propagates to every captured season with one non-sharded pass. Run
+    :func:`build_season_aggregate` afterwards to recompile the season parquet.
+
+    Returns:
+        Number of teams (re)written.
+    """
+    count = _backfill_rosters_from_legacy(season, league, root, overwrite) if kind == "rosters" else 0
+    html_dir = Path(root) / league / kind / "html" / str(season)
+    if not html_dir.is_dir():
+        return count
+    for html_file in sorted(html_dir.glob("*.html")):
+        team_id = html_file.stem
+        json_path = dataset_path(root, league, kind, "json", season, team_id)
+        if not overwrite and json_path.exists():
+            continue
+        _PERSISTERS[kind](
+            html_file.read_text(encoding="utf-8"),
+            team_id,
+            season,
+            league=league,
+            root=root,
+            overwrite=overwrite,
+        )
+        count += 1
+    if count:
+        logger.info("rebuilt %d %s frames for season=%s from committed html", count, kind, season)
+    return count
+
+
+def build_season_aggregate(kind: str, season: int, *, league: str, root: Union[str, Path]) -> pl.DataFrame:
+    """Compile every per-team json into the ONE season parquet.
+
+    Run this as a SEPARATE non-sharded pass. A ``--shard i/N`` worker sees only
+    its team slice, and there is exactly one output file -- concurrent shard
+    writers would race each other into a truncated dataset.
+
+    Each row carries ``team_id`` + the team NAME, so the concatenated season
+    file stays self-describing once every team is folded in.
+    """
+    columns = SCHEDULE_COLUMNS if kind == "schedules" else ROSTER_COLUMNS
+    types = _SCHEDULE_TYPES if kind == "schedules" else _ROSTER_TYPES
+    json_dir = Path(root) / league / kind / "json" / str(season)
+    parts = sorted(json_dir.glob("*.json")) if json_dir.is_dir() else []
+    # Conform each team before concatenating: a team whose column came back
+    # all-null reads as Null dtype, which would otherwise poison the union.
+    frames = [_conform(pl.read_json(p), columns, types) for p in parts]
+    if frames:
+        combined = pl.concat(frames, how="diagonal_relaxed").select(columns)
+        sort_key = ["team_id", "game_date", "contest_id"] if kind == "schedules" else ["team_id", "player_id"]
+        combined = combined.sort([c for c in sort_key if c in combined.columns])
+    else:
+        combined = _empty(columns, types)
+    _write_parquet(combined, dataset_path(root, league, kind, "parquet", season))
+    logger.info("%s season parquet: %d rows from %d teams (season=%s)", kind, combined.height, len(parts), season)
+    return combined
+
+
+def _espn_crosswalk(league: str) -> Optional[pl.DataFrame]:
+    """The sdv-py NCAA<->ESPN crosswalk, or ``None`` when it isn't published.
+
+    Built in parallel as an sdv-py data asset + loader; the teams tree must not
+    block on it, so a missing loader degrades to null ESPN columns.
+    """
+    for modname in (
+        f"sportsdataverse.{league}.{league}_ncaa_espn_crosswalk",
+        f"sportsdataverse.{league}",
+        "sportsdataverse",
+    ):
+        try:
+            mod = importlib.import_module(modname)
+        except ImportError:
+            continue
+        fn = getattr(mod, "ncaa_espn_team_crosswalk", None)
+        if fn is not None:
+            return fn(league=league)
+    return None
+
+
+def _with_espn(teams: pl.DataFrame, league: str, season: int) -> pl.DataFrame:
+    """Left-join ESPN identifiers onto *teams*; null-fill when unavailable.
+
+    The loader keys ``ncaa_team_id`` as Int64 and ``season`` as ``"YYYY-YY"``,
+    so the id is cast Int64 -> Utf8 (never via Float64, which would stringify as
+    ``"609554.0"``) and the season is matched against ``season_ncaa``.
+    """
+    nulls = [pl.lit(None, dtype=pl.Utf8).alias(c) for c in _ESPN_COLUMNS]
+    xwalk = _espn_crosswalk(league)
+    if xwalk is None:
+        logger.info("ncaa_espn_team_crosswalk not importable -- ESPN columns emitted as nulls (season=%s)", season)
+        return teams.with_columns(nulls)
+
+    have = [c for c in _ESPN_COLUMNS if c in xwalk.columns]
+    if _ESPN_ID_COLUMN not in xwalk.columns or not have:
+        logger.warning(
+            "ncaa_espn_team_crosswalk schema drifted (want %r + %s, saw %s) -- ESPN columns emitted as nulls",
+            _ESPN_ID_COLUMN,
+            _ESPN_COLUMNS,
+            xwalk.columns,
+        )
+        return teams.with_columns(nulls)
+
+    if _ESPN_SEASON_COLUMN in xwalk.columns:
+        xwalk = xwalk.filter(pl.col(_ESPN_SEASON_COLUMN).cast(pl.Utf8) == season_ncaa(season))
+
+    right = (
+        xwalk.select(
+            pl.col(_ESPN_ID_COLUMN).cast(pl.Int64, strict=False).cast(pl.Utf8).alias("ncaa_team_id"),
+            *[pl.col(c).cast(pl.Utf8) for c in have],
+        )
+        .drop_nulls("ncaa_team_id")
+        .unique(subset="ncaa_team_id", keep="first")
+    )
+    assert teams.schema["ncaa_team_id"] == right.schema["ncaa_team_id"], "ncaa_team_id dtype mismatch on the ESPN join"
+    joined = teams.join(right, on="ncaa_team_id", how="left")
+    missing = [pl.lit(None, dtype=pl.Utf8).alias(c) for c in _ESPN_COLUMNS if c not in have]
+    joined = joined.with_columns(missing) if missing else joined
+    matched = joined.filter(pl.col(have[0]).is_not_null()).height
+    logger.info("ESPN crosswalk joined: %d/%d teams matched (season=%s)", matched, joined.height, season)
+    return joined
+
+
+def _teams_html(df: pl.DataFrame, league: str, season: int) -> str:
+    """A generated HTML table of the teams frame.
+
+    There is no single upstream team-list PAGE behind this dataset -- the teams
+    frame is the bundled crosswalk (itself distilled from many scoreboard
+    pages), and the sweep fetches per-TEAM pages, not a roster of teams. Rather
+    than skip the html format, the frame is rendered as a table so all three
+    formats exist for every dataset.
+    """
+    head = "".join(f"<th>{_html.escape(c)}</th>" for c in df.columns)
+    body = "".join(
+        "<tr>" + "".join(f"<td>{'' if v is None else _html.escape(str(v))}</td>" for v in row) + "</tr>"
+        for row in df.iter_rows()
+    )
+    return (
+        "<!doctype html>\n<html><head><meta charset='utf-8'>"
+        f"<title>{_html.escape(league)} NCAA Division-{DIVISION} teams {season}</title></head><body>"
+        f"<h1>{_html.escape(league)} NCAA Division-{DIVISION} teams — {season}</h1>"
+        f"<table><thead><tr>{head}</tr></thead><tbody>{body}</tbody></table>"
+        "</body></html>\n"
+    )
+
+
+def build_teams(season: int, *, league: str, root: Union[str, Path], overwrite: bool = True) -> pl.DataFrame:
+    """Build ``{lg}/teams/{html,json,parquet}/{season}.*``. Fully offline.
+
+    One row per team per season: the NCAA id + NCAA name + conference +
+    ``division`` (constant ``"I"`` -- the bundled crosswalk is scoped to the
+    Division-I ``season_divisions`` id), plus ESPN identifiers when the sdv-py
+    ``ncaa_espn_team_crosswalk`` loader is importable (nulls otherwise).
+    """
+    df = _teams_with_espn(league, season).select(TEAMS_COLUMNS)
+    html_path = dataset_path(root, league, "teams", "html", season)
+    if overwrite or not html_path.exists():
+        html_path.parent.mkdir(parents=True, exist_ok=True)
+        html_path.write_text(_teams_html(df, league, season), encoding="utf-8")
+    json_path = dataset_path(root, league, "teams", "json", season)
+    if overwrite or not json_path.exists():
+        _write_json(df, json_path)
+    pq_path = dataset_path(root, league, "teams", "parquet", season)
+    if overwrite or not pq_path.exists():
+        _write_parquet(df, pq_path)
+    logger.info("teams season=%s league=%s: %d teams", season, league, df.height)
+    return df
+
+
+def _main(default_league: str) -> None:
+    parser = argparse.ArgumentParser(
+        description="Build the committed schedules/teams/rosters trees (offline; no network)."
+    )
+    parser.add_argument("--season", type=int, required=True, help="Ending year of the season, e.g. 2026.")
+    parser.add_argument(
+        "--league", default=default_league, help=f"League slug: 'mbb' or 'wbb' (default: {default_league})."
+    )
+    parser.add_argument("--root", default=str(Path(__file__).resolve().parents[1]), help="Root of the raw data tree.")
+    parser.add_argument(
+        "--what",
+        default="all",
+        choices=["all", "schedules", "rosters", "teams"],
+        help="Which tree(s) to build (default: all).",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Re-derive json/parquet even where they already exist (after a parser fix).",
+    )
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    summary: Dict[str, int] = {}
+    for kind in ("schedules", "rosters"):
+        if args.what in ("all", kind):
+            rebuild_missing(kind, args.season, league=args.league, root=args.root, overwrite=args.overwrite)
+            summary[kind] = build_season_aggregate(kind, args.season, league=args.league, root=args.root).height
+    if args.what in ("all", "teams"):
+        summary["teams"] = build_teams(args.season, league=args.league, root=args.root).height
+    print(f"datasets season={args.season} league={args.league}: " + json.dumps(summary))

--- a/sportsdataverse/scrape/ncaa/discover.py
+++ b/sportsdataverse/scrape/ncaa/discover.py
@@ -1,0 +1,374 @@
+"""Season -> contest_id discovery (team-ids -> schedules -> dedup).
+
+Reuses the bigballR port already vendored in sdv-py: the ``(team, season) ->
+id`` crosswalk (:func:`ncaa_mbb_team_ids` / :func:`ncaa_mbb_team_ids`), the
+team-schedule-page parser (:func:`parse_ncaa_bb_team_schedule`), and the
+browser-transport fetcher (:class:`NcaaFetcher`) for the live path. Each game
+appears on two teams' schedules, so the core job here is: fetch every team
+page for a season, extract ``contests/{id}/`` links, and dedup across teams.
+
+Discovery runs single-threaded (one browser, one team page at a time) --
+Playwright's sync API is not thread-safe. Parallelism for the heavier
+capture stage is achieved by running separate launcher PROCESSES over
+disjoint shards, never internal threads sharing one browser.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Callable, List, Optional, Union
+
+import polars as pl
+
+from sportsdataverse.mbb.mbb_ncaa_schedule import parse_ncaa_bb_team_schedule
+
+# The schedules dataset tree is a pure side effect of the sweep below: this
+# module already fetches every team's page, so persisting it costs zero extra
+# HTTP. ncaa_datasets is a leaf (it never imports this module) -- no cycle.
+from .datasets import TEAM_ID_CROSSWALKS as _TEAM_ID_CROSSWALKS
+from .datasets import persist_schedule, read_html
+
+logger = logging.getLogger(__name__)
+
+FetchFn = Callable[[int], str]
+
+_MASTER_COLUMNS: List[str] = ["contest_id", "season", "captured"]
+
+#: Fetch attempts per team page before skipping it (bm-verify flake tolerance).
+_TEAM_TRIES = 3
+#: Consecutive fully-failed teams that reads as a ban -> abort the sweep.
+_MAX_CONSECUTIVE_TEAM_FAILURES = 5
+
+__all__ = ["discover_season"]
+
+
+def _season_str(season: int) -> str:
+    """Ending-year int -> crosswalk ``"YYYY-YY"`` (2026 -> "2025-26")."""
+    return f"{season - 1}-{str(season)[-2:]}"
+
+
+def _default_fetch_fn(shard_i: int = 0, shard_n: int = 1) -> FetchFn:
+    """Live fetch: one shared browser-transport session, ``teams/{id}``.
+
+    ``NCAA_VENDOR`` (e.g. ``decodo_patchright``) routes discovery through a
+    ``canary_vendors.toml`` transport — the same seam capture uses. Team pages
+    sit behind the same Akamai bm-verify as game pages, and the ProxyBonanza
+    datacenter pool stopped clearing it (2026-08-01: a 2025 discovery burned
+    35 minutes in re-solve loops with zero yield), while Decodo US-residential
+    cleared the same canary 10/10.
+    """
+    vendor = os.environ.get("NCAA_VENDOR")
+    if vendor:
+        from .capture import _vendor_fetcher
+
+        repo_root = Path(__file__).resolve().parents[1]
+        fetcher = _vendor_fetcher(vendor, repo_root, shard_i=shard_i, shard_n=shard_n)
+        return lambda team_id: fetcher.fetch_html(f"teams/{team_id}")
+    from sportsdataverse.mbb.mbb_ncaa_fetch import NcaaFetcher
+
+    fetcher = NcaaFetcher.with_browser()
+    return lambda team_id: fetcher.fetch_html(f"teams/{team_id}")
+
+
+def _contest_ids_from_html(
+    html: str, team_id: int, league: str, season: int, root: Optional[Union[str, Path]]
+) -> List[str]:
+    """Contest ids for one team page, persisting the schedules tree en route.
+
+    With a *root* the page is written to ``{lg}/schedules/{html,json,parquet}/``
+    and the ids come off the enriched frame -- ONE parse either way, so the
+    dataset tree costs no extra parse and no extra fetch.
+    """
+    if root is None:
+        return (
+            parse_ncaa_bb_team_schedule(html, int(team_id), league=league).get_column("game_id").drop_nulls().to_list()
+        )
+    df = persist_schedule(html, team_id, season, league=league, root=root)
+    return df.get_column("contest_id").drop_nulls().to_list()
+
+
+def _team_contest_ids(
+    team_id: int, fetch_fn: FetchFn, league: str, season: int, root: Optional[Union[str, Path]]
+) -> List[str]:
+    try:
+        html = fetch_fn(team_id)
+    except RuntimeError:
+        # NcaaFetcher raises RuntimeError on a ban-suspect / exhausted-proxy
+        # response ("BAN-SUSPECT:<marker>" is folded into the message). The
+        # sweep in discover_season decides retry/skip/abort -- one flaky
+        # bm-verify solve must not read as a ban.
+        logger.warning("fetch failed for team_id=%s (bm-verify / ban-suspect)", team_id)
+        raise
+    return _contest_ids_from_html(html, team_id, league, season, root)
+
+
+def discover_season(
+    season: int,
+    *,
+    league: str,
+    limit_teams: Optional[int] = None,
+    fetch_fn: Optional[FetchFn] = None,
+    team_ids: Optional[List[int]] = None,
+    root: Optional[Union[str, Path]] = None,
+    shard: "tuple[int, int]" = (0, 1),
+    write_master: bool = True,
+) -> pl.DataFrame:
+    """Discover every ``contest_id`` played in *season* by sweeping team pages.
+
+    Args:
+        season: Ending year of the season, e.g. ``2026`` for 2025-26 (matches
+            the launcher's ``--season``). Converted to the crosswalk's
+            ``"YYYY-YY"`` format to filter the bundled ``(team, season) ->
+            id`` crosswalk (live path); stamped as-is on the returned frame's
+            ``season`` column.
+        league: ``"mbb"`` or ``"wbb"`` -- selects both the ``(team, season)
+            -> id`` crosswalk (both are bundled in sdv-py) and the schedule
+            parser's league mode.
+        limit_teams: Cap the number of teams swept (a small live smoke, e.g.
+            one conference).
+        fetch_fn: ``team_id -> html``. Defaults to a live fetch through one
+            shared :class:`NcaaFetcher.with_browser` session (the team page
+            can be Akamai-challenged like game pages). Inject a fake for
+            offline tests.
+        team_ids: Explicit team id list that bypasses the crosswalk filter
+            entirely -- lets offline tests drive discovery without the
+            crosswalk having the fixture's team id for the given season.
+        root: If given, also write/merge ``{root}/{league}/schedule_master.
+            parquet`` (columns ``contest_id``, ``season``, ``captured``), and
+            checkpoint each swept team page to ``{root}/{league}/.discover/
+            {season}/{team_id}.json`` so an aborted sweep RESUMES instead of
+            restarting (disk-is-checkpoint, same pattern as capture). Delete
+            that directory to force a from-scratch re-sweep of the season.
+
+            It ALSO persists the schedules dataset tree from the very same
+            fetch -- ``{root}/{league}/schedules/html/{season}/{team_id}.html``
+            plus the parsed ``.../json/{season}/{team_id}.json`` (see
+            :mod:`ncaa_datasets`). That costs zero extra HTTP: the page was
+            already being fetched and its HTML discarded. A team whose HTML is
+            already committed is re-parsed offline, so a re-run neither
+            re-fetches it nor loses its dataset row. The compiled
+            ``schedules/parquet/{season}.parquet`` is NOT written here (a shard
+            sees only its slice, and one shared output file would race) -- run
+            ``scripts/run_datasets.sh`` for that.
+        shard: ``(i, N)`` -- with ``N > 1`` this process sweeps only the
+            ``ids[i::N]`` slice, so ``N`` launcher PROCESSES cover disjoint
+            teams (see :func:`_default_fetch_fn` for the per-worker proxy
+            rotation that keeps their sticky sessions disjoint too).
+        write_master: Set ``False`` on a sharded run -- a shard sees only its
+            slice, so only the final shard-less merge pass should write
+            ``schedule_master.parquet``.
+
+    Returns:
+        One row per unique ``contest_id`` (deduped across teams, sorted):
+        ``contest_id`` (Utf8), ``season`` (Utf8).
+
+    Raises:
+        ValueError: *league* isn't ``"mbb"`` or ``"wbb"``, or the crosswalk
+            filter for *season* matched zero teams on the live path
+            (``team_ids`` not given) -- the latter almost certainly a
+            season-format drift, raised loudly instead of silently returning
+            an empty, complete-looking contest list.
+        RuntimeError: ``_MAX_CONSECUTIVE_TEAM_FAILURES`` teams in a row failed
+            every retry -- the real-ban signature. Whatever was swept before
+            the abort is already checkpointed to disk, so the re-run resumes.
+    """
+    if team_ids is not None:
+        ids = list(team_ids)
+    else:
+        try:
+            crosswalk_fn = _TEAM_ID_CROSSWALKS[league]
+        except KeyError:
+            raise ValueError(f"unrecognized league={league!r}; expected one of {sorted(_TEAM_ID_CROSSWALKS)}") from None
+        season_str = _season_str(season)
+        crosswalk = crosswalk_fn()
+        ids = crosswalk.filter(pl.col("season") == season_str).get_column("id").to_list()
+        if not ids:
+            raise ValueError(
+                f"No teams found in {league!r} crosswalk for season={season!r} "
+                f"(tried season_str={season_str!r}); "
+                "the NCAA team-ids season format may have drifted."
+            )
+    if limit_teams is not None:
+        ids = ids[:limit_teams]
+    shard_i, shard_n = shard
+    if shard_n > 1:
+        # Disjoint team slice per worker. Each shard writes its own per-team
+        # checkpoints; a final shard-less pass reads ALL of them (every team
+        # then hits the checkpoint branch, so it fetches nothing) and writes
+        # schedule_master -- which is why shard runs pass write_master=False.
+        ids = ids[shard_i::shard_n]
+
+    fn = fetch_fn if fetch_fn is not None else _default_fetch_fn(shard_i=shard_i, shard_n=shard_n)
+
+    # Per-team tolerance + a consecutive-failure ban detector. bm-verify
+    # clearing is flaky per navigation (~5% per page on the canary-validated
+    # vendor; the first navigation of a cold profile fails most of all), so a
+    # ~350-team sweep that hard-stops on the FIRST failure has ~zero chance of
+    # completing (0.95^350). Each game appears on TWO teams' pages, so a team
+    # skipped after retries is nearly lossless. A real ban looks like EVERY
+    # team failing -- abort only on a consecutive-failure run.
+    # Per-team disk checkpoint: a swept team's contest ids persist immediately,
+    # so an abort (ban detector, Ctrl-C, crash) never loses the sweep -- the
+    # re-run skips checkpointed teams and only fetches the remainder.
+    scratch: Optional[Path] = None
+    checkpointed: "dict[int, List[str]]" = {}
+    if root is not None:
+        scratch = Path(root) / league / ".discover" / str(season)
+        if scratch.is_dir():
+            for f in scratch.glob("*.json"):
+                try:
+                    checkpointed[int(f.stem)] = json.loads(f.read_text())
+                except (ValueError, json.JSONDecodeError):
+                    continue
+        if checkpointed:
+            already = sum(1 for t in ids if t in checkpointed)
+            logger.info(
+                "resuming discovery: %d/%d team pages already checkpointed",
+                already,
+                len(ids),
+            )
+
+    contest_ids: "set[str]" = set()
+    consecutive = 0
+    skipped: "List[int]" = []
+    for team_id in ids:
+        # The committed schedules HTML outranks the .discover checkpoint: it is
+        # the same page, durably tracked in git, and re-parsing it offline both
+        # yields the contest ids and refreshes json/parquet after a parser fix.
+        # Either way the network is not touched for this team.
+        cached = read_html(root, league, "schedules", season, team_id) if root is not None else None
+        if cached is not None:
+            got_cached = _contest_ids_from_html(cached, team_id, league, season, root)
+            contest_ids.update(got_cached)
+            if scratch is not None:
+                scratch.mkdir(parents=True, exist_ok=True)
+                (scratch / f"{team_id}.json").write_text(json.dumps(got_cached))
+            continue
+        if team_id in checkpointed:
+            # Legacy resume path: swept before the schedules tree existed, so
+            # the HTML is gone. The ids still stand; the dataset row does not.
+            contest_ids.update(checkpointed[team_id])
+            continue
+        got: Optional[List[str]] = None
+        for _ in range(_TEAM_TRIES):
+            try:
+                got = _team_contest_ids(team_id, fn, league, season, root)
+                break
+            except RuntimeError:
+                continue
+        if got is None:
+            consecutive += 1
+            skipped.append(team_id)
+            logger.warning(
+                "team_id=%s skipped after %d tries (%d consecutive team failures)",
+                team_id,
+                _TEAM_TRIES,
+                consecutive,
+            )
+            if consecutive >= _MAX_CONSECUTIVE_TEAM_FAILURES:
+                raise RuntimeError(
+                    f"discovery aborted: {consecutive} consecutive teams failed "
+                    f"(ban-suspect); {len(contest_ids)} contest_ids gathered before abort"
+                )
+            continue
+        consecutive = 0
+        contest_ids.update(got)
+        if scratch is not None:
+            scratch.mkdir(parents=True, exist_ok=True)
+            (scratch / f"{team_id}.json").write_text(json.dumps(got))
+    if skipped:
+        logger.warning(
+            "discovery finished with %d/%d teams skipped: %s%s",
+            len(skipped),
+            len(ids),
+            skipped[:10],
+            "..." if len(skipped) > 10 else "",
+        )
+
+    result = pl.DataFrame({"contest_id": sorted(contest_ids)}, schema={"contest_id": pl.Utf8}).with_columns(
+        pl.lit(str(season)).alias("season")
+    )
+
+    if root is not None and write_master:
+        _write_master(result, root, league)
+
+    return result
+
+
+def _write_master(result: pl.DataFrame, root: Union[str, Path], league: str) -> Path:
+    """Merge *result* into ``{root}/{league}/schedule_master.parquet``.
+
+    Add-column-if-absent guard for ``captured`` (schema predates the column
+    on an older master file), then union new contest_ids in without
+    dropping any existing ``captured=True`` row.
+    """
+    path = Path(root) / league / "schedule_master.parquet"
+    new_rows = result.with_columns(pl.lit(False).alias("captured")).select(_MASTER_COLUMNS)
+
+    if path.exists():
+        existing = pl.read_parquet(path)
+        if "captured" not in existing.columns:
+            existing = existing.with_columns(pl.lit(False).alias("captured"))
+        combined = (
+            pl.concat([existing.select(_MASTER_COLUMNS), new_rows], how="diagonal_relaxed")
+            .sort("captured", descending=True)
+            .unique(subset="contest_id", keep="first")
+        )
+    else:
+        combined = new_rows
+
+    combined = combined.select(_MASTER_COLUMNS).sort("contest_id")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    combined.write_parquet(path)
+    return path
+
+
+def _main(default_league: str) -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Discover a season's contest_ids and write schedule_master.parquet.")
+    parser.add_argument(
+        "--season",
+        type=int,
+        required=True,
+        help="Ending year of the season, e.g. 2026.",
+    )
+    parser.add_argument(
+        "--root",
+        default=str(Path(__file__).resolve().parents[1]),
+        help="Root of the raw data tree (default: repo root).",
+    )
+    parser.add_argument("--league", default=default_league, help="League slug: 'mbb' or 'wbb' (default: mbb).")
+    parser.add_argument(
+        "--limit-teams",
+        type=int,
+        default=None,
+        help="Cap the number of teams swept -- a small live smoke. Pair with --root <scratch> to keep a smoke out of the committed tree.",
+    )
+    parser.add_argument(
+        "--shard",
+        default="0/1",
+        help="This process's shard as 'i/N'. A sharded run sweeps only its "
+        "team slice and does NOT write schedule_master -- run a final "
+        "shard-less pass (all teams checkpointed, so it fetches nothing) "
+        "to merge every shard's checkpoints into the master.",
+    )
+    args = parser.parse_args()
+    i, n = (int(x) for x in args.shard.split("/"))
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    result = discover_season(
+        args.season,
+        league=args.league,
+        root=args.root,
+        shard=(i, n),
+        limit_teams=args.limit_teams,
+        write_master=(n == 1),
+    )
+    print(
+        f"discovered {result.height} contest_ids for season={args.season} "
+        f"shard={args.shard}{'' if n == 1 else ' (master NOT written -- merge pass pending)'}"
+    )

--- a/sportsdataverse/scrape/ncaa/espn_game_xwalk.py
+++ b/sportsdataverse/scrape/ncaa/espn_game_xwalk.py
@@ -1,0 +1,371 @@
+"""Season crosswalk: NCAA ``contest_id`` -> ESPN event id (``espn_game_id``).
+
+Distinct from sdv-py's ``ncaa_espn_team_crosswalk`` (a TEAM-id crosswalk) --
+this one keys GAMES. Nothing in the ecosystem carried an ESPN event id against
+an NCAA contest id before, so it is derived here and cached to disk:
+
+    {root}/{league}/xwalk/espn_game_id/{season}.json
+
+Building it is the ONLY step that touches the network (one sdv-py release-loader
+call per season). :func:`load_espn_game_index` is then a pure offline read, which
+is what ``ncaa_identity.enrich_parsed`` uses -- so parsing 18k bundles never
+hits the wire.
+
+**Both sides are already ESPN-team-id-bearing**, so no name matching is needed:
+
+* NCAA side -- ``{root}/{league}/schedules/parquet/{season}.parquet`` carries
+  ``contest_id``, ``game_date``, ``espn_team_id`` (the row's own team) and
+  ``opponent_espn_team_id``. Each contest appears twice (once per team's
+  schedule page); orientation comes from whether the row's ``team`` is the
+  ``home`` or the ``away`` name.
+* ESPN side -- ``load_{mbb,wbb}_schedule(seasons=[season])``: ``game_id``,
+  ``game_date``, ``home_id``, ``away_id``.
+
+**Four tiers, tried in order, each recorded in ``match_method``.** Every tier
+drops any key resolving to more than one ESPN game before it joins, so an
+ambiguous contest lands on NULL rather than a guess:
+
+1. ``exact`` -- ``(game_date, home_espn_team_id, away_espn_team_id)``.
+2. ``date_window`` -- same key, ESPN date shifted +/-1 day. Late tip-offs and
+   timezone handling put a handful of games on the neighbouring date.
+3. ``unordered_pair`` -- exact date, home/away treated as an unordered pair.
+   Neutral-site games are the bulk of this tier: the NCAA and ESPN sides
+   disagree about which side is nominally "home".
+4. ``single_team`` -- exact date plus the ONE ESPN team id we have, and only
+   when that team has exactly one ESPN game that date. This is what covers
+   games against a non-D-I opponent: stats.ncaa.org gives such an opponent no
+   NCAA team id at all (and therefore no ESPN one), so tiers 1-3 cannot fire.
+
+A contest that survives all four keeps a NULL ``espn_game_id``. Rows are never
+dropped for failing to match, and an ESPN game id claimed by two different
+contests is voided on both sides rather than assigned to either.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, List, Union
+
+import polars as pl
+
+logger = logging.getLogger(__name__)
+
+
+__all__ = [
+    "MATCH_METHODS",
+    "build_season_xwalk",
+    "load_espn_game_index",
+    "write_season_xwalk",
+    "xwalk_path",
+]
+
+#: Tier labels, in the order they are attempted.
+MATCH_METHODS = ("exact", "date_window", "unordered_pair", "single_team")
+
+_EXACT_KEYS = ["game_date", "home_espn_team_id", "away_espn_team_id"]
+_PAIR_KEYS = ["game_date", "team_lo", "team_hi"]
+_SINGLE_KEYS = ["game_date", "espn_team_id"]
+
+
+def xwalk_path(root: Union[str, Path], league: str, season: int) -> Path:
+    """``{root}/{league}/xwalk/espn_game_id/{season}.json``."""
+    return Path(root) / league / "xwalk" / "espn_game_id" / f"{season}.json"
+
+
+def _utf8_id(column: str) -> pl.Expr:
+    """Int-bearing id column -> Utf8. Via ``Int64`` so a float never renders ``"123.0"``."""
+    return pl.col(column).cast(pl.Int64).cast(pl.Utf8)
+
+
+def _pair_bounds() -> "tuple[pl.Expr, pl.Expr]":
+    return (
+        pl.min_horizontal("home_espn_team_id", "away_espn_team_id").alias("team_lo"),
+        pl.max_horizontal("home_espn_team_id", "away_espn_team_id").alias("team_hi"),
+    )
+
+
+def ncaa_schedule_side(root: Union[str, Path], league: str, season: int) -> pl.DataFrame:
+    """One row per contest: ``contest_id``, ``game_date``, both ESPN team ids.
+
+    Empty frame (documented schema) when the season's schedules tree was never
+    built -- the caller then writes an empty crosswalk rather than raising.
+    """
+    schema = {
+        "contest_id": pl.Utf8,
+        "game_date": pl.Date,
+        "home_espn_team_id": pl.Utf8,
+        "away_espn_team_id": pl.Utf8,
+    }
+    path = Path(root) / league / "schedules" / "parquet" / f"{season}.parquet"
+    if not path.is_file():
+        return pl.DataFrame(schema=schema)
+
+    is_home = pl.col("team") == pl.col("home")
+    is_away = pl.col("team") == pl.col("away")
+    frame = pl.read_parquet(path).select(
+        pl.col("contest_id").cast(pl.Utf8),
+        pl.col("game_date").str.to_date("%m/%d/%Y", strict=False).alias("game_date"),
+        pl.when(is_home)
+        .then(pl.col("espn_team_id"))
+        .when(is_away)
+        .then(pl.col("opponent_espn_team_id"))
+        .otherwise(None)
+        .cast(pl.Utf8)
+        .alias("home_espn_team_id"),
+        pl.when(is_away)
+        .then(pl.col("espn_team_id"))
+        .when(is_home)
+        .then(pl.col("opponent_espn_team_id"))
+        .otherwise(None)
+        .cast(pl.Utf8)
+        .alias("away_espn_team_id"),
+    )
+    # Both of a contest's two schedule-page rows describe the same game; prefer
+    # the one that resolved BOTH sides (a row whose own team matched neither the
+    # home nor the away name yields two nulls and is the weaker copy).
+    return (
+        frame.filter(pl.col("contest_id").is_not_null())
+        .sort(pl.col("home_espn_team_id").is_null() | pl.col("away_espn_team_id").is_null())
+        .unique(subset=["contest_id"], keep="first", maintain_order=True)
+        .sort("contest_id")
+    )
+
+
+def espn_schedule_side(league: str, season: int) -> pl.DataFrame:
+    """ESPN's own season schedule via the sdv-py release loaders (the one network call)."""
+    if league == "wbb":
+        from sportsdataverse.wbb import load_wbb_schedule as _load
+    else:
+        from sportsdataverse.mbb import load_mbb_schedule as _load
+
+    return (
+        _load(seasons=[season])
+        .select(
+            _utf8_id("game_id").alias("espn_game_id"),
+            pl.col("game_date").cast(pl.Date),
+            _utf8_id("home_id").alias("home_espn_team_id"),
+            _utf8_id("away_id").alias("away_espn_team_id"),
+        )
+        .drop_nulls("espn_game_id")
+    )
+
+
+def _unambiguous(frame: pl.DataFrame, keys: List[str]) -> pl.DataFrame:
+    """``keys -> espn_game_id``, keeping only keys that resolve to exactly one game."""
+    return (
+        frame.group_by(keys)
+        .agg(
+            pl.col("espn_game_id").n_unique().alias("_candidates"),
+            pl.col("espn_game_id").first().alias("espn_game_id"),
+        )
+        .filter(pl.col("_candidates") == 1)
+        .drop("_candidates")
+    )
+
+
+def _apply_tier(
+    pending: pl.DataFrame, lookup: pl.DataFrame, keys: List[str], method: str
+) -> "tuple[pl.DataFrame, pl.DataFrame]":
+    """Left-join *pending* against *lookup*; return ``(matched, still_pending)``."""
+    joined = pending.join(lookup, on=keys, how="left")
+    matched = joined.filter(pl.col("espn_game_id").is_not_null()).with_columns(
+        pl.lit(method, dtype=pl.Utf8).alias("match_method")
+    )
+    still = joined.filter(pl.col("espn_game_id").is_null()).drop("espn_game_id")
+    return matched, still
+
+
+def build_season_xwalk(root: Union[str, Path], league: str, season: int) -> pl.DataFrame:
+    """``contest_id -> espn_game_id`` for one season, with the tier that matched it.
+
+    Returns:
+        ``contest_id`` (Utf8), ``espn_game_id`` (Utf8, nullable),
+        ``match_method`` (Utf8, one of :data:`MATCH_METHODS`, null when
+        unmatched) -- one row per NCAA contest, none ever dropped.
+    """
+    ncaa = ncaa_schedule_side(root, league, season)
+    out_schema = {
+        "contest_id": pl.Utf8,
+        "espn_game_id": pl.Utf8,
+        "match_method": pl.Utf8,
+    }
+    if ncaa.height == 0:
+        logger.info(
+            "ncaa_espn_game_xwalk: %s %s -- no schedules parquet; empty crosswalk",
+            league,
+            season,
+        )
+        return pl.DataFrame(schema=out_schema)
+
+    espn = espn_schedule_side(league, season)
+    if espn.height == 0:
+        logger.warning("ncaa_espn_game_xwalk: %s %s -- ESPN loader returned 0 rows", league, season)
+        return ncaa.select(
+            "contest_id",
+            pl.lit(None, dtype=pl.Utf8).alias("espn_game_id"),
+            pl.lit(None, dtype=pl.Utf8).alias("match_method"),
+        )
+
+    lo, hi = _pair_bounds()
+    espn_long = pl.concat(
+        [
+            espn.select("espn_game_id", "game_date", pl.col(side).alias("espn_team_id"))
+            for side in ("home_espn_team_id", "away_espn_team_id")
+        ]
+    )
+    windowed = pl.concat([espn.with_columns((pl.col("game_date") + pl.duration(days=d))) for d in (-1, 1)])
+
+    tiers = (
+        ("exact", _EXACT_KEYS, lambda: _unambiguous(espn, _EXACT_KEYS), None),
+        (
+            "date_window",
+            _EXACT_KEYS,
+            lambda: _unambiguous(windowed, _EXACT_KEYS),
+            None,
+        ),
+        (
+            "unordered_pair",
+            _PAIR_KEYS,
+            lambda: _unambiguous(espn.with_columns(lo, hi), _PAIR_KEYS),
+            (lo, hi),
+        ),
+        (
+            "single_team",
+            _SINGLE_KEYS,
+            lambda: _unambiguous(espn_long, _SINGLE_KEYS),
+            (pl.coalesce("home_espn_team_id", "away_espn_team_id").alias("espn_team_id"),),
+        ),
+    )
+
+    pending = ncaa
+    matched: List[pl.DataFrame] = []
+    for method, keys, lookup_fn, extra in tiers:
+        if pending.height == 0:
+            break
+        prepared = pending.with_columns(*extra) if extra else pending
+        hit, pending = _apply_tier(prepared, lookup_fn(), keys, method)
+        if hit.height:
+            matched.append(hit.select("contest_id", "espn_game_id", "match_method"))
+        pending = pending.select(ncaa.columns)
+
+    unmatched = pending.select(
+        "contest_id",
+        pl.lit(None, dtype=pl.Utf8).alias("espn_game_id"),
+        pl.lit(None, dtype=pl.Utf8).alias("match_method"),
+    )
+    result = pl.concat([*matched, unmatched]) if matched else unmatched
+
+    # One ESPN game belongs to one contest. A collision means at least one of
+    # the two is wrong and we cannot tell which -- void both rather than assign.
+    contested = (
+        result.drop_nulls("espn_game_id")
+        .group_by("espn_game_id")
+        .agg(pl.len().alias("n"))
+        .filter(pl.col("n") > 1)
+        .get_column("espn_game_id")
+        .to_list()
+    )
+    if contested:
+        logger.warning(
+            "ncaa_espn_game_xwalk: %s %s -- %d ESPN game ids claimed by >1 contest; voided",
+            league,
+            season,
+            len(contested),
+        )
+        clash = pl.col("espn_game_id").is_in(contested)
+        result = result.with_columns(
+            pl.when(clash).then(None).otherwise(pl.col("espn_game_id")).alias("espn_game_id"),
+            pl.when(clash).then(None).otherwise(pl.col("match_method")).alias("match_method"),
+        )
+    return result.sort("contest_id")
+
+
+def write_season_xwalk(root: Union[str, Path], league: str, season: int, frame: pl.DataFrame) -> Path:
+    """Write *frame* to :func:`xwalk_path` as plain utf-8 JSON (atomic)."""
+    path = xwalk_path(root, league, season)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(frame.to_dicts()), encoding="utf-8")
+    tmp.replace(path)
+    return path
+
+
+@lru_cache(maxsize=8)
+def load_espn_game_index(root: str, league: str, season: int) -> Dict[str, str]:
+    """``{contest_id: espn_game_id}`` for one season -- offline, cached.
+
+    Unmatched contests are omitted (the caller emits NULL for them), and a
+    missing crosswalk file yields an empty dict rather than an exception, so a
+    season whose crosswalk was never built still parses.
+    """
+    path = xwalk_path(root, league, season)
+    if not path.is_file():
+        return {}
+    try:
+        rows = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        logger.warning(
+            "ncaa_espn_game_xwalk: unreadable crosswalk %s; ids emitted as nulls",
+            path,
+            exc_info=True,
+        )
+        return {}
+    return {str(r["contest_id"]): str(r["espn_game_id"]) for r in rows if r.get("contest_id") and r.get("espn_game_id")}
+
+
+def summarize(frame: pl.DataFrame) -> Dict[str, int]:
+    """Per-tier hit counts + the unmatched residue, for the build log."""
+    counts = {m: 0 for m in MATCH_METHODS}
+    if frame.height:
+        for row in (
+            frame.drop_nulls("match_method").group_by("match_method").agg(pl.len().alias("n")).iter_rows(named=True)
+        ):
+            counts[row["match_method"]] = row["n"]
+    counts["unmatched"] = int(frame.get_column("espn_game_id").null_count()) if frame.height else 0
+    counts["contests"] = frame.height
+    return counts
+
+
+def _main(default_league: str) -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Build the NCAA contest_id -> ESPN game_id crosswalk for one or more seasons."
+    )
+    parser.add_argument(
+        "--root",
+        default=str(Path(__file__).resolve().parents[1]),
+        help="Root of the raw data tree (default: repo root).",
+    )
+    parser.add_argument("--league", default=default_league, help=f"League slug (default: {default_league}).")
+    parser.add_argument(
+        "--seasons",
+        nargs="+",
+        type=int,
+        required=True,
+        help="Ending years, e.g. --seasons 2023 2024 2025 2026.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report match rates without writing the crosswalk files.",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    for season in args.seasons:
+        frame = build_season_xwalk(args.root, args.league, season)
+        stats = summarize(frame)
+        matched = stats["contests"] - stats["unmatched"]
+        pct = round(100 * matched / stats["contests"], 2) if stats["contests"] else 0.0
+        if not args.dry_run and stats["contests"]:
+            write_season_xwalk(args.root, args.league, season, frame)
+        print(
+            f"{args.league} {season}: contests={stats['contests']} matched={matched} ({pct}%) "
+            + " ".join(f"{m}={stats[m]}" for m in MATCH_METHODS)
+            + f" unmatched={stats['unmatched']}",
+            flush=True,
+        )

--- a/sportsdataverse/scrape/ncaa/identity.py
+++ b/sportsdataverse/scrape/ncaa/identity.py
@@ -1,0 +1,495 @@
+"""Stamp team + player IDENTIFIERS and readable names onto the parsed families.
+
+The parser stack speaks three name dialects and NO ids:
+
+* ``FIRST.LAST`` ALL-CAPS -- pbp ``player_1``/``player_2``/``home_N``/``away_N``,
+  ``player_box.player``, ``possessions.home_N``/``away_N``.
+* ``"Last, First"`` display form -- ``lineups[].players[].id.name`` (already
+  properly cased; what it lacks is the id).
+* A CamelCase within-team code (``"AnBrizzi"``) -- ``shots.shooter_id`` and
+  ``lineups[].players[].code``.
+
+...and team NAMES only (``"Buffalo"``), with no NCAA or ESPN team id anywhere.
+
+This module joins all three against the committed datasets trees -- fully
+offline, no network -- and writes ids + a properly-cased ``clean_name``
+ALONGSIDE every existing column. Nothing is renamed or removed.
+
+Sources (both written by :mod:`ncaa_datasets`):
+
+* ``{root}/{lg}/rosters/json/{season}/{team_id}.json`` -- ``player_id``,
+  ``clean_name``, ``player``, ``team_id``, ``team``.
+* ``{root}/{lg}/teams/json/{season}.json`` -- ``ncaa_team_id``, ``team``,
+  ``espn_team_id``, ``espn_display_name``, ``espn_mascot``, ``conference``.
+
+Two join keys, both reused rather than reinvented:
+
+* :func:`_key_name` -- the format-immune name signature, copied VERBATIM from
+  ``ncaa-{lg}-hoops-data``'s ``ncaa_{lg}_data_build/derived.py`` so the two
+  repos key players identically. Strip diacritics, casefold, drop suffix
+  tokens, sorted-letter signature: ``"Talton Jr, Derrick"`` and
+  ``"DERRICK.TALTON"`` both land on the same key.
+* :func:`~sportsdataverse.mbb.mbb_ncaa_stints.build_player_code` -- sdv-py's
+  own code builder, i.e. the exact function that MINTED ``shooter_id`` in the
+  first place, run over the roster's ``clean_name`` to invert it. Not a second
+  name normalizer; a different key space (codes, not names).
+
+**The per-game families carry BOTH id namespaces.** Every team-name column on
+``pbp`` / ``possessions`` / ``player_box`` / ``team_box`` / ``shots`` /
+``lineups`` gets an ``_ncaa_team_id`` AND an ``_espn_team_id`` beside it, and
+every row gets the game-level ``espn_game_id`` (from
+:mod:`ncaa_espn_game_xwalk`) next to its ``contest_id``. That makes each family
+independently joinable against both the NCAA and the ESPN/hoopR-wehoop sides
+without a lookup hop through the ``teams`` block -- which keeps its own full
+ESPN identity (display name, mascot, conference) as the reference row.
+
+**Never guesses, never drops.** The player index is scoped to the two teams in
+the game, and any key that resolves to more than one ``player_id`` is dropped
+from the index -- an ambiguous or unmatched name keeps its row and gets a NULL
+id, it is never dropped and never approximated. Same for teams: a non-D-I
+exhibition opponent has no crosswalk row, so it stays null.
+
+**Degrades to nulls.** A season with no rosters/teams tree yet (most historical
+seasons) still parses: every new column is emitted as a typed null and one line
+is logged. Absence of a source is never an exception.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import unicodedata
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+logger = logging.getLogger(__name__)
+
+
+__all__ = [
+    "LINEUP_TEAM_COLUMNS",
+    "PLAYER_COLUMNS",
+    "TEAM_COLUMNS",
+    "enrich_parsed",
+    "load_roster_index",
+    "load_team_index",
+]
+
+# --- the format-immune name key --------------------------------------------
+# Copied VERBATIM from ncaa-mbb-hoops-data/python/ncaa_mbb_data_build/derived.py
+# (_NAME_SPLIT / _NAME_SUFFIXES / _key_name). It is duplicated rather than
+# imported because the two repos are separate checkouts with no shared package;
+# any change MUST land in both or the repos stop agreeing on player keys.
+_NAME_SPLIT = re.compile(r"[^a-z0-9']+")
+_NAME_SUFFIXES = {"jr", "sr", "ii", "iii", "iv", "v"}
+
+#: The pbp stream's placeholder for a team rebound / team turnover. Not a
+#: person, so it must never resolve to one -- excluded from the join and from
+#: the reported miss counts.
+_NOT_A_PLAYER = {"TEAM", ""}
+
+
+def _key_name(name: str) -> str:
+    """Format-immune canonical form of one player name for hashing.
+
+    The sources render the same player differently -- the roster keeps display
+    form (``"Talton Jr, Derrick"`` / ``"B.J. Edwards"``) while pbp carries the
+    engine's ``"DERRICK.TALTON"`` / ``"BJ.EDWARDS"`` normalization, which DROPS
+    suffixes and collapses initials. So: strip diacritics, casefold, split on
+    non-alphanumerics, drop suffix tokens, sort the letters. Both forms above
+    map to the same key.
+    """
+    ascii_name = unicodedata.normalize("NFKD", name).encode("ascii", "ignore").decode("ascii")
+    words = [w for w in _NAME_SPLIT.split(ascii_name.casefold()) if w]
+    words = [w for w in words if w not in _NAME_SUFFIXES]
+    # Sorted-letter signature: immune to word order, hyphen/space-collapsed
+    # compound surnames (PORTERBROWN vs Porter-Brown), apostrophes (JEKEL vs
+    # Je'Kel), and collapsed initials. Collision = exact-anagram teammates,
+    # which at team-season scope is negligible -- and is dropped anyway.
+    return "".join(sorted("".join(words).replace("'", "")))
+
+
+def _utf8_id(value: Any) -> Optional[str]:
+    """Any id -> Utf8, or ``None``. NEVER stringifies a float directly.
+
+    ``str(123.0)`` is ``"123.0"`` -- the classic join-breaking defect. A float
+    id goes through ``int`` first; a non-integral float is not an id at all and
+    becomes ``None`` rather than a plausible-looking wrong string.
+    """
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, float):
+        return str(int(value)) if value.is_integer() else None
+    return str(value)
+
+
+# --- the enriched column plan ----------------------------------------------
+#: family -> the existing team-NAME columns that get ``_ncaa_team_id`` and
+#: ``_espn_team_id`` stamped beside them.
+TEAM_COLUMNS: Dict[str, Tuple[str, ...]] = {
+    "pbp": ("home", "away", "event_team", "poss_team"),
+    "possessions": ("home", "away", "poss_team"),
+    "player_box": ("home", "away", "team"),
+    "team_box": ("home", "away", "team"),
+    # `shots.team_id` holds a team NAME despite its column name (the shots
+    # adapter fills it from `shooting.team.name`); it is left untouched and the
+    # real ids land in `ncaa_team_id` / `espn_team_id`.
+    "shots": ("team_id",),
+}
+
+#: The ten on-court lineup slots. Same ALL-CAPS ``FIRST.LAST`` codes as
+#: ``player_1``/``player_2``, so they resolve through the same game-scoped
+#: player index -- no second lookup.
+_ONCOURT: Tuple[str, ...] = tuple(f"{side}_{slot}" for side in ("home", "away") for slot in range(1, 6))
+_ONCOURT_SPECS: Tuple[Tuple[str, str, str], ...] = tuple(
+    (column, f"{column}_player_id", f"{column}_clean_name") for column in _ONCOURT
+)
+
+#: ``lineups`` carries its teams as nested ``{"team": {"name": ...}}`` structs,
+#: so it gets flat sidecar columns instead of a ``{col}_`` suffix pair.
+LINEUP_TEAM_COLUMNS: Tuple[str, ...] = ("team", "opponent")
+
+#: family -> (existing ALL-CAPS name column, new id column, new readable column).
+PLAYER_COLUMNS: Dict[str, Tuple[Tuple[str, str, str], ...]] = {
+    "pbp": (
+        ("player_1", "player_1_id", "player_1_clean_name"),
+        ("player_2", "player_2_id", "player_2_clean_name"),
+    )
+    + _ONCOURT_SPECS,
+    "player_box": (("player", "player_id", "clean_name"),),
+    "possessions": _ONCOURT_SPECS,
+}
+
+#: The id columns stamped for every team-name column, in both the ``{column}_``
+#: suffixed form and (on ``shots``) the bare form.
+_TEAM_ID_KEYS = ("ncaa_team_id", "espn_team_id")
+_SHOTS_PLAYER_KEYS = ("shooter_player_id", "shooter_clean_name")
+
+#: The game-level ESPN event id, stamped on every row of every per-game family
+#: beside ``contest_id``. Built offline by :mod:`ncaa_espn_game_xwalk`.
+_ESPN_GAME_ID_KEY = "espn_game_id"
+
+#: The six per-game families, i.e. every family that gets ``espn_game_id``.
+#: Kept in sync with ``ncaa_parse.PER_GAME_FAMILIES`` (duplicated for the same
+#: reason ``_key_name`` is: no shared package across these checkouts).
+_PER_GAME_FAMILIES: Tuple[str, ...] = (
+    "pbp",
+    "lineups",
+    "player_box",
+    "team_box",
+    "shots",
+    "possessions",
+)
+
+
+def _teams_path(root: Union[str, Path], league: str, season: int) -> Path:
+    return Path(root) / league / "teams" / "json" / f"{season}.json"
+
+
+def _rosters_dir(root: Union[str, Path], league: str, season: int) -> Path:
+    return Path(root) / league / "rosters" / "json" / str(season)
+
+
+@lru_cache(maxsize=8)
+def load_team_index(root: str, league: str, season: int) -> Dict[str, Dict[str, Optional[str]]]:
+    """``team name -> {ncaa_team_id, espn_team_id, espn_display_name, ...}``.
+
+    Empty dict when the season's teams file was never built -- the caller then
+    emits null ids rather than raising.
+    """
+    path = _teams_path(root, league, season)
+    if not path.is_file():
+        return {}
+    rows = json.loads(path.read_text(encoding="utf-8"))
+    index: Dict[str, Dict[str, Optional[str]]] = {}
+    for row in rows:
+        team = row.get("team")
+        if not team:
+            continue
+        index[team] = {
+            "team": team,
+            "ncaa_team_id": _utf8_id(row.get("ncaa_team_id")),
+            "espn_team_id": _utf8_id(row.get("espn_team_id")),
+            "espn_display_name": row.get("espn_display_name"),
+            "espn_mascot": row.get("espn_mascot"),
+            "conference": row.get("conference"),
+            "division": row.get("division"),
+        }
+    return index
+
+
+@lru_cache(maxsize=8)
+def load_roster_index(root: str, league: str, season: int) -> Dict[str, Dict[str, Dict[str, Tuple[str, str]]]]:
+    """``team_id -> {"names": {key_name: (player_id, clean_name)}, "codes": {...}}``.
+
+    Both key spaces are built per team so the per-game index can be assembled
+    from just the two teams on the floor. A key that resolves to more than one
+    ``player_id`` within a team is DROPPED -- better a null than a coin flip.
+
+    Empty dict when the season's rosters tree was never built.
+    """
+    directory = _rosters_dir(root, league, season)
+    if not directory.is_dir():
+        return {}
+
+    # Imported here, not at module scope: the code inversion is the only reason
+    # this module needs sdv-py at all, and a season with no rosters must not pay
+    # the import at all.
+    from sportsdataverse.mbb.mbb_ncaa_models import TeamId
+    from sportsdataverse.mbb.mbb_ncaa_stints import build_player_code
+
+    index: Dict[str, Dict[str, Dict[str, Tuple[str, str]]]] = {}
+    for path in sorted(directory.glob("*.json")):
+        try:
+            rows = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            logger.warning("ncaa_identity: unreadable roster %s; skipped", path, exc_info=True)
+            continue
+        names: Dict[str, set] = {}
+        codes: Dict[str, set] = {}
+        for row in rows:
+            player_id = _utf8_id(row.get("player_id"))
+            clean_name = row.get("clean_name")
+            if not player_id or not clean_name:
+                continue
+            entry = (player_id, clean_name)
+            # Key on BOTH the display form and the roster's own ALL-CAPS
+            # `player` column: they normalize to the same key in the common
+            # case, and to two keys exactly where the pbp spelling diverges.
+            for raw in (clean_name, row.get("player")):
+                if raw:
+                    names.setdefault(_key_name(raw), set()).add(entry)
+            team = row.get("team")
+            try:
+                code = build_player_code(clean_name, TeamId(team) if team else None).code
+            except Exception:  # noqa: BLE001 -- an un-codeable name just has no code key
+                continue
+            codes.setdefault(code, set()).add(entry)
+        index[path.stem] = {
+            "names": {k: next(iter(v)) for k, v in names.items() if len({e[0] for e in v}) == 1},
+            "codes": {k: next(iter(v)) for k, v in codes.items() if len({e[0] for e in v}) == 1},
+        }
+    return index
+
+
+def _game_player_index(
+    roster_index: Dict[str, Dict[str, Dict[str, Tuple[str, str]]]], team_ids: List[str]
+) -> Tuple[Dict[str, Tuple[str, str]], Dict[str, Tuple[str, str]]]:
+    """Merge the two teams' indices; drop keys the two teams disagree on.
+
+    Scoping to the game (rather than the whole season) is what makes a bare
+    name resolvable at all -- and keeps a cross-team anagram from resolving to
+    the wrong player, because it is dropped instead.
+    """
+    merged: Dict[str, Dict[str, set]] = {"names": {}, "codes": {}}
+    for team_id in team_ids:
+        team_index = roster_index.get(team_id)
+        if not team_index:
+            continue
+        for space in ("names", "codes"):
+            for key, entry in team_index[space].items():
+                merged[space].setdefault(key, set()).add(entry)
+    names = {k: next(iter(v)) for k, v in merged["names"].items() if len({e[0] for e in v}) == 1}
+    codes = {k: next(iter(v)) for k, v in merged["codes"].items() if len({e[0] for e in v}) == 1}
+    return names, codes
+
+
+def _stamp_team(
+    row: Dict[str, Any],
+    column: str,
+    teams: Dict[str, Dict[str, Optional[str]]],
+    stats: Dict[str, int],
+) -> None:
+    """Write ``{column}_ncaa_team_id`` / ``{column}_espn_team_id`` beside *column*."""
+    name = row.get(column)
+    hit = teams.get(name) if name else None
+    for key in _TEAM_ID_KEYS:
+        row[f"{column}_{key}"] = hit[key] if hit else None
+    if name:
+        stats["team_total"] += 1
+        stats["team_hit" if hit else "team_miss"] += 1
+
+
+def _stamp_player(
+    row: Dict[str, Any],
+    name_column: str,
+    id_column: str,
+    readable_column: str,
+    names: Dict[str, Tuple[str, str]],
+    stats: Dict[str, int],
+) -> None:
+    """Write the id + properly-cased name beside an ALL-CAPS name column."""
+    raw = row.get(name_column)
+    hit = names.get(_key_name(raw)) if raw and raw.upper() not in _NOT_A_PLAYER else None
+    row[id_column] = hit[0] if hit else None
+    row[readable_column] = hit[1] if hit else None
+    if raw and raw.upper() not in _NOT_A_PLAYER:
+        stats["player_total"] += 1
+        stats["player_hit" if hit else "player_miss"] += 1
+
+
+def _espn_game_id_for(root: Union[str, Path], league: str, season: Optional[int], contest_id: Any) -> Optional[str]:
+    """This contest's ESPN event id from the offline crosswalk, or ``None``.
+
+    Absence of a crosswalk is never an exception: an unbuilt season, an
+    unmatched contest and an unreadable file all yield ``None``.
+    """
+    if season is None or not contest_id:
+        return None
+    from .espn_game_xwalk import load_espn_game_index
+
+    return load_espn_game_index(str(root), league, season).get(str(contest_id))
+
+
+def _team_name(value: Any) -> Optional[str]:
+    """``lineups`` renders a team as ``{"team": {"name": "Buffalo"}, ...}``."""
+    if isinstance(value, dict):
+        inner = value.get("team")
+        if isinstance(inner, dict):
+            return inner.get("name")
+        return value.get("name")
+    return value if isinstance(value, str) else None
+
+
+def enrich_parsed(
+    parsed: Dict[str, Any],
+    *,
+    root: Union[str, Path],
+    league: str,
+    season: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Stamp ids + readable names onto every family of one parsed game.
+
+    Covers the ten on-court slots (``home_1``..``home_5`` / ``away_1``..
+    ``away_5`` on ``pbp`` and ``possessions``) as well as the event players --
+    each gets ``{slot}_player_id`` + ``{slot}_clean_name`` off the same
+    game-scoped index.
+
+    Strictly additive: existing keys are never renamed, removed or rewritten.
+    The one exception is ``lineups[].players[].ncaa_id``, the parser model's own
+    always-null slot for the NCAA player id, which is FILLED (that is what it
+    is for) rather than shadowed by a duplicate key.
+
+    Args:
+        parsed: The dict :func:`ncaa_parse.parse_bundle` builds.
+        root: Repo root -- the datasets trees live at ``{root}/{league}/``.
+        league: ``"mbb"`` or ``"wbb"``.
+        season: Ending year, e.g. ``2026``. ``None`` skips enrichment's joins
+            and emits nulls (the season is unknown, so no index can be chosen).
+
+    Returns:
+        The same dict, mutated in place, plus a new top-level ``teams`` list
+        (one row per side with the full readable team identity). Every row of
+        every per-game family additionally carries ``espn_game_id`` -- always
+        present, null when the season's crosswalk is unbuilt or the contest has
+        no unambiguous ESPN match.
+    """
+    teams = load_team_index(str(root), league, season) if season is not None else {}
+    rosters = load_roster_index(str(root), league, season) if season is not None else {}
+    if season is not None and not (teams and rosters):
+        logger.info(
+            "ncaa_identity: contest_id=%s season=%s league=%s -- %s%s not built; ids emitted as nulls",
+            parsed.get("contest_id"),
+            season,
+            league,
+            "" if teams else "teams ",
+            "" if rosters else "rosters",
+        )
+
+    pbp = parsed.get("pbp") or []
+    home = pbp[0].get("home") if pbp else None
+    away = pbp[0].get("away") if pbp else None
+    sides = [("home", home), ("away", away)]
+    team_ids = [teams[n]["ncaa_team_id"] for _, n in sides if n and n in teams and teams[n]["ncaa_team_id"]]
+    names, codes = _game_player_index(rosters, [t for t in team_ids if t])
+
+    stats = {
+        "team_total": 0,
+        "team_hit": 0,
+        "team_miss": 0,
+        "player_total": 0,
+        "player_hit": 0,
+        "player_miss": 0,
+    }
+
+    for family, columns in TEAM_COLUMNS.items():
+        for row in parsed.get(family) or []:
+            for column in columns:
+                if family == "shots":
+                    hit = teams.get(row.get(column))
+                    for key in _TEAM_ID_KEYS:
+                        row[key] = hit[key] if hit else None
+                    if row.get(column):
+                        stats["team_total"] += 1
+                        stats["team_hit" if hit else "team_miss"] += 1
+                else:
+                    _stamp_team(row, column, teams, stats)
+
+    for family, specs in PLAYER_COLUMNS.items():
+        for row in parsed.get(family) or []:
+            for name_column, id_column, readable_column in specs:
+                _stamp_player(row, name_column, id_column, readable_column, names, stats)
+
+    for row in parsed.get("shots") or []:
+        code = row.get("shooter_id")
+        hit = codes.get(code) if code else None
+        row[_SHOTS_PLAYER_KEYS[0]] = hit[0] if hit else None
+        row[_SHOTS_PLAYER_KEYS[1]] = hit[1] if hit else None
+        if code:
+            stats["player_total"] += 1
+            stats["player_hit" if hit else "player_miss"] += 1
+
+    for lineup in parsed.get("lineups") or []:
+        for side in LINEUP_TEAM_COLUMNS:
+            hit = teams.get(_team_name(lineup.get(side)))
+            for key in _TEAM_ID_KEYS:
+                lineup[f"{side}_{key}"] = hit[key] if hit else None
+            if _team_name(lineup.get(side)):
+                stats["team_total"] += 1
+                stats["team_hit" if hit else "team_miss"] += 1
+        for slot in ("players", "players_in", "players_out"):
+            for player in lineup.get(slot) or []:
+                if not isinstance(player, dict):
+                    continue
+                # `code` first (exact, team-scoped); the display name is the
+                # fallback for a player the roster spells differently.
+                hit = codes.get(player.get("code"))
+                if hit is None:
+                    display = (player.get("id") or {}).get("name") if isinstance(player.get("id"), dict) else None
+                    hit = names.get(_key_name(display)) if display else None
+                player["ncaa_id"] = hit[0] if hit else None
+                stats["player_total"] += 1
+                stats["player_hit" if hit else "player_miss"] += 1
+
+    # The game-level ESPN event id, on every row of every family beside its
+    # contest_id. A season with no crosswalk built (or a contest ESPN has no
+    # match for) emits the key as null -- the column is always PRESENT so the
+    # frame schema never varies game-to-game.
+    espn_game_id = _espn_game_id_for(root, league, season, parsed.get("contest_id"))
+    for family in _PER_GAME_FAMILIES:
+        for row in parsed.get(family) or []:
+            row[_ESPN_GAME_ID_KEY] = espn_game_id
+
+    parsed["teams"] = [
+        dict(teams[name], side=side) if name in teams else {"side": side, "team": name} for side, name in sides if name
+    ]
+    for team_row in parsed["teams"]:
+        team_row[_ESPN_GAME_ID_KEY] = espn_game_id
+
+    # The join rate is REPORTED, never enforced: an unmatched name keeps its row
+    # with a null id (a non-D-I exhibition opponent has no crosswalk row, a
+    # mid-season addition is not on the captured roster snapshot). Logged rather
+    # than stored, so the committed JSON stays exactly the documented families.
+    if stats["team_miss"] or stats["player_miss"]:
+        logger.info(
+            "ncaa_identity: contest_id=%s teams %d/%d matched, players %d/%d matched",
+            parsed.get("contest_id"),
+            stats["team_hit"],
+            stats["team_total"],
+            stats["player_hit"],
+            stats["player_total"],
+        )
+    return parsed

--- a/sportsdataverse/scrape/ncaa/league_config.py
+++ b/sportsdataverse/scrape/ncaa/league_config.py
@@ -1,0 +1,50 @@
+"""League identity for the stats.ncaa.org college-basketball sweep engine.
+
+The capture stack itself is league-agnostic: stats.ncaa.org serves men's and
+women's pages from one contest-id namespace with identical URL shapes, HTML
+structure and bot-management behavior, and sdv-py's NCAA parser stack is
+already league-parametric (period model and three-point arc are selected by the
+``league`` argument). ``sportsdataverse.wbb.wbb_ncaa_fetch`` is itself a
+by-reference re-export of the men's fetch layer for exactly this reason.
+
+So a league is only ever a **token threaded through calls** — which is why the
+engine's public functions take ``league`` as a *required* keyword rather than
+defaulting it. A shared engine that defaults to one league is precisely how a
+women's run silently reads men's data: before this extraction,
+``ncaa_capture``'s CLI in the MBB repo hardcoded both the schedule-master path
+and the capture league to ``"mbb"``, so it could not be pointed anywhere else.
+
+Each ``-raw`` repo binds its own league in a thin shim; these configs name the
+per-league facts the engine or a caller may need.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class NcaaLeagueConfig:
+    """Identity facts for one college-basketball league's raw sweep.
+
+    Attributes:
+        league: The slug threaded through every engine call (``"mbb"`` /
+            ``"wbb"``). It selects the store subtree, the ``(team, season)``
+            id crosswalk, the play-by-play period model (halves vs quarters)
+            and the three-point arc used to classify shots.
+        repo: Owning ``-raw`` repository name (log/runbook text only).
+        periods: Regulation period count — men's halves vs women's quarters.
+    """
+
+    league: str
+    repo: str
+    periods: int
+
+
+MBB = NcaaLeagueConfig(league="mbb", repo="ncaa-mbb-hoops-raw", periods=2)
+WBB = NcaaLeagueConfig(league="wbb", repo="ncaa-wbb-hoops-raw", periods=4)
+
+_BY_LEAGUE = {c.league: c for c in (MBB, WBB)}
+
+
+def by_league(league: str) -> NcaaLeagueConfig:
+    """The config for a league slug (raises ``KeyError`` on unknown)."""
+    return _BY_LEAGUE[league]

--- a/sportsdataverse/scrape/ncaa/parse.py
+++ b/sportsdataverse/scrape/ncaa/parse.py
@@ -1,0 +1,383 @@
+"""Decoupled PARSE step: raw captured bundle -> combined parsed JSON.
+
+Reads a raw bundle written by :mod:`ncaa_bundle` (``play_by_play`` /
+``box_score`` / ``individual_stats`` pages) and runs it through the sdv-py
+bigballR/cbb-explorer parser stack, producing ONE combined record with six
+datasets: ``pbp``, ``lineups``, ``player_box``, ``team_box``, ``shots``,
+``possessions``.
+
+**Robustness contract:** each of the six families is computed in its own
+``try/except`` -- a parser bug in one family (e.g. a legacy box-score layout
+tripping ``get_box_lineup``) logs a warning and yields ``[]`` for that family
+only; it never aborts the other five. Across ~6k real games some games WILL
+hit parser edge cases -- a game with 5/6 families populated is a success, a
+crashed run is not.
+
+Call sequence per family (see ``tests/mbb/test_mbb_ncaa_lineup_aggregation_e2e.py``
+for the ``get_box_lineup`` -> ``create_lineup_data`` sequence this mirrors):
+
+* ``pbp`` -- ``parse_ncaa_bb_game_pbp(play_by_play_html, contest_id)``.
+* ``lineups`` -- per team (home, away): ``get_box_lineup(individual_stats_html,
+  TeamId(team))`` then ``create_lineup_data(play_by_play_html, box_lineup)``;
+  the "good" stints from both teams are concatenated.
+* ``player_box`` / ``team_box`` -- ``ncaa_mbb_player_stats(pbp)`` /
+  ``ncaa_mbb_team_stats(pbp)``, aggregated directly off the parsed pbp frame
+  (no extra HTML parse needed -- the box-score page carries no data these two
+  don't already derive from play-by-play).
+* ``shots`` -- ``get_box_lineup(individual_stats_html, TeamId(home))`` (fresh
+  call, kept independent of the ``lineups`` family) feeds
+  ``create_shot_event_data(box_score_html, box_lineup)`` (the SVG shot map
+  lives on the ``box_score`` page, confirmed against the committed fixtures --
+  NOT the ``individual_stats`` page despite the module docstring's generic
+  "box-score-page" wording), then ``shot_events_to_frame(...)``.
+* ``possessions`` -- ``ncaa_mbb_possessions(pbp)``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from dataclasses import fields as dc_fields
+from dataclasses import is_dataclass
+from datetime import date, datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any, Optional, Union
+
+import polars as pl
+
+from .identity import enrich_parsed
+from sportsdataverse.mbb.mbb_ncaa_boxscore_parser import get_box_lineup
+from sportsdataverse.mbb.mbb_ncaa_data_quality import ParseError
+from sportsdataverse.mbb.mbb_ncaa_game_pbp import parse_ncaa_bb_game_pbp
+from sportsdataverse.mbb.mbb_ncaa_models import LineupEvent, TeamId
+from sportsdataverse.mbb.mbb_ncaa_pbp_parser import create_lineup_data
+from sportsdataverse.mbb.mbb_ncaa_possession_seg import ncaa_mbb_possessions
+from sportsdataverse.mbb.mbb_ncaa_shot_parser import create_shot_event_data
+from sportsdataverse.mbb.mbb_ncaa_stats_agg import (
+    ncaa_mbb_player_stats,
+    ncaa_mbb_team_stats,
+)
+from sportsdataverse.mbb.mbb_shots_adapter import shot_events_to_frame
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["parse_bundle", "write_parsed", "parse_and_write"]
+
+_WBB_PERIOD_MODEL: "tuple[int, int, int]" = (4, 600, 300)
+_SEASON_RE = re.compile(r"^(\d{4})-(\d{2})$")
+
+#: The six per-game families, i.e. every key of the parsed record that is a list
+#: of game rows. ``teams`` is deliberately absent: it is per-game reference data
+#: added by :mod:`ncaa_identity`, not a play/stat family.
+PER_GAME_FAMILIES: "tuple[str, ...]" = (
+    "pbp",
+    "lineups",
+    "player_box",
+    "team_box",
+    "shots",
+    "possessions",
+)
+
+
+def _ending_year(season: Optional[str]) -> int:
+    """``"2025-26"`` -> ``2026``; falls back to the current year on drift."""
+    if season:
+        m = _SEASON_RE.match(season)
+        if m:
+            start, suffix = int(m.group(1)), int(m.group(2))
+            end = (start // 100) * 100 + suffix
+            return end if end > start else end + 100
+        try:
+            return int(season)
+        except ValueError:
+            pass
+    return datetime.now().year
+
+
+def _jsonable(obj: Any) -> Any:
+    """Recursively convert a parser-model value tree to plain JSON-able types.
+
+    Handles the shapes the cbb-explorer dataclasses (``LineupEvent`` and its
+    nested ``LineupEventStats``/``PlayerCodeId``/etc.) actually carry:
+    dataclasses -> dict, ``Enum`` -> ``.value``, ``date``/``datetime`` ->
+    ISO string, list/tuple/set/frozenset -> list, dict -> str-keyed dict.
+    Everything else (str/int/float/bool/None) passes through unchanged.
+    """
+    if is_dataclass(obj) and not isinstance(obj, type):
+        return {f.name: _jsonable(getattr(obj, f.name)) for f in dc_fields(obj)}
+    if isinstance(obj, Enum):
+        return obj.value
+    if isinstance(obj, date):  # datetime is a date subclass
+        return obj.isoformat()
+    if isinstance(obj, dict):
+        return {str(k): _jsonable(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple, set, frozenset)):
+        return [_jsonable(v) for v in obj]
+    return obj
+
+
+def _parse_lineups(contest_id: str, pbp_df: pl.DataFrame, pbp_html: str, stats_html: str) -> "list[dict[str, Any]]":
+    """Both teams' box lineups -> stint events (good stints only)."""
+    home_team = pbp_df["home"][0]
+    away_team = pbp_df["away"][0]
+    events: "list[LineupEvent]" = []
+    for team_name in (home_team, away_team):
+        if not team_name:
+            continue
+        box_lineup = get_box_lineup(
+            f"individual_stats_{contest_id}.html",
+            stats_html,
+            TeamId(team_name),
+            format_version=1,
+        )
+        if isinstance(box_lineup, list):  # list[ParseError]
+            continue
+        lineup_result = create_lineup_data(f"pbp_{contest_id}.html", pbp_html, box_lineup, format_version=1)
+        if isinstance(lineup_result, list):  # list[ParseError]
+            continue
+        good, _bad = lineup_result
+        events.extend(good)
+    return [_jsonable(ev) for ev in events]
+
+
+def _parse_shots(
+    contest_id: str,
+    pbp_df: pl.DataFrame,
+    stats_html: str,
+    box_html: str,
+    season: Optional[str],
+    league: str,
+) -> "list[dict[str, Any]]":
+    """The SVG shot map on the ``box_score`` page, keyed off the home team's box lineup."""
+    home_team = pbp_df["home"][0]
+    if not home_team:
+        return []
+    box_lineup: Union[LineupEvent, "list[ParseError]"] = get_box_lineup(
+        f"individual_stats_{contest_id}.html",
+        stats_html,
+        TeamId(home_team),
+        format_version=1,
+    )
+    if isinstance(box_lineup, list):
+        return []
+    shots = create_shot_event_data(f"box_score_{contest_id}.html", box_html, box_lineup)
+    if not shots or isinstance(shots[0], ParseError):
+        return []
+    frame = shot_events_to_frame(
+        shots,
+        season=_ending_year(season),
+        league="womens" if league == "wbb" else "mens",
+    )
+    return frame.to_dicts()
+
+
+def parse_bundle(
+    bundle: "dict[str, Any]",
+    *,
+    league: str,
+    root: "Optional[Union[str, Path]]" = None,
+) -> "dict[str, Any]":
+    """Parse one raw captured bundle into the six combined datasets.
+
+    Args:
+        bundle: A raw bundle as returned by :func:`ncaa_bundle.read_bundle`
+            (``contest_id``, ``season``, ``pages`` with ``play_by_play`` /
+            ``box_score`` / ``individual_stats`` HTML).
+        league: ``"mbb"`` (default) or ``"wbb"`` -- selects the pbp period
+            model (halves vs. quarters) and the shots frame's league label.
+        root: Repo root, for the offline identity join against the committed
+            ``{league}/rosters/`` + ``{league}/teams/`` trees. Defaults to this
+            repo. A season whose trees were never built still parses -- the id
+            columns come back as nulls.
+
+    Returns:
+        ``{"contest_id": str, "pbp": [...], "lineups": [...], "player_box":
+        [...], "team_box": [...], "shots": [...], "possessions": [...],
+        "teams": [...]}`` -- every dataset a ``list[dict]``. Any family whose
+        parse failed is an empty list (never raises). ``teams`` is the
+        two-row readable team identity added by :mod:`ncaa_identity`, which
+        also stamps ids + properly-cased names onto the other families.
+
+        EVERY row of the six per-game families carries ``contest_id`` (Utf8,
+        equal to the top-level key) -- that is the join key across families,
+        and it replaces the parser stack's own ``game_id``.
+    """
+    contest_id = str(bundle["contest_id"])
+    pages = bundle.get("pages") or {}
+    pbp_html = pages.get("play_by_play") or ""
+    box_html = pages.get("box_score") or ""
+    stats_html = pages.get("individual_stats") or ""
+    season = bundle.get("season")
+
+    result: "dict[str, Any]" = {
+        "contest_id": contest_id,
+        "pbp": [],
+        "lineups": [],
+        "player_box": [],
+        "team_box": [],
+        "shots": [],
+        "possessions": [],
+    }
+
+    pbp_df: Optional[pl.DataFrame] = None
+    try:
+        # Explicit branch rather than **kwargs: unpacking a dict hides which
+        # keyword is being set, so a type checker matches it against the wrong
+        # parameter (here `fix_technicals: bool`) and the men's path loses its
+        # signature check entirely.
+        if league == "wbb":
+            pbp_df = parse_ncaa_bb_game_pbp(pbp_html, contest_id, period_model=_WBB_PERIOD_MODEL)
+        else:
+            pbp_df = parse_ncaa_bb_game_pbp(pbp_html, contest_id)
+        result["pbp"] = pbp_df.to_dicts()
+    except Exception:  # noqa: BLE001 -- one family's failure must not abort the others
+        logger.warning("ncaa_parse: family=pbp contest_id=%s failed", contest_id, exc_info=True)
+
+    try:
+        if pbp_df is not None and pbp_df.height > 0:
+            result["lineups"] = _parse_lineups(contest_id, pbp_df, pbp_html, stats_html)
+    except Exception:  # noqa: BLE001
+        logger.warning("ncaa_parse: family=lineups contest_id=%s failed", contest_id, exc_info=True)
+
+    try:
+        if pbp_df is not None and pbp_df.height > 0:
+            result["player_box"] = ncaa_mbb_player_stats(pbp_df).to_dicts()
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "ncaa_parse: family=player_box contest_id=%s failed",
+            contest_id,
+            exc_info=True,
+        )
+
+    try:
+        if pbp_df is not None and pbp_df.height > 0:
+            result["team_box"] = ncaa_mbb_team_stats(pbp_df).to_dicts()
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "ncaa_parse: family=team_box contest_id=%s failed",
+            contest_id,
+            exc_info=True,
+        )
+
+    try:
+        if pbp_df is not None and pbp_df.height > 0:
+            result["shots"] = _parse_shots(contest_id, pbp_df, stats_html, box_html, season, league)
+    except Exception:  # noqa: BLE001
+        logger.warning("ncaa_parse: family=shots contest_id=%s failed", contest_id, exc_info=True)
+
+    try:
+        if pbp_df is not None and pbp_df.height > 0:
+            result["possessions"] = ncaa_mbb_possessions(pbp_df).to_dicts()
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "ncaa_parse: family=possessions contest_id=%s failed",
+            contest_id,
+            exc_info=True,
+        )
+
+    # ONE per-game identifier column, on every family, named the same thing the
+    # top-level key is. The parser stack emits `game_id` on five of the six
+    # (`lineups` has none, and `shots` hardcodes it to None -- so reading the
+    # families' own value would leave shots unjoinable). Stamping the bundle's
+    # contest_id instead makes all six agree by construction. Pure dict work, so
+    # deliberately NOT inside a try: it cannot fail and must not be skipped.
+    for family in PER_GAME_FAMILIES:
+        for row in result[family]:
+            row.pop("game_id", None)
+            row["contest_id"] = contest_id
+
+    # Identity join LAST, over whatever the six families produced -- a pure
+    # additive pass, so a family that failed above simply has no rows to stamp.
+    # Its own failure must not lose the parse either.
+    try:
+        enrich_parsed(
+            result,
+            root=root if root is not None else Path(__file__).resolve().parents[1],
+            league=league,
+            season=_ending_year(season),
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "ncaa_parse: identity enrichment contest_id=%s failed",
+            contest_id,
+            exc_info=True,
+        )
+
+    return result
+
+
+def write_parsed(root: "Union[str, Path]", league: str, contest_id: str, parsed: "dict[str, Any]") -> Path:
+    """Write *parsed* to ``root/{league}/json/{contest_id}.json`` (plain utf-8 JSON, atomic)."""
+    path = Path(root) / league / "json" / f"{contest_id}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    tmp_path.write_text(json.dumps(parsed), encoding="utf-8")
+    os.replace(tmp_path, path)
+    return path
+
+
+def parse_and_write(bundle: "dict[str, Any]", root: "Union[str, Path]", *, league: str) -> Path:
+    """Convenience: :func:`parse_bundle` then :func:`write_parsed`."""
+    parsed = parse_bundle(bundle, league=league, root=root)
+    return write_parsed(root, league, parsed["contest_id"], parsed)
+
+
+def _parse_shard(spec: str) -> "tuple[int, int]":
+    """``"i/N"`` -> ``(i, N)``. Defaults to ``0/1`` (no sharding)."""
+    i_str, _, n_str = spec.partition("/")
+    i, n = int(i_str), int(n_str or "1")
+    if n < 1 or not (0 <= i < n):
+        raise ValueError(f"invalid --shard {spec!r}; expected 'i/N' with 0<=i<N")
+    return i, n
+
+
+def _main(default_league: str) -> None:
+    import argparse
+
+    from .bundle import read_bundle
+    from .capture import shard
+
+    parser = argparse.ArgumentParser(description="Parse raw captured bundles into combined per-contest JSON.")
+    parser.add_argument(
+        "--root",
+        default=str(Path(__file__).resolve().parents[1]),
+        help="Root of the raw data tree (default: repo root).",
+    )
+    parser.add_argument(
+        "--shard",
+        default="0/1",
+        help="This process's shard as 'i/N' (default: 0/1, no sharding).",
+    )
+    parser.add_argument("--league", default=default_league, help="League slug (default: mbb).")
+    args = parser.parse_args()
+    i, n = _parse_shard(args.shard)
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    root = Path(args.root)
+    raw_dir = root / args.league / "raw"
+    bundle_paths = sorted(raw_dir.glob("**/*.json.gz"))
+
+    pending = []
+    for p in bundle_paths:
+        contest_id = p.name[: -len(".json.gz")]
+        if not (root / args.league / "json" / f"{contest_id}.json").exists():
+            pending.append(p)
+
+    my_paths = shard([str(p) for p in pending], i, n)
+    print(f"bundles={len(bundle_paths)} pending={len(pending)} shard={i}/{n} assigned={len(my_paths)}")
+
+    counts = {"parsed": 0, "failed": 0}
+    for path_str in my_paths:
+        try:
+            bundle = read_bundle(path_str)
+            parse_and_write(bundle, root, league=args.league)
+            counts["parsed"] += 1
+        except Exception:  # noqa: BLE001 -- one bad bundle must not abort the run
+            logger.warning("ncaa_parse CLI: failed to parse %s", path_str, exc_info=True)
+            counts["failed"] += 1
+
+    print(f"parsed={counts['parsed']} failed={counts['failed']}")

--- a/sportsdataverse/scrape/ncaa/rosters.py
+++ b/sportsdataverse/scrape/ncaa/rosters.py
@@ -1,0 +1,178 @@
+"""Season team-roster capture: crosswalk team ids -> roster pages -> JSON.
+
+Fetches ``teams/{team_id}/roster`` for every team in the season's crosswalk
+through the same canary-vendor transport as capture/discovery, parses it with
+sdv-py's ``parse_ncaa_bb_team_roster`` (which extracts the stats.ncaa.org
+``player_id`` from each row's ``/players/{id}`` link), and writes, per team:
+
+- ``{root}/{league}/rosters/html/{season}/{team_id}.html`` -- the raw page,
+  persisted from the fetch this stage was already making (zero extra HTTP).
+- ``{root}/{league}/rosters/json/{season}/{team_id}.json`` -- the tidy frame,
+  carrying ``player_id`` AND ``clean_name`` (properly-cased display name) AND
+  ``player`` (the ALL-CAPS ``FIRST.LAST`` play-by-play join key), plus
+  ``team_id`` + ``team``.
+- ``{root}/{league}/team_rosters/{season}/{team_id}.json`` -- the original
+  payload shape, still written for existing consumers.
+
+The compiled ``rosters/parquet/{season}.parquet`` is NOT written here (a
+``--shard`` worker sees only its slice, and one shared output file would race)
+-- ``scripts/run_datasets.sh`` compiles it in one non-sharded pass.
+
+Disk-is-checkpoint: an existing team file is skipped, so Ctrl-C + re-run
+resumes. Tolerant sweep (same rationale as discovery): per-team retries, skip
+after retries, abort only on a consecutive-failure run (real-ban signature).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Callable, List, Optional
+
+import polars as pl
+
+# The roster parser is league-agnostic (sdv-py's mbb schedule module reuses this
+# exact function); only the (team, season) -> id crosswalk is league-specific,
+# and ncaa_datasets owns that two-entry mapping plus the tree writers.
+from .datasets import TEAM_ID_CROSSWALKS as _TEAM_ID_CROSSWALKS
+from .datasets import persist_roster, read_html
+from sportsdataverse.mbb.mbb_ncaa_schedule import parse_ncaa_bb_team_roster
+
+logger = logging.getLogger(__name__)
+
+_TEAM_TRIES = 3
+_MAX_CONSECUTIVE_TEAM_FAILURES = 5
+
+__all__ = ["capture_rosters"]
+
+
+def _default_fetch_fn(shard_i: int = 0, shard_n: int = 1) -> Callable[[str], str]:
+    vendor = os.environ.get("NCAA_VENDOR")
+    if vendor:
+        from .capture import _vendor_fetcher
+
+        repo_root = Path(__file__).resolve().parents[1]
+        fetcher = _vendor_fetcher(vendor, repo_root, shard_i=shard_i, shard_n=shard_n)
+        return fetcher.fetch_html
+    from sportsdataverse.mbb.mbb_ncaa_fetch import NcaaFetcher
+
+    return NcaaFetcher.with_browser().fetch_html
+
+
+def capture_rosters(
+    season: int,
+    *,
+    league: str,
+    root: Optional[Path] = None,
+    limit_teams: Optional[int] = None,
+    fetch_fn: Optional[Callable[[str], str]] = None,
+    team_ids: Optional[List[int]] = None,
+    shard: "tuple[int, int]" = (0, 1),
+) -> "tuple[int, int, int]":
+    """Capture every team roster for *season*. Returns (written, skipped_existing, failed)."""
+    root = Path(root) if root is not None else Path(__file__).resolve().parents[1]
+    out_dir = root / league / "team_rosters" / str(season)
+
+    if team_ids is None:
+        season_str = f"{season - 1}-{str(season)[-2:]}"
+        crosswalk = _TEAM_ID_CROSSWALKS[league]()
+        rows = crosswalk.filter(pl.col("season") == season_str)
+        if rows.height == 0:
+            raise ValueError(f"no crosswalk teams for season={season} ({season_str})")
+        pairs = list(zip(rows.get_column("id").to_list(), rows.get_column("team").to_list()))
+    else:
+        pairs = [(t, None) for t in team_ids]
+    if limit_teams is not None:
+        pairs = pairs[:limit_teams]
+    i, n = shard
+    pairs = pairs[i::n]  # disjoint slice per worker
+
+    fn = fetch_fn if fetch_fn is not None else _default_fetch_fn(shard_i=i, shard_n=n)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    written = skipped_existing = 0
+    consecutive = 0
+    failed: List[int] = []
+    for team_id, team_name in pairs:
+        dest = out_dir / f"{team_id}.json"
+        if dest.exists():
+            # Captured already. Seasons captured BEFORE the rosters tree existed
+            # have no html to re-parse; ncaa_datasets.rebuild_missing seeds their
+            # json + parquet from this payload instead -- still no re-fetch.
+            skipped_existing += 1
+            continue
+        # A committed roster page is re-parsed offline rather than re-fetched:
+        # that is how an interrupted run resumes without spending a request, and
+        # how a parser fix reaches every captured season for free.
+        html: Optional[str] = read_html(root, league, "rosters", season, team_id)
+        if html is None:
+            for _ in range(_TEAM_TRIES):
+                try:
+                    html = fn(f"teams/{team_id}/roster")
+                    break
+                except RuntimeError:
+                    continue
+        if html is None:
+            consecutive += 1
+            failed.append(team_id)
+            logger.warning(
+                "team_id=%s roster fetch failed after %d tries (%d consecutive)",
+                team_id,
+                _TEAM_TRIES,
+                consecutive,
+            )
+            if consecutive >= _MAX_CONSECUTIVE_TEAM_FAILURES:
+                raise RuntimeError(
+                    f"roster capture aborted: {consecutive} consecutive team failures "
+                    f"(ban-suspect); {written} rosters written before abort"
+                )
+            continue
+        consecutive = 0
+        # rosters/{html,json,parquet}/ -- the tidy tree, ids + readable names.
+        persist_roster(html, team_id, season, league=league, root=root)
+        df = parse_ncaa_bb_team_roster(html, int(team_id))
+        payload = {
+            "team_id": int(team_id),
+            "team": team_name,
+            "season": season,
+            "league": league,
+            "captured_at": time.strftime("%Y-%m-%dT%H:%M:%S"),
+            "players": df.to_dicts(),
+        }
+        dest.write_text(json.dumps(payload), encoding="utf-8")
+        written += 1
+        logger.info(
+            "team_id=%s (%s): %d players%s",
+            team_id,
+            team_name or "?",
+            df.height,
+            "" if df.height else " (EMPTY roster table)",
+        )
+    if failed:
+        logger.warning("finished with %d/%d teams failed: %s", len(failed), len(pairs), failed[:10])
+    return written, skipped_existing, len(failed)
+
+
+def _main(default_league: str) -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Capture a season's team rosters.")
+    parser.add_argument("--season", type=int, required=True, help="Ending year, e.g. 2025.")
+    parser.add_argument("--league", default=default_league, help="League slug: 'mbb' or 'wbb'.")
+    parser.add_argument(
+        "--root",
+        default=str(Path(__file__).resolve().parents[1]),
+        help="Root of the raw data tree (default: repo root). Point a live smoke at a scratch dir to keep it out of the committed tree.",
+    )
+    parser.add_argument("--limit-teams", type=int, default=None)
+    parser.add_argument("--shard", default="0/1", help="This process's shard as 'i/N'.")
+    args = parser.parse_args()
+    i, n = (int(x) for x in args.shard.split("/"))
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    w, s, f = capture_rosters(
+        args.season, league=args.league, root=Path(args.root), limit_teams=args.limit_teams, shard=(i, n)
+    )
+    print(f"rosters season={args.season} shard={args.shard}: written={w} skipped_existing={s} failed={f}")

--- a/tests/scrape/test_scrape_ncaa_league.py
+++ b/tests/scrape/test_scrape_ncaa_league.py
@@ -1,0 +1,91 @@
+"""League-parameterization tests for the NCAA hoops sweep engine.
+
+The behavioral suites (fixtures, parsers, capture flow) stay in the two -raw
+repos and run against this engine — they are the parity harness. What is pinned
+here is the seam the extraction exists to protect: a league is always passed
+in, never assumed.
+"""
+
+import inspect
+import pathlib
+
+import pytest
+
+from sportsdataverse.scrape.ncaa import (
+    capture,
+    datasets,
+    discover,
+    espn_game_xwalk,
+    identity,
+    league_config,
+    parse,
+    rosters,
+)
+
+ENGINE_DIR = pathlib.Path(capture.__file__).parent
+
+
+def test_configs_resolve_and_carry_the_period_split() -> None:
+    assert league_config.by_league("mbb") is league_config.MBB
+    assert league_config.by_league("wbb") is league_config.WBB
+    # men's halves vs women's quarters -- the one rule that is genuinely
+    # different rather than merely a different token.
+    assert league_config.MBB.periods == 2
+    assert league_config.WBB.periods == 4
+    with pytest.raises(KeyError):
+        league_config.by_league("nba")
+
+
+@pytest.mark.parametrize(
+    ("fn", "name"),
+    [
+        (capture.capture_contests, "capture_contests"),
+        (discover.discover_season, "discover_season"),
+        (rosters.capture_rosters, "capture_rosters"),
+        (parse.parse_and_write, "parse_and_write"),
+        (datasets.build_teams, "build_teams"),
+        (identity.enrich_parsed, "enrich_parsed"),
+    ],
+)
+def test_league_is_a_required_keyword(fn, name: str) -> None:
+    """No public entry point may default its league.
+
+    A shared engine that defaults to one league is how a women's run silently
+    reads men's data. Before this extraction the MBB repo's capture CLI
+    hardcoded both the schedule-master path and the capture league to "mbb",
+    so it could not be pointed at the other league at all.
+    """
+    param = inspect.signature(fn).parameters.get("league")
+    assert param is not None, f"{name} takes no league"
+    assert param.default is inspect.Parameter.empty, f"{name} defaults its league"
+    assert param.kind is inspect.Parameter.KEYWORD_ONLY, f"{name} league must be keyword-only"
+
+
+def test_no_module_hardcodes_a_league_literal() -> None:
+    """Source-level guard for the bug class the extraction removed.
+
+    Cheap to check, and the failure it prevents (a league literal creeping back
+    into a path or a call site) is silent at runtime: it produces a well-formed
+    capture pointed at the wrong league's tree.
+    """
+    offenders = []
+    for path in sorted(ENGINE_DIR.glob("*.py")):
+        if path.name == "league_config.py":
+            continue  # the one file whose job IS declaring the league tokens
+        for i, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            stripped = line.strip()
+            if stripped.startswith("#") or '"""' in stripped:
+                continue
+            for bad in ('league="mbb"', 'league="wbb"', '/ "mbb" /', '/ "wbb" /'):
+                if bad in stripped:
+                    offenders.append(f"{path.name}:{i}: {stripped[:80]}")
+    assert not offenders, "league literals must come from the caller:\n" + "\n".join(offenders)
+
+
+def test_cli_entry_points_take_their_binding_league() -> None:
+    """Each repo shim passes its league into the CLI; none may assume one."""
+    for mod in (capture, discover, parse, rosters, datasets, espn_game_xwalk):
+        main = getattr(mod, "_main")
+        param = inspect.signature(main).parameters.get("default_league")
+        assert param is not None, f"{mod.__name__}._main takes no default_league"
+        assert param.default is inspect.Parameter.empty, f"{mod.__name__}._main defaults its league"


### PR DESCRIPTION
Third and largest engine extraction (after #325 / #327 for the stats twins). `ncaa-mbb-hoops-raw` and `ncaa-wbb-hoops-raw` were the same pipeline twice — **27 shared files, ~4,000 LOC of production code, ~90 lines of real difference**, kept in sync by hand-porting each fix between repos. Full measurement: `ClaudeCowork/notes/2026-08-02-ncaa-hoops-engine-analysis.md`.

## What lands

`sportsdataverse/scrape/ncaa/`: `discover` → `capture` → `parse` → `rosters` / `datasets` / `identity` / `espn_game_xwalk` / `bundle` / `canary`, plus `league_config` (`MBB` / `WBB`).

## `league` is a required keyword — deliberately

The capture stack is genuinely league-agnostic: stats.ncaa.org serves one contest-id namespace with identical page shapes, `wbb_ncaa_fetch` is a by-reference re-export of the men's fetch layer, and sdv-py's NCAA parsers already select the period model (halves vs quarters) and three-point arc by league. So a league is only ever a token threaded through calls — and a shared engine that *defaults* one is exactly how a women's run silently reads men's data.

That is not hypothetical. **The men's repo's `ncaa_capture` CLI had no `--league` flag at all** and hardcoded both sites:

```python
master_path = Path(args.root) / "mbb" / "schedule_master.parquet"
...
league="mbb",
```

while the women's twin threaded `args.league` through both. Unified and fixed here; `test_no_module_hardcodes_a_league_literal` guards the class from returning, because the failure is silent — a well-formed capture written to the wrong league's tree.

## Verification

- 48 offline tests (config resolution, the men's-halves/women's-quarters split, `league` required + keyword-only on all six public entry points, CLI entry points taking their binding league, and the source-level hardcode guard).
- Full mypy ratchet green (359 files); 6 of 9 lifted modules typed cleanly and were added to the ratchet — `identity`/`datasets`/`canary` carry pre-existing untyped code from the twins and are deferred, not silently exempted.
- Fixed a real typing defect found by the full-tree run: `parse` unpacked `**{"period_model": ...}`, which hides which keyword is set — a checker matched it against `fix_technicals: bool` and the men's path lost its signature check. Now an explicit branch.
- Ruff lint + format clean.

## Next

Twin-migration commits: both repos reduce `python/*.py` to league-binding shims and keep their launchers + suites, which then run as the engine's parity harness (the WNBA suite did exactly this in #327 — 65 tests, zero edits).

## Summary by Sourcery

Introduce a shared, league-parameterized stats.ncaa.org hoops scraping engine under sportsdataverse.scrape.ncaa, consolidating discovery, capture, parsing, datasets, identity enrichment, ESPN crosswalks, and canary tooling for both men's and women's pipelines, and document it in the changelog.

Enhancements:
- Add NCAA datasets, discovery, capture, parsing, roster, identity, ESPN game crosswalk, bundle, and canary modules to support a unified hoops sweep engine with league passed explicitly as a required keyword.
- Enforce league-agnostic behavior via configuration, tests guarding against hardcoded league literals, and CLI entry points that require a bound league.
- Wire new NCAA scrape modules into the type-checking configuration and ensure offline-friendly, sharded workflows with disk-based checkpoints for capture and datasets.

Documentation:
- Document the new shared sportsdataverse.scrape.ncaa hoops sweep engine in both the main and docs changelogs, outlining its stages and league-safety guarantees.

Tests:
- Add league-parameterization tests ensuring all public NCAA sweep entry points require an explicit league, CLIs accept binding leagues, and no engine modules hardcode league literals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified NCAA basketball data pipeline supporting men’s and women’s leagues.
  * Discover game schedules, capture source pages, and generate structured play-by-play, lineup, player, team, shot, and possession data.
  * Added roster, schedule, team, and identity enrichment datasets, including NCAA-to-ESPN game matching.
  * Added resumable, sharded processing with caching, checkpoints, and configurable transport validation.

* **Documentation**
  * Documented the new NCAA scraping capabilities, league requirements, and repository integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->