### PR TITLE
refactor(nba): repoint the _v3 loaders onto the production release tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Unreleased](#unreleased)
+  - [Deprecated — the three NBA `*_v3` loaders now read the production releases](#deprecated--the-three-nba-_v3-loaders-now-read-the-production-releases)
+  - [Docs — NBA shifted loaders: the `season` COLUMN is the END year](#docs--nba-shifted-loaders-the-season-column-is-the-end-year)
   - [New — `sportsdataverse.wexp`: win-expectancy bake-off harness (NFL + CFB)](#new--sportsdataversewexp-win-expectancy-bake-off-harness-nfl--cfb)
   - [New — `load_nfl_ratings_weekly`: per-week as-of NFL ratings vintages](#new--load_nfl_ratings_weekly-per-week-as-of-nfl-ratings-vintages)
   - [New — `sportsdataverse.scrape.espn`: shared ESPN `-raw` archive engine](#new--sportsdataversescrapeespn-shared-espn--raw-archive-engine)
@@ -230,6 +232,54 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Unreleased
+
+### Deprecated — the three NBA `*_v3` loaders now read the production releases
+
+`load_nba_stats_pbp_v3`, `load_nba_stats_possessions_v3` and
+`load_nba_stats_lineups_v3` read one-asset, season-2025-only release tags
+(`nba_stats_pbpv3`, `nba_stats_possessions_v3`, `nba_stats_lineups_v3`) that are
+being retired. Those assets were built before the 2025-26 Finals ended and are
+missing six games (`0042500317`, `0042500401`–`0405`).
+
+The Program V pipeline now admits every game type (preseason `001`, regular
+`002`, All-Star `003`, playoffs `004`, play-in `005`, NBA Cup `006`) across all
+30 seasons, so the production tags carry a **strict superset** — verified live
+for the overlapping season: 707,440 rows / 1,400 games vs 704,314 / 1,394, with
+zero games lost, zero games short a row, and no column dropped (production adds
+`season`).
+
+All three keep working and are now **`DeprecationWarning` shims** (removal in
+`0.1.0`) forwarding to their production successors:
+
+| Deprecated | Use instead | Release now read |
+|---|---|---|
+| `load_nba_stats_pbp_v3` | `load_nba_stats_pbp` | `nba_stats_pbp` |
+| `load_nba_stats_possessions_v3` | `load_nba_stats_possessions` | `nba_stats_possessions` |
+| `load_nba_stats_lineups_v3` | `load_nba_stats_game_lineups` | `nba_stats_game_lineups` |
+
+**The `seasons` argument is unchanged.** It was the season's START year before
+and still is: `load_nba_stats_pbp_v3(seasons=2025)` meant 2025-26 when it read
+`play_by_play_v3_2025.parquet` and still means 2025-26 now that it reads
+`nba_play_by_play_2026.parquet`. The retired assets were START-year keyed and the
+production assets are END-year keyed; that translation lives in the loader's
+`{season + 1}` asset-path template, so the shims forward `seasons` untouched.
+
+### Docs — NBA shifted loaders: the `season` COLUMN is the END year
+
+The four NBA loaders whose asset path carries `{season + 1}`
+(`load_nba_stats_schedules`, `load_nba_stats_pbp`, `load_nba_stats_possessions`,
+`load_nba_stats_game_lineups`) return frames stamped with the **asset's** year,
+so the `season` column does not equal the `seasons` argument:
+`load_nba_stats_schedules(seasons=2024)` returns rows reading `season == 2025`.
+Unshifted NBA siblings (`team_boxscores`, `officials`, `rosters`) stamp `2024`
+for that same real season.
+
+This was undocumented and is load-bearing — a partitioner keying off the column
+writes the 2024-25 season over the 2025-26 partition. The divergence is now
+documented in all four docstrings (and the three shims that inherit it), with a
+codegen test that fails if a future shifted loader ships silent. The column is
+**documented, not restamped**: it is the published asset's own identity, and
+rewriting it would make the frame disagree with the file it came from.
 
 ### New — `sportsdataverse.wexp`: win-expectancy bake-off harness (NFL + CFB)
 

--- a/docs/docs/nba/reference/loaders.md
+++ b/docs/docs/nba/reference/loaders.md
@@ -30,16 +30,16 @@ flowchart LR
 | `load_nba_stats_coaches` | [nba_stats_coaches](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_coaches) | — |
 | `load_nba_stats_game_rosters` | [nba_stats_game_rosters](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_game_rosters) | — |
 | `load_nba_stats_lineups` | [nba_stats_lineups](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_lineups) | — |
-| `load_nba_stats_lineups_v3` | [nba_stats_lineups_v3](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_lineups_v3) | — |
+| `load_nba_stats_lineups_v3` | [nba_stats_game_lineups](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_game_lineups) | — |
 | `load_nba_stats_officials` | [nba_stats_officials](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_officials) | — |
 | `load_nba_stats_pbp` | [nba_stats_pbp](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_pbp) | — |
 | `load_nba_stats_possessions` | [nba_stats_possessions](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_possessions) | — |
 | `load_nba_stats_game_lineups` | [nba_stats_game_lineups](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_game_lineups) | — |
-| `load_nba_stats_pbp_v3` | [nba_stats_pbpv3](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_pbpv3) | — |
+| `load_nba_stats_pbp_v3` | [nba_stats_pbp](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_pbp) | — |
 | `load_nba_stats_player_boxscores` | [nba_stats_player_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_player_boxscores) | — |
 | `load_nba_stats_player_game_logs` | [nba_stats_player_game_logs](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_player_game_logs) | — |
 | `load_nba_stats_player_season_stats` | [nba_stats_player_season_stats](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_player_season_stats) | — |
-| `load_nba_stats_possessions_v3` | [nba_stats_possessions_v3](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_possessions_v3) | — |
+| `load_nba_stats_possessions_v3` | [nba_stats_possessions](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_possessions) | — |
 | `load_nba_stats_rosters` | [nba_stats_rosters](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_rosters) | — |
 | `load_nba_stats_shots` | [nba_stats_shots](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_shots) | — |
 | `load_nba_stats_standings` | [nba_stats_standings](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_standings) | — |
@@ -898,7 +898,7 @@ load_nba_stats_lineups(seasons=2025)
 
 ## `load_nba_stats_lineups_v3`
 
-Release: [nba_stats_lineups_v3](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_lineups_v3) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_lineups_v3/nba_lineups_v3_{season}.parquet`
+Release: [nba_stats_game_lineups](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_game_lineups) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_game_lineups/nba_lineups_{season + 1}.parquet`
 ### Returns
 
 | col_name | type | description |
@@ -916,6 +916,7 @@ Release: [nba_stats_lineups_v3](https://github.com/sportsdataverse/sportsdataver
 | `away_player_3` | Int64 |  |
 | `away_player_4` | Int64 |  |
 | `away_player_5` | Int64 |  |
+| `season` | Int64 | Season year. |
 
 ```python
 load_nba_stats_lineups_v3(seasons=2025)
@@ -1075,7 +1076,7 @@ load_nba_stats_game_lineups(seasons=2025)
 
 ## `load_nba_stats_pbp_v3`
 
-Release: [nba_stats_pbpv3](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_pbpv3) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_pbpv3/play_by_play_v3_{season}.parquet`
+Release: [nba_stats_pbp](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_pbp) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_pbp/nba_play_by_play_{season + 1}.parquet`
 ### Returns
 
 | col_name | type | description |
@@ -1128,6 +1129,7 @@ Release: [nba_stats_pbpv3](https://github.com/sportsdataverse/sportsdataverse-da
 | `def_player_3` | Int64 |  |
 | `def_player_4` | Int64 |  |
 | `def_player_5` | Int64 |  |
+| `season` | Int64 | Season year. |
 
 ```python
 load_nba_stats_pbp_v3(seasons=2025)
@@ -1446,7 +1448,7 @@ load_nba_stats_player_season_stats(seasons=2025)
 
 ## `load_nba_stats_possessions_v3`
 
-Release: [nba_stats_possessions_v3](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_possessions_v3) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_possessions_v3/nba_possessions_v3_{season}.parquet`
+Release: [nba_stats_possessions](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_possessions) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_possessions/nba_possessions_{season + 1}.parquet`
 ### Returns
 
 | col_name | type | description |
@@ -1485,6 +1487,7 @@ Release: [nba_stats_possessions_v3](https://github.com/sportsdataverse/sportsdat
 | `def_player_4` | Int64 |  |
 | `def_player_5` | Int64 |  |
 | `lineup_source` | String |  |
+| `season` | Int64 | Season year. |
 
 ```python
 load_nba_stats_possessions_v3(seasons=2025)

--- a/docs/src/pages/CHANGELOG.md
+++ b/docs/src/pages/CHANGELOG.md
@@ -3,6 +3,8 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Unreleased](#unreleased)
+  - [Deprecated — the three NBA `*_v3` loaders now read the production releases](#deprecated--the-three-nba-_v3-loaders-now-read-the-production-releases)
+  - [Docs — NBA shifted loaders: the `season` COLUMN is the END year](#docs--nba-shifted-loaders-the-season-column-is-the-end-year)
   - [New — `sportsdataverse.wexp`: win-expectancy bake-off harness (NFL + CFB)](#new--sportsdataversewexp-win-expectancy-bake-off-harness-nfl--cfb)
   - [New — `load_nfl_ratings_weekly`: per-week as-of NFL ratings vintages](#new--load_nfl_ratings_weekly-per-week-as-of-nfl-ratings-vintages)
   - [New — `sportsdataverse.scrape.espn`: shared ESPN `-raw` archive engine](#new--sportsdataversescrapeespn-shared-espn--raw-archive-engine)
@@ -230,6 +232,54 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Unreleased
+
+### Deprecated — the three NBA `*_v3` loaders now read the production releases
+
+`load_nba_stats_pbp_v3`, `load_nba_stats_possessions_v3` and
+`load_nba_stats_lineups_v3` read one-asset, season-2025-only release tags
+(`nba_stats_pbpv3`, `nba_stats_possessions_v3`, `nba_stats_lineups_v3`) that are
+being retired. Those assets were built before the 2025-26 Finals ended and are
+missing six games (`0042500317`, `0042500401`–`0405`).
+
+The Program V pipeline now admits every game type (preseason `001`, regular
+`002`, All-Star `003`, playoffs `004`, play-in `005`, NBA Cup `006`) across all
+30 seasons, so the production tags carry a **strict superset** — verified live
+for the overlapping season: 707,440 rows / 1,400 games vs 704,314 / 1,394, with
+zero games lost, zero games short a row, and no column dropped (production adds
+`season`).
+
+All three keep working and are now **`DeprecationWarning` shims** (removal in
+`0.1.0`) forwarding to their production successors:
+
+| Deprecated | Use instead | Release now read |
+|---|---|---|
+| `load_nba_stats_pbp_v3` | `load_nba_stats_pbp` | `nba_stats_pbp` |
+| `load_nba_stats_possessions_v3` | `load_nba_stats_possessions` | `nba_stats_possessions` |
+| `load_nba_stats_lineups_v3` | `load_nba_stats_game_lineups` | `nba_stats_game_lineups` |
+
+**The `seasons` argument is unchanged.** It was the season's START year before
+and still is: `load_nba_stats_pbp_v3(seasons=2025)` meant 2025-26 when it read
+`play_by_play_v3_2025.parquet` and still means 2025-26 now that it reads
+`nba_play_by_play_2026.parquet`. The retired assets were START-year keyed and the
+production assets are END-year keyed; that translation lives in the loader's
+`{season + 1}` asset-path template, so the shims forward `seasons` untouched.
+
+### Docs — NBA shifted loaders: the `season` COLUMN is the END year
+
+The four NBA loaders whose asset path carries `{season + 1}`
+(`load_nba_stats_schedules`, `load_nba_stats_pbp`, `load_nba_stats_possessions`,
+`load_nba_stats_game_lineups`) return frames stamped with the **asset's** year,
+so the `season` column does not equal the `seasons` argument:
+`load_nba_stats_schedules(seasons=2024)` returns rows reading `season == 2025`.
+Unshifted NBA siblings (`team_boxscores`, `officials`, `rosters`) stamp `2024`
+for that same real season.
+
+This was undocumented and is load-bearing — a partitioner keying off the column
+writes the 2024-25 season over the 2025-26 partition. The divergence is now
+documented in all four docstrings (and the three shims that inherit it), with a
+codegen test that fails if a future shifted loader ships silent. The column is
+**documented, not restamped**: it is the published asset's own identity, and
+rewriting it would make the frame disagree with the file it came from.
 
 ### New — `sportsdataverse.wexp`: win-expectancy bake-off harness (NFL + CFB)
 

--- a/sportsdataverse/cfb/cfb_loaders.py
+++ b/sportsdataverse/cfb/cfb_loaders.py
@@ -13,6 +13,7 @@ from sportsdataverse._codegen_runtime import (
     _read_release_parquet,
     cli_warn,
 )
+from sportsdataverse._deprecation import warn_deprecated  # noqa: F401  (used only by deprecated_for shims)
 
 __all__ = [
     "load_cfb_pbp",

--- a/sportsdataverse/mbb/mbb_loaders.py
+++ b/sportsdataverse/mbb/mbb_loaders.py
@@ -13,6 +13,7 @@ from sportsdataverse._codegen_runtime import (
     _read_release_parquet,
     cli_warn,
 )
+from sportsdataverse._deprecation import warn_deprecated  # noqa: F401  (used only by deprecated_for shims)
 
 __all__ = [
     "load_mbb_pbp",

--- a/sportsdataverse/mlb/mlb_loaders.py
+++ b/sportsdataverse/mlb/mlb_loaders.py
@@ -13,6 +13,7 @@ from sportsdataverse._codegen_runtime import (
     _read_release_parquet,
     cli_warn,
 )
+from sportsdataverse._deprecation import warn_deprecated  # noqa: F401  (used only by deprecated_for shims)
 
 __all__ = [
     "load_mlb_re24_matrix",

--- a/sportsdataverse/nba/nba_loaders.py
+++ b/sportsdataverse/nba/nba_loaders.py
@@ -13,6 +13,7 @@ from sportsdataverse._codegen_runtime import (
     _read_release_parquet,
     cli_warn,
 )
+from sportsdataverse._deprecation import warn_deprecated  # noqa: F401  (used only by deprecated_for shims)
 
 __all__ = [
     "load_nba_pbp",
@@ -1021,6 +1022,14 @@ def load_nba_stats_schedules(seasons, return_as_pandas: bool = False):
         A polars (or pandas) DataFrame; seasons with no published asset are
         skipped with a warning rather than raising (404-safe).
 
+        .. warning:: The ``season`` COLUMN carries the END year -- it is the
+           published asset's own stamp and is **not** the ``seasons`` argument
+           you passed. ``load_nba_stats_schedules(seasons=2024)`` returns rows whose
+           ``season`` reads ``2025`` (the 2024-25 season). Unshifted NBA
+           siblings (team_boxscores, officials, rosters) stamp the START year
+           for that same real season, so do not join on ``season`` across the
+           two groups without normalizing first.
+
         |col_name               |type   |
         |:----------------------|:------|
         |game_id                |String |
@@ -1399,17 +1408,33 @@ def load_nba_stats_lineups(seasons, return_as_pandas: bool = False):
 
 
 def load_nba_stats_lineups_v3(seasons, return_as_pandas: bool = False):
-    """Load nba_stats_lineups_v3 (sportsdataverse-data release).
+    """Deprecated alias for ``load_nba_stats_game_lineups``.
 
-    Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_lineups_v3
+    Forwards to :func:`load_nba_stats_game_lineups`, which reads the ``nba_stats_game_lineups``
+    release -- a superset of the retired tag this loader used to read.
+    Will be removed in 0.1.0; migrate callers to
+    ``load_nba_stats_game_lineups``. The ``seasons`` argument is unchanged.
+
+    Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_game_lineups
 
     Args:
-        seasons: an int or iterable of seasons (>= 2025).
+        seasons: an int or iterable of seasons (>= 1996).
+            Pass the season's START year (e.g. ``1996`` for the 1996-97
+            season); the published asset is keyed by the END year and the
+            loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
         A polars (or pandas) DataFrame; seasons with no published asset are
         skipped with a warning rather than raising (404-safe).
+
+        .. warning:: The ``season`` COLUMN carries the END year -- it is the
+           published asset's own stamp and is **not** the ``seasons`` argument
+           you passed. ``load_nba_stats_lineups_v3(seasons=2024)`` returns rows whose
+           ``season`` reads ``2025`` (the 2024-25 season). Unshifted NBA
+           siblings (team_boxscores, officials, rosters) stamp the START year
+           for that same real season, so do not join on ``season`` across the
+           two groups without normalizing first.
 
         |col_name      |type   |
         |:-------------|:------|
@@ -1426,32 +1451,25 @@ def load_nba_stats_lineups_v3(seasons, return_as_pandas: bool = False):
         |away_player_3 |Int64  |
         |away_player_4 |Int64  |
         |away_player_5 |Int64  |
+        |season        |Int64  |
 
     Raises:
-        SeasonNotFoundError: if a requested season is below 2025.
+        SeasonNotFoundError: if a requested season is below 1996.
 
     Example:
         Quick start::
 
             load_nba_stats_lineups_v3(seasons=2025)
     """
-    frames, missing = [], []
-    for season in _as_season_list(seasons):
-        if int(season) < 2025:
-            raise SeasonNotFoundError("season cannot be less than 2025")
-        df = _read_release_parquet(
-            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_lineups_v3/nba_lineups_v3_{season}.parquet"
-        )
-        if df is None:
-            missing.append(season)
-            continue
-        frames.append(df)
-    if missing:
-        cli_warn("load_nba_stats_lineups_v3: no data for season(s) {missing} (skipped)".format(missing=missing))
-    # diagonal: per-season release schemas can drift (columns added/dropped
-    # over the years) -- union columns, null-fill gaps.
-    out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
-    return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
+    warn_deprecated(
+        "load_nba_stats_lineups_v3",
+        replacement="load_nba_stats_game_lineups",
+        removed_in="0.1.0",
+    )
+    # Pure pass-through: both loaders take the season's START year, so no offset
+    # is applied here. The START -> END year translation lives in the target's
+    # own asset-path template ({season + N}), not at this boundary.
+    return load_nba_stats_game_lineups(seasons, return_as_pandas=return_as_pandas)
 
 
 def load_nba_stats_officials(seasons, return_as_pandas: bool = False):
@@ -1518,6 +1536,14 @@ def load_nba_stats_pbp(seasons, return_as_pandas: bool = False):
     Returns:
         A polars (or pandas) DataFrame; seasons with no published asset are
         skipped with a warning rather than raising (404-safe).
+
+        .. warning:: The ``season`` COLUMN carries the END year -- it is the
+           published asset's own stamp and is **not** the ``seasons`` argument
+           you passed. ``load_nba_stats_pbp(seasons=2024)`` returns rows whose
+           ``season`` reads ``2025`` (the 2024-25 season). Unshifted NBA
+           siblings (team_boxscores, officials, rosters) stamp the START year
+           for that same real season, so do not join on ``season`` across the
+           two groups without normalizing first.
 
         |col_name          |type    |
         |:-----------------|:-------|
@@ -1614,6 +1640,14 @@ def load_nba_stats_possessions(seasons, return_as_pandas: bool = False):
         A polars (or pandas) DataFrame; seasons with no published asset are
         skipped with a warning rather than raising (404-safe).
 
+        .. warning:: The ``season`` COLUMN carries the END year -- it is the
+           published asset's own stamp and is **not** the ``seasons`` argument
+           you passed. ``load_nba_stats_possessions(seasons=2024)`` returns rows whose
+           ``season`` reads ``2025`` (the 2024-25 season). Unshifted NBA
+           siblings (team_boxscores, officials, rosters) stamp the START year
+           for that same real season, so do not join on ``season`` across the
+           two groups without normalizing first.
+
         |col_name                |type    |
         |:-----------------------|:-------|
         |game_id                 |String  |
@@ -1695,6 +1729,14 @@ def load_nba_stats_game_lineups(seasons, return_as_pandas: bool = False):
         A polars (or pandas) DataFrame; seasons with no published asset are
         skipped with a warning rather than raising (404-safe).
 
+        .. warning:: The ``season`` COLUMN carries the END year -- it is the
+           published asset's own stamp and is **not** the ``seasons`` argument
+           you passed. ``load_nba_stats_game_lineups(seasons=2024)`` returns rows whose
+           ``season`` reads ``2025`` (the 2024-25 season). Unshifted NBA
+           siblings (team_boxscores, officials, rosters) stamp the START year
+           for that same real season, so do not join on ``season`` across the
+           two groups without normalizing first.
+
         |col_name      |type   |
         |:-------------|:------|
         |game_id       |String |
@@ -1740,17 +1782,33 @@ def load_nba_stats_game_lineups(seasons, return_as_pandas: bool = False):
 
 
 def load_nba_stats_pbp_v3(seasons, return_as_pandas: bool = False):
-    """Load nba_stats_pbpv3 (sportsdataverse-data release).
+    """Deprecated alias for ``load_nba_stats_pbp``.
 
-    Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_pbpv3
+    Forwards to :func:`load_nba_stats_pbp`, which reads the ``nba_stats_pbp``
+    release -- a superset of the retired tag this loader used to read.
+    Will be removed in 0.1.0; migrate callers to
+    ``load_nba_stats_pbp``. The ``seasons`` argument is unchanged.
+
+    Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_pbp
 
     Args:
-        seasons: an int or iterable of seasons (>= 2025).
+        seasons: an int or iterable of seasons (>= 1996).
+            Pass the season's START year (e.g. ``1996`` for the 1996-97
+            season); the published asset is keyed by the END year and the
+            loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
         A polars (or pandas) DataFrame; seasons with no published asset are
         skipped with a warning rather than raising (404-safe).
+
+        .. warning:: The ``season`` COLUMN carries the END year -- it is the
+           published asset's own stamp and is **not** the ``seasons`` argument
+           you passed. ``load_nba_stats_pbp_v3(seasons=2024)`` returns rows whose
+           ``season`` reads ``2025`` (the 2024-25 season). Unshifted NBA
+           siblings (team_boxscores, officials, rosters) stamp the START year
+           for that same real season, so do not join on ``season`` across the
+           two groups without normalizing first.
 
         |col_name          |type    |
         |:-----------------|:-------|
@@ -1802,32 +1860,25 @@ def load_nba_stats_pbp_v3(seasons, return_as_pandas: bool = False):
         |def_player_3      |Int64   |
         |def_player_4      |Int64   |
         |def_player_5      |Int64   |
+        |season            |Int64   |
 
     Raises:
-        SeasonNotFoundError: if a requested season is below 2025.
+        SeasonNotFoundError: if a requested season is below 1996.
 
     Example:
         Quick start::
 
             load_nba_stats_pbp_v3(seasons=2025)
     """
-    frames, missing = [], []
-    for season in _as_season_list(seasons):
-        if int(season) < 2025:
-            raise SeasonNotFoundError("season cannot be less than 2025")
-        df = _read_release_parquet(
-            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_pbpv3/play_by_play_v3_{season}.parquet"
-        )
-        if df is None:
-            missing.append(season)
-            continue
-        frames.append(df)
-    if missing:
-        cli_warn("load_nba_stats_pbp_v3: no data for season(s) {missing} (skipped)".format(missing=missing))
-    # diagonal: per-season release schemas can drift (columns added/dropped
-    # over the years) -- union columns, null-fill gaps.
-    out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
-    return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
+    warn_deprecated(
+        "load_nba_stats_pbp_v3",
+        replacement="load_nba_stats_pbp",
+        removed_in="0.1.0",
+    )
+    # Pure pass-through: both loaders take the season's START year, so no offset
+    # is applied here. The START -> END year translation lives in the target's
+    # own asset-path template ({season + N}), not at this boundary.
+    return load_nba_stats_pbp(seasons, return_as_pandas=return_as_pandas)
 
 
 def load_nba_stats_player_boxscores(seasons, return_as_pandas: bool = False):
@@ -2237,17 +2288,33 @@ def load_nba_stats_player_season_stats(seasons, return_as_pandas: bool = False):
 
 
 def load_nba_stats_possessions_v3(seasons, return_as_pandas: bool = False):
-    """Load nba_stats_possessions_v3 (sportsdataverse-data release).
+    """Deprecated alias for ``load_nba_stats_possessions``.
 
-    Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_possessions_v3
+    Forwards to :func:`load_nba_stats_possessions`, which reads the ``nba_stats_possessions``
+    release -- a superset of the retired tag this loader used to read.
+    Will be removed in 0.1.0; migrate callers to
+    ``load_nba_stats_possessions``. The ``seasons`` argument is unchanged.
+
+    Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_possessions
 
     Args:
-        seasons: an int or iterable of seasons (>= 2025).
+        seasons: an int or iterable of seasons (>= 1996).
+            Pass the season's START year (e.g. ``1996`` for the 1996-97
+            season); the published asset is keyed by the END year and the
+            loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
         A polars (or pandas) DataFrame; seasons with no published asset are
         skipped with a warning rather than raising (404-safe).
+
+        .. warning:: The ``season`` COLUMN carries the END year -- it is the
+           published asset's own stamp and is **not** the ``seasons`` argument
+           you passed. ``load_nba_stats_possessions_v3(seasons=2024)`` returns rows whose
+           ``season`` reads ``2025`` (the 2024-25 season). Unshifted NBA
+           siblings (team_boxscores, officials, rosters) stamp the START year
+           for that same real season, so do not join on ``season`` across the
+           two groups without normalizing first.
 
         |col_name                |type    |
         |:-----------------------|:-------|
@@ -2285,32 +2352,25 @@ def load_nba_stats_possessions_v3(seasons, return_as_pandas: bool = False):
         |def_player_4            |Int64   |
         |def_player_5            |Int64   |
         |lineup_source           |String  |
+        |season                  |Int64   |
 
     Raises:
-        SeasonNotFoundError: if a requested season is below 2025.
+        SeasonNotFoundError: if a requested season is below 1996.
 
     Example:
         Quick start::
 
             load_nba_stats_possessions_v3(seasons=2025)
     """
-    frames, missing = [], []
-    for season in _as_season_list(seasons):
-        if int(season) < 2025:
-            raise SeasonNotFoundError("season cannot be less than 2025")
-        df = _read_release_parquet(
-            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_possessions_v3/nba_possessions_v3_{season}.parquet"
-        )
-        if df is None:
-            missing.append(season)
-            continue
-        frames.append(df)
-    if missing:
-        cli_warn("load_nba_stats_possessions_v3: no data for season(s) {missing} (skipped)".format(missing=missing))
-    # diagonal: per-season release schemas can drift (columns added/dropped
-    # over the years) -- union columns, null-fill gaps.
-    out = pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
-    return out.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else out
+    warn_deprecated(
+        "load_nba_stats_possessions_v3",
+        replacement="load_nba_stats_possessions",
+        removed_in="0.1.0",
+    )
+    # Pure pass-through: both loaders take the season's START year, so no offset
+    # is applied here. The START -> END year translation lives in the target's
+    # own asset-path template ({season + N}), not at this boundary.
+    return load_nba_stats_possessions(seasons, return_as_pandas=return_as_pandas)
 
 
 def load_nba_stats_rosters(seasons, return_as_pandas: bool = False):

--- a/sportsdataverse/nhl/nhl_loaders.py
+++ b/sportsdataverse/nhl/nhl_loaders.py
@@ -13,6 +13,7 @@ from sportsdataverse._codegen_runtime import (
     _read_release_parquet,
     cli_warn,
 )
+from sportsdataverse._deprecation import warn_deprecated  # noqa: F401  (used only by deprecated_for shims)
 
 __all__ = [
     "load_nhl_pbp",

--- a/sportsdataverse/pwhl/pwhl_loaders.py
+++ b/sportsdataverse/pwhl/pwhl_loaders.py
@@ -13,6 +13,7 @@ from sportsdataverse._codegen_runtime import (
     _read_release_parquet,
     cli_warn,
 )
+from sportsdataverse._deprecation import warn_deprecated  # noqa: F401  (used only by deprecated_for shims)
 
 __all__ = [
     "load_phf_pbp",

--- a/sportsdataverse/wbb/wbb_loaders.py
+++ b/sportsdataverse/wbb/wbb_loaders.py
@@ -13,6 +13,7 @@ from sportsdataverse._codegen_runtime import (
     _read_release_parquet,
     cli_warn,
 )
+from sportsdataverse._deprecation import warn_deprecated  # noqa: F401  (used only by deprecated_for shims)
 
 __all__ = [
     "load_wbb_pbp",

--- a/sportsdataverse/wnba/wnba_loaders.py
+++ b/sportsdataverse/wnba/wnba_loaders.py
@@ -13,6 +13,7 @@ from sportsdataverse._codegen_runtime import (
     _read_release_parquet,
     cli_warn,
 )
+from sportsdataverse._deprecation import warn_deprecated  # noqa: F401  (used only by deprecated_for shims)
 
 __all__ = [
     "load_wnba_pbp",

--- a/tests/codegen/test_loader_season_convention.py
+++ b/tests/codegen/test_loader_season_convention.py
@@ -39,6 +39,20 @@ CASES = [
     ("load_wnba_stats_possessions", "wnba", 2025, "wnba_possessions_2025.parquet"),
     ("load_wnba_stats_game_lineups", "wnba", 1997, "wnba_lineups_1997.parquet"),
     ("load_wnba_stats_game_lineups", "wnba", 2025, "wnba_lineups_2025.parquet"),
+    # Retired-tag shims. These used to read START-year-keyed ``*_v3_{season}``
+    # assets off their own tags; they now forward to the production loaders. The
+    # public ``seasons`` argument was START-year before and must stay START-year,
+    # so 2025 has to keep meaning 2025-26 -- i.e. the SAME asset the target picks.
+    ("load_nba_stats_pbp_v3", "nba", 2025, "nba_play_by_play_2026.parquet"),
+    ("load_nba_stats_possessions_v3", "nba", 2025, "nba_possessions_2026.parquet"),
+    ("load_nba_stats_lineups_v3", "nba", 2025, "nba_lineups_2026.parquet"),
+]
+
+# Deprecated shim -> the loader it forwards to.
+SHIMS = [
+    ("load_nba_stats_pbp_v3", "load_nba_stats_pbp"),
+    ("load_nba_stats_possessions_v3", "load_nba_stats_possessions"),
+    ("load_nba_stats_lineups_v3", "load_nba_stats_game_lineups"),
 ]
 
 
@@ -82,4 +96,67 @@ def test_only_nba_stats_families_carry_the_end_year_offset():
         "load_nba_stats_pbp",
         "load_nba_stats_possessions",
         "load_nba_stats_game_lineups",
+        # The retired-tag shims inherit their target's END-year asset path.
+        "load_nba_stats_pbp_v3",
+        "load_nba_stats_possessions_v3",
+        "load_nba_stats_lineups_v3",
     }
+
+
+@pytest.mark.parametrize(("shim", "target"), SHIMS)
+def test_shim_is_a_pure_pass_through(shim, target):
+    """The shim must not apply its own year arithmetic.
+
+    Both sides take the START year, so the shim forwards ``seasons`` untouched.
+    Adding an offset at this boundary would double-count the ``{season + 1}``
+    already in the target's asset path and shift every caller by a year.
+    """
+    for season in (1996, 2010, 2025):
+        assert _requested_url(shim, "nba", season) == _requested_url(target, "nba", season)
+
+
+@pytest.mark.parametrize(("shim", "target"), SHIMS)
+def test_shim_warns_and_names_its_replacement(shim, target):
+    import importlib
+
+    mod = importlib.import_module("sportsdataverse.nba.nba_loaders")
+    with patch.object(mod.pl, "read_parquet", side_effect=FileNotFoundError("404")):
+        with pytest.warns(DeprecationWarning, match=target):
+            getattr(mod, shim)(seasons=2025)
+
+
+def test_shifted_loaders_document_the_season_column_divergence():
+    """A ``{season + N}`` loader whose frame has a ``season`` column MUST say so.
+
+    The asset is END-year keyed and the frame carries the asset's own stamp, so
+    ``load_nba_stats_pbp(seasons=2024)`` returns rows reading ``season == 2025``
+    while unshifted siblings read ``2024`` for that same real season. Silence
+    here reads as "season means the same thing everywhere", which is false --
+    and downstream partitioners key off this column, so the wrong reading
+    overwrites the neighbouring season rather than duplicating it.
+    """
+    import importlib
+
+    import yaml
+
+    schemas = yaml.safe_load((ROOT / "tools" / "codegen" / "schemas" / "loader_schemas.yaml").read_text("utf-8"))
+    offenders = []
+    for ld in spec.load_releases(REL).loaders:
+        m = spec.SEASON_TOKEN.search(ld.url)
+        if not (m and m.group(1)):
+            continue
+        if not any(c["name"] == "season" for c in schemas.get(ld.fn) or []):
+            continue
+        mod = importlib.import_module(f"sportsdataverse.{ld.league}.{ld.league}_loaders")
+        doc = getattr(mod, ld.fn).__doc__ or ""
+        if "COLUMN carries the END year" not in doc:
+            offenders.append(ld.fn)
+    assert not offenders, f"shifted loaders missing the season-column warning: {offenders}"
+
+
+def test_retired_v3_tags_are_unreferenced():
+    """No loader may still point at a retired ``*_v3`` release tag."""
+    retired = {"nba_stats_pbpv3", "nba_stats_possessions_v3", "nba_stats_lineups_v3"}
+    for ld in spec.load_releases(REL).loaders:
+        assert ld.tag not in retired, f"{ld.fn} still reads retired tag {ld.tag}"
+        assert not any(t in ld.url for t in retired), f"{ld.fn} url still reads a retired tag: {ld.url}"

--- a/tools/codegen/endpoints/releases.yaml
+++ b/tools/codegen/endpoints/releases.yaml
@@ -902,9 +902,10 @@ loaders:
 - fn: load_nba_stats_lineups_v3
   league: nba
   base: sdv_releases
-  url: nba_stats_lineups_v3/nba_lineups_v3_{season}.parquet
-  tag: nba_stats_lineups_v3
-  min_season: 2025
+  url: nba_stats_game_lineups/nba_lineups_{season + 1}.parquet
+  tag: nba_stats_game_lineups
+  deprecated_for: load_nba_stats_game_lineups
+  min_season: 1996
   example_args:
     seasons: 2025
 - fn: load_nba_stats_officials
@@ -942,9 +943,10 @@ loaders:
 - fn: load_nba_stats_pbp_v3
   league: nba
   base: sdv_releases
-  url: nba_stats_pbpv3/play_by_play_v3_{season}.parquet
-  tag: nba_stats_pbpv3
-  min_season: 2025
+  url: nba_stats_pbp/nba_play_by_play_{season + 1}.parquet
+  tag: nba_stats_pbp
+  deprecated_for: load_nba_stats_pbp
+  min_season: 1996
   example_args:
     seasons: 2025
 - fn: load_nba_stats_player_boxscores
@@ -974,9 +976,10 @@ loaders:
 - fn: load_nba_stats_possessions_v3
   league: nba
   base: sdv_releases
-  url: nba_stats_possessions_v3/nba_possessions_v3_{season}.parquet
-  tag: nba_stats_possessions_v3
-  min_season: 2025
+  url: nba_stats_possessions/nba_possessions_{season + 1}.parquet
+  tag: nba_stats_possessions
+  deprecated_for: load_nba_stats_possessions
+  min_season: 1996
   example_args:
     seasons: 2025
 - fn: load_nba_stats_rosters

--- a/tools/codegen/generate.py
+++ b/tools/codegen/generate.py
@@ -1065,6 +1065,12 @@ def _loader_schemas() -> dict:
     return schemas
 
 
+# Release named in every generated loader deprecation. Per sportsdataverse
+# ._deprecation policy a deprecated API survives >= 2 minor releases, so this
+# stays 0.1.0 until the removals actually land.
+LOADER_DEPRECATION_REMOVED_IN = "0.1.0"
+
+
 def _build_loader_docstring(ld: spec.Loader) -> str:
     """4-space-indented docstring block for a generated dataset loader.
 
@@ -1072,6 +1078,13 @@ def _build_loader_docstring(ld: spec.Loader) -> str:
     schema was introspected for ``ld.fn``, so the generated docstrings carry the
     same column documentation the hand-written loaders lacked."""
     lines = [f'"""Load {ld.tag} (sportsdataverse-data release).', ""]
+    if ld.deprecated_for:
+        lines[0] = f'"""Deprecated alias for ``{ld.deprecated_for}``.'
+        lines.append(f"Forwards to :func:`{ld.deprecated_for}`, which reads the ``{ld.tag}``")
+        lines.append("release -- a superset of the retired tag this loader used to read.")
+        lines.append(f"Will be removed in {LOADER_DEPRECATION_REMOVED_IN}; migrate callers to")
+        lines.append(f"``{ld.deprecated_for}``. The ``seasons`` argument is unchanged.")
+        lines.append("")
     lines.append(f"Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/{ld.tag}")
     lines.append("")
     lines.append("Args:")
@@ -1089,6 +1102,21 @@ def _build_loader_docstring(ld: spec.Loader) -> str:
     lines.append("Returns:")
     lines.append("    A polars (or pandas) DataFrame; seasons with no published asset are")
     lines.append("    skipped with a warning rather than raising (404-safe).")
+    # Same token, same reason as the Args note: when the asset year is shifted, the
+    # frame carries the ASSET's stamp, so the `season` column does NOT equal the
+    # `seasons` argument. Documented rather than restamped -- rewriting the column
+    # would make the frame disagree with the file it was read from, and downstream
+    # partitioners key off this value.
+    if token and token.group(1) and any(c["name"] == "season" for c in _loader_schemas().get(ld.fn) or []):
+        off = int(token.group(1))
+        lines.append("")
+        lines.append("    .. warning:: The ``season`` COLUMN carries the END year -- it is the")
+        lines.append("       published asset's own stamp and is **not** the ``seasons`` argument")
+        lines.append(f"       you passed. ``{ld.fn}(seasons=2024)`` returns rows whose")
+        lines.append(f"       ``season`` reads ``{2024 + off}`` (the 2024-25 season). Unshifted NBA")
+        lines.append("       siblings (team_boxscores, officials, rosters) stamp the START year")
+        lines.append("       for that same real season, so do not join on ``season`` across the")
+        lines.append("       two groups without normalizing first.")
     cols = _loader_schemas().get(ld.fn) or []
     if cols:
         width = max([len("col_name")] + [len(c["name"]) for c in cols])
@@ -1121,6 +1149,8 @@ class _LoaderView:
         self.example_args = ld.example_args
         self.stub = ld.stub
         self.stub_message = ld.stub_message
+        self.deprecated_for = ld.deprecated_for
+        self.removed_in = LOADER_DEPRECATION_REMOVED_IN
         self.abs_url = "" if ld.stub else f"{bases[ld.base]}{ld.url}"
         self.docstring = _build_loader_docstring(ld)
         self.id_int64 = ld.id_int64

--- a/tools/codegen/schemas/loader_schemas.yaml
+++ b/tools/codegen/schemas/loader_schemas.yaml
@@ -7901,6 +7901,8 @@ load_nba_stats_lineups_v3:
   type: Int64
 - name: away_player_5
   type: Int64
+- name: season
+  type: Int64
 load_nba_stats_officials:
 - name: official_id
   type: Int64
@@ -8109,6 +8111,8 @@ load_nba_stats_pbp_v3:
 - name: def_player_4
   type: Int64
 - name: def_player_5
+  type: Int64
+- name: season
   type: Int64
 load_nba_stats_player_boxscores:
 - name: team_id
@@ -8803,6 +8807,8 @@ load_nba_stats_possessions_v3:
   type: Int64
 - name: lineup_source
   type: String
+- name: season
+  type: Int64
 load_nba_stats_rosters:
 - name: team_id
   type: Int64

--- a/tools/codegen/spec.py
+++ b/tools/codegen/spec.py
@@ -131,6 +131,13 @@ class Loader:
     notebook: Optional[str] = None
     stub: bool = False
     stub_message: Optional[str] = None
+    # Name of the loader that supersedes this one. When set, the generated body is
+    # a DeprecationWarning shim that forwards to that loader instead of reading
+    # ``url`` itself -- used when a release tag is retired and its content is
+    # already carried by another (superset) tag. Both loaders must expose the same
+    # public ``seasons`` convention so forwarding needs no year arithmetic; the
+    # ``{season + N}`` offset in ``url`` is what keeps the two aligned.
+    deprecated_for: Optional[str] = None
     # Id columns to canonicalize to Int64 at the loader boundary. Producers have
     # shipped the same ESPN id as String, Int32 and Int64 across releases, which
     # makes a cross-dataset join on that id silently match nothing. Declaring the
@@ -290,6 +297,7 @@ def load_releases(path: Path) -> ReleasesConfig:
             notebook=ld.get("notebook"),
             stub=ld.get("stub", False),
             stub_message=ld.get("stub_message"),
+            deprecated_for=ld.get("deprecated_for"),
             id_int64=list(ld.get("id_int64", []) or []),
         )
         for ld in raw["loaders"]

--- a/tools/codegen/templates/load_module.py.jinja
+++ b/tools/codegen/templates/load_module.py.jinja
@@ -12,6 +12,7 @@ from sportsdataverse._codegen_runtime import (
     _read_release_parquet,
     cli_warn,
 )
+from sportsdataverse._deprecation import warn_deprecated  # noqa: F401  (used only by deprecated_for shims)
 
 __all__ = [
 {% for ld in loaders %}
@@ -25,6 +26,16 @@ def {{ ld.fn }}(seasons, return_as_pandas: bool = False):
 {{ ld.docstring }}
 {% if ld.stub %}
     raise NotImplementedError({{ ld.stub_message|py_repr }})
+{% elif ld.deprecated_for %}
+    warn_deprecated(
+        {{ ld.fn|py_repr }},
+        replacement={{ ld.deprecated_for|py_repr }},
+        removed_in={{ ld.removed_in|py_repr }},
+    )
+    # Pure pass-through: both loaders take the season's START year, so no offset
+    # is applied here. The START -> END year translation lives in the target's
+    # own asset-path template ({season + N}), not at this boundary.
+    return {{ ld.deprecated_for }}(seasons, return_as_pandas=return_as_pandas)
 {% else %}
     frames, missing = [], []
     for season in _as_season_list(seasons):


### PR DESCRIPTION
## What

Repoints the three NBA `_v3` loaders off the release tags being retired
(`nba_stats_pbpv3`, `nba_stats_possessions_v3`, `nba_stats_lineups_v3`) and onto
the production tags. **No tag or asset is retired or deleted here** — this is
repointing only, so the tags can be retired separately.

## Superset verification (done before changing anything)

Each `_v3` tag holds one season-2025 asset, built before the 2025-26 Finals
ended. I read both live assets and compared game-id sets directly:

| dataset | `_v3` rows / games | production rows / games | v3 games missing from prod |
|---|---|---|---|
| pbp | 704,314 / 1,394 | **707,440 / 1,400** | **0** |
| possessions | 277,222 / 1,394 | **278,341 / 1,400** | **0** |
| lineups | 704,314 / 1,394 | **707,440 / 1,400** | **0** |

The six extra games are exactly `0042500317`, `0042500401`–`0405`. Prefix
breakdown confirms every game type is admitted:

```
v3   {'001': 71, '002': 1230, '003': 7, '004': 79, '005': 6, '006': 1}
prod {'001': 71, '002': 1230, '003': 7, '004': 85, '005': 6, '006': 1}
```

Two checks beyond game-id containment, because "same games" is not "same data":

- **Row-level:** on the 1,394 shared games, **0** games have fewer rows in
  production than in `_v3`.
- **Column-level:** `_v3` has **no** column production lacks; production adds
  exactly one (`season`); zero dtype divergence.

## Which option I chose: (b) deprecate

`load_nba_stats_*_v3` become `DeprecationWarning` shims (removal `0.1.0`)
forwarding to the production loaders. They keep working.

Rationale — (b) over (a):

1. The repo has a **formal deprecation policy** (`sportsdataverse/_deprecation.py`)
   and an established precedent (`load_nfl_ngs_*`, `load_nfl_pfr_advstats_*`).
   CLAUDE.md names it as the pattern. (a) would leave three permanently
   misleading names promising a "v3" dataset that no longer exists distinctly.
2. Post-repoint these are **exact functional duplicates** of the production
   loaders — same season convention, same columns, same data. Keeping two names
   for one dataset forever is the cost (a) never stops paying.
3. Nothing is silently deleted; callers get a warning naming the replacement.

| Deprecated | Forwards to | Release now read |
|---|---|---|
| `load_nba_stats_pbp_v3` | `load_nba_stats_pbp` | `nba_stats_pbp` |
| `load_nba_stats_possessions_v3` | `load_nba_stats_possessions` | `nba_stats_possessions` |
| `load_nba_stats_lineups_v3` | `load_nba_stats_game_lineups` | `nba_stats_game_lineups` |

`lineups_v3` maps to **`game_lineups`**, not `lineups` — `nba_stats_lineups` is
the leaguedash lineup cube, a different dataset (different shape, `min_season`
2007). Asset sizes corroborate: `nba_lineups_v3_2025` 1,039,847 B vs
`nba_lineups_2026` 1,051,800 B.

## Season convention — unchanged (the highest-risk part)

**Every one of these loaders exposed a START-year `seasons` argument before this
change and still does.** The `_v3` assets were START-year keyed
(`play_by_play_v3_2025` = 2025-26) and production is END-year keyed
(`nba_play_by_play_2026` = 2025-26), but that translation lives in the codegen
asset-path template (`{season + 1}`), **not** at the shim boundary. So the shims
forward `seasons` **untouched, with no arithmetic**:

| loader | `seasons` before | `seasons` after | 2025 resolves to |
|---|---|---|---|
| `load_nba_stats_pbp_v3` | START year | **START year** | `nba_play_by_play_2026.parquet` (2025-26) |
| `load_nba_stats_possessions_v3` | START year | **START year** | `nba_possessions_2026.parquet` (2025-26) |
| `load_nba_stats_lineups_v3` | START year | **START year** | `nba_lineups_2026.parquet` (2025-26) |

Tests pin each shim to the same asset as its target for 1996 / 2010 / 2025, so a
future off-by-one fails rather than silently shifting every caller by a year.

## Live verification

Actually called, asserting **populated** output (these loaders `cli_warn`-and-skip
a missing season, so "no exception" proves nothing):

```
load_nba_stats_pbp_v3(seasons=2025)          rows=707,440  games=1400  cols=49
  DeprecationWarning: ... use load_nba_stats_pbp instead.
  prefixes {'001': 71, '002': 1230, '003': 7, '004': 85, '005': 6, '006': 1}
  vs retired _v3: +3,126 rows, +6 games   shim output == target  OK
load_nba_stats_possessions_v3(seasons=2025)  rows=278,341  games=1400  cols=35
  vs retired _v3: +1,119 rows, +6 games   shim output == target  OK
load_nba_stats_lineups_v3(seasons=2025)      rows=707,440  games=1400  cols=14
  vs retired _v3: +3,126 rows, +6 games   shim output == target  OK
```

## Also here: the `season` COLUMN divergence (undocumented until now)

A parallel sdv-db investigation surfaced that the four `{season + 1}`-shifted NBA
loaders return frames stamped with the **asset's** year, so the `season` column
does **not** equal the `seasons` argument. I confirmed this independently against
live assets rather than taking it on report:

```
pbp / schedules / possessions / game_lineups (shifted)   season col = [2026]
team_boxscores / officials      (unshifted)              season col = [2025]
```

Both are the 2025-26 season. This was silent, and it is load-bearing: a
partitioner keying off the column writes 2024-25 **over** the 2025-26 partition.

**Decision: document, do not restamp.** The column is the published asset's own
identity; rewriting it would make the frame disagree with the file it was read
from and destroy provenance for exactly the debugging this causes. sdv-db has
already shipped `key_on_requested_season` (#36) on the assumption the column stays
END-year — restamping would re-break what was just fixed. Restamping is also a
silent mutation of a column callers may already join on.

Applied at the single token-driven point in the docstring builder, so it covers
all four shifted loaders **and** the three shims automatically and cannot drift
from the asset path it describes. A new codegen test fails if a future shifted
loader ships without the note (mutation-tested — it catches all 7 when the text
is removed).

## Implementation note

Added a `deprecated_for:` field to the loader codegen (`spec.py` + template +
`generate.py`) rather than hand-editing a generated module — `nba_loaders.py` is
`DO NOT EDIT`. The other seven `*_loaders.py` diffs are one added import line
each from the shared template.

## Verification

- `generate.py --check` — green
- `tests/codegen/` — 157 passed, 11 skipped
- `tests/codegen/test_loader_season_convention.py` — 29 passed (was 16)
- `ruff check` / `ruff format --check` — clean
- `nba_loaders.py` is not in the mypy ratchet

Not merging.

## Summary by Sourcery

Deprecate the three NBA `*_v3` stats loaders in favor of their production counterparts and document the season-year semantics for NBA loaders whose assets use an end-year key, backed by codegen and tests to enforce the behavior and deprecation policy.

Enhancements:
- Introduce codegen support for deprecated loaders via a `deprecated_for` field, generating shims that forward to replacement loaders while emitting standardized deprecation warnings.
- Update NBA `_v3` loaders (`pbp_v3`, `possessions_v3`, `lineups_v3`) to act as pass-through shims to the corresponding production loaders and extend their supported season range via shared asset paths.

Documentation:
- Document in NBA loader docstrings and changelog that the `season` column reflects the asset END year, not the requested `seasons` START year, and warn users against joining across shifted and unshifted loaders without normalization.
- Refresh NBA loader reference docs and CHANGELOG entries to show that the `_v3` loaders now read production releases and include the `season` column in their schemas.

Tests:
- Add tests ensuring `_v3` NBA loaders forward to the same assets as their production counterparts, emit `DeprecationWarning` naming the replacement, and that no loader still references retired `*_v3` release tags.
- Add a codegen test that requires all season-shifted loaders with a `season` column to include the documented column divergence warning in their docstrings.

Chores:
- Import the shared deprecation helper into all league loader modules so future generated shims can rely on a single `warn_deprecated` implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Deprecations**
  - NBA lineups, play-by-play, and possessions V3 loaders now warn and forward requests to their recommended replacements.
  - Deprecated loaders support seasons from 1996 onward while preserving start-year season inputs.

- **Data Updates**
  - Returned `season` values for shifted NBA datasets now clearly reflect the asset’s end year.

- **Documentation**
  - Updated NBA loader references, schemas, release links, migration guidance, and deprecation notices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->