### PR TITLE
fix(mbb): treat NIU / Northern Ill. as equivalent, not a directional rewrite

### DIFF
--- a/sportsdataverse/mbb/mbb_ncaa_data_quality.py
+++ b/sportsdataverse/mbb/mbb_ncaa_data_quality.py
@@ -293,7 +293,10 @@ team_aliases: dict[Year, dict[TeamId, TeamId]] = {
 """Season-scoped team renames (``DataQualityIssues.team_aliases``)."""
 
 
-team_name_equivalents: tuple[frozenset[str], ...] = (frozenset({"New Orleans", "LSU New Orleans"}),)
+team_name_equivalents: tuple[frozenset[str], ...] = (
+    frozenset({"New Orleans", "LSU New Orleans"}),
+    frozenset({"NIU", "Northern Ill."}),
+)
 """Names that denote the SAME school, as an equivalence -- not a rewrite.
 
 Distinct from :data:`team_aliases`, which models a mid-season RENAME and
@@ -318,6 +321,26 @@ The far more common failure (456 MBB / 333 WBB events) was NOT an alias at
 all: the box page names only ONE team when the opponent is non-D-I, handled
 in :func:`~sportsdataverse.mbb.mbb_ncaa_stints.parse_team_name` with the
 caller's known sides.
+
+The `NIU` / `Northern Ill.` class fixes the INHERITED :data:`team_aliases`
+entry ``Year(2021): {NIU -> Northern Ill.}``, which has this exact
+directional flaw. Measured on real games, that rewrite is a perfect trade --
+it repairs one direction by breaking the other:
+
+    season 2021-22 (alias active)  target `NIU` FAIL x3   `Northern Ill.` OK x3
+    season 2015    (no alias)      target `NIU` OK        `Northern Ill.` FAIL
+
+Both targets occur in the SAME season, so no directional rewrite can be
+right. The class is ADDITIVE: the rewrite still fires and `same_school` then
+matches the rewritten name against either spelling, so the inherited entry is
+left untouched rather than diverging further from the Scala oracle.
+
+Surfaced by the skip ledger during the corpus re-parse -- 6 events, all NIU,
+all with BOTH titles present and one exactly equal to the target.
+
+Every remaining `team_aliases` entry is a directional rewrite and can fail the
+same way in the season its target uses the other spelling; auditing them all
+is tracked separately.
 
 Do NOT add a fuzzy team matcher here. `Miami (FL)` / `Miami (OH)`,
 `New Orleans` / `Southern-N.O.` and `Loyola (IL)` / `Loyola (MD)` are

--- a/tests/mbb/test_mbb_ncaa_stints.py
+++ b/tests/mbb/test_mbb_ncaa_stints.py
@@ -798,3 +798,46 @@ def test_duration_from_period_is_next_periods_start() -> None:
     assert duration_from_period(1, is_women_game=False) == 20.0  # end of men's 1st half
     assert duration_from_period(2, is_women_game=False) == start_time_from_period(3, is_women_game=False) == 40.0
     assert duration_from_period(4, is_women_game=True) == start_time_from_period(5, is_women_game=True) == 40.0
+
+
+class TestTeamNameEquivalence:
+    """A directional alias fixes one spelling by breaking the other.
+
+    `team_aliases` rewrites a page name to a canonical one. That works only
+    while every game in the season targets the canonical spelling -- and both
+    spellings occur in the SAME season, so the rewrite is a perfect trade.
+    Measured on the inherited `Year(2021): {NIU -> Northern Ill.}` entry
+    before the equivalence class existed:
+
+        season 2021-22 (alias active)  target `NIU` FAIL x3  `Northern Ill.` OK x3
+        season 2015    (no alias)      target `NIU` OK       `Northern Ill.` FAIL
+
+    Six of these reached the skip ledger during the corpus re-parse, every one
+    with BOTH titles present and one exactly equal to the target.
+    """
+
+    @staticmethod
+    def _ok(titles, target, year):
+        from sportsdataverse.mbb.mbb_ncaa_data_quality import ParseError
+
+        return not isinstance(parse_team_name(titles, TeamId(target), Year(year)), ParseError)
+
+    def test_both_spellings_resolve_in_the_aliased_season(self):
+        """Year 2021 has the rewrite active; both targets must still match."""
+        for target in ("NIU", "Northern Ill."):
+            for titles in (["Bradley", "NIU"], ["NIU", "Drake"], ["Bradley", "Northern Ill."]):
+                assert self._ok(titles, target, 2021), (target, titles)
+
+    def test_both_spellings_resolve_in_an_unaliased_season(self):
+        """Year 2015 has no rewrite; the equivalence must carry it alone."""
+        for target in ("NIU", "Northern Ill."):
+            for titles in (["Bradley", "NIU"], ["Bradley", "Northern Ill."]):
+                assert self._ok(titles, target, 2015), (target, titles)
+
+    def test_distinct_schools_are_not_merged(self):
+        """The guard on the whole approach: near-identical names stay distinct."""
+        from sportsdataverse.mbb.mbb_ncaa_data_quality import same_school
+
+        assert not same_school("Miami (FL)", "Miami (OH)")
+        assert not same_school("New Orleans", "Southern-N.O.")
+        assert not same_school("Loyola (IL)", "Loyola (MD)")


### PR DESCRIPTION
Follow-up to #373, **found by the skip ledger that PR added** — 6 events during the corpus re-parse, all NIU, every one with BOTH page titles present and one exactly equal to the target:

```
Could not find/match team names (target=[TeamId(NIU)]): Bradley/NIU
Could not find/match team names (target=[TeamId(NIU)]): NIU/Drake
Could not find/match team names (target=[TeamId(NIU)]): Ball St./NIU
```

## Cause

The **inherited** `team_aliases` entry `Year(2021): {NIU -> Northern Ill.}` rewrites the page name away from the target. It is the identical directional flaw already fixed in #373 for `New Orleans` / `LSU New Orleans` — sitting in the Scala-ported table.

Measured, the rewrite is a perfect trade: it repairs one direction by breaking the other.

| season | target `NIU` | target `Northern Ill.` |
|---|---|---|
| 2021-22 (alias active) | **FAIL** ×3 | OK ×3 |
| 2015 (no alias) | OK | **FAIL** |

Both targets occur in the **same season**, so no directional rewrite can be correct.

## Fix

Add `frozenset({"NIU", "Northern Ill."})` to `team_name_equivalents`. Failures across both eras and both spellings go **6 → 0**.

The class is **additive** and the inherited entry is left in place: the rewrite still fires, and `same_school` then matches the rewritten name against either spelling. That avoids diverging from the Scala oracle further than necessary — one line, no behaviour removed.

## Tests

Pin both eras and both spellings, plus the guard the whole equivalence approach rests on: `Miami (FL)`/`Miami (OH)`, `New Orleans`/`Southern-N.O.` and `Loyola (IL)`/`Loyola (MD)` must stay distinct. A silently wrong team is far worse than a dropped game.

## Scope

Deliberately narrow. **Every remaining `team_aliases` entry is a directional rewrite** and can fail the same way in the season its target uses the other spelling — auditing the whole table is tracked separately rather than folded in here.

Blast radius is one team-season, so this needs only a targeted `--season` re-parse of 2022 afterwards, not another full-corpus run.

## Gates

ruff, mypy (395 files), codegen drift clean, `tests/mbb` + `tests/wbb` 1156 passed.

## Summary by Sourcery

Resolve NIU team names consistently across seasonal spelling variants without weakening safeguards for distinct schools.

Bug Fixes:
- Treat NIU and Northern Ill. as equivalent team names so games using either spelling resolve correctly across aliased and unaliased seasons.

Enhancements:
- Preserve distinctions between similarly named but different schools while expanding team-name equivalence handling.

Tests:
- Add coverage for both NIU spellings across 2021 and 2015, including safeguards against merging distinct schools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved team matching by recognizing “NIU” and “Northern Ill.” as the same team across supported seasons.
  * Preserved distinctions between similarly named schools to prevent incorrect matches.

* **Tests**
  * Added coverage for aliased and unaliased seasons, including safeguards against merging separate schools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->