### PR TITLE
feat(nba_stats)!: point the remaining 12 loaders at END-year-named assets

### DIFF
--- a/docs/docs/nba/reference/loaders.md
+++ b/docs/docs/nba/reference/loaders.md
@@ -659,7 +659,7 @@ load_nba_stats_schedules(seasons=2025)
 
 ## `load_nba_stats_coaches`
 
-Release: [nba_stats_coaches](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_coaches) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_coaches/coaches_{season}.parquet`
+Release: [nba_stats_coaches](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_coaches) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_coaches/coaches_{season + 1}.parquet`
 ### Returns
 
 | col_name | type | description |
@@ -682,7 +682,7 @@ load_nba_stats_coaches(seasons=2025)
 
 ## `load_nba_stats_game_rosters`
 
-Release: [nba_stats_game_rosters](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_game_rosters) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_game_rosters/game_rosters_{season}.parquet`
+Release: [nba_stats_game_rosters](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_game_rosters) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_game_rosters/game_rosters_{season + 1}.parquet`
 ### Returns
 
 | col_name | type | description |
@@ -704,7 +704,7 @@ load_nba_stats_game_rosters(seasons=2025)
 
 ## `load_nba_stats_lineups`
 
-Release: [nba_stats_lineups](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_lineups) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_lineups/lineups_{season}.parquet`
+Release: [nba_stats_lineups](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_lineups) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_lineups/lineups_{season + 1}.parquet`
 ### Returns
 
 | col_name | type | description |
@@ -924,7 +924,7 @@ load_nba_stats_lineups_v3(seasons=2025)
 
 ## `load_nba_stats_officials`
 
-Release: [nba_stats_officials](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_officials) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_officials/officials_{season}.parquet`
+Release: [nba_stats_officials](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_officials) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_officials/officials_{season + 1}.parquet`
 ### Returns
 
 | col_name | type | description |
@@ -1137,7 +1137,7 @@ load_nba_stats_pbp_v3(seasons=2025)
 
 ## `load_nba_stats_player_boxscores`
 
-Release: [nba_stats_player_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_player_boxscores) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_player_boxscores/player_boxscores_{season}.parquet`
+Release: [nba_stats_player_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_player_boxscores) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_player_boxscores/player_boxscores_{season + 1}.parquet`
 ### Returns
 
 | col_name | type | description |
@@ -1183,7 +1183,7 @@ load_nba_stats_player_boxscores(seasons=2025)
 
 ## `load_nba_stats_player_game_logs`
 
-Release: [nba_stats_player_game_logs](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_player_game_logs) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_player_game_logs/player_game_logs_{season}.parquet`
+Release: [nba_stats_player_game_logs](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_player_game_logs) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_player_game_logs/player_game_logs_{season + 1}.parquet`
 ### Returns
 
 | col_name | type | description |
@@ -1226,7 +1226,7 @@ load_nba_stats_player_game_logs(seasons=2025)
 
 ## `load_nba_stats_player_season_stats`
 
-Release: [nba_stats_player_season_stats](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_player_season_stats) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_player_season_stats/player_season_stats_{season}.parquet`
+Release: [nba_stats_player_season_stats](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_player_season_stats) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_player_season_stats/player_season_stats_{season + 1}.parquet`
 ### Returns
 
 | col_name | type | description |
@@ -1495,7 +1495,7 @@ load_nba_stats_possessions_v3(seasons=2025)
 
 ## `load_nba_stats_rosters`
 
-Release: [nba_stats_rosters](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_rosters) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_rosters/rosters_{season}.parquet`
+Release: [nba_stats_rosters](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_rosters) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_rosters/rosters_{season + 1}.parquet`
 ### Returns
 
 | col_name | type | description |
@@ -1524,7 +1524,7 @@ load_nba_stats_rosters(seasons=2025)
 
 ## `load_nba_stats_shots`
 
-Release: [nba_stats_shots](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_shots) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_shots/shots_{season}.parquet`
+Release: [nba_stats_shots](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_shots) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_shots/shots_{season + 1}.parquet`
 ### Returns
 
 | col_name | type | description |
@@ -1554,7 +1554,7 @@ load_nba_stats_shots(seasons=2025)
 
 ## `load_nba_stats_standings`
 
-Release: [nba_stats_standings](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_standings) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_standings/standings_{season}.parquet`
+Release: [nba_stats_standings](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_standings) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_standings/standings_{season + 1}.parquet`
 ### Returns
 
 | col_name | type | description |
@@ -1660,7 +1660,7 @@ load_nba_stats_standings(seasons=2025)
 
 ## `load_nba_stats_team_boxscores`
 
-Release: [nba_stats_team_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_team_boxscores) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_team_boxscores/team_boxscores_{season}.parquet`
+Release: [nba_stats_team_boxscores](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_team_boxscores) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_team_boxscores/team_boxscores_{season + 1}.parquet`
 ### Returns
 
 | col_name | type | description |
@@ -1698,7 +1698,7 @@ load_nba_stats_team_boxscores(seasons=2025)
 
 ## `load_nba_stats_team_season_stats`
 
-Release: [nba_stats_team_season_stats](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_team_season_stats) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_team_season_stats/team_season_stats_{season}.parquet`
+Release: [nba_stats_team_season_stats](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/nba_stats_team_season_stats) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_team_season_stats/team_season_stats_{season + 1}.parquet`
 ### Returns
 
 | col_name | type | description |

--- a/sportsdataverse/nba/nba_loaders.py
+++ b/sportsdataverse/nba/nba_loaders.py
@@ -1013,9 +1013,9 @@ def load_nba_stats_schedules(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
-            Pass the season's START year (e.g. ``1996`` for the 1996-97
-            season); the published asset is keyed by the END year and the
-            loader translates internally.
+            Pass the season's START year (e.g. ``1996`` for the
+            1996-97 season); the published asset is keyed by the
+            END year and the loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
@@ -1084,9 +1084,9 @@ def load_nba_stats_coaches(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
-            Pass the season's START year (e.g. ``1996`` for the 1996-97
-            season); the published asset is keyed by the END year and the
-            loader translates internally.
+            Pass the season's START year (e.g. ``1996`` for the
+            1996-97 season); the published asset is keyed by the
+            END year and the loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
@@ -1151,9 +1151,9 @@ def load_nba_stats_game_rosters(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
-            Pass the season's START year (e.g. ``1996`` for the 1996-97
-            season); the published asset is keyed by the END year and the
-            loader translates internally.
+            Pass the season's START year (e.g. ``1996`` for the
+            1996-97 season); the published asset is keyed by the
+            END year and the loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
@@ -1217,9 +1217,9 @@ def load_nba_stats_lineups(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 2007).
-            Pass the season's START year (e.g. ``1996`` for the 1996-97
-            season); the published asset is keyed by the END year and the
-            loader translates internally.
+            Pass the season's START year (e.g. ``2007`` for the
+            2007-08 season); the published asset is keyed by the
+            END year and the loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
@@ -1460,9 +1460,9 @@ def load_nba_stats_lineups_v3(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
-            Pass the season's START year (e.g. ``1996`` for the 1996-97
-            season); the published asset is keyed by the END year and the
-            loader translates internally.
+            Pass the season's START year (e.g. ``1996`` for the
+            1996-97 season); the published asset is keyed by the
+            END year and the loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
@@ -1522,9 +1522,9 @@ def load_nba_stats_officials(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
-            Pass the season's START year (e.g. ``1996`` for the 1996-97
-            season); the published asset is keyed by the END year and the
-            loader translates internally.
+            Pass the season's START year (e.g. ``1996`` for the
+            1996-97 season); the published asset is keyed by the
+            END year and the loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
@@ -1584,9 +1584,9 @@ def load_nba_stats_pbp(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
-            Pass the season's START year (e.g. ``1996`` for the 1996-97
-            season); the published asset is keyed by the END year and the
-            loader translates internally.
+            Pass the season's START year (e.g. ``1996`` for the
+            1996-97 season); the published asset is keyed by the
+            END year and the loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
@@ -1689,9 +1689,9 @@ def load_nba_stats_possessions(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
-            Pass the season's START year (e.g. ``1996`` for the 1996-97
-            season); the published asset is keyed by the END year and the
-            loader translates internally.
+            Pass the season's START year (e.g. ``1996`` for the
+            1996-97 season); the published asset is keyed by the
+            END year and the loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
@@ -1780,9 +1780,9 @@ def load_nba_stats_game_lineups(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
-            Pass the season's START year (e.g. ``1996`` for the 1996-97
-            season); the published asset is keyed by the END year and the
-            loader translates internally.
+            Pass the season's START year (e.g. ``1996`` for the
+            1996-97 season); the published asset is keyed by the
+            END year and the loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
@@ -1855,9 +1855,9 @@ def load_nba_stats_pbp_v3(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
-            Pass the season's START year (e.g. ``1996`` for the 1996-97
-            season); the published asset is keyed by the END year and the
-            loader translates internally.
+            Pass the season's START year (e.g. ``1996`` for the
+            1996-97 season); the published asset is keyed by the
+            END year and the loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
@@ -1952,9 +1952,9 @@ def load_nba_stats_player_boxscores(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
-            Pass the season's START year (e.g. ``1996`` for the 1996-97
-            season); the published asset is keyed by the END year and the
-            loader translates internally.
+            Pass the season's START year (e.g. ``1996`` for the
+            1996-97 season); the published asset is keyed by the
+            END year and the loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
@@ -2042,9 +2042,9 @@ def load_nba_stats_player_game_logs(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
-            Pass the season's START year (e.g. ``1996`` for the 1996-97
-            season); the published asset is keyed by the END year and the
-            loader translates internally.
+            Pass the season's START year (e.g. ``1996`` for the
+            1996-97 season); the published asset is keyed by the
+            END year and the loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
@@ -2129,9 +2129,9 @@ def load_nba_stats_player_season_stats(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
-            Pass the season's START year (e.g. ``1996`` for the 1996-97
-            season); the published asset is keyed by the END year and the
-            loader translates internally.
+            Pass the season's START year (e.g. ``1996`` for the
+            1996-97 season); the published asset is keyed by the
+            END year and the loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
@@ -2402,9 +2402,9 @@ def load_nba_stats_possessions_v3(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
-            Pass the season's START year (e.g. ``1996`` for the 1996-97
-            season); the published asset is keyed by the END year and the
-            loader translates internally.
+            Pass the season's START year (e.g. ``1996`` for the
+            1996-97 season); the published asset is keyed by the
+            END year and the loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
@@ -2485,9 +2485,9 @@ def load_nba_stats_rosters(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
-            Pass the season's START year (e.g. ``1996`` for the 1996-97
-            season); the published asset is keyed by the END year and the
-            loader translates internally.
+            Pass the season's START year (e.g. ``1996`` for the
+            1996-97 season); the published asset is keyed by the
+            END year and the loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
@@ -2558,9 +2558,9 @@ def load_nba_stats_shots(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
-            Pass the season's START year (e.g. ``1996`` for the 1996-97
-            season); the published asset is keyed by the END year and the
-            loader translates internally.
+            Pass the season's START year (e.g. ``1996`` for the
+            1996-97 season); the published asset is keyed by the
+            END year and the loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
@@ -2632,9 +2632,9 @@ def load_nba_stats_standings(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
-            Pass the season's START year (e.g. ``1996`` for the 1996-97
-            season); the published asset is keyed by the END year and the
-            loader translates internally.
+            Pass the season's START year (e.g. ``1996`` for the
+            1996-97 season); the published asset is keyed by the
+            END year and the loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
@@ -2782,9 +2782,9 @@ def load_nba_stats_team_boxscores(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
-            Pass the season's START year (e.g. ``1996`` for the 1996-97
-            season); the published asset is keyed by the END year and the
-            loader translates internally.
+            Pass the season's START year (e.g. ``1996`` for the
+            1996-97 season); the published asset is keyed by the
+            END year and the loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
@@ -2864,9 +2864,9 @@ def load_nba_stats_team_season_stats(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
-            Pass the season's START year (e.g. ``1996`` for the 1996-97
-            season); the published asset is keyed by the END year and the
-            loader translates internally.
+            Pass the season's START year (e.g. ``1996`` for the
+            1996-97 season); the published asset is keyed by the
+            END year and the loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:

--- a/sportsdataverse/nba/nba_loaders.py
+++ b/sportsdataverse/nba/nba_loaders.py
@@ -1026,10 +1026,11 @@ def load_nba_stats_schedules(seasons, return_as_pandas: bool = False):
            published asset's own stamp and is **not** the ``seasons`` argument
            you passed. ``load_nba_stats_schedules(seasons=2024)`` returns rows whose
            ``season`` reads ``2025`` (the 2024-25 season).
-           Unshifted ``nba_stats`` siblings (``team_boxscores``,
-           ``officials``, ``rosters``) stamp the START year for that same
-           real season, so do not join on ``season`` across the two groups
-           without normalizing first.
+           Every ``nba_stats`` loader stamps the END year as of the
+           2026-08-13 republish, so they agree with each other and with
+           the ``nba`` (ESPN) schema. Football (``cfb``, ``nfl``) still
+           names a season by its STARTING year, so normalize before
+           joining on ``season`` across those.
 
         |col_name               |type   |
         |:----------------------|:------|
@@ -1083,11 +1084,24 @@ def load_nba_stats_coaches(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
+            Pass the season's START year (e.g. ``1996`` for the 1996-97
+            season); the published asset is keyed by the END year and the
+            loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
         A polars (or pandas) DataFrame; seasons with no published asset are
         skipped with a warning rather than raising (404-safe).
+
+        .. warning:: The ``season`` COLUMN carries the END year -- it is the
+           published asset's own stamp and is **not** the ``seasons`` argument
+           you passed. ``load_nba_stats_coaches(seasons=2024)`` returns rows whose
+           ``season`` reads ``2025`` (the 2024-25 season).
+           Every ``nba_stats`` loader stamps the END year as of the
+           2026-08-13 republish, so they agree with each other and with
+           the ``nba`` (ESPN) schema. Football (``cfb``, ``nfl``) still
+           names a season by its STARTING year, so normalize before
+           joining on ``season`` across those.
 
         |col_name          |type   |
         |:-----------------|:------|
@@ -1116,7 +1130,7 @@ def load_nba_stats_coaches(seasons, return_as_pandas: bool = False):
         if int(season) < 1996:
             raise SeasonNotFoundError("season cannot be less than 1996")
         df = _read_release_parquet(
-            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_coaches/coaches_{season}.parquet"
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_coaches/coaches_{season + 1}.parquet"
         )
         if df is None:
             missing.append(season)
@@ -1137,11 +1151,24 @@ def load_nba_stats_game_rosters(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
+            Pass the season's START year (e.g. ``1996`` for the 1996-97
+            season); the published asset is keyed by the END year and the
+            loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
         A polars (or pandas) DataFrame; seasons with no published asset are
         skipped with a warning rather than raising (404-safe).
+
+        .. warning:: The ``season`` COLUMN carries the END year -- it is the
+           published asset's own stamp and is **not** the ``seasons`` argument
+           you passed. ``load_nba_stats_game_rosters(seasons=2024)`` returns rows whose
+           ``season`` reads ``2025`` (the 2024-25 season).
+           Every ``nba_stats`` loader stamps the END year as of the
+           2026-08-13 republish, so they agree with each other and with
+           the ``nba`` (ESPN) schema. Football (``cfb``, ``nfl``) still
+           names a season by its STARTING year, so normalize before
+           joining on ``season`` across those.
 
         |col_name          |type   |
         |:-----------------|:------|
@@ -1169,7 +1196,7 @@ def load_nba_stats_game_rosters(seasons, return_as_pandas: bool = False):
         if int(season) < 1996:
             raise SeasonNotFoundError("season cannot be less than 1996")
         df = _read_release_parquet(
-            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_game_rosters/game_rosters_{season}.parquet"
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_game_rosters/game_rosters_{season + 1}.parquet"
         )
         if df is None:
             missing.append(season)
@@ -1190,11 +1217,24 @@ def load_nba_stats_lineups(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 2007).
+            Pass the season's START year (e.g. ``1996`` for the 1996-97
+            season); the published asset is keyed by the END year and the
+            loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
         A polars (or pandas) DataFrame; seasons with no published asset are
         skipped with a warning rather than raising (404-safe).
+
+        .. warning:: The ``season`` COLUMN carries the END year -- it is the
+           published asset's own stamp and is **not** the ``seasons`` argument
+           you passed. ``load_nba_stats_lineups(seasons=2024)`` returns rows whose
+           ``season`` reads ``2025`` (the 2024-25 season).
+           Every ``nba_stats`` loader stamps the END year as of the
+           2026-08-13 republish, so they agree with each other and with
+           the ``nba`` (ESPN) schema. Football (``cfb``, ``nfl``) still
+           names a season by its STARTING year, so normalize before
+           joining on ``season`` across those.
 
         |col_name                |type    |
         |:-----------------------|:-------|
@@ -1394,7 +1434,7 @@ def load_nba_stats_lineups(seasons, return_as_pandas: bool = False):
         if int(season) < 2007:
             raise SeasonNotFoundError("season cannot be less than 2007")
         df = _read_release_parquet(
-            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_lineups/lineups_{season}.parquet"
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_lineups/lineups_{season + 1}.parquet"
         )
         if df is None:
             missing.append(season)
@@ -1433,10 +1473,11 @@ def load_nba_stats_lineups_v3(seasons, return_as_pandas: bool = False):
            published asset's own stamp and is **not** the ``seasons`` argument
            you passed. ``load_nba_stats_lineups_v3(seasons=2024)`` returns rows whose
            ``season`` reads ``2025`` (the 2024-25 season).
-           Unshifted ``nba_stats`` siblings (``team_boxscores``,
-           ``officials``, ``rosters``) stamp the START year for that same
-           real season, so do not join on ``season`` across the two groups
-           without normalizing first.
+           Every ``nba_stats`` loader stamps the END year as of the
+           2026-08-13 republish, so they agree with each other and with
+           the ``nba`` (ESPN) schema. Football (``cfb``, ``nfl``) still
+           names a season by its STARTING year, so normalize before
+           joining on ``season`` across those.
 
         |col_name      |type   |
         |:-------------|:------|
@@ -1481,11 +1522,24 @@ def load_nba_stats_officials(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
+            Pass the season's START year (e.g. ``1996`` for the 1996-97
+            season); the published asset is keyed by the END year and the
+            loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
         A polars (or pandas) DataFrame; seasons with no published asset are
         skipped with a warning rather than raising (404-safe).
+
+        .. warning:: The ``season`` COLUMN carries the END year -- it is the
+           published asset's own stamp and is **not** the ``seasons`` argument
+           you passed. ``load_nba_stats_officials(seasons=2024)`` returns rows whose
+           ``season`` reads ``2025`` (the 2024-25 season).
+           Every ``nba_stats`` loader stamps the END year as of the
+           2026-08-13 republish, so they agree with each other and with
+           the ``nba`` (ESPN) schema. Football (``cfb``, ``nfl``) still
+           names a season by its STARTING year, so normalize before
+           joining on ``season`` across those.
 
         |col_name    |type   |
         |:-----------|:------|
@@ -1509,7 +1563,7 @@ def load_nba_stats_officials(seasons, return_as_pandas: bool = False):
         if int(season) < 1996:
             raise SeasonNotFoundError("season cannot be less than 1996")
         df = _read_release_parquet(
-            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_officials/officials_{season}.parquet"
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_officials/officials_{season + 1}.parquet"
         )
         if df is None:
             missing.append(season)
@@ -1543,10 +1597,11 @@ def load_nba_stats_pbp(seasons, return_as_pandas: bool = False):
            published asset's own stamp and is **not** the ``seasons`` argument
            you passed. ``load_nba_stats_pbp(seasons=2024)`` returns rows whose
            ``season`` reads ``2025`` (the 2024-25 season).
-           Unshifted ``nba_stats`` siblings (``team_boxscores``,
-           ``officials``, ``rosters``) stamp the START year for that same
-           real season, so do not join on ``season`` across the two groups
-           without normalizing first.
+           Every ``nba_stats`` loader stamps the END year as of the
+           2026-08-13 republish, so they agree with each other and with
+           the ``nba`` (ESPN) schema. Football (``cfb``, ``nfl``) still
+           names a season by its STARTING year, so normalize before
+           joining on ``season`` across those.
 
         |col_name          |type    |
         |:-----------------|:-------|
@@ -1647,10 +1702,11 @@ def load_nba_stats_possessions(seasons, return_as_pandas: bool = False):
            published asset's own stamp and is **not** the ``seasons`` argument
            you passed. ``load_nba_stats_possessions(seasons=2024)`` returns rows whose
            ``season`` reads ``2025`` (the 2024-25 season).
-           Unshifted ``nba_stats`` siblings (``team_boxscores``,
-           ``officials``, ``rosters``) stamp the START year for that same
-           real season, so do not join on ``season`` across the two groups
-           without normalizing first.
+           Every ``nba_stats`` loader stamps the END year as of the
+           2026-08-13 republish, so they agree with each other and with
+           the ``nba`` (ESPN) schema. Football (``cfb``, ``nfl``) still
+           names a season by its STARTING year, so normalize before
+           joining on ``season`` across those.
 
         |col_name                |type    |
         |:-----------------------|:-------|
@@ -1737,10 +1793,11 @@ def load_nba_stats_game_lineups(seasons, return_as_pandas: bool = False):
            published asset's own stamp and is **not** the ``seasons`` argument
            you passed. ``load_nba_stats_game_lineups(seasons=2024)`` returns rows whose
            ``season`` reads ``2025`` (the 2024-25 season).
-           Unshifted ``nba_stats`` siblings (``team_boxscores``,
-           ``officials``, ``rosters``) stamp the START year for that same
-           real season, so do not join on ``season`` across the two groups
-           without normalizing first.
+           Every ``nba_stats`` loader stamps the END year as of the
+           2026-08-13 republish, so they agree with each other and with
+           the ``nba`` (ESPN) schema. Football (``cfb``, ``nfl``) still
+           names a season by its STARTING year, so normalize before
+           joining on ``season`` across those.
 
         |col_name      |type   |
         |:-------------|:------|
@@ -1811,10 +1868,11 @@ def load_nba_stats_pbp_v3(seasons, return_as_pandas: bool = False):
            published asset's own stamp and is **not** the ``seasons`` argument
            you passed. ``load_nba_stats_pbp_v3(seasons=2024)`` returns rows whose
            ``season`` reads ``2025`` (the 2024-25 season).
-           Unshifted ``nba_stats`` siblings (``team_boxscores``,
-           ``officials``, ``rosters``) stamp the START year for that same
-           real season, so do not join on ``season`` across the two groups
-           without normalizing first.
+           Every ``nba_stats`` loader stamps the END year as of the
+           2026-08-13 republish, so they agree with each other and with
+           the ``nba`` (ESPN) schema. Football (``cfb``, ``nfl``) still
+           names a season by its STARTING year, so normalize before
+           joining on ``season`` across those.
 
         |col_name          |type    |
         |:-----------------|:-------|
@@ -1894,11 +1952,24 @@ def load_nba_stats_player_boxscores(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
+            Pass the season's START year (e.g. ``1996`` for the 1996-97
+            season); the published asset is keyed by the END year and the
+            loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
         A polars (or pandas) DataFrame; seasons with no published asset are
         skipped with a warning rather than raising (404-safe).
+
+        .. warning:: The ``season`` COLUMN carries the END year -- it is the
+           published asset's own stamp and is **not** the ``seasons`` argument
+           you passed. ``load_nba_stats_player_boxscores(seasons=2024)`` returns rows whose
+           ``season`` reads ``2025`` (the 2024-25 season).
+           Every ``nba_stats`` loader stamps the END year as of the
+           2026-08-13 republish, so they agree with each other and with
+           the ``nba`` (ESPN) schema. Football (``cfb``, ``nfl``) still
+           names a season by its STARTING year, so normalize before
+           joining on ``season`` across those.
 
         |col_name                  |type    |
         |:-------------------------|:-------|
@@ -1950,7 +2021,7 @@ def load_nba_stats_player_boxscores(seasons, return_as_pandas: bool = False):
         if int(season) < 1996:
             raise SeasonNotFoundError("season cannot be less than 1996")
         df = _read_release_parquet(
-            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_player_boxscores/player_boxscores_{season}.parquet"
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_player_boxscores/player_boxscores_{season + 1}.parquet"
         )
         if df is None:
             missing.append(season)
@@ -1971,11 +2042,24 @@ def load_nba_stats_player_game_logs(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
+            Pass the season's START year (e.g. ``1996`` for the 1996-97
+            season); the published asset is keyed by the END year and the
+            loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
         A polars (or pandas) DataFrame; seasons with no published asset are
         skipped with a warning rather than raising (404-safe).
+
+        .. warning:: The ``season`` COLUMN carries the END year -- it is the
+           published asset's own stamp and is **not** the ``seasons`` argument
+           you passed. ``load_nba_stats_player_game_logs(seasons=2024)`` returns rows whose
+           ``season`` reads ``2025`` (the 2024-25 season).
+           Every ``nba_stats`` loader stamps the END year as of the
+           2026-08-13 republish, so they agree with each other and with
+           the ``nba`` (ESPN) schema. Football (``cfb``, ``nfl``) still
+           names a season by its STARTING year, so normalize before
+           joining on ``season`` across those.
 
         |col_name          |type    |
         |:-----------------|:-------|
@@ -2024,7 +2108,7 @@ def load_nba_stats_player_game_logs(seasons, return_as_pandas: bool = False):
         if int(season) < 1996:
             raise SeasonNotFoundError("season cannot be less than 1996")
         df = _read_release_parquet(
-            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_player_game_logs/player_game_logs_{season}.parquet"
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_player_game_logs/player_game_logs_{season + 1}.parquet"
         )
         if df is None:
             missing.append(season)
@@ -2045,11 +2129,24 @@ def load_nba_stats_player_season_stats(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
+            Pass the season's START year (e.g. ``1996`` for the 1996-97
+            season); the published asset is keyed by the END year and the
+            loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
         A polars (or pandas) DataFrame; seasons with no published asset are
         skipped with a warning rather than raising (404-safe).
+
+        .. warning:: The ``season`` COLUMN carries the END year -- it is the
+           published asset's own stamp and is **not** the ``seasons`` argument
+           you passed. ``load_nba_stats_player_season_stats(seasons=2024)`` returns rows whose
+           ``season`` reads ``2025`` (the 2024-25 season).
+           Every ``nba_stats`` loader stamps the END year as of the
+           2026-08-13 republish, so they agree with each other and with
+           the ``nba`` (ESPN) schema. Football (``cfb``, ``nfl``) still
+           names a season by its STARTING year, so normalize before
+           joining on ``season`` across those.
 
         |col_name                |type    |
         |:-----------------------|:-------|
@@ -2277,7 +2374,7 @@ def load_nba_stats_player_season_stats(seasons, return_as_pandas: bool = False):
         if int(season) < 1996:
             raise SeasonNotFoundError("season cannot be less than 1996")
         df = _read_release_parquet(
-            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_player_season_stats/player_season_stats_{season}.parquet"
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_player_season_stats/player_season_stats_{season + 1}.parquet"
         )
         if df is None:
             missing.append(season)
@@ -2318,10 +2415,11 @@ def load_nba_stats_possessions_v3(seasons, return_as_pandas: bool = False):
            published asset's own stamp and is **not** the ``seasons`` argument
            you passed. ``load_nba_stats_possessions_v3(seasons=2024)`` returns rows whose
            ``season`` reads ``2025`` (the 2024-25 season).
-           Unshifted ``nba_stats`` siblings (``team_boxscores``,
-           ``officials``, ``rosters``) stamp the START year for that same
-           real season, so do not join on ``season`` across the two groups
-           without normalizing first.
+           Every ``nba_stats`` loader stamps the END year as of the
+           2026-08-13 republish, so they agree with each other and with
+           the ``nba`` (ESPN) schema. Football (``cfb``, ``nfl``) still
+           names a season by its STARTING year, so normalize before
+           joining on ``season`` across those.
 
         |col_name                |type    |
         |:-----------------------|:-------|
@@ -2387,11 +2485,24 @@ def load_nba_stats_rosters(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
+            Pass the season's START year (e.g. ``1996`` for the 1996-97
+            season); the published asset is keyed by the END year and the
+            loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
         A polars (or pandas) DataFrame; seasons with no published asset are
         skipped with a warning rather than raising (404-safe).
+
+        .. warning:: The ``season`` COLUMN carries the END year -- it is the
+           published asset's own stamp and is **not** the ``seasons`` argument
+           you passed. ``load_nba_stats_rosters(seasons=2024)`` returns rows whose
+           ``season`` reads ``2025`` (the 2024-25 season).
+           Every ``nba_stats`` loader stamps the END year as of the
+           2026-08-13 republish, so they agree with each other and with
+           the ``nba`` (ESPN) schema. Football (``cfb``, ``nfl``) still
+           names a season by its STARTING year, so normalize before
+           joining on ``season`` across those.
 
         |col_name     |type    |
         |:------------|:-------|
@@ -2426,7 +2537,7 @@ def load_nba_stats_rosters(seasons, return_as_pandas: bool = False):
         if int(season) < 1996:
             raise SeasonNotFoundError("season cannot be less than 1996")
         df = _read_release_parquet(
-            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_rosters/rosters_{season}.parquet"
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_rosters/rosters_{season + 1}.parquet"
         )
         if df is None:
             missing.append(season)
@@ -2447,11 +2558,24 @@ def load_nba_stats_shots(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
+            Pass the season's START year (e.g. ``1996`` for the 1996-97
+            season); the published asset is keyed by the END year and the
+            loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
         A polars (or pandas) DataFrame; seasons with no published asset are
         skipped with a warning rather than raising (404-safe).
+
+        .. warning:: The ``season`` COLUMN carries the END year -- it is the
+           published asset's own stamp and is **not** the ``seasons`` argument
+           you passed. ``load_nba_stats_shots(seasons=2024)`` returns rows whose
+           ``season`` reads ``2025`` (the 2024-25 season).
+           Every ``nba_stats`` loader stamps the END year as of the
+           2026-08-13 republish, so they agree with each other and with
+           the ``nba`` (ESPN) schema. Football (``cfb``, ``nfl``) still
+           names a season by its STARTING year, so normalize before
+           joining on ``season`` across those.
 
         |col_name      |type   |
         |:-------------|:------|
@@ -2487,7 +2611,7 @@ def load_nba_stats_shots(seasons, return_as_pandas: bool = False):
         if int(season) < 1996:
             raise SeasonNotFoundError("season cannot be less than 1996")
         df = _read_release_parquet(
-            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_shots/shots_{season}.parquet"
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_shots/shots_{season + 1}.parquet"
         )
         if df is None:
             missing.append(season)
@@ -2508,11 +2632,24 @@ def load_nba_stats_standings(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
+            Pass the season's START year (e.g. ``1996`` for the 1996-97
+            season); the published asset is keyed by the END year and the
+            loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
         A polars (or pandas) DataFrame; seasons with no published asset are
         skipped with a warning rather than raising (404-safe).
+
+        .. warning:: The ``season`` COLUMN carries the END year -- it is the
+           published asset's own stamp and is **not** the ``seasons`` argument
+           you passed. ``load_nba_stats_standings(seasons=2024)`` returns rows whose
+           ``season`` reads ``2025`` (the 2024-25 season).
+           Every ``nba_stats`` loader stamps the END year as of the
+           2026-08-13 republish, so they agree with each other and with
+           the ``nba`` (ESPN) schema. Football (``cfb``, ``nfl``) still
+           names a season by its STARTING year, so normalize before
+           joining on ``season`` across those.
 
         |col_name                  |type    |
         |:-------------------------|:-------|
@@ -2624,7 +2761,7 @@ def load_nba_stats_standings(seasons, return_as_pandas: bool = False):
         if int(season) < 1996:
             raise SeasonNotFoundError("season cannot be less than 1996")
         df = _read_release_parquet(
-            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_standings/standings_{season}.parquet"
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_standings/standings_{season + 1}.parquet"
         )
         if df is None:
             missing.append(season)
@@ -2645,11 +2782,24 @@ def load_nba_stats_team_boxscores(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
+            Pass the season's START year (e.g. ``1996`` for the 1996-97
+            season); the published asset is keyed by the END year and the
+            loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
         A polars (or pandas) DataFrame; seasons with no published asset are
         skipped with a warning rather than raising (404-safe).
+
+        .. warning:: The ``season`` COLUMN carries the END year -- it is the
+           published asset's own stamp and is **not** the ``seasons`` argument
+           you passed. ``load_nba_stats_team_boxscores(seasons=2024)`` returns rows whose
+           ``season`` reads ``2025`` (the 2024-25 season).
+           Every ``nba_stats`` loader stamps the END year as of the
+           2026-08-13 republish, so they agree with each other and with
+           the ``nba`` (ESPN) schema. Football (``cfb``, ``nfl``) still
+           names a season by its STARTING year, so normalize before
+           joining on ``season`` across those.
 
         |col_name                  |type    |
         |:-------------------------|:-------|
@@ -2693,7 +2843,7 @@ def load_nba_stats_team_boxscores(seasons, return_as_pandas: bool = False):
         if int(season) < 1996:
             raise SeasonNotFoundError("season cannot be less than 1996")
         df = _read_release_parquet(
-            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_team_boxscores/team_boxscores_{season}.parquet"
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_team_boxscores/team_boxscores_{season + 1}.parquet"
         )
         if df is None:
             missing.append(season)
@@ -2714,11 +2864,24 @@ def load_nba_stats_team_season_stats(seasons, return_as_pandas: bool = False):
 
     Args:
         seasons: an int or iterable of seasons (>= 1996).
+            Pass the season's START year (e.g. ``1996`` for the 1996-97
+            season); the published asset is keyed by the END year and the
+            loader translates internally.
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
         A polars (or pandas) DataFrame; seasons with no published asset are
         skipped with a warning rather than raising (404-safe).
+
+        .. warning:: The ``season`` COLUMN carries the END year -- it is the
+           published asset's own stamp and is **not** the ``seasons`` argument
+           you passed. ``load_nba_stats_team_season_stats(seasons=2024)`` returns rows whose
+           ``season`` reads ``2025`` (the 2024-25 season).
+           Every ``nba_stats`` loader stamps the END year as of the
+           2026-08-13 republish, so they agree with each other and with
+           the ``nba`` (ESPN) schema. Football (``cfb``, ``nfl``) still
+           names a season by its STARTING year, so normalize before
+           joining on ``season`` across those.
 
         |col_name                |type    |
         |:-----------------------|:-------|
@@ -2914,7 +3077,7 @@ def load_nba_stats_team_season_stats(seasons, return_as_pandas: bool = False):
         if int(season) < 1996:
             raise SeasonNotFoundError("season cannot be less than 1996")
         df = _read_release_parquet(
-            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_team_season_stats/team_season_stats_{season}.parquet"
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/nba_stats_team_season_stats/team_season_stats_{season + 1}.parquet"
         )
         if df is None:
             missing.append(season)

--- a/tests/codegen/test_loader_season_convention.py
+++ b/tests/codegen/test_loader_season_convention.py
@@ -101,9 +101,7 @@ def test_only_nba_stats_families_carry_the_end_year_offset():
     # a bare truth test would accept `{season + 2}` as satisfying the END-year
     # contract. The contract is exactly one year.
     offset = {
-        ld.fn
-        for ld in spec.load_releases(REL).loaders
-        if (m := spec.SEASON_TOKEN.search(ld.url)) and m.group(1) == "1"
+        ld.fn for ld in spec.load_releases(REL).loaders if (m := spec.SEASON_TOKEN.search(ld.url)) and m.group(1) == "1"
     }
     assert offset == {
         "load_nba_stats_schedules",

--- a/tests/codegen/test_loader_season_convention.py
+++ b/tests/codegen/test_loader_season_convention.py
@@ -97,7 +97,14 @@ def test_only_nba_stats_families_carry_the_end_year_offset():
     8 wnba urls by accident, because ``wnba_stats_`` contains ``nba_stats_``.
     Asserting the exact set, rather than "all nba_stats", is what catches it.
     """
-    offset = {ld.fn for ld in spec.load_releases(REL).loaders if (m := spec.SEASON_TOKEN.search(ld.url)) and m.group(1)}
+    # `== "1"`, not truthiness: SEASON_TOKEN captures the N in `{season + N}`, so
+    # a bare truth test would accept `{season + 2}` as satisfying the END-year
+    # contract. The contract is exactly one year.
+    offset = {
+        ld.fn
+        for ld in spec.load_releases(REL).loaders
+        if (m := spec.SEASON_TOKEN.search(ld.url)) and m.group(1) == "1"
+    }
     assert offset == {
         "load_nba_stats_schedules",
         "load_nba_stats_pbp",

--- a/tests/codegen/test_loader_season_convention.py
+++ b/tests/codegen/test_loader_season_convention.py
@@ -86,9 +86,16 @@ def test_fill_season_offset_and_identity():
 
 
 def test_only_nba_stats_families_carry_the_end_year_offset():
-    """Guard the blast radius: the +1 belongs to the four NBA stats families only.
+    """Guard the blast radius: the +1 belongs to nba_stats, and to nothing else.
 
-    WNBA seasons are single-calendar-year, so an offset there would be an off-by-one.
+    Every nba_stats release loader carries it as of the 2026-08-13 republish,
+    which moved the remaining START-year-named assets onto END-year names. Before
+    it, only four did — one schema publishing two conventions.
+
+    WNBA seasons are single-calendar-year, so an offset there would be an
+    off-by-one. That is not theoretical: the first cut of the republish shifted
+    8 wnba urls by accident, because ``wnba_stats_`` contains ``nba_stats_``.
+    Asserting the exact set, rather than "all nba_stats", is what catches it.
     """
     offset = {ld.fn for ld in spec.load_releases(REL).loaders if (m := spec.SEASON_TOKEN.search(ld.url)) and m.group(1)}
     assert offset == {
@@ -96,11 +103,25 @@ def test_only_nba_stats_families_carry_the_end_year_offset():
         "load_nba_stats_pbp",
         "load_nba_stats_possessions",
         "load_nba_stats_game_lineups",
+        # moved onto END-year assets by the 2026-08-13 republish
+        "load_nba_stats_coaches",
+        "load_nba_stats_game_rosters",
+        "load_nba_stats_lineups",
+        "load_nba_stats_officials",
+        "load_nba_stats_player_boxscores",
+        "load_nba_stats_player_game_logs",
+        "load_nba_stats_player_season_stats",
+        "load_nba_stats_rosters",
+        "load_nba_stats_shots",
+        "load_nba_stats_standings",
+        "load_nba_stats_team_boxscores",
+        "load_nba_stats_team_season_stats",
         # The retired-tag shims inherit their target's END-year asset path.
         "load_nba_stats_pbp_v3",
         "load_nba_stats_possessions_v3",
         "load_nba_stats_lineups_v3",
     }
+    assert not any(fn.startswith("load_wnba") for fn in offset)
 
 
 @pytest.mark.parametrize(("shim", "target"), SHIMS)

--- a/tools/codegen/endpoints/releases.yaml
+++ b/tools/codegen/endpoints/releases.yaml
@@ -878,7 +878,7 @@ loaders:
 - fn: load_nba_stats_coaches
   league: nba
   base: sdv_releases
-  url: nba_stats_coaches/coaches_{season}.parquet
+  url: nba_stats_coaches/coaches_{season + 1}.parquet
   tag: nba_stats_coaches
   min_season: 1996
   example_args:
@@ -886,7 +886,7 @@ loaders:
 - fn: load_nba_stats_game_rosters
   league: nba
   base: sdv_releases
-  url: nba_stats_game_rosters/game_rosters_{season}.parquet
+  url: nba_stats_game_rosters/game_rosters_{season + 1}.parquet
   tag: nba_stats_game_rosters
   min_season: 1996
   example_args:
@@ -894,7 +894,7 @@ loaders:
 - fn: load_nba_stats_lineups
   league: nba
   base: sdv_releases
-  url: nba_stats_lineups/lineups_{season}.parquet
+  url: nba_stats_lineups/lineups_{season + 1}.parquet
   tag: nba_stats_lineups
   min_season: 2007
   example_args:
@@ -911,7 +911,7 @@ loaders:
 - fn: load_nba_stats_officials
   league: nba
   base: sdv_releases
-  url: nba_stats_officials/officials_{season}.parquet
+  url: nba_stats_officials/officials_{season + 1}.parquet
   tag: nba_stats_officials
   min_season: 1996
   example_args:
@@ -952,7 +952,7 @@ loaders:
 - fn: load_nba_stats_player_boxscores
   league: nba
   base: sdv_releases
-  url: nba_stats_player_boxscores/player_boxscores_{season}.parquet
+  url: nba_stats_player_boxscores/player_boxscores_{season + 1}.parquet
   tag: nba_stats_player_boxscores
   min_season: 1996
   example_args:
@@ -960,7 +960,7 @@ loaders:
 - fn: load_nba_stats_player_game_logs
   league: nba
   base: sdv_releases
-  url: nba_stats_player_game_logs/player_game_logs_{season}.parquet
+  url: nba_stats_player_game_logs/player_game_logs_{season + 1}.parquet
   tag: nba_stats_player_game_logs
   min_season: 1996
   example_args:
@@ -968,7 +968,7 @@ loaders:
 - fn: load_nba_stats_player_season_stats
   league: nba
   base: sdv_releases
-  url: nba_stats_player_season_stats/player_season_stats_{season}.parquet
+  url: nba_stats_player_season_stats/player_season_stats_{season + 1}.parquet
   tag: nba_stats_player_season_stats
   min_season: 1996
   example_args:
@@ -985,7 +985,7 @@ loaders:
 - fn: load_nba_stats_rosters
   league: nba
   base: sdv_releases
-  url: nba_stats_rosters/rosters_{season}.parquet
+  url: nba_stats_rosters/rosters_{season + 1}.parquet
   tag: nba_stats_rosters
   min_season: 1996
   example_args:
@@ -993,7 +993,7 @@ loaders:
 - fn: load_nba_stats_shots
   league: nba
   base: sdv_releases
-  url: nba_stats_shots/shots_{season}.parquet
+  url: nba_stats_shots/shots_{season + 1}.parquet
   tag: nba_stats_shots
   min_season: 1996
   example_args:
@@ -1001,7 +1001,7 @@ loaders:
 - fn: load_nba_stats_standings
   league: nba
   base: sdv_releases
-  url: nba_stats_standings/standings_{season}.parquet
+  url: nba_stats_standings/standings_{season + 1}.parquet
   tag: nba_stats_standings
   min_season: 1996
   example_args:
@@ -1009,7 +1009,7 @@ loaders:
 - fn: load_nba_stats_team_boxscores
   league: nba
   base: sdv_releases
-  url: nba_stats_team_boxscores/team_boxscores_{season}.parquet
+  url: nba_stats_team_boxscores/team_boxscores_{season + 1}.parquet
   tag: nba_stats_team_boxscores
   min_season: 1996
   example_args:
@@ -1017,7 +1017,7 @@ loaders:
 - fn: load_nba_stats_team_season_stats
   league: nba
   base: sdv_releases
-  url: nba_stats_team_season_stats/team_season_stats_{season}.parquet
+  url: nba_stats_team_season_stats/team_season_stats_{season + 1}.parquet
   tag: nba_stats_team_season_stats
   min_season: 1996
   example_args:

--- a/tools/codegen/generate.py
+++ b/tools/codegen/generate.py
@@ -1119,10 +1119,11 @@ def _build_loader_docstring(ld: spec.Loader) -> str:
         # league-agnostic and must not assert NBA table names over a future
         # {season + N} loader in some other league.
         if ld.league == "nba":
-            lines.append("       Unshifted ``nba_stats`` siblings (``team_boxscores``,")
-            lines.append("       ``officials``, ``rosters``) stamp the START year for that same")
-            lines.append("       real season, so do not join on ``season`` across the two groups")
-            lines.append("       without normalizing first.")
+            lines.append("       Every ``nba_stats`` loader stamps the END year as of the")
+            lines.append("       2026-08-13 republish, so they agree with each other and with")
+            lines.append("       the ``nba`` (ESPN) schema. Football (``cfb``, ``nfl``) still")
+            lines.append("       names a season by its STARTING year, so normalize before")
+            lines.append("       joining on ``season`` across those.")
         else:
             lines.append("       Unshifted sibling loaders in this league stamp the START year")
             lines.append("       for that same real season, so do not join on ``season`` across")

--- a/tools/codegen/generate.py
+++ b/tools/codegen/generate.py
@@ -1094,9 +1094,13 @@ def _build_loader_docstring(ld: spec.Loader) -> str:
     # asset path it describes.
     token = spec.SEASON_TOKEN.search(ld.url)
     if token and token.group(1):
-        lines.append("        Pass the season's START year (e.g. ``1996`` for the 1996-97")
-        lines.append("        season); the published asset is keyed by the END year and the")
-        lines.append("        loader translates internally.")
+        # Example year comes from the loader's own floor, not a hard-coded 1996:
+        # load_nba_stats_lineups starts at 2007 and RAISES SeasonNotFoundError
+        # below it, so a fixed example told users to make a call that errors.
+        ex = ld.min_season or 1996
+        lines.append(f"        Pass the season's START year (e.g. ``{ex}`` for the")
+        lines.append(f"        {ex}-{str(ex + 1)[-2:]} season); the published asset is keyed by the")
+        lines.append("        END year and the loader translates internally.")
     lines.append("    return_as_pandas: return a pandas DataFrame instead of polars.")
     lines.append("")
     lines.append("Returns:")


### PR DESCRIPTION
**BREAKING** for anyone fetching the release assets directly by URL. The public `seasons` argument is **unchanged** — still the season's START year for every nba_stats loader.

## Why

The nba_stats release tags were internally inconsistent: **4 END-year named** (`nba_play_by_play_{season + 1}`) against **47 START-year named** (`shots_{season}`, plus the whole 36-table leaguedash cube). One schema, two conventions.

The 2026-08-13 republish moved all **1,931 assets across 14 tags** onto END-year names and rewrote their `season` column to match. These 12 loaders follow it:

`coaches`, `game_rosters`, `lineups`, `officials`, `player_boxscores`, `player_game_logs`, `player_season_stats`, `rosters`, `shots`, `standings`, `team_boxscores`, `team_season_stats`

Verified live against the republished assets:

```
load_nba_stats_coaches(seasons=2025) -> rows=267     season=[2026]
load_nba_stats_shots(seasons=2025)   -> rows=233632  season=[2026]
```

2025-26 is what the `nba` (ESPN) schema has always called 2026, so the two now agree.

## wnba_stats is deliberately untouched

WNBA is single-calendar-year — start and end are the same year, so shifting it would walk it off by one. Worth calling out: **my first cut shifted 8 WNBA URLs by accident**, because `wnba_stats_` contains the substring `nba_stats_`. Reverted and redone with an anchored pattern; the sdv-db side has a test asserting WNBA URLs stay unshifted.

## Docstring correction

The generated `.. warning::` named `team_boxscores`, `officials` and `rosters` as "unshifted siblings" to avoid joining against — all three are shifted by this change, so that guidance had become actively wrong. It now states the whole nba_stats family agrees and points at football (`cfb`/`nfl`) as the remaining START-year convention.

## Related

Pairs with sdv-db's END-year re-key (sdv-db #41) — the database moved to END-year season keys in the same operation, so the loader, the asset and the warehouse now use one convention for NBA.

## Summary by Sourcery

Align nba_stats loaders and documentation with END-year keyed release assets while keeping the public seasons argument as the START year.

Enhancements:
- Update 12 nba_stats loaders to fetch END-year-named parquet assets while translating from START-year seasons internally.
- Unify NBA loader docstrings to state that all nba_stats tables now carry END-year season stamps and to highlight cross-sport START vs END year conventions.

Build:
- Adjust codegen release endpoint templates so generated NBA loaders use END-year-based asset URLs for the nba_stats family.

Documentation:
- Refresh NBA loader reference docs to reflect END-year-based asset filenames for the affected nba_stats releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected NBA data loading so starting-year seasons consistently retrieve assets labeled by the following end year.
  * Updated season labels across coaches, rosters, game data, player and team statistics, standings, shots, lineups, officials, and logs.
  * Preserved compatibility for deprecated loader aliases.
  * Confirmed WNBA loaders retain their existing season convention.

* **Documentation**
  * Clarified NBA season conventions, republished dataset coverage, and differences from college football and NFL labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->