### PR TITLE
fix(scrape): NCAA stage CLIs must take the repo root from the caller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Unreleased](#unreleased)
+  - [Fix — `scrape.ncaa` CLIs pointed at the wrong repo root (silent no-op)](#fix--scrapencaa-clis-pointed-at-the-wrong-repo-root-silent-no-op)
   - [`scrape.ncaa.parse` — the parse stage is now re-runnable (`--season`, `--force`)](#scrapencaaparse--the-parse-stage-is-now-re-runnable---season---force)
   - [New — `sportsdataverse.scrape.ncaa`: shared stats.ncaa.org hoops sweep engine](#new--sportsdataversescrapencaa-shared-statsncaaorg-hoops-sweep-engine)
   - [`sportsdataverse.scrape.stats` — league-parameterized capture layer (Phase 2)](#sportsdataversescrapestats--league-parameterized-capture-layer-phase-2)
@@ -223,6 +224,22 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Unreleased
+
+### Fix — `scrape.ncaa` CLIs pointed at the wrong repo root (silent no-op)
+
+The lifted modules defaulted `--root` to `Path(__file__).resolve().parents[1]`.
+That meant "the -raw repo root" while they lived in `<repo>/python/`, and
+silently meant `sportsdataverse/scrape/` once they moved into sdv-py — so
+every stage CLI in both NCAA repos scanned an empty tree and **reported
+success having done nothing** (`bundles=0`, `EXIT=0`). No launcher passes
+`--root`, so all of them were affected.
+
+The engine cannot infer a caller's repo root, so it no longer tries: `_main`
+takes `default_root` from the shim (each repo's own `REPO_ROOT`), and the
+library-level fallbacks raise a message naming the fix instead of inventing a
+path. The parse stage now also exits non-zero when a run matches no bundles —
+the silent-success that let this hide in the first place.
+
 
 ### `scrape.ncaa.parse` — the parse stage is now re-runnable (`--season`, `--force`)
 

--- a/docs/src/pages/CHANGELOG.md
+++ b/docs/src/pages/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Unreleased](#unreleased)
+  - [Fix — `scrape.ncaa` CLIs pointed at the wrong repo root (silent no-op)](#fix--scrapencaa-clis-pointed-at-the-wrong-repo-root-silent-no-op)
   - [`scrape.ncaa.parse` — the parse stage is now re-runnable (`--season`, `--force`)](#scrapencaaparse--the-parse-stage-is-now-re-runnable---season---force)
   - [New — `sportsdataverse.scrape.ncaa`: shared stats.ncaa.org hoops sweep engine](#new--sportsdataversescrapencaa-shared-statsncaaorg-hoops-sweep-engine)
   - [`sportsdataverse.scrape.stats` — league-parameterized capture layer (Phase 2)](#sportsdataversescrapestats--league-parameterized-capture-layer-phase-2)
@@ -223,6 +224,22 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Unreleased
+
+### Fix — `scrape.ncaa` CLIs pointed at the wrong repo root (silent no-op)
+
+The lifted modules defaulted `--root` to `Path(__file__).resolve().parents[1]`.
+That meant "the -raw repo root" while they lived in `<repo>/python/`, and
+silently meant `sportsdataverse/scrape/` once they moved into sdv-py — so
+every stage CLI in both NCAA repos scanned an empty tree and **reported
+success having done nothing** (`bundles=0`, `EXIT=0`). No launcher passes
+`--root`, so all of them were affected.
+
+The engine cannot infer a caller's repo root, so it no longer tries: `_main`
+takes `default_root` from the shim (each repo's own `REPO_ROOT`), and the
+library-level fallbacks raise a message naming the fix instead of inventing a
+path. The parse stage now also exits non-zero when a run matches no bundles —
+the silent-success that let this hide in the first place.
+
 
 ### `scrape.ncaa.parse` — the parse stage is now re-runnable (`--season`, `--force`)
 

--- a/sportsdataverse/scrape/ncaa/capture.py
+++ b/sportsdataverse/scrape/ncaa/capture.py
@@ -306,7 +306,7 @@ def _select_pending(master_path: Union[str, Path], season: int) -> "List[str]":
     )
 
 
-def _main(default_league: str) -> None:
+def _main(default_league: str, default_root: str) -> None:
     import argparse
 
     parser = argparse.ArgumentParser(description="Capture the 3-page bundle for a season's not-yet-captured contests.")
@@ -319,7 +319,7 @@ def _main(default_league: str) -> None:
     )
     parser.add_argument(
         "--root",
-        default=str(Path(__file__).resolve().parents[1]),
+        default=default_root,
         help="Root of the raw data tree (default: repo root).",
     )
     parser.add_argument(

--- a/sportsdataverse/scrape/ncaa/datasets.py
+++ b/sportsdataverse/scrape/ncaa/datasets.py
@@ -665,7 +665,7 @@ def build_teams(season: int, *, league: str, root: Union[str, Path], overwrite: 
     return df
 
 
-def _main(default_league: str) -> None:
+def _main(default_league: str, default_root: str) -> None:
     parser = argparse.ArgumentParser(
         description="Build the committed schedules/teams/rosters trees (offline; no network)."
     )
@@ -673,7 +673,7 @@ def _main(default_league: str) -> None:
     parser.add_argument(
         "--league", default=default_league, help=f"League slug: 'mbb' or 'wbb' (default: {default_league})."
     )
-    parser.add_argument("--root", default=str(Path(__file__).resolve().parents[1]), help="Root of the raw data tree.")
+    parser.add_argument("--root", default=default_root, help="Root of the raw data tree.")
     parser.add_argument(
         "--what",
         default="all",

--- a/sportsdataverse/scrape/ncaa/discover.py
+++ b/sportsdataverse/scrape/ncaa/discover.py
@@ -50,7 +50,7 @@ def _season_str(season: int) -> str:
     return f"{season - 1}-{str(season)[-2:]}"
 
 
-def _default_fetch_fn(shard_i: int = 0, shard_n: int = 1) -> FetchFn:
+def _default_fetch_fn(root: "Optional[Union[str, Path]]", shard_i: int = 0, shard_n: int = 1) -> FetchFn:
     """Live fetch: one shared browser-transport session, ``teams/{id}``.
 
     ``NCAA_VENDOR`` (e.g. ``decodo_patchright``) routes discovery through a
@@ -64,7 +64,13 @@ def _default_fetch_fn(shard_i: int = 0, shard_n: int = 1) -> FetchFn:
     if vendor:
         from .capture import _vendor_fetcher
 
-        repo_root = Path(__file__).resolve().parents[1]
+        if root is None:
+            raise ValueError(
+                "root is required when NCAA_VENDOR is set: the vendor transport writes "
+                "session state under the -raw repo, and the engine cannot infer that "
+                "repo's location. Pass root=... (the shim's REPO_ROOT)."
+            )
+        repo_root = Path(root)
         fetcher = _vendor_fetcher(vendor, repo_root, shard_i=shard_i, shard_n=shard_n)
         return lambda team_id: fetcher.fetch_html(f"teams/{team_id}")
     from sportsdataverse.mbb.mbb_ncaa_fetch import NcaaFetcher
@@ -201,7 +207,7 @@ def discover_season(
         # schedule_master -- which is why shard runs pass write_master=False.
         ids = ids[shard_i::shard_n]
 
-    fn = fetch_fn if fetch_fn is not None else _default_fetch_fn(shard_i=shard_i, shard_n=shard_n)
+    fn = fetch_fn if fetch_fn is not None else _default_fetch_fn(root, shard_i=shard_i, shard_n=shard_n)
 
     # Per-team tolerance + a consecutive-failure ban detector. bm-verify
     # clearing is flaky per navigation (~5% per page on the canary-validated
@@ -326,7 +332,7 @@ def _write_master(result: pl.DataFrame, root: Union[str, Path], league: str) -> 
     return path
 
 
-def _main(default_league: str) -> None:
+def _main(default_league: str, default_root: str) -> None:
     import argparse
 
     parser = argparse.ArgumentParser(description="Discover a season's contest_ids and write schedule_master.parquet.")
@@ -338,7 +344,7 @@ def _main(default_league: str) -> None:
     )
     parser.add_argument(
         "--root",
-        default=str(Path(__file__).resolve().parents[1]),
+        default=default_root,
         help="Root of the raw data tree (default: repo root).",
     )
     parser.add_argument("--league", default=default_league, help="League slug: 'mbb' or 'wbb' (default: mbb).")

--- a/sportsdataverse/scrape/ncaa/espn_game_xwalk.py
+++ b/sportsdataverse/scrape/ncaa/espn_game_xwalk.py
@@ -329,7 +329,7 @@ def summarize(frame: pl.DataFrame) -> Dict[str, int]:
     return counts
 
 
-def _main(default_league: str) -> None:
+def _main(default_league: str, default_root: str) -> None:
     import argparse
 
     parser = argparse.ArgumentParser(
@@ -337,7 +337,7 @@ def _main(default_league: str) -> None:
     )
     parser.add_argument(
         "--root",
-        default=str(Path(__file__).resolve().parents[1]),
+        default=default_root,
         help="Root of the raw data tree (default: repo root).",
     )
     parser.add_argument("--league", default=default_league, help=f"League slug (default: {default_league}).")

--- a/sportsdataverse/scrape/ncaa/parse.py
+++ b/sportsdataverse/scrape/ncaa/parse.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import json
 import logging
+import sys
 import os
 import re
 from dataclasses import fields as dc_fields
@@ -295,7 +296,7 @@ def parse_bundle(
     try:
         enrich_parsed(
             result,
-            root=root if root is not None else Path(__file__).resolve().parents[1],
+            root=root,
             league=league,
             season=_ending_year(season),
         )
@@ -334,7 +335,7 @@ def _parse_shard(spec: str) -> "tuple[int, int]":
     return i, n
 
 
-def _main(default_league: str) -> None:
+def _main(default_league: str, default_root: str) -> None:
     import argparse
 
     from .bundle import read_bundle
@@ -343,7 +344,7 @@ def _main(default_league: str) -> None:
     parser = argparse.ArgumentParser(description="Parse raw captured bundles into combined per-contest JSON.")
     parser.add_argument(
         "--root",
-        default=str(Path(__file__).resolve().parents[1]),
+        default=default_root,
         help="Root of the raw data tree (default: repo root).",
     )
     parser.add_argument(
@@ -390,6 +391,15 @@ def _main(default_league: str) -> None:
         # those games keep their stale output forever otherwise.
         if args.force or not (root / args.league / "json" / f"{contest_id}.json").exists():
             pending.append(p)
+
+    if not bundle_paths:
+        scope_msg = ",".join(sorted(args.season)) if args.season else "all seasons"
+        print(
+            f"ERROR: no bundles under {raw_dir} for {scope_msg} -- nothing to parse. "
+            "Check --root (it must be the -raw repo root) and --season.",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
 
     my_paths = shard([str(p) for p in pending], i, n)
     scope = ",".join(sorted(args.season)) if args.season else "all"

--- a/sportsdataverse/scrape/ncaa/rosters.py
+++ b/sportsdataverse/scrape/ncaa/rosters.py
@@ -30,7 +30,7 @@ import logging
 import os
 import time
 from pathlib import Path
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Union
 
 import polars as pl
 
@@ -49,12 +49,12 @@ _MAX_CONSECUTIVE_TEAM_FAILURES = 5
 __all__ = ["capture_rosters"]
 
 
-def _default_fetch_fn(shard_i: int = 0, shard_n: int = 1) -> Callable[[str], str]:
+def _default_fetch_fn(root: "Union[str, Path]", shard_i: int = 0, shard_n: int = 1) -> Callable[[str], str]:
     vendor = os.environ.get("NCAA_VENDOR")
     if vendor:
         from .capture import _vendor_fetcher
 
-        repo_root = Path(__file__).resolve().parents[1]
+        repo_root = Path(root)
         fetcher = _vendor_fetcher(vendor, repo_root, shard_i=shard_i, shard_n=shard_n)
         return fetcher.fetch_html
     from sportsdataverse.mbb.mbb_ncaa_fetch import NcaaFetcher
@@ -73,7 +73,12 @@ def capture_rosters(
     shard: "tuple[int, int]" = (0, 1),
 ) -> "tuple[int, int, int]":
     """Capture every team roster for *season*. Returns (written, skipped_existing, failed)."""
-    root = Path(root) if root is not None else Path(__file__).resolve().parents[1]
+    if root is None:
+        raise ValueError(
+            "root is required: the engine cannot infer a -raw repo's location. "
+            "Pass root=... (the repo shim's `Path(__file__).resolve().parents[1]`)."
+        )
+    root = Path(root)
     out_dir = root / league / "team_rosters" / str(season)
 
     if team_ids is None:
@@ -90,7 +95,7 @@ def capture_rosters(
     i, n = shard
     pairs = pairs[i::n]  # disjoint slice per worker
 
-    fn = fetch_fn if fetch_fn is not None else _default_fetch_fn(shard_i=i, shard_n=n)
+    fn = fetch_fn if fetch_fn is not None else _default_fetch_fn(root, shard_i=i, shard_n=n)
     out_dir.mkdir(parents=True, exist_ok=True)
 
     written = skipped_existing = 0
@@ -156,7 +161,7 @@ def capture_rosters(
     return written, skipped_existing, len(failed)
 
 
-def _main(default_league: str) -> None:
+def _main(default_league: str, default_root: str) -> None:
     import argparse
 
     parser = argparse.ArgumentParser(description="Capture a season's team rosters.")
@@ -164,7 +169,7 @@ def _main(default_league: str) -> None:
     parser.add_argument("--league", default=default_league, help="League slug: 'mbb' or 'wbb'.")
     parser.add_argument(
         "--root",
-        default=str(Path(__file__).resolve().parents[1]),
+        default=default_root,
         help="Root of the raw data tree (default: repo root). Point a live smoke at a scratch dir to keep it out of the committed tree.",
     )
     parser.add_argument("--limit-teams", type=int, default=None)

--- a/tests/scrape/test_scrape_ncaa_league.py
+++ b/tests/scrape/test_scrape_ncaa_league.py
@@ -110,10 +110,34 @@ def test_parse_stage_can_target_a_season_and_reprocess() -> None:
 
     with mock.patch.object(argparse.ArgumentParser, "parse_args", fake_parse_args):
         with pytest.raises(SystemExit):
-            parse._main("mbb")
+            parse._main("mbb", "/tmp/root-not-used-by-this-test")
 
     opts = captured["opts"]
     assert "season" in opts, "parse stage cannot target a season"
     assert opts["season"].__class__.__name__ == "_AppendAction", "--season must be repeatable"
     assert "force" in opts, "parse stage cannot reprocess existing output"
     assert opts["force"].const is True, "--force must be a flag"
+
+
+def test_no_module_infers_a_repo_root_from_its_own_location() -> None:
+    """The engine lives in sdv-py; a -raw repo's root is NOT derivable from it.
+
+    The lifted modules originally defaulted `--root` to
+    ``Path(__file__).resolve().parents[1]`` -- correct when they lived in
+    ``<repo>/python/``, and silently wrong once they moved here: every stage
+    CLI pointed at ``sportsdataverse/scrape/`` and reported success having
+    done nothing (`bundles=0`, `EXIT=0`). The caller supplies the root.
+    """
+    offenders = []
+    for path in sorted(ENGINE_DIR.glob("*.py")):
+        for i, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if "parents[1]" in line and not line.lstrip().startswith(("#", '"')):
+                offenders.append(f"{path.name}:{i}: {line.strip()[:80]}")
+    assert not offenders, "root must come from the caller:\n" + "\n".join(offenders)
+
+
+def test_cli_entry_points_require_a_root() -> None:
+    for mod in (capture, discover, parse, rosters, datasets, espn_game_xwalk):
+        param = inspect.signature(mod._main).parameters.get("default_root")
+        assert param is not None, f"{mod.__name__}._main takes no default_root"
+        assert param.default is inspect.Parameter.empty, f"{mod.__name__}._main defaults its root"


### PR DESCRIPTION
Regression from #328, caught by actually running the pipeline rather than the tests.

Every lifted module defaulted `--root` to `Path(__file__).resolve().parents[1]`. That resolved to the `-raw` repo root while the modules lived in `<repo>/python/`; after the extraction it resolves to `sportsdataverse/scrape/`. **No launcher passes `--root`**, so every stage CLI in both NCAA repos was pointed at an empty tree — and reported success:

```
seasons=2026 bundles=0 pending=0 force=True shard=9/12 assigned=0
parsed=0 failed=0
EXIT=0
```

6,297 bundles exist for that season. The suites never caught it because tests pass roots explicitly; only the CLI path was broken.

## Change

- `_main(default_league, default_root)` — the shim supplies its own `REPO_ROOT`; the engine never infers one.
- Library fallbacks that guessed a root now raise a message naming the fix.
- `_default_fetch_fn` takes the root explicitly (it needed one for vendor session state) and raises clearly when `NCAA_VENDOR` is set without a root, instead of `Path(None)`.
- **The parse stage exits non-zero when a run matches no bundles** — the silent success is what let this hide.
- Both repos' 18 shims updated to pass `REPO_ROOT`.

## Verification

51 offline tests (two new: no engine module may derive a root from `__file__`; every `_main` requires `default_root`); full mypy ratchet green (359 files) — it also caught a real `Optional` leak into the vendor path; ruff clean.

## Summary by Sourcery

Ensure NCAA scrape CLI stages receive the raw repo root from their callers instead of inferring it, preventing silent no-op runs against an empty tree.

Bug Fixes:
- Fix NCAA scrape CLI defaults so `--root` comes from the caller’s repo shim rather than the engine module location, avoiding scans of the wrong directory.
- Make the parse stage exit with a non-zero status when no bundles are found under the specified root and season scope, instead of reporting successful completion.
- Require an explicit root when NCAA vendor transport is enabled so session state is written to the correct raw repo path.

Enhancements:
- Tighten CLI entry-point contracts by requiring a non-defaulted `default_root` parameter for NCAA scrape stage `_main` functions and removing internal root inference.
- Add tests to enforce that engine modules never derive a repo root from `__file__` and that CLI `_main` functions require a caller-provided default root.

Documentation:
- Document the NCAA scrape CLI root-handling fix and non-zero exit on empty parses in the changelog and its user-facing docs mirror.