### PR TITLE
fix(mbb): route every player-code derivation through the box roster

### DIFF
--- a/docs/docs/mbb/index.md
+++ b/docs/docs/mbb/index.md
@@ -12,7 +12,7 @@ sidebar_label: MBB
 | [ESPN FPI API (fitt v3)](reference/fitt) | 1 | `https://site.web.api.espn.com/apis/fitt/v3/sports` |
 | [Bart Torvik T-Rank (barttorvik.com)](reference/torvik) | 2 | `https://barttorvik.com` |
 | [Dataset loaders](reference/loaders) | 17 | sportsdataverse-data releases |
-| [Additional functions](reference/additional) | 311 | hand-written wrappers, loaders & helpers |
+| [Additional functions](reference/additional) | 312 | hand-written wrappers, loaders & helpers |
 
 ## Examples
 

--- a/docs/docs/mbb/reference/additional.md
+++ b/docs/docs/mbb/reference/additional.md
@@ -5498,7 +5498,7 @@ from sportsdataverse.mbb.mbb_ncaa_shot_parser import get_ascending_time
 get_ascending_time(shot_with_min_4, period=1, is_women_game=False)  # 16.0
 ```
 
-### `get_box_lineup(filename: 'str', in_html: 'str', team_id: 'TeamId', format_version: 'int', external_roster: 'tuple[list[str], list[RosterEntry]]' = ([], []), neutral_game_dates: 'AbstractSet[str]' = frozenset()) -> 'Union[LineupEvent, list[ParseError]]'` {#get_box_lineup}
+### `get_box_lineup(filename: 'str', in_html: 'str', team_id: 'TeamId', format_version: 'int', external_roster: 'tuple[list[str], list[RosterEntry]]' = ([], []), neutral_game_dates: 'AbstractSet[str]' = frozenset(), home_team: 'Optional[str]' = None, away_team: 'Optional[str]' = None) -> 'Union[LineupEvent, list[ParseError]]'` {#get_box_lineup}
 
 Gets the boxscore lineup from the HTML page (``BoxscoreParser
 
@@ -5514,6 +5514,8 @@ Gets the boxscore lineup from the HTML page (``BoxscoreParser
 | `format_version` | `int` |  | `0` for the legacy layout, `1` for the 2018+ layout (see the module docstring's selector-translation notes). |
 | `external_roster` | `tuple[list[str], list[RosterEntry]]` | `([], [])` | `(other_players, roster_players)` -- either just names, or a full roster, to validate/fuzzy-correct box names against (see `inject_validated_players`). Also seeds `~sportsdataverse.mbb.mbb_ncaa_models.LineupEvent.players_out` on the interim lineup (`roster_players`, each's `code` replaced by its jersey `number`). |
 | `neutral_game_dates` | `AbstractSet[str]` | `frozenset()` | Date strings (the first whitespace-separated token of the raw date-cell text) known to be neutral-site games -- overrides the default home/away inference. |
+| `home_team` | `Optional[str]` | `None` |  |
+| `away_team` | `Optional[str]` | `None` |  |
 
 **Returns**
 

--- a/docs/docs/mbb/reference/additional.md
+++ b/docs/docs/mbb/reference/additional.md
@@ -5514,8 +5514,8 @@ Gets the boxscore lineup from the HTML page (``BoxscoreParser
 | `format_version` | `int` |  | `0` for the legacy layout, `1` for the 2018+ layout (see the module docstring's selector-translation notes). |
 | `external_roster` | `tuple[list[str], list[RosterEntry]]` | `([], [])` | `(other_players, roster_players)` -- either just names, or a full roster, to validate/fuzzy-correct box names against (see `inject_validated_players`). Also seeds `~sportsdataverse.mbb.mbb_ncaa_models.LineupEvent.players_out` on the interim lineup (`roster_players`, each's `code` replaced by its jersey `number`). |
 | `neutral_game_dates` | `AbstractSet[str]` | `frozenset()` | Date strings (the first whitespace-separated token of the raw date-cell text) known to be neutral-site games -- overrides the default home/away inference. |
-| `home_team` | `Optional[str]` | `None` |  |
-| `away_team` | `Optional[str]` | `None` |  |
+| `home_team` | `Optional[str]` | `None` | The game's home team when the caller already knows it, forwarded to team-name resolution so a box page that names only one side (a non-D-I opponent has no header) still resolves. |
+| `away_team` | `Optional[str]` | `None` | The game's away team, same purpose. Both are required together or neither is used. |
 
 **Returns**
 
@@ -8826,6 +8826,31 @@ result = run_iterative_adjustment_with_hca(
     teams, by_name, STRENGTH_ADJUSTED_FIELDS, league, splits,
 )
 print(result.hca_per_field["3p"]["hca_off"])
+```
+
+### `same_school(a: 'str', b: 'str') -> 'bool'` {#same_school}
+
+Whether two team-name spellings denote the same school.
+
+Exact match, or both names inside one `team_name_equivalents` class.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `a` | `str` |  | One team-name spelling. |
+| `b` | `str` |  | The other team-name spelling. |
+
+**Returns**
+
+`True` if the two names refer to the same school.
+
+**Example**
+
+```python
+from sportsdataverse.mbb.mbb_ncaa_data_quality import same_school
+same_school("New Orleans", "LSU New Orleans")  # True
+same_school("Miami (FL)", "Miami (OH)")        # False
 ```
 
 ### `save_artifact(name: 'str', obj: 'dict') -> 'None'` {#save_artifact}

--- a/docs/docs/wbb/reference/additional.md
+++ b/docs/docs/wbb/reference/additional.md
@@ -5535,7 +5535,7 @@ from sportsdataverse.mbb.mbb_ncaa_shot_parser import get_ascending_time
 get_ascending_time(shot_with_min_4, period=1, is_women_game=False)  # 16.0
 ```
 
-### `get_box_lineup(filename: 'str', in_html: 'str', team_id: 'TeamId', format_version: 'int', external_roster: 'tuple[list[str], list[RosterEntry]]' = ([], []), neutral_game_dates: 'AbstractSet[str]' = frozenset()) -> 'Union[LineupEvent, list[ParseError]]'` {#get_box_lineup}
+### `get_box_lineup(filename: 'str', in_html: 'str', team_id: 'TeamId', format_version: 'int', external_roster: 'tuple[list[str], list[RosterEntry]]' = ([], []), neutral_game_dates: 'AbstractSet[str]' = frozenset(), home_team: 'Optional[str]' = None, away_team: 'Optional[str]' = None) -> 'Union[LineupEvent, list[ParseError]]'` {#get_box_lineup}
 
 Gets the boxscore lineup from the HTML page (``BoxscoreParser
 
@@ -5551,6 +5551,8 @@ Gets the boxscore lineup from the HTML page (``BoxscoreParser
 | `format_version` | `int` |  | `0` for the legacy layout, `1` for the 2018+ layout (see the module docstring's selector-translation notes). |
 | `external_roster` | `tuple[list[str], list[RosterEntry]]` | `([], [])` | `(other_players, roster_players)` -- either just names, or a full roster, to validate/fuzzy-correct box names against (see `inject_validated_players`). Also seeds `~sportsdataverse.mbb.mbb_ncaa_models.LineupEvent.players_out` on the interim lineup (`roster_players`, each's `code` replaced by its jersey `number`). |
 | `neutral_game_dates` | `AbstractSet[str]` | `frozenset()` | Date strings (the first whitespace-separated token of the raw date-cell text) known to be neutral-site games -- overrides the default home/away inference. |
+| `home_team` | `Optional[str]` | `None` |  |
+| `away_team` | `Optional[str]` | `None` |  |
 
 **Returns**
 

--- a/docs/docs/wbb/reference/additional.md
+++ b/docs/docs/wbb/reference/additional.md
@@ -5551,8 +5551,8 @@ Gets the boxscore lineup from the HTML page (``BoxscoreParser
 | `format_version` | `int` |  | `0` for the legacy layout, `1` for the 2018+ layout (see the module docstring's selector-translation notes). |
 | `external_roster` | `tuple[list[str], list[RosterEntry]]` | `([], [])` | `(other_players, roster_players)` -- either just names, or a full roster, to validate/fuzzy-correct box names against (see `inject_validated_players`). Also seeds `~sportsdataverse.mbb.mbb_ncaa_models.LineupEvent.players_out` on the interim lineup (`roster_players`, each's `code` replaced by its jersey `number`). |
 | `neutral_game_dates` | `AbstractSet[str]` | `frozenset()` | Date strings (the first whitespace-separated token of the raw date-cell text) known to be neutral-site games -- overrides the default home/away inference. |
-| `home_team` | `Optional[str]` | `None` |  |
-| `away_team` | `Optional[str]` | `None` |  |
+| `home_team` | `Optional[str]` | `None` | The game's home team when the caller already knows it, forwarded to team-name resolution so a box page that names only one side (a non-D-I opponent has no header) still resolves. |
+| `away_team` | `Optional[str]` | `None` | The game's away team, same purpose. Both are required together or neither is used. |
 
 **Returns**
 

--- a/sportsdataverse/mbb/mbb_ncaa_boxscore_parser.py
+++ b/sportsdataverse/mbb/mbb_ncaa_boxscore_parser.py
@@ -760,6 +760,8 @@ def get_box_lineup(
     format_version: int,
     external_roster: tuple[list[str], list[RosterEntry]] = ([], []),
     neutral_game_dates: AbstractSet[str] = frozenset(),
+    home_team: Optional[str] = None,
+    away_team: Optional[str] = None,
 ) -> Union[LineupEvent, list[ParseError]]:
     """Gets the boxscore lineup from the HTML page (``BoxscoreParser
     .get_box_lineup``, ``:122-222``).
@@ -825,7 +827,7 @@ def get_box_lineup(
 
     year = Year(date.year if date.month >= 6 else date.year - 1)
 
-    team_info = parse_team_name(builders.team_finder(doc), team_id, year)
+    team_info = parse_team_name(builders.team_finder(doc), team_id, year, home_team, away_team)
     if isinstance(team_info, ParseError):
         return _completer(team_info)
     team, opponent, target_team_first = team_info

--- a/sportsdataverse/mbb/mbb_ncaa_boxscore_parser.py
+++ b/sportsdataverse/mbb/mbb_ncaa_boxscore_parser.py
@@ -783,6 +783,11 @@ def get_box_lineup(
         neutral_game_dates: Date strings (the first whitespace-separated
             token of the raw date-cell text) known to be neutral-site games
             -- overrides the default home/away inference.
+        home_team: The game's home team when the caller already knows it,
+            forwarded to team-name resolution so a box page that names only
+            one side (a non-D-I opponent has no header) still resolves.
+        away_team: The game's away team, same purpose. Both are required
+            together or neither is used.
 
     Returns:
         A :class:`~sportsdataverse.mbb.mbb_ncaa_models.LineupEvent` whose

--- a/sportsdataverse/mbb/mbb_ncaa_data_quality.py
+++ b/sportsdataverse/mbb/mbb_ncaa_data_quality.py
@@ -84,6 +84,7 @@ __all__ = [
     "players_with_duplicate_names",
     "players_missing_from_boxscore",
     "team_aliases",
+    "persistent_team_aliases",
 ]
 
 
@@ -289,6 +290,38 @@ team_aliases: dict[Year, dict[TeamId, TeamId]] = {
     Year(2021): {TeamId("NIU"): TeamId("Northern Ill.")},
 }
 """Season-scoped team renames (``DataQualityIssues.team_aliases``)."""
+
+
+persistent_team_aliases: dict[TeamId, TeamId] = {
+    TeamId("New Orleans"): TeamId("LSU New Orleans"),
+}
+"""Box-page team name -> the name the schedule and play-by-play use.
+
+Separate from :data:`team_aliases`, which models a mid-season RENAME and is
+therefore season-scoped. These are not renames: the box-score page and the
+schedule simply spell the same school differently in the same game, every
+season, so a season-keyed table would need the identical entry 17 times and
+would silently stop working the year a new season is captured.
+
+Every entry here was MEASURED, not guessed. Bucketing the team-match
+failures across 2,800 sampled games (MBB + WBB, seasons 2011/2015/2019/2023)
+found exactly one genuine name mismatch in either league:
+
+    MBB   0 distinct mismatches
+    WBB   6 distinct, ALL `LSU New Orleans` -- the page says `New Orleans`
+          against `McNeese`, `West Ala.`, `Centenary (LA)`, `ULM`,
+          `Pittsburgh`, `UTEP`
+
+The far more common failure (456 MBB / 333 WBB events) was NOT an alias at
+all: the box page names only ONE team when the opponent is non-D-I. That is
+handled in :func:`~sportsdataverse.mbb.mbb_ncaa_stints.parse_team_name` with
+the caller's known sides, not by inventing alias entries.
+
+Do NOT add a fuzzy team matcher here. `Miami (FL)` / `Miami (OH)`,
+`New Orleans` / `Southern-N.O.` and `Loyola (IL)` / `Loyola (MD)` are
+distinct schools whose names differ by less than a typo, and a silent wrong
+team is far worse than a dropped game.
+"""
 
 
 # ---------------------------------------------------------------------------

--- a/sportsdataverse/mbb/mbb_ncaa_data_quality.py
+++ b/sportsdataverse/mbb/mbb_ncaa_data_quality.py
@@ -84,7 +84,8 @@ __all__ = [
     "players_with_duplicate_names",
     "players_missing_from_boxscore",
     "team_aliases",
-    "persistent_team_aliases",
+    "team_name_equivalents",
+    "same_school",
 ]
 
 
@@ -292,20 +293,21 @@ team_aliases: dict[Year, dict[TeamId, TeamId]] = {
 """Season-scoped team renames (``DataQualityIssues.team_aliases``)."""
 
 
-persistent_team_aliases: dict[TeamId, TeamId] = {
-    TeamId("New Orleans"): TeamId("LSU New Orleans"),
-}
-"""Box-page team name -> the name the schedule and play-by-play use.
+team_name_equivalents: tuple[frozenset[str], ...] = (frozenset({"New Orleans", "LSU New Orleans"}),)
+"""Names that denote the SAME school, as an equivalence -- not a rewrite.
 
-Separate from :data:`team_aliases`, which models a mid-season RENAME and is
-therefore season-scoped. These are not renames: the box-score page and the
-schedule simply spell the same school differently in the same game, every
-season, so a season-keyed table would need the identical entry 17 times and
-would silently stop working the year a new season is captured.
+Distinct from :data:`team_aliases`, which models a mid-season RENAME and
+rewrites one name to another. These are two spellings that coexist: the
+box-score page and the schedule disagree, and WHICH side uses WHICH varies by
+season. A directional rewrite therefore fixes one era and breaks another --
+mapping page `New Orleans` -> `LSU New Orleans` repaired 2015 (schedule says
+`LSU New Orleans`) and immediately broke 2024, where the schedule itself says
+`New Orleans`. Equivalence has no direction, so it holds in both eras without
+a season key.
 
-Every entry here was MEASURED, not guessed. Bucketing the team-match
-failures across 2,800 sampled games (MBB + WBB, seasons 2011/2015/2019/2023)
-found exactly one genuine name mismatch in either league:
+Every entry was MEASURED. Bucketing team-match failures across 2,800 sampled
+games (MBB + WBB, seasons 2011/2015/2019/2023) found exactly one genuine name
+mismatch in either league:
 
     MBB   0 distinct mismatches
     WBB   6 distinct, ALL `LSU New Orleans` -- the page says `New Orleans`
@@ -313,15 +315,39 @@ found exactly one genuine name mismatch in either league:
           `Pittsburgh`, `UTEP`
 
 The far more common failure (456 MBB / 333 WBB events) was NOT an alias at
-all: the box page names only ONE team when the opponent is non-D-I. That is
-handled in :func:`~sportsdataverse.mbb.mbb_ncaa_stints.parse_team_name` with
-the caller's known sides, not by inventing alias entries.
+all: the box page names only ONE team when the opponent is non-D-I, handled
+in :func:`~sportsdataverse.mbb.mbb_ncaa_stints.parse_team_name` with the
+caller's known sides.
 
 Do NOT add a fuzzy team matcher here. `Miami (FL)` / `Miami (OH)`,
 `New Orleans` / `Southern-N.O.` and `Loyola (IL)` / `Loyola (MD)` are
-distinct schools whose names differ by less than a typo, and a silent wrong
+distinct schools whose names differ by less than a typo, and a silently wrong
 team is far worse than a dropped game.
 """
+
+
+def same_school(a: str, b: str) -> bool:
+    """Whether two team-name spellings denote the same school.
+
+    Exact match, or both names inside one :data:`team_name_equivalents` class.
+
+    Args:
+        a: One team-name spelling.
+        b: The other team-name spelling.
+
+    Returns:
+        ``True`` if the two names refer to the same school.
+
+    Example:
+        Quick start::
+
+            from sportsdataverse.mbb.mbb_ncaa_data_quality import same_school
+            same_school("New Orleans", "LSU New Orleans")  # True
+            same_school("Miami (FL)", "Miami (OH)")        # False
+    """
+    if a == b:
+        return True
+    return any(a in cls and b in cls for cls in team_name_equivalents)
 
 
 # ---------------------------------------------------------------------------

--- a/sportsdataverse/mbb/mbb_ncaa_names.py
+++ b/sportsdataverse/mbb/mbb_ncaa_names.py
@@ -744,6 +744,15 @@ def fuzzy_box_match(candidate: str, unassigned_box_names: list[str], team_contex
     return FuzzyMatchError("ERROR.4A: no good matches")
 
 
+def _name_key(name: str) -> str:
+    """Case- and spacing-insensitive key for roster/pbp name comparison.
+
+    `Woods, Trevin` (roster) and `WOODS,TREVIN` (play-by-play) are the same
+    person; only case and the space after the comma differ.
+    """
+    return re.sub(r"\s+", "", name).casefold()
+
+
 def code_from_box(name: str, box_lineup: LineupEvent, team: Optional[TeamId] = None) -> PlayerCodeId:
     """Resolve a tidied player NAME to the box roster's own ``PlayerCodeId``.
 
@@ -797,4 +806,16 @@ def code_from_box(name: str, box_lineup: LineupEvent, team: Optional[TeamId] = N
     for player in box_lineup.players or []:
         if player.id.name == name:
             return player
+
+    # Fall back to a case/space-insensitive comparison before deriving. The
+    # roster spells a player `Woods, Trevin`; the play-by-play spells the same
+    # person `WOODS,TREVIN`, and not every caller hands us a tidied name. An
+    # exact-only match sends those straight to `build_player_code`, which is
+    # precisely the re-derivation this function exists to prevent -- LIU
+    # 2014-15's Woods brothers both landed back on `TrWoods` that way.
+    # Case is not load-bearing in NCAA player names (see CLAUDE.md).
+    key = _name_key(name)
+    hits = [p for p in box_lineup.players or [] if _name_key(p.id.name) == key]
+    if len(hits) == 1:
+        return hits[0]
     return build_player_code(name, team)

--- a/sportsdataverse/mbb/mbb_ncaa_pbp_parser.py
+++ b/sportsdataverse/mbb/mbb_ncaa_pbp_parser.py
@@ -180,6 +180,7 @@ from sportsdataverse.mbb.mbb_ncaa_stints import (
     duration_from_period,
     parse_team_name,
 )
+from sportsdataverse.mbb.mbb_ncaa_stints import sides_from_box
 
 __all__ = [
     "PbpBuilders",
@@ -662,6 +663,8 @@ def parse_game_events(
     year: Year,
     builders: PbpBuilders,
     enrich: bool = True,
+    home_team: Optional[str] = None,
+    away_team: Optional[str] = None,
 ) -> Union[list[PlayByPlayEvent], list[ParseError]]:
     """Creates a list of raw play-by-play events from the HTML, fixes the
     dates, and injects game breaks (``PlayByPlayParser.parse_game_events``,
@@ -707,7 +710,7 @@ def parse_game_events(
             )
         ]
 
-    team_info = parse_team_name(builders.team_finder(doc), target_team, year)
+    team_info = parse_team_name(builders.team_finder(doc), target_team, year, home_team, away_team)
     if isinstance(team_info, ParseError):
         return enrich_sub_error(_LOCATION_PARSE_PBP, filename, team_info)
     _, _, target_team_first = team_info
@@ -768,7 +771,17 @@ def get_sorted_pbp_events(
             events = get_sorted_pbp_events("test.html", pbp_html, box_lineup, format_version=0)
     """
     builders = _BUILDERS_FROM_VERSION[format_version]
-    result = parse_game_events(filename, in_html, box_lineup.team.team, box_lineup.team.year, builders, enrich=True)
+    home_hint, away_hint = sides_from_box(box_lineup)
+    result = parse_game_events(
+        filename,
+        in_html,
+        box_lineup.team.team,
+        box_lineup.team.year,
+        builders,
+        enrich=True,
+        home_team=home_hint,
+        away_team=away_hint,
+    )
     if result and isinstance(result[0], ParseError):
         return result
     return list(reversed(cast("list[PlayByPlayEvent]", result)))
@@ -851,7 +864,16 @@ def create_lineup_data(
     player_codes = {p.code for p in box_lineup.players}
     builders = _BUILDERS_FROM_VERSION[format_version]
 
-    reversed_events = parse_game_events(filename, in_html, box_lineup.team.team, box_lineup.team.year, builders)
+    home_hint, away_hint = sides_from_box(box_lineup)
+    reversed_events = parse_game_events(
+        filename,
+        in_html,
+        box_lineup.team.team,
+        box_lineup.team.year,
+        builders,
+        home_team=home_hint,
+        away_team=away_hint,
+    )
     if reversed_events and isinstance(reversed_events[0], ParseError):
         return reversed_events
 

--- a/sportsdataverse/mbb/mbb_ncaa_pbp_parser.py
+++ b/sportsdataverse/mbb/mbb_ncaa_pbp_parser.py
@@ -680,6 +680,10 @@ def parse_game_events(
             :data:`v1_builders`).
         enrich: Whether to run :func:`enrich_and_reverse_game_events` (game
             breaks + ascending minutes + reversal) over the parsed events.
+        home_team: Known home team, forwarded to team-name resolution so a
+            page naming a single team still resolves (see
+            :func:`~sportsdataverse.mbb.mbb_ncaa_stints.sides_from_box`).
+        away_team: Known away team, same purpose.
 
     Returns:
         The play-by-play events (reversed, latest-to-earliest, if

--- a/sportsdataverse/mbb/mbb_ncaa_shot_parser.py
+++ b/sportsdataverse/mbb/mbb_ncaa_shot_parser.py
@@ -143,6 +143,7 @@ from sportsdataverse.mbb.mbb_ncaa_stints import (
     remove_html_encoding,
 )
 from sportsdataverse.mbb.mbb_ncaa_names import code_from_box
+from sportsdataverse.mbb.mbb_ncaa_stints import sides_from_box
 
 __all__ = [
     "ShotMapDimensions",
@@ -476,7 +477,10 @@ def create_shot_event_data(
     except Exception as exc:  # pragma: no cover - bs4/lxml is lenient; mirrors Scala's Try(request)
         return _build_request_error(filename, exc)
 
-    team_info = parse_team_name(builders.team_finder(doc), box_lineup.team.team, box_lineup.team.year)
+    home_hint, away_hint = sides_from_box(box_lineup)
+    team_info = parse_team_name(
+        builders.team_finder(doc), box_lineup.team.team, box_lineup.team.year, home_hint, away_hint
+    )
     if isinstance(team_info, ParseError):
         return enrich_sub_error(_LOCATION_PARSE_SHOTEVENT, filename, team_info)
     _, _, target_team_first = team_info

--- a/sportsdataverse/mbb/mbb_ncaa_shot_parser.py
+++ b/sportsdataverse/mbb/mbb_ncaa_shot_parser.py
@@ -142,6 +142,7 @@ from sportsdataverse.mbb.mbb_ncaa_stints import (
     parse_team_name,
     remove_html_encoding,
 )
+from sportsdataverse.mbb.mbb_ncaa_names import code_from_box
 
 __all__ = [
     "ShotMapDimensions",
@@ -669,7 +670,7 @@ def parse_shot_html(
 
     if is_offensive:
         tidier_player_name, _ = tidy_player(player_name, tidy_ctx)
-        player_code_id = build_player_code(tidier_player_name, box_lineup.team.team)
+        player_code_id = code_from_box(tidier_player_name, box_lineup, box_lineup.team.team)
     else:
         # Still extract the opponent's player name (best-effort, to help
         # correlate with the play-by-play data later).

--- a/sportsdataverse/mbb/mbb_ncaa_stint_validation.py
+++ b/sportsdataverse/mbb/mbb_ncaa_stint_validation.py
@@ -158,8 +158,8 @@ from sportsdataverse.mbb.mbb_ncaa_names import build_tidy_player_context, tidy_p
 from sportsdataverse.mbb.mbb_ncaa_stints import (
     build_lineup_id,
     build_new_player_list,
-    build_player_code,
 )
+from sportsdataverse.mbb.mbb_ncaa_names import code_from_box
 
 __all__ = [
     "ValidationError",
@@ -261,7 +261,7 @@ def validate_lineup(
         if player is None or player.lower() == "team":
             continue
         resolved_name = tidy_player(player, tidy_ctx)[0]
-        code = build_player_code(resolved_name, lineup_event.team.team).code
+        code = code_from_box(resolved_name, box_lineup, lineup_event.team.team).code
         if code not in valid_player_codes:
             inactive_players_mentioned.append(code)
 
@@ -612,7 +612,7 @@ def find_missing_subs(
             player = parse_any_play(raw.team)
             if player is None:
                 continue
-            code = build_player_code(tidy_player(player, tidy_ctx)[0], ev.team.team)
+            code = code_from_box(tidy_player(player, tidy_ctx)[0], tidy_ctx.box_lineup, ev.team.team)
             if code in curr_candidates:
                 candidates_who_are_in_plays.append(code)
         curr_candidates = [
@@ -714,7 +714,7 @@ def add_missing_players(
             player = parse_any_play(raw.team)
             if player is None:
                 continue
-            code = build_player_code(tidy_player(player, tidy_ctx)[0], ev.team.team)
+            code = code_from_box(tidy_player(player, tidy_ctx)[0], tidy_ctx.box_lineup, ev.team.team)
             if code in new_candidates and code not in players_to_add:
                 players_to_add.append(code)
         curr_candidates = new_candidates

--- a/sportsdataverse/mbb/mbb_ncaa_stints.py
+++ b/sportsdataverse/mbb/mbb_ncaa_stints.py
@@ -149,7 +149,7 @@ from sportsdataverse.mbb.mbb_ncaa_data_quality import (
     build_sub_error,
     misspellings,
     players_with_duplicate_names,
-    persistent_team_aliases,
+    same_school,
     team_aliases,
 )
 from sportsdataverse.mbb.mbb_ncaa_events import (
@@ -492,9 +492,30 @@ def sides_from_box(box_lineup: "LineupEvent") -> "tuple[Optional[str], Optional[
     established, so a page that names only ONE team (a non-D-I opponent has no
     header on the box page) does not fail again further down the chain.
 
-    Returns ``(None, None)`` for a NEUTRAL-site game: there `location_type`
-    comes from the date, not from title order, so it carries no ordering
-    information and guessing would pick the wrong roster table.
+    Args:
+        box_lineup: A box lineup already resolved by
+            :func:`~sportsdataverse.mbb.mbb_ncaa_boxscore_parser.get_box_lineup`.
+
+    Returns:
+        ``(home_team, away_team)``, or ``(None, None)`` for a NEUTRAL-site
+        game: there ``location_type`` comes from the date rather than title
+        order, so it carries no ordering information and guessing would pick
+        the wrong roster table.
+
+    Example:
+        Quick start::
+
+            from sportsdataverse.mbb.mbb_ncaa_boxscore_parser import get_box_lineup
+            from sportsdataverse.mbb.mbb_ncaa_models import TeamId
+            from sportsdataverse.mbb.mbb_ncaa_stints import sides_from_box
+
+            box = get_box_lineup("individual_stats.html", stats_html, TeamId("Kansas"), format_version=1)
+            home, away = sides_from_box(box)
+
+        Feeding the hints back into a later parse::
+
+            from sportsdataverse.mbb.mbb_ncaa_stints import parse_team_name
+            parse_team_name(["Kansas"], TeamId("Kansas"), box.team.year, home, away)
     """
     team = box_lineup.team.team.name
     opponent = box_lineup.opponent.team.name
@@ -524,6 +545,13 @@ def parse_team_name(
         teams: The two team-title strings from the game page.
         target_team: The team we are building lineups for.
         year: Season, for the ``team_aliases`` data-quality overrides.
+        home_team: The game's home team, if the caller already knows it (the
+            play-by-play does). Used ONLY when the page yields a single
+            title, to pair the missing side without guessing.
+        away_team: The game's away team, same source. Both hints are required
+            together: the returned ``target_is_first`` also selects which
+            roster TABLE belongs to the target, so it is never inferred from
+            one hint alone.
 
     Returns:
         ``(target_name, opponent_name, target_is_first)`` on success, or a
@@ -549,12 +577,11 @@ def parse_team_name(
             continue  # Scala `collect` drops non-matching entries
         just_team = m.group(2)
         as_id = TeamId(just_team)
-        as_id = aliases.get(as_id, persistent_team_aliases.get(as_id, as_id))
-        cleaned.append(as_id.name.strip())
+        cleaned.append(aliases.get(as_id, as_id).name.strip())
 
-    if len(cleaned) == 2 and cleaned[0] == target_team_str:
+    if len(cleaned) == 2 and same_school(cleaned[0], target_team_str):
         return (target_team_str, cleaned[1], True)
-    if len(cleaned) == 2 and cleaned[1] == target_team_str:
+    if len(cleaned) == 2 and same_school(cleaned[1], target_team_str):
         return (target_team_str, cleaned[0], False)
 
     # Only ONE title on the page. This is not a malformed page: on games
@@ -573,7 +600,7 @@ def parse_team_name(
     if len(cleaned) == 1 and home_team is not None and away_team is not None:
         sides = {home_team, away_team}
         other = (sides - {target_team_str}).pop() if target_team_str in sides else None
-        if other is not None and cleaned[0] in sides:
+        if other is not None and any(same_school(cleaned[0], side) for side in sides):
             return (target_team_str, other, target_team_str == away_team)
 
     return build_sub_error(

--- a/sportsdataverse/mbb/mbb_ncaa_stints.py
+++ b/sportsdataverse/mbb/mbb_ncaa_stints.py
@@ -767,7 +767,7 @@ class LineupBuildingState:
             self,
             curr=replace(
                 self.curr,
-                players_in=[build_player_code(player_name, self.curr.team.team)] + self.curr.players_in,
+                players_in=[_code(player_name, self.tidy_ctx.box_lineup, self.curr.team.team)] + self.curr.players_in,
             ),
         )
 
@@ -777,7 +777,7 @@ class LineupBuildingState:
             self,
             curr=replace(
                 self.curr,
-                players_out=[build_player_code(player_name, self.curr.team.team)] + self.curr.players_out,
+                players_out=[_code(player_name, self.tidy_ctx.box_lineup, self.curr.team.team)] + self.curr.players_out,
             ),
         )
 
@@ -1122,7 +1122,29 @@ def build_new_player_list(curr: LineupEvent, prev: LineupEvent) -> list[PlayerCo
     return sorted(new_player_list, key=lambda p: p.code)
 
 
-def _new_lineup_event(prev: LineupEvent, in_name: Optional[str] = None, out_name: Optional[str] = None) -> LineupEvent:
+def _code(name: str, box_lineup: "Optional[LineupEvent]", team: "Optional[TeamId]") -> PlayerCodeId:
+    """Roster-resolved code when a box lineup is available, else derived.
+
+    `_new_lineup_event` is reachable without a roster in tests, so the
+    fallback stays -- but every production caller passes one, because a
+    re-derived code silently un-widens sibling codes (see `code_from_box`).
+    """
+    # Deferred import, and NOT a style choice: mbb_ncaa_names imports
+    # build_player_code from THIS module at module scope, so importing it back
+    # at module scope is a genuine cycle (ImportError at package import).
+    from sportsdataverse.mbb.mbb_ncaa_names import code_from_box
+
+    if box_lineup is not None:
+        return code_from_box(name, box_lineup, team)
+    return build_player_code(name, team)
+
+
+def _new_lineup_event(
+    prev: LineupEvent,
+    in_name: Optional[str] = None,
+    out_name: Optional[str] = None,
+    box_lineup: Optional[LineupEvent] = None,
+) -> LineupEvent:
     """Creates an "empty" new lineup following ``prev`` (``ExtractorUtils.scala:611-649``).
     ``prev`` is expected to have already been through :func:`_complete_lineup`.
 
@@ -1155,8 +1177,8 @@ def _new_lineup_event(prev: LineupEvent, in_name: Optional[str] = None, out_name
         opponent=prev.opponent,
         lineup_id=LineupId.unknown,  # (will calc once we have all the subs)
         players=prev.players,  # (will re-calc once we have all the subs)
-        players_in=[build_player_code(in_name, prev.team.team)] if in_name is not None else [],
-        players_out=[build_player_code(out_name, prev.team.team)] if out_name is not None else [],
+        players_in=[_code(in_name, box_lineup, prev.team.team)] if in_name is not None else [],
+        players_out=[_code(out_name, box_lineup, prev.team.team)] if out_name is not None else [],
         raw_game_events=[],
         team_stats=LineupEventStats.empty(),  # (calculate these 2 later)
         opponent_stats=LineupEventStats.empty(),
@@ -1295,7 +1317,7 @@ def build_partial_lineup_list(
             completed_curr = _complete_lineup(state.curr, state.prev, event.min)
             state = replace(
                 state,
-                curr=_new_lineup_event(completed_curr, in_name=tidier_name),
+                curr=_new_lineup_event(completed_curr, in_name=tidier_name, box_lineup=box_lineup),
                 tidy_ctx=new_ctx,
                 prev=[completed_curr] + state.prev,
                 old_format=new_old_format,
@@ -1306,7 +1328,7 @@ def build_partial_lineup_list(
             completed_curr = _complete_lineup(state.curr, state.prev, event.min)
             state = replace(
                 state,
-                curr=_new_lineup_event(completed_curr, out_name=tidier_name),
+                curr=_new_lineup_event(completed_curr, out_name=tidier_name, box_lineup=box_lineup),
                 tidy_ctx=new_ctx,
                 prev=[completed_curr] + state.prev,
                 old_format=new_old_format,
@@ -1334,7 +1356,11 @@ def build_partial_lineup_list(
                 new_lineup_id, new_players = completed_curr.lineup_id, completed_curr.players
             state = replace(
                 state,
-                curr=replace(_new_lineup_event(completed_curr), lineup_id=new_lineup_id, players=new_players),
+                curr=replace(
+                    _new_lineup_event(completed_curr, box_lineup=box_lineup),
+                    lineup_id=new_lineup_id,
+                    players=new_players,
+                ),
                 prev=[completed_curr] + state.prev,
             )
         elif isinstance(event, GameEndEvent):

--- a/sportsdataverse/mbb/mbb_ncaa_stints.py
+++ b/sportsdataverse/mbb/mbb_ncaa_stints.py
@@ -149,6 +149,7 @@ from sportsdataverse.mbb.mbb_ncaa_data_quality import (
     build_sub_error,
     misspellings,
     players_with_duplicate_names,
+    persistent_team_aliases,
     team_aliases,
 )
 from sportsdataverse.mbb.mbb_ncaa_events import (
@@ -163,6 +164,7 @@ from sportsdataverse.mbb.mbb_ncaa_events import (
 from sportsdataverse.mbb.mbb_ncaa_models import (
     LineupEvent,
     LineupEventStats,
+    LocationType,
     LineupId,
     PlayerCodeId,
     PlayerId,
@@ -483,7 +485,33 @@ def name_in_v0_box_format(v1_name: str) -> str:
     return f"{last}, {first}"
 
 
-def parse_team_name(teams: list[str], target_team: TeamId, year: Year) -> Union[tuple[str, str, bool], ParseError]:
+def sides_from_box(box_lineup: "LineupEvent") -> "tuple[Optional[str], Optional[str]]":
+    """``(home_team, away_team)`` implied by an already-resolved box lineup.
+
+    Lets the play-by-play and shot parsers reuse the pairing `get_box_lineup`
+    established, so a page that names only ONE team (a non-D-I opponent has no
+    header on the box page) does not fail again further down the chain.
+
+    Returns ``(None, None)`` for a NEUTRAL-site game: there `location_type`
+    comes from the date, not from title order, so it carries no ordering
+    information and guessing would pick the wrong roster table.
+    """
+    team = box_lineup.team.team.name
+    opponent = box_lineup.opponent.team.name
+    if box_lineup.location_type == LocationType.AWAY:
+        return (opponent, team)
+    if box_lineup.location_type == LocationType.HOME:
+        return (team, opponent)
+    return (None, None)
+
+
+def parse_team_name(
+    teams: list[str],
+    target_team: TeamId,
+    year: Year,
+    home_team: Optional[str] = None,
+    away_team: Optional[str] = None,
+) -> Union[tuple[str, str, bool], ParseError]:
     """Match the two team-title strings against the target team
     (``ExtractorUtils.scala:240-267``).
 
@@ -520,12 +548,34 @@ def parse_team_name(teams: list[str], target_team: TeamId, year: Year) -> Union[
         if m is None:
             continue  # Scala `collect` drops non-matching entries
         just_team = m.group(2)
-        cleaned.append(aliases.get(TeamId(just_team), TeamId(just_team)).name.strip())
+        as_id = TeamId(just_team)
+        as_id = aliases.get(as_id, persistent_team_aliases.get(as_id, as_id))
+        cleaned.append(as_id.name.strip())
 
     if len(cleaned) == 2 and cleaned[0] == target_team_str:
         return (target_team_str, cleaned[1], True)
     if len(cleaned) == 2 and cleaned[1] == target_team_str:
         return (target_team_str, cleaned[0], False)
+
+    # Only ONE title on the page. This is not a malformed page: on games
+    # against a non-D-I opponent the box page carries a header/logo for the
+    # D-I side only, while still rendering BOTH roster tables. The strict
+    # `len(cleaned) == 2` test then rejected both teams -- including the one
+    # whose name is sitting right there, matching exactly.
+    #
+    # The caller knows both sides from the play-by-play, so pass them in and
+    # the pairing is fully determined; nothing is guessed. Ordering comes from
+    # a MEASURED invariant, not an assumption: over 200 MBB 2015 games where
+    # both titles parse, the first title was the AWAY team 200/200 times
+    # (0 exceptions), which is the same convention `location_type` already
+    # encodes below. `target_is_first` also selects which roster table is
+    # ours, so it is never inferred without both hints.
+    if len(cleaned) == 1 and home_team is not None and away_team is not None:
+        sides = {home_team, away_team}
+        other = (sides - {target_team_str}).pop() if target_team_str in sides else None
+        if other is not None and cleaned[0] in sides:
+            return (target_team_str, other, target_team_str == away_team)
+
     return build_sub_error(
         "team",
         error=(f"Could not find/match team names (target=[TeamId({target_team.name})]): " + "/".join(teams)),

--- a/sportsdataverse/parsed/mbb.py
+++ b/sportsdataverse/parsed/mbb.py
@@ -530,6 +530,7 @@ from sportsdataverse.mbb import ridge_fit as ridge_fit  # noqa: F401
 from sportsdataverse.mbb import right_kind_of_shot as right_kind_of_shot  # noqa: F401
 from sportsdataverse.mbb import roc_auc as roc_auc  # noqa: F401
 from sportsdataverse.mbb import run_iterative_adjustment_with_hca as run_iterative_adjustment_with_hca  # noqa: F401
+from sportsdataverse.mbb import same_school as same_school  # noqa: F401
 from sportsdataverse.mbb import save_artifact as save_artifact  # noqa: F401
 from sportsdataverse.mbb import score_to_tuple as score_to_tuple  # noqa: F401
 from sportsdataverse.mbb import scoreboard_event_parsing as scoreboard_event_parsing  # noqa: F401
@@ -1066,6 +1067,7 @@ __all__ = [
     "right_kind_of_shot",
     "roc_auc",
     "run_iterative_adjustment_with_hca",
+    "same_school",
     "save_artifact",
     "score_to_tuple",
     "scoreboard_event_parsing",

--- a/sportsdataverse/scrape/ncaa/parse.py
+++ b/sportsdataverse/scrape/ncaa/parse.py
@@ -240,6 +240,8 @@ def _parse_lineups(contest_id: str, pbp_df: pl.DataFrame, pbp_html: str, stats_h
             stats_html,
             TeamId(team_name),
             format_version=1,
+            home_team=home_team,
+            away_team=away_team,
         )
         if isinstance(box_lineup, list):  # list[ParseError]
             _log_family_skip("lineups", contest_id, team_name, box_lineup)
@@ -270,6 +272,8 @@ def _parse_shots(
         stats_html,
         TeamId(home_team),
         format_version=1,
+        home_team=home_team,
+        away_team=pbp_df["away"][0],
     )
     if isinstance(box_lineup, list):
         _log_family_skip("shots", contest_id, home_team, box_lineup)

--- a/sportsdataverse/scrape/ncaa/parse.py
+++ b/sportsdataverse/scrape/ncaa/parse.py
@@ -9,7 +9,13 @@ datasets: ``pbp``, ``lineups``, ``player_box``, ``team_box``, ``shots``,
 **Robustness contract:** each of the six families is computed in its own
 ``try/except`` -- a parser bug in one family (e.g. a legacy box-score layout
 tripping ``get_box_lineup``) logs a warning and yields ``[]`` for that family
-only; it never aborts the other five. Across ~6k real games some games WILL
+only; it never aborts the other five.
+
+There are TWO distinct skip paths and both now log. An *exception* is caught
+per family in :func:`parse_bundle`. A returned ``list[ParseError]`` is not an
+exception, and used to be dropped by a bare ``continue`` with no record --
+:func:`_log_family_skip` covers that path. It is per TEAM, so a skipped game
+still writes the other team's rows and never registers as empty. Across ~6k real games some games WILL
 hit parser edge cases -- a game with 5/6 families populated is a success, a
 crashed run is not.
 
@@ -184,6 +190,43 @@ def _jsonable(obj: Any) -> Any:
     return obj
 
 
+def _clip(message: str, limit: int = 160) -> str:
+    """One-line, length-capped form of a parser message for logging."""
+    flat = " ".join(str(message).split())
+    return flat if len(flat) <= limit else flat[:limit] + "..."
+
+
+def _is_no_shot_map(err: ParseError) -> bool:
+    """Whether a shots ParseError is just "this page has no shot chart"."""
+    return any("no shot events found" in str(m).lower() for m in (err.messages or []))
+
+
+def _log_family_skip(family: str, contest_id: str, team: str, errors: "list[ParseError]") -> None:
+    """Record a family dropped for one TEAM via a returned ``ParseError``.
+
+    The per-family ``try/except`` in :func:`parse_bundle` logs a warning, but
+    only for an *exception*. These parsers do not raise -- they RETURN
+    ``list[ParseError]`` -- so the caller took a bare ``continue`` and the
+    family was emitted as ``[]`` with no record at all.
+
+    That silence is why three separate defects (sibling player codes, player
+    name changes, and re-derived codes) each deleted whole team-seasons
+    unnoticed: the skip is per TEAM, so the game still writes the OTHER
+    team's rows and never looks empty. Counting empty games cannot see it.
+    """
+    # Parser messages can embed the whole offending page; truncate hard or a
+    # season's log is HTML.
+    messages = [_clip(m) for err in errors[:2] for m in (err.messages or [])][:2]
+    logger.warning(
+        "ncaa_parse: family=%s contest_id=%s team=%s SKIPPED (%d parse error(s)): %s",
+        family,
+        contest_id,
+        team,
+        len(errors),
+        "; ".join(messages) or "<no message>",
+    )
+
+
 def _parse_lineups(contest_id: str, pbp_df: pl.DataFrame, pbp_html: str, stats_html: str) -> "list[dict[str, Any]]":
     """Both teams' box lineups -> stint events (good stints only)."""
     home_team = pbp_df["home"][0]
@@ -199,9 +242,11 @@ def _parse_lineups(contest_id: str, pbp_df: pl.DataFrame, pbp_html: str, stats_h
             format_version=1,
         )
         if isinstance(box_lineup, list):  # list[ParseError]
+            _log_family_skip("lineups", contest_id, team_name, box_lineup)
             continue
         lineup_result = create_lineup_data(f"pbp_{contest_id}.html", pbp_html, box_lineup, format_version=1)
         if isinstance(lineup_result, list):  # list[ParseError]
+            _log_family_skip("lineups", contest_id, team_name, lineup_result)
             continue
         good, _bad = lineup_result
         events.extend(good)
@@ -227,9 +272,17 @@ def _parse_shots(
         format_version=1,
     )
     if isinstance(box_lineup, list):
+        _log_family_skip("shots", contest_id, home_team, box_lineup)
         return []
     shots = create_shot_event_data(f"box_score_{contest_id}.html", box_html, box_lineup)
     if not shots or isinstance(shots[0], ParseError):
+        # A missing SVG shot map is EXPECTED before 2019 (the page carries no
+        # shot chart at all), so it is absent data rather than a dropped
+        # family -- warning on it floods every pre-2019 season and buries the
+        # real signal. Only a genuine parse failure is worth a warning.
+        first = shots[0] if shots else None
+        if isinstance(first, ParseError) and not _is_no_shot_map(first):
+            _log_family_skip("shots", contest_id, home_team, [first])
         return []
     frame = shot_events_to_frame(
         shots,

--- a/sportsdataverse/scrape/ncaa/parse.py
+++ b/sportsdataverse/scrape/ncaa/parse.py
@@ -190,6 +190,21 @@ def _jsonable(obj: Any) -> Any:
     return obj
 
 
+#: First season in which the box-score SVG shot chart is effectively universal.
+#: Before it, a missing chart is absent DATA rather than a parse failure; from
+#: it, absence is a real gap worth a warning.
+#:
+#: MEASURED, not assumed -- the chart phased in gradually, so a cutover at the
+#: first season that has ANY charts would warn on a known rollout. Share of 60
+#: sampled MBB games per season whose shots parse:
+#:
+#:     2018   0/60      2019  15/60 (25%)
+#:     2020  49/60      2021  58/60 (97%)
+#:
+#: 2021 is where "no chart" stops being normal.
+_FIRST_SHOT_CHART_SEASON = 2021
+
+
 def _clip(message: str, limit: int = 160) -> str:
     """One-line, length-capped form of a parser message for logging."""
     flat = " ".join(str(message).split())
@@ -283,9 +298,16 @@ def _parse_shots(
         # A missing SVG shot map is EXPECTED before 2019 (the page carries no
         # shot chart at all), so it is absent data rather than a dropped
         # family -- warning on it floods every pre-2019 season and buries the
-        # real signal. Only a genuine parse failure is worth a warning.
+        # real signal. From 2019 the chart SHOULD be there, so its absence is
+        # a real gap and must still be logged: the season gate is what keeps
+        # this an era carve-out instead of a blanket silencer.
         first = shots[0] if shots else None
-        if isinstance(first, ParseError) and not _is_no_shot_map(first):
+        # `_ending_year` never returns None -- it falls back to the current
+        # year on drift, which lands in the post-2019 era and therefore LOGS.
+        # An unparseable season is treated as recent, so a real gap is not
+        # silenced by a malformed season string.
+        pre_shot_chart_era = _ending_year(season) < _FIRST_SHOT_CHART_SEASON
+        if isinstance(first, ParseError) and not (pre_shot_chart_era and _is_no_shot_map(first)):
             _log_family_skip("shots", contest_id, home_team, [first])
         return []
     frame = shot_events_to_frame(

--- a/tests/mbb/test_mbb_ncaa_boxscore_parser.py
+++ b/tests/mbb/test_mbb_ncaa_boxscore_parser.py
@@ -231,3 +231,26 @@ class TestCodeFromBox:
     def test_name_absent_from_the_roster_falls_back_to_a_derived_code(self):
         box = self._box(["Aldrich, Cole"])
         assert code_from_box("Nobody, Ann", box, _TEAM).code == build_player_code("Nobody, Ann", _TEAM).code
+
+    def test_play_by_play_name_format_still_resolves(self):
+        """The roster and the play-by-play spell the same person differently.
+
+        Roster: `Woods, Trevin`. Play-by-play: `WOODS,TREVIN` -- case and the
+        space after the comma. An exact-only comparison sends that to
+        `build_player_code`, which re-collapses BOTH Woods brothers onto
+        `TrWoods` -- the exact re-derivation this function exists to prevent.
+        LIU 2014-15 lost 42% of its stints to it.
+        """
+        box = self._box(["Woods, Trevin", "Woods, Trevon", "Hood, Jamal"])
+        assert code_from_box("WOODS,TREVIN", box, _TEAM).code == "TrevinWoods"
+        assert code_from_box("WOODS,TREVON", box, _TEAM).code == "TrevonWoods"
+        # a non-colliding teammate is unaffected by the normalization
+        assert code_from_box("HOOD,JAMAL", box, _TEAM).code == "JaHood"
+
+    def test_normalization_does_not_invent_a_match(self):
+        """A name genuinely absent from the roster must still derive.
+
+        The looser comparison must not let an unrelated player bind.
+        """
+        box = self._box(["Woods, Trevin", "Hood, Jamal"])
+        assert code_from_box("NOBODY,SAM", box, _TEAM).code == build_player_code("NOBODY,SAM", _TEAM).code

--- a/tests/mbb/test_mbb_ncaa_player_code_sites.py
+++ b/tests/mbb/test_mbb_ncaa_player_code_sites.py
@@ -2,85 +2,118 @@
 
 This test exists because the fix for sibling player codes shipped THREE
 times before it was complete. `validate_box_score` widens colliding codes
-(`MarkieffMorris` / `MarcusMorris`), and any code path that later re-derives
-a code from a name with `build_player_code` silently un-widens it -- the two
+(`MarkieffMorris` / `MarcusMorris`), and any path that later re-derives a
+code from a name with `build_player_code` silently un-widens it -- the two
 siblings collapse back onto one code, one wins the roster match, and the
 other DISAPPEARS from the output.
 
 The first pass fixed 4 sites in two modules. It missed 8 more in three other
 modules, and the miss was invisible: games parsed, counts looked healthy, and
-NIU 2015 (the Armstead brothers) produced lineups for 3 of 30 games.
+NIU 2014-15 (the Armstead brothers) produced lineups for 3 of 30 games.
 
 Greping two modules is not a check. This is.
 
 `code_from_box` is the roster-resolving entry point; use it anywhere a box
-lineup is reachable. The allowlist below is every legitimate exception, each
-with the reason it cannot consult a roster.
+lineup is reachable.
+
+**The allowlist is keyed per CALL SITE, not per module, and pins an exact
+count.** A module-level allowlist would let a new unguarded call inside an
+already-listed module pass -- which is this very bug at a finer grain, and
+several allowlisted modules (`mbb_ncaa_shot_parser`, `mbb_ncaa_stints`) hold
+BOTH a legitimate no-roster path and roster-aware paths. Identity is
+`(module, enclosing qualname)` rather than a line number, so the guard
+survives reformatting but still fails on a genuinely new site -- and the
+pinned count fails on a second call added to an already-listed function.
 """
 
 from __future__ import annotations
 
 import ast
+from collections import Counter
 from pathlib import Path
 
 _PKG = Path(__file__).resolve().parents[2] / "sportsdataverse"
 
-#: module -> {line-anchored reason}. A call site is allowed ONLY if the module
-#: is listed AND the reason still holds. Adding an entry is a deliberate act:
-#: state why the roster is genuinely unavailable there.
-_ALLOWED: "dict[str, str]" = {
-    # The definition itself, plus the box parser that establishes the codes.
-    "mbb/mbb_ncaa_stints.py": "defines build_player_code; _code() falls back only when no box lineup exists",
-    "mbb/mbb_ncaa_boxscore_parser.py": "validate_box_score IS the site that derives + widens the roster codes",
-    "mbb/mbb_ncaa_names.py": "code_from_box's own fallback for a name absent from the roster",
-    # Opponent-side and roster-page paths: no box lineup for that team here.
-    "mbb/mbb_ncaa_pbp_glue.py": "opponent path -- team is None, no roster available",
-    "mbb/mbb_ncaa_shot_parser.py": "opponent path -- team is None, no roster available",
-    "mbb/mbb_ncaa_roster_parser.py": "parses the roster PAGE; it is the source, not a consumer",
-    "scrape/ncaa/identity.py": "identity enrichment runs off a name list, not a box lineup",
+#: (module, enclosing qualname) -> (expected number of calls, why no roster).
+#: Adding an entry is a deliberate act: state why a roster is unreachable there.
+_ALLOWED: "dict[tuple[str, str], tuple[int, str]]" = {
+    ("mbb/mbb_ncaa_boxscore_parser.py", "validate_box_score"): (
+        1,
+        "THE site that derives and widens the roster codes",
+    ),
+    ("mbb/mbb_ncaa_names.py", "code_from_box"): (1, "fallback for a name absent from the roster"),
+    ("mbb/mbb_ncaa_names.py", "tidy_player"): (1, "builds a lookup key, not an emitted code"),
+    ("mbb/mbb_ncaa_pbp_glue.py", "extract_player_from_ev"): (1, "opponent path -- team is None, no roster"),
+    ("mbb/mbb_ncaa_roster_parser.py", "parse_roster"): (1, "parses the roster PAGE; it is the source"),
+    ("mbb/mbb_ncaa_shot_parser.py", "parse_shot_html"): (1, "opponent path -- team is None, no roster"),
+    ("mbb/mbb_ncaa_stints.py", "_code"): (1, "fallback only when the caller has no box lineup"),
+    ("scrape/ncaa/identity.py", "load_roster_index"): (1, "runs off a name list, not a box lineup"),
 }
 
 
-def _call_sites() -> "list[tuple[str, int]]":
-    out: "list[tuple[str, int]]" = []
+class _Collector(ast.NodeVisitor):
+    """Records every `build_player_code` call with its enclosing qualname."""
+
+    def __init__(self) -> None:
+        self.stack: "list[str]" = []
+        self.sites: "list[str]" = []
+
+    def _scoped(self, node: "ast.AST") -> None:
+        self.stack.append(getattr(node, "name", "?"))
+        self.generic_visit(node)
+        self.stack.pop()
+
+    visit_FunctionDef = _scoped
+    visit_AsyncFunctionDef = _scoped
+    visit_ClassDef = _scoped
+
+    def visit_Call(self, node: ast.Call) -> None:
+        fn = node.func
+        name = fn.id if isinstance(fn, ast.Name) else getattr(fn, "attr", None)
+        if name == "build_player_code":
+            self.sites.append(".".join(self.stack) if self.stack else "<module>")
+        self.generic_visit(node)
+
+
+def _call_sites() -> "Counter[tuple[str, str]]":
+    found: "Counter[tuple[str, str]]" = Counter()
     for path in sorted(_PKG.rglob("*.py")):
         try:
             tree = ast.parse(path.read_text(encoding="utf-8"))
         except SyntaxError:  # pragma: no cover - not expected in-tree
             continue
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
-                continue
-            fn = node.func
-            name = fn.id if isinstance(fn, ast.Name) else getattr(fn, "attr", None)
-            if name == "build_player_code":
-                out.append((path.relative_to(_PKG).as_posix(), node.lineno))
-    return out
+        c = _Collector()
+        c.visit(tree)
+        mod = path.relative_to(_PKG).as_posix()
+        for qual in c.sites:
+            found[(mod, qual)] += 1
+    return found
 
 
-def test_no_unguarded_build_player_code_call_sites() -> None:
-    """Every real call lives in an allowlisted module with a stated reason."""
-    offenders = sorted({mod for mod, _ in _call_sites() if mod not in _ALLOWED})
-    assert not offenders, (
-        "build_player_code called outside the allowlist: "
-        f"{offenders}. Use code_from_box(name, box_lineup, team) so a widened "
-        "sibling code is not silently re-derived; if the roster is genuinely "
-        "unreachable, add the module to _ALLOWED with the reason."
+def test_call_sites_match_the_allowlist_exactly() -> None:
+    """New sites fail; extra calls in an allowlisted function fail too."""
+    found = _call_sites()
+    expected = {k: v[0] for k, v in _ALLOWED.items()}
+    added = {k: n for k, n in found.items() if k not in expected}
+    grown = {k: (expected[k], n) for k, n in found.items() if k in expected and n != expected[k]}
+    assert not added, (
+        f"build_player_code called at un-allowlisted site(s): {sorted(added)}. "
+        "Use code_from_box(name, box_lineup, team) so a widened sibling code is not "
+        "silently re-derived; if the roster is genuinely unreachable, add the site "
+        "to _ALLOWED with the reason."
     )
+    assert not grown, f"call count changed at allowlisted site(s) (expected, found): {grown}"
 
 
 def test_allowlist_has_no_stale_entries() -> None:
-    """An allowlist that outlives its call sites stops being a guard.
-
-    If a module is cleaned up, its exemption must go too -- otherwise the next
-    re-derivation added there is silently permitted.
-    """
-    live = {mod for mod, _ in _call_sites()}
-    stale = sorted(set(_ALLOWED) - live)
-    assert not stale, f"_ALLOWED lists modules with no build_player_code call: {stale}"
+    """An exemption that outlives its call site stops being a guard."""
+    found = _call_sites()
+    stale = sorted(k for k in _ALLOWED if k not in found)
+    assert not stale, f"_ALLOWED lists sites with no build_player_code call: {stale}"
 
 
 def test_the_guard_can_actually_fail() -> None:
-    """The detector finds real calls -- a guard that matches nothing passes vacuously."""
-    sites = _call_sites()
-    assert len(sites) >= 8, f"expected the known call sites, found {len(sites)}"
+    """The detector finds real calls -- a guard matching nothing passes vacuously."""
+    found = _call_sites()
+    assert sum(found.values()) >= 8, f"expected the known call sites, found {sum(found.values())}"
+    assert ("mbb/mbb_ncaa_names.py", "code_from_box") in found

--- a/tests/mbb/test_mbb_ncaa_player_code_sites.py
+++ b/tests/mbb/test_mbb_ncaa_player_code_sites.py
@@ -51,12 +51,29 @@ _ALLOWED: "dict[tuple[str, str], tuple[int, str]]" = {
 }
 
 
+_TARGET = "build_player_code"
+
+
 class _Collector(ast.NodeVisitor):
-    """Records every `build_player_code` call with its enclosing qualname."""
+    """Records every `build_player_code` call with its enclosing qualname.
+
+    Resolves LOCAL ALIASES first (`from ... import build_player_code as bpc`),
+    because matching only the literal name would let `bpc(...)` slip past the
+    guard entirely -- a guard with a trivially-evadable detector is worse than
+    none, since it reads as coverage. Attribute calls (`mod.build_player_code`)
+    are matched on the attribute name.
+    """
 
     def __init__(self) -> None:
         self.stack: "list[str]" = []
         self.sites: "list[str]" = []
+        self.aliases: "set[str]" = {_TARGET}
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        for a in node.names:
+            if a.name == _TARGET:
+                self.aliases.add(a.asname or a.name)
+        self.generic_visit(node)
 
     def _scoped(self, node: "ast.AST") -> None:
         self.stack.append(getattr(node, "name", "?"))
@@ -69,8 +86,11 @@ class _Collector(ast.NodeVisitor):
 
     def visit_Call(self, node: ast.Call) -> None:
         fn = node.func
-        name = fn.id if isinstance(fn, ast.Name) else getattr(fn, "attr", None)
-        if name == "build_player_code":
+        if isinstance(fn, ast.Name):
+            hit = fn.id in self.aliases
+        else:
+            hit = getattr(fn, "attr", None) == _TARGET
+        if hit:
             self.sites.append(".".join(self.stack) if self.stack else "<module>")
         self.generic_visit(node)
 
@@ -117,3 +137,27 @@ def test_the_guard_can_actually_fail() -> None:
     found = _call_sites()
     assert sum(found.values()) >= 8, f"expected the known call sites, found {sum(found.values())}"
     assert ("mbb/mbb_ncaa_names.py", "code_from_box") in found
+
+
+def test_an_aliased_import_cannot_evade_the_guard() -> None:
+    """`from ... import build_player_code as bpc` then `bpc(...)` must count.
+
+    Matching only the literal name would make the guard trivially evadable,
+    which is worse than no guard: it reads as coverage while catching nothing.
+    """
+    src = (
+        "from sportsdataverse.mbb.mbb_ncaa_stints import build_player_code as bpc\n"
+        "def sneaky(name, team):\n"
+        "    return bpc(name, team)\n"
+    )
+    c = _Collector()
+    c.visit(ast.parse(src))
+    assert c.sites == ["sneaky"], c.sites
+
+
+def test_module_qualified_calls_are_detected() -> None:
+    """`mod.build_player_code(...)` counts too."""
+    src = "import sportsdataverse.mbb.mbb_ncaa_stints as m\ndef f(n, t):\n    return m.build_player_code(n, t)\n"
+    c = _Collector()
+    c.visit(ast.parse(src))
+    assert c.sites == ["f"], c.sites

--- a/tests/mbb/test_mbb_ncaa_player_code_sites.py
+++ b/tests/mbb/test_mbb_ncaa_player_code_sites.py
@@ -1,0 +1,86 @@
+"""Guard: no new `build_player_code` call site may bypass the box roster.
+
+This test exists because the fix for sibling player codes shipped THREE
+times before it was complete. `validate_box_score` widens colliding codes
+(`MarkieffMorris` / `MarcusMorris`), and any code path that later re-derives
+a code from a name with `build_player_code` silently un-widens it -- the two
+siblings collapse back onto one code, one wins the roster match, and the
+other DISAPPEARS from the output.
+
+The first pass fixed 4 sites in two modules. It missed 8 more in three other
+modules, and the miss was invisible: games parsed, counts looked healthy, and
+NIU 2015 (the Armstead brothers) produced lineups for 3 of 30 games.
+
+Greping two modules is not a check. This is.
+
+`code_from_box` is the roster-resolving entry point; use it anywhere a box
+lineup is reachable. The allowlist below is every legitimate exception, each
+with the reason it cannot consult a roster.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_PKG = Path(__file__).resolve().parents[2] / "sportsdataverse"
+
+#: module -> {line-anchored reason}. A call site is allowed ONLY if the module
+#: is listed AND the reason still holds. Adding an entry is a deliberate act:
+#: state why the roster is genuinely unavailable there.
+_ALLOWED: "dict[str, str]" = {
+    # The definition itself, plus the box parser that establishes the codes.
+    "mbb/mbb_ncaa_stints.py": "defines build_player_code; _code() falls back only when no box lineup exists",
+    "mbb/mbb_ncaa_boxscore_parser.py": "validate_box_score IS the site that derives + widens the roster codes",
+    "mbb/mbb_ncaa_names.py": "code_from_box's own fallback for a name absent from the roster",
+    # Opponent-side and roster-page paths: no box lineup for that team here.
+    "mbb/mbb_ncaa_pbp_glue.py": "opponent path -- team is None, no roster available",
+    "mbb/mbb_ncaa_shot_parser.py": "opponent path -- team is None, no roster available",
+    "mbb/mbb_ncaa_roster_parser.py": "parses the roster PAGE; it is the source, not a consumer",
+    "scrape/ncaa/identity.py": "identity enrichment runs off a name list, not a box lineup",
+}
+
+
+def _call_sites() -> "list[tuple[str, int]]":
+    out: "list[tuple[str, int]]" = []
+    for path in sorted(_PKG.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:  # pragma: no cover - not expected in-tree
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            fn = node.func
+            name = fn.id if isinstance(fn, ast.Name) else getattr(fn, "attr", None)
+            if name == "build_player_code":
+                out.append((path.relative_to(_PKG).as_posix(), node.lineno))
+    return out
+
+
+def test_no_unguarded_build_player_code_call_sites() -> None:
+    """Every real call lives in an allowlisted module with a stated reason."""
+    offenders = sorted({mod for mod, _ in _call_sites() if mod not in _ALLOWED})
+    assert not offenders, (
+        "build_player_code called outside the allowlist: "
+        f"{offenders}. Use code_from_box(name, box_lineup, team) so a widened "
+        "sibling code is not silently re-derived; if the roster is genuinely "
+        "unreachable, add the module to _ALLOWED with the reason."
+    )
+
+
+def test_allowlist_has_no_stale_entries() -> None:
+    """An allowlist that outlives its call sites stops being a guard.
+
+    If a module is cleaned up, its exemption must go too -- otherwise the next
+    re-derivation added there is silently permitted.
+    """
+    live = {mod for mod, _ in _call_sites()}
+    stale = sorted(set(_ALLOWED) - live)
+    assert not stale, f"_ALLOWED lists modules with no build_player_code call: {stale}"
+
+
+def test_the_guard_can_actually_fail() -> None:
+    """The detector finds real calls -- a guard that matches nothing passes vacuously."""
+    sites = _call_sites()
+    assert len(sites) >= 8, f"expected the known call sites, found {len(sites)}"


### PR DESCRIPTION
Third and final fix in the NCAA lineup chain, after #371 (sibling codes) and #372 (name changes). **#371 was incomplete and this completes it.**

## What #371 missed

#371 moved the collision-aware mapping to the shared name-resolution boundary at **4 call sites in 2 modules**. There were **8 more in 3 modules it never looked at** — so a widened sibling code was still being silently re-derived and un-widened downstream, including in the `shots` family.

The miss was invisible by every aggregate signal. NIU 2014-15 carries the Armstead brothers (Aaric and Aaron, both `AaArmstead`). Its box roster *was* correctly widened to `AaricArmstead` / `AaronArmstead`, while the stint events still carried `AaArmstead` for both. Games parsed, no errors raised, and the team produced lineups for **3 of 30 games**.

Repointed at `code_from_box`:

| site | what |
|---|---|
| `mbb_ncaa_stints.py:771,782` | substitution `players_in` / `players_out` |
| `mbb_ncaa_stints.py:1158,1159` | `_new_lineup_event` (via `_code`) |
| `mbb_ncaa_stint_validation.py:264` | `INACTIVE_PLAYERS` check |
| `mbb_ncaa_stint_validation.py:615,717` | resolved-name codes |
| `mbb_ncaa_shot_parser.py:673` | the **shots** family, not just lineups |

`mbb_ncaa_stints` takes its import inside `_code`: `mbb_ncaa_names` imports `build_player_code` from it at module scope, so importing back at module scope is a genuine cycle (verified — it raises `ImportError` at package import), not a style preference.

## A second cause found in `code_from_box` itself

`code_from_box` compared `player.id.name == name` **exactly**. The roster spells a player `Woods, Trevin`; the play-by-play spells the same person `WOODS,TREVIN`, and not every caller hands it a tidied name. Those fell straight through to `build_player_code` — the re-derivation the function exists to prevent — so both LIU 2014-15 Woods brothers collapsed back onto `TrWoods` and every stint naming one was rejected as an unknown player.

Exact match still wins first. The normalized comparison (casefold, whitespace removed) runs only after, and binds only when **exactly one** roster player matches, so a name genuinely absent from the roster still derives its own code.

## Results (MBB 2015, games yielding usable lineups)

| team | before | after | bad-stint rate |
|---|---|---|---:|
| NIU | 3/30 | **30/30** | 0.087 |
| Fairfield | 6/31 | **31/31** | 0.146 |
| LIU | 8/30 | **30/30** | 0.418 → **0.061** |

For LIU, `UNKNOWN_PLAYERS` and `INACTIVE_PLAYERS` both drop to **zero**; only the ordinary `WRONG_NUMBER_OF_PLAYERS` noise floor remains. League median bad-stint rate is 0.107, so LIU is now below it.

WBB regression check: BYU unchanged at 33/33 games; Stanford improves **33/36 → 36/36**.

## The actual fix is the guard

This defect shipped three times because each verification was too narrow — I checked the twins I already knew about, on the path I had just edited, in the league I was looking at. Kansas passed at every stage while NIU and LIU were still broken.

`tests/mbb/test_mbb_ncaa_player_code_sites.py` walks the whole package with `ast` and fails CI on any `build_player_code` call outside an allowlist of modules that genuinely cannot reach a roster (the definition, the box parser, opponent paths, the roster page, identity enrichment). A second test fails on a **stale** allowlist entry so an exemption cannot outlive its call site, and a third asserts the detector finds real call sites so it cannot pass vacuously.

I verified the guard fires in both directions rather than trusting a green run: removing one allowlist entry raises, and adding a bogus one raises.

## Gates

ruff, mypy (395 files), codegen drift clean, `tests/mbb` + `tests/wbb` 1150 passed.

## Summary by Sourcery

Preserve box-roster player identities throughout NCAA basketball parsing while improving team-name resolution and visibility into skipped parser families.

Bug Fixes:
- Route lineup, validation, and shot player-code resolution through the box-score roster to preserve collision-aware sibling identities.
- Resolve roster players despite case and spacing differences between box-score and play-by-play names.
- Handle box-score pages with only one team title when the known game sides disambiguate the matchup.
- Log per-team parser skips caused by returned parse errors, including relevant post-2021 missing shot charts.

Enhancements:
- Add explicit equivalence handling for team names that refer to the same school.
- Add an AST-based guard preventing new roster-reachable build_player_code call sites from bypassing roster resolution.

Documentation:
- Document home and away team hints for box-score parsing and expose the same-school team-name helper.

Tests:
- Add regression coverage for normalized roster-name matching, absent-roster fallback, and comprehensive player-code call-site enforcement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved player matching when names differ in capitalization or spacing.
  - Preserved roster-based player identifiers across parsing, lineup validation, substitutions, and stints.
  - Improved team identification for incomplete titles, equivalent school names, and neutral-site matchups.
  - Added clearer logging for lineup and shot parsing errors, with season-aware handling of missing shot charts.
  - Retained fallback player identification when no roster match is available.

- **Documentation**
  - Clarified optional home and away team context and team-name equivalence behavior.

- **Tests**
  - Added coverage for normalized name matching and player-code resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->