### PR TITLE
feat(validation): season event-rate collapse check (catches the 2013 sack outage)

### DIFF
--- a/tests/contracts/test_rate_anomaly.py
+++ b/tests/contracts/test_rate_anomaly.py
@@ -1,0 +1,75 @@
+import polars as pl
+import pytest
+
+from tools.validation.checks import rate_anomaly
+from tools.validation.findings import CheckContext, Severity
+
+
+def _ctx(**kw):
+    base = dict(domain="cfb", dataset="cfb_pbp", schema={})
+    base.update(kw)
+    return CheckContext(**base)
+
+
+def _season(season: int, games: int, sacks_per_game: int) -> list[dict]:
+    """One synthetic season: `games` games each carrying `sacks_per_game` sacks."""
+    rows = []
+    for g in range(games):
+        for s in range(max(sacks_per_game, 1)):
+            rows.append({"season": season, "game_id": season * 1000 + g, "sack": s < sacks_per_game})
+    return rows
+
+
+def test_collapsed_season_is_flagged_with_ratio():
+    # four healthy seasons at 4 sacks/game, one collapsed season at 0
+    rows = []
+    for yr in (2010, 2011, 2012, 2014):
+        rows += _season(yr, 10, 4)
+    rows += _season(2013, 10, 0)
+    findings = rate_anomaly.run("cfb_pbp", pl.DataFrame(rows), _ctx())
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.severity is Severity.WARN and f.needs_judgment
+    assert f.locator == {"column": "sack", "season": 2013}
+    assert f.metric == 0.0
+    assert "collapsed in 2013" in f.message
+
+
+def test_healthy_variation_is_not_flagged():
+    """Normal era swing (measured worst non-outage cell was 0.56x) must stay silent."""
+    rows = []
+    for yr, spg in ((2010, 4), (2011, 4), (2012, 3), (2013, 5), (2014, 4)):
+        rows += _season(yr, 10, spg)
+    assert rate_anomaly.run("cfb_pbp", pl.DataFrame(rows), _ctx()) == []
+
+
+def test_too_few_seasons_skips():
+    """A median over one or two seasons is not a baseline."""
+    rows = _season(2013, 10, 0) + _season(2014, 10, 4)
+    assert rate_anomaly.run("cfb_pbp", pl.DataFrame(rows), _ctx()) == []
+
+
+def test_zero_median_flag_is_skipped_not_divided_by_zero():
+    rows = []
+    for yr in (2011, 2012, 2013):
+        rows += [{"season": yr, "game_id": yr * 100 + g, "sack": False} for g in range(5)]
+    assert rate_anomaly.run("cfb_pbp", pl.DataFrame(rows), _ctx()) == []
+
+
+def test_unregistered_dataset_and_missing_columns_skip():
+    frame = pl.DataFrame([{"season": 2013, "game_id": 1, "sack": True}])
+    assert rate_anomaly.run("not_registered", frame, _ctx(dataset="not_registered")) == []
+    assert rate_anomaly.run("cfb_pbp", pl.DataFrame([{"sack": True}]), _ctx()) == []
+
+
+@pytest.mark.parametrize("floor,expected", [(0.5, 1), (0.1, 0)])
+def test_floor_is_threshold_driven(floor, expected):
+    """A partial collapse (0.25x median) fires at the shipped floor but not at a
+    lower one -- proving the floor discriminates rather than always firing. A
+    rate of exactly 0 is below every positive floor, so it cannot show this."""
+    rows = []
+    for yr in (2010, 2011, 2012, 2014):
+        rows += _season(yr, 10, 4)
+    rows += _season(2013, 10, 1)  # 1/game vs median 4/game -> 0.25x
+    ctx = _ctx(thresholds={"season_rate_floor": floor})
+    assert len(rate_anomaly.run("cfb_pbp", pl.DataFrame(rows), ctx)) == expected

--- a/tools/validation/checks/rate_anomaly.py
+++ b/tools/validation/checks/rate_anomaly.py
@@ -72,6 +72,23 @@ def run(dataset: str, frame: pl.DataFrame, ctx: CheckContext) -> list[Finding]:
 
     Returns:
         One Finding per (flag, season) collapse; empty when every season holds.
+        Never raises: an unregistered dataset, missing columns, too few seasons,
+        or a zero-median flag all short-circuit to an empty list, because a
+        check that aborts a run is worse than one that reports nothing.
+
+    Example:
+        Run the check over a registered dataset::
+
+            from tools.validation.checks import rate_anomaly
+            from tools.validation.registry import resolve
+
+            frame, ctx = resolve("cfb_pbp")
+            for finding in rate_anomaly.run("cfb_pbp", frame, ctx):
+                print(finding.severity.value, finding.message)
+
+        Tighten or loosen the collapse floor per run::
+
+            ctx = dataclasses.replace(ctx, thresholds={"season_rate_floor": 0.25})
     """
     spec = RATE_SPECS.get(dataset)
     if spec is None:

--- a/tools/validation/checks/rate_anomaly.py
+++ b/tools/validation/checks/rate_anomaly.py
@@ -1,0 +1,132 @@
+"""Per-season event-rate collapse.
+
+Row-level rules check that a play is *internally* consistent. They cannot see
+that an entire event type went **missing for a season** -- every surviving row
+stays perfectly self-consistent, so nothing fires.
+
+That is exactly how the 2013 sack outage hid: the published 2013 season carries
+32 ``type.text == "Sack"`` plays against 3,047 in 2012 and 3,213 in 2014, and
+``yds_sacked`` is 100% null. The parser is not at fault -- the 2013 feed simply
+does not contain sacks, and they were not folded into rushes either
+(rush-for-loss holds at 2.84/game in 2013 vs 2.86 in 2012 and 3.06 in 2014).
+No row-level rule can catch an absence.
+
+This check compares each season's per-game event rate against the **median
+season** for that flag and reports the collapses. Measured over 2004-2025
+(22 seasons x 12 flags = 264 season-flag cells): 2013/sack is the sole cell
+below 0.5x median, at **0.015x**; the next-worst cell anywhere is 0.560x. The
+floor is therefore well separated from normal era variation rather than tuned.
+
+Findings are WARN/``needs_judgment``: a rate collapse is sometimes a genuine
+rule change (kickoff rates move when touchback rules change), so it is a triage
+signal, not an automatic defect.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+from tools.validation.findings import CheckContext, Finding, Severity
+
+#: dataset -> (season column, per-season denominator key, flag columns)
+RATE_SPECS: dict[str, tuple[str, str, tuple[str, ...]]] = {
+    "cfb_pbp": (
+        "season",
+        "game_id",
+        (
+            "rush",
+            "pass",
+            "completion",
+            "sack",
+            "int",
+            "fumble_vec",
+            "penalty_flag",
+            "td_play",
+            "kickoff_play",
+            "punt_play",
+            "fg_attempt",
+            "safety",
+        ),
+    ),
+}
+
+#: Ratio-to-median below which a season's rate counts as a collapse. Measured:
+#: 2013/sack = 0.015, next-worst cell = 0.560, so 0.5 separates the real outage
+#: from every normal era swing without landing between two observed values.
+DEFAULT_FLOOR = 0.5
+_MIN_SEASONS = 3
+
+
+def run(dataset: str, frame: pl.DataFrame, ctx: CheckContext) -> list[Finding]:
+    """Report seasons whose per-game event rate collapsed versus the median season.
+
+    Skips when the dataset has no spec, the season/denominator columns are
+    absent, or fewer than ``_MIN_SEASONS`` seasons are present (a median over
+    one or two seasons is not a baseline). Flags whose median rate is zero are
+    skipped -- there is no meaningful ratio to take.
+
+    Args:
+        dataset: Registered dataset name.
+        frame: The data frame under validation.
+        ctx: Check context supplying the domain and thresholds.
+
+    Returns:
+        One Finding per (flag, season) collapse; empty when every season holds.
+    """
+    spec = RATE_SPECS.get(dataset)
+    if spec is None:
+        return []
+    season_col, denom_col, flags = spec
+    if season_col not in frame.columns or denom_col not in frame.columns:
+        return []
+    usable = [f for f in flags if f in frame.columns]
+    if not usable:
+        return []
+
+    per_season = (
+        frame.group_by(season_col)
+        .agg(
+            _denom=pl.col(denom_col).n_unique(),
+            **{f: (pl.col(f) == True).fill_null(False).sum() for f in usable},  # noqa: E712
+        )
+        .sort(season_col)
+    )
+    if per_season.height < _MIN_SEASONS:
+        return []
+
+    rates = per_season.select(
+        season_col,
+        pl.col("_denom"),
+        *[(pl.col(f) / pl.col("_denom")).alias(f) for f in usable],
+    )
+    floor = ctx.thresholds.get("season_rate_floor", DEFAULT_FLOOR)
+
+    findings: list[Finding] = []
+    for flag in usable:
+        median = rates.get_column(flag).median()
+        if not median:  # zero or null median -> no meaningful ratio
+            continue
+        collapsed = (
+            rates.select(season_col, "_denom", flag, _ratio=pl.col(flag) / median)
+            .filter(pl.col("_ratio") < floor)
+            .sort("_ratio")
+        )
+        for row in collapsed.to_dicts():
+            findings.append(
+                Finding(
+                    "rate_anomaly",
+                    Severity.WARN,
+                    ctx.domain,
+                    dataset,
+                    f"{flag!r} rate collapsed in {row[season_col]}: "
+                    f"{row[flag]:.3f}/game vs median {median:.3f}/game "
+                    f"({row['_ratio']:.3f}x, floor {floor})",
+                    locator={"column": flag, "season": row[season_col]},
+                    expected=round(median, 4),
+                    actual=round(row[flag], 4),
+                    metric=round(row["_ratio"], 4),
+                    needs_judgment=True,
+                    sample=[{"season": row[season_col], "games": row["_denom"], "rate": round(row[flag], 4)}],
+                )
+            )
+    return findings

--- a/tools/validation/cli.py
+++ b/tools/validation/cli.py
@@ -14,6 +14,7 @@ from tools.validation.checks import (
     definitional,
     extraction,
     numeric_parity,
+    rate_anomaly,
     r_python_output_parity,
     schema_contract,
     sweep,
@@ -38,6 +39,7 @@ _CHECKS = (
     constant_column,
     definitional,
     combo_drift,
+    rate_anomaly,
 )
 
 _LINTERS: dict[str, ModuleType] = {"python": leakage_python, "r": leakage_r}


### PR DESCRIPTION
## Why

Row-level rules cannot see that an entire event type went **missing for a season** — every surviving row stays internally consistent, so nothing fires. That is exactly how the 2013 sack outage hid behind a fully green rule set.

## Root cause established — and it corrects my earlier read

The 2013 problem is **not a parser bug**:

| season | text says "sacked" | `sack` flag | `type.text == "Sack"` | rush-for-loss(≤−3)/game |
|---|---:|---:|---:|---:|
| 2012 | 3,254 | 3,254 | 3,047 | 2.86 |
| **2013** | **54** | **52** | **32** | **2.84** |
| 2014 | 3,601 | 3,537 | 3,213 | 3.06 |

The parser correctly flags 52 of the 54 plays whose text says "sacked". ESPN's own `type.text` classification has only 32 sacks that season. They were **not** folded into rushes either — rush-for-loss holds flat at 2.84/game, between 2012's 2.86 and 2014's 3.06.

**~3,000 sacks are simply absent from the 2013 feed. No parser change can recover data that is not in the source** — it needs a re-scrape or acceptance as a known-bad season.

## What this PR adds

`rate_anomaly` compares each season's per-game event rate against the median season. Calibration over **22 seasons × 12 flags = 264 season-flag cells**:

- **2013/sack = 0.015× median** (0.061/game vs 3.997/game) — the *only* cell below 0.5×
- next-worst cell anywhere = **0.560×** (fumble_vec, 2021)

The 0.5 floor sits in a wide empty gap between the real outage and normal era variation, so it is separated rather than tuned. Findings are WARN/`needs_judgment` — a rate move can be a genuine rule change (kickoff rates shift with touchback rules), so it is a triage signal, not an automatic defect. The floor is threshold-driven via `season_rate_floor`.

## Testing

169 contract tests pass (6 new). Run against the real 22-season dataset it emits exactly one finding — the 2013 sack collapse — with the measured numbers.

## Summary by Sourcery

Add a season-level event-rate collapse validation check and integrate it into the validation CLI for CFB play-by-play data.

New Features:
- Introduce a rate_anomaly check that detects seasons where key event rates collapse relative to the median season across historical data.

Enhancements:
- Wire the new rate_anomaly validation check into the validation CLI and leakage suites so it runs as part of standard validations.

Tests:
- Add contract tests covering normal variation, true collapses, threshold configuration, dataset/column mismatches, and edge cases like zero medians and short histories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added season-level rate anomaly validation for supported datasets.
  - Detects unusually low event rates compared with the median across seasons.
  - Reports affected seasons, event columns, expected and actual rates, and severity.
  - Supports configurable detection thresholds.

- **Bug Fixes**
  - Validation safely skips unsupported, incomplete, or insufficient data scenarios.
  - Handles zero or unavailable baselines without producing misleading findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->