### PR TITLE
fix(crosswalk): send ESPN's Division I group on the college scoreboard sweep

### DIFF
--- a/sportsdataverse/_crosswalk_basketball_sources.py
+++ b/sportsdataverse/_crosswalk_basketball_sources.py
@@ -398,7 +398,9 @@ def espn_scoreboard_games(league: str, dates: Sequence[date], **kwargs: Any) -> 
     Args:
         league: ``"mbb"``, ``"wbb"``, ``"nba"`` or ``"wnba"``.
         dates: ET calendar dates to fetch.
-        **kwargs: Forwarded to the scoreboard wrapper.
+        **kwargs: Forwarded to the scoreboard wrapper. For ``"mbb"`` / ``"wbb"``
+            ``groups`` defaults to ESPN's Division I root group (50) so the full
+            slate is returned; pass ``groups=`` explicitly to override.
 
     Returns:
         ``pl.DataFrame`` with ``espn_game_id``, ``game_date`` (ET),
@@ -413,6 +415,12 @@ def espn_scoreboard_games(league: str, dates: Sequence[date], **kwargs: Any) -> 
             df = espn_scoreboard_games("wnba", [dt.date(2025, 6, 1)])
     """
     scoreboard = _espn_accessors(league)["scoreboard"]
+    # ESPN's college scoreboard defaults to a small featured/ranked subset, not the
+    # day's full Division I slate (2026-01-15: 10 events bare vs 82 with groups=50).
+    # The R producers always send groups=50, which is why the ESPN side of the
+    # college crosswalks collapsed without it. Pro leagues have no group axis.
+    if _ncaa_group_accessors(league) is not None:
+        kwargs.setdefault("groups", _NCAA_ROOT_GROUP)
     frames: List[pl.DataFrame] = []
     for day in dates:
         try:

--- a/tests/test_crosswalk_basketball_sources.py
+++ b/tests/test_crosswalk_basketball_sources.py
@@ -18,8 +18,9 @@ was attempted and aborted:
 from __future__ import annotations
 
 import json
+from datetime import date
 from pathlib import Path
-from typing import Any
+from typing import Any, List, Optional
 
 import polars as pl
 import pytest
@@ -29,6 +30,7 @@ from sportsdataverse._crosswalk_basketball_sources import (
     bart_super_sked,
     espn_conference_map,
     espn_rosters,
+    espn_scoreboard_games,
     espn_team_directory,
     require_source,
     stats_schedule_games,
@@ -188,6 +190,48 @@ def test_stats_schedule_games_allows_a_provably_empty_season(monkeypatch: pytest
         else ["game_date", "season_type", "wnba_game_id", "wnba_game_code", "wnba_home_team_id", "wnba_away_team_id"]
     )
     assert out.columns == expected
+
+
+@pytest.mark.parametrize(
+    ("league", "expected"),
+    [("wbb", 50), ("mbb", 50), ("nba", None), ("wnba", None)],
+)
+def test_espn_scoreboard_games_sends_the_ncaa_root_group(
+    monkeypatch: pytest.MonkeyPatch, league: str, expected: Optional[int]
+) -> None:
+    """College scoreboards without ``groups`` return a featured subset, not the slate.
+
+    ESPN answered 2026-01-15 with 10 WBB events bare and 82 with ``groups=50``,
+    which is why the ESPN side of the college crosswalks collapsed. Pro leagues
+    have no group axis, so they must stay bare.
+    """
+    seen: List[dict] = []
+
+    def fake_scoreboard(**kwargs: Any) -> pl.DataFrame:
+        seen.append(kwargs)
+        return pl.DataFrame()
+
+    monkeypatch.setattr(
+        "sportsdataverse._crosswalk_basketball_sources._espn_accessors",
+        lambda lg: {"scoreboard": fake_scoreboard},
+    )
+    espn_scoreboard_games(league, [date(2026, 1, 15)])
+    assert seen and seen[0].get("groups") == expected
+
+
+def test_espn_scoreboard_games_lets_the_caller_override_groups(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: List[dict] = []
+
+    def fake_scoreboard(**kwargs: Any) -> pl.DataFrame:
+        seen.append(kwargs)
+        return pl.DataFrame()
+
+    monkeypatch.setattr(
+        "sportsdataverse._crosswalk_basketball_sources._espn_accessors",
+        lambda lg: {"scoreboard": fake_scoreboard},
+    )
+    espn_scoreboard_games("wbb", [date(2026, 1, 15)], groups=100)
+    assert seen[0]["groups"] == 100
 
 
 @pytest.mark.parametrize("athlete_key", ["athlete_id", "id"])


### PR DESCRIPTION
## What

`espn_scoreboard_games()` (the shared source adapter behind the mbb/wbb/nba/wnba
schedule crosswalks) called ESPN's scoreboard without `groups`. For the two
college leagues that endpoint answers a small **featured/ranked subset**, not the
day's full Division I slate:

| date | bare | `limit=500` | `groups=50` |
|---|---:|---:|---:|
| 2026-01-15 | 10 | 10 | **82** |
| 2025-12-22 | 5 | 5 | **20** |
| 2026-02-10 | 1 | 1 | **17** |

`limit` is not the lever; `groups` is. The R producers have always sent
`groups=50&limit=1000` (`wehoop::parse_espn_wbb_scoreboard`, hoopR's MBB twin).

## Impact

`wbb_schedule_crosswalk(2026)` was returning **1,083 ESPN games** against the R
golden's 6,054, with 5,018 golden game ids absent entirely and `match_method`
inverted (`bart_only` 5038 / `both` 991 vs the golden's `both` 5562).

## Fix

Default `groups` to ESPN's Division I root group (50) for `mbb`/`wbb` inside the
shared function — so `mbb_schedule_crosswalk` is fixed by the same line. NBA/WNBA
have no group axis and stay bare. Callers may still pass `groups=` to override.

## Live verification (season 2026, vs the committed R golden)

```
live rows=6577   golden rows=6521
live espn_game_id non-null=6054   golden=6054
golden ESPN ids absent from live: 0    live-only: 0     <- exact set match
live   match_method: both 5506, espn_only 548, bart_only 523
golden match_method: both 5562, espn_only 492, bart_only 467
```

The residual 56 `both` rows are **upstream ESPN drift since the golden was built
on 2026-08-01**, not a code gap — three Torvik schools no longer resolve to an
ESPN id because ESPN changed its own directory:

* `2443` renamed `New Orleans` -> `LSU New Orleans`
* `2900` renamed `St. Thomas-Minnesota` -> `St. Thomas` (which inverts the R
  alias `"St. Thomas" = "St. Thomas-Minnesota"`, so the R producer would lose
  these too if re-run today)
* `2598` `Saint Francis` has been **dropped from ESPN's D-I WBB directory**
  (362 teams live vs 363 in Torvik)

Left alone deliberately: the alias table is mirrored from `wehoop`, and curating
it against drifted ESPN names is an R-side-first decision, not something to patch
into the Python port unilaterally.

## Gates

* `ruff check` / `ruff format --check` clean
* `mypy sportsdataverse/_crosswalk_basketball_sources.py` clean
* `pytest tests/test_crosswalk_basketball_sources.py tests/test_basketball_crosswalk_parity.py tests/test_id_conventions.py` -> 77 passed
* `tools/codegen/generate.py --check` -> all generated files current

Two offline regression tests lock the behavior in: the NCAA leagues must send
`groups=50`, the pro leagues must not, and an explicit `groups=` wins.

## Summary by Sourcery

Ensure ESPN college basketball scoreboard requests use the Division I root group so crosswalks pull the full slate instead of a featured subset.

Bug Fixes:
- Fix mbb/wbb schedule crosswalks returning incomplete ESPN game sets by defaulting scoreboard requests to the Division I group.

Enhancements:
- Clarify espn_scoreboard_games documentation and behavior by describing the default NCAA group and allowing explicit overrides.

Tests:
- Add regression tests that NCAA leagues send the root group, pro leagues do not, and explicit groups parameters override the default.