### PR TITLE
refactor(scrape): type the deferred NCAA engine modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -658,4 +658,7 @@ files = [
     "sportsdataverse/scrape/ncaa/discover.py",
     "sportsdataverse/scrape/ncaa/capture.py",
     "sportsdataverse/scrape/ncaa/parse.py",
+    "sportsdataverse/scrape/ncaa/identity.py",
+    "sportsdataverse/scrape/ncaa/datasets.py",
+    "sportsdataverse/scrape/ncaa/canary.py",
 ]

--- a/sportsdataverse/scrape/ncaa/canary.py
+++ b/sportsdataverse/scrape/ncaa/canary.py
@@ -380,10 +380,10 @@ def build_fetcher(vendor: dict, cache_dir: Path) -> NcaaFetcher:
         # fails a game in ~20s instead of ~40s; a real IP resolves well under it.
         return NcaaFetcher.with_browser(cfg, proxy_pool=list(vendor["proxies"]), nav_timeout_ms=20000)
     if vtype == "proxy_patchright":
-        cfg = NcaaFetchConfig(cache_dir=cache_dir, transport=_PatchrightTransport())  # type: ignore[arg-type]
+        cfg = NcaaFetchConfig(cache_dir=cache_dir, transport=_PatchrightTransport())
         return NcaaFetcher(cfg, proxy_pool=list(vendor["proxies"]))
     if vtype == "managed_cdp":
-        cfg = NcaaFetchConfig(cache_dir=cache_dir, transport=_ManagedCdpTransport(vendor["cdp_url"]))  # type: ignore[arg-type]
+        cfg = NcaaFetchConfig(cache_dir=cache_dir, transport=_ManagedCdpTransport(vendor["cdp_url"]))
         return NcaaFetcher(cfg, proxy_pool=None)
     if vtype == "unblocker_zyte":
         transport = _make_zyte_transport(vendor["api_key"], vendor.get("render", "browserHtml"))
@@ -391,7 +391,7 @@ def build_fetcher(vendor: dict, cache_dir: Path) -> NcaaFetcher:
         transport = _make_unblocker_proxy_transport(vendor["proxy"])
     else:  # pragma: no cover - guarded by _vendor_ready
         raise ValueError(f"unknown vendor type {vtype!r}")
-    cfg = NcaaFetchConfig(cache_dir=cache_dir, transport=transport)  # type: ignore[arg-type]
+    cfg = NcaaFetchConfig(cache_dir=cache_dir, transport=transport)
     return NcaaFetcher(cfg, proxy_pool=None)
 
 

--- a/sportsdataverse/scrape/ncaa/datasets.py
+++ b/sportsdataverse/scrape/ncaa/datasets.py
@@ -312,7 +312,7 @@ def _conform(df: pl.DataFrame, columns: List[str], types: Dict[str, pl.DataType]
     have = set(df.columns)
     return df.select(
         [pl.col(c) if c in have else pl.lit(None, dtype=types.get(c, pl.Utf8)).alias(c) for c in columns]
-    ).cast(types)  # type: ignore[arg-type]
+    ).cast(types)
 
 
 def _enrich_schedule(df: pl.DataFrame, team_id: Union[int, str], season: int, league: str) -> pl.DataFrame:

--- a/sportsdataverse/scrape/ncaa/identity.py
+++ b/sportsdataverse/scrape/ncaa/identity.py
@@ -331,13 +331,17 @@ def _stamp_player(
         stats["player_hit" if hit else "player_miss"] += 1
 
 
-def _espn_game_id_for(root: Union[str, Path], league: str, season: Optional[int], contest_id: Any) -> Optional[str]:
+def _espn_game_id_for(
+    root: Optional[Union[str, Path]], league: str, season: Optional[int], contest_id: Any
+) -> Optional[str]:
     """This contest's ESPN event id from the offline crosswalk, or ``None``.
 
     Absence of a crosswalk is never an exception: an unbuilt season, an
     unmatched contest and an unreadable file all yield ``None``.
     """
-    if season is None or not contest_id:
+    # Explicit: a None root reached str() as the literal "None", which only
+    # happened to work because that path never exists.
+    if root is None or season is None or not contest_id:
         return None
     from .espn_game_xwalk import load_espn_game_index
 
@@ -357,7 +361,7 @@ def _team_name(value: Any) -> Optional[str]:
 def enrich_parsed(
     parsed: Dict[str, Any],
     *,
-    root: Union[str, Path],
+    root: Optional[Union[str, Path]],
     league: str,
     season: Optional[int] = None,
 ) -> Dict[str, Any]:
@@ -435,34 +439,36 @@ def enrich_parsed(
 
     for row in parsed.get("shots") or []:
         code = row.get("shooter_id")
-        hit = codes.get(code) if code else None
-        row[_SHOTS_PLAYER_KEYS[0]] = hit[0] if hit else None
-        row[_SHOTS_PLAYER_KEYS[1]] = hit[1] if hit else None
+        player_hit = codes.get(code) if code else None
+        row[_SHOTS_PLAYER_KEYS[0]] = player_hit[0] if player_hit else None
+        row[_SHOTS_PLAYER_KEYS[1]] = player_hit[1] if player_hit else None
         if code:
             stats["player_total"] += 1
-            stats["player_hit" if hit else "player_miss"] += 1
+            stats["player_hit" if player_hit else "player_miss"] += 1
 
     for lineup in parsed.get("lineups") or []:
         for side in LINEUP_TEAM_COLUMNS:
-            hit = teams.get(_team_name(lineup.get(side)))
+            side_name = _team_name(lineup.get(side))
+            team_hit = teams.get(side_name) if side_name else None
             for key in _TEAM_ID_KEYS:
-                lineup[f"{side}_{key}"] = hit[key] if hit else None
+                lineup[f"{side}_{key}"] = team_hit[key] if team_hit else None
             if _team_name(lineup.get(side)):
                 stats["team_total"] += 1
-                stats["team_hit" if hit else "team_miss"] += 1
+                stats["team_hit" if team_hit else "team_miss"] += 1
         for slot in ("players", "players_in", "players_out"):
             for player in lineup.get(slot) or []:
                 if not isinstance(player, dict):
                     continue
                 # `code` first (exact, team-scoped); the display name is the
                 # fallback for a player the roster spells differently.
-                hit = codes.get(player.get("code"))
-                if hit is None:
+                code = player.get("code")
+                player_hit = codes.get(code) if code else None
+                if player_hit is None:
                     display = (player.get("id") or {}).get("name") if isinstance(player.get("id"), dict) else None
-                    hit = names.get(_key_name(display)) if display else None
-                player["ncaa_id"] = hit[0] if hit else None
+                    player_hit = names.get(_key_name(display)) if display else None
+                player["ncaa_id"] = player_hit[0] if player_hit else None
                 stats["player_total"] += 1
-                stats["player_hit" if hit else "player_miss"] += 1
+                stats["player_hit" if player_hit else "player_miss"] += 1
 
     # The game-level ESPN event id, on every row of every family beside its
     # contest_id. A season with no crosswalk built (or a contest ESPN has no


### PR DESCRIPTION
Closes the ratchet gap left open in #328, where `identity` / `datasets` / `canary` were added to `sportsdataverse.scrape.ncaa` but held off the mypy gate as pre-existing untyped code. All three now type cleanly and are on the ratchet (362 files green).

## What the types surfaced

- **`identity`: one name, two shapes.** `hit` held both `teams.get(...)` (a dict indexed by key) and `codes/names.get(...)` (a tuple indexed by position) in a single scope — correct at runtime, untypeable as written. Split into `team_hit` / `player_hit`, and guarded the two lookups that could pass a `None` key.
- **`identity`: `root` is genuinely optional.** `enrich_parsed` and `_espn_game_id_for` now say so. With no root the ids stamp null and the families are still emitted — which is the documented schema-stability contract. A `None` root previously reached `str()` as the literal `"None"` and only worked because that path never exists; it is now an explicit guard.
- **`datasets` / `canary`:** removed 4 `type: ignore` comments mypy rejects as unused.

## A behavioral trap this caught

My first attempt "cleaned up" the `Optional` by skipping enrichment when no root was given. That looked tidier and **broke the schema contract** — the `teams` family disappeared and 3 tests in each twin failed. Enrichment must always run so the output shape never varies game-to-game (the code comment says exactly that). Reverted; the fix is the type, not the behavior.

## Verification

- Twin suites green: **93/93** (ncaa-mbb-hoops-raw), **100/100** (ncaa-wbb-hoops-raw).
- Real-data parity: re-parsing **24 contests across 2024-2026** reproduces the committed JSON **byte-for-byte** (those files were written hours earlier by the pre-change engine, so they are a clean oracle).
- Full mypy ratchet green (362 files); ruff lint + format clean; 51 offline scrape tests green.

## Summary by Sourcery

Type and ratchet remaining NCAA scrape engine modules while preserving existing behavior and schema contracts.

Enhancements:
- Clarify identity enrichment logic by separating player and team lookup paths and explicitly treating the root path as optional.
- Improve typing in NCAA datasets and canary modules to align with mypy expectations without changing runtime behavior.

Build:
- Add ncaa identity, datasets, and canary modules to the mypy ratchet file list and remove now-unnecessary type ignore annotations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NCAA data enrichment when repository or season information is unavailable.
  * Preserved reliable player and team matching, including fallback handling when identifiers are missing.
  * Maintained consistent support for multiple data-fetching configurations.

* **Maintenance**
  * Improved type-checking coverage across NCAA scraping components without changing expected runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->