### PR TITLE
fix(cfb): count completions on penalty plays that stood + document text_dupe contract

### DIFF
--- a/sportsdataverse/cfb/cfb_pbp.py
+++ b/sportsdataverse/cfb/cfb_pbp.py
@@ -1108,6 +1108,12 @@ class CFBPlayProcess(object):
                 .otherwise(pl.lit(False)),
             )
         )
+        # The dupe rows are removed HERE, so the text_dupe column that reaches
+        # the output is always False by construction -- it is the residue of a
+        # filter that already ran, not a marker consumers can use to dedupe.
+        # Rows with identical text but DIFFERENT start states (e.g. repeated
+        # degenerate feed texts advancing the yardline) are deliberately kept:
+        # they are distinct plays with bad text, not duplicates.
         pbp_txt["plays"] = pbp_txt["plays"].filter(pl.col("text_dupe") == False)
         pbp_txt["plays"] = pbp_txt["plays"].with_row_index("game_play_number", 1)
         pbp_txt["plays"] = (
@@ -2987,6 +2993,17 @@ class CFBPlayProcess(object):
                 # --- Pass Completions, Attempts and Targets -------
                 completion=pl.when(
                     pl.col("type.text").is_in(["Pass Reception", "Pass Completion", "Passing Touchdown"]),
+                )
+                .then(True)
+                # A completion on a penalty play COUNTS when the play stood
+                # (penalty_no_play False). ESPN's box includes these; measured
+                # against the team box this is a +0.1 to +0.4pp monotone gain
+                # in every season, never negative. Nullified plays stay
+                # excluded -- counting those is catastrophic in every season.
+                .when(
+                    (pl.col("type.text") == "Penalty")
+                    .and_(pl.col("text").str.contains(r"(?i)pass complete"))
+                    .and_(pl.col("penalty_no_play") == False),
                 )
                 .then(True)
                 .when(


### PR DESCRIPTION
Two follow-ups from the boxscore-parity program, both measurement-backed.

**1. Penalty-stands completions.** A completion embedded in a Penalty-typed row counts in ESPN's box when the play stood (`penalty_no_play == False`). Measured against the team box: **+0.1 to +0.4pp monotone exact-match gain in every season, never negative**. Nullified plays remain excluded — counting them was measured catastrophic everywhere (2018: 95.0% → 72.5%).

**2. `text_dupe` contract documented (correction, not a code change).** The earlier catalog claim that the flag is 'inert' was wrong: flagged rows are **filtered out during processing**, so the column reaching output is always-False *by construction* — a spent filter residue, not a consumer-usable dedup marker. Rows with identical degenerate text but different start states are deliberately kept (distinct feed plays; de-duplicating them measured worse in every season). The dupe-drop stage now carries that contract in a comment.

## Testing
- 66 offline pipeline tests pass (both pipelines exercised)
- Codegen drift gate green locally; branch rebased on main with #353/#355 in the base

## Summary by Sourcery

Align CFB play-by-play completion flags and text_dupe handling with measured boxscore behavior.

Bug Fixes:
- Count completions embedded in standing penalty plays toward passing completion statistics while keeping nullified plays excluded.

Documentation:
- Document the processing contract for the text_dupe flag, clarifying that duplicate-text rows are filtered earlier and that remaining rows are distinct plays despite degenerate text.