### PR TITLE
test(ratings): stop asserting the reference-team bug db4361a4 fixed

### DIFF
--- a/tests/common/test_ratings_ridge.py
+++ b/tests/common/test_ratings_ridge.py
@@ -106,9 +106,14 @@ def test_dropped_level_ridge_emits_the_reference_team_at_the_intercept() -> None
     assert sorted(offense["team_id"].to_list()) == teams
     assert sorted(defense["team_id"].to_list()) == teams
 
-    # "Alpha" sorts first, so it is the reference level: effect 0, strength == intercept.
+    # "Alpha" sorts first, so it is the reference level on BOTH sides: effect 0,
+    # strength == intercept. Checked on offense and defense separately -- the two
+    # sides are built from separate coefficient blocks, so a wrong value on one
+    # would otherwise ride through on the other's assertion.
     alpha_off = offense.filter(pl.col("team_id") == "Alpha")["adjmodelOff"].item()
+    alpha_def = defense.filter(pl.col("team_id") == "Alpha")["adjmodelDef"].item()
     assert alpha_off == pytest.approx(intercept, abs=1e-12)
+    assert alpha_def == pytest.approx(intercept, abs=1e-12)
 
     # The fit still recovers the injected ordering (Alpha 0.15 > Beta 0.0 > Gamma -0.15),
     # so keeping the reference row has not distorted the ratings it sits alongside.

--- a/tests/common/test_ratings_ridge.py
+++ b/tests/common/test_ratings_ridge.py
@@ -7,6 +7,7 @@ byte-for-byte regression against real data lives in each league's own
 
 import numpy as np
 import polars as pl
+import pytest
 
 from sportsdataverse._common.ratings import dropped_level_ridge, opponent_adjusted_ridge
 
@@ -70,7 +71,22 @@ def test_opponent_adjusted_ridge_home_edge_positive() -> None:
     assert 0.0 < home_coef < 0.06
 
 
-def test_dropped_level_ridge_drops_first_team_alphabetically() -> None:
+def test_dropped_level_ridge_emits_the_reference_team_at_the_intercept() -> None:
+    """The reference level has no design-matrix column, but it IS a team.
+
+    This test previously asserted the opposite -- that the first-sorted team was
+    absent from the output -- which encoded the bug db4361a4 fixed. Emitting only
+    the dummy columns silently dropped one team per side from every fit, and the
+    season path joins opponent strength with ``fill_strength=None``, so that
+    team's opponents got a null adjustment and were filtered out downstream too.
+    Which team it hit was arbitrary: the sort runs on the STRING id, so it was
+    whichever sorted first lexicographically ("100" < "1005" < "101").
+
+    Under model.matrix encoding the reference effect is 0 and lives in the
+    intercept, so its strength is exactly ``intercept`` -- asserted below rather
+    than merely checking presence, because a reference row carrying some other
+    value would be a different bug wearing the same shape.
+    """
     rng = np.random.default_rng(1)
     rows = []
     teams = ["Alpha", "Beta", "Gamma"]
@@ -85,10 +101,18 @@ def test_dropped_level_ridge_drops_first_team_alphabetically() -> None:
         rows, schema=["pos_team_id", "def_pos_team_id", "pos_team", "home", "EPA", "pass", "rush"], orient="row"
     ).with_columns(hfa=pl.lit(0))
     offense, defense, intercept = dropped_level_ridge(clean, ridge_lambda=5.0)
-    # "Alpha" is the first sorted team_id -> dropped as the reference level.
-    assert "Alpha" not in offense["team_id"].to_list()
-    assert "Beta" in offense["team_id"].to_list() and "Gamma" in offense["team_id"].to_list()
+
+    # No team may be missing from either side -- that is the regression.
+    assert sorted(offense["team_id"].to_list()) == teams
+    assert sorted(defense["team_id"].to_list()) == teams
+
+    # "Alpha" sorts first, so it is the reference level: effect 0, strength == intercept.
+    alpha_off = offense.filter(pl.col("team_id") == "Alpha")["adjmodelOff"].item()
+    assert alpha_off == pytest.approx(intercept, abs=1e-12)
+
+    # The fit still recovers the injected ordering (Alpha 0.15 > Beta 0.0 > Gamma -0.15),
+    # so keeping the reference row has not distorted the ratings it sits alongside.
     beta_off = offense.filter(pl.col("team_id") == "Beta")["adjmodelOff"].item()
     gamma_off = offense.filter(pl.col("team_id") == "Gamma")["adjmodelOff"].item()
-    assert beta_off > gamma_off
+    assert alpha_off > beta_off > gamma_off
     assert isinstance(intercept, float)


### PR DESCRIPTION
`tests/common/test_ratings_ridge.py::test_dropped_level_ridge_drops_first_team_alphabetically` has been **red on main** and is the last place encoding a bug that was already fixed.

## The test asserted the defect

It required the first-sorted team to be **absent** from the ridge output. Per `db4361a4` ("fix(cfb): make the ridge opponent adjustment actually adjust"), that was the bug:

> Emitting only the dummy columns silently dropped one team per side from every fit — and because the season path joins opponent strength with `fill_strength=None`, that team's opponents got a null adjustment and were filtered out downstream too. Which team it hit was arbitrary: `sorted()` runs on the STRING id, so it is whichever id sorts first lexicographically (`"100" < "1005" < "101"`).

That commit fixed the engine and updated `tests/cfb/test_cfb_ratings.py` and `tests/cfb/test_ridge_lambda_calibration.py` — both now state the correct rule, *"model.matrix drops the reference level from the DESIGN, not from the OUTPUT"*. This `tests/common` sibling was missed.

## Verified before rewriting

Rather than assume the test was stale, I ran the engine on its own fixture:

```
intercept        : -0.0015593514993450643
offense rows     : ['Alpha', 'Beta', 'Gamma']
  Alpha  adjmodelOff = -0.0015593514993450643   == intercept? True
```

The reference team is emitted with effect 0, so its strength is exactly the intercept — the documented contract.

## What the test now asserts

- **No team is missing from either side** — that is the regression being guarded.
- The reference row carries **exactly** the intercept, not merely a row. A reference row holding some other value would be a different bug wearing the same shape, and presence-only would not catch it.
- The fit still recovers the injected ordering (Alpha 0.15 > Beta 0.0 > Gamma −0.15), so keeping the reference row has not distorted its neighbours.

Renamed accordingly — the old name asserted the old behaviour.

## Verification

- `tests/common/test_ratings_ridge.py`: **4 passed**
- `tests/common` + `tests/cfb/test_cfb_ratings.py` + `tests/cfb/test_ridge_lambda_calibration.py`: **62 passed**
- `ruff check` / `ruff format --check` clean

## Summary by Sourcery

Tests:
- Strengthen dropped-level ridge test to assert no team is missing, the reference team matches the intercept value, and the original rating ordering is preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage to verify that all teams appear in offense and defense ratings.
  * Confirmed the reference team’s rating matches the intercept.
  * Preserved validation of the expected rating order using approximate-value assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->