### PR TITLE
feat(scrape): shared ESPN -raw archive engine (sportsdataverse.scrape.espn)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
+- [Unreleased](#unreleased)
+  - [New — `sportsdataverse.scrape.espn`: shared ESPN `-raw` archive engine](#new--sportsdataversescrapeespn-shared-espn--raw-archive-engine)
 - [0.0.75 Release: August 2, 2026](#0075-release-august-2-2026)
   - [Fix — `scrape.ncaa` CLIs pointed at the wrong repo root (silent no-op)](#fix--scrapencaa-clis-pointed-at-the-wrong-repo-root-silent-no-op)
   - [`scrape.ncaa.parse` — the parse stage is now re-runnable (`--season`, `--force`)](#scrapencaaparse--the-parse-stage-is-now-re-runnable---season---force)
@@ -224,6 +226,46 @@
 - [0.0.5 Release: October 20, 2021](#005-release-october-20-2021)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Unreleased
+
+### New — `sportsdataverse.scrape.espn`: shared ESPN `-raw` archive engine
+
+The fourth and last duplicated scrape stack in the ecosystem. `hoopR-nba-raw`,
+`hoopR-mbb-raw`, `wehoop-wnba-raw` and `wehoop-wbb-raw` run the same numbered
+stage sequence against the same tree shape — but only `wehoop-wbb-raw` had
+grown a shared package (`wbb_raw_scrape`, 451 LOC), a test suite, and the write
+guard. The other three inline those concerns in every numbered script: 22
+copy-pasted `str2bool` definitions between them, and no write guard at all.
+
+That package now lives here, parameterized on `LeagueConfig`:
+
+- `scrape/espn/persist.py` — the write guard. **The raw tree is the scrape
+  checkpoint, so a persisted provider error body is permanent**: it yields an
+  empty dataset for that key on every rebuild, forever, with nothing failing.
+  Refusing the write is the whole fix — a refused key simply looks un-scraped,
+  so the next run retries it and the archive self-heals.
+- `scrape/espn/cli.py` — the `str2bool` / `season_args` contract. `type=bool`
+  is a trap: bash passes the *string* `"false"`, and `bool("false")` is `True`.
+  `rescrape_default=` is exposed so the three repos that shipped `default=True`
+  can migrate without changing cron behavior, then flip it deliberately.
+- `scrape/espn/ids.py` — one id canonicalizer; a lossy cast raises rather than
+  silently producing an id that joins to the wrong row.
+- `scrape/espn/schedule.py` / `master.py` / `paths.py` — capture flags, URL
+  columns, the season→master union and coverage index.
+- `scrape/espn/league_config.py` — `NBA` / `MBB` / `WNBA` / `WBB` identity,
+  including which per-game families each league actually publishes (ESPN serves
+  an officials feed for the two women's leagues only).
+
+**`league` is a required keyword on every public entry point.** A defaulted
+league is how a well-formed capture ends up written under the wrong league's
+tree — wrong data, no error — which is exactly the bug the NCAA extraction
+found in `ncaa-mbb-hoops-raw`'s capture CLI. An AST-based test enforces that no
+module outside `league_config.py` names a league in executable code.
+
+86 offline tests, ported from `wehoop-wbb-raw`'s suite so the WBB assertions
+stand as the parity oracle for the lift, and extended with the league
+parameterization.
 
 ## 0.0.75 Release: August 2, 2026
 

--- a/docs/src/pages/CHANGELOG.md
+++ b/docs/src/pages/CHANGELOG.md
@@ -2,6 +2,8 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
+- [Unreleased](#unreleased)
+  - [New — `sportsdataverse.scrape.espn`: shared ESPN `-raw` archive engine](#new--sportsdataversescrapeespn-shared-espn--raw-archive-engine)
 - [0.0.75 Release: August 2, 2026](#0075-release-august-2-2026)
   - [Fix — `scrape.ncaa` CLIs pointed at the wrong repo root (silent no-op)](#fix--scrapencaa-clis-pointed-at-the-wrong-repo-root-silent-no-op)
   - [`scrape.ncaa.parse` — the parse stage is now re-runnable (`--season`, `--force`)](#scrapencaaparse--the-parse-stage-is-now-re-runnable---season---force)
@@ -224,6 +226,46 @@
 - [0.0.5 Release: October 20, 2021](#005-release-october-20-2021)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Unreleased
+
+### New — `sportsdataverse.scrape.espn`: shared ESPN `-raw` archive engine
+
+The fourth and last duplicated scrape stack in the ecosystem. `hoopR-nba-raw`,
+`hoopR-mbb-raw`, `wehoop-wnba-raw` and `wehoop-wbb-raw` run the same numbered
+stage sequence against the same tree shape — but only `wehoop-wbb-raw` had
+grown a shared package (`wbb_raw_scrape`, 451 LOC), a test suite, and the write
+guard. The other three inline those concerns in every numbered script: 22
+copy-pasted `str2bool` definitions between them, and no write guard at all.
+
+That package now lives here, parameterized on `LeagueConfig`:
+
+- `scrape/espn/persist.py` — the write guard. **The raw tree is the scrape
+  checkpoint, so a persisted provider error body is permanent**: it yields an
+  empty dataset for that key on every rebuild, forever, with nothing failing.
+  Refusing the write is the whole fix — a refused key simply looks un-scraped,
+  so the next run retries it and the archive self-heals.
+- `scrape/espn/cli.py` — the `str2bool` / `season_args` contract. `type=bool`
+  is a trap: bash passes the *string* `"false"`, and `bool("false")` is `True`.
+  `rescrape_default=` is exposed so the three repos that shipped `default=True`
+  can migrate without changing cron behavior, then flip it deliberately.
+- `scrape/espn/ids.py` — one id canonicalizer; a lossy cast raises rather than
+  silently producing an id that joins to the wrong row.
+- `scrape/espn/schedule.py` / `master.py` / `paths.py` — capture flags, URL
+  columns, the season→master union and coverage index.
+- `scrape/espn/league_config.py` — `NBA` / `MBB` / `WNBA` / `WBB` identity,
+  including which per-game families each league actually publishes (ESPN serves
+  an officials feed for the two women's leagues only).
+
+**`league` is a required keyword on every public entry point.** A defaulted
+league is how a well-formed capture ends up written under the wrong league's
+tree — wrong data, no error — which is exactly the bug the NCAA extraction
+found in `ncaa-mbb-hoops-raw`'s capture CLI. An AST-based test enforces that no
+module outside `league_config.py` names a league in executable code.
+
+86 offline tests, ported from `wehoop-wbb-raw`'s suite so the WBB assertions
+stand as the parity oracle for the lift, and extended with the league
+parameterization.
 
 ## 0.0.75 Release: August 2, 2026
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -661,4 +661,12 @@ files = [
     "sportsdataverse/scrape/ncaa/identity.py",
     "sportsdataverse/scrape/ncaa/datasets.py",
     "sportsdataverse/scrape/ncaa/canary.py",
+    "sportsdataverse/scrape/espn/__init__.py",
+    "sportsdataverse/scrape/espn/league_config.py",
+    "sportsdataverse/scrape/espn/paths.py",
+    "sportsdataverse/scrape/espn/ids.py",
+    "sportsdataverse/scrape/espn/persist.py",
+    "sportsdataverse/scrape/espn/cli.py",
+    "sportsdataverse/scrape/espn/master.py",
+    "sportsdataverse/scrape/espn/schedule.py",
 ]

--- a/sportsdataverse/scrape/espn/__init__.py
+++ b/sportsdataverse/scrape/espn/__init__.py
@@ -1,0 +1,56 @@
+"""Shared engine for the ESPN ``-raw`` archives (nba, mbb, wnba, wbb).
+
+The four ``hoopR``/``wehoop`` ESPN raw repos each run a numbered
+``espn_<lg>_NN_*_scrape.py`` stage sequence against the same tree shape. The
+stages are league-specific; everything two of them would otherwise duplicate
+lives here, parameterized on :class:`~.league_config.LeagueConfig`.
+
+This is the same one-core-plus-league-bindings shape already proven by
+:mod:`sportsdataverse.scrape.stats` (NBA/WNBA stats API) and
+:mod:`sportsdataverse.scrape.ncaa` (MBB/WBB stats.ncaa.org). It was lifted from
+``wehoop-wbb-raw``'s in-repo ``wbb_raw_scrape`` package, which was the only one
+of the four to have grown a shared package, a test suite, and the write guard.
+
+Every entry point takes ``league`` as a **required keyword**. A defaulted
+league is how a well-formed capture ends up under the wrong league's tree --
+a failure with no error, only wrong data.
+"""
+
+from sportsdataverse.scrape.espn.cli import season_args, str2bool
+from sportsdataverse.scrape.espn.ids import to_int64, with_int64_ids
+from sportsdataverse.scrape.espn.league_config import MBB, NBA, WBB, WNBA, LeagueConfig, by_key
+from sportsdataverse.scrape.espn.master import build_coverage, build_master
+from sportsdataverse.scrape.espn.paths import (
+    family_json_path,
+    game_json_path,
+    raw_github_url,
+)
+from sportsdataverse.scrape.espn.persist import (
+    is_error_payload,
+    scan_for_error_payloads,
+    write_payload,
+)
+from sportsdataverse.scrape.espn.schedule import add_capture_columns, resolve_league
+
+__all__ = [
+    "MBB",
+    "NBA",
+    "WBB",
+    "WNBA",
+    "LeagueConfig",
+    "add_capture_columns",
+    "build_coverage",
+    "build_master",
+    "by_key",
+    "family_json_path",
+    "game_json_path",
+    "is_error_payload",
+    "raw_github_url",
+    "resolve_league",
+    "scan_for_error_payloads",
+    "season_args",
+    "str2bool",
+    "to_int64",
+    "with_int64_ids",
+    "write_payload",
+]

--- a/sportsdataverse/scrape/espn/cli.py
+++ b/sportsdataverse/scrape/espn/cli.py
@@ -1,0 +1,94 @@
+"""The one CLI contract every ESPN raw scraper uses.
+
+``argparse(type=bool)`` is a trap and three of these repos fell into it: bash
+hands over the *string* ``"false"``, and ``bool("false")`` is ``True``.
+Combined with ``default=True`` it meant both ``-r false`` and omitting the flag
+re-fetched every already-captured game, on every daily run, against ESPN.
+
+Parse the text; never cast it. And default to NOT re-scraping: the raw tree is
+the checkpoint (see each repo's README and the SDV scraping standards).
+"""
+
+from __future__ import annotations
+
+import argparse
+
+_TRUE = frozenset({"1", "true", "t", "yes", "y", "on"})
+_FALSE = frozenset({"0", "false", "f", "no", "n", "off", ""})
+
+
+def str2bool(value: str | bool) -> bool:
+    """Parse a shell-supplied boolean.
+
+    Args:
+        value: Either a real bool or the string form bash passes through.
+
+    Returns:
+        The parsed boolean. Unrecognised text is treated as False, because the
+        expensive mistake is re-scraping the archive, not skipping a run.
+
+    Raises:
+        argparse.ArgumentTypeError: never -- kept total on purpose so a typo in
+            a cron definition cannot trigger a full re-scrape.
+    """
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in _TRUE:
+        return True
+    if text in _FALSE:
+        return False
+    return False
+
+
+def season_args(argv: list[str] | None = None, *, rescrape_default: bool = False) -> argparse.Namespace:
+    """Parse the standard ``--start_year`` / ``--end_year`` / ``--rescrape``.
+
+    Args:
+        argv: Argument list; defaults to ``sys.argv[1:]``.
+        rescrape_default: Value used when ``--rescrape`` is omitted. Defaults
+            to False (the archive is the checkpoint). The three hoopR/wehoop
+            ESPN repos historically defaulted to True and their shell drivers
+            still pass ``-r`` explicitly, so they can migrate without changing
+            cron behavior by passing ``rescrape_default=True`` and flipping it
+            deliberately in a separate, reviewable commit.
+
+    Returns:
+        Namespace with ``start_year: int``, ``end_year: int`` (defaulting to
+        ``start_year``), and ``rescrape: bool``.
+
+    Example:
+        Typical use in a scraper entrypoint::
+
+            from sportsdataverse.scrape.espn.cli import season_args
+
+            args = season_args()
+            for season in range(args.start_year, args.end_year + 1):
+                scrape_season(season, rescrape=args.rescrape)
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--start_year",
+        "-s",
+        type=int,
+        required=True,
+        help="Start season end-year (YYYY, e.g. 2026 for 2025-26)",
+    )
+    parser.add_argument(
+        "--end_year",
+        "-e",
+        type=int,
+        default=None,
+        help="End season end-year (YYYY); defaults to --start_year",
+    )
+    parser.add_argument(
+        "--rescrape",
+        "-r",
+        type=str2bool,
+        default=rescrape_default,
+        help=f"Re-fetch payloads already on disk (default: {str(rescrape_default).lower()})",
+    )
+    args = parser.parse_args(argv)
+    if args.end_year is None:
+        args.end_year = args.start_year
+    return args

--- a/sportsdataverse/scrape/espn/ids.py
+++ b/sportsdataverse/scrape/espn/ids.py
@@ -1,0 +1,67 @@
+"""The one id canonicalizer: every id is Int64, cast losslessly or refused.
+
+Ids are join keys, and a join is only as correct as the dtype agreement on both
+sides. These archives ship ``game_id``/``athlete_id``/``team_id`` as Int32 in
+places while play ids (18 digits) and the wider ecosystem are Int64 -- the same
+mismatch class the CFB loader-boundary canonicalization exists to close.
+
+Refusing a lossy cast matters more than performing one: a truncated or
+float-rounded id produces a structurally valid frame that joins to the wrong
+row, which is strictly worse than an exception.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+_WIDENABLE = (
+    pl.Int8,
+    pl.Int16,
+    pl.Int32,
+    pl.UInt8,
+    pl.UInt16,
+    pl.UInt32,
+)
+
+
+def to_int64(series: pl.Series) -> pl.Series:
+    """Canonicalize an id series to Int64, refusing any lossy conversion.
+
+    Args:
+        series: Ids as Int*, UInt*, Float*, or numeric Utf8.
+
+    Returns:
+        The same values as ``Int64``, nulls preserved.
+
+    Raises:
+        ValueError: If a float carries a fractional part, a string is not
+            numeric, or the dtype is not an id-shaped type.
+    """
+    dtype = series.dtype
+    if dtype == pl.Int64:
+        return series
+    if dtype in _WIDENABLE:
+        return series.cast(pl.Int64)
+    if dtype in (pl.Float32, pl.Float64):
+        nonnull = series.drop_nulls()
+        if len(nonnull) and (nonnull != nonnull.round(0)).any():
+            raise ValueError(f"lossy float->Int64 id cast on {series.name!r}")
+        return series.cast(pl.Int64)
+    if dtype == pl.Utf8:
+        out = series.cast(pl.Int64, strict=False)
+        if out.null_count() > series.null_count():
+            raise ValueError(f"non-numeric id value in {series.name!r}")
+        return out
+    raise ValueError(f"unsupported id dtype {dtype} on {series.name!r}")
+
+
+def with_int64_ids(df: pl.DataFrame, *columns: str) -> pl.DataFrame:
+    """Return ``df`` with each named id column canonicalized to Int64.
+
+    Columns absent from the frame are skipped, so one call covers families that
+    carry different id sets.
+    """
+    present = [c for c in columns if c in df.columns]
+    if not present:
+        return df
+    return df.with_columns([to_int64(df[c]).alias(c) for c in present])

--- a/sportsdataverse/scrape/espn/league_config.py
+++ b/sportsdataverse/scrape/espn/league_config.py
@@ -1,0 +1,109 @@
+"""League identity for the ESPN ``-raw`` scrape engine.
+
+One frozen config per league carries the facts the engine cannot derive: the
+tree prefix the archive hangs off, the owning ``-raw`` repository (which is
+also the host of the public ``raw.githubusercontent`` URLs the schedules
+advertise), and which per-game payload families that league actually has.
+
+The families differ for real reasons, not oversight -- ESPN publishes an
+officials feed for the two women's leagues and not for the two men's, and only
+the two professional leagues have a draft. Encoding that here means a league
+without a family simply never gets its column, instead of every scraper
+carrying a conditional.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+#: ``(column stem, tree segments under <league>/)`` for a per-game payload
+#: family. The stem names both the ``<stem>_url`` column and, when flagged,
+#: the ``has_<stem>`` capture boolean.
+Family = tuple[str, tuple[str, ...]]
+
+_GAME_JSON: Family = ("game_json", ("json", "final"))
+_GAME_JSON_RAW: Family = ("game_json_raw", ("json", "raw"))
+_GAME_ROSTERS: Family = ("game_rosters_json", ("game_rosters", "json"))
+_OFFICIALS: Family = ("officials_json", ("officials", "json"))
+
+
+@dataclass(frozen=True)
+class LeagueConfig:
+    """Identity facts for one ESPN ``-raw`` archive.
+
+    Attributes:
+        key: Tree prefix and short league slug (``"nba"`` / ``"mbb"`` /
+            ``"wnba"`` / ``"wbb"``). Every path under the archive hangs off it.
+        repo: Owning ``-raw`` repository, used to build the public
+            ``raw.githubusercontent`` URLs the season schedules carry.
+        families: Per-game payload families this league publishes.
+        flagged: Stems that get a ``has_<stem>`` capture boolean.
+        logfile: The repo's module-level log destination.
+
+    Note:
+        ``game_json_raw`` is deliberately absent from ``flagged`` everywhere:
+        it is written by the same call as ``game_json``, so their presence
+        cannot diverge and a second flag could only ever lie.
+    """
+
+    key: str
+    repo: str
+    families: tuple[Family, ...]
+    flagged: tuple[str, ...]
+    logfile: str
+
+
+NBA = LeagueConfig(
+    key="nba",
+    repo="hoopR-nba-raw",
+    families=(_GAME_JSON, _GAME_JSON_RAW, _GAME_ROSTERS),
+    flagged=("game_json", "game_rosters_json"),
+    logfile="hoopR_nba_raw_logfile.txt",
+)
+
+MBB = LeagueConfig(
+    key="mbb",
+    repo="hoopR-mbb-raw",
+    families=(_GAME_JSON, _GAME_JSON_RAW, _GAME_ROSTERS),
+    flagged=("game_json", "game_rosters_json"),
+    logfile="hoopR_mbb_raw_logfile.txt",
+)
+
+WNBA = LeagueConfig(
+    key="wnba",
+    repo="wehoop-wnba-raw",
+    families=(_GAME_JSON, _GAME_JSON_RAW, _GAME_ROSTERS, _OFFICIALS),
+    flagged=("game_json", "game_rosters_json", "officials_json"),
+    logfile="wehoop_wnba_raw_logfile.txt",
+)
+
+WBB = LeagueConfig(
+    key="wbb",
+    repo="wehoop-wbb-raw",
+    families=(_GAME_JSON, _GAME_JSON_RAW, _GAME_ROSTERS, _OFFICIALS),
+    flagged=("game_json", "game_rosters_json", "officials_json"),
+    logfile="wehoop_wbb_raw_logfile.txt",
+)
+
+_BY_KEY: dict[str, LeagueConfig] = {c.key: c for c in (NBA, MBB, WNBA, WBB)}
+
+
+def by_key(key: str) -> LeagueConfig:
+    """Look up a league config by its slug.
+
+    Args:
+        key: ``"nba"``, ``"mbb"``, ``"wnba"``, or ``"wbb"``.
+
+    Returns:
+        The frozen config for that league.
+
+    Raises:
+        ValueError: If the slug is unknown. Naming the valid set in the message
+            matters here because the caller is usually a shell driver passing
+            ``--league`` straight through from a cron definition.
+    """
+    try:
+        return _BY_KEY[key]
+    except KeyError:
+        valid = ", ".join(sorted(_BY_KEY))
+        raise ValueError(f"unknown ESPN league {key!r}; expected one of: {valid}") from None

--- a/sportsdataverse/scrape/espn/master.py
+++ b/sportsdataverse/scrape/espn/master.py
@@ -1,0 +1,74 @@
+"""Union the per-season schedules into a master + a coverage index.
+
+The master computes NO flags of its own: every ``has_*`` column is inherited
+from the season files by union. Ragged inputs are reconciled with a diagonal
+concat so a column present in one season is null-filled in the others -- which
+is what fixes the historical drift where the master carried ``venue_capacity``
+and the yearly files did not.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+from sportsdataverse.scrape.espn.ids import with_int64_ids
+
+ID_COLUMNS = ("game_id", "home_id", "away_id", "venue_id")
+
+
+def build_master(season_frames: list[pl.DataFrame]) -> pl.DataFrame:
+    """Concatenate season schedules into one frame with a pinned column order.
+
+    Args:
+        season_frames: One frame per season, as written by step 01.
+
+    Returns:
+        The union, ids canonicalized to Int64, columns in a stable order and
+        rows sorted by ``(season, game_id)``.
+
+    Raises:
+        ValueError: If no frames are given.
+    """
+    if not season_frames:
+        raise ValueError("build_master() requires at least one season frame")
+    frames = [with_int64_ids(df, *ID_COLUMNS) for df in season_frames]
+    master = pl.concat(frames, how="diagonal_relaxed")
+    ordered = sorted(master.columns)
+    sort_keys = [k for k in ("season", "game_id") if k in master.columns]
+    master = master.select(ordered)
+    return master.sort(sort_keys) if sort_keys else master
+
+
+def build_coverage(master: pl.DataFrame) -> pl.DataFrame:
+    """One row per ``(season, season_type)`` with capture percentages.
+
+    Args:
+        master: The frame from :func:`build_master`.
+
+    Returns:
+        ``season``, ``season_type``, ``n_games``, ``first_date``, ``last_date``,
+        a ``pct_<flag>`` per ``has_*`` column, and ``pct_json_captured`` as a
+        convenience alias for ``pct_has_game_json``.
+
+    Raises:
+        ValueError: If the master carries neither ``season`` nor ``season_type``.
+    """
+    flags = [c for c in master.columns if c.startswith("has_")]
+    group_keys = [k for k in ("season", "season_type") if k in master.columns]
+    if not group_keys:
+        raise ValueError("master frame has neither season nor season_type")
+
+    aggs: list[pl.Expr] = [pl.len().alias("n_games")]
+    if "date" in master.columns:
+        aggs += [
+            pl.col("date").min().alias("first_date"),
+            pl.col("date").max().alias("last_date"),
+        ]
+    aggs += [pl.col(flag).mean().alias(f"pct_{flag}") for flag in flags]
+
+    # maintain_order keeps the group order deterministic; the sort below then
+    # pins it regardless of polars' internal grouping strategy.
+    coverage = master.group_by(group_keys, maintain_order=True).agg(aggs)
+    if "pct_has_game_json" in coverage.columns:
+        coverage = coverage.with_columns(pl.col("pct_has_game_json").alias("pct_json_captured"))
+    return coverage.sort(group_keys)

--- a/sportsdataverse/scrape/espn/paths.py
+++ b/sportsdataverse/scrape/espn/paths.py
@@ -1,0 +1,36 @@
+"""Raw-tree path builders and the public raw.githubusercontent URL form."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+GITHUB_RAW = "https://raw.githubusercontent.com/sportsdataverse"
+BRANCH = "main"
+
+
+def raw_github_url(repo: str, *parts: str) -> str:
+    """Public URL for a file committed in an SDV ``-raw`` repo.
+
+    Args:
+        repo: Repository name, e.g. ``"wehoop-wbb-raw"``.
+        *parts: Path segments under the repo root.
+
+    Returns:
+        The ``raw.githubusercontent.com`` URL for that file.
+
+    Example:
+        ::
+
+            raw_github_url("wehoop-wbb-raw", "wbb", "json", "final", "401811123.json")
+    """
+    return f"{GITHUB_RAW}/{repo}/{BRANCH}/" + "/".join(parts)
+
+
+def game_json_path(root: Path | str, league: str, game_id: int | str, kind: str = "final") -> Path:
+    """On-disk path for a per-game summary payload (``kind``: raw | final)."""
+    return Path(root) / league / "json" / kind / f"{game_id}.json"
+
+
+def family_json_path(root: Path | str, league: str, family: str, game_id: int | str) -> Path:
+    """On-disk path for a per-game sibling family (game_rosters, officials)."""
+    return Path(root) / league / family / "json" / f"{game_id}.json"

--- a/sportsdataverse/scrape/espn/persist.py
+++ b/sportsdataverse/scrape/espn/persist.py
@@ -1,0 +1,91 @@
+"""Write guard: never let a provider error body into the archive.
+
+The raw tree is the scrape checkpoint -- a captured file is never re-fetched.
+So a persisted error body is permanent: it silently yields an empty dataset for
+that key on every rebuild, forever, with nothing failing anywhere. Seven such
+files were found in ``wbb/team_stats/json/`` when the sportsdataverse payload
+schemas were first run against the committed tree, spanning 2007-2023.
+
+Refusing the write is deliberately the whole fix. A refused key simply looks
+un-scraped, so the next run retries it -- the archive self-heals instead of
+accumulating a quarantine directory nobody reads.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+# Key sets that only ever appear in a provider ERROR body, never in a data
+# payload. Matched as subsets so extra keys in the error body still match.
+_ERROR_SIGNATURES: tuple[frozenset[str], ...] = (
+    # Spring-style error, e.g. {"error","message","path","status","timestamp"}
+    # where `status` is an int HTTP code. Seen at wbb/team_stats/json/2007/2948.
+    frozenset({"error", "message", "status"}),
+    # ESPN API error, e.g. {"code": 404, "detail": "no data"}.
+    frozenset({"code", "detail"}),
+)
+
+
+def is_error_payload(payload: Any) -> bool:
+    """True when a payload is empty or is a provider error body.
+
+    A structurally valid but empty *collection* (``{"count": 0, "items": []}``)
+    is NOT an error -- it is a real answer meaning "nothing here", and treating
+    it as a failure would re-scrape that key on every run forever.
+    """
+    if not payload or not isinstance(payload, dict):
+        return True
+    keys = set(payload)
+    return any(signature <= keys for signature in _ERROR_SIGNATURES)
+
+
+def write_payload(path: Path | str, payload: dict, *, indent: int | None = None) -> bool:
+    """Persist a payload unless it is empty or an error body.
+
+    Args:
+        path: Destination file. Parent directories are created as needed.
+        payload: The parsed provider response.
+        indent: ``json.dump`` indent. Defaults to None (compact), which is what
+            ``wehoop-wbb-raw`` has always written. The hoopR/wehoop ESPN
+            archives were written with ``indent=0`` and pass that through, so
+            adopting this guard does not silently reformat a tree that is
+            committed to git -- a format flip would churn the diff of every
+            file any later run happens to rewrite.
+
+    Returns:
+        True when written, False when refused. Refusing leaves any existing
+        capture at ``path`` untouched -- a later error must never truncate an
+        earlier success, which is the failure that turns a working season into
+        a silent gap.
+    """
+    if is_error_payload(payload):
+        return False
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=indent), encoding="utf-8")
+    return True
+
+
+def scan_for_error_payloads(root: Path | str, pattern: str) -> list[Path]:
+    """Find committed captures that are error bodies, empty, or unreadable.
+
+    Args:
+        root: Directory to scan from.
+        pattern: Glob relative to ``root``, e.g. ``"wbb/team_stats/json/*/*.json"``.
+
+    Returns:
+        Sorted paths of every file that should not be in the archive.
+    """
+    root = Path(root)
+    bad: list[Path] = []
+    for path in sorted(root.glob(pattern)):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            bad.append(path)
+            continue
+        if is_error_payload(payload):
+            bad.append(path)
+    return bad

--- a/sportsdataverse/scrape/espn/schedule.py
+++ b/sportsdataverse/scrape/espn/schedule.py
@@ -1,0 +1,100 @@
+"""Capture-state and URL columns for the per-season schedule files.
+
+The per-season schedule is the ORIGIN of every flag. The master does not
+compute flags -- it inherits them by union, so a flag added here appears in the
+master and the coverage index with no further wiring.
+
+These archives carry ``has_*`` (capture) flags only. ``in_*`` (build) flags are
+a ``-data`` repo fact; stamping them here would make the archive read the data
+repo, a dependency in the wrong direction that goes stale whenever either side
+rebuilds alone.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import polars as pl
+
+from sportsdataverse.scrape.espn.ids import with_int64_ids
+from sportsdataverse.scrape.espn.league_config import LeagueConfig, by_key
+from sportsdataverse.scrape.espn.paths import raw_github_url
+
+ID_COLUMNS = ("game_id", "home_id", "away_id", "venue_id")
+
+
+def resolve_league(league: str | LeagueConfig) -> LeagueConfig:
+    """Accept either a league slug or an already-resolved config.
+
+    Shell drivers pass a slug; callers that already hold a config should not be
+    forced to round-trip it through a string.
+    """
+    return league if isinstance(league, LeagueConfig) else by_key(league)
+
+
+def add_capture_columns(df: pl.DataFrame, *, root: Path | str, league: str | LeagueConfig) -> pl.DataFrame:
+    """Add per-family URL columns and ``has_*`` capture flags to a schedule.
+
+    Args:
+        df: A season schedule frame containing ``game_id``.
+        root: Repo root the ``<league>/`` tree hangs off.
+        league: League slug (``"nba"``/``"mbb"``/``"wnba"``/``"wbb"``) or a
+            :class:`LeagueConfig`. Required and keyword-only: a defaulted league
+            is how a well-formed capture ends up written under the wrong
+            league's tree, which fails silently.
+
+    Returns:
+        The frame with ids canonicalized to Int64, one ``<stem>_url`` column
+        per family this league publishes, and a ``has_<stem>`` boolean for each
+        flagged family.
+
+    URLs are emitted for every row whether or not the file exists -- the
+    ``has_*`` flag is the truth, the URL is the address. Filenames are built
+    from the integer id, so a float-origin id can never address ``123.0.json``.
+    """
+    config = resolve_league(league)
+    root = Path(root)
+    out = with_int64_ids(df, *ID_COLUMNS)
+    game_ids = out["game_id"].to_list()
+
+    columns: list[pl.Series] = []
+    for stem, segments in config.families:
+        columns.append(
+            pl.Series(
+                f"{stem}_url",
+                [
+                    None if gid is None else raw_github_url(config.repo, config.key, *segments, f"{gid}.json")
+                    for gid in game_ids
+                ],
+                dtype=pl.Utf8,
+            )
+        )
+        if stem in config.flagged:
+            captured = _captured_ids(root / config.key / Path(*segments))
+            columns.append(
+                pl.Series(
+                    f"has_{stem}",
+                    [gid is not None and gid in captured for gid in game_ids],
+                    dtype=pl.Boolean,
+                )
+            )
+    return out.with_columns(columns)
+
+
+def _captured_ids(directory: Path) -> set[int]:
+    """Every game id present in a family directory, as one listing.
+
+    A per-game ``Path.exists()`` would be ~400k syscalls across the full
+    archive (133k games x 3 families) and made the daily step crawl on Windows.
+    One scandir per family is O(files) and answers every membership test.
+    """
+    if not directory.is_dir():
+        return set()
+    ids: set[int] = set()
+    with os.scandir(directory) as entries:
+        for entry in entries:
+            name, _, ext = entry.name.rpartition(".")
+            if ext == "json" and name.isdigit():
+                ids.add(int(name))
+    return ids

--- a/tests/scrape/test_scrape_espn_engine.py
+++ b/tests/scrape/test_scrape_espn_engine.py
@@ -1,0 +1,487 @@
+"""The shared ESPN ``-raw`` engine: league config, ids, capture columns, master.
+
+Ported from ``wehoop-wbb-raw``'s in-repo suite (the only one of the four ESPN
+raw repos that had one) and extended with the league parameterization. The WBB
+assertions are kept verbatim on purpose: they are the parity oracle proving the
+lift did not change behavior for the repo the code came from.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from sportsdataverse.scrape.espn import league_config as lc
+from sportsdataverse.scrape.espn.cli import season_args, str2bool
+from sportsdataverse.scrape.espn.ids import to_int64, with_int64_ids
+from sportsdataverse.scrape.espn.master import build_coverage, build_master
+from sportsdataverse.scrape.espn.paths import raw_github_url
+from sportsdataverse.scrape.espn.persist import (
+    is_error_payload,
+    scan_for_error_payloads,
+    write_payload,
+)
+from sportsdataverse.scrape.espn.schedule import add_capture_columns
+
+# --- league config -----------------------------------------------------------
+
+
+@pytest.mark.parametrize("key", ["nba", "mbb", "wnba", "wbb"])
+def test_every_league_resolves(key):
+    assert lc.by_key(key).key == key
+
+
+def test_unknown_league_names_the_valid_set():
+    """The caller is usually a shell driver passing --league from a cron line."""
+    with pytest.raises(ValueError, match="mbb, nba, wbb, wnba"):
+        lc.by_key("ncaam")
+
+
+@pytest.mark.parametrize("key,expected", [("nba", False), ("mbb", False), ("wnba", True), ("wbb", True)])
+def test_officials_exist_only_for_the_womens_leagues(key, expected):
+    stems = [stem for stem, _ in lc.by_key(key).families]
+    assert ("officials_json" in stems) is expected
+
+
+@pytest.mark.parametrize("key", ["nba", "mbb", "wnba", "wbb"])
+def test_game_json_raw_is_never_flagged(key):
+    """It is written by the same call as game_json, so a second flag could only
+    ever lie about a divergence that cannot happen."""
+    config = lc.by_key(key)
+    assert "game_json_raw" not in config.flagged
+
+
+@pytest.mark.parametrize("key", ["nba", "mbb", "wnba", "wbb"])
+def test_every_flagged_stem_is_a_real_family(key):
+    config = lc.by_key(key)
+    stems = {stem for stem, _ in config.families}
+    assert set(config.flagged) <= stems
+
+
+def test_each_league_owns_a_distinct_repo():
+    repos = [lc.by_key(k).repo for k in ("nba", "mbb", "wnba", "wbb")]
+    assert len(set(repos)) == 4
+
+
+# --- the league keyword is required, not defaulted ---------------------------
+
+
+def test_add_capture_columns_requires_league_as_a_keyword():
+    """A defaulted league is how a well-formed capture lands under the wrong
+    league's tree -- wrong data, no error. Guarded structurally, because the
+    NCAA extraction shipped exactly that bug (a capture CLI with no --league).
+    """
+    sig = inspect.signature(add_capture_columns)
+    league = sig.parameters["league"]
+    assert league.kind is inspect.Parameter.KEYWORD_ONLY
+    assert league.default is inspect.Parameter.empty
+
+
+def test_calling_without_a_league_is_a_typeerror():
+    with pytest.raises(TypeError):
+        add_capture_columns(pl.DataFrame({"game_id": [1]}), root=".")  # type: ignore[call-arg]
+
+
+# --- ids ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "values,dtype",
+    [
+        ([401811123], pl.Int32),
+        ([401811123], pl.Int64),
+        (["401811123"], pl.Utf8),
+        ([401811123.0], pl.Float64),
+    ],
+    ids=["int32", "int64", "utf8", "float64"],
+)
+def test_every_source_dtype_lands_on_int64(values, dtype):
+    out = to_int64(pl.Series("game_id", values, dtype=dtype))
+    assert out.dtype == pl.Int64
+    assert out[0] == 401811123
+
+
+def test_nulls_survive_canonicalization():
+    out = to_int64(pl.Series("game_id", [None, 401811123], dtype=pl.Int64))
+    assert out.null_count() == 1
+
+
+def test_lossy_float_refuses_rather_than_truncating():
+    with pytest.raises(ValueError, match="lossy"):
+        to_int64(pl.Series("game_id", [401811123.5]))
+
+
+def test_non_numeric_string_refuses():
+    with pytest.raises(ValueError, match="non-numeric"):
+        to_int64(pl.Series("game_id", ["not-an-id"]))
+
+
+def test_with_int64_ids_skips_absent_columns():
+    df = pl.DataFrame({"game_id": [1]}, schema={"game_id": pl.Int32})
+    out = with_int64_ids(df, "game_id", "venue_id")
+    assert out.schema["game_id"] == pl.Int64
+    assert "venue_id" not in out.columns
+
+
+# --- per-season capture columns ----------------------------------------------
+
+WBB_COLUMNS = [
+    "game_json_url",
+    "game_json_raw_url",
+    "game_rosters_json_url",
+    "officials_json_url",
+    "has_game_json",
+    "has_game_rosters_json",
+    "has_officials_json",
+]
+
+
+def _tree(tmp_path: Path, league: str) -> Path:
+    for stem, segments in lc.by_key(league).families:
+        (tmp_path / league / Path(*segments)).mkdir(parents=True, exist_ok=True)
+    (tmp_path / league / "json" / "final" / "401811123.json").write_text("{}")
+    (tmp_path / league / "game_rosters" / "json" / "401811123.json").write_text("{}")
+    return tmp_path
+
+
+def _schedule() -> pl.DataFrame:
+    return pl.DataFrame({"game_id": [401811123, 401811124]}, schema={"game_id": pl.Int32})
+
+
+def test_adds_every_column(tmp_path):
+    out = add_capture_columns(_schedule(), root=_tree(tmp_path, "wbb"), league="wbb")
+    for column in WBB_COLUMNS:
+        assert column in out.columns
+
+
+def test_a_league_without_officials_gets_no_officials_columns(tmp_path):
+    out = add_capture_columns(_schedule(), root=_tree(tmp_path, "nba"), league="nba")
+    assert "officials_json_url" not in out.columns
+    assert "has_officials_json" not in out.columns
+    assert "has_game_json" in out.columns
+
+
+def test_urls_are_league_and_repo_scoped(tmp_path):
+    out = add_capture_columns(_schedule(), root=_tree(tmp_path, "nba"), league="nba")
+    url = out["game_json_url"][0]
+    assert "/hoopR-nba-raw/" in url
+    assert url.endswith("nba/json/final/401811123.json")
+
+
+def test_urls_emitted_for_every_row_even_when_the_file_is_absent(tmp_path):
+    out = add_capture_columns(_schedule(), root=_tree(tmp_path, "wbb"), league="wbb")
+    assert out["game_json_url"].null_count() == 0
+    assert out["game_json_url"][1].endswith("wbb/json/final/401811124.json")
+
+
+def test_has_flags_reflect_what_is_on_disk(tmp_path):
+    out = add_capture_columns(_schedule(), root=_tree(tmp_path, "wbb"), league="wbb")
+    assert out["has_game_json"].to_list() == [True, False]
+    assert out["has_game_rosters_json"].to_list() == [True, False]
+    assert out["has_officials_json"].to_list() == [False, False]
+
+
+def test_game_id_is_canonicalized_to_int64(tmp_path):
+    out = add_capture_columns(_schedule(), root=_tree(tmp_path, "wbb"), league="wbb")
+    assert out.schema["game_id"] == pl.Int64
+
+
+def test_url_never_contains_a_float_artifact(tmp_path):
+    """A float-origin id stringifies as "123.0" and addresses nothing."""
+    df = pl.DataFrame({"game_id": [401811123.0]})
+    out = add_capture_columns(df, root=_tree(tmp_path, "wbb"), league="wbb")
+    assert ".0.json" not in out["game_json_url"][0]
+    assert out["game_json_url"][0].endswith("401811123.json")
+
+
+def test_a_league_config_may_be_passed_directly(tmp_path):
+    out = add_capture_columns(_schedule(), root=_tree(tmp_path, "wbb"), league=lc.WBB)
+    assert out["has_game_json"].to_list() == [True, False]
+
+
+def test_raw_github_url_shape():
+    assert raw_github_url("wehoop-wbb-raw", "wbb", "json", "final", "1.json") == (
+        "https://raw.githubusercontent.com/sportsdataverse/wehoop-wbb-raw/main/wbb/json/final/1.json"
+    )
+
+
+# --- CLI contract ------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("false", False),
+        ("False", False),
+        ("FALSE", False),
+        (" false ", False),
+        ("0", False),
+        ("no", False),
+        ("off", False),
+        ("", False),
+        ("true", True),
+        ("True", True),
+        ("1", True),
+        ("yes", True),
+        ("on", True),
+        (True, True),
+        (False, False),
+    ],
+)
+def test_str2bool_parses_shell_strings(raw, expected):
+    assert str2bool(raw) is expected
+
+
+def test_unrecognised_text_does_not_trigger_a_rescrape():
+    """A typo in a cron definition must not re-fetch the whole archive."""
+    assert str2bool("ture") is False
+    assert str2bool("maybe") is False
+
+
+def test_rescrape_defaults_to_false():
+    assert season_args(["--start_year", "2026"]).rescrape is False
+
+
+def test_rescrape_default_is_overridable_for_migrating_repos():
+    """nba/mbb/wnba-raw shipped default=True; they migrate without changing
+    cron behavior, then flip it in a separate reviewable commit."""
+    assert season_args(["--start_year", "2026"], rescrape_default=True).rescrape is True
+    assert season_args(["--start_year", "2026", "-r", "false"], rescrape_default=True).rescrape is False
+
+
+def test_rescrape_false_string_stays_false():
+    assert season_args(["--start_year", "2026", "-r", "false"]).rescrape is False
+
+
+def test_rescrape_true_string_is_honoured():
+    assert season_args(["--start_year", "2026", "-r", "true"]).rescrape is True
+
+
+def test_end_year_defaults_to_start_year():
+    assert season_args(["--start_year", "2026"]).end_year == 2026
+
+
+def test_explicit_range_is_preserved():
+    args = season_args(["-s", "2007", "-e", "2013"])
+    assert (args.start_year, args.end_year) == (2007, 2013)
+
+
+def test_start_year_is_required():
+    with pytest.raises(SystemExit):
+        season_args([])
+
+
+# --- write guard -------------------------------------------------------------
+
+SPRING_ERROR = {
+    "error": "Not Found",
+    "message": "",
+    "path": "/apis/site/v2/...",
+    "status": 404,
+    "timestamp": "2026-01-01T00:00:00Z",
+}
+ESPN_ERROR = {"code": 404, "detail": "no data"}
+GOOD = {"results": {"stats": []}, "team": {"id": "52"}}
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [SPRING_ERROR, ESPN_ERROR, {}, [], None, ""],
+    ids=["spring", "espn", "empty-dict", "list", "none", "empty-str"],
+)
+def test_error_and_empty_payloads_are_recognized(payload):
+    assert is_error_payload(payload) is True
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [GOOD, {"items": [], "count": 0}, {"categories": [], "teams": {}}],
+    ids=["team_stats", "officials-envelope", "player_season_stats"],
+)
+def test_real_payloads_are_not_errors(payload):
+    assert is_error_payload(payload) is False
+
+
+def test_an_empty_but_valid_collection_is_not_an_error():
+    """A zero-row Core v2 page is a real answer: this team had no officials.
+    Treating it as an error would re-scrape it forever."""
+    assert is_error_payload({"count": 0, "items": [], "pageCount": 0}) is False
+
+
+def test_write_refuses_an_error_payload(tmp_path):
+    path = tmp_path / "2948.json"
+    assert write_payload(path, ESPN_ERROR) is False
+    assert not path.exists()
+
+
+def test_write_persists_a_real_payload(tmp_path):
+    path = tmp_path / "52.json"
+    assert write_payload(path, GOOD) is True
+    assert json.loads(path.read_text(encoding="utf-8")) == GOOD
+
+
+def test_write_preserves_an_archives_existing_byte_format(tmp_path):
+    """These archives are committed to git. The hoopR/wehoop trees were written
+    with indent=0; adopting the guard must not reformat them, or any later
+    rewrite churns the diff of every file it touches."""
+    compact = tmp_path / "compact.json"
+    indented = tmp_path / "indented.json"
+    write_payload(compact, GOOD)
+    write_payload(indented, GOOD, indent=0)
+    assert "\n" not in compact.read_text(encoding="utf-8")
+    assert "\n" in indented.read_text(encoding="utf-8")
+    assert json.loads(compact.read_text(encoding="utf-8")) == json.loads(indented.read_text(encoding="utf-8"))
+
+
+def test_write_creates_missing_parents(tmp_path):
+    path = tmp_path / "2026" / "52.json"
+    assert write_payload(path, GOOD) is True
+    assert path.exists()
+
+
+def test_write_never_truncates_a_good_file_with_a_bad_one(tmp_path):
+    """The failure that actually matters: a good capture overwritten later by
+    an error response, turning a working season into a silent gap."""
+    path = tmp_path / "52.json"
+    write_payload(path, GOOD)
+    assert write_payload(path, SPRING_ERROR) is False
+    assert json.loads(path.read_text(encoding="utf-8")) == GOOD
+
+
+def test_scan_finds_error_payloads(tmp_path):
+    (tmp_path / "2007").mkdir()
+    (tmp_path / "2007" / "2948.json").write_text(json.dumps(ESPN_ERROR), encoding="utf-8")
+    (tmp_path / "2007" / "52.json").write_text(json.dumps(GOOD), encoding="utf-8")
+    found = scan_for_error_payloads(tmp_path, "*/*.json")
+    assert [p.name for p in found] == ["2948.json"]
+
+
+def test_scan_reports_unreadable_files(tmp_path):
+    (tmp_path / "broken.json").write_text("{not json", encoding="utf-8")
+    assert [p.name for p in scan_for_error_payloads(tmp_path, "*.json")] == ["broken.json"]
+
+
+# --- master + coverage --------------------------------------------------------
+
+
+def _season(season: int, n: int, captured: int) -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "game_id": [900000 + season * 100 + i for i in range(n)],
+            "season": [season] * n,
+            "season_type": [2] * n,
+            "date": ["2025-11-0%d" % (i % 9 + 1) for i in range(n)],
+            "has_game_json": [i < captured for i in range(n)],
+            "has_game_rosters_json": [False] * n,
+            "has_officials_json": [False] * n,
+        }
+    )
+
+
+def test_master_is_the_union_of_seasons():
+    master = build_master([_season(2025, 4, 2), _season(2026, 6, 6)])
+    assert master.height == 10
+    assert set(master["season"].unique().to_list()) == {2025, 2026}
+
+
+def test_master_pins_one_column_order_across_ragged_inputs():
+    a = _season(2025, 2, 1)
+    b = _season(2026, 2, 2).with_columns(pl.lit(1200).alias("venue_capacity"))
+    assert build_master([a, b]).columns == build_master([b, a]).columns
+
+
+def test_a_column_missing_from_one_season_is_null_filled():
+    a = _season(2025, 2, 1)
+    b = _season(2026, 2, 2).with_columns(pl.lit(1200).alias("venue_capacity"))
+    master = build_master([a, b])
+    assert master["venue_capacity"].null_count() == 2
+
+
+def test_master_game_id_is_int64():
+    assert build_master([_season(2026, 2, 2)]).schema["game_id"] == pl.Int64
+
+
+def test_build_master_refuses_an_empty_input():
+    with pytest.raises(ValueError, match="at least one"):
+        build_master([])
+
+
+def test_coverage_is_one_row_per_season_and_type():
+    coverage = build_coverage(build_master([_season(2025, 4, 2), _season(2026, 6, 6)]))
+    assert coverage.height == 2
+    row = coverage.filter(pl.col("season") == 2025).to_dicts()[0]
+    assert row["n_games"] == 4
+    assert row["pct_json_captured"] == pytest.approx(0.5)
+
+
+def test_coverage_has_a_pct_column_per_flag():
+    coverage = build_coverage(build_master([_season(2026, 2, 1)]))
+    for column in (
+        "pct_has_game_json",
+        "pct_has_game_rosters_json",
+        "pct_has_officials_json",
+    ):
+        assert column in coverage.columns
+
+
+def test_coverage_carries_the_date_range():
+    coverage = build_coverage(build_master([_season(2026, 4, 4)]))
+    row = coverage.to_dicts()[0]
+    assert row["first_date"] <= row["last_date"]
+
+
+def test_coverage_refuses_a_frame_with_no_season_keys():
+    with pytest.raises(ValueError, match="neither season"):
+        build_coverage(pl.DataFrame({"game_id": [1]}))
+
+
+# --- no module may hardcode a league -----------------------------------------
+
+
+def _docstring_nodes(tree: ast.AST) -> set[int]:
+    """Ids of every Constant node that is a docstring rather than a value.
+
+    Scanning source text cannot distinguish the two: the engine's docstrings
+    legitimately *name* the leagues while documenting the ``league=`` argument,
+    and a line-based check flags that prose as a hardcoded literal.
+    """
+    ids: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        body = getattr(node, "body", None)
+        if not body:
+            continue
+        first = body[0]
+        if isinstance(first, ast.Expr) and isinstance(first.value, ast.Constant):
+            if isinstance(first.value.value, str):
+                ids.add(id(first.value))
+    return ids
+
+
+def test_no_engine_module_hardcodes_a_league_literal():
+    """The failure this guards is silent: a well-formed capture written under
+    the wrong league's tree. Only league_config.py may name a league.
+
+    Checked on the AST, and only on non-docstring string constants -- comments
+    and documentation are free to name leagues, executable code is not.
+    """
+    keys = {"nba", "mbb", "wnba", "wbb"}
+    engine = Path(lc.__file__).parent
+    offenders = []
+    for module in sorted(engine.glob("*.py")):
+        if module.name in ("league_config.py", "__init__.py"):
+            continue
+        tree = ast.parse(module.read_text(encoding="utf-8"))
+        docstrings = _docstring_nodes(tree)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Constant) or id(node) in docstrings:
+                continue
+            if isinstance(node.value, str) and node.value in keys:
+                offenders.append(f"{module.name}:{node.lineno}: {node.value!r}")
+    assert offenders == [], offenders


### PR DESCRIPTION
The fourth and last duplicated scrape stack in the ecosystem, after
`scrape.stats` (#325/#327) and `scrape.ncaa` (#328/#330/#331).

## Why

`hoopR-nba-raw`, `hoopR-mbb-raw`, `wehoop-wnba-raw` and `wehoop-wbb-raw` run the
same numbered stage sequence over the same tree shape. Only `wehoop-wbb-raw`
had grown a shared package (`wbb_raw_scrape`, 451 LOC), a test suite, and a
write guard. The other three inline those concerns in every numbered script:
**22 copy-pasted `str2bool` definitions** between them, zero tests, and no
write guard.

That last one is not cosmetic. The raw tree is the scrape checkpoint — a
captured file is never re-fetched — so a persisted provider error body is
**permanent**: it yields an empty dataset for that key on every rebuild,
forever, with nothing failing anywhere. A sweep of all four archives before
this PR:

| archive | json files | error/empty payloads |
|---|---:|---:|
| wbb (**has the guard**) | 535,556 | **0** |
| mbb | 480,784 | **42** |
| wnba | 23,938 | **9** |
| nba | 102,669 | **1** |

The one archive with the guard is clean. The 42 in mbb are all
`500 Internal Server Error` stamped `2026-07-16` — a single bad scrape session
fossilised into the tree.

## What

`sportsdataverse/scrape/espn/`, parameterized on `LeagueConfig`:

- `persist.py` — the write guard. Refusing the write is the whole fix: a
  refused key simply looks un-scraped, so the next run retries it and the
  archive self-heals instead of accumulating a quarantine nobody reads.
- `cli.py` — the `str2bool` / `season_args` contract. `type=bool` is a trap:
  bash passes the string `"false"` and `bool("false")` is `True`.
  `rescrape_default=` lets the three repos that shipped `default=True` migrate
  without changing cron behavior, then flip it in a separate reviewable commit.
- `ids.py` — one id canonicalizer; a lossy cast raises rather than silently
  producing an id that joins to the wrong row.
- `schedule.py` / `master.py` / `paths.py` — capture flags, URL columns, the
  season→master union and coverage index.
- `league_config.py` — `NBA` / `MBB` / `WNBA` / `WBB`, including which per-game
  families each league publishes (ESPN serves officials for the two women's
  leagues only; draft for the two professional ones).

## Notes for review

- **`league` is a required keyword on every public entry point**, enforced by an
  AST-based test that no module outside `league_config.py` may name a league in
  executable code. A defaulted league is how a well-formed capture lands under
  the wrong league's tree — wrong data, no error. That is the exact bug the
  NCAA extraction found in `ncaa-mbb-hoops-raw`'s capture CLI.
- `write_payload` takes an `indent` passthrough so the hoopR/wehoop archives
  keep their existing `indent=0` byte format. These trees are **committed to
  git**; a silent reformat would churn the diff of every file a later run
  rewrites.
- 87 offline tests, ported from `wehoop-wbb-raw`'s suite so its assertions stand
  as the parity oracle for the lift, then extended with the league
  parameterization.
- mypy ratchet 362 → 370 files, all green. ruff clean. codegen `--check` clean.

Repo migrations follow in separate PRs per repo, sequenced around live crons
(`wehoop-wnba-raw` scrapes daily at 06:30 UTC in season).

## Summary by Sourcery

Introduce a shared ESPN -raw scrape engine module to consolidate common functionality across hoopR/wehoop ESPN archives and enforce league-scoped capture behavior.

New Features:
- Add sportsdataverse.scrape.espn package providing league configuration, shared CLI, id canonicalization, schedule capture columns, master/coverage builders, path helpers, and write guard utilities for ESPN -raw archives.

Enhancements:
- Document the new shared ESPN -raw engine in both the main and docs changelogs, marking it as an unreleased addition.
- Tighten invariants around league usage by requiring league as a keyword-only parameter and preventing hardcoded league literals outside league_config.

Build:
- Register the new sportsdataverse.scrape.espn modules in pyproject.toml for type checking and tooling coverage.

Tests:
- Add a comprehensive offline test suite for the ESPN -raw engine covering league configs, CLI behavior, id canonicalization, capture column generation, write guarding, error payload scanning, and master/coverage aggregation behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared ESPN raw archive support for NBA, men’s and women’s college basketball, and WNBA.
  * Added standardized season and rescrape command-line options.
  * Added reliable ID normalization, schedule enrichment, archive paths, coverage metrics, and multi-league configuration.
  * Added safeguards to prevent invalid or provider-error responses from overwriting valid archived data.

* **Documentation**
  * Added unreleased changelog documentation describing the ESPN archive capabilities.

* **Tests**
  * Added comprehensive offline coverage for validation, persistence, parsing, URLs, and multi-league behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->