### PR TITLE
fix(wbb): use the halves period model for pre-2016 NCAA women's seasons

### DIFF
--- a/sportsdataverse/scrape/ncaa/parse.py
+++ b/sportsdataverse/scrape/ncaa/parse.py
@@ -89,9 +89,44 @@ _SEASON_RE = re.compile(r"^(\d{4})-(\d{2})$")
 def wbb_period_model(season: Optional[str]) -> "tuple[int, int, int]":
     """Period model for a WBB season: halves through 2015, quarters from 2016.
 
-    An unparseable/absent season falls back to quarters, matching the modern
-    era: the raw bundles carry ``season``, so this only bites on a hand-made
-    payload, and guessing modern is the smaller error for new data.
+    NCAA women's basketball moved from two 20-minute halves to four 10-minute
+    quarters for the 2015-16 season; the men's game never switched. Feeding the
+    wrong model to :func:`~sportsdataverse.mbb.mbb_ncaa_game_pbp.parse_ncaa_bb_game_pbp`
+    does not raise -- it silently yields a frame with no rows -- so the era must
+    be resolved from the season rather than discovered on failure.
+
+    Args:
+        season: Season as an ending year (``"2015"``) or hyphenated span
+            (``"2014-15"``); both forms appear in captured raw bundles.
+            ``None`` or an unparseable value is treated as the modern era.
+
+    Returns:
+        ``(periods, regulation_period_seconds, overtime_seconds)`` --
+        ``(2, 1200, 300)`` for seasons before 2016, ``(4, 600, 300)`` otherwise.
+        Never raises: an unrecognised season falls back to quarters, since the
+        raw bundles always carry ``season`` and guessing modern is the smaller
+        error for new data.
+
+    Example:
+        Resolve the model for either era::
+
+            from sportsdataverse.scrape.ncaa.parse import wbb_period_model
+
+            wbb_period_model("2015")     # (2, 1200, 300) -- halves
+            wbb_period_model("2015-16")  # (4, 600, 300)  -- quarters
+
+        Parse a captured bundle's play-by-play with the right model::
+
+            from sportsdataverse.mbb.mbb_ncaa_game_pbp import parse_ncaa_bb_game_pbp
+
+            df = parse_ncaa_bb_game_pbp(
+                pbp_html, contest_id, period_model=wbb_period_model(season)
+            )
+
+        See Also:
+            * `wehoop`_ -- the R women's-basketball package this feed backs.
+
+        .. _wehoop: https://wehoop.sportsdataverse.org
     """
     year = _ending_year(season)
     if year and year < _WBB_FIRST_QUARTERS_SEASON:

--- a/sportsdataverse/scrape/ncaa/parse.py
+++ b/sportsdataverse/scrape/ncaa/parse.py
@@ -65,10 +65,39 @@ from sportsdataverse.mbb.mbb_shots_adapter import shot_events_to_frame
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["parse_bundle", "write_parsed", "parse_and_write"]
+__all__ = ["parse_bundle", "write_parsed", "parse_and_write", "wbb_period_model"]
 
-_WBB_PERIOD_MODEL: "tuple[int, int, int]" = (4, 600, 300)
+#: NCAA women's basketball moved from two 20-minute halves to four 10-minute
+#: quarters for the **2015-16** season. Seasons are ending-year, so 2016 is the
+#: first quarters season and 2015 the last halves season. Men's basketball never
+#: switched, which is why only the women's side needs an era split.
+#:
+#: Applying the wrong model does NOT fail loudly -- it silently yields a frame
+#: with no rows. The quarters model was applied to every WBB season until
+#: 2026-08-18, so every pre-2016 game parsed to an EMPTY record while the parse
+#: stage reported success (it counted files written, not rows extracted), and
+#: seasons 2010-2015 were published as ~0.6%-populated datasets. Measured on
+#: real bundles: 2015 quarters=0 rows / halves=520; 2012 quarters=0 / halves=566;
+#: 2010 quarters=0 / halves=527. The reverse also degrades -- 2016 quarters=550
+#: / halves=262 -- so this is a real discriminator, not a fallback.
+_WBB_QUARTERS_MODEL: "tuple[int, int, int]" = (4, 600, 300)
+_WBB_HALVES_MODEL: "tuple[int, int, int]" = (2, 1200, 300)
+_WBB_FIRST_QUARTERS_SEASON = 2016
 _SEASON_RE = re.compile(r"^(\d{4})-(\d{2})$")
+
+
+def wbb_period_model(season: Optional[str]) -> "tuple[int, int, int]":
+    """Period model for a WBB season: halves through 2015, quarters from 2016.
+
+    An unparseable/absent season falls back to quarters, matching the modern
+    era: the raw bundles carry ``season``, so this only bites on a hand-made
+    payload, and guessing modern is the smaller error for new data.
+    """
+    year = _ending_year(season)
+    if year and year < _WBB_FIRST_QUARTERS_SEASON:
+        return _WBB_HALVES_MODEL
+    return _WBB_QUARTERS_MODEL
+
 
 #: The six per-game families, i.e. every key of the parsed record that is a list
 #: of game rows. ``teams`` is deliberately absent: it is per-game reference data
@@ -230,7 +259,7 @@ def parse_bundle(
         # parameter (here `fix_technicals: bool`) and the men's path loses its
         # signature check entirely.
         if league == "wbb":
-            pbp_df = parse_ncaa_bb_game_pbp(pbp_html, contest_id, period_model=_WBB_PERIOD_MODEL)
+            pbp_df = parse_ncaa_bb_game_pbp(pbp_html, contest_id, period_model=wbb_period_model(season))
         else:
             pbp_df = parse_ncaa_bb_game_pbp(pbp_html, contest_id)
         result["pbp"] = pbp_df.to_dicts()

--- a/tests/scrape/test_ncaa_wbb_period_model.py
+++ b/tests/scrape/test_ncaa_wbb_period_model.py
@@ -1,0 +1,62 @@
+"""WBB period-model era split (halves through 2015, quarters from 2016).
+
+NCAA women's basketball moved from two 20-minute halves to four 10-minute
+quarters for the 2015-16 season; men's basketball never switched. The parser
+applied the quarters model to EVERY women's season until 2026-08-18, which does
+not fail loudly -- it yields a frame with no rows. Every pre-2016 women's game
+therefore parsed to an empty record while the parse stage reported success (it
+counted files written, not rows extracted), and six seasons were published
+~0.6% populated.
+
+Measured on real captured bundles at the time of the fix:
+
+    season  quarters  halves
+    2016         550     262
+    2015           0     520
+    2012           0     566
+    2010           0     527
+
+The reverse degrades too, so the model is a real discriminator rather than a
+fallback -- which is why this is an era SPLIT and not a "try one, then the
+other".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sportsdataverse.scrape.ncaa.parse import wbb_period_model
+
+_HALVES = (2, 1200, 300)
+_QUARTERS = (4, 600, 300)
+
+
+@pytest.mark.parametrize("season", ["2010", "2011", "2012", "2013", "2014", "2015"])
+def test_halves_era_seasons(season):
+    assert wbb_period_model(season) == _HALVES
+
+
+@pytest.mark.parametrize("season", ["2016", "2017", "2020", "2026"])
+def test_quarters_era_seasons(season):
+    assert wbb_period_model(season) == _QUARTERS
+
+
+def test_boundary_is_2015_16():
+    """2015-16 is the FIRST quarters season; 2014-15 the last halves season."""
+    assert wbb_period_model("2015") == _HALVES
+    assert wbb_period_model("2016") == _QUARTERS
+
+
+@pytest.mark.parametrize(
+    ("season", "expected"),
+    [("2014-15", _HALVES), ("2015-16", _QUARTERS), ("2009-10", _HALVES)],
+)
+def test_accepts_hyphenated_season_form(season, expected):
+    """Raw bundles carry `season` as an ending year OR a `YYYY-YY` string."""
+    assert wbb_period_model(season) == expected
+
+
+def test_unknown_season_falls_back_to_modern():
+    """Absent/garbage season -> quarters: guessing modern is the smaller error."""
+    assert wbb_period_model(None) == _QUARTERS
+    assert wbb_period_model("not-a-season") == _QUARTERS


### PR DESCRIPTION
## The bug

NCAA women's basketball moved from **two 20-minute halves to four 10-minute quarters for the 2015‑16 season**. Men's basketball never switched.

`sportsdataverse/scrape/ncaa/parse.py` applied `_WBB_PERIOD_MODEL = (4, 600, 300)` — quarters — to **every** women's season unconditionally. Every women's game played through season 2015 was parsed against the wrong period model.

**Applying the wrong model does not raise. It returns a frame with no rows.**

## Why it went unnoticed

The parse stage counted *files written*, not *rows extracted*, so it reported complete success — `parsed == captured == 93,884` — while six seasons of output were empty records. Those seasons were then built and published as ~0.6%-populated datasets. The row-count cliff is what finally exposed it:

| dataset | 2016 | 2015 |
|---|---|---|
| pbp | 2,565,990 | **18,902** |
| player_box | 113,714 | **656** |
| team_box | 11,220 | **68** |
| schedule | 5,610 | **34** |

This is "presence is not validity" one layer deeper than usual: the JSON files existed, were well-formed, and carried the correct top-level keys — the *families inside them* were empty (1 game in 400 had any rows).

The capture was never at fault. 2015 bundles are 27.1KB vs 2016's 27.7KB, and 5,592 of 5,602 payloads are present.

## Evidence

Measured on real captured bundles:

| season | quarters (shipped) | halves |
|---|---|---|
| 2016 | **550** | 262 |
| 2015 | **0** | **520** |
| 2012 | **0** | **566** |
| 2010 | **0** | **527** |

The reverse degrades too (2016: halves 262 vs quarters 550), so this is a genuine discriminator — hence an era **split**, not a try-one-then-the-other fallback.

## The fix

`wbb_period_model(season)` returns halves below season 2016 and quarters from 2016, accepting both the ending-year (`"2015"`) and hyphenated (`"2014-15"`) forms the raw bundles carry. An absent or unparseable season falls back to quarters — guessing modern is the smaller error for new data.

The men's path is untouched. MBB is `(2, 1200, 300)` in every era, which is precisely why the MBB twin published all 17 seasons correctly and served as the control that isolated this to the women's parser.

## Verification

- 15 new tests covering both eras, the 2015/2016 boundary, both season string forms, and the unknown-season fallback.
- **1,079 passed** across `tests/scrape` + `tests/mbb` (no regression in the shared parser stack).
- ruff clean; codegen drift gate clean.

## Downstream

`ncaa-wbb-hoops-raw` is re-parsing seasons 2010–2015 with this fix (committing in batches), after which `ncaa-wbb-hoops-data` rebuilds and republishes those six seasons. Seasons 2026–2016 are unaffected and already correct.

## Summary by Sourcery

Parse NCAA women's basketball seasons with the period model appropriate to their rules era.

Bug Fixes:
- Select the correct NCAA women's basketball period model by season, restoring halves-based parsing through 2015 and quarters-based parsing from 2016.

Enhancements:
- Expose reusable women's basketball period-model resolution that supports ending-year and hyphenated season formats and defaults unknown seasons to the modern model.

Tests:
- Add coverage for both period-model eras, the 2015–16 boundary, supported season formats, and unknown-season fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NCAA women’s basketball data now uses the correct game-period format based on the season.
  * Historical seasons use two halves, while 2016 and later use four quarters.
  * Unrecognized season formats default to the modern quarter-based format.

* **Tests**
  * Added coverage for historical, modern, hyphenated, boundary, and unknown season formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->