### PR TITLE
fix(nba): drafthistory is live for LeagueID=00, not barren

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -643,7 +643,7 @@ Savant surface** (`baseballsavant.mlb.com`) under the canonical naming
 
 Two codegen-generated flat-API stems wrap the official stats API surface:
 
-- **`nba_stats`** — 112 wrappers at `stats.nba.com`. League is chosen per call via `league_id`: `"00"` → NBA, `"20"` → G-League, `"15"` → Summer League. One stem, one host. Named `nba_stats_<slug>` (e.g. `nba_stats_leaguedashplayerstats`, `nba_stats_playercareerstats`).
+- **`nba_stats`** — 113 wrappers at `stats.nba.com`. League is chosen per call via `league_id`: `"00"` → NBA, `"20"` → G-League, `"15"` → Summer League. One stem, one host. Named `nba_stats_<slug>` (e.g. `nba_stats_leaguedashplayerstats`, `nba_stats_playercareerstats`).
 - **`wnba_stats`** — 95 wrappers at `stats.wnba.com` (WNBA `LeagueID=10`). Thin shim re-exporting the NBA-stats runtime with the WNBA host. Named `wnba_stats_<slug>`.
 - **Codegen surface = capture-confirmed `live`, non-deprecated only.** `gen_nba_stats._stats_eps()` keeps an endpoint for a league iff `league_applicability[league_id] == "live"` AND no source marks it deprecated. `untested`/`barren`/`dead` and the 26 deprecated endpoints are dropped. The wrapper counts therefore track the committed capture sweep (`sdv-internal-refs/nba/ENDPOINT_HEALTH.md`); a fresh sweep that resolves more `untested` endpoints raises the counts on the next `gen_nba_stats.py` + re-vendor of `tools/codegen/inputs/nba_canonical_catalog.json`.
 

--- a/docs/docs/nba/index.md
+++ b/docs/docs/nba/index.md
@@ -10,7 +10,7 @@ sidebar_label: NBA
 | [ESPN web API (v3)](reference/web) | 5 | `https://site.web.api.espn.com/apis/common/v3/sports` |
 | [ESPN core API (v2)](reference/core) | 82 | `https://sports.core.api.espn.com/v2/sports` |
 | [ESPN FPI API (fitt v3)](reference/fitt) | 1 | `https://site.web.api.espn.com/apis/fitt/v3/sports` |
-| [NBA Stats API (stats.nba.com)](reference/nba_stats) | 112 | `https://stats.nba.com` |
+| [NBA Stats API (stats.nba.com)](reference/nba_stats) | 113 | `https://stats.nba.com` |
 | [Dataset loaders](reference/loaders) | 36 | sportsdataverse-data releases |
 | [Additional functions](reference/additional) | 132 | hand-written wrappers, loaders & helpers |
 

--- a/docs/docs/nba/reference/nba_stats.md
+++ b/docs/docs/nba/reference/nba_stats.md
@@ -1544,7 +1544,7 @@ GET /stats/drafthistory
 
 **Endpoint URL:** `GET https://stats.nba.com/stats/drafthistory`
 
-**Valid URL:** [https://stats.nba.com/stats/drafthistory?LeagueID=00](https://stats.nba.com/stats/drafthistory?LeagueID=00)
+**Valid URL:** [https://stats.nba.com/stats/drafthistory?LeagueID=00&Season=2024](https://stats.nba.com/stats/drafthistory?LeagueID=00&Season=2024)
 
 | API Parameter | Python | Pattern | Required | Nullable | Description |
 |---|---|:---:|:---:|:---:|---|
@@ -1582,7 +1582,7 @@ GET /stats/drafthistory
 ### Example
 
 ```python
-nba_stats_drafthistory(league_id='00')
+nba_stats_drafthistory(league_id='00', season_year_nullable='2024')
 ```
 
 _Last validated n/a._

--- a/docs/docs/nba/reference/nba_stats.md
+++ b/docs/docs/nba/reference/nba_stats.md
@@ -5,7 +5,7 @@ sidebar_position: 10
 ---
 # NBA — NBA Stats API (stats.nba.com)
 
-`sportsdataverse.nba` — 112 endpoints.
+`sportsdataverse.nba` — 113 endpoints.
 
 ## `nba_stats_alltimeleadersgrids`
 
@@ -1534,6 +1534,55 @@ GET /stats/draftcombinestats
 
 ```python
 nba_stats_draftcombinestats(league_id='00')
+```
+
+_Last validated n/a._
+
+## `nba_stats_drafthistory`
+
+GET /stats/drafthistory
+
+**Endpoint URL:** `GET https://stats.nba.com/stats/drafthistory`
+
+**Valid URL:** [https://stats.nba.com/stats/drafthistory?LeagueID=00](https://stats.nba.com/stats/drafthistory?LeagueID=00)
+
+| API Parameter | Python | Pattern | Required | Nullable | Description |
+|---|---|:---:|:---:|:---:|---|
+| `College` | `college_nullable` |  |  | `Y` |  |
+| `LeagueID` | `league_id` |  |  | `Y` |  |
+| `OverallPick` | `overall_pick_nullable` |  |  | `Y` |  |
+| `RoundNum` | `round_num_nullable` |  |  | `Y` |  |
+| `RoundPick` | `round_pick_nullable` |  |  | `Y` |  |
+| `Season` | `season_year_nullable` |  |  | `Y` |  |
+| `TeamID` | `team_id_nullable` |  |  | `Y` |  |
+| `TopX` | `topx_nullable` |  |  | `Y` |  |
+
+### Returns
+
+**`return_parsed=True`** (default) — a tidy `polars.DataFrame` with the columns below; pass `return_as_pandas=True` for a `pandas.DataFrame`.
+| col_name | type | description |
+|---|---|---|
+| `person_id` | integer | Unique player identifier (V3 endpoints). |
+| `player_name` | character | Player name. |
+| `season` | character | Season year. |
+| `round_number` | integer | Numeric round. |
+| `round_pick` | integer | Round pick. |
+| `overall_pick` | integer | Overall pick. |
+| `draft_type` | character | NBA or WNBA Stats value for draft type in the drafthistory result set. |
+| `team_id` | integer | Unique team identifier. |
+| `team_city` | character | Team city or region (e.g. 'Las Vegas'). |
+| `team_name` | character | Full team display name (e.g. 'Las Vegas Aces'). |
+| `team_abbreviation` | character | Short team abbreviation (e.g. 'LAS'). |
+| `organization` | character | Organization. |
+| `organization_type` | character | Organization type. |
+| `player_profile_flag` | integer | Player profile flag. |
+
+**`return_parsed=False`** — the raw JSON `Dict` payload, unparsed.
+
+### Example
+
+```python
+nba_stats_drafthistory(league_id='00')
 ```
 
 _Last validated n/a._

--- a/docs/docs/wnba/reference/wnba_stats.md
+++ b/docs/docs/wnba/reference/wnba_stats.md
@@ -1382,7 +1382,7 @@ GET /stats/drafthistory
 
 **Endpoint URL:** `GET https://stats.wnba.com/stats/drafthistory`
 
-**Valid URL:** [https://stats.wnba.com/stats/drafthistory?LeagueID=10](https://stats.wnba.com/stats/drafthistory?LeagueID=10)
+**Valid URL:** [https://stats.wnba.com/stats/drafthistory?LeagueID=10&Season=2024](https://stats.wnba.com/stats/drafthistory?LeagueID=10&Season=2024)
 
 | API Parameter | Python | Pattern | Required | Nullable | Description |
 |---|---|:---:|:---:|:---:|---|
@@ -1420,7 +1420,7 @@ GET /stats/drafthistory
 ### Example
 
 ```python
-wnba_stats_drafthistory(league_id='10')
+wnba_stats_drafthistory(league_id='10', season_year_nullable='2024')
 ```
 
 _Last validated n/a._

--- a/sportsdataverse/nba/nba_stats.py
+++ b/sportsdataverse/nba/nba_stats.py
@@ -41,6 +41,7 @@ __all__ = [
     "nba_stats_draftcombineplayeranthro",
     "nba_stats_draftcombinespotshooting",
     "nba_stats_draftcombinestats",
+    "nba_stats_drafthistory",
     "nba_stats_fantasywidget",
     "nba_stats_franchisehistory",
     "nba_stats_franchiseleaders",
@@ -1423,6 +1424,64 @@ def nba_stats_draftcombinestats(
         params={
             "LeagueID": league_id,
             "SeasonYear": season_all_time,
+        },
+        **kwargs,
+    )
+    if return_parsed:
+        return parse_nba_stats_result_sets(raw, return_as_pandas=return_as_pandas)
+    return raw
+
+
+def nba_stats_drafthistory(
+    college_nullable: Optional[str] = "",
+    league_id: Optional[str] = "00",
+    overall_pick_nullable: Optional[str] = "",
+    round_num_nullable: Optional[str] = "",
+    round_pick_nullable: Optional[str] = "",
+    season_year_nullable: Optional[str] = None,
+    team_id_nullable: Optional[str] = "0",
+    topx_nullable: Optional[str] = "",
+    *,
+    return_parsed: bool = True,
+    return_as_pandas: bool = False,
+    **kwargs,
+) -> Union[pl.DataFrame, pd.DataFrame, Dict]:
+    """GET /stats/drafthistory
+
+    Endpoint: ``GET https://stats.nba.com/stats/drafthistory``
+    Example URL: https://stats.nba.com/stats/drafthistory?LeagueID=00
+
+    Args:
+        college_nullable: College query parameter.
+        league_id: LeagueID query parameter.
+        overall_pick_nullable: OverallPick query parameter.
+        round_num_nullable: RoundNum query parameter.
+        round_pick_nullable: RoundPick query parameter.
+        season_year_nullable: Season query parameter.
+        team_id_nullable: TeamID query parameter.
+        topx_nullable: TopX query parameter.
+        return_parsed: parse the payload through parse_nba_stats_result_sets -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
+        return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
+
+    Returns:
+        A polars/pandas DataFrame by default; the raw JSON ``Dict`` when ``return_parsed=False``.
+
+    Example:
+        Quick start::
+
+            nba_stats_drafthistory(league_id='00')
+    """
+    raw = _get(
+        "https://stats.nba.com/stats/drafthistory",
+        params={
+            "College": college_nullable,
+            "LeagueID": league_id,
+            "OverallPick": overall_pick_nullable,
+            "RoundNum": round_num_nullable,
+            "RoundPick": round_pick_nullable,
+            "Season": season_year_nullable,
+            "TeamID": team_id_nullable,
+            "TopX": topx_nullable,
         },
         **kwargs,
     )

--- a/sportsdataverse/nba/nba_stats.py
+++ b/sportsdataverse/nba/nba_stats.py
@@ -1449,7 +1449,7 @@ def nba_stats_drafthistory(
     """GET /stats/drafthistory
 
     Endpoint: ``GET https://stats.nba.com/stats/drafthistory``
-    Example URL: https://stats.nba.com/stats/drafthistory?LeagueID=00
+    Example URL: https://stats.nba.com/stats/drafthistory?LeagueID=00&Season=2024
 
     Args:
         college_nullable: College query parameter.
@@ -1462,14 +1462,29 @@ def nba_stats_drafthistory(
         topx_nullable: TopX query parameter.
         return_parsed: parse the payload through parse_nba_stats_result_sets -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
+        **kwargs: Forwarded to the underlying HTTP getter.
 
     Returns:
         A polars/pandas DataFrame by default; the raw JSON ``Dict`` when ``return_parsed=False``.
 
+    Raises:
+        ImportError: ``curl_cffi`` is not installed. stats.nba.com/stats.wnba.com TLS-fingerprint-block plain ``requests``, so the live transport requires it (``pip install curl_cffi``, or ``pip install sportsdataverse[all]``).
+        curl_cffi.requests.errors.RequestsError: Connection-level failure (timeout, reset) raised by the transport once ``SDV_PY_NBA_STATS_RETRIES`` retries are exhausted. A non-200 or empty body does NOT raise -- ``_get`` returns ``{}`` and the parser yields a zero-row frame.
+
     Example:
         Quick start::
 
-            nba_stats_drafthistory(league_id='00')
+            from sportsdataverse.nba.nba_stats import nba_stats_drafthistory
+            nba_stats_drafthistory(league_id='00', season_year_nullable='2024')
+
+        See Also:
+            * `wnba_stats_drafthistory`_ - the WNBA sibling wrapper (same resultSets envelope, LeagueID=10)
+            * `hoopR`_ - R sister package for the NBA stats API
+            * `nba_api`_ - Python alternative client
+
+        .. _wnba_stats_drafthistory: https://sportsdataverse-py.sportsdataverse.org/docs/wnba/reference/wnba_stats
+        .. _hoopR: https://hoopR.sportsdataverse.org
+        .. _nba_api: https://github.com/swar/nba_api
     """
     raw = _get(
         "https://stats.nba.com/stats/drafthistory",

--- a/sportsdataverse/scrape/stats/endpoints.py
+++ b/sportsdataverse/scrape/stats/endpoints.py
@@ -135,7 +135,21 @@ def measure_types_for(fn_name: str, param: str, default: tuple[str, ...]) -> tup
 #: (playergamelogs, teamgamelogs) were called with NO season filter at all --
 #: the API answered nothing and 100% of those captures were empty in both
 #: leagues.
-_SEASON_PARAMS = ("season", "season_nullable", "season_year", "season_all_time")
+#:
+#: ``season_year_nullable`` is the same bug one spelling further out, and it
+#: fails LOUDER than an empty capture: drafthistory is the only endpoint that
+#: spells it that way, and unfiltered it answers with the FULL draft history
+#: (1947-2026) rather than nothing. A season sweep that drops the filter writes
+#: that same payload under every season -- which is exactly the state
+#: wehoop-wnba-stats-raw is in (30 byte-identical drafthistory/{season}.json,
+#: all md5 b682aa93cc, "Season": null in each one's echoed parameters).
+_SEASON_PARAMS = (
+    "season",
+    "season_nullable",
+    "season_year",
+    "season_year_nullable",
+    "season_all_time",
+)
 _LEAGUE_PARAMS = ("league_id", "league_id_nullable")
 
 PER_MODES = ("Totals", "PerGame")

--- a/sportsdataverse/wnba/wnba_stats.py
+++ b/sportsdataverse/wnba/wnba_stats.py
@@ -1323,7 +1323,7 @@ def wnba_stats_drafthistory(
     """GET /stats/drafthistory
 
     Endpoint: ``GET https://stats.wnba.com/stats/drafthistory``
-    Example URL: https://stats.wnba.com/stats/drafthistory?LeagueID=10
+    Example URL: https://stats.wnba.com/stats/drafthistory?LeagueID=10&Season=2024
 
     Args:
         college_nullable: College query parameter.
@@ -1336,14 +1336,29 @@ def wnba_stats_drafthistory(
         topx_nullable: TopX query parameter.
         return_parsed: parse the payload through parse_wnba_stats_result_sets -> polars DataFrame (default True). Pass return_parsed=False for the raw JSON Dict.
         return_as_pandas: with return_parsed, return a pandas DataFrame instead of polars.
+        **kwargs: Forwarded to the underlying HTTP getter.
 
     Returns:
         A polars/pandas DataFrame by default; the raw JSON ``Dict`` when ``return_parsed=False``.
 
+    Raises:
+        ImportError: ``curl_cffi`` is not installed. stats.nba.com/stats.wnba.com TLS-fingerprint-block plain ``requests``, so the live transport requires it (``pip install curl_cffi``, or ``pip install sportsdataverse[all]``).
+        curl_cffi.requests.errors.RequestsError: Connection-level failure (timeout, reset) raised by the transport once ``SDV_PY_NBA_STATS_RETRIES`` retries are exhausted. A non-200 or empty body does NOT raise -- ``_get`` returns ``{}`` and the parser yields a zero-row frame.
+
     Example:
         Quick start::
 
-            wnba_stats_drafthistory(league_id='10')
+            from sportsdataverse.wnba.wnba_stats import wnba_stats_drafthistory
+            wnba_stats_drafthistory(league_id='10', season_year_nullable='2024')
+
+        See Also:
+            * `nba_stats_drafthistory`_ - the NBA sibling wrapper (same resultSets envelope, LeagueID=00)
+            * `wehoop`_ - R sister package for the WNBA stats API
+            * `nba_api`_ - Python alternative client
+
+        .. _nba_stats_drafthistory: https://sportsdataverse-py.sportsdataverse.org/docs/nba/reference/nba_stats
+        .. _wehoop: https://wehoop.sportsdataverse.org
+        .. _nba_api: https://github.com/swar/nba_api
     """
     raw = _get(
         "https://stats.wnba.com/stats/drafthistory",

--- a/tests/codegen/test_nba_stats_codegen.py
+++ b/tests/codegen/test_nba_stats_codegen.py
@@ -13,7 +13,10 @@ def test_nba_stats_module_imports_and_has_workhorse():
     # upstream-deprecated endpoints stay excluded from codegen
     assert not hasattr(mod, "nba_stats_scoreboardv2")
     assert not hasattr(mod, "nba_stats_boxscoretraditionalv2")
-    assert len(mod.__all__) == 112  # live, non-deprecated stats endpoints
+    # drafthistory joined at 113: LeagueID=00 was mis-marked "barren" in the
+    # catalog, so it had never been generated for the NBA side.
+    assert hasattr(mod, "nba_stats_drafthistory")
+    assert len(mod.__all__) == 113  # live, non-deprecated stats endpoints
 
 
 def test_wnba_stats_module_imports():

--- a/tests/scrape/test_scrape_stats_league.py
+++ b/tests/scrape/test_scrape_stats_league.py
@@ -38,9 +38,20 @@ def test_unknown_league_id_raises() -> None:
 # -- endpoints: span vs bare season spelling -----------------------------------
 
 
-def _fake_endpoint_span(season: str = "", league_id: str = "") -> None: ...
-def _fake_endpoint_year(season_year: str = "", league_id: str = "") -> None: ...
-def _fake_endpoint_year_nullable(season_year_nullable: str = "", league_id: str = "") -> None: ...
+# Signature-only stubs: season_variants() introspects the parameter NAMES to pick
+# the season spelling, so a docstring body is all these need. (A bare ``...`` body
+# would be collapsed back onto the ``def`` line by ruff format, which trips E704 in
+# formatter-unaware linters -- ruff itself documents E704 as formatter-conflicting.)
+def _fake_endpoint_span(season: str = "", league_id: str = "") -> None:
+    """Stub taking the span-spelled ``season`` param."""
+
+
+def _fake_endpoint_year(season_year: str = "", league_id: str = "") -> None:
+    """Stub taking the bare-year ``season_year`` param."""
+
+
+def _fake_endpoint_year_nullable(season_year_nullable: str = "", league_id: str = "") -> None:
+    """Stub taking the nullable bare-year ``season_year_nullable`` param."""
 
 
 def test_nba_spans_the_season_string_wnba_stays_bare() -> None:

--- a/tests/scrape/test_scrape_stats_league.py
+++ b/tests/scrape/test_scrape_stats_league.py
@@ -40,6 +40,7 @@ def test_unknown_league_id_raises() -> None:
 
 def _fake_endpoint_span(season: str = "", league_id: str = "") -> None: ...
 def _fake_endpoint_year(season_year: str = "", league_id: str = "") -> None: ...
+def _fake_endpoint_year_nullable(season_year_nullable: str = "", league_id: str = "") -> None: ...
 
 
 def test_nba_spans_the_season_string_wnba_stays_bare() -> None:
@@ -57,6 +58,22 @@ def test_season_year_is_bare_in_both_leagues() -> None:
     for league_id in ("00", "10"):
         (variant,) = list(season_variants(_fake_endpoint_year, 2019, league_id))
         assert variant[1]["season_year"] == "2019"
+
+
+def test_season_year_nullable_is_still_a_season_filter() -> None:
+    """drafthistory's spelling must not fall through to "no season".
+
+    _SEASON_PARAMS is matched by EXACT name, so `season_year_nullable` did not
+    match `season_year` and the sweep sent league_id alone. Unfiltered,
+    drafthistory answers with the whole 1947-2026 history, so the miss does not
+    surface as an empty capture — it writes the identical full-history payload
+    under every season (the state wehoop-wnba-stats-raw is in today).
+    """
+    for league_id in ("00", "10"):
+        (variant,) = list(season_variants(_fake_endpoint_year_nullable, 2003, league_id))
+        assert variant[1]["season_year_nullable"] == "2003", (
+            "season_year_nullable dropped -> every season captures the full draft history"
+        )
 
 
 def test_season_string_spelling() -> None:

--- a/tools/codegen/endpoints/nba_stats.yaml
+++ b/tools/codegen/endpoints/nba_stats.yaml
@@ -721,6 +721,46 @@ endpoints:
 - example_args:
     league_id: '00'
   extra_params:
+  - default: ''
+    name: college_nullable
+    query_key: College
+    type: str
+  - default: '00'
+    name: league_id
+    query_key: LeagueID
+    type: str
+  - default: ''
+    name: overall_pick_nullable
+    query_key: OverallPick
+    type: str
+  - default: ''
+    name: round_num_nullable
+    query_key: RoundNum
+    type: str
+  - default: ''
+    name: round_pick_nullable
+    query_key: RoundPick
+    type: str
+  - default: null
+    name: season_year_nullable
+    query_key: Season
+    type: str
+  - default: '0'
+    name: team_id_nullable
+    query_key: TeamID
+    type: str
+  - default: ''
+    name: topx_nullable
+    query_key: TopX
+    type: str
+  parser: parse_nba_stats_result_sets
+  path: /stats/drafthistory
+  returns_schema: native/nba_stats/drafthistory
+  short: drafthistory
+  summary: GET /stats/drafthistory
+- example_args:
+    league_id: '00'
+  extra_params:
   - default: N
     name: active_players
     query_key: ActivePlayers

--- a/tools/codegen/endpoints/nba_stats.yaml
+++ b/tools/codegen/endpoints/nba_stats.yaml
@@ -718,8 +718,30 @@ endpoints:
   returns_schema: native/nba_stats/draftcombinestats
   short: draftcombinestats
   summary: GET /stats/draftcombinestats
-- example_args:
+- docstring:
+    example_import: true
+    example_import_from: sportsdataverse.nba.nba_stats
+    raises:
+    - 'ImportError: ``curl_cffi`` is not installed. stats.nba.com/stats.wnba.com TLS-fingerprint-block
+      plain ``requests``, so the live transport requires it (``pip install curl_cffi``,
+      or ``pip install sportsdataverse[all]``).'
+    - 'curl_cffi.requests.errors.RequestsError: Connection-level failure (timeout,
+      reset) raised by the transport once ``SDV_PY_NBA_STATS_RETRIES`` retries are
+      exhausted. A non-200 or empty body does NOT raise -- ``_get`` returns ``{}``
+      and the parser yields a zero-row frame.'
+    see_also:
+    - name: wnba_stats_drafthistory
+      note: the WNBA sibling wrapper (same resultSets envelope, LeagueID=10)
+      url: https://sportsdataverse-py.sportsdataverse.org/docs/wnba/reference/wnba_stats
+    - name: hoopR
+      note: R sister package for the NBA stats API
+      url: https://hoopR.sportsdataverse.org
+    - name: nba_api
+      note: Python alternative client
+      url: https://github.com/swar/nba_api
+  example_args:
     league_id: '00'
+    season_year_nullable: '2024'
   extra_params:
   - default: ''
     name: college_nullable

--- a/tools/codegen/endpoints/wnba_stats.yaml
+++ b/tools/codegen/endpoints/wnba_stats.yaml
@@ -685,8 +685,30 @@ endpoints:
   returns_schema: native/wnba_stats/draftcombinestats
   short: draftcombinestats
   summary: GET /stats/draftcombinestats
-- example_args:
+- docstring:
+    example_import: true
+    example_import_from: sportsdataverse.wnba.wnba_stats
+    raises:
+    - 'ImportError: ``curl_cffi`` is not installed. stats.nba.com/stats.wnba.com TLS-fingerprint-block
+      plain ``requests``, so the live transport requires it (``pip install curl_cffi``,
+      or ``pip install sportsdataverse[all]``).'
+    - 'curl_cffi.requests.errors.RequestsError: Connection-level failure (timeout,
+      reset) raised by the transport once ``SDV_PY_NBA_STATS_RETRIES`` retries are
+      exhausted. A non-200 or empty body does NOT raise -- ``_get`` returns ``{}``
+      and the parser yields a zero-row frame.'
+    see_also:
+    - name: nba_stats_drafthistory
+      note: the NBA sibling wrapper (same resultSets envelope, LeagueID=00)
+      url: https://sportsdataverse-py.sportsdataverse.org/docs/nba/reference/nba_stats
+    - name: wehoop
+      note: R sister package for the WNBA stats API
+      url: https://wehoop.sportsdataverse.org
+    - name: nba_api
+      note: Python alternative client
+      url: https://github.com/swar/nba_api
+  example_args:
     league_id: '10'
+    season_year_nullable: '2024'
   extra_params:
   - default: ''
     name: college_nullable

--- a/tools/codegen/gen_nba_stats.py
+++ b/tools/codegen/gen_nba_stats.py
@@ -77,6 +77,57 @@ _REPRESENTATIVE_RESULT_SETS = {
 }
 
 
+# What actually propagates out of nba_stats_runtime._get. A non-200 / blank /
+# undecodable body is NOT an exception there -- it returns {} and the parser
+# yields a zero-row frame -- so only these two reach the caller.
+_STATS_RAISES = [
+    "ImportError: ``curl_cffi`` is not installed. stats.nba.com/stats.wnba.com "
+    "TLS-fingerprint-block plain ``requests``, so the live transport requires it "
+    "(``pip install curl_cffi``, or ``pip install sportsdataverse[all]``).",
+    "curl_cffi.requests.errors.RequestsError: Connection-level failure (timeout, "
+    "reset) raised by the transport once ``SDV_PY_NBA_STATS_RETRIES`` retries are "
+    "exhausted. A non-200 or empty body does NOT raise -- ``_get`` returns ``{}`` "
+    "and the parser yields a zero-row frame.",
+]
+_SIBLING = {"nba_stats": ("wnba_stats", "wnba", "10"), "wnba_stats": ("nba_stats", "nba", "00")}
+_R_COMPANION = {
+    "nba_stats": ("hoopR", "https://hoopR.sportsdataverse.org", "R sister package for the NBA stats API"),
+    "wnba_stats": ("wehoop", "https://wehoop.sportsdataverse.org", "R sister package for the WNBA stats API"),
+}
+# Endpoints that opt into the extended docstring contract (Raises + See Also +
+# an import-bearing Example). Declared PER ENDPOINT: the family-level
+# ``docstring:`` block would rewrite all ~112 wrappers in this family.
+_DOCSTRING_ENDPOINTS = ("drafthistory",)
+# Curated example args for those endpoints, so the Example block is a real,
+# copy-pasteable call rather than the whole draft history.
+_EXAMPLE_ARGS = {"drafthistory": {"season_year_nullable": "2024"}}
+
+
+def _docstring_extras(slug: str, stem: str) -> Dict[str, Any]:
+    """Per-endpoint ``docstring:`` extras consumed by ``generate._build_docstring``."""
+    if slug not in _DOCSTRING_ENDPOINTS:
+        return {}
+    sib_stem, sib_league, sib_league_id = _SIBLING[stem]
+    r_name, r_url, r_note = _R_COMPANION[stem]
+    return {
+        "example_import": True,
+        # sportsdataverse.{nba,wnba} does NOT re-export these wrappers -- they are
+        # reachable only through their own module, so the Example imports from there.
+        "example_import_from": f"sportsdataverse.{STEMS[stem]['league']}.{stem}",
+        "raises": list(_STATS_RAISES),
+        "see_also": [
+            {
+                "name": f"{sib_stem}_{slug}",
+                "url": f"https://sportsdataverse-py.sportsdataverse.org/docs/{sib_league}/reference/{sib_stem}",
+                "note": f"the {sib_league.upper()} sibling wrapper (same resultSets "
+                f"envelope, LeagueID={sib_league_id})",
+            },
+            {"name": r_name, "url": r_url, "note": r_note},
+            {"name": "nba_api", "url": "https://github.com/swar/nba_api", "note": "Python alternative client"},
+        ],
+    }
+
+
 def _stats_eps(league_id: str) -> List[dict]:
     return sorted(
         (
@@ -128,15 +179,21 @@ def _endpoint_entry(ep: dict, stem: str, default_league: str, parser_name: str) 
                     "default": _clean_default(p["name"], p["query_key"], p.get("default")),
                 }
             )
-    return {
+    example_args: Dict[str, Any] = {"league_id": default_league} if has_league else {}
+    example_args.update(_EXAMPLE_ARGS.get(ep["slug"], {}))
+    entry: Dict[str, Any] = {
         "short": ep["slug"],
         "summary": f"GET /stats/{ep['slug']}",
         "path": f"/stats/{ep['slug']}",
         "extra_params": extra,
         "parser": parser_name,
         "returns_schema": f"native/{stem}/{ep['slug']}",
-        "example_args": {"league_id": default_league} if has_league else {},
+        "example_args": example_args,
     }
+    extras = _docstring_extras(ep["slug"], stem)
+    if extras:
+        entry["docstring"] = extras
+    return entry
 
 
 def _write_yaml(path: Path, obj: Any) -> None:

--- a/tools/codegen/generate.py
+++ b/tools/codegen/generate.py
@@ -147,8 +147,12 @@ def _build_docstring(
     lines.append("Example:")
     lines.append("    Quick start::")
     lines.append("")
-    if extras.get("example_import") and import_from:
-        lines.append(f"        from {import_from} import {example_call.split('(', 1)[0]}")
+    # ``example_import_from`` overrides the default league-package import path for
+    # families the league package does NOT re-export (the wrapper lives only in its
+    # own module) -- without it the Example's import line is not runnable.
+    example_module = str(extras.get("example_import_from") or import_from)
+    if extras.get("example_import") and example_module:
+        lines.append(f"        from {example_module} import {example_call.split('(', 1)[0]}")
     lines.append(f"        {example_call}")
     see_also = list(extras.get("see_also") or [])
     if see_also:
@@ -983,7 +987,9 @@ def _flat_views(api: spec.FlatApi, league_prefix: str = "") -> list[_EndpointVie
                 flat=True,
                 auth=api.auth,
                 raw_types=api.raw_types,
-                doc_extras=api.docstring,
+                # Per-endpoint extras win over the family block, so a large family
+                # can document one wrapper without rewriting all of its siblings.
+                doc_extras=ep.docstring or api.docstring,
             )
         )
     return views

--- a/tools/codegen/inputs/nba_canonical_catalog.json
+++ b/tools/codegen/inputs/nba_canonical_catalog.json
@@ -12204,7 +12204,7 @@
         "stats.wnba.com"
       ],
       "league_applicability": {
-        "00": "barren",
+        "00": "live",
         "10": "live",
         "15": "barren",
         "20": "barren"

--- a/tools/codegen/schemas/native/nba_stats/drafthistory.yaml
+++ b/tools/codegen/schemas/native/nba_stats/drafthistory.yaml
@@ -1,0 +1,45 @@
+columns:
+- description: ''
+  name: person_id
+  type: integer
+- description: ''
+  name: player_name
+  type: character
+- description: ''
+  name: season
+  type: character
+- description: ''
+  name: round_number
+  type: integer
+- description: ''
+  name: round_pick
+  type: integer
+- description: ''
+  name: overall_pick
+  type: integer
+- description: ''
+  name: draft_type
+  type: character
+- description: ''
+  name: team_id
+  type: integer
+- description: ''
+  name: team_city
+  type: character
+- description: ''
+  name: team_name
+  type: character
+- description: ''
+  name: team_abbreviation
+  type: character
+- description: ''
+  name: organization
+  type: character
+- description: ''
+  name: organization_type
+  type: character
+- description: ''
+  name: player_profile_flag
+  type: integer
+kind: dataframe
+schema: drafthistory

--- a/tools/codegen/spec.py
+++ b/tools/codegen/spec.py
@@ -44,6 +44,11 @@ class Endpoint:
     now_variant: Optional[str] = None  # alternate path when the now_toggle param is None
     now_toggle: Optional[str] = None  # the path param whose None selects now_variant
     exclude_leagues: List[str] = field(default_factory=list)
+    # Same shape as FlatApi.docstring, scoped to ONE endpoint. Declared per
+    # endpoint when a family is too large to opt in wholesale: the family-level
+    # block rewrites every wrapper in the family, this one changes only its own.
+    # Takes precedence over the family block when both are present.
+    docstring: Dict[str, object] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -249,6 +254,7 @@ def _parse_endpoint(e: dict, registry: Dict[str, Param], path: Path) -> Endpoint
         now_variant=e.get("now_variant"),
         now_toggle=e.get("now_toggle"),
         exclude_leagues=list(e.get("exclude_leagues", [])),
+        docstring=dict(e.get("docstring") or {}),
     )
     # validate path tokens (excluding the {sport}/{league} slugs) have a known param;
     # strip optional-segment brackets first so "[/{token}]" tokens are seen.


### PR DESCRIPTION
## Why

`nba_stats_drafthistory` did not exist. The canonical catalog marked drafthistory `league_applicability["00"] = "barren"`, `gen_nba_stats._stats_eps()` keeps only `"live"`, so the wrapper was never generated.

That is load-bearing beyond the missing wrapper: the raw-store sweep discovers season endpoints by **introspecting the generated module** (`scrape/stats/endpoints.discover()`), so with no wrapper `hoopR-nba-stats-raw` could never capture drafthistory at all. `nba_stats/json/drafthistory/` is absent from the NBA archive while the WNBA twin — marked `live` — has captured it since 1997.

## Measurement

Probed against stats.nba.com from a residential IP on 2026-08-12, with a `franchisehistory` **control** in the same session to distinguish a real zero-row answer from the host's silent-hang block (a hang is not evidence of barren):

| call | result |
|---|---|
| `franchisehistory` LeagueID=00 (control) | 74 rows, 1.0s |
| `drafthistory` LeagueID=00, no season | **8,434 rows, seasons 1947–2026** |
| `drafthistory` LeagueID=00, Season=2003 | **58 rows**, #1 LeBron James, CLE |
| `drafthistory` LeagueID=15 | 0 rows |
| `drafthistory` LeagueID=20 | 0 rows |

`barren` is **correct** for Summer League and the G-League, so this flips `"00"` alone and leaves `15`/`20` untouched.

## Second fix: the season filter was silently dropped

`_SEASON_PARAMS` is matched by **exact** name. drafthistory is the only endpoint spelling its season `season_year_nullable`, which does not match `season_year`, so `season_variants()` emitted `{"league_id": "00"}` — no season at all.

This is the same bug the list's own comment already records for `season_nullable`, but it fails far more quietly. Unfiltered, drafthistory returns the **full** history rather than nothing, so a season sweep does not produce an obviously-empty capture — it writes the *identical* payload under every season.

That is not hypothetical: `wehoop-wnba-stats-raw` is in exactly that state today — 30 byte-identical `drafthistory/{season}.json` files, every one `md5 b682aa93cc`, each echoing `"Season": null`. Capturing NBA without this fix would have reproduced it.

## Changes

- `nba_canonical_catalog.json` — drafthistory `"00"`: `barren` → `live` (only that key)
- `scrape/stats/endpoints.py` — add `season_year_nullable` to `_SEASON_PARAMS`; kept out of `_SPAN_SEASON_PARAMS` because the measured shape is a bare draft year
- regenerated: `nba_stats` **112 → 113** endpoints, + returns-schema, + reference docs
- regression test asserting the season filter survives for that spelling

## Verification

- `codegen --check`: green
- `tests/scrape/test_scrape_stats_league.py`: 17 passed
- `ruff`: clean
- live through the new wrapper: `nba_stats_drafthistory(league_id="00", season_year_nullable="2003")` → `(58, 14)`, LeBron / Darko / Carmelo at picks 1-3
- `season_variants(...)` now yields `{'season_year_nullable': '2003', 'league_id': '00'}`

Unblocks the NBA `drafthistory` capture + the `nba_stats_draft` release.

## Summary by Sourcery

Add support for the NBA Stats drafthistory endpoint and ensure its season filter is correctly treated as a season parameter for league sweeps.

New Features:
- Introduce nba_stats_drafthistory wrapper and wire it into the NBA Stats endpoint catalog, schema, and reference documentation.

Bug Fixes:
- Treat season_year_nullable as a season parameter so league sweeps apply the season filter instead of capturing full unfiltered draft history.

Enhancements:
- Update NBA Stats endpoint counts and reference docs to reflect the new drafthistory endpoint.

Tests:
- Add regression test verifying that season_variants preserves the season_year_nullable filter for drafthistory across leagues.

Chores:
- Mark drafthistory as live for NBA LeagueID 00 in the canonical catalog to enable discovery and capture of its data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added access to NBA draft history statistics.
  * Supports filtering by season, league, college, team, draft round, draft pick, overall pick, and top results.
  * Results can be returned as parsed data or in the raw API response format.

* **Documentation**
  * Added endpoint usage details, parameters, response fields, and examples.
  * Updated NBA Stats API documentation to list 113 endpoints.
  * Improved NBA and WNBA draft-history examples and references.

* **Bug Fixes**
  * Preserved season-year filtering across NBA and WNBA statistics endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->