### PR TITLE
feat(crosswalk): resolve ESPN conference labels from the Core v2 group tree

### DIFF
--- a/sportsdataverse/_crosswalk_basketball_sources.py
+++ b/sportsdataverse/_crosswalk_basketball_sources.py
@@ -314,9 +314,12 @@ def espn_conference_map(league: str, season: int, **kwargs: Any) -> pl.DataFrame
         raise CrosswalkSourceError(
             f"espn_conference_map({league!r}, {season}) walked {len(group_ids)} conference groups and resolved no teams"
         )
-    return pl.DataFrame({"team_id": team_ids, "conference_name": names}).unique(
-        subset=["team_id"], keep="first", maintain_order=True
-    )
+    # Pinned, not inferred: ``team_id`` is a join key, so every return path of
+    # this function hands back the same Utf8 dtype the empty frame declares.
+    return pl.DataFrame(
+        {"team_id": team_ids, "conference_name": names},
+        schema={"team_id": pl.Utf8, "conference_name": pl.Utf8},
+    ).unique(subset=["team_id"], keep="first", maintain_order=True)
 
 
 def espn_team_directory(league: str, season: Optional[int] = None, **kwargs: Any) -> pl.DataFrame:
@@ -378,8 +381,15 @@ def espn_team_directory(league: str, season: Optional[int] = None, **kwargs: Any
     # take a different parameter set.
     conferences = espn_conference_map(league, int(season))
     # Join on Utf8 both sides -- as_str_id keeps a numeric id off the float
-    # path, so an Int64 team_id stringifies as "123" and never "123.0".
-    return out.with_columns(str_id(out, "team_id")).join(conferences, on="team_id", how="left")
+    # path, so an Int64 team_id stringifies as "123" and never "123.0". The
+    # assert makes that agreement a checked precondition instead of an
+    # inference both sides happen to share today.
+    out = out.with_columns(str_id(out, "team_id"))
+    assert out.schema["team_id"] == conferences.schema["team_id"] == pl.Utf8, (
+        f"team_id join-key dtype mismatch: directory={out.schema['team_id']}, "
+        f"conferences={conferences.schema['team_id']} (both must be {pl.Utf8})"
+    )
+    return out.join(conferences, on="team_id", how="left")
 
 
 def espn_scoreboard_games(league: str, dates: Sequence[date], **kwargs: Any) -> pl.DataFrame:

--- a/sportsdataverse/_crosswalk_basketball_sources.py
+++ b/sportsdataverse/_crosswalk_basketball_sources.py
@@ -13,6 +13,7 @@ These adapters own that rename so the assemblers can stay a literal port.
 from __future__ import annotations
 
 import json
+import re
 from datetime import date, datetime
 from typing import Any, Callable, Dict, List, Optional, Sequence
 
@@ -24,6 +25,7 @@ from sportsdataverse.errors import SportsDataverseError
 __all__ = [
     "CrosswalkSourceError",
     "require_source",
+    "espn_conference_map",
     "espn_team_directory",
     "espn_scoreboard_games",
     "espn_rosters",
@@ -190,6 +192,133 @@ def _espn_accessors(league: str) -> Dict[str, Callable[..., Any]]:
     raise ValueError(f"unknown league {league!r}")
 
 
+# ESPN's "NCAA Division I" parent group; its children are the conferences.
+_NCAA_ROOT_GROUP = 50
+# Trailing numeric id of a Core v2 ``.../groups/{id}`` or ``.../teams/{id}`` $ref.
+_REF_ID = re.compile(r"/(?:groups|teams)/(\d+)")
+
+
+def _ncaa_group_accessors(league: str) -> Optional[Dict[str, Callable[..., Any]]]:
+    """The three Core v2 group wrappers for an NCAA league, else ``None``."""
+    if league == "wbb":
+        from sportsdataverse.wbb.wbb_espn_ext import (
+            espn_wbb_season_group,
+            espn_wbb_season_group_children,
+            espn_wbb_season_group_teams,
+        )
+
+        return {
+            "group": espn_wbb_season_group,
+            "children": espn_wbb_season_group_children,
+            "teams": espn_wbb_season_group_teams,
+        }
+    if league == "mbb":
+        from sportsdataverse.mbb.mbb_espn_ext import (
+            espn_mbb_season_group,
+            espn_mbb_season_group_children,
+            espn_mbb_season_group_teams,
+        )
+
+        return {
+            "group": espn_mbb_season_group,
+            "children": espn_mbb_season_group_children,
+            "teams": espn_mbb_season_group_teams,
+        }
+    return None
+
+
+def _ref_ids(frame: Any) -> List[int]:
+    """Numeric ids parsed out of a Core v2 ``{items: [{$ref}]}`` parsed frame."""
+    if not isinstance(frame, pl.DataFrame) or frame.height == 0 or "$ref" not in frame.columns:
+        return []
+    return [int(m.group(1)) for ref in frame["$ref"].drop_nulls() if (m := _REF_ID.search(str(ref)))]
+
+
+def espn_conference_map(league: str, season: int, **kwargs: Any) -> pl.DataFrame:
+    """ESPN team -> conference name for one NCAA season, via the Core v2 group tree.
+
+    The Site v2 ``teams`` directory carries no conference, so the R producers
+    (``wehoop::espn_wbb_teams()`` / ``hoopR::espn_mbb_teams()``) reconstruct it
+    by walking ESPN's season group tree: the children of group
+    ``50`` ("NCAA Division I") are the conferences, and each conference group
+    lists its member teams. This is the same walk, through sdv-py's existing
+    ``espn_{lg}_season_group*`` wrappers.
+
+    One conference that fails to fetch is skipped rather than fatal, matching
+    the R producers' per-item tolerance; a walk that yields nothing at all
+    raises, because a silently empty map would ship an all-null
+    ``espn_conference`` column.
+
+    Args:
+        league: ``"mbb"`` or ``"wbb"``. Any other league has no NCAA group
+            tree and yields a typed empty frame.
+        season: Season year (4-digit, e.g. ``2026``).
+        **kwargs: Forwarded to the group wrappers.
+
+    Returns:
+        ``pl.DataFrame`` with ``team_id`` (``Utf8``, the crosswalk join dtype)
+        and ``conference_name`` (``Utf8``), one row per team.
+
+    Raises:
+        CrosswalkSourceError: ``league`` is an NCAA league but the walk
+            produced no team-to-conference rows at all.
+
+    Example:
+        Quick start::
+
+            from sportsdataverse._crosswalk_basketball_sources import espn_conference_map
+            df = espn_conference_map("wbb", 2026)
+            print(df.height, df["conference_name"].n_unique())
+
+        Look one team up::
+
+            df.filter(pl.col("team_id") == "2579")
+
+        See Also:
+            * `wehoop`_ -- R sister package whose ``espn_wbb_teams()`` walk this ports
+            * `hoopR`_ -- the men's-side equivalent
+
+        .. _wehoop: https://wehoop.sportsdataverse.org
+        .. _hoopR: https://hoopR.sportsdataverse.org
+    """
+    empty = pl.DataFrame(schema={"team_id": pl.Utf8, "conference_name": pl.Utf8})
+    accessors = _ncaa_group_accessors(league)
+    if accessors is None:
+        return empty
+
+    group_ids = _ref_ids(
+        require_source(
+            f"espn_{league}_season_group_children({season}, 2, {_NCAA_ROOT_GROUP})",
+            lambda: accessors["children"](season, 2, _NCAA_ROOT_GROUP, limit=1000, return_parsed=True, **kwargs),
+        )
+    )
+
+    team_ids: List[str] = []
+    names: List[str] = []
+    for group_id in group_ids:
+        try:
+            group = accessors["group"](season, 2, group_id, return_parsed=True, **kwargs)
+            members = accessors["teams"](season, 2, group_id, limit=500, return_parsed=True, **kwargs)
+        except Exception:
+            continue
+        if not isinstance(group, pl.DataFrame) or group.height == 0 or "name" not in group.columns:
+            continue
+        name = group["name"][0]
+        if name is None:
+            continue
+        for team_id in _ref_ids(members):
+            team_ids.append(str(team_id))
+            names.append(str(name))
+
+    if not team_ids:
+        raise CrosswalkSourceError(
+            f"espn_conference_map({league!r}, {season}) walked {len(group_ids)} conference groups and resolved no teams"
+        )
+    return pl.DataFrame({"team_id": team_ids, "conference_name": names}).unique(
+        subset=["team_id"], keep="first", maintain_order=True
+    )
+
+
 def espn_team_directory(league: str, season: Optional[int] = None, **kwargs: Any) -> pl.DataFrame:
     """ESPN team directory projected onto the R accessor's column names.
 
@@ -198,20 +327,35 @@ def espn_team_directory(league: str, season: Optional[int] = None, **kwargs: Any
     ``abbreviation`` / ``display_name`` / ``short_name`` / ``team`` /
     ``mascot``. This renames one to the other.
 
+    ``conference_name`` is taken from the upstream frame when it carries one.
+    It does not for any sdv-py league, so for the NCAA leagues (``"mbb"`` /
+    ``"wbb"``) with a ``season`` given it is instead reconstructed through
+    :func:`espn_conference_map`, matching what the R producers do.
+
     Args:
         league: ``"mbb"``, ``"wbb"``, ``"nba"`` or ``"wnba"``.
-        season: Unused by the ESPN teams endpoint; accepted for symmetry.
+        season: Season year. Required to resolve ``conference_name`` for the
+            NCAA leagues; unused by the ESPN teams endpoint itself.
         **kwargs: Forwarded to the accessor.
 
     Returns:
-        ``pl.DataFrame``, one row per team. ``conference_name`` is present only
-        when the upstream frame carries it (sdv-py's does not).
+        ``pl.DataFrame``, one row per team, with ``conference_name`` populated
+        for the NCAA leagues and null for ``"nba"`` / ``"wnba"`` (whose
+        crosswalks do not carry it).
+
+    Raises:
+        CrosswalkSourceError: The NCAA conference walk produced nothing.
 
     Example:
         Quick start::
 
             from sportsdataverse._crosswalk_basketball_sources import espn_team_directory
             print(espn_team_directory("wnba").columns)
+
+        With conferences resolved::
+
+            df = espn_team_directory("wbb", season=2026)
+            print(df["conference_name"].drop_nulls().len(), "of", df.height)
     """
     raw = _espn_accessors(league)["teams"](**kwargs)
     if not isinstance(raw, pl.DataFrame):
@@ -226,9 +370,16 @@ def espn_team_directory(league: str, season: Optional[int] = None, **kwargs: Any
     )
     for candidate in ("team_conference_name", "conference_name", "group_name"):
         if candidate in raw.columns:
-            out = out.with_columns(raw[candidate].cast(pl.Utf8).alias("conference_name"))
-            break
-    return out
+            return out.with_columns(raw[candidate].cast(pl.Utf8).alias("conference_name"))
+
+    if season is None or _ncaa_group_accessors(league) is None:
+        return out
+    # Not **kwargs: those are the *teams* accessor's, and the group endpoints
+    # take a different parameter set.
+    conferences = espn_conference_map(league, int(season))
+    # Join on Utf8 both sides -- as_str_id keeps a numeric id off the float
+    # path, so an Int64 team_id stringifies as "123" and never "123.0".
+    return out.with_columns(str_id(out, "team_id")).join(conferences, on="team_id", how="left")
 
 
 def espn_scoreboard_games(league: str, dates: Sequence[date], **kwargs: Any) -> pl.DataFrame:

--- a/sportsdataverse/mbb/mbb_crosswalk.py
+++ b/sportsdataverse/mbb/mbb_crosswalk.py
@@ -448,16 +448,26 @@ def mbb_team_crosswalk(
         :data:`TEAM_COLUMNS`.
 
     Note:
-        ``espn_conference`` is null unless the ESPN frame carries a
-        ``conference_name`` column -- sdv-py's ``espn_mbb_teams()`` does not
-        ship conference labels.
+        sdv-py's ``espn_mbb_teams()`` ships no conference labels, so
+        ``espn_conference`` is reconstructed from ESPN's Core v2 season group
+        tree (see
+        :func:`~sportsdataverse._crosswalk_basketball_sources.espn_conference_map`),
+        the same walk the R producer does. There is no ``espn`` parameter --
+        the directory is always fetched here; when the upstream ESPN response
+        does carry ``conference_name``,
+        :func:`~sportsdataverse._crosswalk_basketball_sources.espn_team_directory`
+        preserves it and the group walk is skipped.
 
     Raises:
         CrosswalkSourceError: A source that was not passed in pre-fetched could
             not be produced (Fox or Torvik). Building on a missing source would
             emit a well-formed crosswalk whose ``fox_*`` / ``bart_*`` columns
             are silently all-null, so it fails here instead. Pass an explicit
-            empty frame (``fox=pl.DataFrame()``) to opt a source out.
+            empty frame (``fox=pl.DataFrame()``) to opt a source out. Also
+            raised, and propagated from
+            :func:`~sportsdataverse._crosswalk_basketball_sources.espn_conference_map`,
+            when the ESPN conference walk resolves no teams at all -- the ESPN
+            directory is not opt-out-able.
 
     Example:
         Quick start::

--- a/sportsdataverse/wbb/wbb_crosswalk.py
+++ b/sportsdataverse/wbb/wbb_crosswalk.py
@@ -369,9 +369,12 @@ def wbb_team_crosswalk(
         :data:`TEAM_COLUMNS`.
 
     Note:
-        ``espn_conference`` is null unless the ESPN frame carries a
-        ``conference_name`` column -- sdv-py's ``espn_wbb_teams()`` does not
-        ship conference labels.
+        sdv-py's ``espn_wbb_teams()`` ships no conference labels, so
+        ``espn_conference`` is reconstructed from ESPN's Core v2 season group
+        tree (see
+        :func:`~sportsdataverse._crosswalk_basketball_sources.espn_conference_map`),
+        the same walk the R producer does. A pre-fetched ``espn`` frame that
+        already carries ``conference_name`` is used as-is.
 
     Raises:
         CrosswalkSourceError: A source that was not passed in pre-fetched could

--- a/sportsdataverse/wbb/wbb_crosswalk.py
+++ b/sportsdataverse/wbb/wbb_crosswalk.py
@@ -373,15 +373,22 @@ def wbb_team_crosswalk(
         ``espn_conference`` is reconstructed from ESPN's Core v2 season group
         tree (see
         :func:`~sportsdataverse._crosswalk_basketball_sources.espn_conference_map`),
-        the same walk the R producer does. A pre-fetched ``espn`` frame that
-        already carries ``conference_name`` is used as-is.
+        the same walk the R producer does. There is no ``espn`` parameter --
+        the directory is always fetched here; when the upstream ESPN response
+        does carry ``conference_name``,
+        :func:`~sportsdataverse._crosswalk_basketball_sources.espn_team_directory`
+        preserves it and the group walk is skipped.
 
     Raises:
         CrosswalkSourceError: A source that was not passed in pre-fetched could
             not be produced (Fox or Torvik). Building on a missing source would
             emit a well-formed crosswalk whose ``fox_*`` / ``bart_*`` columns
             are silently all-null, so it fails here instead. Pass an explicit
-            empty frame (``fox=pl.DataFrame()``) to opt a source out.
+            empty frame (``fox=pl.DataFrame()``) to opt a source out. Also
+            raised, and propagated from
+            :func:`~sportsdataverse._crosswalk_basketball_sources.espn_conference_map`,
+            when the ESPN conference walk resolves no teams at all -- the ESPN
+            directory is not opt-out-able.
 
     Example:
         Quick start::

--- a/tests/test_crosswalk_basketball_sources.py
+++ b/tests/test_crosswalk_basketball_sources.py
@@ -27,7 +27,9 @@ import pytest
 from sportsdataverse._crosswalk_basketball_sources import (
     CrosswalkSourceError,
     bart_super_sked,
+    espn_conference_map,
     espn_rosters,
+    espn_team_directory,
     require_source,
     stats_schedule_games,
 )
@@ -412,3 +414,134 @@ def test_team_crosswalk_supplied_ratings_frame_needs_no_provider_module(
     out = getattr(crosswalk, f"{league}_team_crosswalk")(season=2026, fox=pl.DataFrame(), bart=pl.DataFrame())
     assert isinstance(out, pl.DataFrame)
     assert out.height == 0
+
+
+# ---------------------------------------------------------------------------
+# ESPN conference labels (the Track X-B blocker).
+#
+# The Site v2 `teams` directory carries no conference, so `espn_conference`
+# shipped 0/362 where the R producer ships 361/361. It is reconstructed from
+# the Core v2 season group tree instead. Locked in here: the $ref id parsing,
+# the raise on an empty walk, and -- the latent one -- that the join key is a
+# clean Utf8 id, since a float-origin id stringifies as "123.0" and would match
+# nothing.
+# ---------------------------------------------------------------------------
+
+_CORE = "http://sports.core.api.espn.com/v2/sports/basketball/leagues/womens-college-basketball/seasons/2026"
+
+
+def _group_stubs(tree: dict[int, tuple[str, list[int]]]) -> dict[str, Any]:
+    """Stub the three Core v2 group wrappers from a {gid: (name, [team ids])}."""
+
+    def children(season: Any, stype: Any, gid: Any, **kw: Any) -> pl.DataFrame:
+        return pl.DataFrame({"$ref": [f"{_CORE}/types/2/groups/{g}?lang=en" for g in tree]})
+
+    def group(season: Any, stype: Any, gid: Any, **kw: Any) -> pl.DataFrame:
+        return pl.DataFrame({"id": [str(gid)], "name": [tree[int(gid)][0]]})
+
+    def teams(season: Any, stype: Any, gid: Any, **kw: Any) -> pl.DataFrame:
+        return pl.DataFrame({"$ref": [f"{_CORE}/teams/{t}?lang=en" for t in tree[int(gid)][1]]})
+
+    return {"children": children, "group": group, "teams": teams}
+
+
+def _patch_tree(monkeypatch: pytest.MonkeyPatch, tree: dict[int, tuple[str, list[int]]]) -> None:
+    import sportsdataverse._crosswalk_basketball_sources as src
+
+    monkeypatch.setattr(src, "_ncaa_group_accessors", lambda league: _group_stubs(tree))
+
+
+def test_espn_conference_map_walks_the_group_tree(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every conference's members carry that conference's name, keyed on Utf8 ids."""
+    _patch_tree(monkeypatch, {2: ("Atlantic Coast Conference", [52, 152]), 8: ("Southeastern Conference", [2579])})
+
+    out = espn_conference_map("wbb", 2026)
+
+    assert out.schema == {"team_id": pl.Utf8, "conference_name": pl.Utf8}
+    assert dict(zip(out["team_id"], out["conference_name"])) == {
+        "52": "Atlantic Coast Conference",
+        "152": "Atlantic Coast Conference",
+        "2579": "Southeastern Conference",
+    }
+
+
+def test_espn_conference_map_raises_when_the_walk_resolves_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An all-null espn_conference column must fail the build, not ship."""
+    _patch_tree(monkeypatch, {})
+    with pytest.raises(CrosswalkSourceError, match="resolved no teams"):
+        espn_conference_map("wbb", 2026)
+
+
+def test_espn_conference_map_tolerates_one_dead_conference(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Per-item tolerance, as in the R producer: one bad group is skipped."""
+    stubs = _group_stubs({2: ("Atlantic Coast Conference", [52]), 8: ("Southeastern Conference", [2579])})
+    healthy = stubs["teams"]
+
+    def flaky(season: Any, stype: Any, gid: Any, **kw: Any) -> pl.DataFrame:
+        if int(gid) == 8:
+            raise RuntimeError("ESPN 403")
+        return healthy(season, stype, gid, **kw)
+
+    stubs["teams"] = flaky
+    import sportsdataverse._crosswalk_basketball_sources as src
+
+    monkeypatch.setattr(src, "_ncaa_group_accessors", lambda league: stubs)
+
+    out = espn_conference_map("wbb", 2026)
+    assert out["team_id"].to_list() == ["52"]
+
+
+def test_espn_conference_map_is_empty_for_non_ncaa_leagues(monkeypatch: pytest.MonkeyPatch) -> None:
+    """NBA/WNBA have no group-50 tree; their crosswalks carry no conference."""
+    for league in ("nba", "wnba"):
+        out = espn_conference_map(league, 2026)
+        assert out.height == 0
+        assert out.columns == ["team_id", "conference_name"]
+
+
+def test_espn_team_directory_joins_conference_on_a_clean_utf8_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An Int64 team_id must join as "52", never the float-origin "52.0"."""
+    import sportsdataverse._crosswalk_basketball_sources as src
+
+    monkeypatch.setattr(
+        src,
+        "_espn_accessors",
+        lambda league: {
+            "teams": lambda **kw: pl.DataFrame(
+                {
+                    "team_id": pl.Series([52, 2579], dtype=pl.Int64),
+                    "team_abbreviation": ["ND", "UT"],
+                    "team_display_name": ["Notre Dame Fighting Irish", "Texas Longhorns"],
+                    "team_short_display_name": ["Notre Dame", "Texas"],
+                    "team_location": ["Notre Dame", "Texas"],
+                    "team_name": ["Fighting Irish", "Longhorns"],
+                }
+            )
+        },
+    )
+    _patch_tree(monkeypatch, {2: ("Atlantic Coast Conference", [52]), 8: ("Southeastern Conference", [2579])})
+
+    out = espn_team_directory("wbb", season=2026)
+
+    assert out["team_id"].to_list() == ["52", "2579"], "a float-origin id would read '52.0'"
+    assert out["conference_name"].to_list() == ["Atlantic Coast Conference", "Southeastern Conference"]
+
+
+def test_espn_team_directory_prefers_an_upstream_conference_column(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A directory that already carries conference is not re-walked."""
+    import sportsdataverse._crosswalk_basketball_sources as src
+
+    monkeypatch.setattr(
+        src,
+        "_espn_accessors",
+        lambda league: {
+            "teams": lambda **kw: pl.DataFrame({"team_id": ["52"], "conference_name": ["Big Ten Conference"]})
+        },
+    )
+
+    def _boom(league: str) -> Any:  # pragma: no cover - must not be reached
+        raise AssertionError("the group tree must not be walked when upstream ships conference")
+
+    monkeypatch.setattr(src, "_ncaa_group_accessors", _boom)
+
+    assert espn_team_directory("wbb", season=2026)["conference_name"].to_list() == ["Big Ten Conference"]

--- a/tests/test_crosswalk_basketball_sources.py
+++ b/tests/test_crosswalk_basketball_sources.py
@@ -496,7 +496,9 @@ def test_espn_conference_map_is_empty_for_non_ncaa_leagues(monkeypatch: pytest.M
     for league in ("nba", "wnba"):
         out = espn_conference_map(league, 2026)
         assert out.height == 0
-        assert out.columns == ["team_id", "conference_name"]
+        # Full schema, not just names: a Null-dtyped ``team_id`` is an unusable
+        # join key that a columns-only assertion would wave through.
+        assert dict(out.schema) == {"team_id": pl.Utf8, "conference_name": pl.Utf8}
 
 
 def test_espn_team_directory_joins_conference_on_a_clean_utf8_id(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## The blocker

`espn_team_directory` emitted **no conference column for any basketball league**, so `wbb_team_crosswalk` shipped `espn_conference` at **0/362** where the R producer ships 361/361. That was the blocker on the WBB crosswalk.

## Where the R producer actually gets it

ESPN's Site v2 `teams` directory genuinely carries no conference — that part of the diagnosis was right. `wehoop::espn_wbb_teams()` reconstructs it by walking the **Core v2 season group tree**:

1. `.../seasons/{year}/types/2/groups/50/children` — the children of group 50 ("NCAA Division I") are the 31 conferences
2. `.../groups/{gid}` — the conference's `name`
3. `.../groups/{gid}/teams` — its member teams

`espn_conference_map()` does the same walk through sdv-py's **already-existing** `espn_{lg}_season_group` / `_children` / `_teams` wrappers. No new endpoint, no codegen change, no new dependency.

## Live 2026 vs the committed R golden

| | live | golden |
|---|---|---|
| `espn_conference` populated | **361/362** | 361/361 |
| distinct conferences | 31 | 31 |
| teams in >1 conference | 0 | — |

`match_method` is **byte-identical to the pre-change baseline** — `fox+bart` 357 / `bart_only` 2 / `fox_only` 2 / `espn_only` 1 — so this change is strictly additive and the `match_method` spread vs the golden is pre-existing live-vs-frozen drift, not introduced here. (Diffed with `eq_missing`, not `filter(~(a == b))`.)

The 20 name differences vs the golden are **ESPN renames since the golden was frozen**: MAAC → "Metro Conference" (13 teams), WAC → "United Athletic Conference" (7). Core v2 and Site v2 `scoreboard/conferences` agree on the new names with **zero disagreement across all 31 groups**, so a fresh R run today produces them too. The single null is West Florida (2697), which live ESPN places in no D-I conference group.

MBB verified live as well (365 teams, 31 conferences) — though the MBB crosswalk stays blocked on KenPom regardless.

## Contract

- A walk that resolves **no teams at all** raises `CrosswalkSourceError` rather than shipping an all-null column.
- A **single** conference that fails to fetch is skipped, matching the R producers' per-item tolerance.
- The join key goes through `str_id`, so an `Int64` team id stringifies as `"52"` and never the float-origin `"52.0"`.
- NBA/WNBA have no group-50 tree and are unchanged (their crosswalks carry no conference column).

## Gates

`ruff check` + `ruff format` clean · `mypy` (both files already on the ratchet) clean · `pytest tests/test_crosswalk_basketball_sources.py tests/test_basketball_crosswalk_parity.py` **68 passed** (6 new) · `generate.py --check` all generated files current.

## Summary by Sourcery

Populate ESPN conference labels for NCAA basketball crosswalks by reconstructing conferences from the Core v2 season group tree and wiring them into the team directory and WBB team crosswalk.

New Features:
- Introduce espn_conference_map to derive ESPN team-to-conference mappings for NCAA seasons via Core v2 season group hierarchies.

Bug Fixes:
- Ensure espn_conference is populated for NCAA WBB teams instead of shipping an all-null conference column.

Enhancements:
- Augment espn_team_directory to resolve conference_name for NCAA leagues when not provided upstream, joining on a canonical string team_id.
- Update WBB team crosswalk documentation to describe conference reconstruction from the Core v2 group tree.

Tests:
- Add unit tests covering the conference group-tree walk, error handling for empty results, tolerance of failing conference groups, non-NCAA league behavior, and correct joining of conference labels into the ESPN team directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added improved NCAA women’s basketball conference mapping using ESPN season data.
  - Team directories now include conference names when available, with automatic reconstruction when upstream labels are missing.
  - Supports more accurate conference assignments across supported seasons and team identifiers.

- **Bug Fixes**
  - Improved handling of incomplete or unavailable conference data without preventing other teams from loading.
  - Preserved existing conference information when it is already provided by ESPN.

- **Documentation**
  - Updated crosswalk documentation to explain conference-name resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->