### PR TITLE
fix(mbb): resolve a unique first-name-only match instead of rejecting it

### DIFF
--- a/sportsdataverse/mbb/mbb_ncaa_names.py
+++ b/sportsdataverse/mbb/mbb_ncaa_names.py
@@ -704,10 +704,42 @@ def fuzzy_box_match(candidate: str, unassigned_box_names: list[str], team_contex
         if any(m.near_first_name is not None for m in no_match):
             bad_l2 = [m for m in no_match if m.near_first_name is not None]
             return FuzzyMatchError(f"ERROR.3B: multiple near first name matches: [{candidate}] vs {bad_l2}")
-        # NOTE (Scala ":890-897"): 'first name only' matches were deliberately
-        # retired due to false positives -- this branch always errors, it
-        # never returns the match, even though it's the only candidate.
-        return FuzzyMatchError(f"ERROR.3C: 'first name only' match: [{first_name_only[0]}]")
+        # DELIBERATE DIVERGENCE from Scala ":890-897", which retired this
+        # branch as a false-positive risk and always errored -- even though
+        # it had already established a UNIQUE exact-first-name match with no
+        # near-miss rivals. That rejection is what deletes name-changed
+        # players: the NCAA retro-updates the roster/box to a player's
+        # CURRENT surname while the play-by-play keeps the surname as of the
+        # game, so `EATON, LEXI` (pbp) never matches `Rydalch, Lexi` (box).
+        # The surname gate scores those at zero, so the first name is the
+        # only signal left -- and the two guards above already require it to
+        # be unique and unrivalled.
+        #
+        # Measured before flipping, over an 800-game sample (WBB 2015 + MBB
+        # 2015, ~4.3k and ~4.0k successful matches respectively). The branch
+        # fires on 13 unique (team, pbp_name, box_name) triples, ALL correct:
+        #
+        #   9  surname changes  EATON->Rydalch, BROADHEAD->Devashrayee,
+        #                       FULLER->Nielson, MORRISON->Pulsipher,
+        #                       OWENS->Mitchell, GORDON->Christensen,
+        #                       SIMS->Harris, HERZBERG->Howell,
+        #                       MCDOWELL->Michael
+        #   3  misspellings     QEDAN->Qeden, ADEJINI->Adeniji, GRAY->Gary
+        #   1  scorer typo      `KELLEY,RYAN Enters Game` (once) on a Siena
+        #                       roster carrying `Oliver, Ryan` (31 pbp
+        #                       mentions) and no Kelley on EITHER roster
+        #
+        # Zero false positives. The men's side is the control: far fewer
+        # surname changes, and it fired only twice in 400 games.
+        #
+        # Rejecting these is not the safe option -- it is its own corruption.
+        # An unmatched sub leaves the on-court set at 4 or 6, every stint is
+        # flagged `player_count_error`, and the team yields ZERO good stints
+        # for the game. BYU 2014-15 had three name-changed players at once
+        # and produced lineups for only 9 of 33 games.
+        #
+        # ERROR.3A (ambiguous) and ERROR.3B (near-miss rival) still reject.
+        return first_name_only[0].box_name
 
     return FuzzyMatchError("ERROR.4A: no good matches")
 

--- a/tests/mbb/test_mbb_ncaa_names.py
+++ b/tests/mbb/test_mbb_ncaa_names.py
@@ -308,17 +308,60 @@ def test_fuzzy_box_match_multiple_weak_error() -> None:
     assert "ERROR.2A" in result.message
 
 
-def test_fuzzy_box_match_first_name_only_retired() -> None:
-    """utest ``:232-241`` -- "3C" support was retired upstream; the single
-    first-name-only match always errors, even though it's the only
-    candidate."""
+def test_fuzzy_box_match_unique_first_name_resolves() -> None:
+    """utest ``:232-241``, INVERTED -- a DELIBERATE divergence from the Scala
+    oracle, which retired this branch ("3C") and errored on a unique
+    first-name-only match.
+
+    The upstream fixture argues our side: `FINKLEA,AMAYA` against a box
+    carrying `Guity, Amaya` is Amaya **Finklea-Guity** -- one compound
+    surname, split across the two pages. The oracle rejected a correct match.
+
+    Rejecting is not the conservative choice. It is how name-changed players
+    are deleted: the NCAA retro-updates the box to a player's CURRENT
+    surname while the play-by-play keeps the surname as of the game, so the
+    surname gate scores zero and the first name is the only signal left.
+    An unresolved sub leaves the on-court set at 4 or 6, every stint is
+    flagged, and the team yields zero good stints for that game.
+
+    Measured over 800 real games before flipping: 13 unique bindings, all
+    correct (9 surname changes, 3 misspellings, 1 scorer typo), 0 false
+    positives. See the comment in `fuzzy_box_match` for the full table.
+    """
     result = fuzzy_box_match(
         "FINKLEA,AMAYA",
         ["Guity, Amaya", "Pryor, DeArica", "Guity, Robison"],
         "test3c",
     )
+    assert result == "Guity, Amaya", result
+
+
+def test_fuzzy_box_match_ambiguous_first_name_still_errors() -> None:
+    """The guards that make the divergence above safe are still guards.
+
+    Two players sharing the first name is genuinely ambiguous, so it must
+    keep erroring -- enabling 3C must not weaken 3A.
+    """
+    result = fuzzy_box_match(
+        "EATON,LEXI",
+        ["Rydalch, Lexi", "Bailey, Lexi"],
+        "test3a",
+    )
     assert isinstance(result, FuzzyMatchError)
-    assert "ERROR.3C" in result.message
+    assert "ERROR.3A" in result.message
+
+
+def test_fuzzy_box_match_surname_change_resolves_by_first_name() -> None:
+    """The real BYU 2014-15 case: three name changes on one roster.
+
+    `EATON` / `BROADHEAD` / `FULLER` are the play-by-play surnames;
+    `Rydalch` / `Devashrayee` / `Nielson` are what the box calls the same
+    three women. Before this change BYU produced lineups for 9 of 33 games.
+    """
+    box = ["Rydalch, Lexi", "Devashrayee, Cassie", "Nielson, Kristine", "Bailey, Morgan"]
+    assert fuzzy_box_match("EATON,LEXI", box, "byu") == "Rydalch, Lexi"
+    assert fuzzy_box_match("BROADHEAD,CASSIE", box, "byu") == "Devashrayee, Cassie"
+    assert fuzzy_box_match("FULLER,KRISTINE", box, "byu") == "Nielson, Kristine"
 
 
 def test_fuzzy_box_match_multiple_first_name_error() -> None:


### PR DESCRIPTION
Second of two fixes to the NCAA lineup chain. #371 fixed sibling player codes; this fixes **name changes**, which delete teams the same way.

## The problem

The NCAA retro-updates the roster and box score to a player's **current** surname while the play-by-play keeps the surname **as of the game**. So `EATON, LEXI` in the pbp never matches `Rydalch, Lexi` in the box — the surname gate scores zero, and the first name is the only signal left.

`fuzzy_box_match` already established that match — a unique exact first-name hit with no near-miss rivals — and then threw it away, because the Scala oracle retired the branch as a false-positive risk (`:890-897`).

**Rejecting it is not the conservative option.** An unresolved substitution leaves the on-court set at 4 or 6, every stint is flagged `player_count_error`, and the team yields ZERO good stints for that game.

## Measured before flipping (800 real games)

WBB 2015 + MBB 2015, ~4.3k and ~4.0k successful matches. The branch fires on **13 unique (team, pbp_name, box_name) triples, all correct, zero false positives**:

| kind | n | examples |
|---|---:|---|
| surname changes | 9 | EATON→Rydalch, BROADHEAD→Devashrayee, FULLER→Nielson, MORRISON→Pulsipher, OWENS→Mitchell, GORDON→Christensen, SIMS→Harris, HERZBERG→Howell, MCDOWELL→Michael |
| misspellings | 3 | QEDAN→Qeden, ADEJINI→Adeniji, GRAY→Gary |
| scorer typo | 1 | `KELLEY,RYAN Enters Game` (once) on a Siena roster carrying `Oliver, Ryan` (31 pbp mentions), no Kelley on either roster |

The men's side is the control — far fewer surname changes, and it fired only twice in 400 games.

The upstream unit fixture argues our side too: `FINKLEA,AMAYA` against a box carrying `Guity, Amaya` is Amaya **Finklea-Guity**, one compound surname split across the two pages. The oracle rejected a correct match. That test is inverted here.

## Result

BYU 2014-15 had three name-changed players on one roster:

| | before | after |
|---|---:|---:|
| games with usable lineups | 9/33 | **33/33** |
| good stints | 13 | **522** |
| bad stints | 571 | 62 |

WBB 2015 season coverage after this plus #371 — the 10-50% band is now empty:

| coverage | teams |
|---|---:|
| ≥90% | 343 |
| 50-90% | 5 |
| 10-50% | 0 |
| <10% | 1 (`LSU New Orleans`, a separate team-name alias bug) |

**BYU's residual 62 bad stints are the league norm, not residue.** Measured over 500 games / 63 teams: median bad-stint rate **0.107**, mean 0.129, p90 0.262. BYU is at **62/584 = 0.106** — the median. The baseline is `WRONG_NUMBER_OF_PLAYERS` from incomplete NCAA substitution logging; the self-healer already recovers 76% of it (BYU 260 pre-heal → 62). Use 0.107 / p90 0.262 as the baseline for any future stint-quality gate; gating at zero would fail every team in the corpus.

## Guards

`ERROR.3A` (ambiguous — two players share the first name) and `ERROR.3B` (near-miss rival) still reject. A new test pins 3A so enabling 3C cannot silently weaken it.

## Gates

ruff + mypy clean (395 files), codegen drift clean, `tests/mbb` + `tests/wbb` 1146 passed.

## Summary by Sourcery

Resolve safe, unique first-name-only NCAA player matches while retaining ambiguity and near-miss protections.

Bug Fixes:
- Resolve unique exact first-name-only NCAA roster matches when no competing near-match exists, preventing name-changed players from being dropped from lineups.

Enhancements:
- Preserve rejection of ambiguous first-name matches and near-miss rivals to avoid weakening existing false-positive safeguards.

Tests:
- Replace the retired first-name-only rejection test with coverage for successful unique matches, ambiguous-name rejection, and real surname-change mappings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved player name matching when a unique first-name match is available.
  * Supports select surname changes while continuing to reject ambiguous matches.
* **Tests**
  * Added coverage for unique, ambiguous, and surname-change matching scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->