### PR TITLE
feat(nba,wnba): repoint stats loaders at the Program V release assets

### DIFF
--- a/docs/docs/nba/index.md
+++ b/docs/docs/nba/index.md
@@ -11,7 +11,7 @@ sidebar_label: NBA
 | [ESPN core API (v2)](reference/core) | 82 | `https://sports.core.api.espn.com/v2/sports` |
 | [ESPN FPI API (fitt v3)](reference/fitt) | 1 | `https://site.web.api.espn.com/apis/fitt/v3/sports` |
 | [NBA Stats API (stats.nba.com)](reference/nba_stats) | 112 | `https://stats.nba.com` |
-| [Dataset loaders](reference/loaders) | 34 | sportsdataverse-data releases |
+| [Dataset loaders](reference/loaders) | 36 | sportsdataverse-data releases |
 | [Additional functions](reference/additional) | 132 | hand-written wrappers, loaders & helpers |
 
 ## Examples

--- a/docs/docs/nba/reference/loaders.md
+++ b/docs/docs/nba/reference/loaders.md
@@ -33,6 +33,8 @@ flowchart LR
 | `load_nba_stats_lineups_v3` | [nba_stats_lineups_v3](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_lineups_v3) | — |
 | `load_nba_stats_officials` | [nba_stats_officials](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_officials) | — |
 | `load_nba_stats_pbp` | [nba_stats_pbp](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_pbp) | — |
+| `load_nba_stats_possessions` | [nba_stats_possessions](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_possessions) | — |
+| `load_nba_stats_game_lineups` | [nba_stats_game_lineups](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_game_lineups) | — |
 | `load_nba_stats_pbp_v3` | [nba_stats_pbpv3](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_pbpv3) | — |
 | `load_nba_stats_player_boxscores` | [nba_stats_player_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_player_boxscores) | — |
 | `load_nba_stats_player_game_logs` | [nba_stats_player_game_logs](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_player_game_logs) | — |
@@ -630,42 +632,26 @@ load_nba_rosters(seasons=2025)
 
 ## `load_nba_stats_schedules`
 
-Release: [nba_stats_schedules](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_schedules) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_schedules/nba_stats_schedule_{season}.parquet`
+Release: [nba_stats_schedules](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_schedules) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_schedules/nba_schedule_{season + 1}.parquet`
 ### Returns
 
 | col_name | type | description |
 |---|---|---|
-| `season_id` | String | Unique season identifier. |
-| `team_id` | Int64 | Unique team identifier. |
-| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
-| `team_name` | String | Full team display name (e.g. 'Las Vegas Aces'). |
 | `game_id` | String | Unique game identifier. |
+| `season` | Int64 | Season year. |
+| `season_type` | String | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
 | `game_date` | String | Game date (YYYY-MM-DD). |
 | `matchup` | String | Matchup. |
-| `wl` | String | Wl. |
-| `min` | Int64 | Minutes played. |
-| `fgm` | Int64 | Field goals made. |
-| `fga` | Int64 | Field goal attempts. |
-| `fg_pct` | Float64 | Field goal percentage (0-1). |
-| `fg3m` | Int64 | Three-point field goals made. |
-| `fg3a` | Int64 | Three-point field goal attempts. |
-| `fg3_pct` | Float64 | Three-point field goal percentage (0-1). |
-| `ftm` | Int64 | Free throws made. |
-| `fta` | Int64 | Free throw attempts. |
-| `ft_pct` | Float64 | Free throw percentage (0-1). |
-| `oreb` | Int64 | Offensive rebounds. |
-| `dreb` | Int64 | Defensive rebounds. |
-| `reb` | Int64 | Rebounds per game. |
-| `ast` | Int64 | Assists. |
-| `stl` | Int64 | Steals. |
-| `blk` | Int64 | Blocks. |
-| `tov` | Int64 | Turnovers. |
-| `pf` | Int64 | Personal fouls. |
-| `pts` | Int64 | Points scored. |
-| `plus_minus` | Int64 | Plus/minus point differential while on court. |
-| `video_available` | Int64 | Video available. |
-| `season` | Int32 | Season year. |
-| `season_type` | String | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
+| `home_team_id` | Int64 | Unique identifier for the home team. |
+| `home_team_abbreviation` | String | Home team abbreviation; `team_detail = TRUE` only. |
+| `home_team_name` | String | Home team name. |
+| `home_pts` | Int64 |  |
+| `home_wl` | String |  |
+| `away_team_id` | Int64 | Unique identifier for the away team. |
+| `away_team_abbreviation` | String | Away team abbreviation; `team_detail = TRUE` only. |
+| `away_team_name` | String | Away team name. |
+| `away_pts` | Int64 |  |
+| `away_wl` | String |  |
 
 ```python
 load_nba_stats_schedules(seasons=2025)
@@ -955,11 +941,12 @@ load_nba_stats_officials(seasons=2025)
 
 ## `load_nba_stats_pbp`
 
-Release: [nba_stats_pbp](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_pbp) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_pbp/play_by_play_{season}.parquet`
+Release: [nba_stats_pbp](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_pbp) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_pbp/nba_play_by_play_{season + 1}.parquet`
 ### Returns
 
 | col_name | type | description |
 |---|---|---|
+| `order_index` | Int64 |  |
 | `action_number` | Int64 | Sequential action number within a game (V3 PBP). |
 | `clock` | String | Game clock value. |
 | `period` | Int64 | Period of the game (1-4 quarters; 5+ for OT). |
@@ -984,10 +971,106 @@ Release: [nba_stats_pbp](https://github.com/sportsdataverse/sportsdataverse-data
 | `shot_value` | Int64 | Point value of the shot (2 or 3). |
 | `action_id` | Int64 | Unique action identifier within a game (V3 PBP). |
 | `game_id` | String | Unique game identifier. |
-| `season` | Int32 | Season year. |
+| `seconds_remaining` | Float64 | Seconds remaining in the period. |
+| `event_type` | String | Event / play type code (V2 PBP). |
+| `is_made_shot` | Boolean |  |
+| `is_missed_shot` | Boolean |  |
+| `is_free_throw` | Boolean |  |
+| `is_rebound` | Boolean |  |
+| `is_turnover` | Boolean | `TRUE` if the play was a turnover. |
+| `is_foul` | Boolean |  |
+| `is_substitution` | Boolean |  |
+| `is_jump_ball` | Boolean |  |
+| `is_timeout` | Boolean |  |
+| `is_period` | Boolean |  |
+| `possession_number` | Int64 | Possession number. |
+| `off_player_1` | Int64 |  |
+| `off_player_2` | Int64 |  |
+| `off_player_3` | Int64 |  |
+| `off_player_4` | Int64 |  |
+| `off_player_5` | Int64 |  |
+| `def_player_1` | Int64 |  |
+| `def_player_2` | Int64 |  |
+| `def_player_3` | Int64 |  |
+| `def_player_4` | Int64 |  |
+| `def_player_5` | Int64 |  |
+| `season` | Int64 | Season year. |
 
 ```python
 load_nba_stats_pbp(seasons=2025)
+```
+
+## `load_nba_stats_possessions`
+
+Release: [nba_stats_possessions](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_possessions) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_possessions/nba_possessions_{season + 1}.parquet`
+### Returns
+
+| col_name | type | description |
+|---|---|---|
+| `game_id` | String | Unique game identifier. |
+| `period` | Int64 | Period of the game (1-4 quarters; 5+ for OT). |
+| `possession_number` | Int64 | Possession number. |
+| `offense_team_id` | Int64 | Unique identifier for offense team. |
+| `defense_team_id` | Int64 |  |
+| `start_order_index` | Int64 |  |
+| `end_order_index` | Int64 |  |
+| `start_seconds_remaining` | Float64 |  |
+| `end_seconds_remaining` | Float64 |  |
+| `points` | Int64 | Points scored. |
+| `is_second_chance` | Boolean |  |
+| `number_in_period` | Int64 |  |
+| `possession_start_type` | String |  |
+| `count_as_possession` | Boolean |  |
+| `fg2a` | Int64 |  |
+| `fg2m` | Int64 |  |
+| `fg3a` | Int64 | Three-point field goal attempts. |
+| `fg3m` | Int64 | Three-point field goals made. |
+| `fta` | Int64 | Free throw attempts. |
+| `ftm` | Int64 | Free throws made. |
+| `oreb` | Int64 | Offensive rebounds. |
+| `dreb` | Int64 | Defensive rebounds. |
+| `tov` | Int64 | Turnovers. |
+| `off_player_1` | Int64 |  |
+| `off_player_2` | Int64 |  |
+| `off_player_3` | Int64 |  |
+| `off_player_4` | Int64 |  |
+| `off_player_5` | Int64 |  |
+| `def_player_1` | Int64 |  |
+| `def_player_2` | Int64 |  |
+| `def_player_3` | Int64 |  |
+| `def_player_4` | Int64 |  |
+| `def_player_5` | Int64 |  |
+| `lineup_source` | String |  |
+| `season` | Int64 | Season year. |
+
+```python
+load_nba_stats_possessions(seasons=2025)
+```
+
+## `load_nba_stats_game_lineups`
+
+Release: [nba_stats_game_lineups](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_game_lineups) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_game_lineups/nba_lineups_{season + 1}.parquet`
+### Returns
+
+| col_name | type | description |
+|---|---|---|
+| `game_id` | String | Unique game identifier. |
+| `action_number` | Int64 | Sequential action number within a game (V3 PBP). |
+| `period` | Int64 | Period of the game (1-4 quarters; 5+ for OT). |
+| `home_player_1` | Int64 |  |
+| `home_player_2` | Int64 |  |
+| `home_player_3` | Int64 |  |
+| `home_player_4` | Int64 |  |
+| `home_player_5` | Int64 |  |
+| `away_player_1` | Int64 |  |
+| `away_player_2` | Int64 |  |
+| `away_player_3` | Int64 |  |
+| `away_player_4` | Int64 |  |
+| `away_player_5` | Int64 |  |
+| `season` | Int64 | Season year. |
+
+```python
+load_nba_stats_game_lineups(seasons=2025)
 ```
 
 ## `load_nba_stats_pbp_v3`

--- a/docs/docs/wnba/index.md
+++ b/docs/docs/wnba/index.md
@@ -11,7 +11,7 @@ sidebar_label: WNBA
 | [ESPN core API (v2)](reference/core) | 81 | `https://sports.core.api.espn.com/v2/sports` |
 | [ESPN FPI API (fitt v3)](reference/fitt) | 1 | `https://site.web.api.espn.com/apis/fitt/v3/sports` |
 | [WNBA Stats API (stats.wnba.com)](reference/wnba_stats) | 95 | `https://stats.wnba.com` |
-| [Dataset loaders](reference/loaders) | 28 | sportsdataverse-data releases |
+| [Dataset loaders](reference/loaders) | 30 | sportsdataverse-data releases |
 | [Additional functions](reference/additional) | 60 | hand-written wrappers, loaders & helpers |
 
 ## Examples

--- a/docs/docs/wnba/reference/loaders.md
+++ b/docs/docs/wnba/reference/loaders.md
@@ -36,6 +36,8 @@ flowchart LR
 | `load_wnba_stats_game_rosters` | [wnba_stats_game_rosters](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wnba_stats_game_rosters) | — |
 | `load_wnba_stats_officials` | [wnba_stats_officials](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wnba_stats_officials) | — |
 | `load_wnba_stats_pbp` | [wnba_stats_pbp](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wnba_stats_pbp) | — |
+| `load_wnba_stats_possessions` | [wnba_stats_possessions](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wnba_stats_possessions) | — |
+| `load_wnba_stats_game_lineups` | [wnba_stats_game_lineups](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wnba_stats_game_lineups) | — |
 | `load_wnba_stats_player_boxscores` | [wnba_stats_player_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wnba_stats_player_boxscores) | — |
 | `load_wnba_stats_player_game_logs` | [wnba_stats_player_game_logs](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wnba_stats_player_game_logs) | — |
 | `load_wnba_stats_rosters` | [wnba_stats_rosters](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wnba_stats_rosters) | — |
@@ -898,11 +900,12 @@ load_wnba_stats_officials(seasons=2026)
 
 ## `load_wnba_stats_pbp`
 
-Release: [wnba_stats_pbp](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wnba_stats_pbp) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/wnba_stats_pbp/play_by_play_{season}.parquet`
+Release: [wnba_stats_pbp](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wnba_stats_pbp) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/wnba_stats_pbp/wnba_play_by_play_{season}.parquet`
 ### Returns
 
 | col_name | type | description |
 |---|---|---|
+| `order_index` | Int64 |  |
 | `action_number` | Int64 | Sequential action number within a game (V3 PBP). |
 | `clock` | String | Game clock value. |
 | `period` | Int64 | Period of the game (1-4 quarters; 5+ for OT). |
@@ -927,10 +930,94 @@ Release: [wnba_stats_pbp](https://github.com/sportsdataverse/sportsdataverse-dat
 | `shot_value` | Int64 | Point value of the shot (2 or 3). |
 | `action_id` | Int64 | Unique action identifier within a game (V3 PBP). |
 | `game_id` | String | Unique game identifier. |
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `seconds_remaining` | Float64 | Seconds remaining in the period. |
+| `event_type` | String | Event / play type code (V2 PBP). |
+| `is_made_shot` | Boolean |  |
+| `is_missed_shot` | Boolean |  |
+| `is_free_throw` | Boolean |  |
+| `is_rebound` | Boolean |  |
+| `is_turnover` | Boolean | `TRUE` if the play was a turnover. |
+| `is_foul` | Boolean |  |
+| `is_substitution` | Boolean |  |
+| `is_jump_ball` | Boolean |  |
+| `is_timeout` | Boolean |  |
+| `is_period` | Boolean |  |
+| `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
 
 ```python
-load_wnba_stats_pbp(seasons=2026)
+load_wnba_stats_pbp(seasons=2025)
+```
+
+## `load_wnba_stats_possessions`
+
+Release: [wnba_stats_possessions](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wnba_stats_possessions) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/wnba_stats_possessions/wnba_possessions_{season}.parquet`
+### Returns
+
+| col_name | type | description |
+|---|---|---|
+| `game_id` | String | Unique game identifier. |
+| `period` | Int64 | Period of the game (1-4 quarters; 5+ for OT). |
+| `possession_number` | Int64 | Possession number. |
+| `offense_team_id` | Int64 | Unique identifier for offense team. |
+| `defense_team_id` | Int64 |  |
+| `start_order_index` | Int64 |  |
+| `end_order_index` | Int64 |  |
+| `start_seconds_remaining` | Float64 |  |
+| `end_seconds_remaining` | Float64 |  |
+| `points` | Int64 | Points scored. |
+| `is_second_chance` | Boolean |  |
+| `number_in_period` | Int64 |  |
+| `possession_start_type` | String |  |
+| `count_as_possession` | Boolean |  |
+| `fg2a` | Int64 |  |
+| `fg2m` | Int64 |  |
+| `fg3a` | Int64 | Three-point field goal attempts. |
+| `fg3m` | Int64 | Three-point field goals made. |
+| `fta` | Int64 | Free throw attempts. |
+| `ftm` | Int64 | Free throws made. |
+| `oreb` | Int64 | Offensive rebounds. |
+| `dreb` | Int64 | Defensive rebounds. |
+| `tov` | Int64 | Turnovers. |
+| `off_player_1` | Int64 |  |
+| `off_player_2` | Int64 |  |
+| `off_player_3` | Int64 |  |
+| `off_player_4` | Int64 |  |
+| `off_player_5` | Int64 |  |
+| `def_player_1` | Int64 |  |
+| `def_player_2` | Int64 |  |
+| `def_player_3` | Int64 |  |
+| `def_player_4` | Int64 |  |
+| `def_player_5` | Int64 |  |
+| `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
+
+```python
+load_wnba_stats_possessions(seasons=2025)
+```
+
+## `load_wnba_stats_game_lineups`
+
+Release: [wnba_stats_game_lineups](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wnba_stats_game_lineups) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/wnba_stats_game_lineups/wnba_lineups_{season}.parquet`
+### Returns
+
+| col_name | type | description |
+|---|---|---|
+| `game_id` | String | Unique game identifier. |
+| `action_number` | Int64 | Sequential action number within a game (V3 PBP). |
+| `period` | Int64 | Period of the game (1-4 quarters; 5+ for OT). |
+| `home_player_1` | Int64 |  |
+| `home_player_2` | Int64 |  |
+| `home_player_3` | Int64 |  |
+| `home_player_4` | Int64 |  |
+| `home_player_5` | Int64 |  |
+| `away_player_1` | Int64 |  |
+| `away_player_2` | Int64 |  |
+| `away_player_3` | Int64 |  |
+| `away_player_4` | Int64 |  |
+| `away_player_5` | Int64 |  |
+| `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
+
+```python
+load_wnba_stats_game_lineups(seasons=2025)
 ```
 
 ## `load_wnba_stats_player_boxscores`
@@ -1058,46 +1145,26 @@ load_wnba_stats_rosters(seasons=2026)
 
 ## `load_wnba_stats_schedules`
 
-Release: [wnba_stats_schedules](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wnba_stats_schedules) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/wnba_stats_schedules/wnba_stats_schedule_{season}.parquet`
+Release: [wnba_stats_schedules](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wnba_stats_schedules) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/wnba_stats_schedules/wnba_schedule_{season}.parquet`
 ### Returns
 
 | col_name | type | description |
 |---|---|---|
-| `season_id` | String | Unique season identifier. |
-| `team_id` | Int64 | Unique team identifier. |
-| `team_abbreviation` | String | Short team abbreviation (e.g. 'LAS'). |
-| `team_name` | String | Full team display name (e.g. 'Las Vegas Aces'). |
 | `game_id` | String | Unique game identifier. |
+| `season` | Int64 | Season identifier (4-digit year or 'YYYY-YY' string). |
+| `season_type` | String | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
 | `game_date` | String | Game date (YYYY-MM-DD). |
 | `matchup` | String | Matchup. |
-| `wl` | String | Wl. |
-| `min` | Int64 | Minutes played. |
-| `fgm` | Int64 | Field goals made. |
-| `fga` | Int64 | Field goal attempts. |
-| `fg_pct` | Float64 | Field goal percentage (0-1). |
-| `fg3m` | Int64 | Three-point field goals made. |
-| `fg3a` | Int64 | Three-point field goal attempts. |
-| `fg3_pct` | Float64 | Three-point field goal percentage (0-1). |
-| `ftm` | Int64 | Free throws made. |
-| `fta` | Int64 | Free throw attempts. |
-| `ft_pct` | Float64 | Free throw percentage (0-1). |
-| `oreb` | Int64 | Offensive rebounds. |
-| `dreb` | Int64 | Defensive rebounds. |
-| `reb` | Int64 | Total rebounds. |
-| `ast` | Int64 | Assists. |
-| `stl` | Int64 | Steals. |
-| `blk` | Int64 | Blocks. |
-| `tov` | Int64 | Turnovers. |
-| `pf` | Int64 | Personal fouls. |
-| `pts` | Int64 | Points scored. |
-| `plus_minus` | Int64 | Plus/minus point differential while on court. |
-| `video_available` | Int64 | Video available. |
-| `season` | Int32 | Season identifier (4-digit year or 'YYYY-YY' string). |
-| `season_type` | String | Season type (1=pre-season, 2=regular season, 3=postseason, 4=off-season for ESPN; or string label for WNBA Stats). |
-| `player_id` | Int64 | Unique player identifier. |
-| `player_name` | String | Player name. |
-| `fantasy_pts` | Float64 |  |
-| `measure_type` | String |  |
+| `home_team_id` | Int64 | Unique identifier for the home team. |
+| `home_team_abbreviation` | String | Home team abbreviation; `team_detail = TRUE` only. |
+| `home_team_name` | String | Home team name. |
+| `home_pts` | Int64 |  |
+| `home_wl` | String |  |
+| `away_team_id` | Int64 | Unique identifier for the away team. |
+| `away_team_abbreviation` | String | Away team abbreviation; `team_detail = TRUE` only. |
+| `away_team_name` | String | Away team name. |
+| `away_pts` | Int64 |  |
+| `away_wl` | String |  |
 
 ```python
 load_wnba_stats_schedules(seasons=2025)

--- a/sportsdataverse/nba/nba_loaders.py
+++ b/sportsdataverse/nba/nba_loaders.py
@@ -34,6 +34,8 @@ __all__ = [
     "load_nba_stats_lineups_v3",
     "load_nba_stats_officials",
     "load_nba_stats_pbp",
+    "load_nba_stats_possessions",
+    "load_nba_stats_game_lineups",
     "load_nba_stats_pbp_v3",
     "load_nba_stats_player_boxscores",
     "load_nba_stats_player_game_logs",
@@ -1010,45 +1012,32 @@ def load_nba_stats_schedules(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
+            Pass the season's START year (e.g. ``1996`` for the 1996-97
+            season); the published asset is keyed by the END year and the
+            loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
         A polars (or pandas) DataFrame; seasons with no published asset are
         skipped with a warning rather than raising (404-safe).
 
-        |col_name          |type    |
-        |:-----------------|:-------|
-        |season_id         |String  |
-        |team_id           |Int64   |
-        |team_abbreviation |String  |
-        |team_name         |String  |
-        |game_id           |String  |
-        |game_date         |String  |
-        |matchup           |String  |
-        |wl                |String  |
-        |min               |Int64   |
-        |fgm               |Int64   |
-        |fga               |Int64   |
-        |fg_pct            |Float64 |
-        |fg3m              |Int64   |
-        |fg3a              |Int64   |
-        |fg3_pct           |Float64 |
-        |ftm               |Int64   |
-        |fta               |Int64   |
-        |ft_pct            |Float64 |
-        |oreb              |Int64   |
-        |dreb              |Int64   |
-        |reb               |Int64   |
-        |ast               |Int64   |
-        |stl               |Int64   |
-        |blk               |Int64   |
-        |tov               |Int64   |
-        |pf                |Int64   |
-        |pts               |Int64   |
-        |plus_minus        |Int64   |
-        |video_available   |Int64   |
-        |season            |Int32   |
-        |season_type       |String  |
+        |col_name               |type   |
+        |:----------------------|:------|
+        |game_id                |String |
+        |season                 |Int64  |
+        |season_type            |String |
+        |game_date              |String |
+        |matchup                |String |
+        |home_team_id           |Int64  |
+        |home_team_abbreviation |String |
+        |home_team_name         |String |
+        |home_pts               |Int64  |
+        |home_wl                |String |
+        |away_team_id           |Int64  |
+        |away_team_abbreviation |String |
+        |away_team_name         |String |
+        |away_pts               |Int64  |
+        |away_wl                |String |
 
     Raises:
         SeasonNotFoundError: if a requested season is below 1996.
@@ -1063,7 +1052,7 @@ def load_nba_stats_schedules(seasons, return_as_pandas: bool = False):
         if int(season) < 1996:
             raise SeasonNotFoundError("season cannot be less than 1996")
         df = _read_release_parquet(
-            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_schedules/nba_stats_schedule_{season}.parquet"
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_schedules/nba_schedule_{season + 1}.parquet"
         )
         if df is None:
             missing.append(season)
@@ -1521,39 +1510,66 @@ def load_nba_stats_pbp(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
+            Pass the season's START year (e.g. ``1996`` for the 1996-97
+            season); the published asset is keyed by the END year and the
+            loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
         A polars (or pandas) DataFrame; seasons with no published asset are
         skipped with a warning rather than raising (404-safe).
 
-        |col_name        |type   |
-        |:---------------|:------|
-        |action_number   |Int64  |
-        |clock           |String |
-        |period          |Int64  |
-        |team_id         |Int64  |
-        |team_tricode    |String |
-        |person_id       |Int64  |
-        |player_name     |String |
-        |player_name_i   |String |
-        |x_legacy        |Int64  |
-        |y_legacy        |Int64  |
-        |shot_distance   |Int64  |
-        |shot_result     |String |
-        |is_field_goal   |Int64  |
-        |score_home      |String |
-        |score_away      |String |
-        |points_total    |Int64  |
-        |location        |String |
-        |description     |String |
-        |action_type     |String |
-        |sub_type        |String |
-        |video_available |Int64  |
-        |shot_value      |Int64  |
-        |action_id       |Int64  |
-        |game_id         |String |
-        |season          |Int32  |
+        |col_name          |type    |
+        |:-----------------|:-------|
+        |order_index       |Int64   |
+        |action_number     |Int64   |
+        |clock             |String  |
+        |period            |Int64   |
+        |team_id           |Int64   |
+        |team_tricode      |String  |
+        |person_id         |Int64   |
+        |player_name       |String  |
+        |player_name_i     |String  |
+        |x_legacy          |Int64   |
+        |y_legacy          |Int64   |
+        |shot_distance     |Int64   |
+        |shot_result       |String  |
+        |is_field_goal     |Int64   |
+        |score_home        |String  |
+        |score_away        |String  |
+        |points_total      |Int64   |
+        |location          |String  |
+        |description       |String  |
+        |action_type       |String  |
+        |sub_type          |String  |
+        |video_available   |Int64   |
+        |shot_value        |Int64   |
+        |action_id         |Int64   |
+        |game_id           |String  |
+        |seconds_remaining |Float64 |
+        |event_type        |String  |
+        |is_made_shot      |Boolean |
+        |is_missed_shot    |Boolean |
+        |is_free_throw     |Boolean |
+        |is_rebound        |Boolean |
+        |is_turnover       |Boolean |
+        |is_foul           |Boolean |
+        |is_substitution   |Boolean |
+        |is_jump_ball      |Boolean |
+        |is_timeout        |Boolean |
+        |is_period         |Boolean |
+        |possession_number |Int64   |
+        |off_player_1      |Int64   |
+        |off_player_2      |Int64   |
+        |off_player_3      |Int64   |
+        |off_player_4      |Int64   |
+        |off_player_5      |Int64   |
+        |def_player_1      |Int64   |
+        |def_player_2      |Int64   |
+        |def_player_3      |Int64   |
+        |def_player_4      |Int64   |
+        |def_player_5      |Int64   |
+        |season            |Int64   |
 
     Raises:
         SeasonNotFoundError: if a requested season is below 1996.
@@ -1568,7 +1584,7 @@ def load_nba_stats_pbp(seasons, return_as_pandas: bool = False):
         if int(season) < 1996:
             raise SeasonNotFoundError("season cannot be less than 1996")
         df = _read_release_parquet(
-            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_pbp/play_by_play_{season}.parquet"
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_pbp/nba_play_by_play_{season + 1}.parquet"
         )
         if df is None:
             missing.append(season)
@@ -1576,6 +1592,147 @@ def load_nba_stats_pbp(seasons, return_as_pandas: bool = False):
         frames.append(df)
     if missing:
         cli_warn("load_nba_stats_pbp: no data for season(s) {missing} (skipped)".format(missing=missing))
+    # diagonal: per-season release schemas can drift (columns added/dropped
+    # over the years) -- union columns, null-fill gaps.
+    out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
+
+
+def load_nba_stats_possessions(seasons, return_as_pandas: bool = False):
+    """Load nba_stats_possessions (sportsdataverse-data release).
+
+    Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_possessions
+
+    Args:
+        seasons: an int or iterable of seasons (>= 1996).
+            Pass the season's START year (e.g. ``1996`` for the 1996-97
+            season); the published asset is keyed by the END year and the
+            loader translates internally.
+        return_as_pandas: return a pandas DataFrame instead of polars.
+
+    Returns:
+        A polars (or pandas) DataFrame; seasons with no published asset are
+        skipped with a warning rather than raising (404-safe).
+
+        |col_name                |type    |
+        |:-----------------------|:-------|
+        |game_id                 |String  |
+        |period                  |Int64   |
+        |possession_number       |Int64   |
+        |offense_team_id         |Int64   |
+        |defense_team_id         |Int64   |
+        |start_order_index       |Int64   |
+        |end_order_index         |Int64   |
+        |start_seconds_remaining |Float64 |
+        |end_seconds_remaining   |Float64 |
+        |points                  |Int64   |
+        |is_second_chance        |Boolean |
+        |number_in_period        |Int64   |
+        |possession_start_type   |String  |
+        |count_as_possession     |Boolean |
+        |fg2a                    |Int64   |
+        |fg2m                    |Int64   |
+        |fg3a                    |Int64   |
+        |fg3m                    |Int64   |
+        |fta                     |Int64   |
+        |ftm                     |Int64   |
+        |oreb                    |Int64   |
+        |dreb                    |Int64   |
+        |tov                     |Int64   |
+        |off_player_1            |Int64   |
+        |off_player_2            |Int64   |
+        |off_player_3            |Int64   |
+        |off_player_4            |Int64   |
+        |off_player_5            |Int64   |
+        |def_player_1            |Int64   |
+        |def_player_2            |Int64   |
+        |def_player_3            |Int64   |
+        |def_player_4            |Int64   |
+        |def_player_5            |Int64   |
+        |lineup_source           |String  |
+        |season                  |Int64   |
+
+    Raises:
+        SeasonNotFoundError: if a requested season is below 1996.
+
+    Example:
+        Quick start::
+
+            load_nba_stats_possessions(seasons=2025)
+    """
+    frames, missing = [], []
+    for season in _as_season_list(seasons):
+        if int(season) < 1996:
+            raise SeasonNotFoundError("season cannot be less than 1996")
+        df = _read_release_parquet(
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_possessions/nba_possessions_{season + 1}.parquet"
+        )
+        if df is None:
+            missing.append(season)
+            continue
+        frames.append(df)
+    if missing:
+        cli_warn("load_nba_stats_possessions: no data for season(s) {missing} (skipped)".format(missing=missing))
+    # diagonal: per-season release schemas can drift (columns added/dropped
+    # over the years) -- union columns, null-fill gaps.
+    out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
+
+
+def load_nba_stats_game_lineups(seasons, return_as_pandas: bool = False):
+    """Load nba_stats_game_lineups (sportsdataverse-data release).
+
+    Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_game_lineups
+
+    Args:
+        seasons: an int or iterable of seasons (>= 1996).
+            Pass the season's START year (e.g. ``1996`` for the 1996-97
+            season); the published asset is keyed by the END year and the
+            loader translates internally.
+        return_as_pandas: return a pandas DataFrame instead of polars.
+
+    Returns:
+        A polars (or pandas) DataFrame; seasons with no published asset are
+        skipped with a warning rather than raising (404-safe).
+
+        |col_name      |type   |
+        |:-------------|:------|
+        |game_id       |String |
+        |action_number |Int64  |
+        |period        |Int64  |
+        |home_player_1 |Int64  |
+        |home_player_2 |Int64  |
+        |home_player_3 |Int64  |
+        |home_player_4 |Int64  |
+        |home_player_5 |Int64  |
+        |away_player_1 |Int64  |
+        |away_player_2 |Int64  |
+        |away_player_3 |Int64  |
+        |away_player_4 |Int64  |
+        |away_player_5 |Int64  |
+        |season        |Int64  |
+
+    Raises:
+        SeasonNotFoundError: if a requested season is below 1996.
+
+    Example:
+        Quick start::
+
+            load_nba_stats_game_lineups(seasons=2025)
+    """
+    frames, missing = [], []
+    for season in _as_season_list(seasons):
+        if int(season) < 1996:
+            raise SeasonNotFoundError("season cannot be less than 1996")
+        df = _read_release_parquet(
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_game_lineups/nba_lineups_{season + 1}.parquet"
+        )
+        if df is None:
+            missing.append(season)
+            continue
+        frames.append(df)
+    if missing:
+        cli_warn("load_nba_stats_game_lineups: no data for season(s) {missing} (skipped)".format(missing=missing))
     # diagonal: per-season release schemas can drift (columns added/dropped
     # over the years) -- union columns, null-fill gaps.
     out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()

--- a/sportsdataverse/parsed/nba.py
+++ b/sportsdataverse/parsed/nba.py
@@ -231,6 +231,7 @@ from sportsdataverse.nba import load_nba_schedule_crosswalk as load_nba_schedule
 from sportsdataverse.nba import load_nba_shots as load_nba_shots  # noqa: F401
 from sportsdataverse.nba import load_nba_standings as load_nba_standings  # noqa: F401
 from sportsdataverse.nba import load_nba_stats_coaches as load_nba_stats_coaches  # noqa: F401
+from sportsdataverse.nba import load_nba_stats_game_lineups as load_nba_stats_game_lineups  # noqa: F401
 from sportsdataverse.nba import load_nba_stats_game_rosters as load_nba_stats_game_rosters  # noqa: F401
 from sportsdataverse.nba import load_nba_stats_lineups as load_nba_stats_lineups  # noqa: F401
 from sportsdataverse.nba import load_nba_stats_lineups_v3 as load_nba_stats_lineups_v3  # noqa: F401
@@ -240,6 +241,7 @@ from sportsdataverse.nba import load_nba_stats_pbp_v3 as load_nba_stats_pbp_v3  
 from sportsdataverse.nba import load_nba_stats_player_boxscores as load_nba_stats_player_boxscores  # noqa: F401
 from sportsdataverse.nba import load_nba_stats_player_game_logs as load_nba_stats_player_game_logs  # noqa: F401
 from sportsdataverse.nba import load_nba_stats_player_season_stats as load_nba_stats_player_season_stats  # noqa: F401
+from sportsdataverse.nba import load_nba_stats_possessions as load_nba_stats_possessions  # noqa: F401
 from sportsdataverse.nba import load_nba_stats_possessions_v3 as load_nba_stats_possessions_v3  # noqa: F401
 from sportsdataverse.nba import load_nba_stats_rosters as load_nba_stats_rosters  # noqa: F401
 from sportsdataverse.nba import load_nba_stats_schedules as load_nba_stats_schedules  # noqa: F401
@@ -538,6 +540,7 @@ __all__ = [
     "load_nba_shots",
     "load_nba_standings",
     "load_nba_stats_coaches",
+    "load_nba_stats_game_lineups",
     "load_nba_stats_game_rosters",
     "load_nba_stats_lineups",
     "load_nba_stats_lineups_v3",
@@ -547,6 +550,7 @@ __all__ = [
     "load_nba_stats_player_boxscores",
     "load_nba_stats_player_game_logs",
     "load_nba_stats_player_season_stats",
+    "load_nba_stats_possessions",
     "load_nba_stats_possessions_v3",
     "load_nba_stats_rosters",
     "load_nba_stats_schedules",

--- a/sportsdataverse/parsed/wnba.py
+++ b/sportsdataverse/parsed/wnba.py
@@ -189,6 +189,7 @@ from sportsdataverse.wnba import load_wnba_shots as load_wnba_shots  # noqa: F40
 from sportsdataverse.wnba import load_wnba_standings as load_wnba_standings  # noqa: F401
 from sportsdataverse.wnba import load_wnba_stats_coaches as load_wnba_stats_coaches  # noqa: F401
 from sportsdataverse.wnba import load_wnba_stats_draft as load_wnba_stats_draft  # noqa: F401
+from sportsdataverse.wnba import load_wnba_stats_game_lineups as load_wnba_stats_game_lineups  # noqa: F401
 from sportsdataverse.wnba import load_wnba_stats_game_rosters as load_wnba_stats_game_rosters  # noqa: F401
 from sportsdataverse.wnba import load_wnba_stats_lineups as load_wnba_stats_lineups  # noqa: F401
 from sportsdataverse.wnba import load_wnba_stats_officials as load_wnba_stats_officials  # noqa: F401
@@ -196,6 +197,7 @@ from sportsdataverse.wnba import load_wnba_stats_pbp as load_wnba_stats_pbp  # n
 from sportsdataverse.wnba import load_wnba_stats_player_boxscores as load_wnba_stats_player_boxscores  # noqa: F401
 from sportsdataverse.wnba import load_wnba_stats_player_game_logs as load_wnba_stats_player_game_logs  # noqa: F401
 from sportsdataverse.wnba import load_wnba_stats_player_season_stats as load_wnba_stats_player_season_stats  # noqa: F401
+from sportsdataverse.wnba import load_wnba_stats_possessions as load_wnba_stats_possessions  # noqa: F401
 from sportsdataverse.wnba import load_wnba_stats_rosters as load_wnba_stats_rosters  # noqa: F401
 from sportsdataverse.wnba import load_wnba_stats_schedules as load_wnba_stats_schedules  # noqa: F401
 from sportsdataverse.wnba import load_wnba_stats_shots as load_wnba_stats_shots  # noqa: F401
@@ -416,6 +418,7 @@ __all__ = [
     "load_wnba_standings",
     "load_wnba_stats_coaches",
     "load_wnba_stats_draft",
+    "load_wnba_stats_game_lineups",
     "load_wnba_stats_game_rosters",
     "load_wnba_stats_lineups",
     "load_wnba_stats_officials",
@@ -423,6 +426,7 @@ __all__ = [
     "load_wnba_stats_player_boxscores",
     "load_wnba_stats_player_game_logs",
     "load_wnba_stats_player_season_stats",
+    "load_wnba_stats_possessions",
     "load_wnba_stats_rosters",
     "load_wnba_stats_schedules",
     "load_wnba_stats_shots",

--- a/sportsdataverse/wnba/wnba_loaders.py
+++ b/sportsdataverse/wnba/wnba_loaders.py
@@ -37,6 +37,8 @@ __all__ = [
     "load_wnba_stats_game_rosters",
     "load_wnba_stats_officials",
     "load_wnba_stats_pbp",
+    "load_wnba_stats_possessions",
+    "load_wnba_stats_game_lineups",
     "load_wnba_stats_player_boxscores",
     "load_wnba_stats_player_game_logs",
     "load_wnba_stats_rosters",
@@ -1556,55 +1558,68 @@ def load_wnba_stats_pbp(seasons, return_as_pandas: bool = False):
     Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wnba_stats_pbp
 
     Args:
-        seasons: an int or iterable of seasons (>= 2026).
+        seasons: an int or iterable of seasons (>= 1997).
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
         A polars (or pandas) DataFrame; seasons with no published asset are
         skipped with a warning rather than raising (404-safe).
 
-        |col_name        |type   |
-        |:---------------|:------|
-        |action_number   |Int64  |
-        |clock           |String |
-        |period          |Int64  |
-        |team_id         |Int64  |
-        |team_tricode    |String |
-        |person_id       |Int64  |
-        |player_name     |String |
-        |player_name_i   |String |
-        |x_legacy        |Int64  |
-        |y_legacy        |Int64  |
-        |shot_distance   |Int64  |
-        |shot_result     |String |
-        |is_field_goal   |Int64  |
-        |score_home      |String |
-        |score_away      |String |
-        |points_total    |Int64  |
-        |location        |String |
-        |description     |String |
-        |action_type     |String |
-        |sub_type        |String |
-        |video_available |Int64  |
-        |shot_value      |Int64  |
-        |action_id       |Int64  |
-        |game_id         |String |
-        |season          |Int32  |
+        |col_name          |type    |
+        |:-----------------|:-------|
+        |order_index       |Int64   |
+        |action_number     |Int64   |
+        |clock             |String  |
+        |period            |Int64   |
+        |team_id           |Int64   |
+        |team_tricode      |String  |
+        |person_id         |Int64   |
+        |player_name       |String  |
+        |player_name_i     |String  |
+        |x_legacy          |Int64   |
+        |y_legacy          |Int64   |
+        |shot_distance     |Int64   |
+        |shot_result       |String  |
+        |is_field_goal     |Int64   |
+        |score_home        |String  |
+        |score_away        |String  |
+        |points_total      |Int64   |
+        |location          |String  |
+        |description       |String  |
+        |action_type       |String  |
+        |sub_type          |String  |
+        |video_available   |Int64   |
+        |shot_value        |Int64   |
+        |action_id         |Int64   |
+        |game_id           |String  |
+        |seconds_remaining |Float64 |
+        |event_type        |String  |
+        |is_made_shot      |Boolean |
+        |is_missed_shot    |Boolean |
+        |is_free_throw     |Boolean |
+        |is_rebound        |Boolean |
+        |is_turnover       |Boolean |
+        |is_foul           |Boolean |
+        |is_substitution   |Boolean |
+        |is_jump_ball      |Boolean |
+        |is_timeout        |Boolean |
+        |is_period         |Boolean |
+        |season            |Int64   |
 
     Raises:
-        SeasonNotFoundError: if a requested season is below 2026.
+        SeasonNotFoundError: if a requested season is below 1997.
 
     Example:
         Quick start::
 
-            load_wnba_stats_pbp(seasons=2026)
+            load_wnba_stats_pbp(seasons=2025)
     """
     frames, missing = [], []
     for season in _as_season_list(seasons):
-        if int(season) < 2026:
-            raise SeasonNotFoundError("season cannot be less than 2026")
+        if int(season) < 1997:
+            raise SeasonNotFoundError("season cannot be less than 1997")
         df = _read_release_parquet(
-            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/wnba_stats_pbp/play_by_play_{season}.parquet"
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/wnba_stats_pbp/wnba_play_by_play_{season}.parquet"
         )
         if df is None:
             missing.append(season)
@@ -1612,6 +1627,140 @@ def load_wnba_stats_pbp(seasons, return_as_pandas: bool = False):
         frames.append(df)
     if missing:
         cli_warn("load_wnba_stats_pbp: no data for season(s) {missing} (skipped)".format(missing=missing))
+    # diagonal: per-season release schemas can drift (columns added/dropped
+    # over the years) -- union columns, null-fill gaps.
+    out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
+
+
+def load_wnba_stats_possessions(seasons, return_as_pandas: bool = False):
+    """Load wnba_stats_possessions (sportsdataverse-data release).
+
+    Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wnba_stats_possessions
+
+    Args:
+        seasons: an int or iterable of seasons (>= 1997).
+        return_as_pandas: return a pandas DataFrame instead of polars.
+
+    Returns:
+        A polars (or pandas) DataFrame; seasons with no published asset are
+        skipped with a warning rather than raising (404-safe).
+
+        |col_name                |type    |
+        |:-----------------------|:-------|
+        |game_id                 |String  |
+        |period                  |Int64   |
+        |possession_number       |Int64   |
+        |offense_team_id         |Int64   |
+        |defense_team_id         |Int64   |
+        |start_order_index       |Int64   |
+        |end_order_index         |Int64   |
+        |start_seconds_remaining |Float64 |
+        |end_seconds_remaining   |Float64 |
+        |points                  |Int64   |
+        |is_second_chance        |Boolean |
+        |number_in_period        |Int64   |
+        |possession_start_type   |String  |
+        |count_as_possession     |Boolean |
+        |fg2a                    |Int64   |
+        |fg2m                    |Int64   |
+        |fg3a                    |Int64   |
+        |fg3m                    |Int64   |
+        |fta                     |Int64   |
+        |ftm                     |Int64   |
+        |oreb                    |Int64   |
+        |dreb                    |Int64   |
+        |tov                     |Int64   |
+        |off_player_1            |Int64   |
+        |off_player_2            |Int64   |
+        |off_player_3            |Int64   |
+        |off_player_4            |Int64   |
+        |off_player_5            |Int64   |
+        |def_player_1            |Int64   |
+        |def_player_2            |Int64   |
+        |def_player_3            |Int64   |
+        |def_player_4            |Int64   |
+        |def_player_5            |Int64   |
+        |season                  |Int64   |
+
+    Raises:
+        SeasonNotFoundError: if a requested season is below 1997.
+
+    Example:
+        Quick start::
+
+            load_wnba_stats_possessions(seasons=2025)
+    """
+    frames, missing = [], []
+    for season in _as_season_list(seasons):
+        if int(season) < 1997:
+            raise SeasonNotFoundError("season cannot be less than 1997")
+        df = _read_release_parquet(
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/wnba_stats_possessions/wnba_possessions_{season}.parquet"
+        )
+        if df is None:
+            missing.append(season)
+            continue
+        frames.append(df)
+    if missing:
+        cli_warn("load_wnba_stats_possessions: no data for season(s) {missing} (skipped)".format(missing=missing))
+    # diagonal: per-season release schemas can drift (columns added/dropped
+    # over the years) -- union columns, null-fill gaps.
+    out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+    return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
+
+
+def load_wnba_stats_game_lineups(seasons, return_as_pandas: bool = False):
+    """Load wnba_stats_game_lineups (sportsdataverse-data release).
+
+    Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wnba_stats_game_lineups
+
+    Args:
+        seasons: an int or iterable of seasons (>= 1997).
+        return_as_pandas: return a pandas DataFrame instead of polars.
+
+    Returns:
+        A polars (or pandas) DataFrame; seasons with no published asset are
+        skipped with a warning rather than raising (404-safe).
+
+        |col_name      |type   |
+        |:-------------|:------|
+        |game_id       |String |
+        |action_number |Int64  |
+        |period        |Int64  |
+        |home_player_1 |Int64  |
+        |home_player_2 |Int64  |
+        |home_player_3 |Int64  |
+        |home_player_4 |Int64  |
+        |home_player_5 |Int64  |
+        |away_player_1 |Int64  |
+        |away_player_2 |Int64  |
+        |away_player_3 |Int64  |
+        |away_player_4 |Int64  |
+        |away_player_5 |Int64  |
+        |season        |Int64  |
+
+    Raises:
+        SeasonNotFoundError: if a requested season is below 1997.
+
+    Example:
+        Quick start::
+
+            load_wnba_stats_game_lineups(seasons=2025)
+    """
+    frames, missing = [], []
+    for season in _as_season_list(seasons):
+        if int(season) < 1997:
+            raise SeasonNotFoundError("season cannot be less than 1997")
+        df = _read_release_parquet(
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/wnba_stats_game_lineups/wnba_lineups_{season}.parquet"
+        )
+        if df is None:
+            missing.append(season)
+            continue
+        frames.append(df)
+    if missing:
+        cli_warn("load_wnba_stats_game_lineups: no data for season(s) {missing} (skipped)".format(missing=missing))
     # diagonal: per-season release schemas can drift (columns added/dropped
     # over the years) -- union columns, null-fill gaps.
     out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
@@ -1840,53 +1989,33 @@ def load_wnba_stats_schedules(seasons, return_as_pandas: bool = False):
     Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/wnba_stats_schedules
 
     Args:
-        seasons: an int or iterable of seasons (>= 2025).
+        seasons: an int or iterable of seasons (>= 1997).
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
         A polars (or pandas) DataFrame; seasons with no published asset are
         skipped with a warning rather than raising (404-safe).
 
-        |col_name          |type    |
-        |:-----------------|:-------|
-        |season_id         |String  |
-        |team_id           |Int64   |
-        |team_abbreviation |String  |
-        |team_name         |String  |
-        |game_id           |String  |
-        |game_date         |String  |
-        |matchup           |String  |
-        |wl                |String  |
-        |min               |Int64   |
-        |fgm               |Int64   |
-        |fga               |Int64   |
-        |fg_pct            |Float64 |
-        |fg3m              |Int64   |
-        |fg3a              |Int64   |
-        |fg3_pct           |Float64 |
-        |ftm               |Int64   |
-        |fta               |Int64   |
-        |ft_pct            |Float64 |
-        |oreb              |Int64   |
-        |dreb              |Int64   |
-        |reb               |Int64   |
-        |ast               |Int64   |
-        |stl               |Int64   |
-        |blk               |Int64   |
-        |tov               |Int64   |
-        |pf                |Int64   |
-        |pts               |Int64   |
-        |plus_minus        |Int64   |
-        |video_available   |Int64   |
-        |season            |Int32   |
-        |season_type       |String  |
-        |player_id         |Int64   |
-        |player_name       |String  |
-        |fantasy_pts       |Float64 |
-        |measure_type      |String  |
+        |col_name               |type   |
+        |:----------------------|:------|
+        |game_id                |String |
+        |season                 |Int64  |
+        |season_type            |String |
+        |game_date              |String |
+        |matchup                |String |
+        |home_team_id           |Int64  |
+        |home_team_abbreviation |String |
+        |home_team_name         |String |
+        |home_pts               |Int64  |
+        |home_wl                |String |
+        |away_team_id           |Int64  |
+        |away_team_abbreviation |String |
+        |away_team_name         |String |
+        |away_pts               |Int64  |
+        |away_wl                |String |
 
     Raises:
-        SeasonNotFoundError: if a requested season is below 2025.
+        SeasonNotFoundError: if a requested season is below 1997.
 
     Example:
         Quick start::
@@ -1895,10 +2024,10 @@ def load_wnba_stats_schedules(seasons, return_as_pandas: bool = False):
     """
     frames, missing = [], []
     for season in _as_season_list(seasons):
-        if int(season) < 2025:
-            raise SeasonNotFoundError("season cannot be less than 2025")
+        if int(season) < 1997:
+            raise SeasonNotFoundError("season cannot be less than 1997")
         df = _read_release_parquet(
-            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/wnba_stats_schedules/wnba_stats_schedule_{season}.parquet"
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/wnba_stats_schedules/wnba_schedule_{season}.parquet"
         )
         if df is None:
             missing.append(season)

--- a/tests/codegen/test_loader_season_convention.py
+++ b/tests/codegen/test_loader_season_convention.py
@@ -1,0 +1,85 @@
+"""Season-identity regression for the NBA/WNBA stats loaders (offline).
+
+The Program V release assets are keyed by the season's END year while the public
+``seasons`` argument stayed the START year, so the loaders carry a ``{season + 1}``
+token. An off-by-one there silently mislabels every season -- a row-count or
+non-empty assertion would not notice. These tests pin the exact asset year each
+public season resolves to.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+from codegen import spec  # noqa: E402
+
+REL = ROOT / "tools" / "codegen" / "endpoints" / "releases.yaml"
+
+# (loader, module, public season, asset basename it MUST resolve to).
+# NBA: start year -> end-year asset (+1). WNBA seasons are single-calendar-year,
+# so start == end and the asset year must equal the argument exactly.
+CASES = [
+    ("load_nba_stats_schedules", "nba", 1996, "nba_schedule_1997.parquet"),
+    ("load_nba_stats_schedules", "nba", 2025, "nba_schedule_2026.parquet"),
+    ("load_nba_stats_pbp", "nba", 1996, "nba_play_by_play_1997.parquet"),
+    ("load_nba_stats_pbp", "nba", 2025, "nba_play_by_play_2026.parquet"),
+    ("load_nba_stats_possessions", "nba", 1996, "nba_possessions_1997.parquet"),
+    ("load_nba_stats_possessions", "nba", 2025, "nba_possessions_2026.parquet"),
+    ("load_nba_stats_game_lineups", "nba", 1996, "nba_lineups_1997.parquet"),
+    ("load_nba_stats_game_lineups", "nba", 2025, "nba_lineups_2026.parquet"),
+    ("load_wnba_stats_schedules", "wnba", 1997, "wnba_schedule_1997.parquet"),
+    ("load_wnba_stats_schedules", "wnba", 2025, "wnba_schedule_2025.parquet"),
+    ("load_wnba_stats_pbp", "wnba", 1997, "wnba_play_by_play_1997.parquet"),
+    ("load_wnba_stats_pbp", "wnba", 2025, "wnba_play_by_play_2025.parquet"),
+    ("load_wnba_stats_possessions", "wnba", 1997, "wnba_possessions_1997.parquet"),
+    ("load_wnba_stats_possessions", "wnba", 2025, "wnba_possessions_2025.parquet"),
+    ("load_wnba_stats_game_lineups", "wnba", 1997, "wnba_lineups_1997.parquet"),
+    ("load_wnba_stats_game_lineups", "wnba", 2025, "wnba_lineups_2025.parquet"),
+]
+
+
+def _requested_url(fn_name: str, league: str, season: int) -> str:
+    """Call the public loader and return the asset URL it actually asked for."""
+    import importlib
+
+    mod = importlib.import_module(f"sportsdataverse.{league}.{league}_loaders")
+    box: dict = {}
+
+    def fake(url, *a, **k):
+        box["url"] = url
+        raise FileNotFoundError("404 not found")  # 404-safe path: warn + skip
+
+    with patch.object(mod.pl, "read_parquet", side_effect=fake):
+        with pytest.warns(UserWarning):
+            getattr(mod, fn_name)(seasons=season)
+    return box["url"]
+
+
+@pytest.mark.parametrize(("fn_name", "league", "season", "asset"), CASES)
+def test_public_season_resolves_to_expected_asset(fn_name, league, season, asset):
+    assert _requested_url(fn_name, league, season).endswith("/" + asset)
+
+
+def test_fill_season_offset_and_identity():
+    assert spec.fill_season("x_{season}.parquet", 2025) == "x_2025.parquet"
+    assert spec.fill_season("x_{season + 1}.parquet", 2025) == "x_2026.parquet"
+    # Whitespace-tolerant, and every occurrence is substituted.
+    assert spec.fill_season("{season}/y_{season+1}.parquet", 1996) == "1996/y_1997.parquet"
+
+
+def test_only_nba_stats_families_carry_the_end_year_offset():
+    """Guard the blast radius: the +1 belongs to the four NBA stats families only.
+
+    WNBA seasons are single-calendar-year, so an offset there would be an off-by-one.
+    """
+    offset = {ld.fn for ld in spec.load_releases(REL).loaders if (m := spec.SEASON_TOKEN.search(ld.url)) and m.group(1)}
+    assert offset == {
+        "load_nba_stats_schedules",
+        "load_nba_stats_pbp",
+        "load_nba_stats_possessions",
+        "load_nba_stats_game_lineups",
+    }

--- a/tests/codegen/test_loaders_parity.py
+++ b/tests/codegen/test_loaders_parity.py
@@ -52,7 +52,7 @@ def test_generated_loader_urls_match_existing():
     for ld in rel.loaders:
         if ld.stub:
             continue
-        gen_url = f"{rel.bases[ld.base]}{ld.url}".replace("{season}", "2024")
+        gen_url = spec.fill_season(f"{rel.bases[ld.base]}{ld.url}", 2024)
         existing = _existing_url(ld.fn, ld.league)
         if existing is None:
             continue  # historical loader not URL-capturable (different mechanism); skip

--- a/tools/codegen/endpoints/releases.yaml
+++ b/tools/codegen/endpoints/releases.yaml
@@ -868,7 +868,9 @@ loaders:
 - fn: load_nba_stats_schedules
   league: nba
   base: sdv_releases
-  url: nba_stats_schedules/nba_stats_schedule_{season}.parquet
+  # {season} stays the START year (1996 = 1996-97); the Program V asset is keyed
+  # by the END year, so the +1 is the translation -- NOT a change to the arg.
+  url: nba_stats_schedules/nba_schedule_{season + 1}.parquet
   tag: nba_stats_schedules
   min_season: 1996
   example_args:
@@ -916,8 +918,24 @@ loaders:
 - fn: load_nba_stats_pbp
   league: nba
   base: sdv_releases
-  url: nba_stats_pbp/play_by_play_{season}.parquet
+  url: nba_stats_pbp/nba_play_by_play_{season + 1}.parquet
   tag: nba_stats_pbp
+  min_season: 1996
+  example_args:
+    seasons: 2025
+- fn: load_nba_stats_possessions
+  league: nba
+  base: sdv_releases
+  url: nba_stats_possessions/nba_possessions_{season + 1}.parquet
+  tag: nba_stats_possessions
+  min_season: 1996
+  example_args:
+    seasons: 2025
+- fn: load_nba_stats_game_lineups
+  league: nba
+  base: sdv_releases
+  url: nba_stats_game_lineups/nba_lineups_{season + 1}.parquet
+  tag: nba_stats_game_lineups
   min_season: 1996
   example_args:
     seasons: 2025
@@ -1528,11 +1546,28 @@ loaders:
 - fn: load_wnba_stats_pbp
   league: wnba
   base: sdv_releases
-  url: wnba_stats_pbp/play_by_play_{season}.parquet
+  # WNBA seasons are single-calendar-year, so start year == end year: no +1 here.
+  url: wnba_stats_pbp/wnba_play_by_play_{season}.parquet
   tag: wnba_stats_pbp
-  min_season: 2026
+  min_season: 1997
   example_args:
-    seasons: 2026
+    seasons: 2025
+- fn: load_wnba_stats_possessions
+  league: wnba
+  base: sdv_releases
+  url: wnba_stats_possessions/wnba_possessions_{season}.parquet
+  tag: wnba_stats_possessions
+  min_season: 1997
+  example_args:
+    seasons: 2025
+- fn: load_wnba_stats_game_lineups
+  league: wnba
+  base: sdv_releases
+  url: wnba_stats_game_lineups/wnba_lineups_{season}.parquet
+  tag: wnba_stats_game_lineups
+  min_season: 1997
+  example_args:
+    seasons: 2025
 - fn: load_wnba_stats_player_boxscores
   league: wnba
   base: sdv_releases
@@ -1560,9 +1595,9 @@ loaders:
 - fn: load_wnba_stats_schedules
   league: wnba
   base: sdv_releases
-  url: wnba_stats_schedules/wnba_stats_schedule_{season}.parquet
+  url: wnba_stats_schedules/wnba_schedule_{season}.parquet
   tag: wnba_stats_schedules
-  min_season: 2025
+  min_season: 1997
   example_args:
     seasons: 2025
 - fn: load_wnba_stats_shots

--- a/tools/codegen/generate.py
+++ b/tools/codegen/generate.py
@@ -1071,6 +1071,13 @@ def _build_loader_docstring(ld: spec.Loader) -> str:
     lines.append("Args:")
     rng = f" (>= {ld.min_season})" if ld.min_season else ""
     lines.append(f"    seasons: an int or iterable of seasons{rng}.")
+    # Driven off the URL token so the documented convention cannot drift from the
+    # asset path it describes.
+    token = spec.SEASON_TOKEN.search(ld.url)
+    if token and token.group(1):
+        lines.append("        Pass the season's START year (e.g. ``1996`` for the 1996-97")
+        lines.append("        season); the published asset is keyed by the END year and the")
+        lines.append("        loader translates internally.")
     lines.append("    return_as_pandas: return a pandas DataFrame instead of polars.")
     lines.append("")
     lines.append("Returns:")
@@ -1477,7 +1484,7 @@ def refresh_loader_schemas() -> int:
         got = None
         for s in dict.fromkeys(seasons):
             try:
-                sch = pl.read_parquet_schema(f"{rel.bases[ld.base]}{ld.url}".replace("{season}", str(s)))
+                sch = pl.read_parquet_schema(spec.fill_season(f"{rel.bases[ld.base]}{ld.url}", s))
                 got = [{"name": k, "type": str(v)} for k, v in sch.items()]
                 break
             except Exception:  # noqa: BLE001

--- a/tools/codegen/schemas/loader_schemas.yaml
+++ b/tools/codegen/schemas/loader_schemas.yaml
@@ -7459,6 +7459,35 @@ load_nba_stats_coaches:
   type: Int64
 - name: season_type
   type: String
+load_nba_stats_game_lineups:
+- name: game_id
+  type: String
+- name: action_number
+  type: Int64
+- name: period
+  type: Int64
+- name: home_player_1
+  type: Int64
+- name: home_player_2
+  type: Int64
+- name: home_player_3
+  type: Int64
+- name: home_player_4
+  type: Int64
+- name: home_player_5
+  type: Int64
+- name: away_player_1
+  type: Int64
+- name: away_player_2
+  type: Int64
+- name: away_player_3
+  type: Int64
+- name: away_player_4
+  type: Int64
+- name: away_player_5
+  type: Int64
+- name: season
+  type: Int64
 load_nba_stats_game_rosters:
 - name: player_id
   type: Int64
@@ -7886,6 +7915,8 @@ load_nba_stats_officials:
 - name: game_id
   type: String
 load_nba_stats_pbp:
+- name: order_index
+  type: Int64
 - name: action_number
   type: Int64
 - name: clock
@@ -7934,8 +7965,54 @@ load_nba_stats_pbp:
   type: Int64
 - name: game_id
   type: String
+- name: seconds_remaining
+  type: Float64
+- name: event_type
+  type: String
+- name: is_made_shot
+  type: Boolean
+- name: is_missed_shot
+  type: Boolean
+- name: is_free_throw
+  type: Boolean
+- name: is_rebound
+  type: Boolean
+- name: is_turnover
+  type: Boolean
+- name: is_foul
+  type: Boolean
+- name: is_substitution
+  type: Boolean
+- name: is_jump_ball
+  type: Boolean
+- name: is_timeout
+  type: Boolean
+- name: is_period
+  type: Boolean
+- name: possession_number
+  type: Int64
+- name: off_player_1
+  type: Int64
+- name: off_player_2
+  type: Int64
+- name: off_player_3
+  type: Int64
+- name: off_player_4
+  type: Int64
+- name: off_player_5
+  type: Int64
+- name: def_player_1
+  type: Int64
+- name: def_player_2
+  type: Int64
+- name: def_player_3
+  type: Int64
+- name: def_player_4
+  type: Int64
+- name: def_player_5
+  type: Int64
 - name: season
-  type: Int32
+  type: Int64
 load_nba_stats_pbp_v3:
 - name: order_index
   type: Int64
@@ -8586,6 +8663,77 @@ load_nba_stats_player_season_stats:
   type: Int64
 - name: pct_pts_rank
   type: Int64
+load_nba_stats_possessions:
+- name: game_id
+  type: String
+- name: period
+  type: Int64
+- name: possession_number
+  type: Int64
+- name: offense_team_id
+  type: Int64
+- name: defense_team_id
+  type: Int64
+- name: start_order_index
+  type: Int64
+- name: end_order_index
+  type: Int64
+- name: start_seconds_remaining
+  type: Float64
+- name: end_seconds_remaining
+  type: Float64
+- name: points
+  type: Int64
+- name: is_second_chance
+  type: Boolean
+- name: number_in_period
+  type: Int64
+- name: possession_start_type
+  type: String
+- name: count_as_possession
+  type: Boolean
+- name: fg2a
+  type: Int64
+- name: fg2m
+  type: Int64
+- name: fg3a
+  type: Int64
+- name: fg3m
+  type: Int64
+- name: fta
+  type: Int64
+- name: ftm
+  type: Int64
+- name: oreb
+  type: Int64
+- name: dreb
+  type: Int64
+- name: tov
+  type: Int64
+- name: off_player_1
+  type: Int64
+- name: off_player_2
+  type: Int64
+- name: off_player_3
+  type: Int64
+- name: off_player_4
+  type: Int64
+- name: off_player_5
+  type: Int64
+- name: def_player_1
+  type: Int64
+- name: def_player_2
+  type: Int64
+- name: def_player_3
+  type: Int64
+- name: def_player_4
+  type: Int64
+- name: def_player_5
+  type: Int64
+- name: lineup_source
+  type: String
+- name: season
+  type: Int64
 load_nba_stats_possessions_v3:
 - name: game_id
   type: String
@@ -8691,67 +8839,35 @@ load_nba_stats_rosters:
 - name: season_type
   type: String
 load_nba_stats_schedules:
-- name: season_id
-  type: String
-- name: team_id
-  type: Int64
-- name: team_abbreviation
-  type: String
-- name: team_name
-  type: String
 - name: game_id
+  type: String
+- name: season
+  type: Int64
+- name: season_type
   type: String
 - name: game_date
   type: String
 - name: matchup
   type: String
-- name: wl
+- name: home_team_id
+  type: Int64
+- name: home_team_abbreviation
   type: String
-- name: min
+- name: home_team_name
+  type: String
+- name: home_pts
   type: Int64
-- name: fgm
+- name: home_wl
+  type: String
+- name: away_team_id
   type: Int64
-- name: fga
+- name: away_team_abbreviation
+  type: String
+- name: away_team_name
+  type: String
+- name: away_pts
   type: Int64
-- name: fg_pct
-  type: Float64
-- name: fg3m
-  type: Int64
-- name: fg3a
-  type: Int64
-- name: fg3_pct
-  type: Float64
-- name: ftm
-  type: Int64
-- name: fta
-  type: Int64
-- name: ft_pct
-  type: Float64
-- name: oreb
-  type: Int64
-- name: dreb
-  type: Int64
-- name: reb
-  type: Int64
-- name: ast
-  type: Int64
-- name: stl
-  type: Int64
-- name: blk
-  type: Int64
-- name: tov
-  type: Int64
-- name: pf
-  type: Int64
-- name: pts
-  type: Int64
-- name: plus_minus
-  type: Int64
-- name: video_available
-  type: Int64
-- name: season
-  type: Int32
-- name: season_type
+- name: away_wl
   type: String
 load_nba_stats_shots:
 - name: game_id
@@ -15509,6 +15625,35 @@ load_wnba_stats_draft:
   type: String
 - name: player_profile_flag
   type: Int64
+load_wnba_stats_game_lineups:
+- name: game_id
+  type: String
+- name: action_number
+  type: Int64
+- name: period
+  type: Int64
+- name: home_player_1
+  type: Int64
+- name: home_player_2
+  type: Int64
+- name: home_player_3
+  type: Int64
+- name: home_player_4
+  type: Int64
+- name: home_player_5
+  type: Int64
+- name: away_player_1
+  type: Int64
+- name: away_player_2
+  type: Int64
+- name: away_player_3
+  type: Int64
+- name: away_player_4
+  type: Int64
+- name: away_player_5
+  type: Int64
+- name: season
+  type: Int64
 load_wnba_stats_game_rosters:
 - name: player_id
   type: Int64
@@ -15544,6 +15689,8 @@ load_wnba_stats_officials:
 - name: game_id
   type: String
 load_wnba_stats_pbp:
+- name: order_index
+  type: Int64
 - name: action_number
   type: Int64
 - name: clock
@@ -15592,8 +15739,32 @@ load_wnba_stats_pbp:
   type: Int64
 - name: game_id
   type: String
+- name: seconds_remaining
+  type: Float64
+- name: event_type
+  type: String
+- name: is_made_shot
+  type: Boolean
+- name: is_missed_shot
+  type: Boolean
+- name: is_free_throw
+  type: Boolean
+- name: is_rebound
+  type: Boolean
+- name: is_turnover
+  type: Boolean
+- name: is_foul
+  type: Boolean
+- name: is_substitution
+  type: Boolean
+- name: is_jump_ball
+  type: Boolean
+- name: is_timeout
+  type: Boolean
+- name: is_period
+  type: Boolean
 - name: season
-  type: Int32
+  type: Int64
 load_wnba_stats_player_boxscores:
 - name: team_id
   type: Int64
@@ -15734,6 +15905,75 @@ load_wnba_stats_player_game_logs:
   type: Float64
 - name: measure_type
   type: String
+load_wnba_stats_possessions:
+- name: game_id
+  type: String
+- name: period
+  type: Int64
+- name: possession_number
+  type: Int64
+- name: offense_team_id
+  type: Int64
+- name: defense_team_id
+  type: Int64
+- name: start_order_index
+  type: Int64
+- name: end_order_index
+  type: Int64
+- name: start_seconds_remaining
+  type: Float64
+- name: end_seconds_remaining
+  type: Float64
+- name: points
+  type: Int64
+- name: is_second_chance
+  type: Boolean
+- name: number_in_period
+  type: Int64
+- name: possession_start_type
+  type: String
+- name: count_as_possession
+  type: Boolean
+- name: fg2a
+  type: Int64
+- name: fg2m
+  type: Int64
+- name: fg3a
+  type: Int64
+- name: fg3m
+  type: Int64
+- name: fta
+  type: Int64
+- name: ftm
+  type: Int64
+- name: oreb
+  type: Int64
+- name: dreb
+  type: Int64
+- name: tov
+  type: Int64
+- name: off_player_1
+  type: Int64
+- name: off_player_2
+  type: Int64
+- name: off_player_3
+  type: Int64
+- name: off_player_4
+  type: Int64
+- name: off_player_5
+  type: Int64
+- name: def_player_1
+  type: Int64
+- name: def_player_2
+  type: Int64
+- name: def_player_3
+  type: Int64
+- name: def_player_4
+  type: Int64
+- name: def_player_5
+  type: Int64
+- name: season
+  type: Int64
 load_wnba_stats_rosters:
 - name: team_id
   type: Int64
@@ -15772,75 +16012,35 @@ load_wnba_stats_rosters:
 - name: season_type
   type: String
 load_wnba_stats_schedules:
-- name: season_id
-  type: String
-- name: team_id
-  type: Int64
-- name: team_abbreviation
-  type: String
-- name: team_name
-  type: String
 - name: game_id
+  type: String
+- name: season
+  type: Int64
+- name: season_type
   type: String
 - name: game_date
   type: String
 - name: matchup
   type: String
-- name: wl
+- name: home_team_id
+  type: Int64
+- name: home_team_abbreviation
   type: String
-- name: min
-  type: Int64
-- name: fgm
-  type: Int64
-- name: fga
-  type: Int64
-- name: fg_pct
-  type: Float64
-- name: fg3m
-  type: Int64
-- name: fg3a
-  type: Int64
-- name: fg3_pct
-  type: Float64
-- name: ftm
-  type: Int64
-- name: fta
-  type: Int64
-- name: ft_pct
-  type: Float64
-- name: oreb
-  type: Int64
-- name: dreb
-  type: Int64
-- name: reb
-  type: Int64
-- name: ast
-  type: Int64
-- name: stl
-  type: Int64
-- name: blk
-  type: Int64
-- name: tov
-  type: Int64
-- name: pf
-  type: Int64
-- name: pts
-  type: Int64
-- name: plus_minus
-  type: Int64
-- name: video_available
-  type: Int64
-- name: season
-  type: Int32
-- name: season_type
+- name: home_team_name
   type: String
-- name: player_id
+- name: home_pts
   type: Int64
-- name: player_name
+- name: home_wl
   type: String
-- name: fantasy_pts
-  type: Float64
-- name: measure_type
+- name: away_team_id
+  type: Int64
+- name: away_team_abbreviation
+  type: String
+- name: away_team_name
+  type: String
+- name: away_pts
+  type: Int64
+- name: away_wl
   type: String
 load_wnba_stats_shots:
 - name: game_id

--- a/tools/codegen/spec.py
+++ b/tools/codegen/spec.py
@@ -96,6 +96,20 @@ class FlatApi:
         return self.name_pattern.split("_{", 1)[0]
 
 
+SEASON_TOKEN = re.compile(r"\{season(?:\s*\+\s*(\d+))?\}")
+
+
+def fill_season(url: str, season: int) -> str:
+    """Resolve a loader asset URL's ``{season}`` / ``{season + N}`` token.
+
+    The ``+ N`` form is the START-year -> END-year translation used by leagues whose
+    published assets are keyed by the season's END year (NBA: ``1996`` = 1996-97 =
+    ``nba_play_by_play_1997.parquet``). The public ``seasons`` argument stays the
+    START year -- the offset lives only in the asset path.
+    """
+    return SEASON_TOKEN.sub(lambda m: str(season + int(m.group(1) or 0)), url)
+
+
 @dataclass(frozen=True)
 class Loader:
     """A 404-safe dataset loader over a sportsdataverse-data release asset."""


### PR DESCRIPTION
Migrates the NBA/WNBA stats loaders onto the Program V release assets published
2026-08-12. Prerequisite for `--retire-legacy-assets` in both stats `-data` repos.

## The season convention (determined from code + live data, not assumed)

**NBA's public `seasons` argument is the START year today, and it stays the START
year.** Evidence:

* `releases.yaml` shipped `load_nba_stats_pbp` as
  `nba_stats_pbp/play_by_play_{season}.parquet` with `min_season: 1996`, and the
  legacy asset range is `play_by_play_1996..2025` — 30 assets for the 30 seasons
  1996-97 through 2025-26.
* `play_by_play_1996.parquet` and the new `nba_play_by_play_1997.parquet` carry the
  **identical 1,261 game ids and 596,315 rows**, all with stats.nba.com game ids of
  the form `00296000xx` (`96` = 1996-97).
* `nba_stats_schedule_1996.parquet` spans 1996-11-01..1997-06-13 — the 1996-97
  season — and matches `nba_schedule_1997.parquet` game-for-game.

So the new assets' END-year key is a **filename** change, not an argument change. The
loaders carry a `{season + 1}` token; callers change nothing.

**WNBA seasons are single-calendar-year**, so start year == end year and the WNBA
loaders substitute the argument unchanged (`wnba_schedule_2025.parquet` and the legacy
`wnba_stats_schedule_2025.parquet` are both 2025-05-16..2025-10-10, same 310 games).

## Changes

| Loader | Before | After |
|---|---|---|
| `load_nba_stats_schedules` | `nba_stats_schedule_{season}` | `nba_schedule_{season + 1}` |
| `load_nba_stats_pbp` | `play_by_play_{season}` | `nba_play_by_play_{season + 1}` |
| `load_nba_stats_possessions` | *(new)* | `nba_possessions_{season + 1}` |
| `load_nba_stats_game_lineups` | *(new)* | `nba_lineups_{season + 1}` |
| `load_wnba_stats_schedules` | `wnba_stats_schedule_{season}` (min 2025) | `wnba_schedule_{season}` (min 1997) |
| `load_wnba_stats_pbp` | `play_by_play_{season}` (min 2026) | `wnba_play_by_play_{season}` (min 1997) |
| `load_wnba_stats_possessions` | *(new)* | `wnba_possessions_{season}` |
| `load_wnba_stats_game_lineups` | *(new)* | `wnba_lineups_{season}` |

The WNBA `min_season` drops are a coverage win, not a semantics change: the legacy
`play_by_play_*` / `wnba_stats_schedule_*` names only ever covered 1-2 seasons, while
the new names backfill 1997-2026.

### `_v3` loaders left alone — deliberately

`load_nba_stats_{pbp,lineups,possessions}_v3` still read their untouched `_v3` tags.
They are **not** equivalent to the new tags: `play_by_play_v3_2025` carries 1,394 games
including preseason (`0012500001`) and All-Star (`0062500001`), versus 1,315
regular+playoff games in `nba_play_by_play_2026`. Consolidating would silently change
their output. They can be retired in the same step that retires the `_v3` tags.

`load_nba_stats_lineups` is also untouched — despite the name, its `nba_stats_lineups`
asset is a 182-column season-level leaguedash aggregate with no `game_id`, a different
dataset from the new per-game `nba_stats_game_lineups`.

### Supporting changes

* `spec.fill_season()` resolves `{season}` / `{season + N}` for every consumer (loader
  schema refresh, parity test). The previous `.replace("{season}", str(s))` calls would
  have emitted a literal `{2025 + 1}`.
* `_build_loader_docstring` documents the START-year convention whenever the URL carries
  an offset — driven off the token, so the prose cannot drift from the path it describes.
* `loader_schemas.yaml` re-introspected for the eight touched loaders only (a full
  `--loader-schemas` run would fold unrelated producer drift into this diff). The new
  schemas are materially different: NBA pbp 25 -> 49 columns, schedule 31 -> 15.

## Live verification

Every family loaded through the **public** loader across 1996-2025 (NBA) and 1997-2025
(WNBA). Season identity is asserted from the **data**, not the filename: stats.nba.com
game ids encode the season's start year at characters `[3:5]`, so an off-by-one in the
translation cannot pass.

```
OK  nba_schedules      season=1996 rows=1261     games=1261  digits=['96']
OK  nba_pbp            season=1996 rows=596315   games=1261  digits=['96']
OK  nba_possessions    season=1996 rows=231024   games=1261  digits=['96']
OK  nba_game_lineups   season=1996 rows=596315   games=1261  digits=['96']
...  (2003 / 2015 / 2024 / 2025 all OK)
OK  wnba_schedules     season=1997 rows=115      games=115   digits=['97']
OK  wnba_pbp           season=1997 rows=47583    games=115   digits=['97']
...  (2005 / 2018 / 2025 all OK)

NBA 1996 schedule date span: 1996-11-01..1997-06-13   (1996-97 season)
WNBA 1997 schedule date span: 1997-06-21..1997-08-30  (1997 season)
legacy play_by_play_1996 games=1261  new load_nba_stats_pbp(1996) games=1261  identical=True
pbp_v3(2025) rows=704314   possessions_v3(2025) rows=277222   (v3 readers still work)

ALL CHECKS PASSED
```

## Tests

New `tests/codegen/test_loader_season_convention.py` — 16 parametrized cases pinning the
exact asset basename each public season resolves to (`load_nba_stats_pbp(1996)` MUST
request `nba_play_by_play_1997.parquet`; `load_wnba_stats_pbp(1997)` MUST request
`wnba_play_by_play_1997.parquet`), plus a blast-radius guard asserting the `+1` offset
appears on exactly the four NBA stats families and nowhere else. An off-by-one in either
direction fails these; a row-count assertion would not.

## Gates

`ruff check` + `ruff format --check` clean · `mypy` 395 files clean ·
`pytest tests/codegen tests/nba/test_nba_loaders.py tests/test_id_conventions.py` →
**153 passed, 11 skipped** · `generate.py --check` → all generated files current.

## Summary by Sourcery

Repoint NBA and WNBA stats loaders and codegen to the Program V release assets while preserving the public season argument semantics.

New Features:
- Add NBA and WNBA stats possessions loaders backed by Program V release assets.
- Add NBA and WNBA per-game lineups loaders backed by Program V release assets.

Enhancements:
- Update NBA and WNBA stats schedules and play-by-play loaders (including schemas and docs) to align with the new asset formats and season keying.
- Introduce a shared season token resolver in codegen so loader URLs can express START-year to END-year offsets safely and keep docstrings in sync.
- Export the new NBA and WNBA stats loaders through the parsed modules and reference documentation, updating loader counts.

Tests:
- Add regression tests that pin the exact asset basename each loader requests for given public seasons and assert that only the intended NBA stats loaders use the +1 season offset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added NBA and WNBA loaders for possessions and game lineups.
  - Expanded play-by-play data with event, possession, timing, and lineup details.
  - Added support for historical WNBA schedules and play-by-play data from 1997 onward.
  - Loaders now support season-based retrieval and optional pandas output.

- **Documentation**
  - Updated loader counts, schemas, asset references, and usage guidance for NBA and WNBA datasets.

- **Bug Fixes**
  - Corrected schedule data descriptions and season-to-asset mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->