### PR TITLE
feat(validation): row-level definitional checks for CFB + NFL pbp

### DIFF
--- a/tests/contracts/test_definitional.py
+++ b/tests/contracts/test_definitional.py
@@ -215,6 +215,15 @@ def test_nfl_posteam_participant_rules_allow_null_posteam():
     assert "defteam_is_a_participant" not in by_rule
 
 
+def test_null_dtype_column_skips_string_rules_instead_of_crashing():
+    # an all-null series polars types as Null; str.contains on it raises
+    # InvalidOperationError (not SchemaError) on 1.42 — the fallback must
+    # skip the rule, not crash run()
+    frame = pl.DataFrame({"passer_player_id": [None, None]})
+    ctx = _ctx(dataset="nfl_model_pbp", domain="nfl", join_keys=())
+    assert definitional.run("nfl_model_pbp", frame, ctx) == []
+
+
 def test_nfl_clock_hierarchy_skips_overtime():
     frame = pl.DataFrame(
         {

--- a/tests/contracts/test_definitional.py
+++ b/tests/contracts/test_definitional.py
@@ -1,0 +1,230 @@
+import polars as pl
+
+from tools.validation.checks import definitional
+from tools.validation.findings import CheckContext, Severity
+
+
+def _ctx(dataset="cfb_model_pbp", domain="cfb", **kw):
+    base = dict(domain=domain, dataset=dataset, schema={}, join_keys=("game_id",))
+    base.update(kw)
+    return CheckContext(**base)
+
+
+def _findings_by_rule(findings):
+    return {f.locator["rule"]: f for f in findings}
+
+
+def test_unknown_dataset_has_no_rules():
+    frame = pl.DataFrame({"rush": [True], "pass": [True]})
+    assert definitional.run("no_such_dataset", frame, _ctx(dataset="no_such_dataset")) == []
+
+
+def test_rule_with_missing_columns_is_skipped_not_failed():
+    # only rush/pass present: every other rule must skip silently
+    frame = pl.DataFrame({"rush": [False], "pass": [True]})
+    assert definitional.run("cfb_model_pbp", frame, _ctx()) == []
+
+
+def test_rush_pass_both_true_is_error_with_count_and_sample():
+    frame = pl.DataFrame(
+        {
+            "game_id": [1, 1, 2],
+            "rush": [True, False, True],
+            "pass": [True, False, True],
+        }
+    )
+    by_rule = _findings_by_rule(definitional.run("cfb_model_pbp", frame, _ctx()))
+    f = by_rule["rush_pass_mutually_exclusive"]
+    assert f.severity is Severity.ERROR
+    assert f.metric == 2.0
+    assert f.sample is not None and f.sample[0]["game_id"] == 1  # join key attached
+    assert "rush" in f.sample[0]
+
+
+def test_null_inputs_do_not_fire_identity_rules():
+    # epa null on row 0, ep_after null on row 1 -> identity not evaluable, no finding
+    frame = pl.DataFrame(
+        {
+            "epa": [None, 2.0, 0.5],
+            "ep_after": [1.0, None, 1.5],
+            "ep_before": [0.5, 0.5, 1.0],
+        }
+    )
+    assert definitional.run("cfb_model_pbp", frame, _ctx()) == []
+
+
+def test_epa_identity_violation_is_warn_needs_judgment():
+    frame = pl.DataFrame({"epa": [9.0], "ep_after": [1.0], "ep_before": [0.5]})
+    by_rule = _findings_by_rule(definitional.run("cfb_model_pbp", frame, _ctx()))
+    f = by_rule["epa_is_ep_after_minus_ep_before"]
+    assert f.severity is Severity.WARN and f.needs_judgment
+
+
+def test_wpa_identity_violation_is_error():
+    frame = pl.DataFrame({"wpa": [0.9], "wp_after": [0.6], "wp_before": [0.5]})
+    by_rule = _findings_by_rule(definitional.run("cfb_model_pbp", frame, _ctx()))
+    f = by_rule["wpa_is_wp_after_minus_wp_before"]
+    assert f.severity is Severity.ERROR
+
+
+def test_game_play_number_window_rule_respects_game_boundaries():
+    # decreasing within game 1 fires; the drop across the 1->2 boundary must not
+    frame = pl.DataFrame(
+        {
+            "game_id": [1, 1, 1, 2, 2],
+            "game_play_number": [1, 3, 2, 1, 2],
+        }
+    )
+    by_rule = _findings_by_rule(definitional.run("cfb_model_pbp", frame, _ctx()))
+    assert by_rule["game_play_number_strictly_increasing"].metric == 1.0
+
+    clean = pl.DataFrame({"game_id": [1, 1, 2], "game_play_number": [1, 2, 1]})
+    assert definitional.run("cfb_model_pbp", clean, _ctx()) == []
+
+
+def test_passing_down_definition_both_directions():
+    # row0: down 2 & 9 flagged False (missed) / row1: down 1 flagged True (spurious)
+    frame = pl.DataFrame(
+        {
+            "rush": [False, True],
+            "pass": [True, False],
+            "passing_down": [False, True],
+            "start.down": [2, 1],
+            "start.distance": [9, 10],
+        }
+    )
+    by_rule = _findings_by_rule(definitional.run("cfb_model_pbp", frame, _ctx()))
+    assert by_rule["passing_down_definition"].metric == 2.0
+
+
+def test_nfl_td_subtype_rules():
+    frame = pl.DataFrame(
+        {
+            "pass_touchdown": [1, 1, 0],
+            "rush_touchdown": [1, 0, 0],
+            "return_touchdown": [0, 0, 0],
+            "touchdown": [1, 0, 0],  # row0: two subtypes; row1: subtype without touchdown
+        }
+    )
+    ctx = _ctx(dataset="nfl_model_pbp", domain="nfl", join_keys=("game_id", "play_id"))
+    by_rule = _findings_by_rule(definitional.run("nfl_model_pbp", frame, ctx))
+    assert by_rule["td_subtypes_at_most_one"].metric == 1.0
+    assert by_rule["td_subtype_implies_touchdown"].metric == 1.0
+
+
+def test_nfl_name_id_pair_mismatch_fires_both_ways():
+    frame = pl.DataFrame(
+        {
+            "passer_player_name": ["P.Mahomes", None, None],
+            "passer_player_id": [None, "00-0033873", None],  # rows 0+1 half-populated
+        }
+    )
+    ctx = _ctx(dataset="nfl_model_pbp", domain="nfl", join_keys=())
+    by_rule = _findings_by_rule(definitional.run("nfl_model_pbp", frame, ctx))
+    assert by_rule["passer_name_id_populated_together"].metric == 2.0
+
+
+def test_nfl_passer_iff_pass_attempt_fires_both_directions():
+    frame = pl.DataFrame(
+        {
+            "pass_attempt": [1, 0, 1, 0],
+            "passer_player_name": [None, "P.Mahomes", "J.Allen", None],  # rows 0+1 violate
+        }
+    )
+    ctx = _ctx(dataset="nfl_model_pbp", domain="nfl", join_keys=())
+    by_rule = _findings_by_rule(definitional.run("nfl_model_pbp", frame, ctx))
+    assert by_rule["passer_iff_pass_attempt"].metric == 2.0
+
+
+def test_nfl_receiver_null_on_incomplete_is_allowed():
+    # throwaway: incomplete pass with no target — must NOT fire
+    frame = pl.DataFrame(
+        {
+            "pass_attempt": [1],
+            "complete_pass": [0],
+            "receiver_player_name": [None],
+        }
+    )
+    ctx = _ctx(dataset="nfl_model_pbp", domain="nfl", join_keys=())
+    assert definitional.run("nfl_model_pbp", frame, ctx) == []
+
+
+def test_nfl_name_in_desc_literal_not_regex():
+    # dots in "P.Mahomes" must match literally, not as regex wildcards
+    frame = pl.DataFrame(
+        {
+            "rusher_player_name": ["P.Mahomes", "J.Allen"],
+            "desc": ["P.Mahomes scrambles for 5 yards.", "K.Murray kneels."],  # row1 missing
+        }
+    )
+    ctx = _ctx(dataset="nfl_model_pbp", domain="nfl", join_keys=())
+    by_rule = _findings_by_rule(definitional.run("nfl_model_pbp", frame, ctx))
+    assert by_rule["rusher_name_appears_in_desc"].metric == 1.0
+
+
+def test_cfb_passer_on_non_pass_play_is_warn_needs_judgment():
+    frame = pl.DataFrame({"pass": [False], "passer_player_name": ["Q.Ewers"]})
+    by_rule = _findings_by_rule(definitional.run("cfb_model_pbp", frame, _ctx(join_keys=())))
+    f = by_rule["passer_only_on_pass_plays"]
+    assert f.severity is Severity.WARN and f.needs_judgment
+
+
+def test_nfl_id_format_catches_float_artifact_and_empty():
+    frame = pl.DataFrame(
+        {
+            "passer_player_id": ["00-0033873", "33873.0", "", None],  # rows 1+2 violate
+        }
+    )
+    ctx = _ctx(dataset="nfl_model_pbp", domain="nfl", join_keys=())
+    by_rule = _findings_by_rule(definitional.run("nfl_model_pbp", frame, ctx))
+    assert by_rule["passer_player_id_format"].metric == 2.0
+
+
+def test_nfl_game_id_format():
+    frame = pl.DataFrame({"game_id": ["2024_01_BAL_KC", "401628319"]})  # ESPN-style id violates
+    ctx = _ctx(dataset="nfl_model_pbp", domain="nfl", join_keys=())
+    by_rule = _findings_by_rule(definitional.run("nfl_model_pbp", frame, ctx))
+    assert by_rule["game_id_format"].metric == 1.0
+
+
+def test_clean_string_rule_flags_empty_and_padded_not_null():
+    frame = pl.DataFrame({"passer_player_name": ["Q.Ewers ", "", None, "J.Allen"]})
+    ctx = _ctx(dataset="nfl_model_pbp", domain="nfl", join_keys=())
+    by_rule = _findings_by_rule(definitional.run("nfl_model_pbp", frame, ctx))
+    assert by_rule["passer_player_name_clean_string"].metric == 2.0  # null + clean rows pass
+
+
+def test_cfb_drive_id_numeric_string_format():
+    frame = pl.DataFrame({"drive.id": ["4016283191", "4016283191.0", None]})
+    by_rule = _findings_by_rule(definitional.run("cfb_model_pbp", frame, _ctx(join_keys=())))
+    assert by_rule["drive.id_format"].metric == 1.0
+
+
+def test_nfl_posteam_participant_rules_allow_null_posteam():
+    frame = pl.DataFrame(
+        {
+            "posteam": [None, "KC", "DEN"],  # null legit; DEN not a participant
+            "defteam": ["BAL", "BAL", "BAL"],
+            "home_team": ["KC", "KC", "KC"],
+            "away_team": ["BAL", "BAL", "BAL"],
+        }
+    )
+    ctx = _ctx(dataset="nfl_model_pbp", domain="nfl", join_keys=())
+    by_rule = _findings_by_rule(definitional.run("nfl_model_pbp", frame, ctx))
+    assert by_rule["posteam_is_a_participant"].metric == 1.0
+    assert "defteam_is_a_participant" not in by_rule
+
+
+def test_nfl_clock_hierarchy_skips_overtime():
+    frame = pl.DataFrame(
+        {
+            "qtr": [5, 2],
+            "quarter_seconds_remaining": [600, 100],
+            "half_seconds_remaining": [600, 50],  # row1 violates in regulation
+            "game_seconds_remaining": [0, 1850],
+        }
+    )
+    ctx = _ctx(dataset="nfl_model_pbp", domain="nfl", join_keys=())
+    by_rule = _findings_by_rule(definitional.run("nfl_model_pbp", frame, ctx))
+    f = by_rule["clock_hierarchy_regulation"]
+    assert f.metric == 1.0  # only the qtr=2 row; the OT row is out of scope

--- a/tools/validation/checks/definitional.py
+++ b/tools/validation/checks/definitional.py
@@ -1,0 +1,624 @@
+"""Row-level definitional consistency rules for play-by-play datasets.
+
+Each rule is a named polars boolean expression where ``True`` means the row
+VIOLATES the definition (e.g. a play flagged both ``rush`` and ``pass``).
+Rules are declared per dataset in ``RULES``; ``run`` evaluates every
+applicable rule's violation count in one pass and emits one Finding per
+fired rule, with up to ``_SAMPLE_N`` offending rows attached for triage.
+
+Null semantics are load-bearing: a violation expression involving a null
+input evaluates to null, and ``sum()`` skips nulls — so identity rules
+(e.g. ``epa == ep_after - ep_before``) automatically apply only to rows
+where every input is populated. Rules therefore do NOT need explicit
+``is_not_null`` guards on their own inputs, only on scope columns whose
+nullness changes the rule's meaning.
+
+Severity calibration policy (mirrors the measured-thresholds rule): a rule
+ships as ERROR only if it fires zero times on the current published data
+(or its firings are confirmed producer bugs); rules that fire on
+legitimate rows are scoped tighter or downgraded to WARN with
+``needs_judgment=True`` so the Tier-2 workflow routes them to a reviewer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import polars as pl
+
+from tools.validation.findings import CheckContext, Finding, Severity
+
+_SAMPLE_N = 3
+_EPS = 1e-6
+
+
+@dataclass(frozen=True)
+class Rule:
+    """One row-level definitional rule.
+
+    Attributes:
+        name: Stable identifier recorded on the finding locator.
+        columns: Every column the expression reads; the rule is skipped
+            (not failed) when any is absent from the frame, so one rule
+            table serves datasets whose column sets drift across releases.
+        violation: Boolean expression; ``True`` marks a violating row.
+        description: Human-readable statement of the violated definition.
+        severity: Severity when the rule fires.
+        needs_judgment: Route the finding to a reviewer (WARN rules whose
+            firings can be legitimate data quirks).
+    """
+
+    name: str
+    columns: tuple[str, ...]
+    violation: pl.Expr
+    description: str
+    severity: Severity = Severity.ERROR
+    needs_judgment: bool = False
+
+
+def _c(name: str) -> pl.Expr:
+    return pl.col(name)
+
+
+def _clean_string_rule(col: str) -> Rule:
+    """A string column must be null or a non-empty, unpadded value.
+
+    Content-level twin of the schema dtype check: catches the
+    empty-string-as-null and whitespace-padding producer bug classes that a
+    declared ``String`` dtype can't see.
+    """
+    return Rule(
+        f"{col}_clean_string",
+        (col,),
+        (_c(col) == "") | (_c(col) != _c(col).str.strip_chars()),
+        f"{col} must be null or a non-empty unpadded string",
+    )
+
+
+def _id_format_rule(col: str, pattern: str, label: str) -> Rule:
+    """A non-null string id must match its canonical format.
+
+    Subsumes the float-artifact ('123.0') and empty-string id bug classes —
+    neither can match a canonical id pattern.
+    """
+    return Rule(
+        f"{col}_format",
+        (col,),
+        ~_c(col).str.contains(pattern),
+        f"{col} must match the {label} format",
+    )
+
+
+# ---------------------------------------------------------------------------
+# CFB — cfb_model_pbp (cfb-data producer output)
+# ---------------------------------------------------------------------------
+
+_CFB_SCRIMMAGE = (_c("pass") == True) | (_c("rush") == True)  # noqa: E712
+
+_CFB_RULES: tuple[Rule, ...] = (
+    Rule(
+        "rush_pass_mutually_exclusive",
+        ("rush", "pass"),
+        (_c("rush") == True) & (_c("pass") == True),  # noqa: E712
+        "a play cannot be flagged both rush and pass",
+    ),
+    Rule(
+        "completion_requires_pass",
+        ("completion", "pass"),
+        (_c("completion") == True) & (_c("pass") == False),  # noqa: E712
+        "completion=True requires pass=True",
+    ),
+    Rule(
+        "cpoe_requires_completion_prob",
+        ("cpoe", "completion_prob"),
+        _c("cpoe").is_not_null() & _c("completion_prob").is_null(),
+        "cpoe is derived from completion_prob and cannot exist without it",
+    ),
+    Rule(
+        "completion_prob_only_on_pass",
+        ("completion_prob", "pass"),
+        _c("completion_prob").is_not_null() & (_c("pass") == False),  # noqa: E712
+        "completion probability is a pass-play model output",
+        severity=Severity.WARN,
+        needs_judgment=True,
+    ),
+    Rule(
+        "scrimmage_down_in_1_4",
+        ("rush", "pass", "start.down"),
+        _CFB_SCRIMMAGE & ~_c("start.down").is_between(1, 4),
+        "a rush/pass play must start on down 1-4",
+    ),
+    Rule(
+        "distance_non_negative",
+        ("start.distance",),
+        _c("start.distance") < 0,
+        "distance-to-first-down cannot be negative",
+    ),
+    Rule(
+        "distance_within_yards_to_endzone",
+        ("rush", "pass", "start.distance", "start.yardsToEndzone"),
+        _CFB_SCRIMMAGE & (_c("start.distance") > _c("start.yardsToEndzone")),
+        "distance to the first-down line cannot exceed distance to the endzone",
+        severity=Severity.WARN,
+        needs_judgment=True,
+    ),
+    Rule(
+        "scrimmage_yards_to_endzone_1_99",
+        ("rush", "pass", "start.yardsToEndzone"),
+        _CFB_SCRIMMAGE & ~_c("start.yardsToEndzone").is_between(1, 99),
+        "a scrimmage play starts 1-99 yards from the endzone",
+    ),
+    Rule(
+        "time_secs_rem_0_1800",
+        ("start.TimeSecsRem",),
+        ~_c("start.TimeSecsRem").is_between(0, 1800),
+        "half seconds remaining must be within [0, 1800]",
+    ),
+    Rule(
+        "period_positive",
+        ("period",),
+        _c("period") < 1,
+        "period must be >= 1",
+    ),
+    # Measured 2026-08-06 on the published sample: fires on ~1.2% of rows
+    # (47/101 last-play-of-period, rest ordinary plays, deviations up to
+    # ~1.4 EP) while the wpa twin holds exactly — epa appears to have its
+    # own computation path in the cfb-data producer rather than being the
+    # snapshot diff. Routed to triage instead of hard-failing.
+    Rule(
+        "epa_is_ep_after_minus_ep_before",
+        ("epa", "ep_after", "ep_before"),
+        (_c("ep_after") - _c("ep_before") - _c("epa")).abs() > _EPS,
+        "epa is expected to equal ep_after - ep_before",
+        severity=Severity.WARN,
+        needs_judgment=True,
+    ),
+    Rule(
+        "wpa_is_wp_after_minus_wp_before",
+        ("wpa", "wp_after", "wp_before"),
+        (_c("wp_after") - _c("wp_before") - _c("wpa")).abs() > _EPS,
+        "wpa must equal wp_after - wp_before",
+    ),
+    Rule(
+        "pos_team_is_a_participant",
+        ("pos_team", "homeTeamId", "awayTeamId"),
+        (_c("pos_team") != _c("homeTeamId")) & (_c("pos_team") != _c("awayTeamId")),
+        "pos_team must be the home or away team",
+    ),
+    Rule(
+        "pos_team_not_def_pos_team",
+        ("pos_team", "def_pos_team"),
+        _c("pos_team") == _c("def_pos_team"),
+        "a team cannot possess and defend on the same play",
+    ),
+    Rule(
+        "is_home_matches_pos_team",
+        ("start.is_home", "pos_team", "homeTeamId"),
+        _c("start.is_home") != (_c("pos_team") == _c("homeTeamId")),
+        "start.is_home must equal (pos_team == homeTeamId)",
+    ),
+    Rule(
+        "passing_down_definition",
+        ("rush", "pass", "passing_down", "start.down", "start.distance"),
+        _CFB_SCRIMMAGE
+        & (
+            _c("passing_down")
+            != (
+                ((_c("start.down") == 2) & (_c("start.distance") >= 8))
+                | (_c("start.down").is_in([3, 4]) & (_c("start.distance") >= 5))
+            )
+        ),
+        "passing_down must equal (down 2 & dist>=8) | (down 3/4 & dist>=5) on scrimmage plays",
+    ),
+    Rule(
+        "game_play_number_strictly_increasing",
+        ("game_id", "game_play_number"),
+        _c("game_play_number").diff().over("game_id") <= 0,
+        "game_play_number must strictly increase within a game",
+    ),
+    # Participant columns (measured 2026-08-07 on the published sample):
+    # passer is populated on 3141/3141 pass plays -> hard invariant; the
+    # reverse direction has 3 legitimate firings (Fumble Return Touchdown
+    # rows where the participants extractor found the passer on a play the
+    # producer classifies as neither rush nor pass) -> triage, not error;
+    # name-appears-in-text held on 3071/3144 (97.7%) -> triage.
+    Rule(
+        "passer_populated_on_pass",
+        ("pass", "passer_player_name"),
+        (_c("pass") == True) & _c("passer_player_name").is_null(),  # noqa: E712
+        "a pass play must carry passer_player_name",
+    ),
+    Rule(
+        "passer_only_on_pass_plays",
+        ("pass", "passer_player_name"),
+        _c("passer_player_name").is_not_null() & (_c("pass") == False),  # noqa: E712
+        "passer_player_name on a non-pass play (fumble-return TDs are known-legit)",
+        severity=Severity.WARN,
+        needs_judgment=True,
+    ),
+    Rule(
+        "passer_name_appears_in_text",
+        ("passer_player_name", "text"),
+        ~_c("text").str.contains(_c("passer_player_name"), literal=True),
+        "the extracted passer name should appear verbatim in the play text",
+        severity=Severity.WARN,
+        needs_judgment=True,
+    ),
+    # Content-level type rules (measured 2026-08-07: 100% clean on the
+    # published sample; drive.id is a pure numeric string — a '.0' float
+    # artifact or empty string cannot match).
+    _clean_string_rule("passer_player_name"),
+    _id_format_rule("drive.id", r"^\d+$", "numeric-string drive id"),
+)
+
+
+def _nfl_pair_rule(stem: str) -> Rule:
+    """Name/id columns of one participant stem must be populated together."""
+    n, i = f"{stem}_player_name", f"{stem}_player_id"
+    return Rule(
+        f"{stem}_name_id_populated_together",
+        (n, i),
+        _c(n).is_null() != _c(i).is_null(),
+        f"{n} and {i} must both be set or both be null",
+    )
+
+
+def _nfl_name_in_desc_rule(stem: str) -> Rule:
+    """An extracted participant name must appear verbatim in the play desc."""
+    n = f"{stem}_player_name"
+    return Rule(
+        f"{stem}_name_appears_in_desc",
+        (n, "desc"),
+        ~_c("desc").str.contains(_c(n), literal=True),
+        f"the extracted {n} should appear verbatim in desc",
+    )
+
+
+# ---------------------------------------------------------------------------
+# NFL — nfl_model_pbp (native pipeline output, nflfastR-shaped 0/1 flags)
+# ---------------------------------------------------------------------------
+
+_NFL_RULES: tuple[Rule, ...] = (
+    Rule(
+        "rush_pass_mutually_exclusive",
+        ("rush_attempt", "pass_attempt"),
+        (_c("rush_attempt") == 1) & (_c("pass_attempt") == 1),
+        "a play cannot be both a rush attempt and a pass attempt",
+    ),
+    Rule(
+        "complete_incomplete_mutually_exclusive",
+        ("complete_pass", "incomplete_pass"),
+        (_c("complete_pass") == 1) & (_c("incomplete_pass") == 1),
+        "a pass cannot be both complete and incomplete",
+    ),
+    Rule(
+        "complete_pass_requires_pass_attempt",
+        ("complete_pass", "pass_attempt"),
+        (_c("complete_pass") == 1) & (_c("pass_attempt") != 1),
+        "complete_pass=1 requires pass_attempt=1",
+    ),
+    Rule(
+        "interception_requires_pass_attempt",
+        ("interception", "pass_attempt"),
+        (_c("interception") == 1) & (_c("pass_attempt") != 1),
+        "an interception requires a pass attempt",
+    ),
+    Rule(
+        "sack_incompatible_with_completion",
+        ("sack", "complete_pass"),
+        (_c("sack") == 1) & (_c("complete_pass") == 1),
+        "a sack cannot also be a completed pass",
+    ),
+    Rule(
+        "td_subtype_implies_touchdown",
+        ("pass_touchdown", "rush_touchdown", "return_touchdown", "touchdown"),
+        ((_c("pass_touchdown") == 1) | (_c("rush_touchdown") == 1) | (_c("return_touchdown") == 1))
+        & (_c("touchdown") != 1),
+        "any touchdown subtype flag requires touchdown=1",
+    ),
+    Rule(
+        "td_subtypes_at_most_one",
+        ("pass_touchdown", "rush_touchdown", "return_touchdown"),
+        (_c("pass_touchdown") + _c("rush_touchdown") + _c("return_touchdown")) > 1,
+        "a play scores at most one kind of touchdown",
+    ),
+    Rule(
+        "touchdown_implies_scoring_play",
+        ("touchdown", "sp"),
+        (_c("touchdown") == 1) & (_c("sp") != 1),
+        "touchdown=1 requires the scoring-play flag sp=1",
+    ),
+    Rule(
+        "fg_results_at_most_one",
+        ("field_goal_made", "field_goal_missed", "field_goal_blocked"),
+        (_c("field_goal_made") + _c("field_goal_missed") + _c("field_goal_blocked")) > 1,
+        "a field goal attempt has at most one outcome",
+    ),
+    Rule(
+        "fg_result_requires_attempt",
+        ("field_goal_made", "field_goal_missed", "field_goal_blocked", "field_goal_attempt"),
+        ((_c("field_goal_made") == 1) | (_c("field_goal_missed") == 1) | (_c("field_goal_blocked") == 1))
+        & (_c("field_goal_attempt") != 1),
+        "a field goal outcome flag requires field_goal_attempt=1",
+    ),
+    Rule(
+        "fumble_lost_requires_fumble",
+        ("fumble_lost", "fumble"),
+        (_c("fumble_lost") == 1) & (_c("fumble") != 1),
+        "fumble_lost=1 requires fumble=1",
+    ),
+    Rule(
+        "down_in_1_4",
+        ("down",),
+        _c("down").is_not_null() & ~_c("down").is_between(1, 4),
+        "down must be 1-4 (or null on untimed/no-down plays)",
+    ),
+    Rule(
+        "ydstogo_non_negative",
+        ("ydstogo",),
+        _c("ydstogo") < 0,
+        "yards to go cannot be negative",
+    ),
+    Rule(
+        "yardline_100_range_on_downed_plays",
+        ("down", "yardline_100"),
+        _c("down").is_not_null() & ~_c("yardline_100").is_between(1, 99),
+        "a play with a down starts 1-99 yards from the opponent endzone",
+    ),
+    Rule(
+        "goal_to_go_means_ydstogo_is_yardline",
+        ("goal_to_go", "ydstogo", "yardline_100"),
+        (_c("goal_to_go") == 1) & (_c("ydstogo") != _c("yardline_100")),
+        "goal-to-go means the first-down line is the goal line",
+        severity=Severity.WARN,
+        needs_judgment=True,
+    ),
+    Rule(
+        "quarter_seconds_0_900",
+        ("quarter_seconds_remaining",),
+        ~_c("quarter_seconds_remaining").is_between(0, 900),
+        "quarter seconds remaining must be within [0, 900]",
+    ),
+    # Scoped to regulation: the producer's OT convention is
+    # game_seconds_remaining = 0 while quarter/half count down from 600
+    # (measured 2026-08-06 — all 483 unscoped firings were qtr 5).
+    Rule(
+        "clock_hierarchy_regulation",
+        ("qtr", "quarter_seconds_remaining", "half_seconds_remaining", "game_seconds_remaining"),
+        (_c("qtr") <= 4)
+        & (
+            (_c("half_seconds_remaining") < _c("quarter_seconds_remaining"))
+            | (_c("game_seconds_remaining") < _c("half_seconds_remaining"))
+        ),
+        "in regulation, game clock >= half clock >= quarter clock",
+    ),
+    Rule(
+        "score_differential_identity",
+        ("score_differential", "posteam_score", "defteam_score"),
+        _c("score_differential") != (_c("posteam_score") - _c("defteam_score")),
+        "score_differential must equal posteam_score - defteam_score",
+    ),
+    Rule(
+        "posteam_timeouts_0_3",
+        ("posteam_timeouts_remaining",),
+        ~_c("posteam_timeouts_remaining").is_between(0, 3),
+        "a team has 0-3 timeouts",
+    ),
+    Rule(
+        "defteam_timeouts_0_3",
+        ("defteam_timeouts_remaining",),
+        ~_c("defteam_timeouts_remaining").is_between(0, 3),
+        "a team has 0-3 timeouts",
+    ),
+    Rule(
+        "kneel_spike_mutually_exclusive",
+        ("qb_kneel", "qb_spike"),
+        (_c("qb_kneel") == 1) & (_c("qb_spike") == 1),
+        "a play cannot be both a kneel and a spike",
+    ),
+    Rule(
+        "kickoff_punt_mutually_exclusive",
+        ("kickoff_attempt", "punt_attempt"),
+        (_c("kickoff_attempt") == 1) & (_c("punt_attempt") == 1),
+        "a play cannot be both a kickoff and a punt",
+    ),
+    Rule(
+        "play_type_run_has_rush_attempt",
+        ("play_type", "rush_attempt"),
+        (_c("play_type") == "run") & (_c("rush_attempt") != 1),
+        "play_type='run' should carry rush_attempt=1",
+        severity=Severity.WARN,
+        needs_judgment=True,
+    ),
+    Rule(
+        "play_type_pass_has_dropback_flag",
+        ("play_type", "pass_attempt", "sack"),
+        (_c("play_type") == "pass") & (_c("pass_attempt") != 1) & (_c("sack") != 1),
+        "play_type='pass' should carry pass_attempt=1 (or be a sack)",
+        severity=Severity.WARN,
+        needs_judgment=True,
+    ),
+    Rule(
+        "air_plus_yac_is_passing_yards",
+        ("complete_pass", "passing_yards", "air_yards", "yards_after_catch"),
+        (_c("complete_pass") == 1) & ((_c("air_yards") + _c("yards_after_catch")) != _c("passing_yards")),
+        "on a completion, air_yards + yards_after_catch should equal passing_yards",
+        severity=Severity.WARN,
+        needs_judgment=True,
+    ),
+    Rule(
+        "home_away_wp_complement",
+        ("home_wp", "away_wp"),
+        (_c("home_wp") + _c("away_wp") - 1.0).abs() > _EPS,
+        "home_wp + away_wp must sum to 1",
+    ),
+    # Participant columns (all measured 2026-08-07 at 100% on 94,978
+    # published rows, both directions unless noted): name/id pairs never
+    # half-populate; passer/rusher are iff their attempt flag (passer
+    # includes sacks); receiver is required on completions but legitimately
+    # null on ~14% of incompletes (throwaways) so only that direction is a
+    # rule; td/penalty/timeout columns are iff their flag; every extracted
+    # name appears verbatim in desc.
+    _nfl_pair_rule("passer"),
+    _nfl_pair_rule("rusher"),
+    _nfl_pair_rule("receiver"),
+    _nfl_pair_rule("td"),
+    Rule(
+        "passer_iff_pass_attempt",
+        ("pass_attempt", "passer_player_name"),
+        (_c("pass_attempt") == 1) != _c("passer_player_name").is_not_null(),
+        "passer_player_name must be populated exactly on pass attempts (incl. sacks)",
+    ),
+    Rule(
+        "rusher_iff_rush_attempt",
+        ("rush_attempt", "rusher_player_name"),
+        (_c("rush_attempt") == 1) != _c("rusher_player_name").is_not_null(),
+        "rusher_player_name must be populated exactly on rush attempts",
+    ),
+    Rule(
+        "receiver_populated_on_completion",
+        ("complete_pass", "receiver_player_name"),
+        (_c("complete_pass") == 1) & _c("receiver_player_name").is_null(),
+        "a completed pass must carry receiver_player_name",
+    ),
+    Rule(
+        "receiver_requires_pass_attempt",
+        ("pass_attempt", "receiver_player_name"),
+        _c("receiver_player_name").is_not_null() & (_c("pass_attempt") != 1),
+        "receiver_player_name requires a pass attempt",
+    ),
+    Rule(
+        "td_player_iff_touchdown",
+        ("touchdown", "td_player_name"),
+        (_c("touchdown") == 1) != _c("td_player_name").is_not_null(),
+        "td_player_name must be populated exactly on touchdowns",
+    ),
+    Rule(
+        "td_team_iff_touchdown",
+        ("touchdown", "td_team"),
+        (_c("touchdown") == 1) != _c("td_team").is_not_null(),
+        "td_team must be populated exactly on touchdowns",
+    ),
+    Rule(
+        "td_team_is_a_participant",
+        ("td_team", "home_team", "away_team"),
+        (_c("td_team") != _c("home_team")) & (_c("td_team") != _c("away_team")),
+        "td_team must be the home or away team",
+    ),
+    Rule(
+        "penalty_team_iff_penalty",
+        ("penalty", "penalty_team"),
+        (_c("penalty") == 1) != _c("penalty_team").is_not_null(),
+        "penalty_team must be populated exactly on penalty plays",
+    ),
+    Rule(
+        "timeout_team_iff_timeout",
+        ("timeout", "timeout_team"),
+        (_c("timeout") == 1) != _c("timeout_team").is_not_null(),
+        "timeout_team must be populated exactly on timeout rows",
+    ),
+    _nfl_name_in_desc_rule("passer"),
+    _nfl_name_in_desc_rule("rusher"),
+    _nfl_name_in_desc_rule("receiver"),
+    _nfl_name_in_desc_rule("td"),
+    # Content-level type rules (all measured 2026-08-07 at 100% on 94,978
+    # published rows): every player id is GSIS-format, game_id is the
+    # nflverse composite key, no empty/padded strings, and posteam/defteam
+    # are always distinct game participants when set (null posteam is legit
+    # on ~1% of rows: kickoffs/timeouts/period markers).
+    _id_format_rule("passer_player_id", r"^\d{2}-\d{7}$", "GSIS id"),
+    _id_format_rule("rusher_player_id", r"^\d{2}-\d{7}$", "GSIS id"),
+    _id_format_rule("receiver_player_id", r"^\d{2}-\d{7}$", "GSIS id"),
+    _id_format_rule("td_player_id", r"^\d{2}-\d{7}$", "GSIS id"),
+    _id_format_rule("game_id", r"^\d{4}_\d{2}_[A-Z]{2,3}_[A-Z]{2,3}$", "nflverse game id"),
+    _clean_string_rule("passer_player_name"),
+    _clean_string_rule("rusher_player_name"),
+    _clean_string_rule("receiver_player_name"),
+    _clean_string_rule("td_player_name"),
+    Rule(
+        "posteam_is_a_participant",
+        ("posteam", "home_team", "away_team"),
+        (_c("posteam") != _c("home_team")) & (_c("posteam") != _c("away_team")),
+        "posteam must be the home or away team",
+    ),
+    Rule(
+        "defteam_is_a_participant",
+        ("defteam", "home_team", "away_team"),
+        (_c("defteam") != _c("home_team")) & (_c("defteam") != _c("away_team")),
+        "defteam must be the home or away team",
+    ),
+    Rule(
+        "posteam_not_defteam",
+        ("posteam", "defteam"),
+        _c("posteam") == _c("defteam"),
+        "a team cannot possess and defend on the same play",
+    ),
+)
+
+
+RULES: dict[str, tuple[Rule, ...]] = {
+    "cfb_model_pbp": _CFB_RULES,
+    "nfl_model_pbp": _NFL_RULES,
+}
+
+
+def run(dataset: str, frame: pl.DataFrame, ctx: CheckContext) -> list[Finding]:
+    """Evaluate the dataset's definitional rules and report violations.
+
+    Rules whose columns are absent from the frame are skipped (schema drift
+    is the ``schema_contract`` check's finding, not a definitional one).
+    All applicable rules' violation counts are computed in a single pass;
+    fired rules each get one Finding carrying the violation count as
+    ``metric`` and up to ``_SAMPLE_N`` offending rows (join keys + the
+    rule's own columns) as ``sample``.
+
+    Args:
+        dataset: Registered dataset name (selects the rule table).
+        frame: The data frame under validation.
+        ctx: Check context supplying domain and join keys.
+
+    Returns:
+        A list of Finding records; empty when no rules are registered for
+        the dataset or nothing fires.
+    """
+    rules = [r for r in RULES.get(dataset, ()) if all(c in frame.columns for c in r.columns)]
+    if not rules:
+        return []
+
+    try:
+        counts = frame.select([r.violation.sum().cast(pl.Int64).alias(r.name) for r in rules]).row(0, named=True)
+    except pl.exceptions.SchemaError:
+        # A degenerate column dtype (e.g. an all-null series polars typed as
+        # Null) breaks schema resolution for string-op rules. Fall back to
+        # per-rule evaluation and skip the unresolvable ones — the dtype
+        # divergence itself is schema_contract's finding, not a definitional
+        # violation.
+        counts = {}
+        for r in rules:
+            try:
+                counts[r.name] = frame.select(r.violation.sum().cast(pl.Int64)).item()
+            except pl.exceptions.SchemaError:
+                counts[r.name] = 0
+
+    findings: list[Finding] = []
+    for rule in rules:
+        n = counts[rule.name] or 0
+        if n == 0:
+            continue
+        sample_cols = [k for k in ctx.join_keys if k in frame.columns]
+        sample_cols += [c for c in rule.columns if c not in sample_cols]
+        sample = frame.filter(rule.violation).select(sample_cols).head(_SAMPLE_N).to_dicts()
+        findings.append(
+            Finding(
+                "definitional",
+                rule.severity,
+                ctx.domain,
+                dataset,
+                f"{rule.name}: {rule.description} ({n} violating row(s))",
+                locator={"rule": rule.name, "columns": list(rule.columns)},
+                metric=float(n),
+                needs_judgment=rule.needs_judgment,
+                sample=sample,
+            )
+        )
+    return findings

--- a/tools/validation/checks/definitional.py
+++ b/tools/validation/checks/definitional.py
@@ -210,11 +210,15 @@ _CFB_RULES: tuple[Rule, ...] = (
         ),
         "passing_down must equal (down 2 & dist>=8) | (down 3/4 & dist>=5) on scrimmage plays",
     ),
+    # Deliberately order-dependent: the harness contract (see
+    # boundary_leakage) is that frames arrive in play order within each
+    # game, and this rule VERIFIES that stored order — sorting by
+    # game_play_number first would make it tautological.
     Rule(
         "game_play_number_strictly_increasing",
         ("game_id", "game_play_number"),
         _c("game_play_number").diff().over("game_id") <= 0,
-        "game_play_number must strictly increase within a game",
+        "game_play_number must strictly increase within a game (in stored row order)",
     ),
     # Participant columns (measured 2026-08-07 on the published sample):
     # passer is populated on 3141/3141 pass plays -> hard invariant; the
@@ -587,19 +591,21 @@ def run(dataset: str, frame: pl.DataFrame, ctx: CheckContext) -> list[Finding]:
 
     try:
         counts = frame.select([r.violation.sum().cast(pl.Int64).alias(r.name) for r in rules]).row(0, named=True)
-    except (pl.exceptions.SchemaError, pl.exceptions.InvalidOperationError):
+    except pl.exceptions.PolarsError:
         # A degenerate column dtype (e.g. an all-null series polars typed as
-        # Null) breaks expression resolution for string-op and arithmetic
-        # rules — as SchemaError for str.strip_chars but
-        # InvalidOperationError for str.contains and abs on polars 1.42.
-        # Fall back to per-rule evaluation and skip the unresolvable ones —
+        # Null) breaks expression resolution — as SchemaError for
+        # str.strip_chars but InvalidOperationError for str.contains and abs
+        # on polars 1.42, and ComputeError for other shapes. Fall back to
+        # per-rule evaluation and skip only the unresolvable rules so one
+        # degenerate column cannot suppress every other rule's findings —
         # the dtype divergence itself is schema_contract's finding, not a
-        # definitional violation.
+        # definitional violation. (Rule-authoring errors are covered by the
+        # per-rule unit tests, not this handler.)
         counts = {}
         for r in rules:
             try:
                 counts[r.name] = frame.select(r.violation.sum().cast(pl.Int64)).item()
-            except (pl.exceptions.SchemaError, pl.exceptions.InvalidOperationError):
+            except pl.exceptions.PolarsError:
                 counts[r.name] = 0
 
     findings: list[Finding] = []

--- a/tools/validation/checks/definitional.py
+++ b/tools/validation/checks/definitional.py
@@ -587,17 +587,19 @@ def run(dataset: str, frame: pl.DataFrame, ctx: CheckContext) -> list[Finding]:
 
     try:
         counts = frame.select([r.violation.sum().cast(pl.Int64).alias(r.name) for r in rules]).row(0, named=True)
-    except pl.exceptions.SchemaError:
+    except (pl.exceptions.SchemaError, pl.exceptions.InvalidOperationError):
         # A degenerate column dtype (e.g. an all-null series polars typed as
-        # Null) breaks schema resolution for string-op rules. Fall back to
-        # per-rule evaluation and skip the unresolvable ones — the dtype
-        # divergence itself is schema_contract's finding, not a definitional
-        # violation.
+        # Null) breaks expression resolution for string-op and arithmetic
+        # rules — as SchemaError for str.strip_chars but
+        # InvalidOperationError for str.contains and abs on polars 1.42.
+        # Fall back to per-rule evaluation and skip the unresolvable ones —
+        # the dtype divergence itself is schema_contract's finding, not a
+        # definitional violation.
         counts = {}
         for r in rules:
             try:
                 counts[r.name] = frame.select(r.violation.sum().cast(pl.Int64)).item()
-            except pl.exceptions.SchemaError:
+            except (pl.exceptions.SchemaError, pl.exceptions.InvalidOperationError):
                 counts[r.name] = 0
 
     findings: list[Finding] = []

--- a/tools/validation/cli.py
+++ b/tools/validation/cli.py
@@ -8,6 +8,7 @@ from types import ModuleType
 from tools.validation.checks import (
     boundary_leakage,
     constant_column,
+    definitional,
     extraction,
     numeric_parity,
     schema_contract,
@@ -17,7 +18,7 @@ from tools.validation.findings import Finding
 from tools.validation.lint import leakage_python, leakage_r
 from tools.validation.registry import LINT_TARGETS, resolve
 
-_CHECKS = (schema_contract, extraction, numeric_parity, sweep, boundary_leakage, constant_column)
+_CHECKS = (schema_contract, extraction, numeric_parity, sweep, boundary_leakage, constant_column, definitional)
 
 _LINTERS: dict[str, ModuleType] = {"python": leakage_python, "r": leakage_r}
 


### PR DESCRIPTION
## Summary

Adds a `definitional` check module to the Tier-1 validation harness: per-dataset rule tables of named polars boolean violation expressions, evaluated in a single select pass, emitting one `Finding` per fired rule with the violation count and up to 3 sample rows for triage. Wired into the CLI's `_CHECKS` dispatch.

**Rule families** (22 CFB + 57 NFL rules):
- **Flag algebra** — rush/pass mutual exclusivity, complete/incomplete exclusivity, TD subtype algebra (≤1 subtype, subtype⇒touchdown⇒sp), FG outcome algebra, fumble_lost⇒fumble, kneel/spike + kickoff/punt exclusivity, the producer's exact `passing_down` definition.
- **Derived-value identities** — epa/wpa snapshot diffs, score_differential, clock hierarchy (scoped to regulation), down/distance/yardline/timeout/clock bounds, strictly-increasing `game_play_number` per game.
- **Participant name/id relationships** — name/id pairs never half-populate, flag-iff-participant (passer/rusher/td/penalty/timeout), receiver required on completions but deliberately allowed null on incompletes (throwaways), extracted names must appear verbatim in the play text.
- **Content-level type rules** — GSIS id format, nflverse game_id format, numeric-string drive.id (structurally subsumes the `"123.0"` float-artifact and empty-string id bug classes), clean-string (no empty/padded values), posteam/defteam participant + distinctness.

**Severity calibration is measured, not guessed**: every rule was run against the published parquet; rules ship as ERROR only where the invariant held 100% (e.g. all 108,828 NFL ids GSIS-format, all names verbatim in desc). Measured exceptions are WARN `needs_judgment` routed to Tier-2 triage, each with the evidence in a code comment (CFB epa≠ep_after−ep_before on ~1.2% of rows while the wpa twin holds exactly; fumble-return-TD passers; nickname-vs-formal name divergence at 97.7%).

Null semantics are load-bearing: violation expressions null-propagate so identity rules automatically apply only to fully-populated rows; a `SchemaError` fallback handles degenerate Null-dtype series (all-null single-file reads) without masking schema_contract's own dtype findings.

## Testing
- 17 new offline tests in `tests/contracts/test_definitional.py` (117 total contracts suite green)
- Calibration runs on both published datasets: zero ERRORs, 5 designed triage WARNs

## Summary by Sourcery

Introduce row-level definitional validation checks for CFB and NFL play-by-play datasets and integrate them into the Tier-1 validation CLI.

New Features:
- Add a definitional check module that evaluates per-dataset boolean rule tables over play-by-play data and emits findings with counts and sample rows.
- Define comprehensive CFB and NFL rule sets covering flag algebra, derived-value identities, participant relationships, and content-level type constraints.
- Integrate the definitional checks into the validation CLI check dispatch sequence.

Tests:
- Add a dedicated test suite for definitional checks covering rule selection, null semantics, sample attachment, severity calibration, and dataset-specific invariants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added definitional validation for college and professional football play-by-play datasets.
  - Checks data consistency, statistical relationships, participant fields, identifiers, string formatting, and game-state rules.
  - Validation results include violation counts, sample records, severity levels, and review guidance.
  - Automatically skips checks when required fields are unavailable.

- **Tests**
  - Added comprehensive coverage for validation rules, edge cases, exceptions, and dataset-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->