### PR TITLE
refactor(codegen): scope the deprecation import and the season-column wording

### DIFF
--- a/sportsdataverse/cfb/cfb_loaders.py
+++ b/sportsdataverse/cfb/cfb_loaders.py
@@ -13,7 +13,6 @@ from sportsdataverse._codegen_runtime import (
     _read_release_parquet,
     cli_warn,
 )
-from sportsdataverse._deprecation import warn_deprecated  # noqa: F401  (used only by deprecated_for shims)
 
 __all__ = [
     "load_cfb_pbp",

--- a/sportsdataverse/mbb/mbb_loaders.py
+++ b/sportsdataverse/mbb/mbb_loaders.py
@@ -13,7 +13,6 @@ from sportsdataverse._codegen_runtime import (
     _read_release_parquet,
     cli_warn,
 )
-from sportsdataverse._deprecation import warn_deprecated  # noqa: F401  (used only by deprecated_for shims)
 
 __all__ = [
     "load_mbb_pbp",

--- a/sportsdataverse/mlb/mlb_loaders.py
+++ b/sportsdataverse/mlb/mlb_loaders.py
@@ -13,7 +13,6 @@ from sportsdataverse._codegen_runtime import (
     _read_release_parquet,
     cli_warn,
 )
-from sportsdataverse._deprecation import warn_deprecated  # noqa: F401  (used only by deprecated_for shims)
 
 __all__ = [
     "load_mlb_re24_matrix",

--- a/sportsdataverse/nba/nba_loaders.py
+++ b/sportsdataverse/nba/nba_loaders.py
@@ -13,7 +13,7 @@ from sportsdataverse._codegen_runtime import (
     _read_release_parquet,
     cli_warn,
 )
-from sportsdataverse._deprecation import warn_deprecated  # noqa: F401  (used only by deprecated_for shims)
+from sportsdataverse._deprecation import warn_deprecated
 
 __all__ = [
     "load_nba_pbp",
@@ -1025,10 +1025,11 @@ def load_nba_stats_schedules(seasons, return_as_pandas: bool = False):
         .. warning:: The ``season`` COLUMN carries the END year -- it is the
            published asset's own stamp and is **not** the ``seasons`` argument
            you passed. ``load_nba_stats_schedules(seasons=2024)`` returns rows whose
-           ``season`` reads ``2025`` (the 2024-25 season). Unshifted NBA
-           siblings (team_boxscores, officials, rosters) stamp the START year
-           for that same real season, so do not join on ``season`` across the
-           two groups without normalizing first.
+           ``season`` reads ``2025`` (the 2024-25 season).
+           Unshifted ``nba_stats`` siblings (``team_boxscores``,
+           ``officials``, ``rosters``) stamp the START year for that same
+           real season, so do not join on ``season`` across the two groups
+           without normalizing first.
 
         |col_name               |type   |
         |:----------------------|:------|
@@ -1431,10 +1432,11 @@ def load_nba_stats_lineups_v3(seasons, return_as_pandas: bool = False):
         .. warning:: The ``season`` COLUMN carries the END year -- it is the
            published asset's own stamp and is **not** the ``seasons`` argument
            you passed. ``load_nba_stats_lineups_v3(seasons=2024)`` returns rows whose
-           ``season`` reads ``2025`` (the 2024-25 season). Unshifted NBA
-           siblings (team_boxscores, officials, rosters) stamp the START year
-           for that same real season, so do not join on ``season`` across the
-           two groups without normalizing first.
+           ``season`` reads ``2025`` (the 2024-25 season).
+           Unshifted ``nba_stats`` siblings (``team_boxscores``,
+           ``officials``, ``rosters``) stamp the START year for that same
+           real season, so do not join on ``season`` across the two groups
+           without normalizing first.
 
         |col_name      |type   |
         |:-------------|:------|
@@ -1540,10 +1542,11 @@ def load_nba_stats_pbp(seasons, return_as_pandas: bool = False):
         .. warning:: The ``season`` COLUMN carries the END year -- it is the
            published asset's own stamp and is **not** the ``seasons`` argument
            you passed. ``load_nba_stats_pbp(seasons=2024)`` returns rows whose
-           ``season`` reads ``2025`` (the 2024-25 season). Unshifted NBA
-           siblings (team_boxscores, officials, rosters) stamp the START year
-           for that same real season, so do not join on ``season`` across the
-           two groups without normalizing first.
+           ``season`` reads ``2025`` (the 2024-25 season).
+           Unshifted ``nba_stats`` siblings (``team_boxscores``,
+           ``officials``, ``rosters``) stamp the START year for that same
+           real season, so do not join on ``season`` across the two groups
+           without normalizing first.
 
         |col_name          |type    |
         |:-----------------|:-------|
@@ -1643,10 +1646,11 @@ def load_nba_stats_possessions(seasons, return_as_pandas: bool = False):
         .. warning:: The ``season`` COLUMN carries the END year -- it is the
            published asset's own stamp and is **not** the ``seasons`` argument
            you passed. ``load_nba_stats_possessions(seasons=2024)`` returns rows whose
-           ``season`` reads ``2025`` (the 2024-25 season). Unshifted NBA
-           siblings (team_boxscores, officials, rosters) stamp the START year
-           for that same real season, so do not join on ``season`` across the
-           two groups without normalizing first.
+           ``season`` reads ``2025`` (the 2024-25 season).
+           Unshifted ``nba_stats`` siblings (``team_boxscores``,
+           ``officials``, ``rosters``) stamp the START year for that same
+           real season, so do not join on ``season`` across the two groups
+           without normalizing first.
 
         |col_name                |type    |
         |:-----------------------|:-------|
@@ -1732,10 +1736,11 @@ def load_nba_stats_game_lineups(seasons, return_as_pandas: bool = False):
         .. warning:: The ``season`` COLUMN carries the END year -- it is the
            published asset's own stamp and is **not** the ``seasons`` argument
            you passed. ``load_nba_stats_game_lineups(seasons=2024)`` returns rows whose
-           ``season`` reads ``2025`` (the 2024-25 season). Unshifted NBA
-           siblings (team_boxscores, officials, rosters) stamp the START year
-           for that same real season, so do not join on ``season`` across the
-           two groups without normalizing first.
+           ``season`` reads ``2025`` (the 2024-25 season).
+           Unshifted ``nba_stats`` siblings (``team_boxscores``,
+           ``officials``, ``rosters``) stamp the START year for that same
+           real season, so do not join on ``season`` across the two groups
+           without normalizing first.
 
         |col_name      |type   |
         |:-------------|:------|
@@ -1805,10 +1810,11 @@ def load_nba_stats_pbp_v3(seasons, return_as_pandas: bool = False):
         .. warning:: The ``season`` COLUMN carries the END year -- it is the
            published asset's own stamp and is **not** the ``seasons`` argument
            you passed. ``load_nba_stats_pbp_v3(seasons=2024)`` returns rows whose
-           ``season`` reads ``2025`` (the 2024-25 season). Unshifted NBA
-           siblings (team_boxscores, officials, rosters) stamp the START year
-           for that same real season, so do not join on ``season`` across the
-           two groups without normalizing first.
+           ``season`` reads ``2025`` (the 2024-25 season).
+           Unshifted ``nba_stats`` siblings (``team_boxscores``,
+           ``officials``, ``rosters``) stamp the START year for that same
+           real season, so do not join on ``season`` across the two groups
+           without normalizing first.
 
         |col_name          |type    |
         |:-----------------|:-------|
@@ -2311,10 +2317,11 @@ def load_nba_stats_possessions_v3(seasons, return_as_pandas: bool = False):
         .. warning:: The ``season`` COLUMN carries the END year -- it is the
            published asset's own stamp and is **not** the ``seasons`` argument
            you passed. ``load_nba_stats_possessions_v3(seasons=2024)`` returns rows whose
-           ``season`` reads ``2025`` (the 2024-25 season). Unshifted NBA
-           siblings (team_boxscores, officials, rosters) stamp the START year
-           for that same real season, so do not join on ``season`` across the
-           two groups without normalizing first.
+           ``season`` reads ``2025`` (the 2024-25 season).
+           Unshifted ``nba_stats`` siblings (``team_boxscores``,
+           ``officials``, ``rosters``) stamp the START year for that same
+           real season, so do not join on ``season`` across the two groups
+           without normalizing first.
 
         |col_name                |type    |
         |:-----------------------|:-------|

--- a/sportsdataverse/nhl/nhl_loaders.py
+++ b/sportsdataverse/nhl/nhl_loaders.py
@@ -13,7 +13,6 @@ from sportsdataverse._codegen_runtime import (
     _read_release_parquet,
     cli_warn,
 )
-from sportsdataverse._deprecation import warn_deprecated  # noqa: F401  (used only by deprecated_for shims)
 
 __all__ = [
     "load_nhl_pbp",

--- a/sportsdataverse/pwhl/pwhl_loaders.py
+++ b/sportsdataverse/pwhl/pwhl_loaders.py
@@ -13,7 +13,6 @@ from sportsdataverse._codegen_runtime import (
     _read_release_parquet,
     cli_warn,
 )
-from sportsdataverse._deprecation import warn_deprecated  # noqa: F401  (used only by deprecated_for shims)
 
 __all__ = [
     "load_phf_pbp",

--- a/sportsdataverse/wbb/wbb_loaders.py
+++ b/sportsdataverse/wbb/wbb_loaders.py
@@ -13,7 +13,6 @@ from sportsdataverse._codegen_runtime import (
     _read_release_parquet,
     cli_warn,
 )
-from sportsdataverse._deprecation import warn_deprecated  # noqa: F401  (used only by deprecated_for shims)
 
 __all__ = [
     "load_wbb_pbp",

--- a/sportsdataverse/wnba/wnba_loaders.py
+++ b/sportsdataverse/wnba/wnba_loaders.py
@@ -13,7 +13,6 @@ from sportsdataverse._codegen_runtime import (
     _read_release_parquet,
     cli_warn,
 )
-from sportsdataverse._deprecation import warn_deprecated  # noqa: F401  (used only by deprecated_for shims)
 
 __all__ = [
     "load_wnba_pbp",

--- a/tools/codegen/generate.py
+++ b/tools/codegen/generate.py
@@ -1113,10 +1113,20 @@ def _build_loader_docstring(ld: spec.Loader) -> str:
         lines.append("    .. warning:: The ``season`` COLUMN carries the END year -- it is the")
         lines.append("       published asset's own stamp and is **not** the ``seasons`` argument")
         lines.append(f"       you passed. ``{ld.fn}(seasons=2024)`` returns rows whose")
-        lines.append(f"       ``season`` reads ``{2024 + off}`` (the 2024-25 season). Unshifted NBA")
-        lines.append("       siblings (team_boxscores, officials, rosters) stamp the START year")
-        lines.append("       for that same real season, so do not join on ``season`` across the")
-        lines.append("       two groups without normalizing first.")
+        lines.append(f"       ``season`` reads ``{2024 + off}`` (the 2024-25 season).")
+        # Concrete sibling names are league-specific, so only name them for the
+        # league whose siblings were actually verified. The codegen is
+        # league-agnostic and must not assert NBA table names over a future
+        # {season + N} loader in some other league.
+        if ld.league == "nba":
+            lines.append("       Unshifted ``nba_stats`` siblings (``team_boxscores``,")
+            lines.append("       ``officials``, ``rosters``) stamp the START year for that same")
+            lines.append("       real season, so do not join on ``season`` across the two groups")
+            lines.append("       without normalizing first.")
+        else:
+            lines.append("       Unshifted sibling loaders in this league stamp the START year")
+            lines.append("       for that same real season, so do not join on ``season`` across")
+            lines.append("       the two groups without normalizing first.")
     cols = _loader_schemas().get(ld.fn) or []
     if cols:
         width = max([len("col_name")] + [len(c["name"]) for c in cols])

--- a/tools/codegen/templates/load_module.py.jinja
+++ b/tools/codegen/templates/load_module.py.jinja
@@ -12,7 +12,9 @@ from sportsdataverse._codegen_runtime import (
     _read_release_parquet,
     cli_warn,
 )
-from sportsdataverse._deprecation import warn_deprecated  # noqa: F401  (used only by deprecated_for shims)
+{% if loaders | selectattr("deprecated_for") | list %}
+from sportsdataverse._deprecation import warn_deprecated
+{% endif %}
 
 __all__ = [
 {% for ld in loaders %}


### PR DESCRIPTION
## What

Follow-up to #365, which was merged before these two bot-review fixes were
pushed. They are code-review cleanups only — **no behavior change** to any
loader, and no change to the `_v3` repoint itself.

## Why this is a separate PR

#365 was squash-merged at 06:08:46Z as `4a30fe62`. The review fixes were pushed
to the branch at ~06:24, after the PR had already closed, so they never made it
onto `main`. Cherry-picked here onto the post-merge `main`.

## CodeRabbit — emit `warn_deprecated` only where a shim exists

The template imported `warn_deprecated` unconditionally, which put an unused
import plus a blanket `# noqa: F401` into all eight generated loader modules
even though only `nba_loaders.py` renders a `deprecated_for` shim.

The import is now conditional on the module actually having one. Net effect on
`main`: the seven modules that gained a spurious one-line import in #365
(`cfb`, `mbb`, `mlb`, `nhl`, `pwhl`, `wbb`, `wnba`) shed it and go back to
matching their pre-#365 content.

## Sourcery — don't assert NBA table names from a league-agnostic builder

The `season`-column warning added in #365 hardcoded *"Unshifted NBA siblings
(team_boxscores, officials, rosters)"* inside `_build_loader_docstring`, which
runs for every league.

It was accurate for every loader it currently renders on —
`test_only_nba_stats_families_carry_the_end_year_offset` pins the shifted set to
NBA — but a future `{season + N}` loader in another league would have been
handed an assertion about NBA tables that isn't true there. Concrete sibling
names are now emitted only when `ld.league == "nba"`; every other league gets
the same hazard stated generically.

## Sourcery — `LOADER_DEPRECATION_REMOVED_IN`: declined, with reasoning

The suggestion was to tie the constant to the package version. `removed_in` is a
*policy* commitment — which future release removes the API — not a function of
the current version. `sportsdataverse/_deprecation.py` requires a deprecation to
survive at least two minor releases and to name its removal version up front;
deriving it from `__version__` would silently change that promise on every
version bump.

On centralization specifically: a module-level constant in `generate.py` is
already *more* centralized than the existing precedent — the hand-written NFL
shims hardcode `removed_in="0.1.0"` at each call site. Hoisting one shared
constant into `_deprecation.py` for both generated and hand-written shims is a
reasonable follow-up, but it touches ~11 unrelated NFL loaders.

## Verification

- `generate.py` then `--check` — clean, no drift
- `ruff check sportsdataverse/ tools/codegen/` — all checks passed
- `tests/codegen/test_loader_season_convention.py` + `test_load_module.py` — 33 passed
- Confirmed post-regen that `warn_deprecated` appears in exactly one generated
  module (`nba_loaders.py`); `nfl_loaders.py` is hand-written and has its own.

Not merging.

## Summary by Sourcery

Tighten codegen around loader deprecations and season-column warnings without changing runtime behavior.

Enhancements:
- Scope the `warn_deprecated` import in generated loader modules so it is only emitted for leagues that actually define deprecation shims.
- Refine the season-column warning text in NBA stats loaders and in the shared docstring generator to distinguish NBA-specific sibling tables from generic league loaders and avoid league-agnostic assertions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved season-related warnings in loader documentation with clearer, league-specific guidance.
  * NBA messages now identify related loaders more explicitly, while other leagues use consistent sibling-loader descriptions.

* **Maintenance**
  * Streamlined generated loader metadata and documentation output.
  * No changes to loader behavior, functionality, or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->