### PR TITLE
fix(wbb,wnba): stop mangling & / - / () boundaries in Fox team-name title case

### DIFF
--- a/sportsdataverse/_fox_layout.py
+++ b/sportsdataverse/_fox_layout.py
@@ -189,9 +189,16 @@ def parse_standings(raw: Dict, team_id: Optional[Union[int, str]] = None) -> Lis
 
 
 def _title_case(name: str) -> str:
-    """Per-word title case that keeps apostrophes lowercase (``ST. JOHN'S`` ->
-    ``St. John's``), matching R ``stringr::str_to_title`` on team names."""
-    return " ".join(w.capitalize() for w in name.lower().split())
+    """Title case matching R ``stringr::str_to_title`` on team names.
+
+    ``str.title()`` capitalizes each *alphabetic run*, treating ``&``/``-``/
+    ``(``/``)`` as word boundaries the same way R's ICU-backed
+    ``str_to_title`` does (``A&T`` -> ``A&T``, ``(OH)`` -> ``(Oh)``,
+    ``MARYLAND-EASTERN`` -> ``Maryland-Eastern``) -- but it also
+    (re-)capitalizes the letter right after an apostrophe (``ST. JOHN'S`` ->
+    ``St. John'S``), which R does not. Undo just that one artifact.
+    """
+    return re.sub(r"(?<=[A-Za-z]')[A-Z]", lambda m: m.group(0).lower(), name.lower().title())
 
 
 def parse_teams(raw: Dict[str, Any]) -> List[Dict[str, Any]]:

--- a/tests/test_fox_wbb_wnba_offline.py
+++ b/tests/test_fox_wbb_wnba_offline.py
@@ -74,6 +74,24 @@ def test_parse_teams_title_case_keeps_apostrophes():
     assert fox_layout._title_case("ST. JOHN'S RED STORM") == "St. John's Red Storm"
 
 
+def test_parse_teams_title_case_matches_r_str_to_title_boundaries():
+    # &, -, ( and ) are word boundaries for R's stringr::str_to_title (ICU
+    # word-break rules) -- verified against the real Fox payload + the
+    # committed wehoop golden crosswalk (wbb_team_crosswalk_2026.parquet).
+    # A whitespace-only split + single capitalize() per token (the prior
+    # sdv-py implementation) mangled every one of these to A&t / (oh) /
+    # -eastern.
+    cases = {
+        "NORTH CAROLINA A&T AGGIES": "North Carolina A&T Aggies",
+        "MIAMI (OH) REDHAWKS": "Miami (Oh) Redhawks",
+        "MARYLAND-EASTERN SHORE HAWKS": "Maryland-Eastern Shore Hawks",
+        "WILLIAM & MARY TRIBE": "William & Mary Tribe",
+        "TEXAS A&M-CORPUS CHRISTI": "Texas A&M-Corpus Christi",
+    }
+    for raw, expected in cases.items():
+        assert fox_layout._title_case(raw) == expected
+
+
 def test_fox_wbb_teams_offline(monkeypatch):
     from sportsdataverse.wbb import fox_wbb_teams
 


### PR DESCRIPTION
sdv-py's own transform was the bug — not Fox, and not the R producer.

Fox returns team titles in ALL CAPS (`entityLink.title`, e.g. `"NORTH CAROLINA A&T AGGIES"`), so neither language passes them through verbatim; both title-case. `wehoop` (`R/fox_basketball.R:195`) uses ICU-backed `stringr::str_to_title(tolower(title))`, which treats `&`, `-`, `(`, `)` as word boundaries and an apostrophe as NOT a boundary.

`_fox_layout._title_case` split on whitespace only and ran `str.capitalize()` per token, so the first character after an internal `&` / `-` / `(` stayed lowercase:

| Fox raw | sdv-py (before) | R / golden |
|---|---|---|
| `NORTH CAROLINA A&T AGGIES` | `North Carolina A&t Aggies` | `North Carolina A&T Aggies` |
| `MIAMI (OH) REDHAWKS` | `Miami (oh) Redhawks` | `Miami (Oh) Redhawks` |
| `MARYLAND-EASTERN SHORE HAWKS` | `Maryland-eastern Shore Hawks` | `Maryland-Eastern Shore Hawks` |

This surfaced as 19 `fox_team_name` mismatches in the 2026-08-12 WBB team-crosswalk flip. Verified against real R 4.3.1 output and the committed golden `wbb_team_crosswalk_2026.parquet`.

Fixed generally — `lower().title()` reproduces the ICU boundary rule, with the one genuine divergence (`str.title()` also capitalizes after an apostrophe: `St. John'S`) corrected by a targeted regex. **No team-name special-casing**: if the rule is wrong it is wrong in general.

Also checked and NOT changed: the 27 `fox_section` differences are real conference realignment, not a parse artifact — 11 of 12 sampled teams match live Fox exactly, and the one that doesn't is Sacramento State's Big Sky → Big West move. The golden is simply older than live Fox.

Tests: `test_parse_teams_title_case_matches_r_str_to_title_boundaries` covers the `&` / `-` / `()` / apostrophe cases. 24 passed on this base; ruff + mypy clean.

## Summary by Sourcery

Align Fox team-name title casing with R stringr::str_to_title behavior, including correct handling of special-character word boundaries and apostrophes.

Enhancements:
- Update _title_case helper to use Python str.title with a regex correction so apostrophes remain lowercase, matching R ICU word-break rules for team names.

Tests:
- Add coverage to verify Fox team-name title casing matches R stringr::str_to_title boundaries for &, -, parentheses, and apostrophes.