### PR TITLE
feat(scrape): make the NCAA parse stage re-runnable (--season, --force)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Unreleased](#unreleased)
+  - [`scrape.ncaa.parse` — the parse stage is now re-runnable (`--season`, `--force`)](#scrapencaaparse--the-parse-stage-is-now-re-runnable---season---force)
   - [New — `sportsdataverse.scrape.ncaa`: shared stats.ncaa.org hoops sweep engine](#new--sportsdataversescrapencaa-shared-statsncaaorg-hoops-sweep-engine)
   - [`sportsdataverse.scrape.stats` — league-parameterized capture layer (Phase 2)](#sportsdataversescrapestats--league-parameterized-capture-layer-phase-2)
   - [Docs — offline full-text search on the documentation site](#docs--offline-full-text-search-on-the-documentation-site)
@@ -222,6 +223,20 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Unreleased
+
+### `scrape.ncaa.parse` — the parse stage is now re-runnable (`--season`, `--force`)
+
+The stage skipped any contest whose JSON already existed, and globbed every
+season. Together that made a reprocess impossible: a parser fix or a later
+identity backfill could never reach already-parsed games. That is not
+hypothetical — the MBB tree carries null `player_id` / `clean_name` /
+`ncaa_team_id` for 2024-2026 because those seasons were parsed before the
+reference backfill taught the pipeline to fill them, and re-running the stage
+was a no-op on exactly those files.
+
+`--season` (repeatable) scopes the sweep; `--force` re-parses existing output.
+Default behavior is unchanged — omit both and the stage still skips existing
+files across every season, so resumability is intact.
 
 ### New — `sportsdataverse.scrape.ncaa`: shared stats.ncaa.org hoops sweep engine
 

--- a/docs/src/pages/CHANGELOG.md
+++ b/docs/src/pages/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Unreleased](#unreleased)
+  - [`scrape.ncaa.parse` — the parse stage is now re-runnable (`--season`, `--force`)](#scrapencaaparse--the-parse-stage-is-now-re-runnable---season---force)
   - [New — `sportsdataverse.scrape.ncaa`: shared stats.ncaa.org hoops sweep engine](#new--sportsdataversescrapencaa-shared-statsncaaorg-hoops-sweep-engine)
   - [`sportsdataverse.scrape.stats` — league-parameterized capture layer (Phase 2)](#sportsdataversescrapestats--league-parameterized-capture-layer-phase-2)
   - [Docs — offline full-text search on the documentation site](#docs--offline-full-text-search-on-the-documentation-site)
@@ -222,6 +223,20 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Unreleased
+
+### `scrape.ncaa.parse` — the parse stage is now re-runnable (`--season`, `--force`)
+
+The stage skipped any contest whose JSON already existed, and globbed every
+season. Together that made a reprocess impossible: a parser fix or a later
+identity backfill could never reach already-parsed games. That is not
+hypothetical — the MBB tree carries null `player_id` / `clean_name` /
+`ncaa_team_id` for 2024-2026 because those seasons were parsed before the
+reference backfill taught the pipeline to fill them, and re-running the stage
+was a no-op on exactly those files.
+
+`--season` (repeatable) scopes the sweep; `--force` re-parses existing output.
+Default behavior is unchanged — omit both and the stage still skips existing
+files across every season, so resumability is intact.
 
 ### New — `sportsdataverse.scrape.ncaa`: shared stats.ncaa.org hoops sweep engine
 

--- a/sportsdataverse/scrape/ncaa/parse.py
+++ b/sportsdataverse/scrape/ncaa/parse.py
@@ -352,6 +352,23 @@ def _main(default_league: str) -> None:
         help="This process's shard as 'i/N' (default: 0/1, no sharding).",
     )
     parser.add_argument("--league", default=default_league, help="League slug (default: mbb).")
+    parser.add_argument(
+        "--season",
+        action="append",
+        default=None,
+        help=(
+            "Restrict to a season directory (repeatable, e.g. --season 2025 --season 2026). "
+            "Default: every season under the raw tree."
+        ),
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Re-parse contests whose JSON already exists. Without this the stage skips them, "
+            "so a parser or enrichment improvement can never reach already-parsed games."
+        ),
+    )
     args = parser.parse_args()
     i, n = _parse_shard(args.shard)
 
@@ -359,16 +376,27 @@ def _main(default_league: str) -> None:
 
     root = Path(args.root)
     raw_dir = root / args.league / "raw"
-    bundle_paths = sorted(raw_dir.glob("**/*.json.gz"))
+    if args.season:
+        wanted = {str(s) for s in args.season}
+        bundle_paths = sorted(p for p in raw_dir.glob("**/*.json.gz") if p.parent.name in wanted)
+    else:
+        bundle_paths = sorted(raw_dir.glob("**/*.json.gz"))
 
     pending = []
     for p in bundle_paths:
         contest_id = p.name[: -len(".json.gz")]
-        if not (root / args.league / "json" / f"{contest_id}.json").exists():
+        # --force makes the stage genuinely re-runnable: identity enrichment and
+        # parser fixes land AFTER a season is parsed, and skip-if-exists means
+        # those games keep their stale output forever otherwise.
+        if args.force or not (root / args.league / "json" / f"{contest_id}.json").exists():
             pending.append(p)
 
     my_paths = shard([str(p) for p in pending], i, n)
-    print(f"bundles={len(bundle_paths)} pending={len(pending)} shard={i}/{n} assigned={len(my_paths)}")
+    scope = ",".join(sorted(args.season)) if args.season else "all"
+    print(
+        f"seasons={scope} bundles={len(bundle_paths)} pending={len(pending)} "
+        f"force={args.force} shard={i}/{n} assigned={len(my_paths)}"
+    )
 
     counts = {"parsed": 0, "failed": 0}
     for path_str in my_paths:

--- a/tests/scrape/test_scrape_ncaa_league.py
+++ b/tests/scrape/test_scrape_ncaa_league.py
@@ -89,3 +89,31 @@ def test_cli_entry_points_take_their_binding_league() -> None:
         param = inspect.signature(main).parameters.get("default_league")
         assert param is not None, f"{mod.__name__}._main takes no default_league"
         assert param.default is inspect.Parameter.empty, f"{mod.__name__}._main defaults its league"
+
+
+def test_parse_stage_can_target_a_season_and_reprocess() -> None:
+    """The parse stage must be re-runnable, not just resumable.
+
+    Skip-if-exists alone means a parser fix or a later identity backfill can
+    never reach already-parsed games — which is exactly how the MBB tree ended
+    up with null player_ids/clean_names for 2024-2026 while the pipeline had
+    long since learned to fill them.
+    """
+    import argparse
+    from unittest import mock
+
+    captured: dict = {}
+
+    def fake_parse_args(self, *a, **k):
+        captured["opts"] = {act.dest: act for act in self._actions}
+        raise SystemExit(0)
+
+    with mock.patch.object(argparse.ArgumentParser, "parse_args", fake_parse_args):
+        with pytest.raises(SystemExit):
+            parse._main("mbb")
+
+    opts = captured["opts"]
+    assert "season" in opts, "parse stage cannot target a season"
+    assert opts["season"].__class__.__name__ == "_AppendAction", "--season must be repeatable"
+    assert "force" in opts, "parse stage cannot reprocess existing output"
+    assert opts["force"].const is True, "--force must be a flag"


### PR DESCRIPTION
The parse stage skipped any contest whose JSON already existed and globbed every season. Together those made a **reprocess impossible** — a parser fix or a later identity backfill could never reach already-parsed games.

Not hypothetical: verifying #328 against the real committed corpus showed the MBB tree carries null `player_id` / `clean_name` / `ncaa_team_id` / `espn_game_id` and a null `teams` family for **2024-2026** (~18,800 bundles), because those seasons were parsed *before* the 2026-08-01 reference backfill taught the pipeline to fill them. Re-running the stage was a no-op on exactly those files. `ncaa-mbb-hoops-data`'s `derived.py` consumes three of those null fields, so the staleness propagates downstream.

## Change

- `--season` (repeatable) scopes the sweep to specific season directories.
- `--force` re-parses contests whose output already exists.
- Default behavior is **unchanged**: omit both and the stage still skips existing files across every season, so resumability is intact.
- The progress line now reports the season scope and force state.

## Verification

49 offline tests green (new case asserts the stage exposes a repeatable `--season` and a `--force` flag — i.e. that it is re-runnable, not merely resumable); full mypy ratchet green (359 files); ruff lint + format clean.

## Summary by Sourcery

Make the NCAA parse stage re-runnable by allowing targeted season sweeps and optional reprocessing of existing outputs.

New Features:
- Add a repeatable --season CLI option to restrict parsing to specific season directories.
- Add a --force CLI flag to re-parse contests even when their JSON output already exists.

Enhancements:
- Update parse-stage progress logging to include season scope and force status.
- Document the new parse-stage rerun behavior and flags in the changelog and docs changelog.

Tests:
- Add a CLI-level test ensuring the parse stage exposes a repeatable --season option and a boolean --force flag for reruns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added repeatable `--season` filters to target specific seasons.
  * Added a `--force` option to reprocess existing outputs.
  * Preserved the default behavior of skipping files that have already been processed.
  * Updated status reporting to display the selected seasons and force mode.

* **Documentation**
  * Added changelog documentation for the new parsing options and rerunnable workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->