### PR TITLE
fix(validation): do not make the CLI need a dev-only dependency

### DIFF
--- a/tests/contracts/test_cli.py
+++ b/tests/contracts/test_cli.py
@@ -2,8 +2,14 @@ from __future__ import annotations
 
 import polars as pl
 
-from tools.validation import cli
+from tools.validation import cli, registry
 from tools.validation.findings import CheckContext
+
+# `cli` imports `resolve` / `LINT_TARGETS` lazily, inside the functions that use
+# them, so that `compare` does not drag in pyyaml (a dev-only dependency -- see
+# test_cli_importable_without_yaml.py). That means there is no `cli.resolve` to
+# patch; the owner is `registry`, and patching it there works precisely because
+# the import happens at call time.
 
 
 def test_run_dataset_aggregates_findings(monkeypatch):
@@ -15,7 +21,7 @@ def test_run_dataset_aggregates_findings(monkeypatch):
         required_columns=("game_id",),
         join_keys=("game_id",),
     )
-    monkeypatch.setattr(cli, "resolve", lambda dataset, release=None: (frame, ctx))
+    monkeypatch.setattr(registry, "resolve", lambda dataset, release=None: (frame, ctx))
     out = cli.run_dataset("nfl_pbp")
     assert any(d["check"] == "schema_contract" and d["severity"] == "error" for d in out)
 
@@ -43,7 +49,7 @@ def test_lint_target_dispatches_python(monkeypatch):
     from tools.validation.registry import LintTarget
 
     monkeypatch.setitem(
-        cli.LINT_TARGETS,
+        registry.LINT_TARGETS,
         "t",
         LintTarget(name="t", path=str(_LEAKY_DIR()), language="python"),
     )
@@ -74,7 +80,7 @@ def test_lint_target_r_dispatches_to_r_linter(monkeypatch):
     # no live R needed: force the graceful "Rscript absent" path and assert it
     # dispatched (INFO finding) rather than raising NotImplementedError.
     monkeypatch.setattr(leakage_r, "rscript_path", lambda: None)
-    monkeypatch.setitem(cli.LINT_TARGETS, "rtgt", LintTarget(name="rtgt", path=".", language="r"))
+    monkeypatch.setitem(registry.LINT_TARGETS, "rtgt", LintTarget(name="rtgt", path=".", language="r"))
     out = cli.lint_target("rtgt")
     assert any(d["severity"] == "info" for d in out)
     assert any(d["severity"] == "info" and d["message"] == "R lint skipped: Rscript not found" for d in out)

--- a/tests/contracts/test_cli_importable_without_yaml.py
+++ b/tests/contracts/test_cli_importable_without_yaml.py
@@ -1,0 +1,82 @@
+"""`tools.validation.cli compare` must work without pyyaml installed.
+
+pyyaml lives in ``[dependency-groups]`` — dev-only, not a runtime dependency —
+but every SDV ``-data`` repo consumes this code by pinning ``sportsdataverse``
+from git, so their venvs have no dev group and no yaml. A module-level
+``from tools.validation.registry import ...`` (registry imports yaml for
+thresholds.yaml) therefore made the whole CLI unimportable for exactly the
+consumers that need `compare`, and it failed only at runtime, in their CI.
+
+`compare` needs neither the dataset registry nor the thresholds, so this asserts
+it does not pay for them. Run in a subprocess with a meta-path finder that
+blocks `yaml`, because the property is about IMPORT TIME and this test process
+has already imported yaml via other tests.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+_PROGRAM = textwrap.dedent(
+    """
+    import sys
+
+    class _BlockYaml:
+        def find_module(self, name, path=None):
+            return self if name == "yaml" or name.startswith("yaml.") else None
+        def find_spec(self, name, path=None, target=None):
+            if name == "yaml" or name.startswith("yaml."):
+                raise ImportError("yaml is blocked for this test")
+            return None
+
+    sys.meta_path.insert(0, _BlockYaml())
+
+    # Sanity: the block actually works, otherwise this test proves nothing.
+    try:
+        import yaml  # noqa: F401
+    except ImportError:
+        pass
+    else:
+        raise SystemExit("BLOCK-FAILED: yaml was importable")
+
+    import polars as pl
+    from tools.validation import cli
+
+    a = pl.DataFrame({"game_id": [1, 2], "epa": [0.5, 0.2]})
+    b = pl.DataFrame({"game_id": [1, 2], "epa": [0.5, 0.9]})
+    import tempfile, pathlib
+    d = pathlib.Path(tempfile.mkdtemp())
+    a.write_parquet(d / "a.parquet")
+    b.write_parquet(d / "b.parquet")
+
+    out = cli.compare_outputs("d", str(d / "a.parquet"), str(d / "b.parquet"), ("game_id",), "nfl")
+    assert any("disagrees" in f["message"] for f in out), out
+    print("OK")
+    """
+)
+
+
+def test_compare_works_without_yaml():
+    proc = subprocess.run(
+        [sys.executable, "-c", _PROGRAM],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout!r}\nstderr={proc.stderr[-2000:]!r}"
+    assert "OK" in proc.stdout
+
+
+def test_run_dataset_still_reaches_the_registry():
+    """The lazy import must not have silently disabled the registry path: with
+    yaml present, an unknown dataset should still raise KeyError from the
+    registry lookup rather than ImportError or NameError."""
+    from tools.validation import cli
+
+    try:
+        cli.run_dataset("definitely_not_a_registered_dataset")
+    except KeyError:
+        pass
+    else:  # pragma: no cover - only reached if the registry stopped being consulted
+        raise AssertionError("expected KeyError from the registry lookup")

--- a/tools/validation/cli.py
+++ b/tools/validation/cli.py
@@ -19,7 +19,14 @@ from tools.validation.checks import (
 )
 from tools.validation.findings import Finding, Severity
 from tools.validation.lint import leakage_python, leakage_r
-from tools.validation.registry import LINT_TARGETS, resolve
+
+# NOTE: `tools.validation.registry` is imported lazily, inside the two functions
+# that need it, rather than here. It pulls in `yaml` (for thresholds.yaml), and
+# pyyaml lives in [dependency-groups] -- dev-only, NOT a runtime dependency. A
+# module-level import therefore makes this whole CLI unimportable from an
+# installed sportsdataverse, which is how every `-data` repo consumes it: they
+# pin the package from git and have no dev group. `compare` needs neither the
+# dataset registry nor the thresholds, so it must not pay for them.
 
 _CHECKS = (schema_contract, extraction, numeric_parity, sweep, boundary_leakage, constant_column, definitional)
 
@@ -36,6 +43,8 @@ def run_dataset(dataset: str, release: str | None = None) -> list[dict]:
     Returns:
         A flat list of finding dicts (each from ``Finding.to_dict()``).
     """
+    from tools.validation.registry import resolve
+
     frame, ctx = resolve(dataset, release=release)
     findings: list[Finding] = []
     for mod in _CHECKS:
@@ -196,6 +205,8 @@ def lint_target(name: str) -> list[dict]:
             ("python" and "r" are both registered; this fires only for some other
             unregistered language).
     """
+    from tools.validation.registry import LINT_TARGETS
+
     target = LINT_TARGETS[name]
     linter = _LINTERS.get(target.language)
     if linter is None:


### PR DESCRIPTION
The validation CLI was unimportable from an **installed** `sportsdataverse`.

`tools.validation.cli` imported `registry` at module level; `registry` imports `yaml` for `thresholds.yaml`; and **pyyaml is declared in `[dependency-groups]` — dev-only, not a runtime dependency**. Every SDV `-data` repo consumes this code by pinning the package from git with no dev group, so `python -m tools.validation.cli compare` died on `ModuleNotFoundError: No module named 'yaml'` — after doing the full build first. Found while wiring the weekly R/Python output-parity job in `wehoop-wnba-data`.

`compare` needs neither the dataset registry nor the thresholds, so it should not pay for them. `registry` is now imported inside `run_dataset()` and `lint_target()`, its only two callers.

### Test changes

`test_cli.py` patched `cli.resolve` / `cli.LINT_TARGETS`, which are no longer module-level names. Repointed at `registry` — the actual owner. This works because the lazy import resolves at call time, and it is less coupled than patching an import location.

### Regression test

`test_cli_importable_without_yaml.py` runs in a **subprocess** with a meta-path finder that blocks `yaml`, because the property under test is about import time and this test process has already imported yaml via other tests. It asserts the block actually took effect before proceeding, so it cannot pass vacuously. A second test confirms the registry path is still reached (unknown dataset still raises `KeyError`, not `NameError`).

### Verification

- `tests/contracts`: **151 passed**
- `ruff check` / `ruff format --check` clean

## Summary by Sourcery

Avoid importing the dataset registry at module load time in the validation CLI so it remains usable without the dev-only pyyaml dependency, and add coverage to ensure this behavior.

Bug Fixes:
- Ensure the validation CLI can be imported and `compare_outputs` used in environments where pyyaml is not installed by lazily importing the dataset registry only inside the functions that need it.

Tests:
- Adjust CLI tests to patch and access registry objects via `tools.validation.registry` rather than CLI module globals.
- Add a subprocess-based regression test that verifies the CLI remains importable and `compare_outputs` works when `yaml` imports are blocked, and that `run_dataset` still consults the registry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The CLI can now run output comparisons without requiring the YAML dependency.
  * Registry-dependent dataset and lint operations continue to work when invoked.
  * Improved handling of unknown datasets during CLI execution.

* **Tests**
  * Added regression coverage for dependency-free CLI imports and dataset resolution.
  * Updated CLI tests to reflect lazy loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->