### PR TITLE
fix(basketball): add fox_nba_teams + make crosswalk provider fetches fail loudly

### DIFF
--- a/docs/docs/mbb/index.md
+++ b/docs/docs/mbb/index.md
@@ -12,7 +12,7 @@ sidebar_label: MBB
 | [ESPN FPI API (fitt v3)](reference/fitt) | 1 | `https://site.web.api.espn.com/apis/fitt/v3/sports` |
 | [Bart Torvik T-Rank (barttorvik.com)](reference/torvik) | 2 | `https://barttorvik.com` |
 | [Dataset loaders](reference/loaders) | 17 | sportsdataverse-data releases |
-| [Additional functions](reference/additional) | 308 | hand-written wrappers, loaders & helpers |
+| [Additional functions](reference/additional) | 310 | hand-written wrappers, loaders & helpers |
 
 ## Examples
 

--- a/docs/docs/mbb/reference/additional.md
+++ b/docs/docs/mbb/reference/additional.md
@@ -5332,6 +5332,65 @@ from sportsdataverse.mbb import fox_mbb_team_stats
 df = fox_mbb_team_stats("...")
 ```
 
+### `fox_mbb_teams(team_id: 'Union[int, str]' = '150', *, return_parsed: 'bool' = True, return_as_pandas: 'bool' = False, **kwargs: 'Any') -> "Union[pl.DataFrame, 'pd.DataFrame', Dict[str, Any]]"` {#fox_mbb_teams}
+
+MBB team directory for one seed team's conference.
+
+College basketball standings are per-conference, so one call returns only
+the seed team's league. Use `fox_mbb_teams_all` for the full
+directory the hoopR MBB team crosswalk consumes.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `team_id` | `Union[int, str]` | `'150'` | Seed Fox Bifrost team id whose standings page is read. Defaults to `"150"`. |
+| `return_parsed` | `bool` | `True` | If `True` (default) flatten the standings to the team directory; if `False` return the raw JSON `dict`. |
+| `return_as_pandas` | `bool` | `False` | If `True` return a pandas DataFrame; otherwise polars. Ignored when `return_parsed=False`. |
+
+**Returns**
+
+A polars DataFrame (default), a pandas DataFrame when `return_as_pandas=True`, or the raw JSON `dict` when `return_parsed=False`.
+
+**Example**
+
+```python
+from sportsdataverse.mbb import fox_mbb_teams
+df = fox_mbb_teams("150")
+```
+
+### `fox_mbb_teams_all(max_id: 'int' = 500, max_calls: 'int' = 60, *, return_as_pandas: 'bool' = False, **kwargs: 'Any') -> "Union[pl.DataFrame, 'pd.DataFrame']"` {#fox_mbb_teams_all}
+
+Full MBB team directory by walking seed ids across conferences.
+
+A single `fox_mbb_teams` call only returns the seed team's
+conference, so this walks candidate team ids (skipping ids already seen in
+an earlier conference) and unions the results, spending at most
+`max_calls` standings fetches. Mirrors `fox_wbb_teams_all`.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `max_id` | `int` | `500` | Highest candidate team id to try. Defaults to `500`. |
+| `max_calls` | `int` | `60` | Budget of standings fetches. Defaults to `60`. |
+| `return_as_pandas` | `bool` | `False` | If `True` return a pandas DataFrame; otherwise polars. |
+
+**Returns**
+
+A polars DataFrame (default) or pandas DataFrame, one row per team: `fox_team_id` / `fox_team_name` / `fox_section`.
+
+**Example**
+
+```python
+from sportsdataverse.mbb import fox_mbb_teams_all
+df = fox_mbb_teams_all()
+
+# Pipeline next step (one line)
+
+df.group_by("fox_section").len().sort("len", descending=True).head()
+```
+
 ### `fuzzy_box_match(candidate: 'str', unassigned_box_names: 'list[str]', team_context: 'str') -> 'Union[str, FuzzyMatchError]'` {#fuzzy_box_match}
 
 Pick the single unassigned box-score name a mis-spelled play-by-play

--- a/docs/docs/nba/index.md
+++ b/docs/docs/nba/index.md
@@ -12,7 +12,7 @@ sidebar_label: NBA
 | [ESPN FPI API (fitt v3)](reference/fitt) | 1 | `https://site.web.api.espn.com/apis/fitt/v3/sports` |
 | [NBA Stats API (stats.nba.com)](reference/nba_stats) | 112 | `https://stats.nba.com` |
 | [Dataset loaders](reference/loaders) | 34 | sportsdataverse-data releases |
-| [Additional functions](reference/additional) | 131 | hand-written wrappers, loaders & helpers |
+| [Additional functions](reference/additional) | 132 | hand-written wrappers, loaders & helpers |
 
 ## Examples
 

--- a/docs/docs/nba/reference/additional.md
+++ b/docs/docs/nba/reference/additional.md
@@ -1851,6 +1851,36 @@ from sportsdataverse.nba import fox_nba_team_stats
 df = fox_nba_team_stats("...")
 ```
 
+### `fox_nba_teams(team_id: 'Union[int, str]' = '1', *, return_parsed: 'bool' = True, return_as_pandas: 'bool' = False, **kwargs: 'Any') -> "Union[pl.DataFrame, 'pd.DataFrame', Dict[str, Any]]"` {#fox_nba_teams}
+
+NBA team directory (`fox_team_id` / `fox_team_name` / `fox_section`).
+
+Derived from the standings endpoint (one league-wide payload of all 30
+teams), this is the frame the hoopR NBA team crosswalk consumes.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `team_id` | `Union[int, str]` | `'1'` | Seed Fox Bifrost team id whose standings page is read. Defaults to `"1"` -- any NBA team id returns the whole league. |
+| `return_parsed` | `bool` | `True` | If `True` (default) flatten the standings to the team directory; if `False` return the raw JSON `dict`. |
+| `return_as_pandas` | `bool` | `False` | If `True` return a pandas DataFrame; otherwise polars. Ignored when `return_parsed=False`. |
+
+**Returns**
+
+A polars DataFrame (default), a pandas DataFrame when `return_as_pandas=True`, or the raw JSON `dict` when `return_parsed=False`.
+
+**Example**
+
+```python
+from sportsdataverse.nba import fox_nba_teams
+df = fox_nba_teams()
+
+# Pipeline next step (one line)
+
+df.select("fox_team_id", "fox_team_name").head()
+```
+
 ### `get_constants(league_id: 'str') -> 'LeagueConstants'` {#get_constants}
 
 Return the `LeagueConstants` for a `league_id`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -435,6 +435,8 @@ files = [
     "sportsdataverse/wnba/wnba_stats_runtime.py",
     "sportsdataverse/wnba/wnba_stats_parsers.py",
     "sportsdataverse/wnba/wnba_fox_ext.py",
+    "sportsdataverse/nba/nba_fox_ext.py",
+    "sportsdataverse/mbb/mbb_fox_ext.py",
     "sportsdataverse/wnba/wnba_engine.py",
     "sportsdataverse/nbagl/nbagl_engine.py",
     "sportsdataverse/nhl/nhl_prediction_constants.py",

--- a/sportsdataverse/_crosswalk_basketball_sources.py
+++ b/sportsdataverse/_crosswalk_basketball_sources.py
@@ -23,6 +23,7 @@ from sportsdataverse.errors import SportsDataverseError
 
 __all__ = [
     "CrosswalkSourceError",
+    "require_source",
     "espn_team_directory",
     "espn_scoreboard_games",
     "espn_rosters",
@@ -80,6 +81,67 @@ _TORVIK_HOST = {
     "mbb": "https://barttorvik.com",
     "wbb": "https://barttorvik.com/ncaaw",
 }
+
+
+def require_source(label: str, fetch: Callable[[], Any]) -> pl.DataFrame:
+    """Run a whole-source provider fetch, raising instead of swallowing failure.
+
+    The guard the crosswalk builders use in place of ``except Exception: x =
+    None``. A provider that *cannot be produced* -- the module is missing, the
+    import fails, the request errors, the payload will not render -- is a build
+    failure, because every downstream row then joins to nothing and the
+    crosswalk ships well-formed and entirely null. A provider that *answered
+    with no rows* is legitimate and passes straight through as a typed empty
+    frame.
+
+    Args:
+        label: Human-readable name of the fetch, quoted into the error message
+            so the failure names what was missing (e.g.
+            ``"fox_nba_teams()"``).
+        fetch: Zero-argument callable performing the fetch. Put the provider's
+            ``import`` inside it so a missing module raises here too.
+
+    Returns:
+        The ``pl.DataFrame`` the callable produced, zero rows included.
+
+    Raises:
+        CrosswalkSourceError: The callable raised, or returned something other
+            than a ``pl.DataFrame``. An inner :class:`CrosswalkSourceError`
+            (from an adapter that already reported precisely) propagates
+            unwrapped.
+
+    Example:
+        Fail loudly when a provider module is missing::
+
+            from sportsdataverse._crosswalk_basketball_sources import (
+                CrosswalkSourceError,
+                require_source,
+            )
+
+            def _fox():
+                from sportsdataverse.nba.nba_fox_ext import fox_nba_teams
+
+                return fox_nba_teams()
+
+            try:
+                fox = require_source("fox_nba_teams()", _fox)
+            except CrosswalkSourceError as exc:
+                print(f"refusing to build a crosswalk: {exc}")
+
+        See Also:
+            * `hoopR`_ -- R sister package whose crosswalks these port
+
+        .. _hoopR: https://hoopR.sportsdataverse.org
+    """
+    try:
+        out = fetch()
+    except CrosswalkSourceError:
+        raise
+    except Exception as exc:
+        raise CrosswalkSourceError(f"{label} could not be produced: {type(exc).__name__}: {exc}") from exc
+    if not isinstance(out, pl.DataFrame):
+        raise CrosswalkSourceError(f"{label} returned {type(out).__name__}, expected a polars DataFrame")
+    return out
 
 
 def _pick(df: pl.DataFrame, *candidates: str) -> pl.Expr:

--- a/sportsdataverse/mbb/mbb_crosswalk.py
+++ b/sportsdataverse/mbb/mbb_crosswalk.py
@@ -35,6 +35,7 @@ from sportsdataverse._crosswalk_basketball_sources import (
     bart_super_sked,
     espn_scoreboard_games,
     espn_team_directory,
+    require_source,
 )
 
 __all__ = [
@@ -451,6 +452,13 @@ def mbb_team_crosswalk(
         ``conference_name`` column -- sdv-py's ``espn_mbb_teams()`` does not
         ship conference labels.
 
+    Raises:
+        CrosswalkSourceError: A source that was not passed in pre-fetched could
+            not be produced (Fox or Torvik). Building on a missing source would
+            emit a well-formed crosswalk whose ``fox_*`` / ``bart_*`` columns
+            are silently all-null, so it fails here instead. Pass an explicit
+            empty frame (``fox=pl.DataFrame()``) to opt a source out.
+
     Example:
         Quick start::
 
@@ -480,17 +488,15 @@ def mbb_team_crosswalk(
     season = int(season) if season is not None else most_recent_mbb_season()
     espn = espn_team_directory("mbb", season=season, **kwargs)
     if fox is None:
-        try:
+
+        def _fox() -> Any:
             from sportsdataverse.mbb.mbb_fox_ext import fox_mbb_teams_all
 
-            fox = fox_mbb_teams_all(**kwargs)
-        except Exception:
-            fox = None
+            return fox_mbb_teams_all(**kwargs)
+
+        fox = require_source("fox_mbb_teams_all()", _fox)
     if bart is None:
-        try:
-            bart = torvik_ratings(year=season, **kwargs)
-        except Exception:
-            bart = None
+        bart = require_source(f"torvik_ratings(year={season})", lambda: torvik_ratings(year=season, **kwargs))
     out = _assemble_team_crosswalk(espn, fox, bart, kenpom, season)
     return out.to_pandas() if return_as_pandas else out
 

--- a/sportsdataverse/mbb/mbb_crosswalk.py
+++ b/sportsdataverse/mbb/mbb_crosswalk.py
@@ -483,7 +483,6 @@ def mbb_team_crosswalk(
         .. _Bart Torvik: https://barttorvik.com
     """
     from sportsdataverse.mbb.mbb_schedule import most_recent_mbb_season
-    from sportsdataverse.mbb.torvik import torvik_ratings
 
     season = int(season) if season is not None else most_recent_mbb_season()
     espn = espn_team_directory("mbb", season=season, **kwargs)
@@ -496,7 +495,15 @@ def mbb_team_crosswalk(
 
         fox = require_source("fox_mbb_teams_all()", _fox)
     if bart is None:
-        bart = require_source(f"torvik_ratings(year={season})", lambda: torvik_ratings(year=season, **kwargs))
+        # The provider import lives inside the callable so a missing/broken
+        # torvik module surfaces as CrosswalkSourceError, and so a caller who
+        # supplied `bart` never pays for (or trips over) the import at all.
+        def _bart() -> Any:
+            from sportsdataverse.mbb.torvik import torvik_ratings
+
+            return torvik_ratings(year=season, **kwargs)
+
+        bart = require_source(f"torvik_ratings(year={season})", _bart)
     out = _assemble_team_crosswalk(espn, fox, bart, kenpom, season)
     return out.to_pandas() if return_as_pandas else out
 

--- a/sportsdataverse/mbb/mbb_fox_ext.py
+++ b/sportsdataverse/mbb/mbb_fox_ext.py
@@ -424,7 +424,10 @@ _TEAMS_SCHEMA = {"fox_team_id": pl.Utf8, "fox_team_name": pl.Utf8, "fox_section"
 
 
 def _teams_frame(rows: "list[dict[str, Any]]", return_as_pandas: bool) -> Union[pl.DataFrame, "pd.DataFrame"]:
-    df = pl.DataFrame(rows, schema=_TEAMS_SCHEMA) if not rows else pl.DataFrame(rows)
+    # Schema on EVERY path: parse_teams can emit None for fox_team_name /
+    # fox_section, and an all-null column would otherwise infer Null while the
+    # empty path infers Utf8 -- an unstable schema for crosswalk consumers.
+    df = pl.DataFrame(rows, schema=_TEAMS_SCHEMA)
     return df.to_pandas() if return_as_pandas else df
 
 
@@ -487,6 +490,8 @@ def fox_mbb_teams(
             df = fox_mbb_teams("150")
 
         See Also:
+            * :func:`fox_mbb_teams_all` - Python alternative in this package for
+              the full cross-conference directory (this call covers one league)
             * `hoopR`_ - R sister package for men's college basketball
             * `Fox Sports`_ - data origin
 
@@ -540,6 +545,8 @@ def fox_mbb_teams_all(
             df.group_by("fox_section").len().sort("len", descending=True).head()
 
         See Also:
+            * :func:`fox_mbb_teams` - Python alternative in this package for a
+              single conference (one fetch instead of this scan)
             * `hoopR`_ - R sister package for men's college basketball
             * `Fox Sports`_ - data origin
 

--- a/sportsdataverse/mbb/mbb_fox_ext.py
+++ b/sportsdataverse/mbb/mbb_fox_ext.py
@@ -26,7 +26,9 @@ from sportsdataverse._fox_layout import (
     parse_standings,
     parse_team_gamelog,
     parse_team_stats,
+    parse_teams,
 )
+from sportsdataverse.errors import NoESPNDataError
 
 __all__ = [
     "fox_mbb_pbp",
@@ -37,6 +39,8 @@ __all__ = [
     "fox_mbb_team_gamelog",
     "fox_mbb_standings",
     "fox_mbb_league_leaders",
+    "fox_mbb_teams",
+    "fox_mbb_teams_all",
 ]
 
 _SPORT = "cbk"
@@ -414,3 +418,152 @@ def fox_mbb_league_leaders(
     """
     raw = fox_get(f"{_SPORT}/league/stats-con/{who}/{category}/{page}", **kwargs)
     return frame(parse_league_leaders(raw), return_as_pandas) if return_parsed else raw
+
+
+_TEAMS_SCHEMA = {"fox_team_id": pl.Utf8, "fox_team_name": pl.Utf8, "fox_section": pl.Utf8}
+
+
+def _teams_frame(rows: "list[dict[str, Any]]", return_as_pandas: bool) -> Union[pl.DataFrame, "pd.DataFrame"]:
+    df = pl.DataFrame(rows, schema=_TEAMS_SCHEMA) if not rows else pl.DataFrame(rows)
+    return df.to_pandas() if return_as_pandas else df
+
+
+@overload
+def fox_mbb_teams(
+    team_id: Union[int, str] = ..., *, return_parsed: Literal[False], return_as_pandas: bool = ..., **kwargs: Any
+) -> Dict[str, Any]: ...
+@overload
+def fox_mbb_teams(
+    team_id: Union[int, str] = ...,
+    *,
+    return_parsed: Literal[True] = ...,
+    return_as_pandas: Literal[True],
+    **kwargs: Any,
+) -> "pd.DataFrame": ...
+@overload
+def fox_mbb_teams(
+    team_id: Union[int, str] = ...,
+    *,
+    return_parsed: Literal[True] = ...,
+    return_as_pandas: Literal[False] = ...,
+    **kwargs: Any,
+) -> pl.DataFrame: ...
+def fox_mbb_teams(
+    team_id: Union[int, str] = "150",
+    *,
+    return_parsed: bool = True,
+    return_as_pandas: bool = False,
+    **kwargs: Any,
+) -> Union[pl.DataFrame, "pd.DataFrame", Dict[str, Any]]:
+    """MBB team directory for one seed team's conference.
+
+    College basketball standings are per-conference, so one call returns only
+    the seed team's league. Use :func:`fox_mbb_teams_all` for the full
+    directory the hoopR MBB team crosswalk consumes.
+
+    Args:
+        team_id: Seed Fox Bifrost team id whose standings page is read.
+            Defaults to ``"150"``.
+        return_parsed: If ``True`` (default) flatten the standings to the team
+            directory; if ``False`` return the raw JSON ``dict``.
+        return_as_pandas: If ``True`` return a pandas DataFrame; otherwise
+            polars. Ignored when ``return_parsed=False``.
+        **kwargs: Forwarded to the underlying HTTP getter.
+
+    Returns:
+        A polars DataFrame (default), a pandas DataFrame when
+        ``return_as_pandas=True``, or the raw JSON ``dict`` when
+        ``return_parsed=False``.
+
+    Raises:
+        sportsdataverse.errors.NoESPNDataError: Fox returned 404 for the requested id.
+        requests.exceptions.RequestException: Connection-level failure after
+            ``dl_utils.download`` exhausts its retries.
+
+    Example:
+        Fetch one conference's team directory::
+
+            from sportsdataverse.mbb import fox_mbb_teams
+            df = fox_mbb_teams("150")
+
+        See Also:
+            * `hoopR`_ - R sister package for men's college basketball
+            * `Fox Sports`_ - data origin
+
+        .. _hoopR: https://hoopR.sportsdataverse.org
+        .. _Fox Sports: https://www.foxsports.com
+    """
+    raw = fox_get(f"{_SPORT}/team/{team_id}/standings", **kwargs)
+    return _teams_frame(parse_teams(raw), return_as_pandas) if return_parsed else raw
+
+
+def fox_mbb_teams_all(
+    max_id: int = 500,
+    max_calls: int = 60,
+    *,
+    return_as_pandas: bool = False,
+    **kwargs: Any,
+) -> Union[pl.DataFrame, "pd.DataFrame"]:
+    """Full MBB team directory by walking seed ids across conferences.
+
+    A single :func:`fox_mbb_teams` call only returns the seed team's
+    conference, so this walks candidate team ids (skipping ids already seen in
+    an earlier conference) and unions the results, spending at most
+    ``max_calls`` standings fetches. Mirrors ``fox_wbb_teams_all``.
+
+    Args:
+        max_id: Highest candidate team id to try. Defaults to ``500``.
+        max_calls: Budget of standings fetches. Defaults to ``60``.
+        return_as_pandas: If ``True`` return a pandas DataFrame; otherwise
+            polars.
+        **kwargs: Forwarded to the underlying HTTP getter.
+
+    Returns:
+        A polars DataFrame (default) or pandas DataFrame, one row per team:
+        ``fox_team_id`` / ``fox_team_name`` / ``fox_section``.
+
+    Raises:
+        requests.exceptions.RequestException: Connection-level failure after
+            ``dl_utils.download`` exhausts its retries. A 404 on an individual
+            candidate id (``NoESPNDataError``) is expected during the scan and is
+            skipped; every other failure propagates rather than silently
+            truncating the directory.
+
+    Example:
+        Build the full directory::
+
+            from sportsdataverse.mbb import fox_mbb_teams_all
+            df = fox_mbb_teams_all()
+
+        Pipeline next step (one line)::
+
+            df.group_by("fox_section").len().sort("len", descending=True).head()
+
+        See Also:
+            * `hoopR`_ - R sister package for men's college basketball
+            * `Fox Sports`_ - data origin
+
+        .. _hoopR: https://hoopR.sportsdataverse.org
+        .. _Fox Sports: https://www.foxsports.com
+    """
+    seen: "set[str]" = set()
+    rows: "list[dict[str, Any]]" = []
+    calls = 0
+    for cand in range(1, max_id + 1):
+        if calls >= max_calls:
+            break
+        if str(cand) in seen:
+            continue
+        try:
+            part = parse_teams(fox_get(f"{_SPORT}/team/{cand}/standings", **kwargs))
+        except NoESPNDataError:
+            # Only "this candidate id does not exist" is expected while scanning.
+            # Transport / auth / rate-limit failures must NOT be laundered into an
+            # empty directory the caller can't tell apart from a valid scan.
+            part = []
+        calls += 1
+        for r in part:
+            if r["fox_team_id"] not in seen:
+                seen.add(r["fox_team_id"])
+                rows.append(r)
+    return _teams_frame(rows, return_as_pandas)

--- a/sportsdataverse/nba/nba_crosswalk.py
+++ b/sportsdataverse/nba/nba_crosswalk.py
@@ -254,15 +254,16 @@ def _stats_team_tricodes(season: int, **kwargs: Any) -> Dict[str, str]:
     Raises:
         CrosswalkSourceError: The game log could not be produced.
     """
-    from sportsdataverse.nba.nba_stats import nba_stats_leaguegamelog
-
     out: Dict[str, str] = {}
     for year in (season, season - 1):
         stats_season = f"{year - 1}-{str(year)[-2:]}"
 
         # Default-bound so the closure captures this iteration's season, not the
-        # loop variable's final value.
+        # loop variable's final value. The provider import is inside the callable
+        # so a missing/broken nba_stats module raises CrosswalkSourceError too.
         def _fetch(s: str = stats_season) -> Any:
+            from sportsdataverse.nba.nba_stats import nba_stats_leaguegamelog
+
             raw = nba_stats_leaguegamelog(league_id="00", season=s, **kwargs)
             return raw.get("LeagueGameLog") if isinstance(raw, dict) else raw
 

--- a/sportsdataverse/nba/nba_crosswalk.py
+++ b/sportsdataverse/nba/nba_crosswalk.py
@@ -26,7 +26,11 @@ from sportsdataverse._common_crosswalk_basketball import (
     normalize_team,
     str_id,
 )
-from sportsdataverse._crosswalk_basketball_sources import espn_scoreboard_games, espn_team_directory
+from sportsdataverse._crosswalk_basketball_sources import (
+    espn_scoreboard_games,
+    espn_team_directory,
+    require_source,
+)
 
 __all__ = [
     "nba_team_crosswalk",
@@ -239,18 +243,69 @@ def _assemble_schedule_crosswalk(
     )
 
 
-def _stats_team_directory(season: int, **kwargs: Any) -> Optional[pl.DataFrame]:
-    """NBA Stats team directory joined to ESPN ids (hoopR ``nba_teams()`` recipe)."""
-    from sportsdataverse.nba.nba_stats import nba_stats_leaguestandingsv3
+def _stats_team_tricodes(season: int, **kwargs: Any) -> Dict[str, str]:
+    """``{stats_team_id: tricode}`` from ``leaguegamelog`` (hoopR's join source).
 
-    try:
-        standings = nba_stats_leaguestandingsv3(season=f"{season - 1}-{str(season)[-2:]}", **kwargs)
-    except Exception:
-        return None
-    if isinstance(standings, dict):
-        standings = standings.get("Standings")
-    if standings is None or not isinstance(standings, pl.DataFrame) or standings.height == 0:
-        return None
+    ``leaguestandingsv3`` has no abbreviation column, so hoopR's ``nba_teams()``
+    picks the tricode up from the game log. An empty log means the season has
+    not tipped off yet; hoopR falls back one season for exactly that case and so
+    does this.
+
+    Raises:
+        CrosswalkSourceError: The game log could not be produced.
+    """
+    from sportsdataverse.nba.nba_stats import nba_stats_leaguegamelog
+
+    out: Dict[str, str] = {}
+    for year in (season, season - 1):
+        stats_season = f"{year - 1}-{str(year)[-2:]}"
+
+        # Default-bound so the closure captures this iteration's season, not the
+        # loop variable's final value.
+        def _fetch(s: str = stats_season) -> Any:
+            raw = nba_stats_leaguegamelog(league_id="00", season=s, **kwargs)
+            return raw.get("LeagueGameLog") if isinstance(raw, dict) else raw
+
+        log = require_source(f"nba_stats_leaguegamelog(season={stats_season!r})", _fetch)
+        if log.height == 0 or "team_abbreviation" not in log.columns:
+            continue
+        ids = log.select(str_id(log, "team_id")).to_series().to_list()
+        for team_id, abbr in zip(ids, log["team_abbreviation"].cast(pl.Utf8).to_list()):
+            if team_id is not None and abbr is not None:
+                out.setdefault(team_id, abbr)
+        break
+    return out
+
+
+def _stats_team_directory(season: int, **kwargs: Any) -> pl.DataFrame:
+    """NBA Stats team directory joined to ESPN ids (hoopR ``nba_teams()`` recipe).
+
+    Follows ``hoopR::nba_teams()``: ``leaguestandingsv3`` carries the city /
+    nickname / slug / conference / division, and ``leaguegamelog`` is joined on
+    ``team_id`` for the tricode -- ``leaguestandingsv3`` publishes no
+    abbreviation column at all (92 columns, none of them a tricode), which is
+    why the abbreviation needs the second call rather than being a projection
+    of the standings payload.
+
+    Raises:
+        CrosswalkSourceError: ``leaguestandingsv3`` or ``leaguegamelog`` could
+            not be produced. A standings payload that renders to zero rows is
+            provably empty (a season whose standings have not opened) and
+            returns a typed empty frame instead.
+    """
+    stats_season = f"{season - 1}-{str(season)[-2:]}"
+    label = f"nba_stats_leaguestandingsv3(season={stats_season!r})"
+
+    def _fetch() -> Any:
+        from sportsdataverse.nba.nba_stats import nba_stats_leaguestandingsv3
+
+        raw = nba_stats_leaguestandingsv3(season=stats_season, **kwargs)
+        return raw.get("Standings") if isinstance(raw, dict) else raw
+
+    standings = require_source(label, _fetch)
+    if standings.height == 0:
+        return pl.DataFrame(schema=_STATS_SCHEMA)
+    tricode = _stats_team_tricodes(season, **kwargs)
     espn = espn_team_directory("nba", **kwargs)
     espn_by_short = {
         normalize_team(name): tid
@@ -258,9 +313,10 @@ def _stats_team_directory(season: int, **kwargs: Any) -> Optional[pl.DataFrame]:
         if name is not None
     }
     names = standings.select(pl.col("team_name")).to_series().to_list()
+    stats_ids = standings.select(str_id(standings, "team_id")).to_series().to_list()
     return standings.select(
         str_id(standings, "team_id").alias("nba_team_id"),
-        pl.lit(None, dtype=pl.Utf8).alias("nba_team_abbreviation"),
+        pl.Series("nba_team_abbreviation", [tricode.get(v) for v in stats_ids], dtype=pl.Utf8),
         (pl.col("team_city") + pl.lit(" ") + pl.col("team_name")).cast(pl.Utf8).alias("nba_team_name"),
         pl.col("team_city").cast(pl.Utf8).alias("nba_team_city"),
         pl.col("team_slug").cast(pl.Utf8).alias("nba_team_slug"),
@@ -308,6 +364,12 @@ def nba_team_crosswalk(
         ``pl.DataFrame`` (or pandas), one row per ESPN team, with
         :data:`TEAM_COLUMNS`.
 
+    Raises:
+        CrosswalkSourceError: A source that was not passed in pre-fetched could
+            not be produced (Fox or the Stats endpoints). Building on a missing
+            source would emit a well-formed crosswalk whose ``fox_*`` /
+            ``nba_*`` columns are silently all-null, so it fails here instead.
+
     Note:
         ``stats.nba.com`` TLS-fingerprint-blocks plain ``requests`` and hangs
         on datacenter IPs; the live path needs ``curl_cffi`` and a residential
@@ -342,12 +404,13 @@ def nba_team_crosswalk(
     if stats is None:
         stats = _stats_team_directory(season, **kwargs)
     if fox is None:
-        try:
+
+        def _fox() -> Any:
             from sportsdataverse.nba.nba_fox_ext import fox_nba_teams
 
-            fox = fox_nba_teams(**kwargs)
-        except Exception:
-            fox = None
+            return fox_nba_teams(**kwargs)
+
+        fox = require_source("fox_nba_teams()", _fox)
     out = _assemble_team_crosswalk(espn, stats, fox, season)
     return out.to_pandas() if return_as_pandas else out
 

--- a/sportsdataverse/nba/nba_fox_ext.py
+++ b/sportsdataverse/nba/nba_fox_ext.py
@@ -26,6 +26,7 @@ from sportsdataverse._fox_layout import (
     parse_standings,
     parse_team_gamelog,
     parse_team_stats,
+    parse_teams,
 )
 
 __all__ = [
@@ -37,6 +38,7 @@ __all__ = [
     "fox_nba_team_gamelog",
     "fox_nba_standings",
     "fox_nba_league_leaders",
+    "fox_nba_teams",
 ]
 
 _SPORT = "nba"
@@ -442,3 +444,84 @@ def fox_nba_league_leaders(
     """
     raw = fox_get(f"{_SPORT}/league/stats-con/{who}/{category}/{page}", **kwargs)
     return frame(parse_league_leaders(raw), return_as_pandas) if return_parsed else raw
+
+
+_TEAMS_SCHEMA = {"fox_team_id": pl.Utf8, "fox_team_name": pl.Utf8, "fox_section": pl.Utf8}
+
+
+@overload
+def fox_nba_teams(
+    team_id: Union[int, str] = ..., *, return_parsed: Literal[False], return_as_pandas: bool = ..., **kwargs: Any
+) -> Dict[str, Any]: ...
+@overload
+def fox_nba_teams(
+    team_id: Union[int, str] = ...,
+    *,
+    return_parsed: Literal[True] = ...,
+    return_as_pandas: Literal[True],
+    **kwargs: Any,
+) -> "pd.DataFrame": ...
+@overload
+def fox_nba_teams(
+    team_id: Union[int, str] = ...,
+    *,
+    return_parsed: Literal[True] = ...,
+    return_as_pandas: Literal[False] = ...,
+    **kwargs: Any,
+) -> pl.DataFrame: ...
+def fox_nba_teams(
+    team_id: Union[int, str] = "1",
+    *,
+    return_parsed: bool = True,
+    return_as_pandas: bool = False,
+    **kwargs: Any,
+) -> Union[pl.DataFrame, "pd.DataFrame", Dict[str, Any]]:
+    """NBA team directory (``fox_team_id`` / ``fox_team_name`` / ``fox_section``).
+
+    Derived from the standings endpoint (one league-wide payload of all 30
+    teams), this is the frame the hoopR NBA team crosswalk consumes.
+
+    Args:
+        team_id: Seed Fox Bifrost team id whose standings page is read.
+            Defaults to ``"1"`` -- any NBA team id returns the whole league.
+        return_parsed: If ``True`` (default) flatten the standings to the team
+            directory; if ``False`` return the raw JSON ``dict``.
+        return_as_pandas: If ``True`` return a pandas DataFrame; otherwise
+            polars. Ignored when ``return_parsed=False``.
+        **kwargs: Forwarded to the underlying HTTP getter.
+
+    Returns:
+        A polars DataFrame (default), a pandas DataFrame when
+        ``return_as_pandas=True``, or the raw JSON ``dict`` when
+        ``return_parsed=False``.
+
+    Raises:
+        sportsdataverse.errors.NoESPNDataError: Fox returned 404 for the requested id.
+        requests.exceptions.RequestException: Connection-level failure after
+            ``dl_utils.download`` exhausts its retries.
+
+    Example:
+        Fetch the league team directory::
+
+            from sportsdataverse.nba import fox_nba_teams
+            df = fox_nba_teams()
+
+        Pipeline next step (one line)::
+
+            df.select("fox_team_id", "fox_team_name").head()
+
+        See Also:
+            * `hoopR`_ - R sister package for the NBA
+            * `nba_api`_ - Python alternative (stats.nba.com)
+            * `Fox Sports`_ - data origin
+
+        .. _hoopR: https://hoopR.sportsdataverse.org
+        .. _nba_api: https://github.com/swar/nba_api
+        .. _Fox Sports: https://www.foxsports.com
+    """
+    raw = fox_get(f"{_SPORT}/team/{team_id}/standings", **kwargs)
+    if not return_parsed:
+        return raw
+    rows = parse_teams(raw)
+    df = pl.DataFrame(rows, schema=_TEAMS_SCHEMA) if not rows else pl.DataFrame(rows)
+    return df.to_pandas() if return_as_pandas else df

--- a/sportsdataverse/nba/nba_fox_ext.py
+++ b/sportsdataverse/nba/nba_fox_ext.py
@@ -523,5 +523,8 @@ def fox_nba_teams(
     if not return_parsed:
         return raw
     rows = parse_teams(raw)
-    df = pl.DataFrame(rows, schema=_TEAMS_SCHEMA) if not rows else pl.DataFrame(rows)
+    # Schema on EVERY path: parse_teams can emit None for fox_team_name /
+    # fox_section, and an all-null column would otherwise infer Null while the
+    # empty path infers Utf8 -- an unstable schema for crosswalk consumers.
+    df = pl.DataFrame(rows, schema=_TEAMS_SCHEMA)
     return df.to_pandas() if return_as_pandas else df

--- a/sportsdataverse/parsed/mbb.py
+++ b/sportsdataverse/parsed/mbb.py
@@ -148,6 +148,7 @@ from sportsdataverse.mbb import fox_mbb_standings as _raw_fox_mbb_standings
 from sportsdataverse.mbb import fox_mbb_team_gamelog as _raw_fox_mbb_team_gamelog
 from sportsdataverse.mbb import fox_mbb_team_roster as _raw_fox_mbb_team_roster
 from sportsdataverse.mbb import fox_mbb_team_stats as _raw_fox_mbb_team_stats
+from sportsdataverse.mbb import fox_mbb_teams as _raw_fox_mbb_teams
 from sportsdataverse.mbb import torvik_ratings as _raw_torvik_ratings
 from sportsdataverse.mbb import torvik_team_factors as _raw_torvik_team_factors
 from sportsdataverse.mbb import AssistEvent as AssistEvent  # noqa: F401
@@ -319,6 +320,7 @@ from sportsdataverse.mbb import fit_shrinkage_k as fit_shrinkage_k  # noqa: F401
 from sportsdataverse.mbb import fix_combos as fix_combos  # noqa: F401
 from sportsdataverse.mbb import fix_possible_score_swap_bug as fix_possible_score_swap_bug  # noqa: F401
 from sportsdataverse.mbb import flatten_json_iterative as flatten_json_iterative  # noqa: F401
+from sportsdataverse.mbb import fox_mbb_teams_all as fox_mbb_teams_all  # noqa: F401
 from sportsdataverse.mbb import fuzzy_box_match as fuzzy_box_match  # noqa: F401
 from sportsdataverse.mbb import get_ascending_time as get_ascending_time  # noqa: F401
 from sportsdataverse.mbb import get_box_lineup as get_box_lineup  # noqa: F401
@@ -852,6 +854,8 @@ __all__ = [
     "fox_mbb_team_gamelog",
     "fox_mbb_team_roster",
     "fox_mbb_team_stats",
+    "fox_mbb_teams",
+    "fox_mbb_teams_all",
     "fuzzy_box_match",
     "get_ascending_time",
     "get_box_lineup",
@@ -2842,6 +2846,20 @@ def fox_mbb_team_stats(*args, **kwargs):
     """
     kwargs.setdefault("return_parsed", True)
     return _raw_fox_mbb_team_stats(*args, **kwargs)
+
+
+def fox_mbb_teams(*args, **kwargs):
+    """``return_parsed=True`` by default (parsed.* mirror of ``mbb.fox_mbb_teams``).
+
+    .. deprecated:: 0.0.54
+       Import :func:`sportsdataverse.mbb.fox_mbb_teams` directly instead;
+       that function now returns a parsed DataFrame by default.
+
+    Pass ``return_parsed=False`` for the raw ``Dict``. See
+    :func:`sportsdataverse.mbb.fox_mbb_teams` for full documentation.
+    """
+    kwargs.setdefault("return_parsed", True)
+    return _raw_fox_mbb_teams(*args, **kwargs)
 
 
 def torvik_ratings(*args, **kwargs):

--- a/sportsdataverse/parsed/nba.py
+++ b/sportsdataverse/parsed/nba.py
@@ -142,6 +142,7 @@ from sportsdataverse.nba import fox_nba_standings as _raw_fox_nba_standings
 from sportsdataverse.nba import fox_nba_team_gamelog as _raw_fox_nba_team_gamelog
 from sportsdataverse.nba import fox_nba_team_roster as _raw_fox_nba_team_roster
 from sportsdataverse.nba import fox_nba_team_stats as _raw_fox_nba_team_stats
+from sportsdataverse.nba import fox_nba_teams as _raw_fox_nba_teams
 from sportsdataverse.nba import nba_stats_leaguedashptstats as _raw_nba_stats_leaguedashptstats
 from sportsdataverse.nba import AdjRapmModel as AdjRapmModel  # noqa: F401
 from sportsdataverse.nba import AgingCurve as AgingCurve  # noqa: F401
@@ -492,6 +493,7 @@ __all__ = [
     "fox_nba_team_gamelog",
     "fox_nba_team_roster",
     "fox_nba_team_stats",
+    "fox_nba_teams",
     "get_constants",
     "get_shrinkage_k",
     "helper_nba_athlete_items",
@@ -2302,6 +2304,20 @@ def fox_nba_team_stats(*args, **kwargs):
     """
     kwargs.setdefault("return_parsed", True)
     return _raw_fox_nba_team_stats(*args, **kwargs)
+
+
+def fox_nba_teams(*args, **kwargs):
+    """``return_parsed=True`` by default (parsed.* mirror of ``nba.fox_nba_teams``).
+
+    .. deprecated:: 0.0.54
+       Import :func:`sportsdataverse.nba.fox_nba_teams` directly instead;
+       that function now returns a parsed DataFrame by default.
+
+    Pass ``return_parsed=False`` for the raw ``Dict``. See
+    :func:`sportsdataverse.nba.fox_nba_teams` for full documentation.
+    """
+    kwargs.setdefault("return_parsed", True)
+    return _raw_fox_nba_teams(*args, **kwargs)
 
 
 def nba_stats_leaguedashptstats(*args, **kwargs):

--- a/sportsdataverse/wbb/wbb_crosswalk.py
+++ b/sportsdataverse/wbb/wbb_crosswalk.py
@@ -403,7 +403,6 @@ def wbb_team_crosswalk(
         .. _wehoop: https://wehoop.sportsdataverse.org
         .. _Bart Torvik: https://barttorvik.com/ncaaw
     """
-    from sportsdataverse.wbb.bart_wbb import bart_wbb_ratings
     from sportsdataverse.wbb.wbb_schedule import most_recent_wbb_season
 
     season = int(season) if season is not None else most_recent_wbb_season()
@@ -417,7 +416,15 @@ def wbb_team_crosswalk(
 
         fox = require_source("fox_wbb_teams_all()", _fox)
     if bart is None:
-        bart = require_source(f"bart_wbb_ratings(year={season})", lambda: bart_wbb_ratings(year=season, **kwargs))
+        # The provider import lives inside the callable so a missing/broken
+        # bart_wbb module surfaces as CrosswalkSourceError, and so a caller who
+        # supplied `bart` never pays for (or trips over) the import at all.
+        def _bart() -> Any:
+            from sportsdataverse.wbb.bart_wbb import bart_wbb_ratings
+
+            return bart_wbb_ratings(year=season, **kwargs)
+
+        bart = require_source(f"bart_wbb_ratings(year={season})", _bart)
     out = _assemble_team_crosswalk(espn, fox, bart, season)
     return out.to_pandas() if return_as_pandas else out
 

--- a/sportsdataverse/wbb/wbb_crosswalk.py
+++ b/sportsdataverse/wbb/wbb_crosswalk.py
@@ -36,6 +36,7 @@ from sportsdataverse._crosswalk_basketball_sources import (
     bart_super_sked,
     espn_scoreboard_games,
     espn_team_directory,
+    require_source,
 )
 
 __all__ = [
@@ -372,6 +373,13 @@ def wbb_team_crosswalk(
         ``conference_name`` column -- sdv-py's ``espn_wbb_teams()`` does not
         ship conference labels.
 
+    Raises:
+        CrosswalkSourceError: A source that was not passed in pre-fetched could
+            not be produced (Fox or Torvik). Building on a missing source would
+            emit a well-formed crosswalk whose ``fox_*`` / ``bart_*`` columns
+            are silently all-null, so it fails here instead. Pass an explicit
+            empty frame (``fox=pl.DataFrame()``) to opt a source out.
+
     Example:
         Quick start::
 
@@ -401,17 +409,15 @@ def wbb_team_crosswalk(
     season = int(season) if season is not None else most_recent_wbb_season()
     espn = espn_team_directory("wbb", season=season, **kwargs)
     if fox is None:
-        from sportsdataverse.wbb.wbb_fox_ext import fox_wbb_teams_all
 
-        try:
-            fox = fox_wbb_teams_all(**kwargs)
-        except Exception:
-            fox = None
+        def _fox() -> Any:
+            from sportsdataverse.wbb.wbb_fox_ext import fox_wbb_teams_all
+
+            return fox_wbb_teams_all(**kwargs)
+
+        fox = require_source("fox_wbb_teams_all()", _fox)
     if bart is None:
-        try:
-            bart = bart_wbb_ratings(year=season, **kwargs)
-        except Exception:
-            bart = None
+        bart = require_source(f"bart_wbb_ratings(year={season})", lambda: bart_wbb_ratings(year=season, **kwargs))
     out = _assemble_team_crosswalk(espn, fox, bart, season)
     return out.to_pandas() if return_as_pandas else out
 

--- a/sportsdataverse/wbb/wbb_fox_ext.py
+++ b/sportsdataverse/wbb/wbb_fox_ext.py
@@ -536,7 +536,10 @@ _TEAMS_SCHEMA = {"fox_team_id": pl.Utf8, "fox_team_name": pl.Utf8, "fox_section"
 
 
 def _teams_frame(rows: "list[dict[str, Any]]", return_as_pandas: bool) -> Union[pl.DataFrame, "pd.DataFrame"]:
-    df = pl.DataFrame(rows, schema=_TEAMS_SCHEMA) if not rows else pl.DataFrame(rows)
+    # Schema on EVERY path: parse_teams can emit None for fox_team_name /
+    # fox_section, and an all-null column would otherwise infer Null while the
+    # empty path infers Utf8 -- an unstable schema for crosswalk consumers.
+    df = pl.DataFrame(rows, schema=_TEAMS_SCHEMA)
     return df.to_pandas() if return_as_pandas else df
 
 

--- a/sportsdataverse/wnba/wnba_crosswalk.py
+++ b/sportsdataverse/wnba/wnba_crosswalk.py
@@ -25,7 +25,11 @@ from sportsdataverse._common_crosswalk_basketball import (
     normalize_team,
     str_id,
 )
-from sportsdataverse._crosswalk_basketball_sources import espn_scoreboard_games, espn_team_directory
+from sportsdataverse._crosswalk_basketball_sources import (
+    espn_scoreboard_games,
+    espn_team_directory,
+    require_source,
+)
 
 __all__ = [
     "wnba_team_crosswalk",
@@ -261,6 +265,12 @@ def wnba_team_crosswalk(
         ``pl.DataFrame`` (or pandas), one row per ESPN team, with
         :data:`TEAM_COLUMNS`.
 
+    Raises:
+        CrosswalkSourceError: A source that was not passed in pre-fetched could
+            not be produced (Fox or the Stats schedule). Building on a missing
+            source would emit a well-formed crosswalk whose ``fox_*`` /
+            ``wnba_*`` columns are silently all-null, so it fails here instead.
+
     Note:
         ``stats.wnba.com`` TLS-fingerprint-blocks plain ``requests`` and hangs
         on datacenter IPs; the live path needs ``curl_cffi`` and a residential
@@ -296,12 +306,13 @@ def wnba_team_crosswalk(
     if stats is None:
         stats = stats_schedule_games("wnba", season, teams=True, **kwargs)
     if fox is None:
-        try:
+
+        def _fox() -> Any:
             from sportsdataverse.wnba.wnba_fox_ext import fox_wnba_teams
 
-            fox = fox_wnba_teams(**kwargs)
-        except Exception:
-            fox = None
+            return fox_wnba_teams(**kwargs)
+
+        fox = require_source("fox_wnba_teams()", _fox)
     out = _assemble_team_crosswalk(espn, stats, fox, season)
     return out.to_pandas() if return_as_pandas else out
 

--- a/sportsdataverse/wnba/wnba_fox_ext.py
+++ b/sportsdataverse/wnba/wnba_fox_ext.py
@@ -631,5 +631,8 @@ def fox_wnba_teams(
     if not return_parsed:
         return raw
     rows = parse_teams(raw)
-    df = pl.DataFrame(rows, schema=_TEAMS_SCHEMA) if not rows else pl.DataFrame(rows)
+    # Schema on EVERY path: parse_teams can emit None for fox_team_name /
+    # fox_section, and an all-null column would otherwise infer Null while the
+    # empty path infers Utf8 -- an unstable schema for crosswalk consumers.
+    df = pl.DataFrame(rows, schema=_TEAMS_SCHEMA)
     return df.to_pandas() if return_as_pandas else df

--- a/tests/fixtures/fox/README.md
+++ b/tests/fixtures/fox/README.md
@@ -15,6 +15,7 @@ captured 2026-08-07. Used by `tests/test_fox_wbb_wnba_offline.py`.
 |---|---|
 | `wnba_team_3_standings.json` | `/wnba/team/3/standings` (league-wide WNBA standings; team directory source) |
 | `wcbk_team_11_standings.json` | `/wcbk/team/11/standings` (Big East standings from the UConn seed) |
+| `nba_team_1_standings.json` | `/nba/team/1/standings` (league-wide NBA standings, all 30 teams; team directory source) |
 
 The CFB Fox pbp fixture lives separately at
 `tests/cfb/fixtures/fox_cfb_event_41616_data.json`.

--- a/tests/fixtures/fox/nba_team_1_standings.json
+++ b/tests/fixtures/fox/nba_team_1_standings.json
@@ -1,0 +1,9110 @@
+{
+ "standingsSections": [
+  {
+   "id": "conference",
+   "title": "CONFERENCE",
+   "pageTitle": "2025-26 NBA CONFERENCE STANDINGS",
+   "lastUpdated": "2026-07-22T08:20:16Z",
+   "standings": [
+    {
+     "template": "table-standings",
+     "headers": [
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "EASTERN CONFERENCE",
+         "priority": 1,
+         "template": "cell-rank",
+         "weight": 0.5,
+         "emphasized": true,
+         "sortable": "none"
+        },
+        {
+         "index": 1,
+         "priority": 2,
+         "template": "cell-entity",
+         "weight": 4.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 2,
+         "text": "W-L",
+         "priority": 3,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 3,
+         "text": "PCT",
+         "priority": 5,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 4,
+         "text": "GB",
+         "priority": 4,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 5,
+         "text": "PF",
+         "priority": 8,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 6,
+         "text": "PA",
+         "priority": 9,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 7,
+         "text": "HOME",
+         "priority": 12,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 8,
+         "text": "AWAY",
+         "priority": 13,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 9,
+         "text": "CONF",
+         "priority": 10,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 10,
+         "text": "DIV",
+         "priority": 11,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 11,
+         "text": "L10",
+         "priority": 7,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 12,
+         "text": "STRK",
+         "priority": 6,
+         "template": "cell-text",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        }
+       ],
+       "isPrimary": true
+      }
+     ],
+     "rows": [
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "1",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Pistons",
+         "superscript": "Z",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pistons.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Detroit Pistons",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pistons.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "60-22",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".732",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "-",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "117.8",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "109.6",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "31-9",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "28-13",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "39-13",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "12-4",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "8-2",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "W3",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "DETROIT PISTONS",
+        "webUrl": "/nba/detroit-pistons-team",
+        "color": "1, 0, 67, 140",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pistons.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Detroit Pistons",
+        "contentUri": "basketball/nba/teams/12",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "12",
+          "contentUri": "basketball/nba/teams/12"
+         }
+        },
+        "analyticsName": "detroit-pistons",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pistons.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "2",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Celtics",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Celtics.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Boston Celtics",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Celtics.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "56-26",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".683",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "4.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "114.8",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "107.2",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "30-11",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "26-15",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "36-16",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "10-6",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "8-2",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "W2",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": true,
+       "entityLink": {
+        "title": "BOSTON CELTICS",
+        "webUrl": "/nba/boston-celtics-team",
+        "color": "1, 0, 131, 55",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Celtics.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Boston Celtics",
+        "contentUri": "basketball/nba/teams/1",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "1",
+          "contentUri": "basketball/nba/teams/1"
+         }
+        },
+        "analyticsName": "boston-celtics",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Celtics.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "3",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Knicks",
+         "superscript": "X",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Knicks.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "New York Knicks",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Knicks.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "53-29",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".646",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "7.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "116.4",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "110.1",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "30-10",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "22-19",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "35-17",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "14-3",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "6-4",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "L1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "NEW YORK KNICKS",
+        "webUrl": "/nba/new-york-knicks-team",
+        "color": "1, 0, 107, 182",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Knicks.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "New York Knicks",
+        "contentUri": "basketball/nba/teams/4",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "4",
+          "contentUri": "basketball/nba/teams/4"
+         }
+        },
+        "analyticsName": "new-york-knicks",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Knicks.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "4",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Cavaliers",
+         "superscript": "X",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Cavaliers.vresize.200.200.medium.1.png",
+         "imageType": "image-logo",
+         "imageAltText": "Cleveland Cavaliers",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Cavaliers.vresize.200.200.medium.1.png"
+        },
+        {
+         "index": 2,
+         "text": "52-30",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".634",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "8.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "119.5",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "115.4",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "27-14",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "25-16",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "33-19",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "11-5",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "7-3",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "W1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "CLEVELAND CAVALIERS",
+        "webUrl": "/nba/cleveland-cavaliers-team",
+        "color": "1, 134, 0, 56",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Cavaliers.vresize.200.200.medium.1.png",
+        "imageType": "image-logo",
+        "imageAltText": "Cleveland Cavaliers",
+        "contentUri": "basketball/nba/teams/11",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "11",
+          "contentUri": "basketball/nba/teams/11"
+         }
+        },
+        "analyticsName": "cleveland-cavaliers",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Cavaliers.vresize.200.200.medium.1.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "5",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Raptors",
+         "superscript": "X",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Raptors.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Toronto Raptors",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Raptors-alternate.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "46-36",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".561",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "14.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "114.6",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "111.8",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "24-17",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "22-19",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "33-19",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "5-12",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "6-4",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "W1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "TORONTO RAPTORS",
+        "webUrl": "/nba/toronto-raptors-team",
+        "color": "1, 206, 17, 65",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Raptors-alternate.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Toronto Raptors",
+        "contentUri": "basketball/nba/teams/30",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "30",
+          "contentUri": "basketball/nba/teams/30"
+         }
+        },
+        "analyticsName": "toronto-raptors",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Raptors.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "6",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Hawks",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Hawks.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Atlanta Hawks",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Hawks.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "46-36",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".561",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "14.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "118.5",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "116.1",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "24-17",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "22-19",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "27-25",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "9-7",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "6-4",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "L1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "ATLANTA HAWKS",
+        "webUrl": "/nba/atlanta-hawks-team",
+        "color": "1, 207, 10, 44",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Hawks.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Atlanta Hawks",
+        "contentUri": "basketball/nba/teams/8",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "8",
+          "contentUri": "basketball/nba/teams/8"
+         }
+        },
+        "analyticsName": "atlanta-hawks",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Hawks.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "7",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "76ers",
+         "superscript": "X",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/76ers.vresize.200.200.medium.2.png",
+         "imageType": "image-logo",
+         "imageAltText": "Philadelphia 76ers",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/76ers-alternate.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "45-37",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".549",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "15.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "115.9",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "116.1",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "23-18",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "22-19",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "27-25",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "9-7",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "6-4",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "W2",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "PHILADELPHIA 76ERS",
+        "webUrl": "/nba/philadelphia-76ers-team",
+        "color": "1, 0, 107, 182",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/76ers-alternate.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Philadelphia 76ers",
+        "contentUri": "basketball/nba/teams/6",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "6",
+          "contentUri": "basketball/nba/teams/6"
+         }
+        },
+        "analyticsName": "philadelphia-76ers",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/76ers.vresize.200.200.medium.2.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "8",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Magic",
+         "superscript": "X",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Magic.vresize.200.200.medium.1.png",
+         "imageType": "image-logo",
+         "imageAltText": "Orlando Magic",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Magic.vresize.200.200.medium.1.png"
+        },
+        {
+         "index": 2,
+         "text": "45-37",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".549",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "15.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "115.7",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "115.1",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "25-15",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "19-20",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "26-26",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "9-8",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "7-3",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "L1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "ORLANDO MAGIC",
+        "webUrl": "/nba/orlando-magic-team",
+        "color": "1, 35, 85, 166",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Magic.vresize.200.200.medium.1.png",
+        "imageType": "image-logo",
+        "imageAltText": "Orlando Magic",
+        "contentUri": "basketball/nba/teams/5",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "5",
+          "contentUri": "basketball/nba/teams/5"
+         }
+        },
+        "analyticsName": "orlando-magic",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Magic.vresize.200.200.medium.1.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "9",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Hornets",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Hornets.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Charlotte Hornets",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Hornets.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "44-38",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".537",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "16.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "116.0",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "111.2",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "21-20",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "23-18",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "26-26",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "11-5",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "6-4",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "W1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "CHARLOTTE HORNETS",
+        "webUrl": "/nba/charlotte-hornets-team",
+        "color": "1, 0, 141, 139",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Hornets.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Charlotte Hornets",
+        "contentUri": "basketball/nba/teams/32",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "32",
+          "contentUri": "basketball/nba/teams/32"
+         }
+        },
+        "analyticsName": "charlotte-hornets",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Hornets.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "10",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Heat",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Heat.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Miami Heat",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Heat.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "43-39",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".524",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "17.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "120.9",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "118.5",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "26-15",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "17-24",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "27-25",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "10-7",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "5-5",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "W2",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": true,
+       "selected": false,
+       "entityLink": {
+        "title": "MIAMI HEAT",
+        "webUrl": "/nba/miami-heat-team",
+        "color": "1, 152, 0, 46",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Heat.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Miami Heat",
+        "contentUri": "basketball/nba/teams/2",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "2",
+          "contentUri": "basketball/nba/teams/2"
+         }
+        },
+        "analyticsName": "miami-heat",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Heat.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "11",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Bucks",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Bucks.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Milwaukee Bucks",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Bucks.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "32-50",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".390",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "28.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "110.6",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "116.8",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "19-22",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "13-28",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "21-31",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "9-7",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "3-7",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "L1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "MILWAUKEE BUCKS",
+        "webUrl": "/nba/milwaukee-bucks-team",
+        "color": "1, 43, 81, 52",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Bucks.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Milwaukee Bucks",
+        "contentUri": "basketball/nba/teams/14",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "14",
+          "contentUri": "basketball/nba/teams/14"
+         }
+        },
+        "analyticsName": "milwaukee-bucks",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Bucks.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "12",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Bulls",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Bulls.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Chicago Bulls",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Bulls.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "31-51",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".378",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "29.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "116.3",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "121.5",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "18-23",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "13-28",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "19-32",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "4-12",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "2-8",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "L2",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "CHICAGO BULLS",
+        "webUrl": "/nba/chicago-bulls-team",
+        "color": "1, 206, 17, 65",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Bulls.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Chicago Bulls",
+        "contentUri": "basketball/nba/teams/10",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "10",
+          "contentUri": "basketball/nba/teams/10"
+         }
+        },
+        "analyticsName": "chicago-bulls",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Bulls.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "13",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Nets",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Nets.vresize.200.200.medium.1.png",
+         "imageType": "image-logo",
+         "imageAltText": "Brooklyn Nets",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Nets.vresize.200.200.medium.1.png"
+        },
+        {
+         "index": 2,
+         "text": "20-62",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".244",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "40.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "105.9",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "115.9",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "12-29",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "8-33",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "14-37",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "3-13",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "3-7",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "L3",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "BROOKLYN NETS",
+        "webUrl": "/nba/brooklyn-nets-team",
+        "color": "1, 51, 51, 51",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Nets.vresize.200.200.medium.1.png",
+        "imageType": "image-logo",
+        "imageAltText": "Brooklyn Nets",
+        "contentUri": "basketball/nba/teams/3",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "3",
+          "contentUri": "basketball/nba/teams/3"
+         }
+        },
+        "analyticsName": "brooklyn-nets",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Nets.vresize.200.200.medium.1.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "14",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Pacers",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pacers.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Indiana Pacers",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pacers.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "19-63",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".232",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "41.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "112.4",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "120.4",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "11-30",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "8-33",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "15-37",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "4-12",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "3-7",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "L2",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "INDIANA PACERS",
+        "webUrl": "/nba/indiana-pacers-team",
+        "color": "1, 253, 187, 52",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pacers.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Indiana Pacers",
+        "contentUri": "basketball/nba/teams/13",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "13",
+          "contentUri": "basketball/nba/teams/13"
+         }
+        },
+        "analyticsName": "indiana-pacers",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pacers.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "15",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Wizards",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Wizards.vresize.200.200.medium.1.png",
+         "imageType": "image-logo",
+         "imageAltText": "Washington Wizards",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Wizards.vresize.200.200.medium.1.png"
+        },
+        {
+         "index": 2,
+         "text": "17-65",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".207",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "43.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "112.9",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "124.9",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "11-30",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "6-35",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "11-41",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "2-14",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "0-10",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "L10",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "WASHINGTON WIZARDS",
+        "webUrl": "/nba/washington-wizards-team",
+        "color": "1, 0, 43, 92",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Wizards.vresize.200.200.medium.1.png",
+        "imageType": "image-logo",
+        "imageAltText": "Washington Wizards",
+        "contentUri": "basketball/nba/teams/7",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "7",
+          "contentUri": "basketball/nba/teams/7"
+         }
+        },
+        "analyticsName": "washington-wizards",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Wizards.vresize.200.200.medium.1.png"
+       },
+       "isFaded": false
+      }
+     ]
+    },
+    {
+     "template": "table-standings",
+     "headers": [
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "WESTERN CONFERENCE",
+         "priority": 1,
+         "template": "cell-rank",
+         "weight": 0.5,
+         "emphasized": true,
+         "sortable": "none"
+        },
+        {
+         "index": 1,
+         "priority": 2,
+         "template": "cell-entity",
+         "weight": 4.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 2,
+         "text": "W-L",
+         "priority": 3,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 3,
+         "text": "PCT",
+         "priority": 5,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 4,
+         "text": "GB",
+         "priority": 4,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 5,
+         "text": "PF",
+         "priority": 8,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 6,
+         "text": "PA",
+         "priority": 9,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 7,
+         "text": "HOME",
+         "priority": 12,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 8,
+         "text": "AWAY",
+         "priority": 13,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 9,
+         "text": "CONF",
+         "priority": 10,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 10,
+         "text": "DIV",
+         "priority": 11,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 11,
+         "text": "L10",
+         "priority": 7,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 12,
+         "text": "STRK",
+         "priority": 6,
+         "template": "cell-text",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        }
+       ],
+       "isPrimary": true
+      }
+     ],
+     "rows": [
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "1",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Thunder",
+         "superscript": "Z",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Thunder.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Oklahoma City Thunder",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Thunder.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "64-18",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".780",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "-",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "119.0",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "107.9",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "34-7",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "30-10",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "41-11",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "12-4",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "7-3",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "L2",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "OKLAHOMA CITY THUNDER",
+        "webUrl": "/nba/oklahoma-city-thunder-team",
+        "color": "1, 0, 45, 98",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Thunder.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Oklahoma City Thunder",
+        "contentUri": "basketball/nba/teams/27",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "27",
+          "contentUri": "basketball/nba/teams/27"
+         }
+        },
+        "analyticsName": "oklahoma-city-thunder",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Thunder.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "2",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Spurs",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Spurs.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "San Antonio Spurs",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Spurs.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "62-20",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".756",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "2.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "119.8",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "111.5",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "32-8",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "29-12",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "36-16",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "13-3",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "8-2",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "L1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "SAN ANTONIO SPURS",
+        "webUrl": "/nba/san-antonio-spurs-team",
+        "color": "1, 51, 51, 51",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Spurs.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "San Antonio Spurs",
+        "contentUri": "basketball/nba/teams/19",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "19",
+          "contentUri": "basketball/nba/teams/19"
+         }
+        },
+        "analyticsName": "san-antonio-spurs",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Spurs.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "3",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Nuggets",
+         "superscript": "X",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Nuggets.vresize.200.200.medium.1.png",
+         "imageType": "image-logo",
+         "imageAltText": "Denver Nuggets",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Nuggets.vresize.200.200.medium.1.png"
+        },
+        {
+         "index": 2,
+         "text": "54-28",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".659",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "10.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "122.1",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "116.9",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "28-13",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "26-15",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "36-16",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "11-5",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "10-0",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "W12",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "DENVER NUGGETS",
+        "webUrl": "/nba/denver-nuggets-team",
+        "color": "1, 9, 32, 60",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Nuggets.vresize.200.200.medium.1.png",
+        "imageType": "image-logo",
+        "imageAltText": "Denver Nuggets",
+        "contentUri": "basketball/nba/teams/16",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "16",
+          "contentUri": "basketball/nba/teams/16"
+         }
+        },
+        "analyticsName": "denver-nuggets",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Nuggets.vresize.200.200.medium.1.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "4",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Lakers",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Lakers.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Los Angeles Lakers",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Lakers.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "53-29",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".646",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "11.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "116.3",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "114.6",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "28-13",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "25-16",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "33-19",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "10-7",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "7-3",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "W3",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "LOS ANGELES LAKERS",
+        "webUrl": "/nba/los-angeles-lakers-team",
+        "color": "1, 85, 37, 130",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Lakers.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Los Angeles Lakers",
+        "contentUri": "basketball/nba/teams/23",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "23",
+          "contentUri": "basketball/nba/teams/23"
+         }
+        },
+        "analyticsName": "los-angeles-lakers",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Lakers.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "5",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Rockets",
+         "superscript": "X",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Rockets.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Houston Rockets",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Rockets-alternate.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "52-30",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".634",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "12.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "115.2",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "110.0",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "30-11",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "22-19",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "29-23",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "10-6",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "9-1",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "W1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "HOUSTON ROCKETS",
+        "webUrl": "/nba/houston-rockets-team",
+        "color": "1, 206, 17, 65",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Rockets-alternate.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Houston Rockets",
+        "contentUri": "basketball/nba/teams/17",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "17",
+          "contentUri": "basketball/nba/teams/17"
+         }
+        },
+        "analyticsName": "houston-rockets",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Rockets.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "6",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Timberwolves",
+         "superscript": "X",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Timberwolves.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Minnesota Timberwolves",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Timberwolves.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "49-33",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".598",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "15.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "118.0",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "114.7",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "26-15",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "23-18",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "31-21",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "9-7",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "5-5",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "W2",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "MINNESOTA TIMBERWOLVES",
+        "webUrl": "/nba/minnesota-timberwolves-team",
+        "color": "1, 0, 85, 139",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Timberwolves.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Minnesota Timberwolves",
+        "contentUri": "basketball/nba/teams/18",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "18",
+          "contentUri": "basketball/nba/teams/18"
+         }
+        },
+        "analyticsName": "minnesota-timberwolves",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Timberwolves.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "7",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Trail Blazers",
+         "superscript": "X",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/TrailBlazers.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Portland Trail Blazers",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/TrailBlazers.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "42-40",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".512",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "22.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "115.5",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "115.8",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "24-17",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "18-23",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "29-23",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "7-9",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "7-3",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "W2",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "PORTLAND TRAIL BLAZERS",
+        "webUrl": "/nba/portland-trail-blazers-team",
+        "color": "1, 224, 58, 62",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/TrailBlazers.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Portland Trail Blazers",
+        "contentUri": "basketball/nba/teams/25",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "25",
+          "contentUri": "basketball/nba/teams/25"
+         }
+        },
+        "analyticsName": "portland-trail-blazers",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/TrailBlazers.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "8",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Suns",
+         "superscript": "X",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Suns.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Phoenix Suns",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Suns.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "45-37",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".549",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "19.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "112.6",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "111.1",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "25-16",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "20-21",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "29-23",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "10-7",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "5-5",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "W1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "PHOENIX SUNS",
+        "webUrl": "/nba/phoenix-suns-team",
+        "color": "1, 63, 38, 128",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Suns.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Phoenix Suns",
+        "contentUri": "basketball/nba/teams/24",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "24",
+          "contentUri": "basketball/nba/teams/24"
+         }
+        },
+        "analyticsName": "phoenix-suns",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Suns.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "9",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Clippers",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Clippers.vresize.200.200.medium.1.png",
+         "imageType": "image-logo",
+         "imageAltText": "LA Clippers",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Clippers.vresize.200.200.medium.1.png"
+        },
+        {
+         "index": 2,
+         "text": "42-40",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".512",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "22.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "113.8",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "112.6",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "23-18",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "19-22",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "25-27",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "10-6",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "6-4",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "W1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "LA CLIPPERS",
+        "webUrl": "/nba/los-angeles-clippers-team",
+        "color": "1, 10, 34, 64",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Clippers.vresize.200.200.medium.1.png",
+        "imageType": "image-logo",
+        "imageAltText": "LA Clippers",
+        "contentUri": "basketball/nba/teams/22",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "22",
+          "contentUri": "basketball/nba/teams/22"
+         }
+        },
+        "analyticsName": "los-angeles-clippers",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Clippers.vresize.200.200.medium.1.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "10",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Warriors",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Warriors.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Golden State Warriors",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Warriors.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "37-45",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".451",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "27.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "114.6",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "115.2",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "22-19",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "15-26",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "24-28",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "7-9",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "3-7",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "L3",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": true,
+       "selected": false,
+       "entityLink": {
+        "title": "GOLDEN STATE WARRIORS",
+        "webUrl": "/nba/golden-state-warriors-team",
+        "color": "1, 0, 67, 140",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Warriors.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Golden State Warriors",
+        "contentUri": "basketball/nba/teams/21",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "21",
+          "contentUri": "basketball/nba/teams/21"
+         }
+        },
+        "analyticsName": "golden-state-warriors",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Warriors.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "11",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Pelicans",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pelicans.vresize.200.200.medium.1.png",
+         "imageType": "image-logo",
+         "imageAltText": "New Orleans Pelicans",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pelicans.vresize.200.200.medium.1.png"
+        },
+        {
+         "index": 2,
+         "text": "26-56",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".317",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "38.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "115.5",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "120.0",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "17-24",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "9-32",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "17-34",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "7-9",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "1-9",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "L2",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "NEW ORLEANS PELICANS",
+        "webUrl": "/nba/new-orleans-pelicans-team",
+        "color": "1, 10, 35, 64",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pelicans.vresize.200.200.medium.1.png",
+        "imageType": "image-logo",
+        "imageAltText": "New Orleans Pelicans",
+        "contentUri": "basketball/nba/teams/9",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "9",
+          "contentUri": "basketball/nba/teams/9"
+         }
+        },
+        "analyticsName": "new-orleans-pelicans",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pelicans.vresize.200.200.medium.1.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "12",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Mavericks",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Mavericks.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Dallas Mavericks",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Mavericks.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "26-56",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".317",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "38.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "114.1",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "119.6",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "16-25",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "10-30",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "14-37",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "4-12",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "3-7",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "W1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "DALLAS MAVERICKS",
+        "webUrl": "/nba/dallas-mavericks-team",
+        "color": "1, 0, 100, 177",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Mavericks.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Dallas Mavericks",
+        "contentUri": "basketball/nba/teams/15",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "15",
+          "contentUri": "basketball/nba/teams/15"
+         }
+        },
+        "analyticsName": "dallas-mavericks",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Mavericks.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "13",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Grizzlies",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Grizzlies.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Memphis Grizzlies",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Grizzlies.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "25-57",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".305",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "39.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "114.7",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "120.7",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "13-27",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "11-29",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "19-33",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "6-10",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "1-9",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "L8",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "MEMPHIS GRIZZLIES",
+        "webUrl": "/nba/memphis-grizzlies-team",
+        "color": "1, 7, 36, 65",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Grizzlies.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Memphis Grizzlies",
+        "contentUri": "basketball/nba/teams/31",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "31",
+          "contentUri": "basketball/nba/teams/31"
+         }
+        },
+        "analyticsName": "memphis-grizzlies",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Grizzlies.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "14",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Kings",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Kings.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Sacramento Kings",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Kings.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "22-60",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".268",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "42.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "111.0",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "121.0",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "15-26",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "7-34",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "14-38",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "4-12",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "3-7",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "L1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "SACRAMENTO KINGS",
+        "webUrl": "/nba/sacramento-kings-team",
+        "color": "1, 91, 43, 130",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Kings.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Sacramento Kings",
+        "contentUri": "basketball/nba/teams/26",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "26",
+          "contentUri": "basketball/nba/teams/26"
+         }
+        },
+        "analyticsName": "sacramento-kings",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Kings.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "15",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Jazz",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Jazz.vresize.200.200.medium.1.png",
+         "imageType": "image-logo",
+         "imageAltText": "Utah Jazz",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Jazz-alternate.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "22-60",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".268",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "42.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "117.6",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "126.0",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "14-27",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "8-33",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "12-40",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "1-15",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "1-9",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "L1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "UTAH JAZZ",
+        "webUrl": "/nba/utah-jazz-team",
+        "color": "1, 78, 0, 142",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Jazz-alternate.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Utah Jazz",
+        "contentUri": "basketball/nba/teams/20",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "20",
+          "contentUri": "basketball/nba/teams/20"
+         }
+        },
+        "analyticsName": "utah-jazz",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Jazz.vresize.200.200.medium.1.png"
+       },
+       "isFaded": false
+      }
+     ]
+    }
+   ],
+   "legend": {
+    "details": [
+     {
+      "key": "Z",
+      "text": "Clinched Conference"
+     },
+     {
+      "key": "Y",
+      "text": "Clinched Division"
+     },
+     {
+      "key": "X",
+      "text": "Clinched Playoffs"
+     }
+    ]
+   },
+   "metadata": {
+    "parameters": {
+     "standingsType": "Conference",
+     "leagueName": "NBA",
+     "teamName": "Boston Celtics",
+     "season": "2025-26"
+    }
+   }
+  },
+  {
+   "id": "division",
+   "title": "DIVISION",
+   "pageTitle": "2025-26 NBA DIVISION STANDINGS",
+   "lastUpdated": "2026-07-22T08:20:16Z",
+   "standings": [
+    {
+     "template": "table-standings",
+     "headers": [
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "ATLANTIC",
+         "priority": 1,
+         "template": "cell-rank",
+         "weight": 0.5,
+         "emphasized": true,
+         "sortable": "none"
+        },
+        {
+         "index": 1,
+         "priority": 2,
+         "template": "cell-entity",
+         "weight": 4.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 2,
+         "text": "W-L",
+         "priority": 3,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 3,
+         "text": "PCT",
+         "priority": 5,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 4,
+         "text": "GB",
+         "priority": 4,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 5,
+         "text": "PF",
+         "priority": 8,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 6,
+         "text": "PA",
+         "priority": 9,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 7,
+         "text": "HOME",
+         "priority": 12,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 8,
+         "text": "AWAY",
+         "priority": 13,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 9,
+         "text": "CONF",
+         "priority": 10,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 10,
+         "text": "DIV",
+         "priority": 11,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 11,
+         "text": "L10",
+         "priority": 7,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 12,
+         "text": "STRK",
+         "priority": 6,
+         "template": "cell-text",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        }
+       ],
+       "isPrimary": true
+      }
+     ],
+     "rows": [
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "1",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Celtics",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Celtics.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Boston Celtics",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Celtics.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "56-26",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".683",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "-",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "114.8",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "107.2",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "30-11",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "26-15",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "36-16",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "10-6",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "8-2",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "W2",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": true,
+       "entityLink": {
+        "title": "BOSTON CELTICS",
+        "webUrl": "/nba/boston-celtics-team",
+        "color": "1, 0, 131, 55",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Celtics.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Boston Celtics",
+        "contentUri": "basketball/nba/teams/1",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "1",
+          "contentUri": "basketball/nba/teams/1"
+         }
+        },
+        "analyticsName": "boston-celtics",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Celtics.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "2",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Knicks",
+         "superscript": "X",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Knicks.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "New York Knicks",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Knicks.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "53-29",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".646",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "3.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "116.4",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "110.1",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "30-10",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "22-19",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "35-17",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "14-3",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "6-4",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "L1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "NEW YORK KNICKS",
+        "webUrl": "/nba/new-york-knicks-team",
+        "color": "1, 0, 107, 182",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Knicks.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "New York Knicks",
+        "contentUri": "basketball/nba/teams/4",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "4",
+          "contentUri": "basketball/nba/teams/4"
+         }
+        },
+        "analyticsName": "new-york-knicks",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Knicks.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "3",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Raptors",
+         "superscript": "X",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Raptors.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Toronto Raptors",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Raptors-alternate.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "46-36",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".561",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "10.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "114.6",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "111.8",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "24-17",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "22-19",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "33-19",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "5-12",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "6-4",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "W1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "TORONTO RAPTORS",
+        "webUrl": "/nba/toronto-raptors-team",
+        "color": "1, 206, 17, 65",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Raptors-alternate.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Toronto Raptors",
+        "contentUri": "basketball/nba/teams/30",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "30",
+          "contentUri": "basketball/nba/teams/30"
+         }
+        },
+        "analyticsName": "toronto-raptors",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Raptors.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "4",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "76ers",
+         "superscript": "X",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/76ers.vresize.200.200.medium.2.png",
+         "imageType": "image-logo",
+         "imageAltText": "Philadelphia 76ers",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/76ers-alternate.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "45-37",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".549",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "11.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "115.9",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "116.1",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "23-18",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "22-19",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "27-25",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "9-7",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "6-4",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "W2",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "PHILADELPHIA 76ERS",
+        "webUrl": "/nba/philadelphia-76ers-team",
+        "color": "1, 0, 107, 182",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/76ers-alternate.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Philadelphia 76ers",
+        "contentUri": "basketball/nba/teams/6",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "6",
+          "contentUri": "basketball/nba/teams/6"
+         }
+        },
+        "analyticsName": "philadelphia-76ers",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/76ers.vresize.200.200.medium.2.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "5",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Nets",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Nets.vresize.200.200.medium.1.png",
+         "imageType": "image-logo",
+         "imageAltText": "Brooklyn Nets",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Nets.vresize.200.200.medium.1.png"
+        },
+        {
+         "index": 2,
+         "text": "20-62",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".244",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "36.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "105.9",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "115.9",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "12-29",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "8-33",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "14-37",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "3-13",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "3-7",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "L3",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "BROOKLYN NETS",
+        "webUrl": "/nba/brooklyn-nets-team",
+        "color": "1, 51, 51, 51",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Nets.vresize.200.200.medium.1.png",
+        "imageType": "image-logo",
+        "imageAltText": "Brooklyn Nets",
+        "contentUri": "basketball/nba/teams/3",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "3",
+          "contentUri": "basketball/nba/teams/3"
+         }
+        },
+        "analyticsName": "brooklyn-nets",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Nets.vresize.200.200.medium.1.png"
+       },
+       "isFaded": false
+      }
+     ]
+    },
+    {
+     "template": "table-standings",
+     "headers": [
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "CENTRAL",
+         "priority": 1,
+         "template": "cell-rank",
+         "weight": 0.5,
+         "emphasized": true,
+         "sortable": "none"
+        },
+        {
+         "index": 1,
+         "priority": 2,
+         "template": "cell-entity",
+         "weight": 4.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 2,
+         "text": "W-L",
+         "priority": 3,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 3,
+         "text": "PCT",
+         "priority": 5,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 4,
+         "text": "GB",
+         "priority": 4,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 5,
+         "text": "PF",
+         "priority": 8,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 6,
+         "text": "PA",
+         "priority": 9,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 7,
+         "text": "HOME",
+         "priority": 12,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 8,
+         "text": "AWAY",
+         "priority": 13,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 9,
+         "text": "CONF",
+         "priority": 10,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 10,
+         "text": "DIV",
+         "priority": 11,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 11,
+         "text": "L10",
+         "priority": 7,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 12,
+         "text": "STRK",
+         "priority": 6,
+         "template": "cell-text",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        }
+       ],
+       "isPrimary": true
+      }
+     ],
+     "rows": [
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "1",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Pistons",
+         "superscript": "Z",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pistons.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Detroit Pistons",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pistons.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "60-22",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".732",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "-",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "117.8",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "109.6",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "31-9",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "28-13",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "39-13",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "12-4",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "8-2",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "W3",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "DETROIT PISTONS",
+        "webUrl": "/nba/detroit-pistons-team",
+        "color": "1, 0, 67, 140",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pistons.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Detroit Pistons",
+        "contentUri": "basketball/nba/teams/12",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "12",
+          "contentUri": "basketball/nba/teams/12"
+         }
+        },
+        "analyticsName": "detroit-pistons",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pistons.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "2",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Cavaliers",
+         "superscript": "X",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Cavaliers.vresize.200.200.medium.1.png",
+         "imageType": "image-logo",
+         "imageAltText": "Cleveland Cavaliers",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Cavaliers.vresize.200.200.medium.1.png"
+        },
+        {
+         "index": 2,
+         "text": "52-30",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".634",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "8.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "119.5",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "115.4",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "27-14",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "25-16",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "33-19",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "11-5",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "7-3",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "W1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "CLEVELAND CAVALIERS",
+        "webUrl": "/nba/cleveland-cavaliers-team",
+        "color": "1, 134, 0, 56",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Cavaliers.vresize.200.200.medium.1.png",
+        "imageType": "image-logo",
+        "imageAltText": "Cleveland Cavaliers",
+        "contentUri": "basketball/nba/teams/11",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "11",
+          "contentUri": "basketball/nba/teams/11"
+         }
+        },
+        "analyticsName": "cleveland-cavaliers",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Cavaliers.vresize.200.200.medium.1.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "3",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Bucks",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Bucks.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Milwaukee Bucks",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Bucks.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "32-50",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".390",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "28.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "110.6",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "116.8",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "19-22",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "13-28",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "21-31",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "9-7",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "3-7",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "L1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "MILWAUKEE BUCKS",
+        "webUrl": "/nba/milwaukee-bucks-team",
+        "color": "1, 43, 81, 52",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Bucks.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Milwaukee Bucks",
+        "contentUri": "basketball/nba/teams/14",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "14",
+          "contentUri": "basketball/nba/teams/14"
+         }
+        },
+        "analyticsName": "milwaukee-bucks",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Bucks.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "4",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Bulls",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Bulls.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Chicago Bulls",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Bulls.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "31-51",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".378",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "29.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "116.3",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "121.5",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "18-23",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "13-28",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "19-32",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "4-12",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "2-8",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "L2",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "CHICAGO BULLS",
+        "webUrl": "/nba/chicago-bulls-team",
+        "color": "1, 206, 17, 65",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Bulls.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Chicago Bulls",
+        "contentUri": "basketball/nba/teams/10",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "10",
+          "contentUri": "basketball/nba/teams/10"
+         }
+        },
+        "analyticsName": "chicago-bulls",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Bulls.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "5",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Pacers",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pacers.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Indiana Pacers",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pacers.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "19-63",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".232",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "41.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "112.4",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "120.4",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "11-30",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "8-33",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "15-37",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "4-12",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "3-7",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "L2",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "INDIANA PACERS",
+        "webUrl": "/nba/indiana-pacers-team",
+        "color": "1, 253, 187, 52",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pacers.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Indiana Pacers",
+        "contentUri": "basketball/nba/teams/13",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "13",
+          "contentUri": "basketball/nba/teams/13"
+         }
+        },
+        "analyticsName": "indiana-pacers",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pacers.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      }
+     ]
+    },
+    {
+     "template": "table-standings",
+     "headers": [
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "SOUTHEAST",
+         "priority": 1,
+         "template": "cell-rank",
+         "weight": 0.5,
+         "emphasized": true,
+         "sortable": "none"
+        },
+        {
+         "index": 1,
+         "priority": 2,
+         "template": "cell-entity",
+         "weight": 4.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 2,
+         "text": "W-L",
+         "priority": 3,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 3,
+         "text": "PCT",
+         "priority": 5,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 4,
+         "text": "GB",
+         "priority": 4,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 5,
+         "text": "PF",
+         "priority": 8,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 6,
+         "text": "PA",
+         "priority": 9,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 7,
+         "text": "HOME",
+         "priority": 12,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 8,
+         "text": "AWAY",
+         "priority": 13,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 9,
+         "text": "CONF",
+         "priority": 10,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 10,
+         "text": "DIV",
+         "priority": 11,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 11,
+         "text": "L10",
+         "priority": 7,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 12,
+         "text": "STRK",
+         "priority": 6,
+         "template": "cell-text",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        }
+       ],
+       "isPrimary": true
+      }
+     ],
+     "rows": [
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "1",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Hawks",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Hawks.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Atlanta Hawks",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Hawks.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "46-36",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".561",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "-",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "118.5",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "116.1",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "24-17",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "22-19",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "27-25",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "9-7",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "6-4",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "L1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "ATLANTA HAWKS",
+        "webUrl": "/nba/atlanta-hawks-team",
+        "color": "1, 207, 10, 44",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Hawks.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Atlanta Hawks",
+        "contentUri": "basketball/nba/teams/8",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "8",
+          "contentUri": "basketball/nba/teams/8"
+         }
+        },
+        "analyticsName": "atlanta-hawks",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Hawks.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "2",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Magic",
+         "superscript": "X",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Magic.vresize.200.200.medium.1.png",
+         "imageType": "image-logo",
+         "imageAltText": "Orlando Magic",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Magic.vresize.200.200.medium.1.png"
+        },
+        {
+         "index": 2,
+         "text": "45-37",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".549",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "1.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "115.7",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "115.1",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "25-15",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "19-20",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "26-26",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "9-8",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "7-3",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "L1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "ORLANDO MAGIC",
+        "webUrl": "/nba/orlando-magic-team",
+        "color": "1, 35, 85, 166",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Magic.vresize.200.200.medium.1.png",
+        "imageType": "image-logo",
+        "imageAltText": "Orlando Magic",
+        "contentUri": "basketball/nba/teams/5",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "5",
+          "contentUri": "basketball/nba/teams/5"
+         }
+        },
+        "analyticsName": "orlando-magic",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Magic.vresize.200.200.medium.1.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "3",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Hornets",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Hornets.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Charlotte Hornets",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Hornets.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "44-38",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".537",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "2.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "116.0",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "111.2",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "21-20",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "23-18",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "26-26",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "11-5",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "6-4",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "W1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "CHARLOTTE HORNETS",
+        "webUrl": "/nba/charlotte-hornets-team",
+        "color": "1, 0, 141, 139",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Hornets.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Charlotte Hornets",
+        "contentUri": "basketball/nba/teams/32",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "32",
+          "contentUri": "basketball/nba/teams/32"
+         }
+        },
+        "analyticsName": "charlotte-hornets",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Hornets.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "4",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Heat",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Heat.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Miami Heat",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Heat.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "43-39",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".524",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "3.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "120.9",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "118.5",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "26-15",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "17-24",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "27-25",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "10-7",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "5-5",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "W2",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "MIAMI HEAT",
+        "webUrl": "/nba/miami-heat-team",
+        "color": "1, 152, 0, 46",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Heat.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Miami Heat",
+        "contentUri": "basketball/nba/teams/2",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "2",
+          "contentUri": "basketball/nba/teams/2"
+         }
+        },
+        "analyticsName": "miami-heat",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Heat.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "5",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Wizards",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Wizards.vresize.200.200.medium.1.png",
+         "imageType": "image-logo",
+         "imageAltText": "Washington Wizards",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Wizards.vresize.200.200.medium.1.png"
+        },
+        {
+         "index": 2,
+         "text": "17-65",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".207",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "29.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "112.9",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "124.9",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "11-30",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "6-35",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "11-41",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "2-14",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "0-10",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "L10",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "WASHINGTON WIZARDS",
+        "webUrl": "/nba/washington-wizards-team",
+        "color": "1, 0, 43, 92",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Wizards.vresize.200.200.medium.1.png",
+        "imageType": "image-logo",
+        "imageAltText": "Washington Wizards",
+        "contentUri": "basketball/nba/teams/7",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "7",
+          "contentUri": "basketball/nba/teams/7"
+         }
+        },
+        "analyticsName": "washington-wizards",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Wizards.vresize.200.200.medium.1.png"
+       },
+       "isFaded": false
+      }
+     ]
+    },
+    {
+     "template": "table-standings",
+     "headers": [
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "NORTHWEST",
+         "priority": 1,
+         "template": "cell-rank",
+         "weight": 0.5,
+         "emphasized": true,
+         "sortable": "none"
+        },
+        {
+         "index": 1,
+         "priority": 2,
+         "template": "cell-entity",
+         "weight": 4.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 2,
+         "text": "W-L",
+         "priority": 3,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 3,
+         "text": "PCT",
+         "priority": 5,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 4,
+         "text": "GB",
+         "priority": 4,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 5,
+         "text": "PF",
+         "priority": 8,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 6,
+         "text": "PA",
+         "priority": 9,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 7,
+         "text": "HOME",
+         "priority": 12,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 8,
+         "text": "AWAY",
+         "priority": 13,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 9,
+         "text": "CONF",
+         "priority": 10,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 10,
+         "text": "DIV",
+         "priority": 11,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 11,
+         "text": "L10",
+         "priority": 7,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 12,
+         "text": "STRK",
+         "priority": 6,
+         "template": "cell-text",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        }
+       ],
+       "isPrimary": true
+      }
+     ],
+     "rows": [
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "1",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Thunder",
+         "superscript": "Z",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Thunder.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Oklahoma City Thunder",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Thunder.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "64-18",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".780",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "-",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "119.0",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "107.9",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "34-7",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "30-10",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "41-11",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "12-4",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "7-3",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "L2",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "OKLAHOMA CITY THUNDER",
+        "webUrl": "/nba/oklahoma-city-thunder-team",
+        "color": "1, 0, 45, 98",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Thunder.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Oklahoma City Thunder",
+        "contentUri": "basketball/nba/teams/27",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "27",
+          "contentUri": "basketball/nba/teams/27"
+         }
+        },
+        "analyticsName": "oklahoma-city-thunder",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Thunder.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "2",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Nuggets",
+         "superscript": "X",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Nuggets.vresize.200.200.medium.1.png",
+         "imageType": "image-logo",
+         "imageAltText": "Denver Nuggets",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Nuggets.vresize.200.200.medium.1.png"
+        },
+        {
+         "index": 2,
+         "text": "54-28",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".659",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "10.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "122.1",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "116.9",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "28-13",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "26-15",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "36-16",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "11-5",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "10-0",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "W12",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "DENVER NUGGETS",
+        "webUrl": "/nba/denver-nuggets-team",
+        "color": "1, 9, 32, 60",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Nuggets.vresize.200.200.medium.1.png",
+        "imageType": "image-logo",
+        "imageAltText": "Denver Nuggets",
+        "contentUri": "basketball/nba/teams/16",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "16",
+          "contentUri": "basketball/nba/teams/16"
+         }
+        },
+        "analyticsName": "denver-nuggets",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Nuggets.vresize.200.200.medium.1.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "3",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Timberwolves",
+         "superscript": "X",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Timberwolves.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Minnesota Timberwolves",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Timberwolves.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "49-33",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".598",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "15.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "118.0",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "114.7",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "26-15",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "23-18",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "31-21",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "9-7",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "5-5",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "W2",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "MINNESOTA TIMBERWOLVES",
+        "webUrl": "/nba/minnesota-timberwolves-team",
+        "color": "1, 0, 85, 139",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Timberwolves.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Minnesota Timberwolves",
+        "contentUri": "basketball/nba/teams/18",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "18",
+          "contentUri": "basketball/nba/teams/18"
+         }
+        },
+        "analyticsName": "minnesota-timberwolves",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Timberwolves.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "4",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Trail Blazers",
+         "superscript": "X",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/TrailBlazers.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Portland Trail Blazers",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/TrailBlazers.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "42-40",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".512",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "22.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "115.5",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "115.8",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "24-17",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "18-23",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "29-23",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "7-9",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "7-3",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "W2",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "PORTLAND TRAIL BLAZERS",
+        "webUrl": "/nba/portland-trail-blazers-team",
+        "color": "1, 224, 58, 62",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/TrailBlazers.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Portland Trail Blazers",
+        "contentUri": "basketball/nba/teams/25",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "25",
+          "contentUri": "basketball/nba/teams/25"
+         }
+        },
+        "analyticsName": "portland-trail-blazers",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/TrailBlazers.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "5",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Jazz",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Jazz.vresize.200.200.medium.1.png",
+         "imageType": "image-logo",
+         "imageAltText": "Utah Jazz",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Jazz-alternate.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "22-60",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".268",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "42.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "117.6",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "126.0",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "14-27",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "8-33",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "12-40",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "1-15",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "1-9",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "L1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "UTAH JAZZ",
+        "webUrl": "/nba/utah-jazz-team",
+        "color": "1, 78, 0, 142",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Jazz-alternate.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Utah Jazz",
+        "contentUri": "basketball/nba/teams/20",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "20",
+          "contentUri": "basketball/nba/teams/20"
+         }
+        },
+        "analyticsName": "utah-jazz",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Jazz.vresize.200.200.medium.1.png"
+       },
+       "isFaded": false
+      }
+     ]
+    },
+    {
+     "template": "table-standings",
+     "headers": [
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "PACIFIC",
+         "priority": 1,
+         "template": "cell-rank",
+         "weight": 0.5,
+         "emphasized": true,
+         "sortable": "none"
+        },
+        {
+         "index": 1,
+         "priority": 2,
+         "template": "cell-entity",
+         "weight": 4.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 2,
+         "text": "W-L",
+         "priority": 3,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 3,
+         "text": "PCT",
+         "priority": 5,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 4,
+         "text": "GB",
+         "priority": 4,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 5,
+         "text": "PF",
+         "priority": 8,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 6,
+         "text": "PA",
+         "priority": 9,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 7,
+         "text": "HOME",
+         "priority": 12,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 8,
+         "text": "AWAY",
+         "priority": 13,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 9,
+         "text": "CONF",
+         "priority": 10,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 10,
+         "text": "DIV",
+         "priority": 11,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 11,
+         "text": "L10",
+         "priority": 7,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 12,
+         "text": "STRK",
+         "priority": 6,
+         "template": "cell-text",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        }
+       ],
+       "isPrimary": true
+      }
+     ],
+     "rows": [
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "1",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Lakers",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Lakers.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Los Angeles Lakers",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Lakers.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "53-29",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".646",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "-",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "116.3",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "114.6",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "28-13",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "25-16",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "33-19",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "10-7",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "7-3",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "W3",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "LOS ANGELES LAKERS",
+        "webUrl": "/nba/los-angeles-lakers-team",
+        "color": "1, 85, 37, 130",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Lakers.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Los Angeles Lakers",
+        "contentUri": "basketball/nba/teams/23",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "23",
+          "contentUri": "basketball/nba/teams/23"
+         }
+        },
+        "analyticsName": "los-angeles-lakers",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Lakers.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "2",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Suns",
+         "superscript": "X",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Suns.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Phoenix Suns",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Suns.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "45-37",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".549",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "8.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "112.6",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "111.1",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "25-16",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "20-21",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "29-23",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "10-7",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "5-5",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "W1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "PHOENIX SUNS",
+        "webUrl": "/nba/phoenix-suns-team",
+        "color": "1, 63, 38, 128",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Suns.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Phoenix Suns",
+        "contentUri": "basketball/nba/teams/24",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "24",
+          "contentUri": "basketball/nba/teams/24"
+         }
+        },
+        "analyticsName": "phoenix-suns",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Suns.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "3",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Clippers",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Clippers.vresize.200.200.medium.1.png",
+         "imageType": "image-logo",
+         "imageAltText": "LA Clippers",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Clippers.vresize.200.200.medium.1.png"
+        },
+        {
+         "index": 2,
+         "text": "42-40",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".512",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "11.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "113.8",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "112.6",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "23-18",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "19-22",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "25-27",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "10-6",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "6-4",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "W1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "LA CLIPPERS",
+        "webUrl": "/nba/los-angeles-clippers-team",
+        "color": "1, 10, 34, 64",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Clippers.vresize.200.200.medium.1.png",
+        "imageType": "image-logo",
+        "imageAltText": "LA Clippers",
+        "contentUri": "basketball/nba/teams/22",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "22",
+          "contentUri": "basketball/nba/teams/22"
+         }
+        },
+        "analyticsName": "los-angeles-clippers",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Clippers.vresize.200.200.medium.1.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "4",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Warriors",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Warriors.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Golden State Warriors",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Warriors.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "37-45",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".451",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "16.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "114.6",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "115.2",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "22-19",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "15-26",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "24-28",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "7-9",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "3-7",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "L3",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "GOLDEN STATE WARRIORS",
+        "webUrl": "/nba/golden-state-warriors-team",
+        "color": "1, 0, 67, 140",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Warriors.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Golden State Warriors",
+        "contentUri": "basketball/nba/teams/21",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "21",
+          "contentUri": "basketball/nba/teams/21"
+         }
+        },
+        "analyticsName": "golden-state-warriors",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Warriors.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "5",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Kings",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Kings.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Sacramento Kings",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Kings.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "22-60",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".268",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "31.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "111.0",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "121.0",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "15-26",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "7-34",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "14-38",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "4-12",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "3-7",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "L1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "SACRAMENTO KINGS",
+        "webUrl": "/nba/sacramento-kings-team",
+        "color": "1, 91, 43, 130",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Kings.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Sacramento Kings",
+        "contentUri": "basketball/nba/teams/26",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "26",
+          "contentUri": "basketball/nba/teams/26"
+         }
+        },
+        "analyticsName": "sacramento-kings",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Kings.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      }
+     ]
+    },
+    {
+     "template": "table-standings",
+     "headers": [
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "SOUTHWEST",
+         "priority": 1,
+         "template": "cell-rank",
+         "weight": 0.5,
+         "emphasized": true,
+         "sortable": "none"
+        },
+        {
+         "index": 1,
+         "priority": 2,
+         "template": "cell-entity",
+         "weight": 4.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 2,
+         "text": "W-L",
+         "priority": 3,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 3,
+         "text": "PCT",
+         "priority": 5,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 4,
+         "text": "GB",
+         "priority": 4,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 5,
+         "text": "PF",
+         "priority": 8,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 6,
+         "text": "PA",
+         "priority": 9,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 7,
+         "text": "HOME",
+         "priority": 12,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 8,
+         "text": "AWAY",
+         "priority": 13,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 9,
+         "text": "CONF",
+         "priority": 10,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 10,
+         "text": "DIV",
+         "priority": 11,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 11,
+         "text": "L10",
+         "priority": 7,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 12,
+         "text": "STRK",
+         "priority": 6,
+         "template": "cell-text",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        }
+       ],
+       "isPrimary": true
+      }
+     ],
+     "rows": [
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "1",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Spurs",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Spurs.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "San Antonio Spurs",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Spurs.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "62-20",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".756",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "-",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "119.8",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "111.5",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "32-8",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "29-12",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "36-16",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "13-3",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "8-2",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "L1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "SAN ANTONIO SPURS",
+        "webUrl": "/nba/san-antonio-spurs-team",
+        "color": "1, 51, 51, 51",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Spurs.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "San Antonio Spurs",
+        "contentUri": "basketball/nba/teams/19",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "19",
+          "contentUri": "basketball/nba/teams/19"
+         }
+        },
+        "analyticsName": "san-antonio-spurs",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Spurs.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "2",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Rockets",
+         "superscript": "X",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Rockets.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Houston Rockets",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Rockets-alternate.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "52-30",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".634",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "10.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "115.2",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "110.0",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "30-11",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "22-19",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "29-23",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "10-6",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "9-1",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "W1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "HOUSTON ROCKETS",
+        "webUrl": "/nba/houston-rockets-team",
+        "color": "1, 206, 17, 65",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Rockets-alternate.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Houston Rockets",
+        "contentUri": "basketball/nba/teams/17",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "17",
+          "contentUri": "basketball/nba/teams/17"
+         }
+        },
+        "analyticsName": "houston-rockets",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Rockets.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "3",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Pelicans",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pelicans.vresize.200.200.medium.1.png",
+         "imageType": "image-logo",
+         "imageAltText": "New Orleans Pelicans",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pelicans.vresize.200.200.medium.1.png"
+        },
+        {
+         "index": 2,
+         "text": "26-56",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".317",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "36.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "115.5",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "120.0",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "17-24",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "9-32",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "17-34",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "7-9",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "1-9",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "L2",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "NEW ORLEANS PELICANS",
+        "webUrl": "/nba/new-orleans-pelicans-team",
+        "color": "1, 10, 35, 64",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pelicans.vresize.200.200.medium.1.png",
+        "imageType": "image-logo",
+        "imageAltText": "New Orleans Pelicans",
+        "contentUri": "basketball/nba/teams/9",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "9",
+          "contentUri": "basketball/nba/teams/9"
+         }
+        },
+        "analyticsName": "new-orleans-pelicans",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pelicans.vresize.200.200.medium.1.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "4",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Mavericks",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Mavericks.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Dallas Mavericks",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Mavericks.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "26-56",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".317",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "36.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "114.1",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "119.6",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "16-25",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "10-30",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "14-37",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "4-12",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "3-7",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "W1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "DALLAS MAVERICKS",
+        "webUrl": "/nba/dallas-mavericks-team",
+        "color": "1, 0, 100, 177",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Mavericks.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Dallas Mavericks",
+        "contentUri": "basketball/nba/teams/15",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "15",
+          "contentUri": "basketball/nba/teams/15"
+         }
+        },
+        "analyticsName": "dallas-mavericks",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Mavericks.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "5",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Grizzlies",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Grizzlies.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Memphis Grizzlies",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Grizzlies.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "25-57",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".305",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "37.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "114.7",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "120.7",
+         "emphasized": false
+        },
+        {
+         "index": 7,
+         "text": "13-27",
+         "emphasized": false
+        },
+        {
+         "index": 8,
+         "text": "11-29",
+         "emphasized": false
+        },
+        {
+         "index": 9,
+         "text": "19-33",
+         "emphasized": false
+        },
+        {
+         "index": 10,
+         "text": "6-10",
+         "emphasized": false
+        },
+        {
+         "index": 11,
+         "text": "1-9",
+         "emphasized": false
+        },
+        {
+         "index": 12,
+         "text": "L8",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "MEMPHIS GRIZZLIES",
+        "webUrl": "/nba/memphis-grizzlies-team",
+        "color": "1, 7, 36, 65",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Grizzlies.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Memphis Grizzlies",
+        "contentUri": "basketball/nba/teams/31",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "31",
+          "contentUri": "basketball/nba/teams/31"
+         }
+        },
+        "analyticsName": "memphis-grizzlies",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Grizzlies.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      }
+     ]
+    }
+   ],
+   "legend": {
+    "details": [
+     {
+      "key": "Z",
+      "text": "Clinched Conference"
+     },
+     {
+      "key": "Y",
+      "text": "Clinched Division"
+     },
+     {
+      "key": "X",
+      "text": "Clinched Playoffs"
+     }
+    ]
+   },
+   "metadata": {
+    "parameters": {
+     "standingsType": "Division",
+     "leagueName": "NBA",
+     "teamName": "Boston Celtics",
+     "season": "2025-26"
+    }
+   }
+  },
+  {
+   "id": "preseason",
+   "title": "PRESEASON",
+   "pageTitle": "2025-26 NBA PRESEASON STANDINGS",
+   "lastUpdated": "2025-10-18T05:33:45Z",
+   "standings": [
+    {
+     "template": "table-standings",
+     "headers": [
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "EASTERN CONFERENCE",
+         "priority": 1,
+         "template": "cell-rank",
+         "weight": 0.5,
+         "emphasized": true,
+         "sortable": "none"
+        },
+        {
+         "index": 1,
+         "priority": 2,
+         "template": "cell-entity",
+         "weight": 4.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 2,
+         "text": "W-L",
+         "priority": 3,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 3,
+         "text": "PCT",
+         "priority": 4,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 4,
+         "text": "PF",
+         "priority": 6,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 5,
+         "text": "PA",
+         "priority": 7,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 6,
+         "text": "STRK",
+         "priority": 5,
+         "template": "cell-text",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        }
+       ],
+       "isPrimary": true
+      }
+     ],
+     "rows": [
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "1",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Magic",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Magic.vresize.200.200.medium.1.png",
+         "imageType": "image-logo",
+         "imageAltText": "Orlando Magic",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Magic.vresize.200.200.medium.1.png"
+        },
+        {
+         "index": 2,
+         "text": "4-0",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": "1.000",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "126.5",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "111.2",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "W4",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "ORLANDO MAGIC",
+        "webUrl": "/nba/orlando-magic-team",
+        "color": "1, 35, 85, 166",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Magic.vresize.200.200.medium.1.png",
+        "imageType": "image-logo",
+        "imageAltText": "Orlando Magic",
+        "contentUri": "basketball/nba/teams/5",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "5",
+          "contentUri": "basketball/nba/teams/5"
+         }
+        },
+        "analyticsName": "orlando-magic",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Magic.vresize.200.200.medium.1.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "2",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Knicks",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Knicks.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "New York Knicks",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Knicks.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "4-1",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".800",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "105.6",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "102.2",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "W1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "NEW YORK KNICKS",
+        "webUrl": "/nba/new-york-knicks-team",
+        "color": "1, 0, 107, 182",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Knicks.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "New York Knicks",
+        "contentUri": "basketball/nba/teams/4",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "4",
+          "contentUri": "basketball/nba/teams/4"
+         }
+        },
+        "analyticsName": "new-york-knicks",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Knicks.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "3",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Bucks",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Bucks.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Milwaukee Bucks",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Bucks.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "3-1",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".750",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "114.8",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "110.2",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "L1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "MILWAUKEE BUCKS",
+        "webUrl": "/nba/milwaukee-bucks-team",
+        "color": "1, 43, 81, 52",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Bucks.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Milwaukee Bucks",
+        "contentUri": "basketball/nba/teams/14",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "14",
+          "contentUri": "basketball/nba/teams/14"
+         }
+        },
+        "analyticsName": "milwaukee-bucks",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Bucks.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "4",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Celtics",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Celtics.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Boston Celtics",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Celtics.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "3-1",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".750",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "118.5",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "106.2",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "W2",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": true,
+       "entityLink": {
+        "title": "BOSTON CELTICS",
+        "webUrl": "/nba/boston-celtics-team",
+        "color": "1, 0, 131, 55",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Celtics.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Boston Celtics",
+        "contentUri": "basketball/nba/teams/1",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "1",
+          "contentUri": "basketball/nba/teams/1"
+         }
+        },
+        "analyticsName": "boston-celtics",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Celtics.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "5",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Raptors",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Raptors.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Toronto Raptors",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Raptors-alternate.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "4-2",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".667",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "114.2",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "112.5",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "W1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "TORONTO RAPTORS",
+        "webUrl": "/nba/toronto-raptors-team",
+        "color": "1, 206, 17, 65",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Raptors-alternate.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Toronto Raptors",
+        "contentUri": "basketball/nba/teams/30",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "30",
+          "contentUri": "basketball/nba/teams/30"
+         }
+        },
+        "analyticsName": "toronto-raptors",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Raptors.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "6",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Bulls",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Bulls.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Chicago Bulls",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Bulls.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "3-2",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".600",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "120.2",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "120.0",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "W1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "CHICAGO BULLS",
+        "webUrl": "/nba/chicago-bulls-team",
+        "color": "1, 206, 17, 65",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Bulls.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Chicago Bulls",
+        "contentUri": "basketball/nba/teams/10",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "10",
+          "contentUri": "basketball/nba/teams/10"
+         }
+        },
+        "analyticsName": "chicago-bulls",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Bulls.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "7",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Hawks",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Hawks.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Atlanta Hawks",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Hawks.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "2-2",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".500",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "117.2",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "122.2",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "L1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "ATLANTA HAWKS",
+        "webUrl": "/nba/atlanta-hawks-team",
+        "color": "1, 207, 10, 44",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Hawks.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Atlanta Hawks",
+        "contentUri": "basketball/nba/teams/8",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "8",
+          "contentUri": "basketball/nba/teams/8"
+         }
+        },
+        "analyticsName": "atlanta-hawks",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Hawks.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "8",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Pistons",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pistons.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Detroit Pistons",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pistons.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "2-2",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".500",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "114.5",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "111.2",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "W1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "DETROIT PISTONS",
+        "webUrl": "/nba/detroit-pistons-team",
+        "color": "1, 0, 67, 140",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pistons.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Detroit Pistons",
+        "contentUri": "basketball/nba/teams/12",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "12",
+          "contentUri": "basketball/nba/teams/12"
+         }
+        },
+        "analyticsName": "detroit-pistons",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pistons.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "9",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Nets",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Nets.vresize.200.200.medium.1.png",
+         "imageType": "image-logo",
+         "imageAltText": "Brooklyn Nets",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Nets.vresize.200.200.medium.1.png"
+        },
+        {
+         "index": 2,
+         "text": "2-2",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".500",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "118.8",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "112.0",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "L1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "BROOKLYN NETS",
+        "webUrl": "/nba/brooklyn-nets-team",
+        "color": "1, 51, 51, 51",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Nets.vresize.200.200.medium.1.png",
+        "imageType": "image-logo",
+        "imageAltText": "Brooklyn Nets",
+        "contentUri": "basketball/nba/teams/3",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "3",
+          "contentUri": "basketball/nba/teams/3"
+         }
+        },
+        "analyticsName": "brooklyn-nets",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Nets.vresize.200.200.medium.1.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "10",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Pacers",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pacers.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Indiana Pacers",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pacers.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "2-2",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".500",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "115.8",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "123.0",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "L2",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "INDIANA PACERS",
+        "webUrl": "/nba/indiana-pacers-team",
+        "color": "1, 253, 187, 52",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pacers.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Indiana Pacers",
+        "contentUri": "basketball/nba/teams/13",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "13",
+          "contentUri": "basketball/nba/teams/13"
+         }
+        },
+        "analyticsName": "indiana-pacers",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pacers.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "11",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Hornets",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Hornets.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Charlotte Hornets",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Hornets.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "2-3",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".400",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "120.6",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "120.4",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "L1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "CHARLOTTE HORNETS",
+        "webUrl": "/nba/charlotte-hornets-team",
+        "color": "1, 0, 141, 139",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Hornets.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Charlotte Hornets",
+        "contentUri": "basketball/nba/teams/32",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "32",
+          "contentUri": "basketball/nba/teams/32"
+         }
+        },
+        "analyticsName": "charlotte-hornets",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Hornets.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "12",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Wizards",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Wizards.vresize.200.200.medium.1.png",
+         "imageType": "image-logo",
+         "imageAltText": "Washington Wizards",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Wizards.vresize.200.200.medium.1.png"
+        },
+        {
+         "index": 2,
+         "text": "1-2",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".333",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "110.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "111.7",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "L1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "WASHINGTON WIZARDS",
+        "webUrl": "/nba/washington-wizards-team",
+        "color": "1, 0, 43, 92",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Wizards.vresize.200.200.medium.1.png",
+        "imageType": "image-logo",
+        "imageAltText": "Washington Wizards",
+        "contentUri": "basketball/nba/teams/7",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "7",
+          "contentUri": "basketball/nba/teams/7"
+         }
+        },
+        "analyticsName": "washington-wizards",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Wizards.vresize.200.200.medium.1.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "13",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Cavaliers",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Cavaliers.vresize.200.200.medium.1.png",
+         "imageType": "image-logo",
+         "imageAltText": "Cleveland Cavaliers",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Cavaliers.vresize.200.200.medium.1.png"
+        },
+        {
+         "index": 2,
+         "text": "1-3",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".250",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "113.5",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "118.8",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "W1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "CLEVELAND CAVALIERS",
+        "webUrl": "/nba/cleveland-cavaliers-team",
+        "color": "1, 134, 0, 56",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Cavaliers.vresize.200.200.medium.1.png",
+        "imageType": "image-logo",
+        "imageAltText": "Cleveland Cavaliers",
+        "contentUri": "basketball/nba/teams/11",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "11",
+          "contentUri": "basketball/nba/teams/11"
+         }
+        },
+        "analyticsName": "cleveland-cavaliers",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Cavaliers.vresize.200.200.medium.1.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "14",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "76ers",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/76ers.vresize.200.200.medium.2.png",
+         "imageType": "image-logo",
+         "imageAltText": "Philadelphia 76ers",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/76ers-alternate.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "1-3",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".250",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "103.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "112.5",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "W1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "PHILADELPHIA 76ERS",
+        "webUrl": "/nba/philadelphia-76ers-team",
+        "color": "1, 0, 107, 182",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/76ers-alternate.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Philadelphia 76ers",
+        "contentUri": "basketball/nba/teams/6",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "6",
+          "contentUri": "basketball/nba/teams/6"
+         }
+        },
+        "analyticsName": "philadelphia-76ers",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/76ers.vresize.200.200.medium.2.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "15",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Heat",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Heat.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Miami Heat",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Heat.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "0-6",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".000",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "110.8",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "120.2",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "L6",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "MIAMI HEAT",
+        "webUrl": "/nba/miami-heat-team",
+        "color": "1, 152, 0, 46",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Heat.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Miami Heat",
+        "contentUri": "basketball/nba/teams/2",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "2",
+          "contentUri": "basketball/nba/teams/2"
+         }
+        },
+        "analyticsName": "miami-heat",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Heat.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      }
+     ]
+    },
+    {
+     "template": "table-standings",
+     "headers": [
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "WESTERN CONFERENCE",
+         "priority": 1,
+         "template": "cell-rank",
+         "weight": 0.5,
+         "emphasized": true,
+         "sortable": "none"
+        },
+        {
+         "index": 1,
+         "priority": 2,
+         "template": "cell-entity",
+         "weight": 4.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 2,
+         "text": "W-L",
+         "priority": 3,
+         "template": "cell-record",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 3,
+         "text": "PCT",
+         "priority": 4,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 4,
+         "text": "PF",
+         "priority": 6,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 5,
+         "text": "PA",
+         "priority": 7,
+         "template": "cell-number",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        },
+        {
+         "index": 6,
+         "text": "STRK",
+         "priority": 5,
+         "template": "cell-text",
+         "weight": 2.5,
+         "emphasized": false,
+         "sortable": "none"
+        }
+       ],
+       "isPrimary": true
+      }
+     ],
+     "rows": [
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "1",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Spurs",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Spurs.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "San Antonio Spurs",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Spurs.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "5-0",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": "1.000",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "124.4",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "107.4",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "W5",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "SAN ANTONIO SPURS",
+        "webUrl": "/nba/san-antonio-spurs-team",
+        "color": "1, 51, 51, 51",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Spurs.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "San Antonio Spurs",
+        "contentUri": "basketball/nba/teams/19",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "19",
+          "contentUri": "basketball/nba/teams/19"
+         }
+        },
+        "analyticsName": "san-antonio-spurs",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Spurs.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "2",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Rockets",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Rockets.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Houston Rockets",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Rockets-alternate.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "4-0",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": "1.000",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "131.2",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "120.8",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "W4",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "HOUSTON ROCKETS",
+        "webUrl": "/nba/houston-rockets-team",
+        "color": "1, 206, 17, 65",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Rockets-alternate.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Houston Rockets",
+        "contentUri": "basketball/nba/teams/17",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "17",
+          "contentUri": "basketball/nba/teams/17"
+         }
+        },
+        "analyticsName": "houston-rockets",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Rockets.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "3",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Suns",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Suns.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Phoenix Suns",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Suns.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "3-1",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".750",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "114.2",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "105.8",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "W1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "PHOENIX SUNS",
+        "webUrl": "/nba/phoenix-suns-team",
+        "color": "1, 63, 38, 128",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Suns.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Phoenix Suns",
+        "contentUri": "basketball/nba/teams/24",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "24",
+          "contentUri": "basketball/nba/teams/24"
+         }
+        },
+        "analyticsName": "phoenix-suns",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Suns.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "4",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Mavericks",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Mavericks.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Dallas Mavericks",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Mavericks.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "3-1",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".750",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "114.2",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "101.0",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "W2",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "DALLAS MAVERICKS",
+        "webUrl": "/nba/dallas-mavericks-team",
+        "color": "1, 0, 100, 177",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Mavericks.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Dallas Mavericks",
+        "contentUri": "basketball/nba/teams/15",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "15",
+          "contentUri": "basketball/nba/teams/15"
+         }
+        },
+        "analyticsName": "dallas-mavericks",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Mavericks.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "5",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Clippers",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Clippers.vresize.200.200.medium.1.png",
+         "imageType": "image-logo",
+         "imageAltText": "LA Clippers",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Clippers.vresize.200.200.medium.1.png"
+        },
+        {
+         "index": 2,
+         "text": "3-1",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".750",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "112.8",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "97.8",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "W2",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "LA CLIPPERS",
+        "webUrl": "/nba/los-angeles-clippers-team",
+        "color": "1, 10, 34, 64",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Clippers.vresize.200.200.medium.1.png",
+        "imageType": "image-logo",
+        "imageAltText": "LA Clippers",
+        "contentUri": "basketball/nba/teams/22",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "22",
+          "contentUri": "basketball/nba/teams/22"
+         }
+        },
+        "analyticsName": "los-angeles-clippers",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Clippers.vresize.200.200.medium.1.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "6",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Thunder",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Thunder.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Oklahoma City Thunder",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Thunder.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "4-2",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".667",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "109.5",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "109.2",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "W2",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "OKLAHOMA CITY THUNDER",
+        "webUrl": "/nba/oklahoma-city-thunder-team",
+        "color": "1, 0, 45, 98",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Thunder.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Oklahoma City Thunder",
+        "contentUri": "basketball/nba/teams/27",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "27",
+          "contentUri": "basketball/nba/teams/27"
+         }
+        },
+        "analyticsName": "oklahoma-city-thunder",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Thunder.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "7",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Warriors",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Warriors.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Golden State Warriors",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Warriors.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "3-2",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".600",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "115.4",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "113.8",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "L1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "GOLDEN STATE WARRIORS",
+        "webUrl": "/nba/golden-state-warriors-team",
+        "color": "1, 0, 67, 140",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Warriors.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Golden State Warriors",
+        "contentUri": "basketball/nba/teams/21",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "21",
+          "contentUri": "basketball/nba/teams/21"
+         }
+        },
+        "analyticsName": "golden-state-warriors",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Warriors.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "8",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Nuggets",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Nuggets.vresize.200.200.medium.1.png",
+         "imageType": "image-logo",
+         "imageAltText": "Denver Nuggets",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Nuggets.vresize.200.200.medium.1.png"
+        },
+        {
+         "index": 2,
+         "text": "3-2",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".600",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "109.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "107.8",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "L1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "DENVER NUGGETS",
+        "webUrl": "/nba/denver-nuggets-team",
+        "color": "1, 9, 32, 60",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Nuggets.vresize.200.200.medium.1.png",
+        "imageType": "image-logo",
+        "imageAltText": "Denver Nuggets",
+        "contentUri": "basketball/nba/teams/16",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "16",
+          "contentUri": "basketball/nba/teams/16"
+         }
+        },
+        "analyticsName": "denver-nuggets",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Nuggets.vresize.200.200.medium.1.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "9",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Pelicans",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pelicans.vresize.200.200.medium.1.png",
+         "imageType": "image-logo",
+         "imageAltText": "New Orleans Pelicans",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pelicans.vresize.200.200.medium.1.png"
+        },
+        {
+         "index": 2,
+         "text": "2-2",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".500",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "121.8",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "112.8",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "L2",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "NEW ORLEANS PELICANS",
+        "webUrl": "/nba/new-orleans-pelicans-team",
+        "color": "1, 10, 35, 64",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pelicans.vresize.200.200.medium.1.png",
+        "imageType": "image-logo",
+        "imageAltText": "New Orleans Pelicans",
+        "contentUri": "basketball/nba/teams/9",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "9",
+          "contentUri": "basketball/nba/teams/9"
+         }
+        },
+        "analyticsName": "new-orleans-pelicans",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Pelicans.vresize.200.200.medium.1.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "10",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Timberwolves",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Timberwolves.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Minnesota Timberwolves",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Timberwolves.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "2-4",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".333",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "119.8",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "112.8",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "L2",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "MINNESOTA TIMBERWOLVES",
+        "webUrl": "/nba/minnesota-timberwolves-team",
+        "color": "1, 0, 85, 139",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Timberwolves.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Minnesota Timberwolves",
+        "contentUri": "basketball/nba/teams/18",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "18",
+          "contentUri": "basketball/nba/teams/18"
+         }
+        },
+        "analyticsName": "minnesota-timberwolves",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Timberwolves.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "11",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Jazz",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Jazz.vresize.200.200.medium.1.png",
+         "imageType": "image-logo",
+         "imageAltText": "Utah Jazz",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Jazz-alternate.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "1-3",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".250",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "122.5",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "129.2",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "W1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "UTAH JAZZ",
+        "webUrl": "/nba/utah-jazz-team",
+        "color": "1, 78, 0, 142",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Jazz-alternate.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Utah Jazz",
+        "contentUri": "basketball/nba/teams/20",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "20",
+          "contentUri": "basketball/nba/teams/20"
+         }
+        },
+        "analyticsName": "utah-jazz",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Jazz.vresize.200.200.medium.1.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "12",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Trail Blazers",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/TrailBlazers.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Portland Trail Blazers",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/TrailBlazers.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "1-3",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".250",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "121.8",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "125.5",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "L2",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "PORTLAND TRAIL BLAZERS",
+        "webUrl": "/nba/portland-trail-blazers-team",
+        "color": "1, 224, 58, 62",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/TrailBlazers.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Portland Trail Blazers",
+        "contentUri": "basketball/nba/teams/25",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "25",
+          "contentUri": "basketball/nba/teams/25"
+         }
+        },
+        "analyticsName": "portland-trail-blazers",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/TrailBlazers.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "13",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Kings",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Kings.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Sacramento Kings",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Kings.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "1-3",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".250",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "113.2",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "119.8",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "W1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "SACRAMENTO KINGS",
+        "webUrl": "/nba/sacramento-kings-team",
+        "color": "1, 91, 43, 130",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Kings.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Sacramento Kings",
+        "contentUri": "basketball/nba/teams/26",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "26",
+          "contentUri": "basketball/nba/teams/26"
+         }
+        },
+        "analyticsName": "sacramento-kings",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Kings.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "14",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Grizzlies",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Grizzlies.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Memphis Grizzlies",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Grizzlies.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "1-4",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".200",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "117.6",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "128.2",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "W1",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "MEMPHIS GRIZZLIES",
+        "webUrl": "/nba/memphis-grizzlies-team",
+        "color": "1, 7, 36, 65",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Grizzlies.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Memphis Grizzlies",
+        "contentUri": "basketball/nba/teams/31",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "31",
+          "contentUri": "basketball/nba/teams/31"
+         }
+        },
+        "analyticsName": "memphis-grizzlies",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Grizzlies.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      },
+      {
+       "columns": [
+        {
+         "index": 0,
+         "text": "15",
+         "emphasized": false
+        },
+        {
+         "index": 1,
+         "text": "Lakers",
+         "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Lakers.vresize.200.200.medium.0.png",
+         "imageType": "image-logo",
+         "imageAltText": "Los Angeles Lakers",
+         "emphasized": false,
+         "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Lakers.vresize.200.200.medium.0.png"
+        },
+        {
+         "index": 2,
+         "text": "1-5",
+         "emphasized": false
+        },
+        {
+         "index": 3,
+         "text": ".167",
+         "emphasized": false
+        },
+        {
+         "index": 4,
+         "text": "104.0",
+         "emphasized": false
+        },
+        {
+         "index": 5,
+         "text": "113.5",
+         "emphasized": false
+        },
+        {
+         "index": 6,
+         "text": "L3",
+         "emphasized": false
+        }
+       ],
+       "isCutoff": false,
+       "selected": false,
+       "entityLink": {
+        "title": "LOS ANGELES LAKERS",
+        "webUrl": "/nba/los-angeles-lakers-team",
+        "color": "1, 85, 37, 130",
+        "imageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Lakers.vresize.200.200.medium.0.png",
+        "imageType": "image-logo",
+        "imageAltText": "Los Angeles Lakers",
+        "contentUri": "basketball/nba/teams/23",
+        "contentType": "team",
+        "layout": {
+         "path": "/layouts?type=layout&subtype=teamsLayout&elementId=nba",
+         "tokens": {
+          "id": "23",
+          "contentUri": "basketball/nba/teams/23"
+         }
+        },
+        "analyticsName": "los-angeles-lakers",
+        "analyticsSport": "nba",
+        "type": "entity",
+        "alternateImageUrl": "https://b.fssta.com/uploads/application/nba/team-logos/Lakers.vresize.200.200.medium.0.png"
+       },
+       "isFaded": false
+      }
+     ]
+    }
+   ],
+   "metadata": {
+    "parameters": {
+     "standingsType": "Preseason",
+     "leagueName": "NBA",
+     "teamName": "Boston Celtics",
+     "season": "2025-26"
+    }
+   }
+  }
+ ]
+}

--- a/tests/test_crosswalk_basketball_sources.py
+++ b/tests/test_crosswalk_basketball_sources.py
@@ -383,6 +383,10 @@ def test_team_crosswalk_raises_when_the_ratings_module_is_missing(monkeypatch: p
 
     module_path, provider = _RATINGS_PROVIDER[league]
     monkeypatch.setitem(sys.modules, module_path, None)  # import of this module now raises
+    # Drop any cached crosswalk module: import_module would otherwise hand back one
+    # imported before the poison, which could still hold a top-level provider import
+    # and let this test pass without proving the import happens inside the guard.
+    monkeypatch.delitem(sys.modules, f"sportsdataverse.{league}.{league}_crosswalk", raising=False)
     crosswalk = importlib.import_module(f"sportsdataverse.{league}.{league}_crosswalk")
     _stub_espn(monkeypatch, crosswalk)
     with pytest.raises(CrosswalkSourceError, match=provider) as exc:
@@ -400,6 +404,9 @@ def test_team_crosswalk_supplied_ratings_frame_needs_no_provider_module(
 
     module_path, _ = _RATINGS_PROVIDER[league]
     monkeypatch.setitem(sys.modules, module_path, None)
+    # Same reason as above: a cached crosswalk module would not exercise the
+    # supplied-frame short-circuit against a genuinely absent provider.
+    monkeypatch.delitem(sys.modules, f"sportsdataverse.{league}.{league}_crosswalk", raising=False)
     crosswalk = importlib.import_module(f"sportsdataverse.{league}.{league}_crosswalk")
     _stub_espn(monkeypatch, crosswalk)
     out = getattr(crosswalk, f"{league}_team_crosswalk")(season=2026, fox=pl.DataFrame(), bart=pl.DataFrame())

--- a/tests/test_crosswalk_basketball_sources.py
+++ b/tests/test_crosswalk_basketball_sources.py
@@ -350,3 +350,58 @@ def test_team_crosswalk_raises_when_fox_cannot_be_produced(
     )
     with pytest.raises(CrosswalkSourceError, match=target):
         getattr(crosswalk, f"{league}_team_crosswalk")(season=2026, **extra)
+
+
+# ---------------------------------------------------------------------------
+# Provider imports must live INSIDE the guarded callable.
+#
+# Hoisting `from ...torvik import torvik_ratings` to the top of the builder
+# defeated the guard twice over: a missing provider module raised a raw
+# ImportError instead of CrosswalkSourceError, and a caller who supplied a
+# pre-fetched `bart` frame still had to have the module installed.
+# ---------------------------------------------------------------------------
+
+_RATINGS_PROVIDER = {
+    "mbb": ("sportsdataverse.mbb.torvik", "torvik_ratings"),
+    "wbb": ("sportsdataverse.wbb.bart_wbb", "bart_wbb_ratings"),
+}
+
+
+def _stub_espn(monkeypatch: pytest.MonkeyPatch, crosswalk: Any) -> None:
+    monkeypatch.setattr(
+        crosswalk,
+        "espn_team_directory",
+        lambda *a, **k: pl.DataFrame(schema={c: pl.Utf8 for c in _ESPN_DIR_COLS}),
+    )
+
+
+@pytest.mark.parametrize("league", ["mbb", "wbb"])
+def test_team_crosswalk_raises_when_the_ratings_module_is_missing(monkeypatch: pytest.MonkeyPatch, league: str) -> None:
+    """An absent Torvik provider must name itself as a CrosswalkSourceError."""
+    import importlib
+    import sys
+
+    module_path, provider = _RATINGS_PROVIDER[league]
+    monkeypatch.setitem(sys.modules, module_path, None)  # import of this module now raises
+    crosswalk = importlib.import_module(f"sportsdataverse.{league}.{league}_crosswalk")
+    _stub_espn(monkeypatch, crosswalk)
+    with pytest.raises(CrosswalkSourceError, match=provider) as exc:
+        getattr(crosswalk, f"{league}_team_crosswalk")(season=2026, fox=pl.DataFrame())
+    assert module_path in str(exc.value), "the error must name the module that was missing"
+
+
+@pytest.mark.parametrize("league", ["mbb", "wbb"])
+def test_team_crosswalk_supplied_ratings_frame_needs_no_provider_module(
+    monkeypatch: pytest.MonkeyPatch, league: str
+) -> None:
+    """A pre-fetched `bart` frame must bypass the provider import entirely."""
+    import importlib
+    import sys
+
+    module_path, _ = _RATINGS_PROVIDER[league]
+    monkeypatch.setitem(sys.modules, module_path, None)
+    crosswalk = importlib.import_module(f"sportsdataverse.{league}.{league}_crosswalk")
+    _stub_espn(monkeypatch, crosswalk)
+    out = getattr(crosswalk, f"{league}_team_crosswalk")(season=2026, fox=pl.DataFrame(), bart=pl.DataFrame())
+    assert isinstance(out, pl.DataFrame)
+    assert out.height == 0

--- a/tests/test_crosswalk_basketball_sources.py
+++ b/tests/test_crosswalk_basketball_sources.py
@@ -28,6 +28,7 @@ from sportsdataverse._crosswalk_basketball_sources import (
     CrosswalkSourceError,
     bart_super_sked,
     espn_rosters,
+    require_source,
     stats_schedule_games,
 )
 from sportsdataverse.nba.nba_stats_parsers import parse_nba_stats_result_sets
@@ -256,3 +257,96 @@ def test_bart_super_sked_raises_when_a_payload_parses_to_nothing(monkeypatch: py
 def test_bart_super_sked_allows_a_provably_empty_season(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("sportsdataverse.mbb.torvik_runtime._get", lambda url, **kw: "[]", raising=True)
     assert bart_super_sked("mbb", 2026).height == 0
+
+
+# ---------------------------------------------------------------------------
+# require_source -- the guard that replaced `except Exception: source = None`.
+#
+# The swallow it replaces is what hid a *missing provider module*: with no
+# `fox_nba_teams` in the package at all, the ImportError was caught and the
+# crosswalk built cleanly with silently-null fox_* columns for every team.
+# ---------------------------------------------------------------------------
+
+
+def test_require_source_passes_a_frame_through_including_an_empty_one() -> None:
+    """A source that answered with no rows is legitimate -- no raise."""
+    empty = pl.DataFrame(schema={"fox_team_id": pl.Utf8})
+    assert require_source("provider()", lambda: empty).height == 0
+    assert require_source("provider()", lambda: pl.DataFrame({"a": [1]})).height == 1
+
+
+def test_require_source_raises_on_a_missing_provider_module() -> None:
+    """The exact defect: an absent module read as a clean build."""
+
+    def _fetch() -> Any:
+        from sportsdataverse.nba.nba_fox_ext import fox_nba_teams_that_do_not_exist  # type: ignore[attr-defined]
+
+        return fox_nba_teams_that_do_not_exist()
+
+    with pytest.raises(CrosswalkSourceError, match="fox_nba_teams") as exc:
+        require_source("fox_nba_teams()", _fetch)
+    assert "ImportError" in str(exc.value), "the error must name why the source was missing"
+
+
+@pytest.mark.parametrize("boom", [TimeoutError("down"), ValueError("bad payload")])
+def test_require_source_raises_on_any_fetch_failure(boom: Exception) -> None:
+    def _fetch() -> Any:
+        raise boom
+
+    with pytest.raises(CrosswalkSourceError, match=type(boom).__name__):
+        require_source("provider()", _fetch)
+
+
+@pytest.mark.parametrize("bad", [None, {}, [], "not a frame"])
+def test_require_source_raises_when_the_result_is_not_a_frame(bad: Any) -> None:
+    with pytest.raises(CrosswalkSourceError, match="expected a polars DataFrame"):
+        require_source("provider()", lambda: bad)
+
+
+def test_require_source_propagates_an_inner_source_error_unwrapped() -> None:
+    """An adapter that already reported precisely must not be re-wrapped."""
+    inner = CrosswalkSourceError("scheduleleaguev2 returned no leagueSchedule envelope")
+
+    def _fetch() -> Any:
+        raise inner
+
+    with pytest.raises(CrosswalkSourceError) as exc:
+        require_source("provider()", _fetch)
+    assert exc.value is inner
+
+
+_ESPN_DIR_COLS = ["team_id", "abbreviation", "display_name", "short_name", "team", "mascot"]
+
+
+def _boom(*args: Any, **kwargs: Any) -> Any:
+    raise TimeoutError("fox is down")
+
+
+@pytest.mark.parametrize(
+    ("league", "target", "extra"),
+    [
+        # nba/wnba resolve Stats before Fox, so hand those in pre-fetched: only
+        # the Fox leg is under test here.
+        ("nba", "fox_nba_teams", {"stats": pl.DataFrame()}),
+        ("wnba", "fox_wnba_teams", {"stats": pl.DataFrame()}),
+        ("mbb", "fox_mbb_teams_all", {"bart": pl.DataFrame()}),
+        ("wbb", "fox_wbb_teams_all", {"bart": pl.DataFrame()}),
+    ],
+)
+def test_team_crosswalk_raises_when_fox_cannot_be_produced(
+    monkeypatch: pytest.MonkeyPatch, league: str, target: str, extra: dict
+) -> None:
+    """A dead Fox source must fail the build, not ship all-null fox_* columns."""
+    import importlib
+
+    monkeypatch.setattr(importlib.import_module(f"sportsdataverse.{league}.{league}_fox_ext"), target, _boom)
+    crosswalk = importlib.import_module(f"sportsdataverse.{league}.{league}_crosswalk")
+    # Bind the ESPN stub in the crosswalk module's own namespace -- it imported
+    # espn_team_directory by value, so patching the source module is a no-op.
+    monkeypatch.setattr(
+        crosswalk,
+        "espn_team_directory",
+        lambda *a, **k: pl.DataFrame(schema={c: pl.Utf8 for c in _ESPN_DIR_COLS}),
+    )
+    with pytest.raises(CrosswalkSourceError, match=target):
+        getattr(crosswalk, f"{league}_team_crosswalk")(season=2026, **extra)

--- a/tests/test_fox_wbb_wnba_offline.py
+++ b/tests/test_fox_wbb_wnba_offline.py
@@ -11,6 +11,7 @@ import json
 from pathlib import Path
 
 import polars as pl
+import pytest
 
 import sportsdataverse._fox_layout as fox_layout
 from sportsdataverse._fox_layout import parse_teams
@@ -105,6 +106,43 @@ def test_fox_teams_empty_payload_keeps_schema(monkeypatch):
     df = fox_wnba_teams()
     assert df.columns == TEAMS_COLS
     assert len(df) == 0
+
+
+TEAMS_SCHEMA = {"fox_team_id": pl.Utf8, "fox_team_name": pl.Utf8, "fox_section": pl.Utf8}
+
+
+@pytest.mark.parametrize(
+    ("league", "getter"),
+    [
+        ("mbb", "fox_mbb_teams"),
+        ("nba", "fox_nba_teams"),
+        ("wbb", "fox_wbb_teams"),
+        ("wnba", "fox_wnba_teams"),
+    ],
+)
+@pytest.mark.parametrize("shape", ["empty", "all_null", "populated"])
+def test_fox_teams_dtypes_are_stable_across_shapes(monkeypatch, league, getter, shape):
+    """Same dtypes whether the result is empty, all-null, or fully populated.
+
+    ``parse_teams`` emits ``None`` for ``fox_team_name`` / ``fox_section`` when the
+    payload omits them; without an explicit schema an all-null column infers
+    ``Null`` while the empty path infers ``Utf8`` -- an unstable schema that
+    breaks the crosswalk joins keyed on these columns.
+    """
+    import importlib
+
+    ext = importlib.import_module(f"sportsdataverse.{league}.{league}_fox_ext")
+    rows = {
+        "empty": [],
+        "all_null": [{"fox_team_id": "1", "fox_team_name": None, "fox_section": None}],
+        "populated": [{"fox_team_id": "1", "fox_team_name": "Some Team", "fox_section": "Some Conf"}],
+    }[shape]
+    monkeypatch.setattr(ext, "parse_teams", lambda raw: rows)
+    monkeypatch.setattr(fox_layout, "_get", lambda url, **kw: {})
+    df = getattr(ext, getter)("1")
+    assert df.columns == TEAMS_COLS
+    assert dict(df.schema) == TEAMS_SCHEMA
+    assert df.height == len(rows)
 
 
 def test_fox_wbb_teams_all_budget_and_dedupe(monkeypatch):

--- a/tests/test_fox_wbb_wnba_offline.py
+++ b/tests/test_fox_wbb_wnba_offline.py
@@ -1,4 +1,4 @@
-"""Offline tests for the Fox Bifrost WBB/WNBA extensions (crosswalk prerequisites).
+"""Offline tests for the Fox Bifrost WBB/WNBA/NBA extensions (crosswalk prerequisites).
 
 Run against committed real captures (see ``tests/fixtures/fox/README.md``) —
 no network. The teams frame (``fox_team_id`` / ``fox_team_name`` /
@@ -31,6 +31,33 @@ def test_parse_teams_wnba_full_league():
     assert len(ids) == len(set(ids)), "fox_team_id must be de-duplicated"
     assert {"Atlanta Dream", "Minnesota Lynx"}.issubset({r["fox_team_name"] for r in rows})
     assert all(set(r) == set(TEAMS_COLS) for r in rows)
+
+
+def test_parse_teams_nba_full_league():
+    rows = parse_teams(_load("nba_team_1_standings.json"))
+    assert len(rows) == 30, "one NBA standings payload carries the whole league"
+    ids = [r["fox_team_id"] for r in rows]
+    assert len(ids) == len(set(ids)), "fox_team_id must be de-duplicated"
+    # The crosswalk joins on the normalized full name, so both must be populated
+    # for every team -- an all-null fox_team_name is what a missing wrapper looked
+    # like downstream.
+    assert all(r["fox_team_id"] and r["fox_team_name"] for r in rows)
+    assert {"Boston Celtics", "Los Angeles Lakers"}.issubset({r["fox_team_name"] for r in rows})
+
+
+def test_fox_nba_teams_offline(monkeypatch):
+    from sportsdataverse.nba import fox_nba_teams
+
+    payload = _load("nba_team_1_standings.json")
+    monkeypatch.setattr(fox_layout, "_get", lambda url, **kw: payload)
+    df = fox_nba_teams()
+    assert isinstance(df, pl.DataFrame)
+    assert df.columns == TEAMS_COLS
+    assert df.height == 30
+    assert df.schema["fox_team_id"] == pl.Utf8
+    assert df["fox_team_id"].null_count() == 0
+    assert df["fox_team_name"].null_count() == 0
+    assert isinstance(fox_nba_teams(return_parsed=False), dict)
 
 
 def test_parse_teams_wcbk_conference_section():


### PR DESCRIPTION
Two related fixes that together unblock the NBA team + player crosswalks.

## 1. `fox_nba_teams` did not exist

`fox_wnba_teams` / `fox_wbb_teams(_all)` shipped in #340, but the NBA Fox
extension never got a team-directory wrapper — so `nba_team_crosswalk` had no
Fox source to call at all. Added `fox_nba_teams`, mirroring
`_fox_layout.parse_teams` and emitting the same
`fox_team_id` / `fox_team_name` / `fox_section` shape the R crosswalk consumes.
Seed id `"1"` matches `hoopR::fox_nba_teams()`; one NBA standings payload is
league-wide, so a single call returns all 30 teams.

**The sweep in (2) surfaced the identical defect in MBB** — `mbb_crosswalk`
called a `fox_mbb_teams_all` that was never written either. Added
`fox_mbb_teams` / `fox_mbb_teams_all` as a slug-swap of the verified
`fox_wbb_teams_all` (college standings are per-conference, so `_all` walks
candidate seed ids under a call budget). Without it, the new raise would turn
MBB's silently-null Fox columns into a hard failure.

## 2. The swallow that hid it

`nba_team_crosswalk` did `except Exception: fox = None`, so a **missing
provider module read as a clean build** with silently-null `fox_*` columns for
every team. Same contract #348 applied to the stats sources, now applied to the
provider fetches: a source that cannot be produced RAISES and names what was
missing and why; a source that legitimately returned no rows still yields a
typed empty frame.

New `require_source(label, fetch)` in `_crosswalk_basketball_sources`; all five
whole-source fetches routed through it:

| Module | Source | Was |
|---|---|---|
| `nba_crosswalk` | Fox teams | `except Exception: fox = None` |
| `nba_crosswalk` | `_stats_team_directory` | `return None` on both failure *and* empty |
| `wnba_crosswalk` | Fox teams | `except Exception: fox = None` |
| `mbb_crosswalk` | Fox teams, Torvik ratings | `except Exception: … = None` |
| `wbb_crosswalk` | Fox teams, Torvik ratings | `except Exception: … = None` |

The provider `import` moves inside the fetch callable so a missing module
surfaces as a named `CrosswalkSourceError` rather than a swallowed
`ImportError`. **Per-item tolerance is unchanged and still deliberate** — one
scoreboard date, one team's roster — only whole-source fetches raise. The
remaining `except Exception` blocks in `cfb_crosswalk` are all per-week loops
that log a warning; left alone.

## 3. `nba_team_abbreviation` was a hard `pl.lit(None)`

Verified: `leaguestandingsv3` publishes **no** tricode among its 92 columns, so
it genuinely is not a projection of the payload `_stats_team_directory` already
fetched. `hoopR::nba_teams()` gets it by joining `leaguegamelog` on `team_id` —
`_stats_team_tricodes` now does the same, including hoopR's
fall-back-one-season behaviour for a season that has not tipped off. Live:
30/30 populated, matching the golden exactly.

## Live verification vs the R goldens

Against `hoopR-nba-data/nba/crosswalk/parquet/`, season 2026:

**Team** — 30 rows, `match_method` 30/30 `exact_name`.

| column | py coverage | golden | agreement over overlap |
|---|---|---|---|
| `nba_team_id` | 30/30 | 30/30 | **30/30** |
| `nba_team_abbreviation` | 30/30 | 30/30 | **30/30** |
| `fox_team_id` | 30/30 | 30/30 | **30/30** |
| `fox_team_name` | 30/30 | 30/30 | **30/30** |

**Player** — 548 rows (golden 544; ESPN rosters grew), 536 overlapping athletes.
`match_method`: 384 `exact_name` / 164 `unmatched` (golden 395 / 149).

| column | agreement | note |
|---|---|---|
| `nba_player_id` | 529/536 = **98.69%** | reproduces the 98.7% benchmark |
| `match_method` | 529/536 = 98.69% | same 7 rows |
| `espn_team_id` | 529/536 = 98.69% | **the same 7 rows** — ESPN team changes since the golden |
| `fox_athlete_id` | 522/536 = 97.39% | 14 diffs, **symmetric**: 7 py-null / 7 golden-null |

Fox coverage: py 532/548 (97.08%) vs golden 528/544 (97.06%) — equal-or-better.
The 14 `fox_athlete_id` diffs are symmetric Fox-roster churn (Draymond Green /
Kawhi Leonard now resolve and did not in the golden; Christian Koloko /
Mac McClung the reverse), not a systematic null. Nothing systematically null
remains.

## Gates

`ruff check` + `ruff format --check` clean · `mypy` clean (394 files;
`nba_fox_ext.py` + `mbb_fox_ext.py` added to the ratchet) ·
`generate.py --check` current · **pytest 2108 passed, 96 skipped, 1 xfailed**
across the touched dirs + `test_basketball_crosswalk_parity.py` +
`test_id_conventions.py`.

New tests assert the **raise** — including the real defect (a missing provider
module, asserting the message names it and cites `ImportError`) — and
separately that an empty-but-valid source still passes through as a typed
empty frame. `fox_nba_teams` is covered offline against a newly committed real
capture, `tests/fixtures/fox/nba_team_1_standings.json`.

## Summary by Sourcery

Add missing Fox team-directory wrappers for NBA and MBB and make basketball crosswalk provider fetches fail loudly instead of silently swallowing errors, while correcting NBA Stats-derived team abbreviations.

New Features:
- Expose `fox_nba_teams` for league-wide NBA team directory ingestion.
- Expose `fox_mbb_teams` and `fox_mbb_teams_all` for conference and full MBB team directory ingestion.
- Add parsed-module mirrors for the new Fox team directory functions in `parsed.nba` and `parsed.mbb`.

Bug Fixes:
- Fix NBA team crosswalk to populate `nba_team_abbreviation` via a Stats game-log tricode join rather than hard-coding nulls.
- Ensure basketball team crosswalks (NBA, WNBA, MBB, WBB) fail when Fox or Torvik providers cannot be produced instead of building with silently-null provider columns.

Enhancements:
- Introduce `require_source` helper to standardize strict error handling for whole-source provider fetches and reuse it across basketball crosswalks.
- Treat provably empty provider responses as valid typed empty frames rather than failures in crosswalk construction.
- Add offline fixture and tests for Fox NBA standings parsing and for the new provider-guard behaviour.

Build:
- Include `nba_fox_ext.py` and `mbb_fox_ext.py` in the `mypy` ratchet configuration to enforce type-checking coverage.

Documentation:
- Document the new `fox_nba_teams`, `fox_mbb_teams`, and `fox_mbb_teams_all` helpers in the NBA and MBB additional reference pages.
- Update MBB and NBA index counts to reflect the added helper functions.

Tests:
- Extend offline Fox tests to cover NBA team standings and the `fox_nba_teams` wrapper.
- Add unit tests for `require_source` and for crosswalk behaviour when Fox providers are unavailable or misconfigured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added NBA and men’s college basketball team-directory lookups from Fox Sports.
  - Results can be returned as raw data or structured Polars/pandas tables.
  - Added support for combining and deduplicating men’s college basketball teams across conferences.
  - Added compatibility through existing parsed namespaces.

- **Bug Fixes**
  - Crosswalks now clearly report unavailable data sources instead of silently producing incomplete results.
  - Improved NBA team abbreviation recovery when standings data is incomplete.
  - Improved consistency of team-directory table schemas, including empty and null-valued results.

- **Documentation**
  - Updated function counts and added usage references for the new team-directory features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->