### PR TITLE
feat(validation): R<->Python output-parity check + compare CLI

### DIFF
--- a/tests/contracts/test_r_python_output_parity.py
+++ b/tests/contracts/test_r_python_output_parity.py
@@ -1,4 +1,7 @@
+import json
+
 import polars as pl
+import pytest
 
 from tools.validation import cli
 from tools.validation.checks import r_python_output_parity as rpp
@@ -226,6 +229,85 @@ def test_cli_compare_honours_ignore_columns(tmp_path):
     ]
     assert cli.main(argv) == 1, "sanity: the stamp diverges when not ignored"
     assert cli.main([*argv, "--ignore-columns", "built_at"]) == 0
+
+
+def test_cli_compare_reports_an_unreadable_parquet_as_a_finding(tmp_path, capsys):
+    """A mistyped release-download path must not lose the documented exit code
+    to a traceback, nor print a traceback where the caller asked for JSON."""
+    good = tmp_path / "good.parquet"
+    pl.DataFrame({"game_id": [1]}).write_parquet(good)
+    code = cli.main(
+        [
+            "compare",
+            "--dataset",
+            "d",
+            "--domain",
+            "nfl",
+            "--r-parquet",
+            str(tmp_path / "nope.parquet"),
+            "--py-parquet",
+            str(good),
+            "--join-keys",
+            "game_id",
+        ]
+    )
+    assert code == 1
+    assert "could not read the R parquet" in capsys.readouterr().out
+
+
+def test_cli_compare_json_survives_date_columns(tmp_path, capsys):
+    """Sample rows come from to_dicts(), so a Date column yields objects the
+    default JSON encoder rejects — after all the comparison work is done."""
+    import datetime as _dt
+
+    rp, pp = _write_pair(
+        tmp_path,
+        pl.DataFrame({"game_id": [1], "d": [_dt.date(2026, 1, 1)]}),
+        pl.DataFrame({"game_id": [1], "d": [_dt.date(2026, 8, 6)]}),
+    )
+    code = cli.main(
+        [
+            "compare",
+            "--dataset",
+            "d",
+            "--domain",
+            "nfl",
+            "--r-parquet",
+            rp,
+            "--py-parquet",
+            pp,
+            "--join-keys",
+            "game_id",
+            "--json",
+        ]
+    )
+    assert code == 1
+    json.loads(capsys.readouterr().out)  # must be parseable, not a traceback
+
+
+def test_cli_compare_rejects_a_negative_tolerance(tmp_path):
+    """abs(diff) > negative is true for every pair, so the run would report a
+    divergence on every row — total failure wearing the costume of thoroughness."""
+    frame = pl.DataFrame({"game_id": [1], "epa": [0.5]})
+    rp, pp = _write_pair(tmp_path, frame, frame.clone())
+    with pytest.raises(SystemExit):
+        cli.main(
+            [
+                "compare",
+                "--dataset",
+                "d",
+                "--domain",
+                "nfl",
+                "--r-parquet",
+                rp,
+                "--py-parquet",
+                pp,
+                "--join-keys",
+                "game_id",
+                "--tolerance",
+                "-1",
+            ]
+        )
 
 
 def test_neither_side_is_described_as_wrong():

--- a/tests/contracts/test_r_python_output_parity.py
+++ b/tests/contracts/test_r_python_output_parity.py
@@ -133,6 +133,26 @@ def test_duplicate_join_keys_stop_before_the_counts_get_inflated():
     assert not any("disagrees" in f.message for f in findings)
 
 
+def test_empty_join_keys_is_reported_not_raised():
+    """polars rejects `on=[]`, and a row comparison with no notion of row
+    identity has nothing to say."""
+    f = pl.DataFrame({"game_id": [1], "epa": [0.1]})
+    findings = rpp.run("d", f, f.clone(), (), "nfl")  # must not raise
+    assert len(findings) == 1
+    assert "no join keys given" in findings[0].message
+
+
+def test_duplicate_keys_are_caught_even_when_no_keys_are_shared():
+    """Duplicates invalidate the premise that a key group is a row, so they must
+    be reported ahead of the row-set and no-shared-keys results, which are
+    computed on deduplicated keys."""
+    r = pl.DataFrame({"game_id": [1, 1], "epa": [0.1, 0.2]})
+    py = pl.DataFrame({"game_id": [9], "epa": [0.5]})
+    findings = _run(r, py)
+    assert any("do not identify a row" in f.message for f in findings)
+    assert not any("no shared key groups" in f.message for f in findings)
+
+
 def test_mixed_kind_dtype_column_is_skipped_not_crashed_on():
     """polars raises comparing String to Int64; one such column must not abort
     the whole comparison. The dtype WARN already names it."""

--- a/tests/contracts/test_r_python_output_parity.py
+++ b/tests/contracts/test_r_python_output_parity.py
@@ -117,6 +117,41 @@ def test_ignored_columns_are_not_compared():
     assert _run(r, py, ignore_columns=("built_at",)) == []
 
 
+def test_duplicate_join_keys_stop_before_the_counts_get_inflated():
+    """A repeated key fans the inner join into a cross product, so 'N of M shared
+    row(s)' would stop meaning key groups — a wrong number stated confidently."""
+    r = pl.DataFrame({"game_id": [1, 1], "epa": [0.1, 0.2]})
+    py = pl.DataFrame({"game_id": [1], "epa": [0.1]})
+    findings = _run(r, py)
+    dup = next(f for f in findings if "do not identify a row" in f.message)
+    assert dup.severity.value == "error"
+    assert "1 duplicate row(s) in R" in dup.message
+    # and it must not have gone on to report per-column counts
+    assert not any("disagrees" in f.message for f in findings)
+
+
+def test_mixed_kind_dtype_column_is_skipped_not_crashed_on():
+    """polars raises comparing String to Int64; one such column must not abort
+    the whole comparison. The dtype WARN already names it."""
+    r = pl.DataFrame({"game_id": [1], "code": ["7"], "epa": [0.1]})
+    py = pl.DataFrame({"game_id": [1], "code": [7], "epa": [0.9]})
+    findings = _run(r, py)  # must not raise
+    assert any("differ in dtype" in f.message for f in findings)
+    # the comparable column is still compared — the skip is surgical
+    assert any("'epa' disagrees" in f.message for f in findings)
+    assert not any("'code' disagrees" in f.message for f in findings)
+
+
+def test_int_vs_float_still_compares_numerically():
+    """Int64-vs-Float64 is a dtype clash but both are numeric, so 10 == 10.0
+    must NOT be reported as a value divergence."""
+    r = pl.DataFrame({"game_id": [1], "yards": [10]})
+    py = pl.DataFrame({"game_id": [1], "yards": [10.0]})
+    findings = _run(r, py)
+    assert any("differ in dtype" in f.message for f in findings)
+    assert not any("disagrees" in f.message for f in findings)
+
+
 def _write_pair(tmp_path, r, py):
     rp, pp = tmp_path / "r.parquet", tmp_path / "py.parquet"
     r.write_parquet(rp)

--- a/tests/contracts/test_r_python_output_parity.py
+++ b/tests/contracts/test_r_python_output_parity.py
@@ -1,0 +1,203 @@
+import polars as pl
+
+from tools.validation import cli
+from tools.validation.checks import r_python_output_parity as rpp
+
+KEYS = ("game_id",)
+
+
+def _run(r, py, **kw):
+    return rpp.run("d", r, py, KEYS, "nfl", **kw)
+
+
+def _checks(findings):
+    return [f.message for f in findings]
+
+
+def test_identical_frames_are_clean():
+    f = pl.DataFrame({"game_id": [1, 2], "epa": [0.5, -0.25], "team": ["KC", "BUF"]})
+    assert _run(f, f.clone()) == []
+
+
+def test_missing_join_key_stops_immediately():
+    r = pl.DataFrame({"epa": [0.5]})
+    py = pl.DataFrame({"game_id": [1], "epa": [0.5]})
+    findings = _run(r, py)
+    assert len(findings) == 1, "must not attempt any comparison without the key"
+    assert "join key(s) absent" in findings[0].message
+    assert findings[0].severity.value == "error"
+
+
+def test_join_key_dtype_mismatch_is_named_not_misreported_as_missing_rows():
+    """The whole point: a Utf8-vs-Int64 key matches nothing, and reporting that
+    as 'no shared rows' sends the reader hunting for missing data."""
+    r = pl.DataFrame({"game_id": ["1", "2"], "epa": [0.5, 0.25]})
+    py = pl.DataFrame({"game_id": [1, 2], "epa": [0.5, 0.25]})
+    findings = _run(r, py)
+    assert len(findings) == 1
+    msg = findings[0].message
+    assert "dtype disagreement" in msg
+    assert "String" in msg and "Int64" in msg
+    # It must NOT have gone on to claim the row sets differ.
+    assert not any("row sets differ" in m for m in _checks(findings))
+
+
+def test_row_set_divergence_reports_both_directions():
+    r = pl.DataFrame({"game_id": [1, 2, 3], "epa": [0.1, 0.2, 0.3]})
+    py = pl.DataFrame({"game_id": [2, 3, 4], "epa": [0.2, 0.3, 0.4]})
+    findings = _run(r, py)
+    row = next(f for f in findings if "row sets differ" in f.message)
+    assert "1 key group(s) only in R" in row.message
+    assert "1 only in Python" in row.message
+    assert row.needs_judgment is True
+
+
+def test_no_shared_keys_fails_loudly_instead_of_passing_vacuously():
+    r = pl.DataFrame({"game_id": [1], "epa": [0.1]})
+    py = pl.DataFrame({"game_id": [9], "epa": [999.0]})
+    findings = _run(r, py)
+    assert any("no shared key groups" in f.message for f in findings)
+    # and it must not have emitted a clean bill of health for `epa`
+    assert not any("epa" in f.message and "disagrees" in f.message for f in findings)
+
+
+def test_column_set_divergence_is_a_warning_not_an_error():
+    """Bundling differences are legitimate (R emits schedules inside the pbp
+    stage), so this informs rather than fails."""
+    r = pl.DataFrame({"game_id": [1], "epa": [0.1], "r_only": [1]})
+    py = pl.DataFrame({"game_id": [1], "epa": [0.1], "py_only": [2]})
+    findings = _run(r, py)
+    col = next(f for f in findings if "column sets differ" in f.message)
+    assert col.severity.value == "warn"
+    assert "['r_only']" in col.message and "['py_only']" in col.message
+
+
+def test_shared_column_dtype_divergence_is_reported():
+    r = pl.DataFrame({"game_id": [1], "yards": [10]})
+    py = pl.DataFrame({"game_id": [1], "yards": [10.0]})
+    findings = _run(r, py)
+    assert any("differ in dtype" in f.message for f in findings)
+
+
+def test_numeric_divergence_beyond_tolerance_is_flagged_with_a_sample():
+    r = pl.DataFrame({"game_id": [1, 2], "epa": [0.50, 0.20]})
+    py = pl.DataFrame({"game_id": [1, 2], "epa": [0.50, 0.99]})
+    findings = _run(r, py)
+    val = next(f for f in findings if "'epa' disagrees" in f.message)
+    assert "1 of 2 shared row(s)" in val.message
+    assert val.sample and val.sample[0]["game_id"] == 2
+    assert val.needs_judgment is True
+
+
+def test_numeric_divergence_within_tolerance_is_clean():
+    r = pl.DataFrame({"game_id": [1], "epa": [0.5000000]})
+    py = pl.DataFrame({"game_id": [1], "epa": [0.5000001]})
+    assert _run(r, py, tolerance=1e-5) == []
+
+
+def test_null_on_one_side_only_is_a_divergence():
+    """Null-vs-value must not slip through: `null - 0.5` is null, so a naive
+    abs()>tol comparison would drop the row rather than flag it."""
+    r = pl.DataFrame({"game_id": [1], "epa": [None]}, schema={"game_id": pl.Int64, "epa": pl.Float64})
+    py = pl.DataFrame({"game_id": [1], "epa": [0.5]})
+    findings = _run(r, py)
+    assert any("'epa' disagrees" in f.message for f in findings)
+
+
+def test_string_divergence_is_flagged():
+    r = pl.DataFrame({"game_id": [1], "team": ["KC"]})
+    py = pl.DataFrame({"game_id": [1], "team": ["KAN"]})
+    findings = _run(r, py)
+    assert any("'team' disagrees" in f.message for f in findings)
+
+
+def test_ignored_columns_are_not_compared():
+    r = pl.DataFrame({"game_id": [1], "epa": [0.1], "built_at": ["2026-01-01"]})
+    py = pl.DataFrame({"game_id": [1], "epa": [0.1], "built_at": ["2026-08-06"]})
+    assert _run(r, py, ignore_columns=("built_at",)) == []
+
+
+def _write_pair(tmp_path, r, py):
+    rp, pp = tmp_path / "r.parquet", tmp_path / "py.parquet"
+    r.write_parquet(rp)
+    py.write_parquet(pp)
+    return str(rp), str(pp)
+
+
+def test_cli_compare_exits_1_on_divergence(tmp_path, capsys):
+    rp, pp = _write_pair(
+        tmp_path,
+        pl.DataFrame({"game_id": [1, 2], "epa": [0.5, 0.2]}),
+        pl.DataFrame({"game_id": [1, 2], "epa": [0.5, 0.9]}),
+    )
+    code = cli.main(
+        [
+            "compare",
+            "--dataset",
+            "d",
+            "--domain",
+            "nfl",
+            "--r-parquet",
+            rp,
+            "--py-parquet",
+            pp,
+            "--join-keys",
+            "game_id",
+        ]
+    )
+    assert code == 1
+    assert "disagrees between the R and Python pipelines" in capsys.readouterr().out
+
+
+def test_cli_compare_exits_0_when_the_pipelines_agree(tmp_path):
+    frame = pl.DataFrame({"game_id": [1, 2], "epa": [0.5, 0.2]})
+    rp, pp = _write_pair(tmp_path, frame, frame.clone())
+    code = cli.main(
+        [
+            "compare",
+            "--dataset",
+            "d",
+            "--domain",
+            "nfl",
+            "--r-parquet",
+            rp,
+            "--py-parquet",
+            pp,
+            "--join-keys",
+            "game_id",
+        ]
+    )
+    assert code == 0
+
+
+def test_cli_compare_honours_ignore_columns(tmp_path):
+    rp, pp = _write_pair(
+        tmp_path,
+        pl.DataFrame({"game_id": [1], "epa": [0.5], "built_at": ["a"]}),
+        pl.DataFrame({"game_id": [1], "epa": [0.5], "built_at": ["b"]}),
+    )
+    argv = [
+        "compare",
+        "--dataset",
+        "d",
+        "--domain",
+        "nfl",
+        "--r-parquet",
+        rp,
+        "--py-parquet",
+        pp,
+        "--join-keys",
+        "game_id",
+    ]
+    assert cli.main(argv) == 1, "sanity: the stamp diverges when not ignored"
+    assert cli.main([*argv, "--ignore-columns", "built_at"]) == 0
+
+
+def test_neither_side_is_described_as_wrong():
+    """The gate's premise is that a divergence is a review item, not a verdict.
+    Wording that blames one pipeline would pre-empt the human decision."""
+    r = pl.DataFrame({"game_id": [1, 2], "epa": [0.1, 0.2]})
+    py = pl.DataFrame({"game_id": [1, 3], "epa": [0.1, 0.9]})
+    for f in _run(r, py):
+        assert "dropped from" not in f.message
+        assert "should be" not in f.message

--- a/tools/validation/checks/r_python_output_parity.py
+++ b/tools/validation/checks/r_python_output_parity.py
@@ -30,8 +30,10 @@ import polars as pl
 
 from tools.validation.findings import Finding, Severity
 
-#: Columns that legitimately differ and should never be value-compared. Build
-#: stamps are wall-clock, so they differ on every run of either pipeline.
+#: Default columns excluded from value comparison — empty ON PURPOSE. Stamp
+#: column names vary by repo and dataset (``built_at``, ``last_updated``, …), so
+#: the caller names them; nothing is skipped implicitly. A silent default here
+#: would hide a genuinely diverging column that happened to share a name.
 _DEFAULT_IGNORE: tuple[str, ...] = ()
 
 #: Suffix polars appends to the RIGHT frame's overlapping columns. ``r_frame`` is
@@ -65,6 +67,30 @@ def run(
 
     Returns:
         A list of Finding records; empty when the two pipelines agree.
+
+    Raises:
+        polars.exceptions.ColumnNotFoundError: If a name in ``ignore_columns``
+            is absent from both frames is NOT raised — unknown names are simply
+            inert. This function raises nothing of its own: every disagreement,
+            including a structurally uncomparable pair, is reported as a Finding
+            so a caller can chain without try/except.
+
+    Example:
+        Compare two frames::
+
+            import polars as pl
+            from tools.validation.checks import r_python_output_parity
+
+            r = pl.DataFrame({"game_id": [1, 2], "epa": [0.5, 0.2]})
+            py = pl.DataFrame({"game_id": [1, 2], "epa": [0.5, 0.9]})
+            for f in r_python_output_parity.run("pbp", r, py, ("game_id",), "nfl"):
+                print(f.severity.value, f.message)
+
+        Exclude a build stamp from the value comparison::
+
+            r_python_output_parity.run(
+                "pbp", r, py, ("game_id",), "nfl", ignore_columns=("built_at",)
+            )
     """
     findings: list[Finding] = []
     keys = list(join_keys)
@@ -147,6 +173,31 @@ def run(
         )
         return findings
 
+    # The keys must IDENTIFY a row. If either side repeats one, the inner join
+    # fans that key out into a cross product, and the "N of M shared row(s)"
+    # denominator at level 4 stops meaning shared key groups — a wrong number
+    # reported with full confidence. Stop here, as the dtype clash does.
+    dup_r = r_frame.height - r_keys.height
+    dup_py = py_frame.height - py_keys.height
+    if dup_r or dup_py:
+        findings.append(
+            Finding(
+                "r_python_output_parity",
+                Severity.ERROR,
+                domain,
+                dataset,
+                f"join keys do not identify a row — {dup_r} duplicate row(s) in R, "
+                f"{dup_py} in Python. The join would fan out and every count below "
+                "would be inflated, so the value comparison was skipped. Widen "
+                "--join-keys until both sides are unique.",
+                locator={"join_keys": keys},
+                expected=0,
+                actual=dup_r + dup_py,
+                metric=float(dup_r + dup_py),
+            )
+        )
+        return findings
+
     # ---- level 2: same columns? ------------------------------------------
     ignore = set(ignore_columns) | set(keys)
     r_cols = set(r_frame.columns) - ignore
@@ -182,7 +233,10 @@ def run(
                 domain,
                 dataset,
                 f"{len(dtype_clashes)} shared column(s) differ in dtype: "
-                + ", ".join(f"{c} (R={rd}, python={pd})" for c, rd, pd in dtype_clashes[:8]),
+                + ", ".join(f"{c} (R={rd}, python={pd})" for c, rd, pd in dtype_clashes[:8])
+                + ". Mixed-kind pairs (e.g. String vs Int64) are excluded from the "
+                "value comparison below — polars cannot compare them, and this "
+                "finding already names the divergence.",
                 locator={"columns": [c for c, _rd, _pd in dtype_clashes]},
                 needs_judgment=True,
             )
@@ -194,10 +248,17 @@ def run(
         pcol = f"{col}{_PY}"
         if pcol not in joined.columns:
             continue
-        r_expr, py_expr = pl.col(col), pl.col(pcol)
+        r_dtype, py_dtype = r_frame.schema[col], py_frame.schema[col]
+        both_numeric = r_dtype.is_numeric() and py_dtype.is_numeric()
+        if not both_numeric and r_dtype != py_dtype:
+            # polars raises on a mixed-kind comparison (String vs Int64), which
+            # would abort the whole run over one column. The level-3 WARN above
+            # already reports the divergence, so skip rather than crash.
+            continue
 
+        r_expr, py_expr = pl.col(col), pl.col(pcol)
         null_mismatch = r_expr.is_null() != py_expr.is_null()
-        if r_frame.schema[col].is_numeric() and py_frame.schema[col].is_numeric():
+        if both_numeric:
             differs = ((r_expr - py_expr).abs() > tolerance) | null_mismatch
         else:
             differs = (r_expr != py_expr) | null_mismatch

--- a/tools/validation/checks/r_python_output_parity.py
+++ b/tools/validation/checks/r_python_output_parity.py
@@ -1,0 +1,223 @@
+"""R <-> Python OUTPUT parity: do the two pipelines produce the same values?
+
+The `-data` repos carry both an R chain and a Python build package for the same
+datasets. ``tests/test_r_python_parity.py`` in those repos is the *contract*
+gate — it proves the two sides declare the same datasets under the same stage
+numbers. It deliberately does not open the data. This is the other half: run
+both pipelines over the same season and compare the frames they emit.
+
+**Neither side is authoritative.** This is the load-bearing difference from
+``prep_published_parity``, which exists to prove a published frame faithfully
+reflects its prep frame and is therefore asymmetric ("dropped from published").
+Here a divergence means the two pipelines disagree and a human decides which is
+right, so every message names both sides and neither is described as wrong.
+
+Comparison is parquet-to-parquet in practice: both chains write
+``{dataset}/{rds,parquet}/`` and would clobber each other at the same path, so
+the R side is normally the artifact already on its release tag and the Python
+side a fresh local build. Nothing here runs R — it takes two frames.
+
+Findings are ordered cheapest-signal-first, because a failure at one level makes
+the next level's output meaningless: join-key dtypes, then key sets, then the
+column sets, then values. A dtype mismatch on a join key is reported as its own
+ERROR rather than being allowed to surface as "every row dropped" — that
+misdiagnosis is the whole reason the ID-dtype discipline exists.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+from tools.validation.findings import Finding, Severity
+
+#: Columns that legitimately differ and should never be value-compared. Build
+#: stamps are wall-clock, so they differ on every run of either pipeline.
+_DEFAULT_IGNORE: tuple[str, ...] = ()
+
+#: Suffix polars appends to the RIGHT frame's overlapping columns. ``r_frame`` is
+#: the left side of the join, so a suffixed column holds the PYTHON value —
+#: named accordingly so nobody reads the sides backwards.
+_PY = "__py__"
+
+
+def run(
+    dataset: str,
+    r_frame: pl.DataFrame,
+    py_frame: pl.DataFrame,
+    join_keys: tuple[str, ...],
+    domain: str,
+    *,
+    tolerance: float = 1e-6,
+    ignore_columns: tuple[str, ...] = _DEFAULT_IGNORE,
+    sample_rows: int = 5,
+) -> list[Finding]:
+    """Compare the R-produced and Python-produced frames for one dataset.
+
+    Args:
+        dataset: Dataset identifier recorded on each finding.
+        r_frame: The frame the R chain emitted.
+        py_frame: The frame the Python build package emitted.
+        join_keys: Columns identifying a row in both frames.
+        domain: Domain identifier recorded on each finding.
+        tolerance: Absolute tolerance for numeric divergence.
+        ignore_columns: Columns excluded from value comparison (build stamps etc.).
+        sample_rows: Max diverging rows to attach to a value finding.
+
+    Returns:
+        A list of Finding records; empty when the two pipelines agree.
+    """
+    findings: list[Finding] = []
+    keys = list(join_keys)
+
+    # ---- level 0: can we even compare? -----------------------------------
+    missing_r = [k for k in keys if k not in r_frame.columns]
+    missing_py = [k for k in keys if k not in py_frame.columns]
+    if missing_r or missing_py:
+        findings.append(
+            Finding(
+                "r_python_output_parity",
+                Severity.ERROR,
+                domain,
+                dataset,
+                f"join key(s) absent — R is missing {missing_r}, Python is missing {missing_py}",
+                locator={"join_keys": keys},
+            )
+        )
+        return findings  # nothing below can mean anything
+
+    # A join-key dtype disagreement yields zero matches and would otherwise be
+    # misread as "the two pipelines share no rows". Name it for what it is.
+    key_dtype_clashes = [
+        (k, str(r_frame.schema[k]), str(py_frame.schema[k])) for k in keys if r_frame.schema[k] != py_frame.schema[k]
+    ]
+    if key_dtype_clashes:
+        findings.append(
+            Finding(
+                "r_python_output_parity",
+                Severity.ERROR,
+                domain,
+                dataset,
+                "join-key dtype disagreement — the join would match nothing and any "
+                "row-level result below would be meaningless: "
+                + ", ".join(f"{k}: R={rd} python={pd}" for k, rd, pd in key_dtype_clashes),
+                locator={"join_keys": keys},
+                expected=[rd for _k, rd, _pd in key_dtype_clashes],
+                actual=[pd for _k, _rd, pd in key_dtype_clashes],
+            )
+        )
+        return findings
+
+    # ---- level 1: same rows? ---------------------------------------------
+    r_keys = r_frame.select(keys).unique()
+    py_keys = py_frame.select(keys).unique()
+    only_r = r_keys.join(py_keys, on=keys, how="anti").height
+    only_py = py_keys.join(r_keys, on=keys, how="anti").height
+    shared = r_keys.join(py_keys, on=keys, how="semi").height
+
+    if only_r or only_py:
+        findings.append(
+            Finding(
+                "r_python_output_parity",
+                Severity.ERROR,
+                domain,
+                dataset,
+                f"row sets differ — {only_r} key group(s) only in R, {only_py} only in Python "
+                f"({shared} shared). Neither side is automatically right: decide which "
+                "pipeline is correct, then fix the other.",
+                locator={"join_keys": keys},
+                expected=r_keys.height,
+                actual=py_keys.height,
+                metric=float(only_r + only_py),
+                needs_judgment=True,
+            )
+        )
+
+    if shared == 0:
+        # Guard the guard: with no shared keys every per-column comparison below
+        # is vacuously clean, which would read as "the pipelines agree".
+        findings.append(
+            Finding(
+                "r_python_output_parity",
+                Severity.ERROR,
+                domain,
+                dataset,
+                "no shared key groups — the value comparison below would pass vacuously, so it was skipped entirely",
+                locator={"join_keys": keys},
+            )
+        )
+        return findings
+
+    # ---- level 2: same columns? ------------------------------------------
+    ignore = set(ignore_columns) | set(keys)
+    r_cols = set(r_frame.columns) - ignore
+    py_cols = set(py_frame.columns) - ignore
+    if r_cols != py_cols:
+        findings.append(
+            Finding(
+                "r_python_output_parity",
+                Severity.WARN,
+                domain,
+                dataset,
+                f"column sets differ — only in R: {sorted(r_cols - py_cols)}; "
+                f"only in Python: {sorted(py_cols - r_cols)}. A bundling difference "
+                "can be legitimate; a renamed or dropped column is not.",
+                locator={"r_only": sorted(r_cols - py_cols), "python_only": sorted(py_cols - r_cols)},
+                needs_judgment=True,
+            )
+        )
+
+    comparable = sorted(r_cols & py_cols)
+
+    # ---- level 3: same dtypes on shared columns? -------------------------
+    dtype_clashes = [
+        (c, str(r_frame.schema[c]), str(py_frame.schema[c]))
+        for c in comparable
+        if r_frame.schema[c] != py_frame.schema[c]
+    ]
+    if dtype_clashes:
+        findings.append(
+            Finding(
+                "r_python_output_parity",
+                Severity.WARN,
+                domain,
+                dataset,
+                f"{len(dtype_clashes)} shared column(s) differ in dtype: "
+                + ", ".join(f"{c} (R={rd}, python={pd})" for c, rd, pd in dtype_clashes[:8]),
+                locator={"columns": [c for c, _rd, _pd in dtype_clashes]},
+                needs_judgment=True,
+            )
+        )
+
+    # ---- level 4: same values? -------------------------------------------
+    joined = r_frame.join(py_frame, on=keys, how="inner", suffix=_PY)
+    for col in comparable:
+        pcol = f"{col}{_PY}"
+        if pcol not in joined.columns:
+            continue
+        r_expr, py_expr = pl.col(col), pl.col(pcol)
+
+        null_mismatch = r_expr.is_null() != py_expr.is_null()
+        if r_frame.schema[col].is_numeric() and py_frame.schema[col].is_numeric():
+            differs = ((r_expr - py_expr).abs() > tolerance) | null_mismatch
+        else:
+            differs = (r_expr != py_expr) | null_mismatch
+
+        bad = joined.filter(differs)
+        if bad.height == 0:
+            continue
+        findings.append(
+            Finding(
+                "r_python_output_parity",
+                Severity.ERROR,
+                domain,
+                dataset,
+                f"{col!r} disagrees between the R and Python pipelines in {bad.height} "
+                f"of {joined.height} shared row(s)",
+                locator={"column": col},
+                metric=float(bad.height),
+                needs_judgment=True,
+                sample=bad.select([*keys, col, pcol]).head(sample_rows).to_dicts(),
+            )
+        )
+
+    return findings

--- a/tools/validation/checks/r_python_output_parity.py
+++ b/tools/validation/checks/r_python_output_parity.py
@@ -96,6 +96,22 @@ def run(
     keys = list(join_keys)
 
     # ---- level 0: can we even compare? -----------------------------------
+    if not keys:
+        # polars rejects an empty `on=[]`, and a comparison with no notion of
+        # row identity has nothing to say anyway.
+        findings.append(
+            Finding(
+                "r_python_output_parity",
+                Severity.ERROR,
+                domain,
+                dataset,
+                "no join keys given — a row-level comparison needs at least one column "
+                "that identifies a row in both frames",
+                locator={"join_keys": []},
+            )
+        )
+        return findings
+
     missing_r = [k for k in keys if k not in r_frame.columns]
     missing_py = [k for k in keys if k not in py_frame.columns]
     if missing_r or missing_py:
@@ -133,9 +149,35 @@ def run(
         )
         return findings
 
-    # ---- level 1: same rows? ---------------------------------------------
+    # ---- level 1a: do the keys identify a row at all? ---------------------
+    # Ahead of every row-set result below, because those are computed on
+    # DEDUPLICATED keys: if a key repeats, the premise that a key group is a row
+    # is already false, and both the shared/only counts and the level-4
+    # denominator would describe something other than what they claim.
     r_keys = r_frame.select(keys).unique()
     py_keys = py_frame.select(keys).unique()
+    dup_r = r_frame.height - r_keys.height
+    dup_py = py_frame.height - py_keys.height
+    if dup_r or dup_py:
+        findings.append(
+            Finding(
+                "r_python_output_parity",
+                Severity.ERROR,
+                domain,
+                dataset,
+                f"join keys do not identify a row — {dup_r} duplicate row(s) in R, "
+                f"{dup_py} in Python. The join would fan out and every count below "
+                "would be inflated, so the comparison was skipped. Widen the join "
+                "keys until both sides are unique.",
+                locator={"join_keys": keys},
+                expected=0,
+                actual=dup_r + dup_py,
+                metric=float(dup_r + dup_py),
+            )
+        )
+        return findings
+
+    # ---- level 1b: same rows? --------------------------------------------
     only_r = r_keys.join(py_keys, on=keys, how="anti").height
     only_py = py_keys.join(r_keys, on=keys, how="anti").height
     shared = r_keys.join(py_keys, on=keys, how="semi").height
@@ -169,31 +211,6 @@ def run(
                 dataset,
                 "no shared key groups — the value comparison below would pass vacuously, so it was skipped entirely",
                 locator={"join_keys": keys},
-            )
-        )
-        return findings
-
-    # The keys must IDENTIFY a row. If either side repeats one, the inner join
-    # fans that key out into a cross product, and the "N of M shared row(s)"
-    # denominator at level 4 stops meaning shared key groups — a wrong number
-    # reported with full confidence. Stop here, as the dtype clash does.
-    dup_r = r_frame.height - r_keys.height
-    dup_py = py_frame.height - py_keys.height
-    if dup_r or dup_py:
-        findings.append(
-            Finding(
-                "r_python_output_parity",
-                Severity.ERROR,
-                domain,
-                dataset,
-                f"join keys do not identify a row — {dup_r} duplicate row(s) in R, "
-                f"{dup_py} in Python. The join would fan out and every count below "
-                "would be inflated, so the value comparison was skipped. Widen "
-                "--join-keys until both sides are unique.",
-                locator={"join_keys": keys},
-                expected=0,
-                actual=dup_r + dup_py,
-                metric=float(dup_r + dup_py),
             )
         )
         return findings

--- a/tools/validation/cli.py
+++ b/tools/validation/cli.py
@@ -5,12 +5,15 @@ import json
 import sys
 from types import ModuleType
 
+import polars as pl
+
 from tools.validation.checks import (
     boundary_leakage,
     constant_column,
     definitional,
     extraction,
     numeric_parity,
+    r_python_output_parity,
     schema_contract,
     sweep,
 )
@@ -38,6 +41,66 @@ def run_dataset(dataset: str, release: str | None = None) -> list[dict]:
     for mod in _CHECKS:
         findings.extend(mod.run(dataset, frame, ctx))
     return [f.to_dict() for f in findings]
+
+
+def compare_outputs(
+    dataset: str,
+    r_parquet: str,
+    py_parquet: str,
+    join_keys: tuple[str, ...],
+    domain: str,
+    *,
+    tolerance: float = 1e-6,
+    ignore_columns: tuple[str, ...] = (),
+) -> list[dict]:
+    """Compare an R-produced and a Python-produced artifact for one dataset.
+
+    Both `-data` chains write ``{dataset}/{rds,parquet}/`` to the SAME path, so
+    in practice the R side is the artifact already on its release tag (fetch it
+    with ``gh release download``) and the Python side a fresh local build. No R
+    runtime is involved — this reads two parquet files.
+
+    Args:
+        dataset: Dataset identifier recorded on each finding.
+        r_parquet: Path to the R-produced parquet.
+        py_parquet: Path to the Python-produced parquet.
+        join_keys: Columns identifying a row in both frames.
+        domain: Domain identifier recorded on each finding.
+        tolerance: Absolute tolerance for numeric divergence.
+        ignore_columns: Columns excluded from value comparison (build stamps etc.).
+
+    Returns:
+        A flat list of finding dicts.
+    """
+    findings = r_python_output_parity.run(
+        dataset,
+        pl.read_parquet(r_parquet),
+        pl.read_parquet(py_parquet),
+        join_keys,
+        domain,
+        tolerance=tolerance,
+        ignore_columns=ignore_columns,
+    )
+    return [f.to_dict() for f in findings]
+
+
+def _emit(out: list[dict], as_json: bool) -> int:
+    """Print findings and return the process exit code.
+
+    Args:
+        out: Finding dicts.
+        as_json: Emit JSON instead of the human-readable lines.
+
+    Returns:
+        1 if any ERROR finding is present, else 0.
+    """
+    if as_json:
+        json.dump(out, sys.stdout)
+        sys.stdout.write("\n")
+    else:
+        for f in out:
+            print(f"{f['severity'].upper():5} [{f['check']}] {f['dataset']} :: {f['message']}")
+    return 1 if any(f["severity"] == "error" for f in out) else 0
 
 
 def lint_target(name: str) -> list[dict]:
@@ -80,27 +143,39 @@ def main(argv: list[str] | None = None) -> int:
     lint = sub.add_parser("lint")
     lint.add_argument("--target", required=True)
     lint.add_argument("--json", action="store_true")
+    cmp_ = sub.add_parser(
+        "compare",
+        help="R-vs-Python output parity for one dataset (two parquet artifacts)",
+    )
+    cmp_.add_argument("--dataset", required=True)
+    cmp_.add_argument("--domain", required=True)
+    cmp_.add_argument("--r-parquet", required=True, help="R-produced artifact (usually the release asset)")
+    cmp_.add_argument("--py-parquet", required=True, help="Python-produced artifact (usually a fresh local build)")
+    cmp_.add_argument("--join-keys", required=True, nargs="+", metavar="COL")
+    cmp_.add_argument("--tolerance", type=float, default=1e-6)
+    cmp_.add_argument("--ignore-columns", nargs="*", default=[], metavar="COL")
+    cmp_.add_argument("--json", action="store_true")
     args = parser.parse_args(argv)
 
     if args.cmd == "run":
-        out = run_dataset(args.dataset, args.release)
-        if args.json:
-            json.dump(out, sys.stdout)
-            sys.stdout.write("\n")
-        else:
-            for f in out:
-                print(f"{f['severity'].upper():5} [{f['check']}] {f['dataset']} :: {f['message']}")
-        return 1 if any(f["severity"] == "error" for f in out) else 0
+        return _emit(run_dataset(args.dataset, args.release), args.json)
 
     if args.cmd == "lint":
-        out = lint_target(args.target)
-        if args.json:
-            json.dump(out, sys.stdout)
-            sys.stdout.write("\n")
-        else:
-            for f in out:
-                print(f"{f['severity'].upper():5} [{f['check']}] {f['dataset']} :: {f['message']}")
-        return 1 if any(f["severity"] == "error" for f in out) else 0
+        return _emit(lint_target(args.target), args.json)
+
+    if args.cmd == "compare":
+        return _emit(
+            compare_outputs(
+                args.dataset,
+                args.r_parquet,
+                args.py_parquet,
+                tuple(args.join_keys),
+                args.domain,
+                tolerance=args.tolerance,
+                ignore_columns=tuple(args.ignore_columns),
+            ),
+            args.json,
+        )
     return 0
 
 

--- a/tools/validation/cli.py
+++ b/tools/validation/cli.py
@@ -17,7 +17,7 @@ from tools.validation.checks import (
     schema_contract,
     sweep,
 )
-from tools.validation.findings import Finding
+from tools.validation.findings import Finding, Severity
 from tools.validation.lint import leakage_python, leakage_r
 from tools.validation.registry import LINT_TARGETS, resolve
 
@@ -91,16 +91,71 @@ def compare_outputs(
             python -m tools.validation.cli compare --dataset wnba_pbp --domain wnba \\
                 --r-parquet r.parquet --py-parquet py.parquet --join-keys game_id
     """
+    # Both paths come from the command line and a release-download path is easy
+    # to mistype. A traceback here would lose the documented exit code and, in
+    # --json mode, print something unparseable after the caller asked for JSON.
+    frames = []
+    for side, path in (("R", r_parquet), ("Python", py_parquet)):
+        try:
+            frames.append(pl.read_parquet(path))
+        # Narrow on purpose. A bare `except Exception` here caught a NameError
+        # during development and reported it as "could not read the parquet" —
+        # a code defect wearing a data defect's clothes, which is the exact
+        # masking this whole check exists to prevent.
+        except (OSError, pl.exceptions.PolarsError) as exc:
+            return [
+                Finding(
+                    "r_python_output_parity",
+                    Severity.ERROR,
+                    domain,
+                    dataset,
+                    f"could not read the {side} parquet at {path!r}: {type(exc).__name__}: {exc}",
+                    locator={"side": side, "path": str(path)},
+                ).to_dict()
+            ]
+
     findings = r_python_output_parity.run(
         dataset,
-        pl.read_parquet(r_parquet),
-        pl.read_parquet(py_parquet),
+        frames[0],
+        frames[1],
         join_keys,
         domain,
         tolerance=tolerance,
         ignore_columns=ignore_columns,
     )
     return [f.to_dict() for f in findings]
+
+
+def _non_negative_float(raw: str) -> float:
+    """argparse type for ``--tolerance``.
+
+    A negative tolerance makes ``abs(r - py) > tolerance`` true for every
+    non-null numeric pair, so the run would report a divergence on every row of
+    every column — a total failure that looks like a thorough one.
+
+    Args:
+        raw: The raw command-line string.
+
+    Returns:
+        The parsed value.
+
+    Raises:
+        argparse.ArgumentTypeError: If ``raw`` is not a number, or is negative.
+
+    Example:
+        Parse a tolerance::
+
+            _non_negative_float("1e-6")
+    """
+    try:
+        value = float(raw)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"{raw!r} is not a number") from None
+    if value < 0:
+        raise argparse.ArgumentTypeError(
+            f"tolerance must be >= 0, got {value} — a negative tolerance flags every row as diverging"
+        )
+    return value
 
 
 def _emit(out: list[dict], as_json: bool) -> int:
@@ -114,7 +169,11 @@ def _emit(out: list[dict], as_json: bool) -> int:
         1 if any ERROR finding is present, else 0.
     """
     if as_json:
-        json.dump(out, sys.stdout)
+        # Findings can carry `sample` rows straight from `DataFrame.to_dicts()`,
+        # so a Date / Datetime / Decimal / Duration column yields values the
+        # default encoder rejects — which would raise AFTER all the comparison
+        # work was done. Sports frames are full of dates; stringify instead.
+        json.dump(out, sys.stdout, default=str)
         sys.stdout.write("\n")
     else:
         for f in out:
@@ -171,7 +230,12 @@ def main(argv: list[str] | None = None) -> int:
     cmp_.add_argument("--r-parquet", required=True, help="R-produced artifact (usually the release asset)")
     cmp_.add_argument("--py-parquet", required=True, help="Python-produced artifact (usually a fresh local build)")
     cmp_.add_argument("--join-keys", required=True, nargs="+", metavar="COL")
-    cmp_.add_argument("--tolerance", type=float, default=1e-6)
+    cmp_.add_argument(
+        "--tolerance",
+        type=_non_negative_float,
+        default=1e-6,
+        help="absolute tolerance for numeric divergence (must be >= 0)",
+    )
     cmp_.add_argument("--ignore-columns", nargs="*", default=[], metavar="COL")
     cmp_.add_argument("--json", action="store_true")
     args = parser.parse_args(argv)

--- a/tools/validation/cli.py
+++ b/tools/validation/cli.py
@@ -71,6 +71,25 @@ def compare_outputs(
 
     Returns:
         A flat list of finding dicts.
+
+    Raises:
+        FileNotFoundError: If either parquet path does not exist.
+        polars.exceptions.ComputeError: If either path is not readable as parquet.
+
+    Example:
+        Compare a released R artifact against a fresh Python build::
+
+            from tools.validation.cli import compare_outputs
+
+            findings = compare_outputs(
+                "wnba_pbp", "r_side.parquet", "py_side.parquet", ("game_id",), "wnba"
+            )
+            print(len(findings), "divergence(s)")
+
+        From the shell, exiting 1 when the pipelines disagree::
+
+            python -m tools.validation.cli compare --dataset wnba_pbp --domain wnba \\
+                --r-parquet r.parquet --py-parquet py.parquet --join-keys game_id
     """
     findings = r_python_output_parity.run(
         dataset,


### PR DESCRIPTION
The `-data` repos gained a **contract** gate this week (`test_r_python_parity.py`: do both languages declare the same datasets under the same stage numbers). It deliberately never opens the data. This is the other half — do the two pipelines produce the same **values**.

## Why a sibling of `prep_published_parity` rather than a reuse

That check is asymmetric *by design*: `prep` is the source of truth and the failure reads "dropped from published". For R-vs-Python **neither side is authoritative** — a divergence is a review item, not a verdict — so every message names both pipelines. Reusing the existing check would have encoded a judgment this one must not make. There is a test asserting no message blames either side.

## Ordering is load-bearing

Findings run cheapest-signal-first and early-return, because a failure at one level makes the next meaningless:

1. **Join-key dtype disagreement is its own ERROR.** A `Utf8`-vs-`Int64` key matches nothing; letting that surface as "no shared rows" sends the reader hunting for missing data instead of a cast.
2. **Zero shared keys is an ERROR, not a silent pass** — otherwise every per-column comparison below is vacuously clean and reads as agreement.
3. **Column-set drift is a WARN** — bundling differences are legitimate (R emits `schedules`/`shots` inside the pbp stage).
4. **Value divergence** carries a sample of the offending rows.

Null-vs-value is compared explicitly: `null - 0.5` is null, so a bare `abs() > tol` would *drop* the row rather than flag it.

## `cli compare`

Runs it over two parquet artifacts — **no R runtime**. Both chains write to the same `{rds,parquet}` path and clobber each other, so in practice the R side is the release asset (`gh release download`) and the Python side a fresh local build.

```
python -m tools.validation.cli compare --dataset wnba_pbp --domain wnba \
  --r-parquet r.parquet --py-parquet py.parquet --join-keys game_id
```

Exit 1 on any ERROR finding, 0 when the pipelines agree.

Also folds the thrice-duplicated print/exit-code block in `main()` into `_emit()`.

## Verification

- 16 new tests; `tests/contracts` **134 passed**
- `ruff check` / `ruff format --check` clean
- `codegen --check: all generated files current`
- CLI exercised end-to-end on real parquet files (exit 1 divergent / 0 identical)

## Not yet done

- Not yet run against a **real R-built release artifact** — that is the remaining Phase-2 work and where it earns its keep.
- No `-data` repo calls `cli compare` from CI yet, so nothing enforces output parity automatically.

## Summary by Sourcery

Add an R-vs-Python output parity check and CLI command to compare parquet artifacts for a dataset, reporting divergences in rows, columns, and values without privileging either pipeline.

New Features:
- Introduce a parity checker that compares R- and Python-produced dataframes on join keys, column sets, dtypes, and values, with configurable tolerance and ignored columns.
- Add a `validation` CLI `compare` subcommand to run R-vs-Python output parity over two parquet artifacts and return a non-zero exit code on parity errors.

Enhancements:
- Refactor CLI finding output and exit-code handling into a shared `_emit` helper to reduce duplication.

Tests:
- Add contract tests covering R-vs-Python parity behavior, including join key validation, row and column set differences, null handling, tolerance behavior, and CLI integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for comparing R and Python output datasets.
  * Added a CLI command for comparing Parquet outputs with configurable join keys and numeric tolerances.
  * Reports missing rows, column and data type differences, value discrepancies, null handling, and sample divergent rows.
  * Supports ignored columns and configurable diagnostic sample sizes.
  * Provides consistent findings and exit codes for automated workflows.

* **Tests**
  * Added comprehensive coverage for output parity, duplicate keys, tolerance handling, ignored columns, and CLI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->