### PR TITLE
fix(cfb): model penalty enforcement and stop counting nullified touchdowns

### DIFF
--- a/sportsdataverse/cfb/cfb_pbp.py
+++ b/sportsdataverse/cfb/cfb_pbp.py
@@ -1793,9 +1793,11 @@ class CFBPlayProcess(object):
                 # rather than a second copy of the pattern.
                 td_play=pl.col("text").str.contains("(?i)touchdown|(?i)for a TD")
                 & ~pl.col("text").str.contains(_PENALTY_NEGATED_TEXT),
-                touchdown=pl.col("type.text").str.contains("(?i)touchdown"),
+                touchdown=pl.col("type.text").str.contains("(?i)touchdown")
+                & ~pl.col("text").str.contains(_PENALTY_NEGATED_TEXT),
                 ## Portion of touchdown check for plays where touchdown is not listed in the play_type--
-                td_check=pl.col("text").str.contains("(?i)touchdown"),
+                td_check=pl.col("text").str.contains("(?i)touchdown")
+                & ~pl.col("text").str.contains(_PENALTY_NEGATED_TEXT),
                 safety=pl.col("text").str.contains("(?i)safety"),
                 fumble_vec=pl.when(pl.col("text").str.contains("(?i)fumble"))
                 .then(True)
@@ -3037,12 +3039,22 @@ class CFBPlayProcess(object):
                 .otherwise(False),
                 pass_breakup=pl.when(pl.col("text").str.contains("(?i)broken up by")).then(True).otherwise(False),
                 # --- Pass/Rush TDs ------
-                pass_td=pl.when(pl.col("type.text").is_in(["Passing Touchdown"]))
+                # ESPN keeps the "Passing Touchdown" / "Rushing Touchdown" label
+                # on a play it also says was wiped out, so gating `td_play`
+                # alone is not enough -- the label branch below would still fire.
+                # Measured on 2025: 15 `pass_td` and 15 `rush_td` on negated
+                # plays, every one of them reaching a player leaderboard, where
+                # `summarize_passer` sums `pass_td` straight into `passing_td`.
+                pass_td=pl.when(pl.col("text").str.contains(_PENALTY_NEGATED_TEXT))
+                .then(False)
+                .when(pl.col("type.text").is_in(["Passing Touchdown"]))
                 .then(True)
                 .when((pl.col("pass") == True).and_(pl.col("td_play") == True))
                 .then(True)
                 .otherwise(False),
-                rush_td=pl.when(pl.col("type.text").is_in(["Rushing Touchdown"]))
+                rush_td=pl.when(pl.col("text").str.contains(_PENALTY_NEGATED_TEXT))
+                .then(False)
+                .when(pl.col("type.text").is_in(["Rushing Touchdown"]))
                 .then(True)
                 .when((pl.col("rush") == True).and_(pl.col("td_play") == True))
                 .then(True)

--- a/sportsdataverse/cfb/cfb_pbp.py
+++ b/sportsdataverse/cfb/cfb_pbp.py
@@ -14,6 +14,45 @@ import pandas as pd
 import polars as pl
 from xgboost import Booster, DMatrix
 
+#: ESPN's OWN verdict that a play did not count. This is the reliable negation
+#: signal and it is deliberately preferred over deriving negation ourselves from
+#: the infraction name, for two reasons measured on the release (see
+#: ``dev/penalty-analysis/DESIGN.md``):
+#:
+#: * a play can carry two fouls on the same side where one is declined and the
+#:   other accepted, so "declined" in the text does NOT mean the play stood; and
+#: * a live-ball foul plus a dead-ball foul can BOTH be accepted, negating the
+#:   play *and* adding yardage.
+#:
+#: ESPN's marker already reflects the net enforcement outcome across every
+#: penalty on the play. Plays carrying it have a ``down_repeated`` rate of
+#: 0.727-0.782 against a 0.155 no-penalty baseline.
+_PENALTY_NEGATED_TEXT = r"(?i)no play|nullified by penalty"
+
+#: Infractions that WIPE OUT the play, measured by how often the down is
+#: replayed among plays with penalty text and no explicit outcome marker
+#: (no-penalty baseline 0.155): false start 0.976, ineligible downfield 0.968,
+#: delay of game 0.919, offside/encroachment 0.761, offensive holding 0.738,
+#: illegal formation/shift/motion 0.627.
+_PENALTY_NEGATING_FOUL = (
+    r"(?i)false start|ineligible|delay of game|offside|encroachment|neutral zone"
+    r"|holding|illegal (formation|shift|motion|substitution)|clipping|chop block"
+)
+
+#: Infractions after which the play STANDS and the down advances: intentional
+#: grounding 0.045 (it is a loss of down, so the down advancing is correct) and
+#: illegal forward pass 0.175 -- both at or below the 0.155 baseline.
+_PENALTY_PLAY_STANDS_FOUL = r"(?i)intentional grounding|illegal forward pass"
+
+#: Infractions carrying an AUTOMATIC FIRST DOWN. These are deliberately NOT
+#: classified. A negated play resets the down to 1 rather than repeating it, so
+#: the replay signal cannot distinguish "wiped out the play" from "dead-ball
+#: foul after a play that stood" -- pass interference measures 0.445 purely as
+#: an artefact of that. ~2,400 leaderboard-reaching plays and roughly +2,650 EPA
+#: sit here; they resolve to ``unknown`` until a valid instrument exists.
+#: Guessing is how cfbfastR-cfb-data#30 shipped.
+_PENALTY_AUTO_FIRST_DOWN_FOUL = r"(?i)pass interference|personal foul|face ?mask|roughing|targeting|unsportsmanlike"
+
 
 def _cfb_resource_filename(package: str, resource: str) -> str:
     """Drop-in replacement for the deprecated ``pkg_resources.resource_filename``.
@@ -1747,7 +1786,13 @@ class CFBPlayProcess(object):
         play_df = (
             play_df.with_columns(
                 scoring_play=pl.when(pl.col("type.text").is_in(scores_vec)).then(True).otherwise(False),
-                td_play=pl.col("text").str.contains("(?i)touchdown|(?i)for a TD"),
+                # A touchdown ESPN says was wiped out is not a touchdown. The
+                # marker has to be applied HERE, at the definition, because the
+                # scoring logic below consumes `td_play` long before
+                # `__setup_penalty_data` runs -- hence the shared constant
+                # rather than a second copy of the pattern.
+                td_play=pl.col("text").str.contains("(?i)touchdown|(?i)for a TD")
+                & ~pl.col("text").str.contains(_PENALTY_NEGATED_TEXT),
                 touchdown=pl.col("type.text").str.contains("(?i)touchdown"),
                 ## Portion of touchdown check for plays where touchdown is not listed in the play_type--
                 td_check=pl.col("text").str.contains("(?i)touchdown"),
@@ -2628,23 +2673,49 @@ class CFBPlayProcess(object):
                 .then(True)
                 .otherwise(False),
                 # -- T/F flag conditions penalty_declined
+                # The second branch is NOT redundant: ESPN labels most penalty
+                # plays as "Penalty", but writes plenty of them onto a normally
+                # labelled play ("Pass Incompletion", "Rush"). Gating only on
+                # the play label missed 576 of 894 "declined" texts in 2025.
                 penalty_declined=pl.when(
                     (pl.col("type.text") == "Penalty").and_(pl.col("text").str.contains("(?i)declined")),
                 )
                 .then(True)
+                .when((pl.col("text").str.contains("(?i)penalty")).and_(pl.col("text").str.contains("(?i)declined")))
+                .then(True)
                 .otherwise(False),
                 # -- T/F flag conditions penalty_no_play
+                # "nullified by penalty" is ESPN's own verdict that the play did
+                # not count, and it is the RELIABLE signal. Deriving negation
+                # ourselves from the infraction name is not safe: a play can
+                # carry two fouls on the same side where one is declined and the
+                # other accepted (so "declined" in the text does NOT mean the
+                # play stood), or a live-ball foul plus a dead-ball foul that are
+                # BOTH accepted. ESPN's marker already reflects the net
+                # enforcement outcome. 179 plays carry it in 2025; 26 of them
+                # say nothing about "no play".
                 penalty_no_play=pl.when(
-                    (pl.col("type.text") == "Penalty").and_(pl.col("text").str.contains("(?i)no play")),
+                    (pl.col("type.text") == "Penalty").and_(pl.col("text").str.contains(_PENALTY_NEGATED_TEXT)),
+                )
+                .then(True)
+                .when(
+                    (pl.col("text").str.contains("(?i)penalty")).and_(
+                        pl.col("text").str.contains(_PENALTY_NEGATED_TEXT)
+                    )
                 )
                 .then(True)
                 .otherwise(False),
                 # -- T/F flag conditions penalty_offset
+                # ESPN spells this BOTH ways and overwhelmingly without the
+                # hyphen: 44 "offsetting" vs 1 "off-setting" in 2025, of which
+                # the hyphen-only pattern matched exactly one.
                 penalty_offset=pl.when(
-                    (pl.col("type.text") == "Penalty").and_(pl.col("text").str.contains("(?i)off-setting")),
+                    (pl.col("type.text") == "Penalty").and_(pl.col("text").str.contains("(?i)off-?setting")),
                 )
                 .then(True)
-                .when((pl.col("text").str.contains("(?i)penalty")).and_(pl.col("text").str.contains("(?i)off-setting")))
+                .when(
+                    (pl.col("text").str.contains("(?i)penalty")).and_(pl.col("text").str.contains("(?i)off-?setting"))
+                )
                 .then(True)
                 .otherwise(False),
                 # -- T/F flag conditions penalty_1st_conv
@@ -2660,12 +2731,62 @@ class CFBPlayProcess(object):
                     (pl.col("text").str.contains("(?i)penalty")).and_(
                         pl.col("type.text") != "Penalty",
                         pl.col("text").str.contains("(?i)declined") == False,
-                        pl.col("text").str.contains("(?i)off-setting") == False,
-                        pl.col("text").str.contains("(?i)no play") == False,
+                        pl.col("text").str.contains("(?i)off-?setting") == False,
+                        pl.col("text").str.contains(_PENALTY_NEGATED_TEXT) == False,
                     ),
                 )
                 .then(True)
                 .otherwise(False),
+            )
+            .with_columns(
+                # ---- per-penalty state -------------------------------------
+                # A play can carry more than one penalty (398 plays across
+                # 2015/2021/2025), and a single boolean cannot represent that.
+                # 54 of those have SOME but not all penalties declined -- their
+                # down-replay rate is 0.231 against 0.813 when none are
+                # declined, so the two groups genuinely differ and collapsing
+                # them loses information.
+                penalty_count=pl.col("text").str.count_matches("(?i)penalty"),
+                penalty_declined_count=pl.col("text").str.count_matches("(?i)declined"),
+            )
+            .with_columns(
+                # Only when EVERY penalty was declined does the play stand.
+                # `penalty_declined` alone (>=1 declined) is not sufficient.
+                penalty_all_declined=(pl.col("penalty_count") > 0)
+                & (pl.col("penalty_count") == pl.col("penalty_declined_count")),
+            )
+            .with_columns(
+                # ---- enforcement class, resolved in priority order ---------
+                # `unknown` is a real answer, not a gap to be filled: the
+                # automatic-first-down fouls cannot be classified from the
+                # signals available (see _PENALTY_AUTO_FIRST_DOWN_FOUL).
+                penalty_enforcement=pl.when(pl.col("penalty_flag") == False)
+                .then(pl.lit(None, dtype=pl.Utf8))
+                .when(pl.col("penalty_no_play") == True)
+                .then(pl.lit("no_play"))
+                .when(pl.col("penalty_all_declined") == True)
+                .then(pl.lit("declined"))
+                .when(pl.col("penalty_offset") == True)
+                .then(pl.lit("offsetting"))
+                .when(pl.col("text").str.contains(_PENALTY_AUTO_FIRST_DOWN_FOUL))
+                .then(pl.lit("unknown"))
+                .when(pl.col("text").str.contains(_PENALTY_NEGATING_FOUL))
+                .then(pl.lit("negating_foul"))
+                .when(pl.col("text").str.contains(_PENALTY_PLAY_STANDS_FOUL))
+                .then(pl.lit("play_stands"))
+                .otherwise(pl.lit("unknown")),
+            )
+            .with_columns(
+                # The consumer-facing answer for the classes we can settle.
+                # NULL (not False) for `unknown`, so a caller cannot silently
+                # treat "we do not know" as "the play counted".
+                penalty_negated_play=pl.when(pl.col("penalty_enforcement").is_null())
+                .then(False)
+                .when(pl.col("penalty_enforcement").is_in(["no_play", "offsetting", "negating_foul"]))
+                .then(True)
+                .when(pl.col("penalty_enforcement").is_in(["declined", "play_stands"]))
+                .then(False)
+                .otherwise(pl.lit(None, dtype=pl.Boolean)),
             )
             .with_columns(
                 penalty_detail=pl.when(pl.col("penalty_offset") == 1)

--- a/tests/cfb/test_cfb_penalty_flags.py
+++ b/tests/cfb/test_cfb_penalty_flags.py
@@ -1,0 +1,132 @@
+"""Penalty flag + enforcement classification (cfbfastR-cfb-data#32).
+
+Every case here is a real play text pattern taken from the release, not an
+invented one -- the bugs these lock in were all found by measuring real seasons
+(`sdv-py/dev/penalty-analysis/`), and a synthetic fixture would not have shown
+any of them.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from sportsdataverse.cfb.cfb_pbp import CFBPlayProcess
+
+# name-mangled private
+_SETUP = CFBPlayProcess._CFBPlayProcess__setup_penalty_data
+
+
+def _run(rows: list[tuple[str, str]]) -> pl.DataFrame:
+    """rows = [(type.text, text)] -> the penalty columns."""
+    df = pl.DataFrame({"type.text": [r[0] for r in rows], "text": [r[1] for r in rows]})
+    return _SETUP(CFBPlayProcess.__new__(CFBPlayProcess), df)
+
+
+def test_offsetting_matches_both_spellings() -> None:
+    """ESPN writes `offsetting` 44x vs `off-setting` 1x in 2025; the old
+    hyphen-only pattern flagged 0 of the 44."""
+    out = _run(
+        [
+            ("Penalty", "PENALTY WKU Holding offsetting MSU Holding offsetting. NO PLAY."),
+            ("Penalty", "PENALTY off-setting penalties. NO PLAY."),
+        ]
+    )
+    assert out["penalty_offset"].to_list() == [True, True]
+
+
+def test_declined_is_flagged_off_a_normally_typed_play() -> None:
+    """The old gate required `type.text == 'Penalty'`, missing 576 of 894
+    declined texts in 2025."""
+    out = _run(
+        [
+            ("Pass Incompletion", "Smith pass incomplete Penalty, Holding declined"),
+            ("Penalty", "PENALTY Holding declined"),
+        ]
+    )
+    assert out["penalty_declined"].to_list() == [True, True]
+
+
+def test_nullified_by_penalty_is_a_no_play() -> None:
+    """ESPN's explicit verdict. 179 plays in 2025; the old rule caught none of
+    the ones that never say 'no play'."""
+    out = _run(
+        [
+            ("Rushing Touchdown", "Lawrence rush left for 8 yards TOUCHDOWN nullified by penalty PENALTY MOST Holding"),
+        ]
+    )
+    assert out["penalty_no_play"][0] is True
+    assert out["penalty_enforcement"][0] == "no_play"
+    assert out["penalty_negated_play"][0] is True
+
+
+def test_multi_penalty_counts_and_all_declined() -> None:
+    """A play can carry two fouls where only one is declined, so `declined` in
+    the text does NOT mean the play stood."""
+    out = _run(
+        [
+            ("Rush", "run for 4 yds Penalty, Holding declined PENALTY Face Mask"),  # 1 of 2 declined
+            ("Rush", "run for 4 yds Penalty, Holding declined"),  # all declined
+        ]
+    )
+    assert out["penalty_count"].to_list() == [2, 1]
+    assert out["penalty_declined_count"].to_list() == [1, 1]
+    assert out["penalty_all_declined"].to_list() == [False, True]
+    # only the all-declined play is classified as having stood
+    assert out["penalty_enforcement"][1] == "declined"
+    assert out["penalty_negated_play"][1] is False
+
+
+def test_negating_and_standing_fouls_are_classified() -> None:
+    out = _run(
+        [
+            ("Rush", "rush for 3 yards Penalty, Offensive Holding (-10 Yards)"),
+            ("Sack", "sacked for -7 yards Penalty, Intentional Grounding"),
+        ]
+    )
+    assert out["penalty_enforcement"].to_list() == ["negating_foul", "play_stands"]
+    assert out["penalty_negated_play"].to_list() == [True, False]
+
+
+def test_auto_first_down_fouls_stay_unknown() -> None:
+    """These CANNOT be classified from the available signals -- a negated play
+    carrying an automatic first down resets the down to 1 instead of repeating
+    it, so the replay signal cannot separate it from a dead-ball foul. Guessing
+    here is how cfbfastR-cfb-data#30 shipped."""
+    out = _run(
+        [
+            ("Pass Incompletion", "pass incomplete for a 1ST down Penalty, Defensive pass interference"),
+            ("Pass Reception", "pass complete for 12 yards Penalty, Personal Foul (15 Yards)"),
+            ("Pass Reception", "pass complete Penalty, Roughing Passer"),
+        ]
+    )
+    assert out["penalty_enforcement"].to_list() == ["unknown"] * 3
+    # null, NOT false -- a consumer must not read "unknown" as "the play counted"
+    assert out["penalty_negated_play"].to_list() == [None, None, None]
+
+
+def test_no_penalty_leaves_enforcement_null() -> None:
+    out = _run([("Rush", "Jones run for 5 yards to the OSU 30")])
+    assert out["penalty_flag"][0] is False
+    assert out["penalty_enforcement"][0] is None
+    assert out["penalty_negated_play"][0] is False
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("TOUCHDOWN nullified by penalty PENALTY Holding", False),
+        ("rush for 8 yards TOUCHDOWN", True),
+        ("pass complete for a TD", True),
+        ("TOUCHDOWN PENALTY Holding. NO PLAY.", False),
+    ],
+)
+def test_td_play_excludes_negated_plays(text: str, expected: bool) -> None:
+    """30 nullified touchdowns across 2015/2021/2025 were still counted."""
+    from sportsdataverse.cfb.cfb_pbp import _PENALTY_NEGATED_TEXT
+
+    df = pl.DataFrame({"text": [text]}).with_columns(
+        td_play=pl.col("text").str.contains("(?i)touchdown|(?i)for a TD")
+        & ~pl.col("text").str.contains(_PENALTY_NEGATED_TEXT)
+    )
+    assert df["td_play"][0] is expected

--- a/tests/cfb/test_cfb_penalty_flags.py
+++ b/tests/cfb/test_cfb_penalty_flags.py
@@ -130,3 +130,53 @@ def test_td_play_excludes_negated_plays(text: str, expected: bool) -> None:
         & ~pl.col("text").str.contains(_PENALTY_NEGATED_TEXT)
     )
     assert df["td_play"][0] is expected
+
+
+def test_negated_touchdown_produces_no_td_flags() -> None:
+    """`td_play` alone was not enough (cfbfastR-cfb-data#32 review).
+
+    ESPN keeps the `Passing Touchdown` / `Rushing Touchdown` label on a play it
+    also says was nullified, and `pass_td` / `rush_td` fire off that label
+    directly -- so gating only `td_play` left them True. Measured on 2025: 15
+    `pass_td` and 15 `rush_td` on negated plays, every one reaching a player
+    leaderboard, where `summarize_passer` sums `pass_td` into `passing_td`.
+    """
+    from sportsdataverse.cfb.cfb_pbp import _PENALTY_NEGATED_TEXT
+
+    rows = [
+        ("Rushing Touchdown", "rush left for 8 yards TOUCHDOWN nullified by penalty PENALTY Holding", True),
+        ("Passing Touchdown", "pass complete for 20 yards TOUCHDOWN PENALTY Holding. NO PLAY.", True),
+        ("Rushing Touchdown", "rush left for 8 yards TOUCHDOWN", False),
+        ("Passing Touchdown", "pass complete for 20 yards TOUCHDOWN", False),
+    ]
+    df = pl.DataFrame(
+        {
+            "type.text": [r[0] for r in rows],
+            "text": [r[1] for r in rows],
+            "negated": [r[2] for r in rows],
+        }
+    )
+    neg = pl.col("text").str.contains(_PENALTY_NEGATED_TEXT)
+    out = df.with_columns(
+        td_play=pl.col("text").str.contains("(?i)touchdown|(?i)for a TD") & ~neg,
+        touchdown=pl.col("type.text").str.contains("(?i)touchdown") & ~neg,
+        td_check=pl.col("text").str.contains("(?i)touchdown") & ~neg,
+        pass_td=pl.when(neg)
+        .then(False)
+        .when(pl.col("type.text").is_in(["Passing Touchdown"]))
+        .then(True)
+        .otherwise(False),
+        rush_td=pl.when(neg)
+        .then(False)
+        .when(pl.col("type.text").is_in(["Rushing Touchdown"]))
+        .then(True)
+        .otherwise(False),
+    )
+    negated = out.filter(pl.col("negated"))
+    for col in ("td_play", "touchdown", "td_check", "pass_td", "rush_td"):
+        assert not any(negated[col].to_list()), f"{col} still True on a negated touchdown"
+    # and a real touchdown is untouched
+    real = out.filter(~pl.col("negated"))
+    assert all(real["td_play"].to_list())
+    assert real["pass_td"].to_list() == [False, True]
+    assert real["rush_td"].to_list() == [True, False]


### PR DESCRIPTION
Addresses [cfbfastR-cfb-data#32](https://github.com/sportsdataverse/cfbfastR-cfb-data/issues/32).

Analysis across 2008 / 2015 / 2021 / 2025 (~610k plays); working notes in
`dev/penalty-analysis/` (gitignored), and the full write-up is on the linked
issue.

## 1. Phantom touchdowns

Plays ESPN **explicitly marks** `nullified by penalty` were still flagged
`td_play` and still reached the player leaderboards.

| marker | plays (2025) | reach leaderboard | still `td_play` | TEPA |
|---|---|---|---|---|
| `nullified by penalty` | 179 | 18 | **18** | +77.3 |
| `no play` | 7,423 | 58 | **15** | +26.1 |

**30 such touchdowns pooled over three seasons, +118.9 EPA.** Their down-replay
rate is 0.500 — a real touchdown ends the drive.

The guard is applied at `td_play`'s definition rather than in
`__setup_penalty_data`, because the scoring logic consumes `td_play` ~850 lines
before the penalty flags are built. Hence the shared `_PENALTY_NEGATED_TEXT`
constant instead of a second copy of the pattern.

## 2. Parser bugs

| bug | evidence |
|---|---|
| `penalty_offset` matched only the hyphenated `off-setting` | ESPN writes `offsetting`: **44 vs 1** in 2025 — the old pattern caught exactly one. Pooled 74/139 |
| `penalty_declined` / `penalty_no_play` lacked the ungated second branch `penalty_offset` and `penalty_1st_conv` already had | pooled `penalty_declined`: **625 of 2,432** text matches (26%) |
| `nullified by penalty` unrecognised | 282 plays pooled; 26 say nothing about "no play" |

## 3. New columns

`penalty_count`, `penalty_declined_count`, `penalty_all_declined`,
`penalty_enforcement`, `penalty_negated_play`.

A play can carry several penalties and a play-level boolean cannot represent
that. Two fouls on one side — one declined, one accepted — put "declined" in the
text while the accepted foul still wiped out the play; a live-ball foul plus a
dead-ball foul can **both** be accepted. Measured: **398** plays carry 2+
penalties, **54** have some-but-not-all declined, and those replay at 0.231
versus 0.813 when none are declined. Only `penalty_all_declined` means the play
stood.

## Validation

Against an independent signal — does the next play repeat the down — which is
derived from the following play and never from the penalty text. No-penalty
baseline **0.149**:

| `penalty_enforcement` | n | down_repeated | verdict |
|---|---|---|---|
| `no_play` | 7,446 | 0.748 | ✅ far above baseline |
| `negating_foul` | 1,445 | 0.725 | ✅ far above baseline |
| `declined` | 781 | 0.106 | ✅ at/below — play stood |
| `play_stands` | 153 | 0.026 | ✅ below — down advances |
| `unknown` | 1,984 | 0.403 | ✅ correctly isolated |
| `offsetting` | 28 | 0.143 | ⚠️ see caveat |

End-to-end through `CFBPlayProcess` on game 401757288: the nullified touchdown
now reads `td_play=False`, `penalty_enforcement='no_play'`,
`penalty_negated_play=True`, `penalty_count=2`.

**Caveat, stated plainly:** `offsetting` (n=28) shows no elevated replay rate.
The rule is unambiguous so it stays classified as negating, but the evidence
does not support it — likely because those plays are labelled `Penalty` and
followed by another `Penalty` row, breaking the next-play lookup. Worth
re-measuring with a drive-aware signal.

## What is deliberately NOT classified

The **automatic-first-down fouls** — pass interference, personal foul, face
mask, roughing, targeting, unsportsmanlike — resolve to `unknown`. A negated
play carrying an automatic first down resets the down to 1 rather than repeating
it, so the replay signal cannot separate "wiped out the play" from "dead-ball
foul after a play that stood". Pass interference's 0.445 is an artefact of that,
not evidence that ~55% of DPIs let the play stand.

That bucket is ~1,150 leaderboard-reaching plays and ~+1,000 EPA in 2025 — the
bulk of the remaining contamination.

`penalty_negated_play` is **NULL, not false**, for `unknown`, so a consumer
cannot silently read "we don't know" as "the play counted". A field-position
test built to settle it **failed its own sanity check** (it judged 41% of
penalty-free plays "negated"), so its results are void; the failure is recorded
in the design notes so the approach is not retried blind.

## Era drift

Why the marker sets are unions rather than one pattern — a rule tuned on 2025
silently under-fires on 2008:

| marker | 2008 | 2015 | 2021 | 2025 |
|---|---|---|---|---|
| `accepted` | **9,026** | 0 | 0 | 0 |
| `enforced` | 0 | 0 | **1,344** | 7 |
| `nullified by penalty` | 0 | 0 | 103 | 179 |

## Test status — please read

- `tests/cfb/test_cfb_penalty_flags.py`: **11 new cases, all passing**, each
  built from real release text patterns rather than invented ones.
- `tests/cfb/`: **610 passed / 54 skipped / 2 xfailed** on the code as of the
  `td_play` + parser-fix stage.
- Codegen drift gate: **clean**.
- **The full-repo `pytest` run was not waited on** — it was still running when
  this was pushed. `tests/cfb/` is the affected surface and it was green, but CI
  is the authority here, not me.

## Follow-up

The corresponding producer change (filtering `penalty_no_play` in the cfb-data
leaderboard frames) is not in this PR. It currently drops zero rows because the
scrimmage filter already removes them, so it costs nothing and closes the hole
as soon as these flags improve.

## Summary by Sourcery

Improve NCAA football play-by-play penalty handling and touchdown detection to correctly treat nullified plays and classify penalty enforcement outcomes.

Bug Fixes:
- Exclude touchdowns explicitly nullified by penalty text from td_play and related scoring logic.
- Correct detection of declined and offsetting penalties across both Penalty-typed and normally typed plays, including support for both spellings of offsetting and recognition of nullified-by-penalty as no-play.

Enhancements:
- Introduce text-derived penalty metadata including per-play penalty counts, all-declined detection, enforcement classification, and a consumer-facing negated-play flag.
- Prefer ESPN’s explicit no-play markers and empirically derived foul categories to infer whether a play was negated, stood, or is unknown.

Tests:
- Add targeted tests that lock in penalty parsing, enforcement classification, negated-play behavior, and td_play exclusion for nullified touchdowns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved college football play parsing for declined, offsetting, and nullified penalties.
  * More accurately identifies whether fouls negate a play or allow it to stand.
  * Prevents touchdowns from being counted on plays explicitly nullified by penalties.
  * Supports multiple penalty outcomes and spelling variations in play descriptions.

* **Tests**
  * Added comprehensive coverage for penalty classifications, enforcement outcomes, and negated touchdown plays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->