### PR TITLE
feat(cfb): harden cfb_ncaa parsers for 2025-season page variants + drive-title/scoring-summary parsers

### DIFF
--- a/sportsdataverse/cfb/cfb_ncaa_box.py
+++ b/sportsdataverse/cfb/cfb_ncaa_box.py
@@ -46,9 +46,12 @@ __all__ = [
     "parse_cfb_ncaa_team_stats",
 ]
 
-_QUARTER_RE = re.compile(r"^(?:(\d+)(?:st|nd|rd|th)\s+Quarter|OT\s*\d*)$", re.I)
-# "1OT"/"2OT", bare "OT" (= 1OT), "OT2", any case -- the same label variants
-# _QUARTER_RE already accepts, so the two never disagree on an OT cell.
+# Period-row labels: "1st Quarter", and every OT spelling stats.ncaa.org emits
+# ("OT", "OT2", "1OT", "2OT", any case). _QUARTER_RE classifies period rows
+# (team stats / linescore); _OT_PERIOD_RE numbers them -- they MUST accept the
+# same OT forms or a "1OT" row gets classified as a team/stat name.
+_OT_LABEL = r"(?:\d*\s*OT\s*\d*)"
+_QUARTER_RE = re.compile(rf"^(?:(\d+)(?:st|nd|rd|th)\s+Quarter|{_OT_LABEL})$", re.I)
 _OT_PERIOD_RE = re.compile(r"^(?:(\d+)\s*OT|OT\s*(\d*))$", re.I)
 _COMPETITOR_ID_RE = re.compile(r"competitor_(\d+)_year_stat_category_(\d+)_data_table")
 

--- a/sportsdataverse/cfb/cfb_ncaa_box.py
+++ b/sportsdataverse/cfb/cfb_ncaa_box.py
@@ -47,7 +47,9 @@ __all__ = [
 ]
 
 _QUARTER_RE = re.compile(r"^(?:(\d+)(?:st|nd|rd|th)\s+Quarter|OT\s*\d*)$", re.I)
-_OT_PERIOD_RE = re.compile(r"^(\d+)OT$")
+# "1OT"/"2OT", bare "OT" (= 1OT), "OT2", any case -- the same label variants
+# _QUARTER_RE already accepts, so the two never disagree on an OT cell.
+_OT_PERIOD_RE = re.compile(r"^(?:(\d+)\s*OT|OT\s*(\d*))$", re.I)
 _COMPETITOR_ID_RE = re.compile(r"competitor_(\d+)_year_stat_category_(\d+)_data_table")
 
 
@@ -116,12 +118,15 @@ def _int(v: str) -> "int | None":
 
 
 def _period_num(v: "str | None") -> "int | None":
-    """``"3"`` -> 3, ``"1OT"`` -> 5, ``"2OT"`` -> 6 (OT periods continue after the 4th)."""
+    """``"3"`` -> 3, ``"1OT"``/``"OT"`` -> 5, ``"2OT"``/``"OT2"`` -> 6 (OT periods continue
+    after the 4th; case-insensitive, an unnumbered ``OT`` is the first one)."""
     if not v:
         return None
+    v = v.strip()
     m = _OT_PERIOD_RE.match(v)
     if m:
-        return 4 + int(m.group(1))
+        n = m.group(1) or m.group(2) or "1"
+        return 4 + int(n)
     return int(v) if v.isdigit() else None
 
 

--- a/sportsdataverse/cfb/cfb_ncaa_box.py
+++ b/sportsdataverse/cfb/cfb_ncaa_box.py
@@ -5,6 +5,8 @@ One parser per stats.ncaa.org tab of a contest (all bm-verify-gated, fetched via
 the shared browser transport in :mod:`sportsdataverse.mbb.mbb_ncaa_fetch`):
 
 * :func:`parse_cfb_ncaa_drives` -- ``/contests/{id}/drives`` (drive-level box).
+* :func:`parse_cfb_ncaa_scoring_summary` -- the ``/contests/{id}/box_score``
+  scoring-summary table (one row per score, running score, OT as period 5+).
 * :func:`parse_cfb_ncaa_team_stats` -- ``/contests/{id}/team_stats`` (team box,
   **with per-quarter breakdown** -- one row per category/stat/period).
 * :func:`parse_cfb_ncaa_player_stats` -- ``/contests/{id}/individual_stats``
@@ -34,15 +36,18 @@ __all__ = [
     "DRIVES_SCHEMA",
     "LINESCORE_SCHEMA",
     "OFFICIALS_SCHEMA",
+    "SCORING_SUMMARY_SCHEMA",
     "TEAM_STATS_SCHEMA",
     "parse_cfb_ncaa_drives",
     "parse_cfb_ncaa_linescore",
     "parse_cfb_ncaa_officials",
     "parse_cfb_ncaa_player_stats",
+    "parse_cfb_ncaa_scoring_summary",
     "parse_cfb_ncaa_team_stats",
 ]
 
 _QUARTER_RE = re.compile(r"^(?:(\d+)(?:st|nd|rd|th)\s+Quarter|OT\s*\d*)$", re.I)
+_OT_PERIOD_RE = re.compile(r"^(\d+)OT$")
 _COMPETITOR_ID_RE = re.compile(r"competitor_(\d+)_year_stat_category_(\d+)_data_table")
 
 
@@ -93,6 +98,7 @@ DRIVES_SCHEMA: "dict[str, pl.DataType]" = {
     "contest_id": pl.Utf8,
     "drive_number": pl.Int64,
     "quarter": pl.Int64,
+    "period": pl.Int64,
     "team": pl.Utf8,
     "start_period": pl.Int64,
     "start_how": pl.Utf8,
@@ -109,14 +115,29 @@ def _int(v: str) -> "int | None":
     return int(v) if v and v.lstrip("-").isdigit() else None
 
 
+def _period_num(v: "str | None") -> "int | None":
+    """``"3"`` -> 3, ``"1OT"`` -> 5, ``"2OT"`` -> 6 (OT periods continue after the 4th)."""
+    if not v:
+        return None
+    m = _OT_PERIOD_RE.match(v)
+    if m:
+        return 4 + int(m.group(1))
+    return int(v) if v.isdigit() else None
+
+
 def parse_cfb_ncaa_drives(
     html: str, contest_id: "str | int | None" = None, *, return_as_pandas: bool = False
 ) -> "Union[pl.DataFrame, pd.DataFrame]":
     """Parse the ``/contests/{id}/drives`` page -> one row per drive.
 
-    Columns: ``drive_number``, ``quarter``, ``team``, ``start_period``/``start_how``
-    (KO/PUNT/DOWNS/…)/``start_clock``/``start_yard_line``, and the ``end_*``
-    equivalents (``end_how`` = TD/FGA/PUNT/DOWNS/…).
+    Columns: ``drive_number``, ``quarter``, ``period``, ``team``,
+    ``start_period``/``start_how`` (KO/PUNT/DOWNS/…)/``start_clock``/
+    ``start_yard_line``, and the ``end_*`` equivalents (``end_how`` =
+    TD/FGA/PUNT/DOWNS/…).
+
+    ``quarter`` is the page's Quarter cell as an int and is **null for overtime
+    drives** (the cell reads ``"1OT"``/``"2OT"``); ``period`` preserves those as
+    5, 6, … so OT drives stay addressable.
     """
     soup = BeautifulSoup(html or "", "html.parser")
     cid = _cid(contest_id)
@@ -131,6 +152,7 @@ def parse_cfb_ncaa_drives(
                     "contest_id": cid,
                     "drive_number": _int(r[0]),
                     "quarter": _int(r[1]),
+                    "period": _period_num(r[1]),
                     "team": r[2] or None,
                     "start_period": _int(r[3]),
                     "start_how": r[4] or None,
@@ -143,6 +165,94 @@ def parse_cfb_ncaa_drives(
                 }
             )
     return _finish(rows, DRIVES_SCHEMA, return_as_pandas)
+
+
+# --- scoring summary ------------------------------------------------------
+
+SCORING_SUMMARY_SCHEMA: "dict[str, pl.DataType]" = {
+    "contest_id": pl.Utf8,
+    "period": pl.Int64,
+    "clock": pl.Utf8,
+    "team": pl.Utf8,
+    "play_text": pl.Utf8,
+    "n_plays": pl.Int64,
+    "yards": pl.Int64,
+    "top": pl.Utf8,
+    "score_away": pl.Int64,
+    "score_home": pl.Int64,
+}
+
+
+def parse_cfb_ncaa_scoring_summary(
+    html: str, contest_id: "str | int | None" = None, *, return_as_pandas: bool = False
+) -> "Union[pl.DataFrame, pd.DataFrame]":
+    """Parse the ``/contests/{id}/box_score`` scoring-summary table -> one row per score.
+
+    The ``scoring_summary_table`` ``tr`` elements concatenate logical rows, so the
+    cells are flattened and re-chunked by the 9-column header (Period, Time,
+    Has Ball, Play, Plays, Yards, TOP, away, home) and de-duplicated preserving
+    order. ``period`` keeps overtime as 5, 6, … (``"1OT"`` -> 5); ``team`` ("Has
+    Ball") and ``play_text`` are null when the page leaves them blank (common on
+    OT rows); ``score_away`` / ``score_home`` are the running score after the play.
+
+    Args:
+        html: Raw HTML of the ``/contests/{id}/box_score`` page.
+        contest_id: Optional stats.ncaa.org contest id, written to every row's
+            ``contest_id`` column. Coerced to ``str``.
+        return_as_pandas: Return a ``pandas.DataFrame`` instead of ``polars``.
+
+    Returns:
+        A ``polars.DataFrame`` (or ``pandas.DataFrame`` when ``return_as_pandas``)
+        with one row per scoring play. Empty/unparseable input returns a
+        **zero-row frame carrying the documented schema**.
+
+    Example:
+        Quick start::
+
+            from sportsdataverse.cfb import parse_cfb_ncaa_scoring_summary
+            df = parse_cfb_ncaa_scoring_summary(open("box_score_6386512.html").read(), contest_id=6386512)
+            print(df.shape)
+
+        Overtime scores only::
+
+            df.filter(pl.col("period") > 4).select("period", "play_text", "score_away", "score_home")
+
+        See Also:
+            * `cfbfastR`_ -- ESPN-sourced college-football scoring plays (R)
+
+        .. _cfbfastR: https://cfbfastR.sportsdataverse.org
+    """
+    soup = BeautifulSoup(html or "", "html.parser")
+    cid = _cid(contest_id)
+    table = soup.find("table", id="scoring_summary_table")
+    rows: "list[dict]" = []
+    if table is not None:
+        cells = [c.get_text(" ", strip=True) for c in table.find_all(["th", "td"])]
+        flat = [c for c in cells if c != "Scoring Summary"]  # drop the title cell
+        if len(flat) >= 9 and flat[0] == "Period":  # drop the 9-cell header
+            flat = flat[9:]
+        for i in range(0, len(flat) - 8, 9):
+            chunk = flat[i : i + 9]
+            period = _period_num(chunk[0])
+            if period is None:
+                continue
+            rows.append(
+                {
+                    "contest_id": cid,
+                    "period": period,
+                    "clock": chunk[1] or None,
+                    "team": chunk[2] or None,
+                    "play_text": chunk[3] or None,
+                    "n_plays": _int(chunk[4]),
+                    "yards": _int(chunk[5]),
+                    "top": chunk[6] or None,
+                    "score_away": _int(chunk[7]),
+                    "score_home": _int(chunk[8]),
+                }
+            )
+    df = pl.DataFrame(rows, schema=SCORING_SUMMARY_SCHEMA) if rows else pl.DataFrame(schema=SCORING_SUMMARY_SCHEMA)
+    df = df.unique(maintain_order=True)  # the tr-concatenation duplicates rows
+    return df.to_pandas() if return_as_pandas else df
 
 
 # --- officials ------------------------------------------------------------

--- a/sportsdataverse/cfb/cfb_ncaa_pbp.py
+++ b/sportsdataverse/cfb/cfb_ncaa_pbp.py
@@ -29,30 +29,38 @@ from bs4 import BeautifulSoup
 if TYPE_CHECKING:
     import pandas as pd
 
-__all__ = ["PBP_SCHEMA", "parse_cfb_ncaa_pbp"]
+__all__ = ["DRIVE_TITLES_SCHEMA", "PBP_SCHEMA", "parse_cfb_ncaa_drive_titles", "parse_cfb_ncaa_pbp"]
 
 # NCAA official "Last,First", incl. suffixes ("Wilborn Jr.,James", "Jordan III,Tre").
 _NAME = r"[A-Z][\w.'\-]+(?:\s(?:Jr|Sr|II|III|IV)\.?)?,\s?[A-Z][\w.'\-]+"
 
-# h5 drive title: "{team} {result} {clock},{yardline}, {n} plays, {yards} yards, {top} {a} - {h}"
+# Yard-line side code. NOT upper-case only: "Ric25" (Rice), "W&M25" (William &
+# Mary) -- an [A-Z]-only class silently drops every such team's drives/plays.
+_SIDE = r"[A-Za-z&]{1,4}"
+
+# h5 drive title: "{team} {RESULT} {clock},{yardline}, {n} plays, {yards} yards, {top} {a} - {h}".
+# RESULT is an OPTIONAL all-caps token (TD/FG/FGA/PUNT/INT/FUMB/DOWNS/HALF/...);
+# anchoring on that keeps multi-word team names intact when it is missing (a
+# lazy `.+?` team + mandatory result donates "Carolina" -> "East Carolina" = "East").
 _DRIVE_RE = re.compile(
-    r"^(?P<team>.+?)\s+(?P<result>[A-Za-z/]+)\s+(?P<start_clock>\d+:\d+),(?P<start_yard_line>[A-Z]{1,4}\d+),\s+"
+    rf"^(?P<team>.+?)(?:\s+(?P<result>[A-Z/]{{2,10}}))?\s+"
+    rf"(?P<start_clock>\d+:\d+),(?P<start_yard_line>{_SIDE}\d+),\s+"
     r"(?P<n_plays>\d+)\s+plays?,\s+(?P<yards>-?\d+)\s+yards?,\s+(?P<top>\d+:\d+)\s+"
     r"(?P<score_away>\d+)\s*-\s*(?P<score_home>\d+)\s*$"
 )
 _DD_RE = re.compile(
-    r"^(?P<down>1st|2nd|3rd|4th)\s+&\s+(?P<distance>\d+|Goal)\s+at\s+(?P<yard_line>[A-Z]{1,4}\d+)",
+    rf"^(?P<down>1st|2nd|3rd|4th)\s+&\s+(?P<distance>\d+|Goal)\s+at\s+(?P<yard_line>{_SIDE}\d+)",
     re.I,
 )
 _DOWN = {"1st": 1, "2nd": 2, "3rd": 3, "4th": 4}
-_YL_SPLIT_RE = re.compile(r"^([A-Z]{1,4})(\d+)$")
+_YL_SPLIT_RE = re.compile(rf"^({_SIDE})(\d+)$")
 
 # --- play_text field regexes ----------------------------------------------
 _CLOCK_RE = re.compile(r"^\((\d{1,2}:\d{2})\)\s*")  # some games prefix each play with "(MM:SS)"
 _FORMATION_RE = re.compile(r"^(No Huddle(?:-Shotgun)?|Shotgun|Wildcat|Pistol)\s+")
 _YARDS_RE = re.compile(r"for (\d+) yards? (gain|loss)", re.I)
 _YARDS_PLAIN_RE = re.compile(r"for (\d+) yards? to the", re.I)  # completed pass / 0-yard run: positive
-_END_YL_RE = re.compile(r"to the ([A-Z]{1,4}\d+)")
+_END_YL_RE = re.compile(rf"to the ({_SIDE}\d+)")
 _RUSH_RE = re.compile(
     rf"(?P<rusher>{_NAME}) rush(?:es)?(?:\s+(?P<dir>left|right|middle|up the middle))?",
     re.I,
@@ -71,7 +79,7 @@ _PUNT_RE = re.compile(
 _SACK_RE = re.compile(rf"(?P<passer>{_NAME}) sacked", re.I)
 _FG_RE = re.compile(rf"(?P<kicker>{_NAME}) field goal", re.I)
 _XP_RE = re.compile(rf"(?P<kicker>{_NAME}) kick attempt", re.I)
-_POSSESSION_RE = re.compile(r"^[A-Z]{2,4} ball on [A-Z]{1,4}\d+")  # "AKR ball on AKR20." drive marker
+_POSSESSION_RE = re.compile(rf"^{_SIDE} ball on {_SIDE}\d+")  # "AKR ball on AKR20." / "Ore ball on Ore25." drive marker
 _TWOPT_RE = re.compile(
     rf"(?P<player>{_NAME}) (?P<kind>pass|run|rush) attempt (?P<result>Successful|failed)",
     re.I,
@@ -447,4 +455,98 @@ def parse_cfb_ncaa_pbp(
             .otherwise(None)
             .alias("qb_scramble")
         )
+    return df.to_pandas() if return_as_pandas else df
+
+
+# --- drive titles (running-score checkpoints) -----------------------------
+
+DRIVE_TITLES_SCHEMA: "dict[str, pl.DataType]" = {
+    "contest_id": pl.Utf8,
+    "drive_number": pl.Int64,
+    "team": pl.Utf8,
+    "result": pl.Utf8,
+    "start_clock": pl.Utf8,
+    "start_yard_line": pl.Utf8,
+    "n_plays": pl.Int64,
+    "yards": pl.Int64,
+    "top": pl.Utf8,
+    "score_away": pl.Int64,
+    "score_home": pl.Int64,
+}
+
+
+def parse_cfb_ncaa_drive_titles(
+    html: str,
+    contest_id: "str | int | None" = None,
+    *,
+    return_as_pandas: bool = False,
+) -> "Union[pl.DataFrame, pd.DataFrame]":
+    """Parse the drive ``h5`` titles of a ``play_by_play`` page -> one row per drive.
+
+    Each drive header on the stats.ncaa.org pbp page reads
+    ``"{team} {RESULT} {clock},{yardline}, {n} plays, {yards} yards, {top} {away} - {home}"``.
+    This lifts it into a frame of per-drive team/result/start/length plus the
+    game score **after** the drive (``score_away`` / ``score_home``) -- an
+    authoritative running-score checkpoint a play-level score can snap to.
+
+    The ``RESULT`` token is optional on some pages and side codes can be mixed
+    case (``Ric25``, ``W&M25``); both variants parse. A title that still does not
+    match yields a row with only ``drive_number`` populated, so drive numbering
+    stays aligned with :func:`parse_cfb_ncaa_pbp`.
+
+    Args:
+        html: Raw HTML of the ``/contests/{id}/play_by_play`` page.
+        contest_id: Optional stats.ncaa.org contest id, written to every row's
+            ``contest_id`` column. Coerced to ``str``.
+        return_as_pandas: Return a ``pandas.DataFrame`` instead of ``polars``.
+
+    Returns:
+        A ``polars.DataFrame`` (or ``pandas.DataFrame`` when ``return_as_pandas``)
+        with one row per drive. Empty/unparseable input returns a **zero-row frame
+        carrying the documented schema**.
+
+    Example:
+        Quick start::
+
+            from sportsdataverse.cfb import parse_cfb_ncaa_drive_titles
+            df = parse_cfb_ncaa_drive_titles(open("contest_6386335.html").read(), contest_id=6386335)
+            print(df.shape)
+
+        Running-score checkpoints::
+
+            df.select("drive_number", "team", "result", "score_away", "score_home")
+
+        See Also:
+            * `cfbfastR`_ -- ESPN-sourced college-football drives (R)
+
+        .. _cfbfastR: https://cfbfastR.sportsdataverse.org
+    """
+    soup = BeautifulSoup(html or "", "html.parser")
+    cid = str(contest_id) if contest_id is not None else None
+    rows: "list[dict]" = []
+    n = 0
+    for container in soup.select("div.drives"):
+        for h5 in container.find_all("h5", recursive=False):
+            classes = h5.get("class") or []
+            if not ("scoring_play" in classes or "non_scoring_play" in classes):
+                continue
+            n += 1
+            m = _DRIVE_RE.match(_spaces(h5.get_text(" ", strip=True)))
+            g = m.groupdict() if m else {}
+            rows.append(
+                {
+                    "contest_id": cid,
+                    "drive_number": n,
+                    "team": g.get("team"),
+                    "result": g.get("result"),
+                    "start_clock": g.get("start_clock"),
+                    "start_yard_line": g.get("start_yard_line"),
+                    "n_plays": int(g["n_plays"]) if m else None,
+                    "yards": int(g["yards"]) if m else None,
+                    "top": g.get("top"),
+                    "score_away": int(g["score_away"]) if m else None,
+                    "score_home": int(g["score_home"]) if m else None,
+                }
+            )
+    df = pl.DataFrame(rows, schema=DRIVE_TITLES_SCHEMA) if rows else pl.DataFrame(schema=DRIVE_TITLES_SCHEMA)
     return df.to_pandas() if return_as_pandas else df

--- a/sportsdataverse/parsed/cfb.py
+++ b/sportsdataverse/parsed/cfb.py
@@ -431,11 +431,13 @@ from sportsdataverse.cfb import load_recruit_classes as load_recruit_classes  # 
 from sportsdataverse.cfb import make_ratings_compute_results as make_ratings_compute_results  # noqa: F401
 from sportsdataverse.cfb import most_recent_cfb_season as most_recent_cfb_season  # noqa: F401
 from sportsdataverse.cfb import normalize_team_roster_columns as normalize_team_roster_columns  # noqa: F401
+from sportsdataverse.cfb import parse_cfb_ncaa_drive_titles as parse_cfb_ncaa_drive_titles  # noqa: F401
 from sportsdataverse.cfb import parse_cfb_ncaa_drives as parse_cfb_ncaa_drives  # noqa: F401
 from sportsdataverse.cfb import parse_cfb_ncaa_linescore as parse_cfb_ncaa_linescore  # noqa: F401
 from sportsdataverse.cfb import parse_cfb_ncaa_officials as parse_cfb_ncaa_officials  # noqa: F401
 from sportsdataverse.cfb import parse_cfb_ncaa_pbp as parse_cfb_ncaa_pbp  # noqa: F401
 from sportsdataverse.cfb import parse_cfb_ncaa_player_stats as parse_cfb_ncaa_player_stats  # noqa: F401
+from sportsdataverse.cfb import parse_cfb_ncaa_scoring_summary as parse_cfb_ncaa_scoring_summary  # noqa: F401
 from sportsdataverse.cfb import parse_cfb_ncaa_team_stats as parse_cfb_ncaa_team_stats  # noqa: F401
 from sportsdataverse.cfb import parse_on3_rankings as parse_on3_rankings  # noqa: F401
 from sportsdataverse.cfb import parse_on3_rdb as parse_on3_rdb  # noqa: F401
@@ -764,11 +766,13 @@ __all__ = [
     "on3_transfers_best_available",
     "on3_transfers_latest",
     "on3_videos_video_key",
+    "parse_cfb_ncaa_drive_titles",
     "parse_cfb_ncaa_drives",
     "parse_cfb_ncaa_linescore",
     "parse_cfb_ncaa_officials",
     "parse_cfb_ncaa_pbp",
     "parse_cfb_ncaa_player_stats",
+    "parse_cfb_ncaa_scoring_summary",
     "parse_cfb_ncaa_team_stats",
     "parse_on3_rankings",
     "parse_on3_rdb",

--- a/tests/cfb/test_cfb_ncaa_box.py
+++ b/tests/cfb/test_cfb_ncaa_box.py
@@ -15,11 +15,13 @@ from sportsdataverse.cfb.cfb_ncaa_box import (
     DRIVES_SCHEMA,
     LINESCORE_SCHEMA,
     OFFICIALS_SCHEMA,
+    SCORING_SUMMARY_SCHEMA,
     TEAM_STATS_SCHEMA,
     parse_cfb_ncaa_drives,
     parse_cfb_ncaa_linescore,
     parse_cfb_ncaa_officials,
     parse_cfb_ncaa_player_stats,
+    parse_cfb_ncaa_scoring_summary,
     parse_cfb_ncaa_team_stats,
 )
 
@@ -141,3 +143,41 @@ def test_linescore_teams_periods_meta() -> None:
 def test_linescore_empty() -> None:
     df = parse_cfb_ncaa_linescore("")
     assert df.height == 0 and df.columns == list(LINESCORE_SCHEMA.keys())
+
+
+# --- overtime variant (contest 6386512 -- Houston @ Oregon St., 1OT, 2025-09-26) --
+
+
+def _ot(tab: str) -> str:
+    return (FIX / f"mfb_{tab}_6386512.html").read_text(encoding="utf-8")
+
+
+def test_drives_period_preserves_overtime() -> None:
+    df = parse_cfb_ncaa_drives(_ot("drives"), contest_id="6386512")
+    assert df.columns == list(DRIVES_SCHEMA.keys())
+    ot = df.filter(pl.col("period") > 4)
+    assert ot.height == 2  # one possession each in 1OT
+    assert ot.get_column("period").unique().to_list() == [5]
+    assert ot.get_column("quarter").is_null().all()  # existing semantics untouched ("1OT" -> null)
+    reg = df.filter(pl.col("period") <= 4)
+    assert (reg.get_column("period") == reg.get_column("quarter")).all()
+
+
+def test_scoring_summary_rows_and_running_score() -> None:
+    df = parse_cfb_ncaa_scoring_summary(_ot("box_score"), contest_id="6386512")
+    assert df.columns == list(SCORING_SUMMARY_SCHEMA.keys())
+    # the table's trs nest/concatenate (81 cells in one tr); re-chunked by 9 -> 9 scores
+    assert df.height == 9
+    assert df.get_column("contest_id").unique().to_list() == ["6386512"]
+    assert df.get_column("period").to_list() == [1, 2, 2, 2, 3, 4, 4, 4, 5]  # "1OT" -> 5
+    assert df.get_column("n_plays").null_count() == 0
+    total = df.get_column("score_away") + df.get_column("score_home")
+    assert (total.diff().drop_nulls() > 0).all()  # strictly running
+    assert (df.item(-1, "score_away"), df.item(-1, "score_home")) == (27, 24)  # final
+    assert df.filter(pl.col("period") <= 4).get_column("play_text").is_not_null().all()
+
+
+def test_scoring_summary_empty() -> None:
+    df = parse_cfb_ncaa_scoring_summary("")
+    assert df.height == 0 and df.columns == list(SCORING_SUMMARY_SCHEMA.keys())
+    assert parse_cfb_ncaa_scoring_summary(_rd("officials")).height == 0  # no table on that tab

--- a/tests/cfb/test_cfb_ncaa_box.py
+++ b/tests/cfb/test_cfb_ncaa_box.py
@@ -175,6 +175,23 @@ def test_scoring_summary_rows_and_running_score() -> None:
     assert (total.diff().drop_nulls() > 0).all()  # strictly running
     assert (df.item(-1, "score_away"), df.item(-1, "score_home")) == (27, 24)  # final
     assert df.filter(pl.col("period") <= 4).get_column("play_text").is_not_null().all()
+    assert df.filter(pl.col("period") == 5).get_column("play_text").is_null().all()  # blank OT Play cell
+
+
+def test_period_num_overtime_label_variants() -> None:
+    from sportsdataverse.cfb.cfb_ncaa_box import _period_num
+
+    assert _period_num("3") == 3
+    assert _period_num("1OT") == 5
+    assert _period_num("2OT") == 6
+    assert _period_num("OT") == 5  # unnumbered = first OT
+    assert _period_num("ot") == 5
+    assert _period_num("1ot") == 5
+    assert _period_num("OT2") == 6
+    assert _period_num(" 1OT ") == 5
+    assert _period_num("") is None
+    assert _period_num(None) is None
+    assert _period_num("Final") is None
 
 
 def test_scoring_summary_empty() -> None:

--- a/tests/cfb/test_cfb_ncaa_box.py
+++ b/tests/cfb/test_cfb_ncaa_box.py
@@ -194,6 +194,17 @@ def test_period_num_overtime_label_variants() -> None:
     assert _period_num("Final") is None
 
 
+def test_quarter_re_and_period_num_agree_on_ot_labels() -> None:
+    """A period row _QUARTER_RE classifies must also be one _period_num numbers."""
+    from sportsdataverse.cfb.cfb_ncaa_box import _QUARTER_RE, _period_num
+
+    for label in ("OT", "OT2", "1OT", "2OT", "1ot", "ot"):
+        assert _QUARTER_RE.match(label), label
+        assert _period_num(label) is not None, label
+    for label in ("Total Offense", "Rushing", "Rice", "OTTO"):
+        assert not _QUARTER_RE.match(label), label
+
+
 def test_scoring_summary_empty() -> None:
     df = parse_cfb_ncaa_scoring_summary("")
     assert df.height == 0 and df.columns == list(SCORING_SUMMARY_SCHEMA.keys())

--- a/tests/cfb/test_cfb_ncaa_pbp.py
+++ b/tests/cfb/test_cfb_ncaa_pbp.py
@@ -14,7 +14,12 @@ from pathlib import Path
 
 import polars as pl
 
-from sportsdataverse.cfb.cfb_ncaa_pbp import PBP_SCHEMA, parse_cfb_ncaa_pbp
+from sportsdataverse.cfb.cfb_ncaa_pbp import (
+    DRIVE_TITLES_SCHEMA,
+    PBP_SCHEMA,
+    parse_cfb_ncaa_drive_titles,
+    parse_cfb_ncaa_pbp,
+)
 
 FIX = Path(__file__).resolve().parents[1] / "fixtures" / "cfb_ncaa"
 GAME = FIX / "cfb_ncaa_pbp_5362535.html"
@@ -196,3 +201,63 @@ def test_parser_generalizes_across_fixtures() -> None:
             & pl.col("play_text").str.contains(r",[A-Z][\w.'\-]+ rush")
         )
         assert bad.height == 0, f.name
+
+
+# --- 2025-season page variants (FCS/G5 captures, 2026-08-19) ---------------
+# Regression fixtures from the 1,685-game 2025 sweep in ncaa-mfb-football-raw:
+#   6386335 Tulsa @ East Carolina -- multi-word team + a drive title with NO result token
+#   6386574 Rice @ South Fla.     -- mixed-case yard-line side code ("Ric25")
+
+
+def _variant(cid: str) -> str:
+    return (FIX / f"mfb_play_by_play_{cid}.html").read_text(encoding="utf-8")
+
+
+def test_multiword_team_not_truncated_when_result_missing() -> None:
+    # lazy `.+?` + mandatory result used to donate "Carolina" to result -> offense "East"
+    df = parse_cfb_ncaa_pbp(_variant("6386335"), contest_id="6386335")
+    assert set(df.get_column("offense").unique().to_list()) == {"Tulsa", "East Carolina"}
+
+
+def test_mixed_case_side_code_parses() -> None:
+    # [A-Z]-only side codes nulled every Rice drive + yard line
+    df = parse_cfb_ncaa_pbp(_variant("6386574"), contest_id="6386574")
+    assert set(df.get_column("offense").unique().to_list()) == {"Rice", "South Fla."}
+    assert df.get_column("yard_line_side").null_count() == 0
+    assert "Ric" in df.get_column("yard_line_side").unique().to_list()
+    assert df.filter(pl.col("end_yard_line").str.starts_with("Ric")).height > 0
+
+
+def test_drive_titles_schema_and_checkpoints() -> None:
+    df = parse_cfb_ncaa_drive_titles(_variant("6386335"), contest_id="6386335")
+    assert df.columns == list(DRIVE_TITLES_SCHEMA.keys())
+    assert df.get_column("drive_number").to_list() == list(range(1, df.height + 1))
+    assert set(df.get_column("team").unique().to_list()) == {"Tulsa", "East Carolina"}
+    assert df.get_column("contest_id").unique().to_list() == ["6386335"]
+    # every title parsed: checkpoints + drive stats populated on every row
+    for c in ("start_clock", "start_yard_line", "n_plays", "yards", "top", "score_away", "score_home"):
+        assert df.get_column(c).null_count() == 0, c
+    # the missing-result variant: one drive has result null but team intact
+    no_result = df.filter(pl.col("result").is_null())
+    assert no_result.height == 1 and no_result.item(0, "team") == "East Carolina"
+    # running score is a monotone checkpoint ending at the final (27-41)
+    total = df.get_column("score_away") + df.get_column("score_home")
+    assert (total.diff().fill_null(0) >= 0).all()
+    assert (df.item(-1, "score_away"), df.item(-1, "score_home")) == (27, 41)
+    # drive numbering aligns with the play-level frame
+    pbp = parse_cfb_ncaa_pbp(_variant("6386335"))
+    assert df.height == pbp.get_column("drive_number").max()
+
+
+def test_drive_titles_mixed_case_side_and_pandas() -> None:
+    import pandas as pd
+
+    df = parse_cfb_ncaa_drive_titles(_variant("6386574"))
+    assert df.filter(pl.col("start_yard_line").str.starts_with("Ric")).height > 0
+    pdf = parse_cfb_ncaa_drive_titles(_variant("6386574"), return_as_pandas=True)
+    assert isinstance(pdf, pd.DataFrame) and list(pdf.columns) == list(DRIVE_TITLES_SCHEMA.keys())
+
+
+def test_drive_titles_empty() -> None:
+    df = parse_cfb_ncaa_drive_titles("")
+    assert df.height == 0 and df.columns == list(DRIVE_TITLES_SCHEMA.keys())

--- a/tests/fixtures/cfb_ncaa/README.md
+++ b/tests/fixtures/cfb_ncaa/README.md
@@ -38,3 +38,18 @@ game, for the box/drives/officials parsers in `cfb/cfb_ncaa_box.py`:
 | `mfb_individual_stats_5362283.html` | Individual Stats | <https://stats.ncaa.org/contests/5362283/individual_stats> |
 | `mfb_officials_5362283.html` | Officials | <https://stats.ncaa.org/contests/5362283/officials> |
 | `mfb_box_score_5362283.html` | Box Score (linescore + game info) | <https://stats.ncaa.org/contests/5362283/box_score> |
+
+## 2025-season page variants (captured 2026-08-19)
+
+Single tabs extracted from the `ncaa-mfb-football-raw` producer's per-game
+bundles (`mfb/json/{id}.json.gz`), captured 2026-08-19 via the same browser
+transport. They pin the page variants surfaced by the full 2025-season sweep
+(1,685 games, 1,685/1,685 exact-final QA) that the original FBS fixtures never
+exercised. Consumed by `tests/cfb/test_cfb_ncaa_pbp.py` + `test_cfb_ncaa_box.py`.
+
+| file | contest_id | game | variant pinned | source URL |
+|---|---|---|---|---|
+| `mfb_play_by_play_6386335.html` | 6386335 | Tulsa @ East Carolina, 2025-10-16 | multi-word team name + a drive title with no result token (`"East Carolina"` was truncated to `"East"`) | <https://stats.ncaa.org/contests/6386335/play_by_play> |
+| `mfb_play_by_play_6386574.html` | 6386574 | Rice @ South Fla., 2025-11-29 | mixed-case yard-line side code (`Ric25`) | <https://stats.ncaa.org/contests/6386574/play_by_play> |
+| `mfb_drives_6386512.html` | 6386512 | Houston @ Oregon St., 2025-09-26 (1OT) | drives tab with `1OT` quarter rows (`period` = 5) | <https://stats.ncaa.org/contests/6386512/drives> |
+| `mfb_box_score_6386512.html` | 6386512 | Houston @ Oregon St., 2025-09-26 (1OT) | `scoring_summary_table` with an OT row (concatenated `tr`s, re-chunked by 9) | <https://stats.ncaa.org/contests/6386512/box_score> |

--- a/tests/fixtures/cfb_ncaa/mfb_box_score_6386512.html
+++ b/tests/fixtures/cfb_ncaa/mfb_box_score_6386512.html
@@ -1,0 +1,806 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<META HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=UTF-8">
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="">
+<meta name="author" content="">
+<meta name="version" content="321d28433e9f7a188596117e6f342ec4a84fb4ed">
+<META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<link rel="shortcut icon" href="/assets/favicon-405088046a5f2bab8eedeacfae7636975c095e9c8decd8c28e3fd0e65c2f51c4.ico" type="image/vnd.microsoft.icon">
+
+<title>NCAA Statistics</title>
+
+<!-- Bootstrap core CSS -->
+
+<!--
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+-->
+<!--
+<link rel="stylesheet" href="https://cdn.datatables.net/2.0.0/css/dataTables.bootstrap4.css" crossorigin="anonymous">
+-->
+<link rel="stylesheet" media="all" href="/assets/application-789c3971842ee3597428ccbebd021716b3231e9cbd0a00a184c3b2d6c8e5f152.css" />
+
+
+<script src="/assets/application-9232576bb3cb000ac0841ff2af81251908ec17312a3c5eb72bf1a32f9754800c.js"></script>
+<!--
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+-->
+<!--
+<script src="https://cdn.datatables.net/2.0.0/js/dataTables.bootstrap4.js" crossorigin="anonymous"></script>
+-->
+
+<meta name="csrf-param" content="authenticity_token" />
+<meta name="csrf-token" content="VkB91a+ZND5oznX7S2KJRHRRLY+YB9yVPDfMcjMHZbziJuYrj0JbAHG/fBKBfDh/7Dkj3qp1RNSCTyTgIKb1Ug==" />
+
+<style>
+.grid {clear: all}
+.grid-item, .name {text-align: center;}
+h1 img {max-height: 33px;}
+
+</style>
+<!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+<!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+      <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+    <![endif]-->
+
+
+<script>(window.BOOMR_mq=window.BOOMR_mq||[]).push(["addVar",{"rua.upush":"false","rua.cpush":"false","rua.upre":"false","rua.cpre":"false","rua.uprl":"false","rua.cprl":"false","rua.cprf":"false","rua.trans":"","rua.cook":"false","rua.ims":"false","rua.ufprl":"false","rua.cfprl":"false","rua.isuxp":"false","rua.texp":"norulematch","rua.ceh":"false","rua.ueh":"false","rua.ieh.st":"0"}]);</script>
+                                <script>!function(e){var n="https://s.go-mpulse.net/boomerang/";if("False"=="True")e.BOOMR_config=e.BOOMR_config||{},e.BOOMR_config.PageParams=e.BOOMR_config.PageParams||{},e.BOOMR_config.PageParams.pci=!0,n="https://s2.go-mpulse.net/boomerang/";if(window.BOOMR_API_key="EVKJV-AGD2E-W66AE-NT84S-K5LTF",function(){function e(){if(!r){var e=document.createElement("script");e.id="boomr-scr-as",e.src=window.BOOMR.url,e.async=!0,o.appendChild(e),r=!0}}function t(e){r=!0;var n,t,a,i,d=document,O=window;if(window.BOOMR.snippetMethod=e?"if":"i",t=function(e,n){var t=d.createElement("script");t.id=n||"boomr-if-as",t.src=window.BOOMR.url,BOOMR_lstart=(new Date).getTime(),e=e||d.body,e.appendChild(t)},!window.addEventListener&&window.attachEvent&&navigator.userAgent.match(/MSIE [67]\./))return window.BOOMR.snippetMethod="s",void t(o,"boomr-async");a=document.createElement("IFRAME"),a.src="about:blank",a.title="",a.role="presentation",a.loading="eager",i=(a.frameElement||a).style,i.width=0,i.height=0,i.border=0,i.display="none",o.appendChild(a);try{O=a.contentWindow,d=O.document.open()}catch(_){n=document.domain,a.src="javascript:var d=document.open();d.domain='"+n+"';void 0;",O=a.contentWindow,d=O.document.open()}if(n)d._boomrl=function(){this.domain=n,t()},d.write("<bo"+"dy onload='document._boomrl();'>");else if(O._boomrl=function(){t()},O.addEventListener)O.addEventListener("load",O._boomrl,!1);else if(O.attachEvent)O.attachEvent("onload",O._boomrl);d.close()}function a(e){window.BOOMR_onload=e&&e.timeStamp||(new Date).getTime()}if(!window.BOOMR||!window.BOOMR.version&&!window.BOOMR.snippetExecuted){window.BOOMR=window.BOOMR||{},window.BOOMR.snippetStart=(new Date).getTime(),window.BOOMR.snippetExecuted=!0,window.BOOMR.snippetVersion=14,window.BOOMR.url=n+"EVKJV-AGD2E-W66AE-NT84S-K5LTF";var i=document.currentScript||document.getElementsByTagName("script")[0],o=i.parentNode,r=!1,d=document.createElement("link");if(d.relList&&"function"==typeof d.relList.supports&&d.relList.supports("preload")&&"as"in d)window.BOOMR.snippetMethod="p",d.href=window.BOOMR.url,d.rel="preload",d.as="script",d.addEventListener("load",e),d.addEventListener("error",function(){t(!0)}),setTimeout(function(){if(!r)t(!0)},3e3),BOOMR_lstart=(new Date).getTime(),o.appendChild(d);else t(!1);if(window.addEventListener)window.addEventListener("load",a,!1);else if(window.attachEvent)window.attachEvent("onload",a)}}(),"".length>0)if(e&&"performance"in e&&e.performance&&"function"==typeof e.performance.setResourceTimingBufferSize)e.performance.setResourceTimingBufferSize();!function(){if(BOOMR=e.BOOMR||{},BOOMR.plugins=BOOMR.plugins||{},!BOOMR.plugins.AK){var n=""=="true"?1:0,t="cookiepresent",a="v2vnq5yxy6s2c2ufu75a-f-778244d43-clientnsv4-s.akamaihd.net",i="false"=="true"?2:1,o={"ak.v":"41","ak.cp":"1168236","ak.ai":parseInt("215853",10),"ak.ol":"0","ak.cr":18,"ak.ipv":4,"ak.proto":"h2","ak.rid":"263f57e8","ak.r":47667,"ak.a2":n,"ak.m":"a","ak.n":"essl","ak.cport":47790,"ak.gh":"23.41.249.132","ak.quicv":"","ak.tlsv":"tls1.3","ak.0rtt":"","ak.0rtt.ed":"","ak.csrc":"-","ak.acc":"","ak.t":"1787144186","ak.ak":"hOBiQwZUYzCg5VSAfCLimQ==JfqQXio19V3AbQKjOmhfhiswuSok9P/t2xH+/6F105wqRr8SReGjBnAYKh7/a380JpIu3f2Ups/iT8xz8WV99IBmKiXmMdCJc842fcuONYy8I8gN+TE28XKJVp+Gk+WqjZGT0W1/Yp78DK6pgVRC2jQcebA/2e6ByFmv1MiAODN0lgDKsr9hDoL0UwHKsVZNGK3mkucrvowcC6OCBtAt5sCCevqBtnBe4Dye5isWH6ZehomaZVvjPmyEQMfje+0i8nbGG+NAEXIrcPkHa3c6G2RMclbLsa9K3VY3KJ8iGFsyEMtOf3irPP2btzLzMrcNGSl+xofSBd8auluc0LNczfRki9OfK426SzI5lcwBgO6LbngivmOt4gd1Ntd/c1igVI6Cvn3EX/J6PettRhIv9T7X+3me4U1tljuqd4I2MXs=","ak.pv":"93","ak.dpoabenc":"","ak.tf":i};if(""!==t)o["ak.ruds"]=t;var r={i:!1,av:function(n){var t="http.initiator";if(n&&(!n[t]||"spa_hard"===n[t]))o["ak.feo"]=void 0!==e.aFeoApplied?1:0,BOOMR.addVar(o)},rv:function(){var e=["ak.cport","ak.cr","ak.csrc","ak.gh","ak.ipv","ak.m","ak.n","ak.ol","ak.proto","ak.quicv","ak.tlsv","ak.0rtt","ak.0rtt.ed","ak.r","ak.acc","ak.t","ak.tf"];BOOMR.removeVar(e)}};BOOMR.plugins.AK={akVars:o,akDNSPreFetchDomain:a,init:function(){if(!r.i){var e=BOOMR.subscribe;e("before_beacon",r.av,null,null),e("onbeacon",r.rv,null,null),r.i=!0}return this},is_complete:function(){return!0}}}}()}(window);</script></head>
+
+  <script>
+
+    
+  //initialize tooltip
+  $(document).ready(function() {
+    //$("body").tooltip({ selector: '[data-toggle=tooltip]' });
+    $('[data-toggle="tooltip"]').tooltip();
+  });
+
+  $(document).ready(function() {
+    $( "#org_name" ).autocomplete({
+      source: '/team/search',
+      select: function( event, ui ) {
+        $("#org_id").val(ui.item.vid);
+        $("#id").val(ui.item.vid);
+        $('#sport_btn').click();
+      }
+    });
+  });
+
+  var body = 'body';
+
+  $.ajaxSetup ({
+    // Disable caching of AJAX responses
+    cache: false
+  });
+
+  function changeSport(field){
+    var el = $(field);
+    var tmList = el.parent().next().find('.new-team-year')[0];
+    if (tmList == null){
+      tmList = el.nextAll('.new-team-year')[0];
+    }
+    $.ajax({
+      url: "/game_sport_year_ctls/"+el.val()+"/available_teams",
+      dataType: "script",
+      success: function(data, status){
+        $(tmList).empty();
+        $(tmList).append(("<option value=''>Select team</option>"));
+        $.each(JSON.parse(data), function(k, v){
+          $(tmList).append($("<option></option>")
+              .attr("value", v["id"])
+              .text(v["member_org"]["name_tabular"]));
+        });
+        $(tmList).trigger("chosen:updated");
+      }
+    });
+  }
+
+    function set_process_styles(fld, start_color, end_color){
+       $('#'+fld).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    var downImage = "/assets/down12.gif";
+    var rightImage = "/assets/right12.gif";
+
+    function highlight(div_id){
+      $(div_id).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    function show_hide_rows(attr_val, link_id){
+      $('#'+attr_val).toggle();
+      if ($('#'+attr_val).is(':visible')) {
+        $('#'+link_id).attr('src', downImage);
+      }else{
+        $('#'+link_id).attr('src', rightImage);
+      }
+    }
+
+    function mask(label){
+      $('body').mask(label);
+    }
+    function unmask(){
+      $('body').unmask();
+    }
+
+    var winHeight = "auto";
+    var winWidth = "auto";
+    var maxHeight = 700;
+    var maxWidth = 1400;
+    var minHeight = 100;
+    var minWidth = 200;
+    
+    var modalOptions = {"width": winWidth,
+                        "height": winHeight,
+                        "maxHeight": maxHeight,
+                        "maxWidth": maxWidth,
+                        "minHeight": minHeight,
+                        "minWidth": minWidth};
+
+    function dialog(url, title){
+
+      $("#stats_app_dialog").dialog({modal:true, minWidth:minWidth, minHeight:minHeight, maxWidth:maxWidth, maxHeight:maxHeight, width:winWidth, height:winHeight, title:title, closeOnEscape: false});
+    
+      modalOptions.title = title;
+    
+      $("#stats_app_dialog").dialog("option", modalOptions);
+    
+      $("#stats_app_dialog").html("Loading...");
+      $("#stats_app_dialog").load(url).dialog('open');
+    }
+
+    function addDatePicker(){
+    $('.adddatepicker').each(function(i, obj){
+      $(obj).datepicker({ 
+        showOn: 'both', 
+        buttonImage: '/assets/calendar.gif', 
+        buttonImageOnly: true,
+      });
+    });
+    }
+
+   $(document).ready(function() {
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   });
+
+   function setClassInputFields(){
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   }
+
+   function isValidDateFormat(dateStr){
+     const regex = /^([1-9]|0[1-9]|1[0-2])\/([1-9]|0[1-9]|[12][0-9]|3[01])\/(19|20)\d{2}$/;
+     if (!regex.test(dateStr)) {
+       return false;
+     }else{
+       return true;
+     }
+   }
+
+  </script>
+
+
+<body style="font-size: .75rem;" onload="if (top != self) { top.location=self.location; }" >
+
+      <header>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0">
+        <a class="navbar-brand mr-0 mr-md-2" href="/" aria-label="statistics">
+                          <img alt="NCAA" style="margin-left: 24px; margin-right: 0; margin-top: 6px;" src="/assets/ncaa-fbc4d0406ae731b47babcc3fca53775b5955ef372bf8b8e998ca9a513e468b8f.svg" />
+                          <span class="title" class="dark-blue-font">Statistics</span>
+        </a>
+       </nav>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0" style="background-color: var(--color-dark-blue) !important;">
+  <button class="navbar-toggler bg-white" type="button" data-toggle="collapse" data-target="#navbarTogglerDemo01" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarTogglerDemo01">
+        <ul class="navbar-nav mr-auto mt-2 mt-lg-0 justify-content-center">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle skipMask" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Rankings
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+          <a class="dropdown-item" href="/rankings">National Rankings</a>
+          <a class="dropdown-item" href="/active_career_leaders">Active Career Leaders</a>
+        </div>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/contests/livestream_scoreboards">Scoreboard</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/selection_rankings/nitty_gritties">Selection Rankings</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/head_coaches">Head Coaches</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/search/players">Players</a>
+      </li>
+     </ul>
+
+    <form onsubmit="mask(&#39;Loading&#39;);" id="change_team_form" style="display:inline;" class="form-inline my-2 my-lg-0" action="/team/index" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="rG40vRGwfZA+GTariDHKOb/GKwk3c3tIvl8ehVpvHOhJexanpDPW1a3IeflRkoGnqbYjIHvCsFIO/QJFmPSopA==" />
+  <div style="display:none;">
+  <input type="submit" name="commit" value="Submit" id="sport_btn" data-disable-with="Submit" />
+  </div>
+    <div id="team_autocomplete" class="ui-widget">
+      <input type="search" name="org_name" id="org_name" style="width:200px; font-size: 12px !important" class="form-control mr-sm-2" placeholder="Team Search" />
+      <input type="hidden" name="org_id" id="org_id" />
+    </div>
+</form>  </div>
+  </nav>
+</nav>
+      </header>
+
+       <div id="stats_app_dialog" style="display:none;">
+        </div>
+
+<div class="card p-1">
+  <div class="card-body application contests p-0">
+    <h3 class="card-title p-0"></h3>
+    <div class="container-fluid p-0">
+      <div class="row align-items-center justify-content-center p-0">
+        <div class="col-sm-12 p-0">
+              <br/>
+
+<br/>
+
+<style>
+.winner{
+  --display: flex;
+  vertical-align: middle;
+}
+.winner:before{
+  content: '\25BA';
+  --display: flex;
+  --align-items: center;
+  vertical-align: middle;
+}
+div.center {
+  margin: auto;
+  width: 50%;
+  --border: 3px solid green;
+  padding: 10px;
+}
+</style>
+
+   <div class="table-responsive">
+   <table align="center">
+     <tr>
+   <td>
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/606107"><img class="large_logo_image" alt="Houston" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//288.gif" /></a>
+   </td>
+   <td valign="center" class="grey_text d-none d-sm-table-cell" nowrap>
+     <span style="font-size:18px">
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/606107">Houston Cougars</a>
+     </span><br/>
+       4-0, Conf 1-0
+   </td>
+   <td valign="center" class="winner">
+   </td>
+   <td valign="center" style="font-size:36px; color: black">
+     27
+   </td>
+     <td style="padding: 0px 30px 0px 30px"  class="d-none d-md-table-cell">
+       <table style="border-collapse: collapse">
+         <tr>
+           <td class="grey_border_bottom"></td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">1</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">2</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">3</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">4</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">1OT</td>
+           <td width="20px" align="right" style="font-weight:bold" class="grey_border_bottom">S</td>
+         </tr>
+           <tr>
+             <td>Houston</td>
+               <td class="grey_text" align="right">0</td>
+               <td class="grey_text" align="right">10</td>
+               <td class="grey_text" align="right">0</td>
+               <td class="grey_text" align="right">14</td>
+               <td class="grey_text" align="right">3</td>
+             <td align="right" style="font-weight:bold">27</td>
+           </tr>
+           <tr>
+             <td>Oregon St.</td>
+               <td class="grey_text" align="right">7</td>
+               <td class="grey_text" align="right">7</td>
+               <td class="grey_text" align="right">3</td>
+               <td class="grey_text" align="right">7</td>
+               <td class="grey_text" align="right">0</td>
+             <td align="right" style="font-weight:bold">24</td>
+           </tr>
+         <tr>
+           <td class="grey_text" colspan="7">09/26/2025 10:30 PM</td>
+         </tr>
+         <tr>
+           <td nowrap class="grey_text" colspan="7">Reser Stadium (Corvallis, OR)</td>
+         </tr>
+         <tr>
+           <td nowrap class="grey_text" colspan="7">Attendance: 29,338</td>
+         </tr>
+       </table>
+     </td>
+   <td>
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/606017"><img class="large_logo_image" alt="Oregon St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//528.gif" /></a>
+   </td>
+   <td valign="center" class="grey_text d-none d-sm-table-cell" nowrap>
+     <span style="font-size:18px">
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/606017">Oregon St. Beavers</a>
+     </span><br/>
+       0-5, Conf 0-0
+   </td>
+   <td valign="center" class="">
+   </td>
+   <td valign="center" style="font-size:36px; color: grey">
+     24
+   </td>
+     </tr>
+     <tr>
+       <td colspan="10" class="grey_border_bottom grey_border_top">
+         <table cellpadding="10px">
+           <tr>
+             <td style="font-size: 16px;">Box Score</td>
+             <td style="font-size: 16px;"><a href="/contests/6386512/team_stats">Team Stats</a></td>
+             <td style="font-size: 16px;"><a href="/contests/6386512/individual_stats">Individual Stats</a></td>
+             <td style="font-size: 16px;"><a href="/contests/6386512/play_by_play">Play By Play</a></td>
+             <td style="font-size: 16px;"><a href="/contests/6386512/drives">Drives</a></td>
+             <td style="font-size: 16px;"><a href="/contests/6386512/officials">Officials</a></td>
+           </tr>
+         </table>
+       </td>
+     </tr>
+   </table>
+ </div>
+
+ <table align="center">
+   <tr>
+     <td valign="top">
+<table id="game_leaders_table" class="display dataTable roundedCorners" width="200px">
+  <thead>
+    <tr>
+      <th class="box_score_summary_th" colspan="9">Game Leaders</th>
+    </tr>
+    <tr>
+    <th></th>
+    <th align="left" width="10%" nowrap><div class='row'><img class="logo_image" alt="Houston" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//288.gif" /><span class='d-none d-sm-block'>Houston</span></div></th>
+    <th align="left" width="10%" nowrap><div class='row'><img class="logo_image" alt="Oregon St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//528.gif" /><span class='d-none d-sm-block'>Oregon St.</span></div></th>
+  </tr>
+  </thead>
+  <tbody>
+      <tr>
+        <td nowrap>Rushing</td>
+        <td nowrap>
+            <a target="PLAYER_HISTORY" class="skipMask" href="/player/game_by_game?game_sport_year_ctl_id=16940&amp;org_id=288&amp;stats_player_seq=2726252">Dean Connors</a>
+            <br/>
+            <span class="grey_text">
+              17 Car, 53 Yds
+            </span>
+        </td>
+        <td nowrap>
+            <a target="PLAYER_HISTORY" class="skipMask" href="/player/game_by_game?game_sport_year_ctl_id=16940&amp;org_id=528&amp;stats_player_seq=3007627">Cornell Hatcher Jr.</a>
+            <br/>
+            <span class="grey_text">
+              17 Car, 93 Yds, 1 TD
+            </span>
+        </td>
+      </tr>
+      <tr>
+        <td nowrap>Passing</td>
+        <td nowrap>
+            <a target="PLAYER_HISTORY" class="skipMask" href="/player/game_by_game?game_sport_year_ctl_id=16940&amp;org_id=288&amp;stats_player_seq=2711730">Conner Weigman</a>
+            <br/>
+            <span class="grey_text">
+              20-36, 270 Yds, 2 TD, 1 Int
+            </span>
+        </td>
+        <td nowrap>
+            <a target="PLAYER_HISTORY" class="skipMask" href="/player/game_by_game?game_sport_year_ctl_id=16940&amp;org_id=528&amp;stats_player_seq=2703688">Maalik Murphy</a>
+            <br/>
+            <span class="grey_text">
+              20-33, 201 Yds, 1 TD
+            </span>
+        </td>
+      </tr>
+      <tr>
+        <td nowrap>Receiving</td>
+        <td nowrap>
+            <a target="PLAYER_HISTORY" class="skipMask" href="/player/game_by_game?game_sport_year_ctl_id=16940&amp;org_id=288&amp;stats_player_seq=2866748">Amare Thomas</a>
+            <br/>
+            <span class="grey_text">
+              6 Rec, 104 Yds
+            </span>
+        </td>
+        <td nowrap>
+            <a target="PLAYER_HISTORY" class="skipMask" href="/player/game_by_game?game_sport_year_ctl_id=16940&amp;org_id=528&amp;stats_player_seq=2553841">Trent Walker</a>
+            <br/>
+            <span class="grey_text">
+              7 Rec, 103 Yds
+            </span>
+        </td>
+      </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="10" style="border-top: 0px solid white"></td></tr>
+  </tfoot>
+</table>
+     </td>
+     <td valign="top" rowspan="2">
+<table id="scoring_summary_table" class="display dataTable roundedCorners" width="200px">
+  <thead>
+    <tr>
+      <th class="box_score_summary_th" colspan="9">Scoring Summary</th>
+    </tr>
+  <tr>
+    <th>Period</th>
+    <th align="right">Clock</th>
+    <th>Has Ball</th>
+    <th>Play</th>
+    <th align="right">Plays</th>
+    <th align="right">Yards</th>
+    <th align="right">TOP</th>
+    <th align="right" width="10%" nowrap><div class='row'><img class="logo_image" alt="Houston" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//288.gif" /><span class='d-none d-sm-block'>Houston</span></div></th>
+    <th align="right" width="10%" nowrap><div class='row'><img class="logo_image" alt="Oregon St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//528.gif" /><span class='d-none d-sm-block'>Oregon St.</span></div></th>
+  </tr>
+  </thead>
+  <tbody>
+      <tr>
+        <td>1</td>
+        <td align="right">08:12</td>
+        <td><img class="logo_image" alt="Oregon St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//528.gif" /></td>
+        <td>
+            (08:16) Reichle,Jake rush middle for 1 yard gain 0 TOUCHDOWN (Ojeda,Caleb kick attempt good (H: Winsor,AJ)
+        </td>
+        <td align="right"><a class="skipMask" data-remote="true" href="/contests/game_drives/3914837/game_period_plays">2</a></td>
+        <td align="right">7</td>
+        <td align="right">00:27</td>
+        <td align="right">0</td>
+        <td align="right">7</td>
+      <tr>
+        <td>2</td>
+        <td align="right">13:43</td>
+        <td><img class="logo_image" alt="Oregon St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//528.gif" /></td>
+        <td>
+            (13:47) Shotgun Murphy,Maalik pass complete short left to Crosby,Marquis caught at HOU10 (Ojeda,Caleb kick attempt good (H: Winsor,AJ)
+        </td>
+        <td align="right"><a class="skipMask" data-remote="true" href="/contests/game_drives/3914838/game_period_plays">11</a></td>
+        <td align="right">70</td>
+        <td align="right">06:20</td>
+        <td align="right">0</td>
+        <td align="right">14</td>
+      <tr>
+        <td>2</td>
+        <td align="right">05:47</td>
+        <td><img class="logo_image" alt="Houston" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//288.gif" /></td>
+        <td>
+            (05:47) Sanchez,Ethan field goal from 25 yards yards (H: Sock,Jake
+        </td>
+        <td align="right"><a class="skipMask" data-remote="true" href="/contests/game_drives/3914852/game_period_plays">17</a></td>
+        <td align="right">78</td>
+        <td align="right">07:47</td>
+        <td align="right">3</td>
+        <td align="right">14</td>
+      <tr>
+        <td>2</td>
+        <td align="right">01:24</td>
+        <td><img class="logo_image" alt="Houston" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//288.gif" /></td>
+        <td>
+            (01:27) No Huddle Weigman,Conner rush middle for 1 yard gain 0 TOUCHDOWN (Sanchez,Ethan kick attempt good (H: Sock,Jake)
+        </td>
+        <td align="right"><a class="skipMask" data-remote="true" href="/contests/game_drives/3914853/game_period_plays">7</a></td>
+        <td align="right">55</td>
+        <td align="right">01:48</td>
+        <td align="right">10</td>
+        <td align="right">14</td>
+      <tr>
+        <td>3</td>
+        <td align="right">05:31</td>
+        <td><img class="logo_image" alt="Oregon St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//528.gif" /></td>
+        <td>
+            (05:33) Ojeda,Caleb field goal from 31 yards yards (H: Winsor,AJ
+        </td>
+        <td align="right"><a class="skipMask" data-remote="true" href="/contests/game_drives/3914842/game_period_plays">7</a></td>
+        <td align="right">48</td>
+        <td align="right">03:39</td>
+        <td align="right">10</td>
+        <td align="right">17</td>
+      <tr>
+        <td>4</td>
+        <td align="right">12:34</td>
+        <td><img class="logo_image" alt="Oregon St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//528.gif" /></td>
+        <td>
+            (12:37) Shotgun Hatcher Jr.,Cornell rush middle for 18 yards gain 0 TOUCHDOWN (Smith,Cameron kick attempt good (H: Winsor,AJ)
+        </td>
+        <td align="right"><a class="skipMask" data-remote="true" href="/contests/game_drives/3914843/game_period_plays">12</a></td>
+        <td align="right">80</td>
+        <td align="right">06:54</td>
+        <td align="right">10</td>
+        <td align="right">24</td>
+      <tr>
+        <td>4</td>
+        <td align="right">05:59</td>
+        <td><img class="logo_image" alt="Houston" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//288.gif" /></td>
+        <td>
+            (06:04) No Huddle-Shotgun Weigman,Conner pass complete deep right to Johnson,Stephon caught at OSU00 (Sanchez,Ethan kick attempt good (H: Sock,Jake)
+        </td>
+        <td align="right"><a class="skipMask" data-remote="true" href="/contests/game_drives/3914859/game_period_plays">7</a></td>
+        <td align="right">76</td>
+        <td align="right">02:18</td>
+        <td align="right">17</td>
+        <td align="right">24</td>
+      <tr>
+        <td>4</td>
+        <td align="right">03:40</td>
+        <td><img class="logo_image" alt="Houston" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//288.gif" /></td>
+        <td>
+            (03:48) Shotgun Weigman,Conner pass complete short middle to Koziol,Tanner caught at OSU35 (Sanchez,Ethan kick attempt good (H: Sock,Jake)
+        </td>
+        <td align="right"><a class="skipMask" data-remote="true" href="/contests/game_drives/3914860/game_period_plays">4</a></td>
+        <td align="right">64</td>
+        <td align="right">00:51</td>
+        <td align="right">24</td>
+        <td align="right">24</td>
+      <tr>
+        <td>1OT</td>
+        <td align="right">00:00</td>
+        <td><img class="logo_image" alt="Houston" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//288.gif" /></td>
+        <td>
+            
+        </td>
+        <td align="right"><a class="skipMask" data-remote="true" href="/contests/game_drives/3914862/game_period_plays">6</a></td>
+        <td align="right">19</td>
+        <td align="right">00:00</td>
+        <td align="right">27</td>
+        <td align="right">24</td>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="10" style="border-top: 0px solid white"></td></tr>
+  </tfoot>
+</table>
+     </td>
+   </tr>
+   <tr>
+     <td valign="top">
+<table id="team_stats_table" class="dataTable roundedCorners" width="200px">
+  <thead>
+    <tr>
+      <th class="box_score_summary_th" colspan="9">Team Stats</th>
+    </tr>
+  </tr>
+  </thead>
+  <tbody>
+
+      <tr>
+        <td>
+          <table class="display dataTable">
+            <thead>
+            <tr>
+              <th colspan="9">TOP</th>
+            </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td nowrap><div class='row'><img class="logo_image" alt="Houston" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//288.gif" /><span class='d-none d-sm-block'>Houston</span></div></td>
+                <td width="80%">
+                  <div class="stat_bar_container">
+                    <div class="stat_bar" style="width: 40.67796610169492%; background-color: grey;"></div>
+                  </div>
+                </td>
+                <td width="5%">24:37</td>
+              </tr>
+              <tr>
+                <td nowrap><div class='row'><img class="logo_image" alt="Oregon St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//528.gif" /><span class='d-none d-sm-block'>Oregon St.</span></div></td>
+                <td width="80%">
+                  <div class="stat_bar_container">
+                    <div class="stat_bar" style="width: 59.32203389830508%; background-color: blue;"></div>
+                  </div>
+                </td>
+                <td width="5%">35:23</td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <table class="display dataTable">
+            <thead>
+            <tr>
+              <th colspan="9">Rush Yds</th>
+            </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td nowrap><div class='row'><img class="logo_image" alt="Houston" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//288.gif" /><span class='d-none d-sm-block'>Houston</span></div></td>
+                <td width="80%">
+                  <div class="stat_bar_container">
+                    <div class="stat_bar" style="width: 30.25830258302583%; background-color: grey;"></div>
+                  </div>
+                </td>
+                <td width="5%">82</td>
+              </tr>
+              <tr>
+                <td nowrap><div class='row'><img class="logo_image" alt="Oregon St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//528.gif" /><span class='d-none d-sm-block'>Oregon St.</span></div></td>
+                <td width="80%">
+                  <div class="stat_bar_container">
+                    <div class="stat_bar" style="width: 69.74169741697416%; background-color: blue;"></div>
+                  </div>
+                </td>
+                <td width="5%">189</td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <table class="display dataTable">
+            <thead>
+            <tr>
+              <th colspan="9">Pass Yds</th>
+            </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td nowrap><div class='row'><img class="logo_image" alt="Houston" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//288.gif" /><span class='d-none d-sm-block'>Houston</span></div></td>
+                <td width="80%">
+                  <div class="stat_bar_container">
+                    <div class="stat_bar" style="width: 57.324840764331206%; background-color: grey;"></div>
+                  </div>
+                </td>
+                <td width="5%">270</td>
+              </tr>
+              <tr>
+                <td nowrap><div class='row'><img class="logo_image" alt="Oregon St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//528.gif" /><span class='d-none d-sm-block'>Oregon St.</span></div></td>
+                <td width="80%">
+                  <div class="stat_bar_container">
+                    <div class="stat_bar" style="width: 42.675159235668794%; background-color: blue;"></div>
+                  </div>
+                </td>
+                <td width="5%">201</td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <table class="display dataTable">
+            <thead>
+            <tr>
+              <th colspan="9">Takeaways</th>
+            </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td nowrap><div class='row'><img class="logo_image" alt="Houston" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//288.gif" /><span class='d-none d-sm-block'>Houston</span></div></td>
+                <td width="80%">
+                  <div class="stat_bar_container">
+                    <div class="stat_bar" style="width: 0%; background-color: grey;"></div>
+                  </div>
+                </td>
+                <td width="5%">0</td>
+              </tr>
+              <tr>
+                <td nowrap><div class='row'><img class="logo_image" alt="Oregon St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//528.gif" /><span class='d-none d-sm-block'>Oregon St.</span></div></td>
+                <td width="80%">
+                  <div class="stat_bar_container">
+                    <div class="stat_bar" style="width: 100.0%; background-color: blue;"></div>
+                  </div>
+                </td>
+                <td width="5%">1</td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <table class="display dataTable">
+            <thead>
+            <tr>
+              <th colspan="9">First Downs</th>
+            </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td nowrap><div class='row'><img class="logo_image" alt="Houston" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//288.gif" /><span class='d-none d-sm-block'>Houston</span></div></td>
+                <td width="80%">
+                  <div class="stat_bar_container">
+                    <div class="stat_bar" style="width: 43.58974358974359%; background-color: grey;"></div>
+                  </div>
+                </td>
+                <td width="5%">17</td>
+              </tr>
+              <tr>
+                <td nowrap><div class='row'><img class="logo_image" alt="Oregon St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//528.gif" /><span class='d-none d-sm-block'>Oregon St.</span></div></td>
+                <td width="80%">
+                  <div class="stat_bar_container">
+                    <div class="stat_bar" style="width: 56.41025641025641%; background-color: blue;"></div>
+                  </div>
+                </td>
+                <td width="5%">22</td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+  </tbody>
+  <tfoot>
+    <tr><td colspan="10" style="border-top: 0px solid white"></td></tr>
+  </tfoot>
+</table>
+     </td>
+   </tr>
+ </table>
+
+
+
+
+       </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<footer>&copy; <script>document.write(new Date().getFullYear())</script> NCAA <a href="http://web1.ncaa.org/web_files/terms_and_conditions.html" title ="Terms and Conditions" target=_blank>Terms and Conditions</a> | <a href="http://web1.ncaa.org/web_files/privacy.html" target=_blank title="Our Privacy Policy">Privacy Policy</a> | <a href="mailto:ncaastats@ncaa.org">Contact Us</a> </footer>
+
+  <!-- /.container -->
+  <script type="text/javascript"  src="/QFrxqVkNu/zpMzxVZYg/LrV9L4r53Db3/PBxcAQ/GF/kteXRIKAwV?v=884a91f9-4223-5731-3b53-ca73b6651729" defer></script></body>
+
+  <script charset="utf-8">
+    $(document).ready(function() {
+      $('a.remote[data-toggle="tab"]').on('show.bs.tab', function (e) {
+        var tab_id = '#' + $(this).attr('aria-controls');
+        $(tab_id).html('<br/><br/><p style="text-align: center"><img style="vertical-align:middle; text-align: center" src="/assets/ajax-loader-6913acdbf4be7d6a2908a84bdecd6cad18110f5fc6d5a07cf8c9ce78d9548700.gif" /> Loading... </p><br/><br/>');
+        $.get($(this).data('remote'), function(data){
+          $(tab_id).html(data);
+        });
+      });
+    });
+
+    function skipMask(obj){
+      if (obj.hasClass('chosen-single') || obj.hasClass('skipMask') || obj.hasClass('ui-datepicker-prev') || obj.hasClass('ui-datepicker-next') || obj.hasClass('ui-corner-all') || obj.hasClass('paginate_button') || obj.hasClass('dt-button')){
+        return true;
+      }else{
+        return false;
+      }
+    }
+
+    $(document).ajaxComplete(function(){
+      unmask();
+    });
+/*
+    $("form").on('submit', function(event){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    */
+    $(document).on('click', 'a', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    $(document).on('click', 'input.green', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+
+  </script>
+</html>

--- a/tests/fixtures/cfb_ncaa/mfb_drives_6386512.html
+++ b/tests/fixtures/cfb_ncaa/mfb_drives_6386512.html
@@ -1,0 +1,1013 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<META HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=UTF-8">
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="">
+<meta name="author" content="">
+<meta name="version" content="321d28433e9f7a188596117e6f342ec4a84fb4ed">
+<META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<link rel="shortcut icon" href="/assets/favicon-405088046a5f2bab8eedeacfae7636975c095e9c8decd8c28e3fd0e65c2f51c4.ico" type="image/vnd.microsoft.icon">
+
+<title>NCAA Statistics</title>
+
+<!-- Bootstrap core CSS -->
+
+<!--
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+-->
+<!--
+<link rel="stylesheet" href="https://cdn.datatables.net/2.0.0/css/dataTables.bootstrap4.css" crossorigin="anonymous">
+-->
+<link rel="stylesheet" media="all" href="/assets/application-789c3971842ee3597428ccbebd021716b3231e9cbd0a00a184c3b2d6c8e5f152.css" />
+
+
+<script src="/assets/application-9232576bb3cb000ac0841ff2af81251908ec17312a3c5eb72bf1a32f9754800c.js"></script>
+<!--
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+-->
+<!--
+<script src="https://cdn.datatables.net/2.0.0/js/dataTables.bootstrap4.js" crossorigin="anonymous"></script>
+-->
+
+<meta name="csrf-param" content="authenticity_token" />
+<meta name="csrf-token" content="6/xrmSE0UcpRKZCrXX+lDt9bNuzo9TQAHcZflPW5OXlfmvBnAe8+9EhYmUKXYRQ1RzM4vdqHrEGjvrcG5hiplw==" />
+
+<style>
+.grid {clear: all}
+.grid-item, .name {text-align: center;}
+h1 img {max-height: 33px;}
+
+</style>
+<!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+<!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+      <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+    <![endif]-->
+
+
+<script>(window.BOOMR_mq=window.BOOMR_mq||[]).push(["addVar",{"rua.upush":"false","rua.cpush":"false","rua.upre":"false","rua.cpre":"false","rua.uprl":"false","rua.cprl":"false","rua.cprf":"false","rua.trans":"","rua.cook":"false","rua.ims":"false","rua.ufprl":"false","rua.cfprl":"false","rua.isuxp":"false","rua.texp":"norulematch","rua.ceh":"false","rua.ueh":"false","rua.ieh.st":"0"}]);</script>
+                                <script>!function(e){var n="https://s.go-mpulse.net/boomerang/";if("False"=="True")e.BOOMR_config=e.BOOMR_config||{},e.BOOMR_config.PageParams=e.BOOMR_config.PageParams||{},e.BOOMR_config.PageParams.pci=!0,n="https://s2.go-mpulse.net/boomerang/";if(window.BOOMR_API_key="EVKJV-AGD2E-W66AE-NT84S-K5LTF",function(){function e(){if(!r){var e=document.createElement("script");e.id="boomr-scr-as",e.src=window.BOOMR.url,e.async=!0,o.appendChild(e),r=!0}}function t(e){r=!0;var n,t,a,i,d=document,O=window;if(window.BOOMR.snippetMethod=e?"if":"i",t=function(e,n){var t=d.createElement("script");t.id=n||"boomr-if-as",t.src=window.BOOMR.url,BOOMR_lstart=(new Date).getTime(),e=e||d.body,e.appendChild(t)},!window.addEventListener&&window.attachEvent&&navigator.userAgent.match(/MSIE [67]\./))return window.BOOMR.snippetMethod="s",void t(o,"boomr-async");a=document.createElement("IFRAME"),a.src="about:blank",a.title="",a.role="presentation",a.loading="eager",i=(a.frameElement||a).style,i.width=0,i.height=0,i.border=0,i.display="none",o.appendChild(a);try{O=a.contentWindow,d=O.document.open()}catch(_){n=document.domain,a.src="javascript:var d=document.open();d.domain='"+n+"';void 0;",O=a.contentWindow,d=O.document.open()}if(n)d._boomrl=function(){this.domain=n,t()},d.write("<bo"+"dy onload='document._boomrl();'>");else if(O._boomrl=function(){t()},O.addEventListener)O.addEventListener("load",O._boomrl,!1);else if(O.attachEvent)O.attachEvent("onload",O._boomrl);d.close()}function a(e){window.BOOMR_onload=e&&e.timeStamp||(new Date).getTime()}if(!window.BOOMR||!window.BOOMR.version&&!window.BOOMR.snippetExecuted){window.BOOMR=window.BOOMR||{},window.BOOMR.snippetStart=(new Date).getTime(),window.BOOMR.snippetExecuted=!0,window.BOOMR.snippetVersion=14,window.BOOMR.url=n+"EVKJV-AGD2E-W66AE-NT84S-K5LTF";var i=document.currentScript||document.getElementsByTagName("script")[0],o=i.parentNode,r=!1,d=document.createElement("link");if(d.relList&&"function"==typeof d.relList.supports&&d.relList.supports("preload")&&"as"in d)window.BOOMR.snippetMethod="p",d.href=window.BOOMR.url,d.rel="preload",d.as="script",d.addEventListener("load",e),d.addEventListener("error",function(){t(!0)}),setTimeout(function(){if(!r)t(!0)},3e3),BOOMR_lstart=(new Date).getTime(),o.appendChild(d);else t(!1);if(window.addEventListener)window.addEventListener("load",a,!1);else if(window.attachEvent)window.attachEvent("onload",a)}}(),"".length>0)if(e&&"performance"in e&&e.performance&&"function"==typeof e.performance.setResourceTimingBufferSize)e.performance.setResourceTimingBufferSize();!function(){if(BOOMR=e.BOOMR||{},BOOMR.plugins=BOOMR.plugins||{},!BOOMR.plugins.AK){var n=""=="true"?1:0,t="cookiepresent",a="v2vnq5yxy6s2c2ufvaoq-f-f4a5746ce-clientnsv4-s.akamaihd.net",i="false"=="true"?2:1,o={"ak.v":"41","ak.cp":"1168236","ak.ai":parseInt("215853",10),"ak.ol":"0","ak.cr":19,"ak.ipv":4,"ak.proto":"h2","ak.rid":"263ffa24","ak.r":47667,"ak.a2":n,"ak.m":"a","ak.n":"essl","ak.cport":47790,"ak.gh":"23.41.249.132","ak.quicv":"","ak.tlsv":"tls1.3","ak.0rtt":"","ak.0rtt.ed":"","ak.csrc":"-","ak.acc":"","ak.t":"1787144221","ak.ak":"hOBiQwZUYzCg5VSAfCLimQ==Tn567jKVyv8hG9NbMfRmYO1lOCfn9fgGT+LRkZwMay8xKZ1dXlCkDC0GuInihbI/VKcpgNVyRHkVEyAT6b5XYJIIN3+H9MycRIc1rppw/CWVqrAMwzKKVN3edmUw65BMeK49VxdYtGGD3aYwu8SEq8yzRnCV9lmLhDsjdOcc8W0WYH/KEFNGPcB7fdbIWyJTt9rmzGo3rg8oPXCQFqlZVBDiQXMkIVOSzNY1KucEJXhLzYB56fqh7LzxHAN6W1NA6YmT4XyufOYQGNx1zLx87NL56dEJtNMYAyP8RdsV91w4KVoqHy/4I4iyHWS6zBFfudXNvNz62vOskRYLn42Ti0htCcG8brXzThxvbCeqivzB8bl4mh+1mXdRRhh1DhPHK1nj+yrhlwPrBDVGBivSLnhJ0RKiwLRwL4uPujTxTUc=","ak.pv":"93","ak.dpoabenc":"","ak.tf":i};if(""!==t)o["ak.ruds"]=t;var r={i:!1,av:function(n){var t="http.initiator";if(n&&(!n[t]||"spa_hard"===n[t]))o["ak.feo"]=void 0!==e.aFeoApplied?1:0,BOOMR.addVar(o)},rv:function(){var e=["ak.cport","ak.cr","ak.csrc","ak.gh","ak.ipv","ak.m","ak.n","ak.ol","ak.proto","ak.quicv","ak.tlsv","ak.0rtt","ak.0rtt.ed","ak.r","ak.acc","ak.t","ak.tf"];BOOMR.removeVar(e)}};BOOMR.plugins.AK={akVars:o,akDNSPreFetchDomain:a,init:function(){if(!r.i){var e=BOOMR.subscribe;e("before_beacon",r.av,null,null),e("onbeacon",r.rv,null,null),r.i=!0}return this},is_complete:function(){return!0}}}}()}(window);</script></head>
+
+  <script>
+
+    
+  //initialize tooltip
+  $(document).ready(function() {
+    //$("body").tooltip({ selector: '[data-toggle=tooltip]' });
+    $('[data-toggle="tooltip"]').tooltip();
+  });
+
+  $(document).ready(function() {
+    $( "#org_name" ).autocomplete({
+      source: '/team/search',
+      select: function( event, ui ) {
+        $("#org_id").val(ui.item.vid);
+        $("#id").val(ui.item.vid);
+        $('#sport_btn').click();
+      }
+    });
+  });
+
+  var body = 'body';
+
+  $.ajaxSetup ({
+    // Disable caching of AJAX responses
+    cache: false
+  });
+
+  function changeSport(field){
+    var el = $(field);
+    var tmList = el.parent().next().find('.new-team-year')[0];
+    if (tmList == null){
+      tmList = el.nextAll('.new-team-year')[0];
+    }
+    $.ajax({
+      url: "/game_sport_year_ctls/"+el.val()+"/available_teams",
+      dataType: "script",
+      success: function(data, status){
+        $(tmList).empty();
+        $(tmList).append(("<option value=''>Select team</option>"));
+        $.each(JSON.parse(data), function(k, v){
+          $(tmList).append($("<option></option>")
+              .attr("value", v["id"])
+              .text(v["member_org"]["name_tabular"]));
+        });
+        $(tmList).trigger("chosen:updated");
+      }
+    });
+  }
+
+    function set_process_styles(fld, start_color, end_color){
+       $('#'+fld).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    var downImage = "/assets/down12.gif";
+    var rightImage = "/assets/right12.gif";
+
+    function highlight(div_id){
+      $(div_id).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    function show_hide_rows(attr_val, link_id){
+      $('#'+attr_val).toggle();
+      if ($('#'+attr_val).is(':visible')) {
+        $('#'+link_id).attr('src', downImage);
+      }else{
+        $('#'+link_id).attr('src', rightImage);
+      }
+    }
+
+    function mask(label){
+      $('body').mask(label);
+    }
+    function unmask(){
+      $('body').unmask();
+    }
+
+    var winHeight = "auto";
+    var winWidth = "auto";
+    var maxHeight = 700;
+    var maxWidth = 1400;
+    var minHeight = 100;
+    var minWidth = 200;
+    
+    var modalOptions = {"width": winWidth,
+                        "height": winHeight,
+                        "maxHeight": maxHeight,
+                        "maxWidth": maxWidth,
+                        "minHeight": minHeight,
+                        "minWidth": minWidth};
+
+    function dialog(url, title){
+
+      $("#stats_app_dialog").dialog({modal:true, minWidth:minWidth, minHeight:minHeight, maxWidth:maxWidth, maxHeight:maxHeight, width:winWidth, height:winHeight, title:title, closeOnEscape: false});
+    
+      modalOptions.title = title;
+    
+      $("#stats_app_dialog").dialog("option", modalOptions);
+    
+      $("#stats_app_dialog").html("Loading...");
+      $("#stats_app_dialog").load(url).dialog('open');
+    }
+
+    function addDatePicker(){
+    $('.adddatepicker').each(function(i, obj){
+      $(obj).datepicker({ 
+        showOn: 'both', 
+        buttonImage: '/assets/calendar.gif', 
+        buttonImageOnly: true,
+      });
+    });
+    }
+
+   $(document).ready(function() {
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   });
+
+   function setClassInputFields(){
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   }
+
+   function isValidDateFormat(dateStr){
+     const regex = /^([1-9]|0[1-9]|1[0-2])\/([1-9]|0[1-9]|[12][0-9]|3[01])\/(19|20)\d{2}$/;
+     if (!regex.test(dateStr)) {
+       return false;
+     }else{
+       return true;
+     }
+   }
+
+  </script>
+
+
+<body style="font-size: .75rem;" onload="if (top != self) { top.location=self.location; }" >
+
+      <header>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0">
+        <a class="navbar-brand mr-0 mr-md-2" href="/" aria-label="statistics">
+                          <img alt="NCAA" style="margin-left: 24px; margin-right: 0; margin-top: 6px;" src="/assets/ncaa-fbc4d0406ae731b47babcc3fca53775b5955ef372bf8b8e998ca9a513e468b8f.svg" />
+                          <span class="title" class="dark-blue-font">Statistics</span>
+        </a>
+       </nav>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0" style="background-color: var(--color-dark-blue) !important;">
+  <button class="navbar-toggler bg-white" type="button" data-toggle="collapse" data-target="#navbarTogglerDemo01" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarTogglerDemo01">
+        <ul class="navbar-nav mr-auto mt-2 mt-lg-0 justify-content-center">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle skipMask" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Rankings
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+          <a class="dropdown-item" href="/rankings">National Rankings</a>
+          <a class="dropdown-item" href="/active_career_leaders">Active Career Leaders</a>
+        </div>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/contests/livestream_scoreboards">Scoreboard</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/selection_rankings/nitty_gritties">Selection Rankings</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/head_coaches">Head Coaches</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/search/players">Players</a>
+      </li>
+     </ul>
+
+    <form onsubmit="mask(&#39;Loading&#39;);" id="change_team_form" style="display:inline;" class="form-inline my-2 my-lg-0" action="/team/index" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="te+Yc1gbhuR/uapMcLS6rjcPlgoEggFmEHUHfZIkTZVQ+rpp7Zgtoexo5R6pF/EwIX+eI0gzynyg1xu9UL/52Q==" />
+  <div style="display:none;">
+  <input type="submit" name="commit" value="Submit" id="sport_btn" data-disable-with="Submit" />
+  </div>
+    <div id="team_autocomplete" class="ui-widget">
+      <input type="search" name="org_name" id="org_name" style="width:200px; font-size: 12px !important" class="form-control mr-sm-2" placeholder="Team Search" />
+      <input type="hidden" name="org_id" id="org_id" />
+    </div>
+</form>  </div>
+  </nav>
+</nav>
+      </header>
+
+       <div id="stats_app_dialog" style="display:none;">
+        </div>
+
+<div class="card p-1">
+  <div class="card-body application contests p-0">
+    <h3 class="card-title p-0"></h3>
+    <div class="container-fluid p-0">
+      <div class="row align-items-center justify-content-center p-0">
+        <div class="col-sm-12 p-0">
+        
+<br/>
+
+<br/>
+
+<style>
+.winner{
+  --display: flex;
+  vertical-align: middle;
+}
+.winner:before{
+  content: '\25BA';
+  --display: flex;
+  --align-items: center;
+  vertical-align: middle;
+}
+div.center {
+  margin: auto;
+  width: 50%;
+  --border: 3px solid green;
+  padding: 10px;
+}
+</style>
+
+   <div class="table-responsive">
+   <table align="center">
+     <tr>
+   <td>
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/606107"><img class="large_logo_image" alt="Houston" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//288.gif" /></a>
+   </td>
+   <td valign="center" class="grey_text d-none d-sm-table-cell" nowrap>
+     <span style="font-size:18px">
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/606107">Houston Cougars</a>
+     </span><br/>
+       4-0, Conf 1-0
+   </td>
+   <td valign="center" class="winner">
+   </td>
+   <td valign="center" style="font-size:36px; color: black">
+     27
+   </td>
+     <td style="padding: 0px 30px 0px 30px"  class="d-none d-md-table-cell">
+       <table style="border-collapse: collapse">
+         <tr>
+           <td class="grey_border_bottom"></td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">1</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">2</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">3</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">4</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">1OT</td>
+           <td width="20px" align="right" style="font-weight:bold" class="grey_border_bottom">S</td>
+         </tr>
+           <tr>
+             <td>Houston</td>
+               <td class="grey_text" align="right">0</td>
+               <td class="grey_text" align="right">10</td>
+               <td class="grey_text" align="right">0</td>
+               <td class="grey_text" align="right">14</td>
+               <td class="grey_text" align="right">3</td>
+             <td align="right" style="font-weight:bold">27</td>
+           </tr>
+           <tr>
+             <td>Oregon St.</td>
+               <td class="grey_text" align="right">7</td>
+               <td class="grey_text" align="right">7</td>
+               <td class="grey_text" align="right">3</td>
+               <td class="grey_text" align="right">7</td>
+               <td class="grey_text" align="right">0</td>
+             <td align="right" style="font-weight:bold">24</td>
+           </tr>
+         <tr>
+           <td class="grey_text" colspan="7">09/26/2025 10:30 PM</td>
+         </tr>
+         <tr>
+           <td nowrap class="grey_text" colspan="7">Reser Stadium (Corvallis, OR)</td>
+         </tr>
+         <tr>
+           <td nowrap class="grey_text" colspan="7">Attendance: 29,338</td>
+         </tr>
+       </table>
+     </td>
+   <td>
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/606017"><img class="large_logo_image" alt="Oregon St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//528.gif" /></a>
+   </td>
+   <td valign="center" class="grey_text d-none d-sm-table-cell" nowrap>
+     <span style="font-size:18px">
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/606017">Oregon St. Beavers</a>
+     </span><br/>
+       0-5, Conf 0-0
+   </td>
+   <td valign="center" class="">
+   </td>
+   <td valign="center" style="font-size:36px; color: grey">
+     24
+   </td>
+     </tr>
+     <tr>
+       <td colspan="10" class="grey_border_bottom grey_border_top">
+         <table cellpadding="10px">
+           <tr>
+             <td style="font-size: 16px;"><a href="/contests/6386512/box_score">Box Score</a></td>
+             <td style="font-size: 16px;"><a href="/contests/6386512/team_stats">Team Stats</a></td>
+             <td style="font-size: 16px;"><a href="/contests/6386512/individual_stats">Individual Stats</a></td>
+             <td style="font-size: 16px;"><a href="/contests/6386512/play_by_play">Play By Play</a></td>
+             <td style="font-size: 16px;">Drives</td>
+             <td style="font-size: 16px;"><a href="/contests/6386512/officials">Officials</a></td>
+           </tr>
+         </table>
+       </td>
+     </tr>
+   </table>
+ </div>
+
+
+<br/>
+ <script>
+var public_game_drives_data_table = null;
+  $(document).ready(function() {
+    public_game_drives_data_table = $('#public_game_drives_data_table').DataTable({
+      "dom": 'BRC<"clear">frtip',
+      "order": [[ 0, "asc" ]],
+      "pageLength": 100,
+      "buttons": [
+      { "extend": 'copy',
+        "exportOptions": {
+          //"columns":  exportableColumns
+        },
+        "footer": true
+      },
+      { "extend": 'excel',
+        "exportOptions": {
+          //"columns":  exportableColumns
+        },
+        "footer": true
+      }
+      ]
+    });
+
+  } );
+  </script>
+
+
+<table id="public_game_drives_data_table"  class="display dataTable" >
+  <thead>
+    <tr>
+        <th>Drive #</th>
+        <th>Quarter</th>
+        <th>Team</th>
+        <th>Start Period</th>
+        <th>Start How</th>
+        <th>Clock</th>
+        <th>Ball on</th>
+        <th>End Period</th>
+        <th>End How</th>
+        <th>Clock</th>
+        <th>End on</th>
+        <th># Plays</th>
+        <th>Yards</th>
+        <th>Time of possession</th>
+        <th>Redzone</th>
+        <th align="right" width="10%" nowrap><div class='row'><img class="logo_image" alt="Houston" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//288.gif" /><span class='d-none d-sm-block'>Houston</span></div></th>
+        <th align="right" width="10%" nowrap><div class='row'><img class="logo_image" alt="Oregon St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//528.gif" /><span class='d-none d-sm-block'>Oregon St.</span></div></th>
+    </tr>
+  </thead>
+  <tbody>
+
+    <tr>
+      <td>1</td>
+      <td>1</td>
+      <td><div class='row'><img class="logo_image" alt="Oregon St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//528.gif" /><span class='d-none d-sm-block'>Oregon St.</span></div></td>
+      <td>1</td>
+      <td>KO</td>
+      <td>15:00</td>
+      <td>OSU25</td>
+      <td>1</td>
+      <td>PUNT</td>
+      <td>11:04</td>
+      <td>HOU47</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3914835/game_period_plays">8</a></td>
+      <td>28</td>
+      <td>03:56</td>
+      <td></td>
+      <td align="right">0</td>
+      <td align="right">0</td>
+    </tr>
+    <tr>
+      <td>2</td>
+      <td>1</td>
+      <td><div class='row'><img class="logo_image" alt="Houston" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//288.gif" /><span class='d-none d-sm-block'>Houston</span></div></td>
+      <td>1</td>
+      <td>PUNT</td>
+      <td>11:04</td>
+      <td>HOU14</td>
+      <td>1</td>
+      <td>PUNT</td>
+      <td>09:49</td>
+      <td>HOU13</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3914849/game_period_plays">3</a></td>
+      <td>-1</td>
+      <td>01:15</td>
+      <td></td>
+      <td align="right">0</td>
+      <td align="right">0</td>
+    </tr>
+    <tr>
+      <td>3</td>
+      <td>1</td>
+      <td><div class='row'><img class="logo_image" alt="Oregon St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//528.gif" /><span class='d-none d-sm-block'>Oregon St.</span></div></td>
+      <td>1</td>
+      <td>PUNT</td>
+      <td>09:49</td>
+      <td>HOU45</td>
+      <td>1</td>
+      <td>PUNT</td>
+      <td>08:49</td>
+      <td>HOU45</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3914836/game_period_plays">3</a></td>
+      <td>0</td>
+      <td>01:00</td>
+      <td></td>
+      <td align="right">0</td>
+      <td align="right">0</td>
+    </tr>
+    <tr>
+      <td>4</td>
+      <td>1</td>
+      <td><div class='row'><img class="logo_image" alt="Houston" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//288.gif" /><span class='d-none d-sm-block'>Houston</span></div></td>
+      <td>1</td>
+      <td>PUNT</td>
+      <td>08:49</td>
+      <td>HOU12</td>
+      <td>1</td>
+      <td>INT</td>
+      <td>08:39</td>
+      <td>HOU12</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3914850/game_period_plays">1</a></td>
+      <td>0</td>
+      <td>00:10</td>
+      <td></td>
+      <td align="right">0</td>
+      <td align="right">0</td>
+    </tr>
+    <tr>
+      <td>5</td>
+      <td>1</td>
+      <td><div class='row'><img class="logo_image" alt="Oregon St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//528.gif" /><span class='d-none d-sm-block'>Oregon St.</span></div></td>
+      <td>1</td>
+      <td>INT</td>
+      <td>08:39</td>
+      <td>HOU6</td>
+      <td>1</td>
+      <td>TD</td>
+      <td>08:12</td>
+      <td></td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3914837/game_period_plays">2</a></td>
+      <td>7</td>
+      <td>00:27</td>
+      <td>Y</td>
+      <td align="right">0</td>
+      <td align="right">7</td>
+    </tr>
+    <tr>
+      <td>6</td>
+      <td>1</td>
+      <td><div class='row'><img class="logo_image" alt="Houston" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//288.gif" /><span class='d-none d-sm-block'>Houston</span></div></td>
+      <td>1</td>
+      <td>KO</td>
+      <td>08:07</td>
+      <td>HOU28</td>
+      <td>1</td>
+      <td>PUNT</td>
+      <td>05:03</td>
+      <td>HOU37</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3914851/game_period_plays">6</a></td>
+      <td>9</td>
+      <td>03:04</td>
+      <td></td>
+      <td align="right">0</td>
+      <td align="right">7</td>
+    </tr>
+    <tr>
+      <td>7</td>
+      <td>1</td>
+      <td><div class='row'><img class="logo_image" alt="Oregon St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//528.gif" /><span class='d-none d-sm-block'>Oregon St.</span></div></td>
+      <td>1</td>
+      <td>PUNT</td>
+      <td>05:03</td>
+      <td>OSU30</td>
+      <td>2</td>
+      <td>TD</td>
+      <td>13:43</td>
+      <td></td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3914838/game_period_plays">11</a></td>
+      <td>70</td>
+      <td>06:20</td>
+      <td>Y</td>
+      <td align="right">0</td>
+      <td align="right">14</td>
+    </tr>
+    <tr>
+      <td>8</td>
+      <td>2</td>
+      <td><div class='row'><img class="logo_image" alt="Houston" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//288.gif" /><span class='d-none d-sm-block'>Houston</span></div></td>
+      <td>2</td>
+      <td>KO</td>
+      <td>13:34</td>
+      <td>HOU15</td>
+      <td>2</td>
+      <td>FG</td>
+      <td>05:47</td>
+      <td>OSU7</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3914852/game_period_plays">17</a></td>
+      <td>78</td>
+      <td>07:47</td>
+      <td>Y</td>
+      <td align="right">3</td>
+      <td align="right">14</td>
+    </tr>
+    <tr>
+      <td>9</td>
+      <td>2</td>
+      <td><div class='row'><img class="logo_image" alt="Oregon St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//528.gif" /><span class='d-none d-sm-block'>Oregon St.</span></div></td>
+      <td>2</td>
+      <td>KO</td>
+      <td>05:47</td>
+      <td>OSU25</td>
+      <td>2</td>
+      <td>PUNT</td>
+      <td>03:12</td>
+      <td>OSU22</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3914839/game_period_plays">3</a></td>
+      <td>-3</td>
+      <td>02:35</td>
+      <td></td>
+      <td align="right">3</td>
+      <td align="right">14</td>
+    </tr>
+    <tr>
+      <td>10</td>
+      <td>2</td>
+      <td><div class='row'><img class="logo_image" alt="Houston" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//288.gif" /><span class='d-none d-sm-block'>Houston</span></div></td>
+      <td>2</td>
+      <td>PUNT</td>
+      <td>03:12</td>
+      <td>HOU45</td>
+      <td>2</td>
+      <td>TD</td>
+      <td>01:24</td>
+      <td></td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3914853/game_period_plays">7</a></td>
+      <td>55</td>
+      <td>01:48</td>
+      <td>Y</td>
+      <td align="right">10</td>
+      <td align="right">14</td>
+    </tr>
+    <tr>
+      <td>11</td>
+      <td>2</td>
+      <td><div class='row'><img class="logo_image" alt="Oregon St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//528.gif" /><span class='d-none d-sm-block'>Oregon St.</span></div></td>
+      <td>2</td>
+      <td>KO</td>
+      <td>01:19</td>
+      <td>OSU25</td>
+      <td>2</td>
+      <td>FGA</td>
+      <td>00:11</td>
+      <td>HOU32</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3914840/game_period_plays">9</a></td>
+      <td>43</td>
+      <td>01:08</td>
+      <td></td>
+      <td align="right">10</td>
+      <td align="right">14</td>
+    </tr>
+    <tr>
+      <td>12</td>
+      <td>2</td>
+      <td><div class='row'><img class="logo_image" alt="Houston" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//288.gif" /><span class='d-none d-sm-block'>Houston</span></div></td>
+      <td>2</td>
+      <td>FGA</td>
+      <td>00:11</td>
+      <td>HOU35</td>
+      <td>2</td>
+      <td>HALF</td>
+      <td>00:00</td>
+      <td>HOU32</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3914854/game_period_plays">1</a></td>
+      <td>-3</td>
+      <td>00:11</td>
+      <td></td>
+      <td align="right">10</td>
+      <td align="right">14</td>
+    </tr>
+    <tr>
+      <td>13</td>
+      <td>3</td>
+      <td><div class='row'><img class="logo_image" alt="Houston" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//288.gif" /><span class='d-none d-sm-block'>Houston</span></div></td>
+      <td>3</td>
+      <td>KO</td>
+      <td>14:54</td>
+      <td>HOU22</td>
+      <td>3</td>
+      <td>PUNT</td>
+      <td>12:56</td>
+      <td>HOU20</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3914855/game_period_plays">3</a></td>
+      <td>-2</td>
+      <td>01:58</td>
+      <td></td>
+      <td align="right">10</td>
+      <td align="right">14</td>
+    </tr>
+    <tr>
+      <td>14</td>
+      <td>3</td>
+      <td><div class='row'><img class="logo_image" alt="Oregon St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//528.gif" /><span class='d-none d-sm-block'>Oregon St.</span></div></td>
+      <td>3</td>
+      <td>PUNT</td>
+      <td>12:56</td>
+      <td>OSU28</td>
+      <td>3</td>
+      <td>PUNT</td>
+      <td>10:53</td>
+      <td>OSU36</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3914841/game_period_plays">3</a></td>
+      <td>8</td>
+      <td>02:03</td>
+      <td></td>
+      <td align="right">10</td>
+      <td align="right">14</td>
+    </tr>
+    <tr>
+      <td>15</td>
+      <td>3</td>
+      <td><div class='row'><img class="logo_image" alt="Houston" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//288.gif" /><span class='d-none d-sm-block'>Houston</span></div></td>
+      <td>3</td>
+      <td>PUNT</td>
+      <td>10:53</td>
+      <td>HOU20</td>
+      <td>3</td>
+      <td>PUNT</td>
+      <td>09:10</td>
+      <td>HOU16</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3914856/game_period_plays">3</a></td>
+      <td>-4</td>
+      <td>01:43</td>
+      <td></td>
+      <td align="right">10</td>
+      <td align="right">14</td>
+    </tr>
+    <tr>
+      <td>16</td>
+      <td>3</td>
+      <td><div class='row'><img class="logo_image" alt="Oregon St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//528.gif" /><span class='d-none d-sm-block'>Oregon St.</span></div></td>
+      <td>3</td>
+      <td>PUNT</td>
+      <td>09:10</td>
+      <td>OSU39</td>
+      <td>3</td>
+      <td>FG</td>
+      <td>05:31</td>
+      <td>HOU13</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3914842/game_period_plays">7</a></td>
+      <td>48</td>
+      <td>03:39</td>
+      <td>Y</td>
+      <td align="right">10</td>
+      <td align="right">17</td>
+    </tr>
+    <tr>
+      <td>17</td>
+      <td>3</td>
+      <td><div class='row'><img class="logo_image" alt="Houston" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//288.gif" /><span class='d-none d-sm-block'>Houston</span></div></td>
+      <td>3</td>
+      <td>KO</td>
+      <td>05:24</td>
+      <td>HOU37</td>
+      <td>3</td>
+      <td>PUNT</td>
+      <td>04:28</td>
+      <td>HOU40</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3914857/game_period_plays">3</a></td>
+      <td>3</td>
+      <td>00:56</td>
+      <td></td>
+      <td align="right">10</td>
+      <td align="right">17</td>
+    </tr>
+    <tr>
+      <td>18</td>
+      <td>3</td>
+      <td><div class='row'><img class="logo_image" alt="Oregon St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//528.gif" /><span class='d-none d-sm-block'>Oregon St.</span></div></td>
+      <td>3</td>
+      <td>PUNT</td>
+      <td>04:28</td>
+      <td>OSU20</td>
+      <td>4</td>
+      <td>TD</td>
+      <td>12:34</td>
+      <td></td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3914843/game_period_plays">12</a></td>
+      <td>80</td>
+      <td>06:54</td>
+      <td>Y</td>
+      <td align="right">10</td>
+      <td align="right">24</td>
+    </tr>
+    <tr>
+      <td>19</td>
+      <td>4</td>
+      <td><div class='row'><img class="logo_image" alt="Houston" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//288.gif" /><span class='d-none d-sm-block'>Houston</span></div></td>
+      <td>4</td>
+      <td>KO</td>
+      <td>12:28</td>
+      <td>HOU17</td>
+      <td>4</td>
+      <td>PUNT</td>
+      <td>11:14</td>
+      <td>HOU25</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3914858/game_period_plays">3</a></td>
+      <td>8</td>
+      <td>01:14</td>
+      <td></td>
+      <td align="right">10</td>
+      <td align="right">24</td>
+    </tr>
+    <tr>
+      <td>20</td>
+      <td>4</td>
+      <td><div class='row'><img class="logo_image" alt="Oregon St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//528.gif" /><span class='d-none d-sm-block'>Oregon St.</span></div></td>
+      <td>4</td>
+      <td>PUNT</td>
+      <td>11:14</td>
+      <td>OSU41</td>
+      <td>4</td>
+      <td>PUNT</td>
+      <td>08:17</td>
+      <td>HOU43</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3914844/game_period_plays">5</a></td>
+      <td>16</td>
+      <td>02:57</td>
+      <td></td>
+      <td align="right">10</td>
+      <td align="right">24</td>
+    </tr>
+    <tr>
+      <td>21</td>
+      <td>4</td>
+      <td><div class='row'><img class="logo_image" alt="Houston" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//288.gif" /><span class='d-none d-sm-block'>Houston</span></div></td>
+      <td>4</td>
+      <td>PUNT</td>
+      <td>08:17</td>
+      <td>HOU24</td>
+      <td>4</td>
+      <td>TD</td>
+      <td>05:59</td>
+      <td></td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3914859/game_period_plays">7</a></td>
+      <td>76</td>
+      <td>02:18</td>
+      <td></td>
+      <td align="right">17</td>
+      <td align="right">24</td>
+    </tr>
+    <tr>
+      <td>22</td>
+      <td>4</td>
+      <td><div class='row'><img class="logo_image" alt="Oregon St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//528.gif" /><span class='d-none d-sm-block'>Oregon St.</span></div></td>
+      <td>4</td>
+      <td>KO</td>
+      <td>05:59</td>
+      <td>OSU25</td>
+      <td>4</td>
+      <td>PUNT</td>
+      <td>04:31</td>
+      <td>OSU30</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3914845/game_period_plays">3</a></td>
+      <td>5</td>
+      <td>01:28</td>
+      <td></td>
+      <td align="right">17</td>
+      <td align="right">24</td>
+    </tr>
+    <tr>
+      <td>23</td>
+      <td>4</td>
+      <td><div class='row'><img class="logo_image" alt="Houston" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//288.gif" /><span class='d-none d-sm-block'>Houston</span></div></td>
+      <td>4</td>
+      <td>PUNT</td>
+      <td>04:31</td>
+      <td>HOU36</td>
+      <td>4</td>
+      <td>TD</td>
+      <td>03:40</td>
+      <td></td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3914860/game_period_plays">4</a></td>
+      <td>64</td>
+      <td>00:51</td>
+      <td></td>
+      <td align="right">24</td>
+      <td align="right">24</td>
+    </tr>
+    <tr>
+      <td>24</td>
+      <td>4</td>
+      <td><div class='row'><img class="logo_image" alt="Oregon St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//528.gif" /><span class='d-none d-sm-block'>Oregon St.</span></div></td>
+      <td>4</td>
+      <td>KO</td>
+      <td>03:36</td>
+      <td>OSU19</td>
+      <td>4</td>
+      <td>PUNT</td>
+      <td>01:45</td>
+      <td>OSU32</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3914846/game_period_plays">5</a></td>
+      <td>13</td>
+      <td>01:51</td>
+      <td></td>
+      <td align="right">24</td>
+      <td align="right">24</td>
+    </tr>
+    <tr>
+      <td>25</td>
+      <td>4</td>
+      <td><div class='row'><img class="logo_image" alt="Houston" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//288.gif" /><span class='d-none d-sm-block'>Houston</span></div></td>
+      <td>4</td>
+      <td>PUNT</td>
+      <td>01:45</td>
+      <td>HOU27</td>
+      <td>4</td>
+      <td>PUNT</td>
+      <td>00:56</td>
+      <td>HOU49</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3914861/game_period_plays">4</a></td>
+      <td>22</td>
+      <td>00:49</td>
+      <td></td>
+      <td align="right">24</td>
+      <td align="right">24</td>
+    </tr>
+    <tr>
+      <td>26</td>
+      <td>4</td>
+      <td><div class='row'><img class="logo_image" alt="Oregon St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//528.gif" /><span class='d-none d-sm-block'>Oregon St.</span></div></td>
+      <td>4</td>
+      <td>PUNT</td>
+      <td>00:56</td>
+      <td>OSU10</td>
+      <td>4</td>
+      <td>FGA</td>
+      <td>00:00</td>
+      <td>HOU29</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3914847/game_period_plays">10</a></td>
+      <td>61</td>
+      <td>00:56</td>
+      <td></td>
+      <td align="right">24</td>
+      <td align="right">24</td>
+    </tr>
+    <tr>
+      <td>27</td>
+      <td>1OT</td>
+      <td><div class='row'><img class="logo_image" alt="Oregon St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//528.gif" /><span class='d-none d-sm-block'>Oregon St.</span></div></td>
+      <td>1OT</td>
+      <td>KO</td>
+      <td>00:00</td>
+      <td>HOU25</td>
+      <td>1OT</td>
+      <td>DOWNS</td>
+      <td>00:00</td>
+      <td>HOU16</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3914848/game_period_plays">4</a></td>
+      <td>9</td>
+      <td>00:00</td>
+      <td>Y</td>
+      <td align="right">0</td>
+      <td align="right">0</td>
+    </tr>
+    <tr>
+      <td>28</td>
+      <td>1OT</td>
+      <td><div class='row'><img class="logo_image" alt="Houston" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//288.gif" /><span class='d-none d-sm-block'>Houston</span></div></td>
+      <td>1OT</td>
+      <td>DOWNS</td>
+      <td>00:00</td>
+      <td>OSU25</td>
+      <td>1OT</td>
+      <td>FG</td>
+      <td>00:00</td>
+      <td>OSU6</td>
+      <td><a class="skipMask" data-remote="true" href="/contests/game_drives/3914862/game_period_plays">6</a></td>
+      <td>19</td>
+      <td>00:00</td>
+      <td>Y</td>
+      <td align="right">0</td>
+      <td align="right">0</td>
+    </tr>
+  </tbody>
+</table>
+
+<br />
+
+       </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<footer>&copy; <script>document.write(new Date().getFullYear())</script> NCAA <a href="http://web1.ncaa.org/web_files/terms_and_conditions.html" title ="Terms and Conditions" target=_blank>Terms and Conditions</a> | <a href="http://web1.ncaa.org/web_files/privacy.html" target=_blank title="Our Privacy Policy">Privacy Policy</a> | <a href="mailto:ncaastats@ncaa.org">Contact Us</a> </footer>
+
+  <!-- /.container -->
+  <script type="text/javascript"  src="/QFrxqVkNu/zpMzxVZYg/LrV9L4r53Db3/PBxcAQ/GF/kteXRIKAwV?v=884a91f9-4223-5731-3b53-ca73b6651729" defer></script></body>
+
+  <script charset="utf-8">
+    $(document).ready(function() {
+      $('a.remote[data-toggle="tab"]').on('show.bs.tab', function (e) {
+        var tab_id = '#' + $(this).attr('aria-controls');
+        $(tab_id).html('<br/><br/><p style="text-align: center"><img style="vertical-align:middle; text-align: center" src="/assets/ajax-loader-6913acdbf4be7d6a2908a84bdecd6cad18110f5fc6d5a07cf8c9ce78d9548700.gif" /> Loading... </p><br/><br/>');
+        $.get($(this).data('remote'), function(data){
+          $(tab_id).html(data);
+        });
+      });
+    });
+
+    function skipMask(obj){
+      if (obj.hasClass('chosen-single') || obj.hasClass('skipMask') || obj.hasClass('ui-datepicker-prev') || obj.hasClass('ui-datepicker-next') || obj.hasClass('ui-corner-all') || obj.hasClass('paginate_button') || obj.hasClass('dt-button')){
+        return true;
+      }else{
+        return false;
+      }
+    }
+
+    $(document).ajaxComplete(function(){
+      unmask();
+    });
+/*
+    $("form").on('submit', function(event){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    */
+    $(document).on('click', 'a', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    $(document).on('click', 'input.green', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+
+  </script>
+</html>

--- a/tests/fixtures/cfb_ncaa/mfb_play_by_play_6386335.html
+++ b/tests/fixtures/cfb_ncaa/mfb_play_by_play_6386335.html
@@ -1,0 +1,3104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<META HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=UTF-8">
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="">
+<meta name="author" content="">
+<meta name="version" content="321d28433e9f7a188596117e6f342ec4a84fb4ed">
+<META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<link rel="shortcut icon" href="/assets/favicon-405088046a5f2bab8eedeacfae7636975c095e9c8decd8c28e3fd0e65c2f51c4.ico" type="image/vnd.microsoft.icon">
+
+<title>NCAA Statistics</title>
+
+<!-- Bootstrap core CSS -->
+
+<!--
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+-->
+<!--
+<link rel="stylesheet" href="https://cdn.datatables.net/2.0.0/css/dataTables.bootstrap4.css" crossorigin="anonymous">
+-->
+<link rel="stylesheet" media="all" href="/assets/application-789c3971842ee3597428ccbebd021716b3231e9cbd0a00a184c3b2d6c8e5f152.css" />
+
+
+<script src="/assets/application-9232576bb3cb000ac0841ff2af81251908ec17312a3c5eb72bf1a32f9754800c.js"></script>
+<!--
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+-->
+<!--
+<script src="https://cdn.datatables.net/2.0.0/js/dataTables.bootstrap4.js" crossorigin="anonymous"></script>
+-->
+
+<meta name="csrf-param" content="authenticity_token" />
+<meta name="csrf-token" content="4cnt2bZtX0jOhGS8naBR4zgtosa6T0xlPVW6Sn+fl4aLr7mC98UmkZekU8xG6tNFT/EyN1ikCn384MHZkOCL9Q==" />
+
+<style>
+.grid {clear: all}
+.grid-item, .name {text-align: center;}
+h1 img {max-height: 33px;}
+
+</style>
+<!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+<!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+      <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+    <![endif]-->
+
+
+<script>(window.BOOMR_mq=window.BOOMR_mq||[]).push(["addVar",{"rua.upush":"false","rua.cpush":"false","rua.upre":"false","rua.cpre":"false","rua.uprl":"false","rua.cprl":"false","rua.cprf":"false","rua.trans":"","rua.cook":"false","rua.ims":"false","rua.ufprl":"false","rua.cfprl":"false","rua.isuxp":"false","rua.texp":"norulematch","rua.ceh":"false","rua.ueh":"false","rua.ieh.st":"0"}]);</script>
+                                <script>!function(e){var n="https://s.go-mpulse.net/boomerang/";if("False"=="True")e.BOOMR_config=e.BOOMR_config||{},e.BOOMR_config.PageParams=e.BOOMR_config.PageParams||{},e.BOOMR_config.PageParams.pci=!0,n="https://s2.go-mpulse.net/boomerang/";if(window.BOOMR_API_key="EVKJV-AGD2E-W66AE-NT84S-K5LTF",function(){function e(){if(!r){var e=document.createElement("script");e.id="boomr-scr-as",e.src=window.BOOMR.url,e.async=!0,o.appendChild(e),r=!0}}function t(e){r=!0;var n,t,a,i,d=document,O=window;if(window.BOOMR.snippetMethod=e?"if":"i",t=function(e,n){var t=d.createElement("script");t.id=n||"boomr-if-as",t.src=window.BOOMR.url,BOOMR_lstart=(new Date).getTime(),e=e||d.body,e.appendChild(t)},!window.addEventListener&&window.attachEvent&&navigator.userAgent.match(/MSIE [67]\./))return window.BOOMR.snippetMethod="s",void t(o,"boomr-async");a=document.createElement("IFRAME"),a.src="about:blank",a.title="",a.role="presentation",a.loading="eager",i=(a.frameElement||a).style,i.width=0,i.height=0,i.border=0,i.display="none",o.appendChild(a);try{O=a.contentWindow,d=O.document.open()}catch(_){n=document.domain,a.src="javascript:var d=document.open();d.domain='"+n+"';void 0;",O=a.contentWindow,d=O.document.open()}if(n)d._boomrl=function(){this.domain=n,t()},d.write("<bo"+"dy onload='document._boomrl();'>");else if(O._boomrl=function(){t()},O.addEventListener)O.addEventListener("load",O._boomrl,!1);else if(O.attachEvent)O.attachEvent("onload",O._boomrl);d.close()}function a(e){window.BOOMR_onload=e&&e.timeStamp||(new Date).getTime()}if(!window.BOOMR||!window.BOOMR.version&&!window.BOOMR.snippetExecuted){window.BOOMR=window.BOOMR||{},window.BOOMR.snippetStart=(new Date).getTime(),window.BOOMR.snippetExecuted=!0,window.BOOMR.snippetVersion=14,window.BOOMR.url=n+"EVKJV-AGD2E-W66AE-NT84S-K5LTF";var i=document.currentScript||document.getElementsByTagName("script")[0],o=i.parentNode,r=!1,d=document.createElement("link");if(d.relList&&"function"==typeof d.relList.supports&&d.relList.supports("preload")&&"as"in d)window.BOOMR.snippetMethod="p",d.href=window.BOOMR.url,d.rel="preload",d.as="script",d.addEventListener("load",e),d.addEventListener("error",function(){t(!0)}),setTimeout(function(){if(!r)t(!0)},3e3),BOOMR_lstart=(new Date).getTime(),o.appendChild(d);else t(!1);if(window.addEventListener)window.addEventListener("load",a,!1);else if(window.attachEvent)window.attachEvent("onload",a)}}(),"".length>0)if(e&&"performance"in e&&e.performance&&"function"==typeof e.performance.setResourceTimingBufferSize)e.performance.setResourceTimingBufferSize();!function(){if(BOOMR=e.BOOMR||{},BOOMR.plugins=BOOMR.plugins||{},!BOOMR.plugins.AK){var n=""=="true"?1:0,t="",a="i54lraqxf4pfq2uftqka-f-da42b26a0-clientnsv4-s.akamaihd.net",i="false"=="true"?2:1,o={"ak.v":"41","ak.cp":"1168236","ak.ai":parseInt("215853",10),"ak.ol":"0","ak.cr":140,"ak.ipv":4,"ak.proto":"h2","ak.rid":"7ad6fc62","ak.r":51513,"ak.a2":n,"ak.m":"a","ak.n":"essl","ak.cport":57728,"ak.gh":"23.3.12.163","ak.quicv":"","ak.tlsv":"tls1.3","ak.0rtt":"","ak.0rtt.ed":"","ak.csrc":"-","ak.acc":"","ak.t":"1787141140","ak.ak":"hOBiQwZUYzCg5VSAfCLimQ==+QK77ioGgj2XY6ld2Y3ETjXp2kCXzqzwycezPlklrgMOk9Zm00eFrYwKb15vKVBeNGFXIE2mgOAQ82oX565FGGSo17KqP0eMoBzwAiZ+T8G3LfITiBgfYM/CaE/T0Fyz73n7s99Ol8wEVSlNE8wfxSb7DTOWt3P/o3YC9HVCpU2q0xTUS2NAj8uanftZiu3hhLkxX51mVQCMeVhBEqLrZPjUtt5ILfdSQF/Dwe3sEFd3GaKQdpOcThmSeBLXJ2F/IKa4bme/C2lzHYEKaQgcIYHhtOzZ40DlU1JVaqG8cLFXyQgQJuxlSBRiS1yl9k2uY8gQGWmZ/wgxfbFv8crgRvfttur4sRRWcMKrO457QdXSWcpYUenVnC09c3hgne/ZJDL8S5hqw0jw50EQFYa6v2mSvHXJ6SSsvuKCjhihdhE=","ak.pv":"93","ak.dpoabenc":"","ak.tf":i};if(""!==t)o["ak.ruds"]=t;var r={i:!1,av:function(n){var t="http.initiator";if(n&&(!n[t]||"spa_hard"===n[t]))o["ak.feo"]=void 0!==e.aFeoApplied?1:0,BOOMR.addVar(o)},rv:function(){var e=["ak.cport","ak.cr","ak.csrc","ak.gh","ak.ipv","ak.m","ak.n","ak.ol","ak.proto","ak.quicv","ak.tlsv","ak.0rtt","ak.0rtt.ed","ak.r","ak.acc","ak.t","ak.tf"];BOOMR.removeVar(e)}};BOOMR.plugins.AK={akVars:o,akDNSPreFetchDomain:a,init:function(){if(!r.i){var e=BOOMR.subscribe;e("before_beacon",r.av,null,null),e("onbeacon",r.rv,null,null),r.i=!0}return this},is_complete:function(){return!0}}}}()}(window);</script></head>
+
+  <script>
+
+    
+  //initialize tooltip
+  $(document).ready(function() {
+    //$("body").tooltip({ selector: '[data-toggle=tooltip]' });
+    $('[data-toggle="tooltip"]').tooltip();
+  });
+
+  $(document).ready(function() {
+    $( "#org_name" ).autocomplete({
+      source: '/team/search',
+      select: function( event, ui ) {
+        $("#org_id").val(ui.item.vid);
+        $("#id").val(ui.item.vid);
+        $('#sport_btn').click();
+      }
+    });
+  });
+
+  var body = 'body';
+
+  $.ajaxSetup ({
+    // Disable caching of AJAX responses
+    cache: false
+  });
+
+  function changeSport(field){
+    var el = $(field);
+    var tmList = el.parent().next().find('.new-team-year')[0];
+    if (tmList == null){
+      tmList = el.nextAll('.new-team-year')[0];
+    }
+    $.ajax({
+      url: "/game_sport_year_ctls/"+el.val()+"/available_teams",
+      dataType: "script",
+      success: function(data, status){
+        $(tmList).empty();
+        $(tmList).append(("<option value=''>Select team</option>"));
+        $.each(JSON.parse(data), function(k, v){
+          $(tmList).append($("<option></option>")
+              .attr("value", v["id"])
+              .text(v["member_org"]["name_tabular"]));
+        });
+        $(tmList).trigger("chosen:updated");
+      }
+    });
+  }
+
+    function set_process_styles(fld, start_color, end_color){
+       $('#'+fld).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    var downImage = "/assets/down12.gif";
+    var rightImage = "/assets/right12.gif";
+
+    function highlight(div_id){
+      $(div_id).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    function show_hide_rows(attr_val, link_id){
+      $('#'+attr_val).toggle();
+      if ($('#'+attr_val).is(':visible')) {
+        $('#'+link_id).attr('src', downImage);
+      }else{
+        $('#'+link_id).attr('src', rightImage);
+      }
+    }
+
+    function mask(label){
+      $('body').mask(label);
+    }
+    function unmask(){
+      $('body').unmask();
+    }
+
+    var winHeight = "auto";
+    var winWidth = "auto";
+    var maxHeight = 700;
+    var maxWidth = 1400;
+    var minHeight = 100;
+    var minWidth = 200;
+    
+    var modalOptions = {"width": winWidth,
+                        "height": winHeight,
+                        "maxHeight": maxHeight,
+                        "maxWidth": maxWidth,
+                        "minHeight": minHeight,
+                        "minWidth": minWidth};
+
+    function dialog(url, title){
+
+      $("#stats_app_dialog").dialog({modal:true, minWidth:minWidth, minHeight:minHeight, maxWidth:maxWidth, maxHeight:maxHeight, width:winWidth, height:winHeight, title:title, closeOnEscape: false});
+    
+      modalOptions.title = title;
+    
+      $("#stats_app_dialog").dialog("option", modalOptions);
+    
+      $("#stats_app_dialog").html("Loading...");
+      $("#stats_app_dialog").load(url).dialog('open');
+    }
+
+    function addDatePicker(){
+    $('.adddatepicker').each(function(i, obj){
+      $(obj).datepicker({ 
+        showOn: 'both', 
+        buttonImage: '/assets/calendar.gif', 
+        buttonImageOnly: true,
+      });
+    });
+    }
+
+   $(document).ready(function() {
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   });
+
+   function setClassInputFields(){
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   }
+
+   function isValidDateFormat(dateStr){
+     const regex = /^([1-9]|0[1-9]|1[0-2])\/([1-9]|0[1-9]|[12][0-9]|3[01])\/(19|20)\d{2}$/;
+     if (!regex.test(dateStr)) {
+       return false;
+     }else{
+       return true;
+     }
+   }
+
+  </script>
+
+
+<body style="font-size: .75rem;" onload="if (top != self) { top.location=self.location; }" >
+
+      <header>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0">
+        <a class="navbar-brand mr-0 mr-md-2" href="/" aria-label="statistics">
+                          <img alt="NCAA" style="margin-left: 24px; margin-right: 0; margin-top: 6px;" src="/assets/ncaa-fbc4d0406ae731b47babcc3fca53775b5955ef372bf8b8e998ca9a513e468b8f.svg" />
+                          <span class="title" class="dark-blue-font">Statistics</span>
+        </a>
+       </nav>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0" style="background-color: var(--color-dark-blue) !important;">
+  <button class="navbar-toggler bg-white" type="button" data-toggle="collapse" data-target="#navbarTogglerDemo01" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarTogglerDemo01">
+        <ul class="navbar-nav mr-auto mt-2 mt-lg-0 justify-content-center">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle skipMask" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Rankings
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+          <a class="dropdown-item" href="/rankings">National Rankings</a>
+          <a class="dropdown-item" href="/active_career_leaders">Active Career Leaders</a>
+        </div>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/contests/livestream_scoreboards">Scoreboard</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/selection_rankings/nitty_gritties">Selection Rankings</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/head_coaches">Head Coaches</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/search/players">Players</a>
+      </li>
+     </ul>
+
+    <form onsubmit="mask(&#39;Loading&#39;);" id="change_team_form" style="display:inline;" class="form-inline my-2 my-lg-0" action="/team/index" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="0cS9P9VoGsWclsxQkN4gyoIk46afMOHxTOLsIa+uUR1OhacUw7YvI+/5rVQdBv7wdrIKCuhU3igb76D3A2EJ2g==" />
+  <div style="display:none;">
+  <input type="submit" name="commit" value="Submit" id="sport_btn" data-disable-with="Submit" />
+  </div>
+    <div id="team_autocomplete" class="ui-widget">
+      <input type="search" name="org_name" id="org_name" style="width:200px; font-size: 12px !important" class="form-control mr-sm-2" placeholder="Team Search" />
+      <input type="hidden" name="org_id" id="org_id" />
+    </div>
+</form>  </div>
+  </nav>
+</nav>
+      </header>
+
+       <div id="stats_app_dialog" style="display:none;">
+        </div>
+
+<div class="card p-1">
+  <div class="card-body application contests p-0">
+    <h3 class="card-title p-0"></h3>
+    <div class="container-fluid p-0">
+      <div class="row align-items-center justify-content-center p-0">
+        <div class="col-sm-12 p-0">
+          <br/>
+
+<br/>
+
+<style>
+.winner{
+  --display: flex;
+  vertical-align: middle;
+}
+.winner:before{
+  content: '\25BA';
+  --display: flex;
+  --align-items: center;
+  vertical-align: middle;
+}
+div.center {
+  margin: auto;
+  width: 50%;
+  --border: 3px solid green;
+  padding: 10px;
+}
+</style>
+
+   <div class="table-responsive">
+   <table align="center">
+     <tr>
+   <td>
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/606050"><img class="large_logo_image" alt="Tulsa" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//719.gif" /></a>
+   </td>
+   <td valign="center" class="grey_text d-none d-sm-table-cell" nowrap>
+     <span style="font-size:18px">
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/606050">Tulsa Golden Hurricane</a>
+     </span><br/>
+       2-5, Conf 0-4
+   </td>
+   <td valign="center" class="">
+   </td>
+   <td valign="center" style="font-size:36px; color: grey">
+     27
+   </td>
+     <td style="padding: 0px 30px 0px 30px"  class="d-none d-md-table-cell">
+       <table style="border-collapse: collapse">
+         <tr>
+           <td class="grey_border_bottom"></td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">1</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">2</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">3</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">4</td>
+           <td width="20px" align="right" style="font-weight:bold" class="grey_border_bottom">S</td>
+         </tr>
+           <tr>
+             <td>Tulsa</td>
+               <td class="grey_text" align="right">7</td>
+               <td class="grey_text" align="right">7</td>
+               <td class="grey_text" align="right">3</td>
+               <td class="grey_text" align="right">10</td>
+             <td align="right" style="font-weight:bold">27</td>
+           </tr>
+           <tr>
+             <td>East Carolina</td>
+               <td class="grey_text" align="right">10</td>
+               <td class="grey_text" align="right">14</td>
+               <td class="grey_text" align="right">7</td>
+               <td class="grey_text" align="right">10</td>
+             <td align="right" style="font-weight:bold">41</td>
+           </tr>
+         <tr>
+           <td class="grey_text" colspan="6">10/16/2025 07:00 PM</td>
+         </tr>
+         <tr>
+           <td nowrap class="grey_text" colspan="6">Dowdy-Ficklen (Greenville, NC)</td>
+         </tr>
+         <tr>
+           <td nowrap class="grey_text" colspan="6">Attendance: 31,307</td>
+         </tr>
+       </table>
+     </td>
+   <td>
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/606096"><img class="large_logo_image" alt="East Carolina" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//196.gif" /></a>
+   </td>
+   <td valign="center" class="grey_text d-none d-sm-table-cell" nowrap>
+     <span style="font-size:18px">
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/606096">East Carolina Pirates</a>
+     </span><br/>
+       4-3, Conf 2-1
+   </td>
+   <td valign="center" class="winner">
+   </td>
+   <td valign="center" style="font-size:36px; color: black">
+     41
+   </td>
+     </tr>
+     <tr>
+       <td colspan="10" class="grey_border_bottom grey_border_top">
+         <table cellpadding="10px">
+           <tr>
+             <td style="font-size: 16px;"><a href="/contests/6386335/box_score">Box Score</a></td>
+             <td style="font-size: 16px;"><a href="/contests/6386335/team_stats">Team Stats</a></td>
+             <td style="font-size: 16px;"><a href="/contests/6386335/individual_stats">Individual Stats</a></td>
+             <td style="font-size: 16px;">Play By Play</td>
+             <td style="font-size: 16px;"><a href="/contests/6386335/drives">Drives</a></td>
+             <td style="font-size: 16px;"><a href="/contests/6386335/officials">Officials</a></td>
+           </tr>
+         </table>
+       </td>
+     </tr>
+   </table>
+ </div>
+
+
+<br/>
+
+  <script>
+ $( function() {
+    $( ".drives" ).accordion({
+      collapsible: true,
+      heightStyle: "content",
+      header: "h5",
+      active: false
+    });
+  } );
+
+ function showScoringPlays(){
+   $('.non_scoring_play').hide();
+ }
+ function showAllPlays(){
+   $('.non_scoring_play').show();
+   $('.drives').accordion("refresh");
+   $('.drives').accordion("option", "active", false);
+ }
+</script>
+
+<style>
+ .ui-state-default, .ui-widget-content .ui-state-default, .ui-widget-header .ui-state-default {
+   overflow: auto;
+ }
+ .ui-state-default, .ui-widget-content .ui-state-default, .ui-widget-header .ui-state-default {
+    border: 1px solid #CCCCCC;
+    background: white;
+    background-image: none;
+    font-weight: normal;
+    color: #808080;
+}
+
+ .headerRight {
+  float: right;
+}
+.headerLeft {
+  float: left;
+}
+.under{
+text-decoration : underline;
+}
+</style>
+
+<div style="width: 50%; margin-left: auto; margin-right: auto;">
+  <div class="headerRight"><a class="skipMask" href="javascript:showAllPlays();">All Drives</a> | <a class="skipMask" href="javascript:showScoringPlays();">Scoring Drives</a></div>
+  <div style="border-bottom: 1px dotted #dcdddf;"><h1>1st Quarter</h1></div>
+<div class="drives">
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Tulsa" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//719.gif" /><span class='d-none d-sm-block'>Tulsa</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">14:56,TLS20, 3 plays, 1 yards, 01:28</span>
+        </div>
+        <div class="headerRight">0 - 0</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU35</br>
+         </span>
+         <span>
+           (15:00) Scott,Everett kickoff 65 yards to the TLS00 Washington,Kelvin return 20 yards to the TLS20 (Wilk,Teagan; Moye,Alex).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS20</br>
+         </span>
+         <span>
+           Tulsa drive start at 14:56.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS20</br>
+         </span>
+         <span>
+           (14:54) Shotgun Richardson,Dominic rush middle for 1 yard gain to the TLS21 (Wilson,Zion; Dankah,Samuel).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 9 at TLS21</br>
+         </span>
+         <span>
+           (14:19) Shotgun Richardson,Dominic rush middle for 0 yards to the TLS21 (Jean,Jonathan; Lowery,Jordy).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 9 at TLS21</br>
+         </span>
+         <span>
+           (13:41) Shotgun Hayes,Baylor pass incomplete short left to Allen,Ajay thrown to TLS19.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 9 at TLS21</br>
+         </span>
+         <span>
+           (13:38) Davies,Angus punt 30 yards to the ECU49.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="East Carolina" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//196.gif" /><span class='d-none d-sm-block'>East Carolina</span></div></div>
+        <div class="headerLeft">FG <br/><span style="font-size: 8px;">13:28,ECU49, 11 plays, 33 yards, 02:36</span>
+        </div>
+        <div class="headerRight">0 - 3</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU49</br>
+         </span>
+         <span>
+           East Carolina drive start at 13:28.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU49</br>
+         </span>
+         <span>
+           (13:27) No Huddle-Shotgun Houser,Katin rush left for 4 yards gain to the TLS47 (Smith,Solento).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 6 at TLS47</br>
+         </span>
+         <span>
+           (13:09) No Huddle-Shotgun Houser,Katin pass complete short right to Riles,Desirrio caught at TLS41, for 10 yards to the TLS37 (Coney,Ray), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS37</br>
+         </span>
+         <span>
+           (12:47) No Huddle-Shotgun Houser,Katin pass incomplete short right to Smith,Yannick thrown to TLS34.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at TLS37</br>
+         </span>
+         <span>
+           (12:46) No Huddle-Shotgun Houser,Katin pass complete short left to Smith,Anthony caught at TLS26, for 11 yards to the TLS26, out of bounds at TLS26, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS26</br>
+         </span>
+         <span>
+           (12:29) No Huddle-Shotgun Houser,Katin pass incomplete deep left to Smith,Anthony thrown to TLS02.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at TLS26</br>
+         </span>
+         <span>
+           (12:24) No Huddle-Shotgun Montgomery,London rush middle for 7 yards gain to the TLS19 (Williams,Zach; Hjelle,Joe).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 3 at TLS19</br>
+         </span>
+         <span>
+           (11:58) No Huddle-Shotgun Montgomery,London rush left for 6 yards gain to the TLS13 (Drew,JD), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS13</br>
+         </span>
+         <span>
+           (11:33) No Huddle-Shotgun Houser,Katin pass incomplete short middle to Spalding,Brock thrown to TLS03 broken up by Smith,Solento.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at TLS13</br>
+         </span>
+         <span>
+           (11:29) No Huddle-Shotgun Montgomery,London rush middle for 0 yards to the TLS13 (Coney,Ray; Ball,Hudson).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 10 at TLS13</br>
+         </span>
+         <span>
+           (11:02) No Huddle-Shotgun Houser,Katin pass incomplete short middle to Smith,Anthony thrown to TLS00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 10 at TLS13</br>
+         </span>
+         <span>
+           (10:54) Mazzie,Nick field goal attempt from 32 yards  nullified by penaltyGOOD (H: Leavy,Ryan, LS: O&#39;Brien,Triston), clock 10:56 PENALTY ECU False Start (O&#39;Brien,Triston) 5 yards from TLS13 to TLS18. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 15 at TLS18</br>
+         </span>
+         <span>
+           (10:52) Mazzie,Nick field goal attempt from 37 yards GOOD (H: Leavy,Ryan, LS: O&#39;Brien,Triston), clock 10:52.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Tulsa" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//719.gif" /><span class='d-none d-sm-block'>Tulsa</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">10:47,TLS25, 3 plays, 8 yards, 01:28</span>
+        </div>
+        <div class="headerRight">0 - 3</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU35</br>
+         </span>
+         <span>
+           (10:52) Scott,Everett kickoff 64 yards to the TLS01 Washington,Kelvin return 24 yards to the TLS25 (Davis,Julien; Duncanson,Ayden).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS25</br>
+         </span>
+         <span>
+           Tulsa drive start at 10:47.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS25</br>
+         </span>
+         <span>
+           (10:47) Shotgun Hayes,Baylor pass incomplete short right to Presley,Braylin thrown to TLS30.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at TLS25</br>
+         </span>
+         <span>
+           (10:42) Shotgun Richardson,Dominic rush middle for 5 yards gain to the TLS30 (Duncanson,Ayden).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 5 at TLS30</br>
+         </span>
+         <span>
+           (10:06) Shotgun Hayes,Baylor pass complete short middle to Richardson,Dominic caught at TLS30, for 3 yards to the TLS33 (Carr,Preston; Johnson Jr.,DJ).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 2 at TLS33</br>
+         </span>
+         <span>
+           (09:30) Davies,Angus punt 56 yards to the ECU11.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="East Carolina" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//196.gif" /><span class='d-none d-sm-block'>East Carolina</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">09:19,ECU11, 4 plays, 25 yards, 01:35</span>
+        </div>
+        <div class="headerRight">0 - 3</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU11</br>
+         </span>
+         <span>
+           East Carolina drive start at 09:19.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU11</br>
+         </span>
+         <span>
+           (09:18) No Huddle-Shotgun Houser,Katin pass complete short right to Wright Jr.,Mike caught at ECU14, for 6 yards to the ECU17 (Drew,JD) PENALTY TLS Face Mask (Drew,JD) 15 yards from ECU17 to ECU32, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU32</br>
+         </span>
+         <span>
+           (09:03) No Huddle-Shotgun Engleman Jr.,TJ rush middle for 7 yards gain to the ECU39 (Coney,Ray; Hjelle,Joe).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 3 at ECU39</br>
+         </span>
+         <span>
+           (08:48) No Huddle-Shotgun Houser,Katin pass incomplete short left to Pettaway,Jaquaize thrown to ECU36.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 3 at ECU39</br>
+         </span>
+         <span>
+           (08:46) No Huddle-Shotgun Houser,Katin pass complete short middle to Pettaway,Jaquaize caught at ECU43, for 2 yards to the ECU41 (Coney,Ray; Anglin,Josh). The previous play is under automatic review - &quot;Short of the line to gain&quot;. PLAY STANDS.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 1 at ECU41</br>
+         </span>
+         <span>
+           (08:00) Leavy,Ryan punt 43 yards to the TLS16 fair catch by Booker,Zion at TLS16 PENALTY ECU Illegal Formation 5 yards from ECU41 to ECU36. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 6 at ECU36</br>
+         </span>
+         <span>
+           (07:53) Leavy,Ryan punt 36 yards to the TLS28 muffed by Booker,Zion at TLS28 recovered by TLS Booker,Zion at TLS33, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Tulsa" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//719.gif" /><span class='d-none d-sm-block'>Tulsa</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">07:44,TLS33, 7 plays, 6 yards, 02:01</span>
+        </div>
+        <div class="headerRight">0 - 3</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS33</br>
+         </span>
+         <span>
+           Tulsa drive start at 07:44.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS33</br>
+         </span>
+         <span>
+           (07:44) Shotgun Hayes,Baylor pass incomplete short right to Tease,Micah thrown to TLS30.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at TLS33</br>
+         </span>
+         <span>
+           (07:39) Shotgun Hayes,Baylor pass incomplete short left to Tease,Micah thrown to TLS32.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 10 at TLS33</br>
+         </span>
+         <span>
+           (07:36) Shotgun Hayes,Baylor pass complete short right to Booker,Zion caught at TLS31, for 9 yards to the TLS42 (Barker,Jackson).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 1 at TLS42</br>
+         </span>
+         <span>
+           (07:08) Allen,Ajay rush right for 1 yard gain to the TLS43 (Riddle,Ja&#39;Marley; Wilson,Zion), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS43</br>
+         </span>
+         <span>
+           (06:38) Shotgun Hayes,Baylor rush middle for 4 yards loss to the TLS39 (Lampley,J.D.).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 14 at TLS39</br>
+         </span>
+         <span>
+           (06:07) Shotgun Hayes,Baylor pass incomplete deep right to Tease,Micah thrown to ECU20.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 14 at TLS39</br>
+         </span>
+         <span>
+           (05:57) Shotgun Hayes,Baylor pass incomplete short right thrown to TLS48 QB hurried by Craig,Ryheem.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 14 at TLS39</br>
+         </span>
+         <span>
+           (05:50) Davies,Angus punt 37 yards to the ECU24 fair catch by Pearson,Kyler at ECU24.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="East Carolina" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//196.gif" /><span class='d-none d-sm-block'>East Carolina</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">05:43,ECU24, 2 plays, 76 yards, 00:35</span>
+        </div>
+        <div class="headerRight">0 - 10</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU24</br>
+         </span>
+         <span>
+           East Carolina drive start at 05:43.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU24</br>
+         </span>
+         <span>
+           (05:43) No Huddle-Shotgun Houser,Katin pass complete short left to Smith,Anthony caught at ECU33, for 10 yards to the ECU34 (Drew,JD), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU34</br>
+         </span>
+         <span>
+           (05:18) No Huddle-Shotgun Houser,Katin pass complete deep left to Smith,Anthony caught at TLS40, for 66 yards to the TLS00 TOUCHDOWN, clock 05:08, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS3</br>
+         </span>
+         <span>
+           Mazzie,Nick kick attempt good (H: Leavy,Ryan, LS: O&#39;Brien,Triston).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Tulsa" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//719.gif" /><span class='d-none d-sm-block'>Tulsa</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">05:04,TLS28, 7 plays, 72 yards, 02:20</span>
+        </div>
+        <div class="headerRight">7 - 10</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU35</br>
+         </span>
+         <span>
+           (05:08) Scott,Everett kickoff 65 yards to the TLS00 Washington,Kelvin return 28 yards to the TLS28 (Jean,Jonathan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS28</br>
+         </span>
+         <span>
+           Tulsa drive start at 05:04.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS28</br>
+         </span>
+         <span>
+           (05:02) Shotgun Hayes,Baylor pass incomplete short right to Tease,Micah thrown to TLS30.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at TLS28</br>
+         </span>
+         <span>
+           (04:57) Shotgun Hayes,Baylor rush left for 4 yards gain to the TLS32 (Merrell,Kevon).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at TLS32</br>
+         </span>
+         <span>
+           (04:30) Shotgun Tease,Micah rush right for 19 yards gain to the ECU49, out of bounds at ECU49, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU49</br>
+         </span>
+         <span>
+           (03:56) Shotgun Hayes,Baylor pass complete short left to Booker,Zion caught at TLS49, for 5 yards to the ECU44 (Merrell,Kevon).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 5 at ECU44</br>
+         </span>
+         <span>
+           (03:37) Shotgun Hayes,Baylor rush left for 13 yards gain (13) to the ECU31, out of bounds at ECU31 PENALTY TLS Holding (Steptoe,Zion) 10 yards from ECU31 to ECU41.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 2 at ECU41</br>
+         </span>
+         <span>
+           (03:07) Shotgun Richardson,Dominic rush middle for 3 yards gain to the ECU38 (Wilson,Zion), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU38</br>
+         </span>
+         <span>
+           (02:51) Shotgun Hayes,Baylor pass complete short middle to Foley,Brody caught at ECU25, for 38 yards to the ECU00 TOUCHDOWN, clock 02:44, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU3</br>
+         </span>
+         <span>
+           Morgan,Seth kick attempt good (H: Davies,Angus, LS: Fedigan,Aidan).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="East Carolina" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//196.gif" /><span class='d-none d-sm-block'>East Carolina</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">02:44,ECU25, 9 plays, 75 yards, 02:47</span>
+        </div>
+        <div class="headerRight">7 - 17</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS35</br>
+         </span>
+         <span>
+           (02:44) Morgan,Seth kickoff 65 yards to the ECU00 fair catch by Pearson,Kyler at ECU00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU25</br>
+         </span>
+         <span>
+           East Carolina drive start at 02:44.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU25</br>
+         </span>
+         <span>
+           (02:43) No Huddle-Shotgun Houser,Katin pass complete short left to Engleman Jr.,TJ caught at ECU20, for 10 yards to the ECU35 (Robinson,Devin; Drew,JD), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU35</br>
+         </span>
+         <span>
+           (02:20) No Huddle-Shotgun Engleman Jr.,TJ rush middle for 7 yards gain to the ECU42 (Anglin,Josh).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 3 at ECU42</br>
+         </span>
+         <span>
+           (01:56) No Huddle-Shotgun Engleman Jr.,TJ rush left for 2 yards gain to the ECU44 (Robinson,Devin; Hjelle,Joe).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at ECU44</br>
+         </span>
+         <span>
+           (01:39) No Huddle-Shotgun Engleman Jr.,TJ rush middle for 5 yards gain to the ECU49 (Coney,Ray), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU49</br>
+         </span>
+         <span>
+           (01:19) No Huddle-Shotgun Houser,Katin pass complete deep middle to Spalding,Brock caught at TLS25, for 30 yards to the TLS21 (Smith,Solento), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS21</br>
+         </span>
+         <span>
+           (01:00) No Huddle-Shotgun Engleman Jr.,TJ rush middle for 6 yards gain to the TLS15 (Robinson,Devin).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 4 at TLS15</br>
+         </span>
+         <span>
+           (00:40) No Huddle-Shotgun Wright Jr.,Mike rush middle for 7 yards gain to the TLS08 (Smith,Solento), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 8 at TLS8</br>
+         </span>
+         <span>
+           (00:10) No Huddle-Shotgun Gunn Jr.,Marlon rush middle for 7 yards gain to the TLS01 (Johnson,Nahki; Smith,Solento).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 1 at TLS1</br>
+         </span>
+         <span>
+           Start of 2nd quarter, clock 15:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 1 at TLS1</br>
+         </span>
+         <span>
+           (15:00) No Huddle-Shotgun Gunn Jr.,Marlon rush middle for 1 yard gain to the TLS00 TOUCHDOWN, clock 14:57.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS3</br>
+         </span>
+         <span>
+           Mazzie,Nick kick attempt good (H: Leavy,Ryan, LS: O&#39;Brien,Triston).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+</div>
+  <div style="border-bottom: 1px dotted #dcdddf;"><h1>2nd Quarter</h1></div>
+<div class="drives">
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Tulsa" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//719.gif" /><span class='d-none d-sm-block'>Tulsa</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">14:52,TLS22, 7 plays, 78 yards, 03:01</span>
+        </div>
+        <div class="headerRight">14 - 17</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU35</br>
+         </span>
+         <span>
+           (14:57) Scott,Everett kickoff 65 yards to the TLS00 Washington,Kelvin return 22 yards to the TLS22 (Miles,Jordan David).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS22</br>
+         </span>
+         <span>
+           Tulsa drive start at 14:52.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS22</br>
+         </span>
+         <span>
+           (14:52) Shotgun Richardson,Dominic rush middle for 8 yards gain to the TLS30 (Riddle,Ja&#39;Marley; Carr,Preston).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 2 at TLS30</br>
+         </span>
+         <span>
+           (14:25) Shotgun Richardson,Dominic rush middle for 2 yards gain to the TLS32 (Wilson,Dameon; Robinson,Jasiyah), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS32</br>
+         </span>
+         <span>
+           (13:59) Shotgun Steptoe,Zion rush right for 32 yards gain to the ECU36 (Johnson Jr.,DJ), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU36</br>
+         </span>
+         <span>
+           (13:28) Shotgun Hayes,Baylor pass complete deep left to Foley,Brody caught at ECU14, for 25 yards to the ECU11, End Of Play, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU11</br>
+         </span>
+         <span>
+           (13:09) Shotgun Hayes,Baylor rush middle for 0 yards to the ECU11 fumbled by Hayes,Baylor at ECU17 recovered by TLS Booker,Zion at ECU11, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at ECU11</br>
+         </span>
+         <span>
+           (12:37) Shotgun Hayes,Baylor rush middle for 7 yards gain to the ECU04 (Wilson,Dameon; Riddle,Ja&#39;Marley).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 3 at ECU4</br>
+         </span>
+         <span>
+           Timeout Tulsa, clock 11:55.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 3 at ECU4</br>
+         </span>
+         <span>
+           (11:53) Shotgun Hayes,Baylor pass complete short middle to Booker,Zion caught at ECU08, for 4 yards to the ECU00 TOUCHDOWN, clock 11:51, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU3</br>
+         </span>
+         <span>
+           Morgan,Seth kick attempt good (H: Davies,Angus, LS: Fedigan,Aidan).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="East Carolina" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//196.gif" /><span class='d-none d-sm-block'>East Carolina</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">11:46,ECU16, 7 plays, 84 yards, 02:13</span>
+        </div>
+        <div class="headerRight">14 - 24</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS35</br>
+         </span>
+         <span>
+           (11:51) Morgan,Seth kickoff 60 yards to the ECU05 Pearson,Kyler return 11 yards to the ECU16 (Collins,Dax).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU16</br>
+         </span>
+         <span>
+           East Carolina drive start at 11:46.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU16</br>
+         </span>
+         <span>
+           (11:46) No Huddle-Shotgun Houser,Katin pass incomplete short left to Spalding,Brock thrown to ECU17.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at ECU16</br>
+         </span>
+         <span>
+           (11:43) No Huddle-Shotgun Spalding,Brock rush left for 8 yards gain to the ECU24 (Smith,Solento; Drew,JD), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at ECU24</br>
+         </span>
+         <span>
+           (11:20) No Huddle-Shotgun Montgomery,London rush middle for 3 yards gain to the ECU27 (Hardiman,Tim), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU27</br>
+         </span>
+         <span>
+           (10:56) No Huddle-Shotgun Houser,Katin pass incomplete short right to Riles,Desirrio thrown to ECU30.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at ECU27</br>
+         </span>
+         <span>
+           (10:50) No Huddle-Shotgun Houser,Katin pass complete short right to Montgomery,London caught at ECU21, for 6 yards to the ECU33 (Coney,Ray).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 4 at ECU33</br>
+         </span>
+         <span>
+           (10:11) No Huddle-Shotgun Houser,Katin pass complete short right to Smith,Yannick caught at ECU35, for 4 yards to the ECU37 (Green,Elijah), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU37</br>
+         </span>
+         <span>
+           (09:43) No Huddle-Shotgun Houser,Katin pass complete deep middle to Smith,Anthony caught at TLS20, for 63 yards to the TLS00 TOUCHDOWN, clock 09:33, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS3</br>
+         </span>
+         <span>
+           Mazzie,Nick kick attempt good (H: Leavy,Ryan, LS: O&#39;Brien,Triston).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Tulsa" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//719.gif" /><span class='d-none d-sm-block'>Tulsa</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">09:24,TLS42, 3 plays, 1 yards, 01:41</span>
+        </div>
+        <div class="headerRight">14 - 24</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU35</br>
+         </span>
+         <span>
+           (09:33) Scott,Everett kickoff 62 yards to the TLS03 Washington,Kelvin return 39 yards to the TLS42 (Jean,Jonathan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS42</br>
+         </span>
+         <span>
+           Tulsa drive start at 09:24.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS42</br>
+         </span>
+         <span>
+           (09:24) Shotgun Richardson,Dominic rush right for 4 yards gain to the TLS46 (Dankah,Samuel).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 6 at TLS46</br>
+         </span>
+         <span>
+           (09:06) Shotgun Hayes,Baylor rush right for 3 yards gain to the TLS49 (Wilson,Zion; Davis,Kieran).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 3 at TLS49</br>
+         </span>
+         <span>
+           (08:22) Shotgun Hayes,Baylor sacked for loss of 6 yards to the TLS43 (Craig,Ryheem, Robinson,Jasiyah).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 9 at TLS43</br>
+         </span>
+         <span>
+           (07:48) Davies,Angus punt 46 yards to the ECU11 fair catch by Pearson,Kyler at ECU11.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="East Carolina" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//196.gif" /><span class='d-none d-sm-block'>East Carolina</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">07:43,ECU11, 11 plays, 31 yards, 03:43</span>
+        </div>
+        <div class="headerRight">14 - 24</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU11</br>
+         </span>
+         <span>
+           East Carolina drive start at 07:43.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU11</br>
+         </span>
+         <span>
+           (07:41) No Huddle-Shotgun Montgomery,London rush middle for 5 yards gain to the ECU16 (Anglin,Josh).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 5 at ECU16</br>
+         </span>
+         <span>
+           (07:21) No Huddle-Shotgun Montgomery,London rush middle for 6 yards gain to the ECU22 (Coney,Ray), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU22</br>
+         </span>
+         <span>
+           (07:06) No Huddle-Shotgun Houser,Katin pass complete short left to Conner,Jayvontay caught at ECU26, for 9 yards to the ECU31 (Green,Elijah).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 1 at ECU31</br>
+         </span>
+         <span>
+           (06:47) No Huddle-Shotgun Montgomery,London rush middle for 4 yards gain to the ECU35 (Newhouse,Tai; Coney,Ray), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU35</br>
+         </span>
+         <span>
+           (06:13) No Huddle-Shotgun Montgomery,London rush left for 7 yards gain to the ECU42 (Williams,Zach; Green,Elijah).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 3 at ECU42</br>
+         </span>
+         <span>
+           (05:57) No Huddle-Shotgun Houser,Katin pass incomplete short right to Spalding,Brock thrown to ECU48.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 3 at ECU42</br>
+         </span>
+         <span>
+           (05:51) No Huddle-Shotgun Houser,Katin pass complete short left to Montgomery,London caught at ECU42, for 3 yards to the ECU45 (Cooper,Ty; Williams,Ashton), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU45</br>
+         </span>
+         <span>
+           (05:29) No Huddle-Shotgun Houser,Katin pass incomplete short left to Johnson,Tyler thrown to TLS40 broken up by Green,Elijah.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at ECU45</br>
+         </span>
+         <span>
+           (05:25) No Huddle-Shotgun Houser,Katin rush middle for 8 yards gain to the TLS47 (Anglin,Josh).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at TLS47</br>
+         </span>
+         <span>
+           (04:54) No Huddle-Shotgun Spalding,Brock rush right for 35 yards gain (4) to the TLS12 (Williams,Ashton; Drew,JD) PENALTY ECU Holding (Riles,Desirrio) 10 yards from TLS43 to ECU47.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 8 at ECU47</br>
+         </span>
+         <span>
+           (04:40) No Huddle-Shotgun Houser,Katin rush middle for 5 yards loss to the ECU42, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 13 at ECU42</br>
+         </span>
+         <span>
+           (04:08) Leavy,Ryan punt 47 yards to the TLS11 fair catch by Booker,Zion at TLS11.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Tulsa" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//719.gif" /><span class='d-none d-sm-block'>Tulsa</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">04:00,TLS11, 7 plays, 30 yards, 02:55</span>
+        </div>
+        <div class="headerRight">14 - 24</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS11</br>
+         </span>
+         <span>
+           Tulsa drive start at 04:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS11</br>
+         </span>
+         <span>
+           (03:59) Shotgun Hayes,Baylor pass complete short left to Tease,Micah caught at TLS10, for 1 yard loss to the TLS10, End Of Play. The previous play is under automatic review - &quot;Runner was down by contact&quot;. PLAY OVERTURNED. (Original Play: (03:59) Shotgun #10 B.Hayes pass complete short left to #3 M.Tease caught at TLS10, for 9 yards to the TLS20 (#3 T.Wilk), out of bounds).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 11 at TLS10</br>
+         </span>
+         <span>
+           (03:31) Shotgun Hayes,Baylor pass complete short middle to Steptoe,Zion caught at TLS23, for 19 yards to the TLS29 (Riddle,Ja&#39;Marley), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS29</br>
+         </span>
+         <span>
+           (02:57) Shotgun Hayes,Baylor rush right for 4 yards gain to the TLS33, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 6 at TLS33</br>
+         </span>
+         <span>
+           (02:38) Shotgun Hayes,Baylor pass complete short right to Booker,Zion caught at TLS41, for 8 yards to the TLS41, End Of Play, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS41</br>
+         </span>
+         <span>
+           (02:00) Shotgun Washington,Kelvin rush left for 1 yard gain to the TLS42 (Carr,Preston).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 9 at TLS42</br>
+         </span>
+         <span>
+           (01:27) Shotgun Hayes,Baylor sacked for loss of 1 yard to the TLS41 (Roseborough,Rion, Davis,Kieran).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 10 at TLS41</br>
+         </span>
+         <span>
+           Timeout East Carolina, clock 01:21.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 10 at TLS41</br>
+         </span>
+         <span>
+           (01:21) Shotgun Hayes,Baylor pass incomplete deep right to Tease,Micah thrown to ECU10.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 10 at TLS41</br>
+         </span>
+         <span>
+           (01:16) Davies,Angus punt 51 yards to the ECU08.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="East Carolina" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//196.gif" /><span class='d-none d-sm-block'>East Carolina</span></div></div>
+        <div class="headerLeft">HALF <br/><span style="font-size: 8px;">01:05,ECU8, 7 plays, 35 yards, 01:05</span>
+        </div>
+        <div class="headerRight">14 - 24</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU8</br>
+         </span>
+         <span>
+           East Carolina drive start at 01:05.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU8</br>
+         </span>
+         <span>
+           (01:04) No Huddle-Shotgun Houser,Katin pass complete short right to Conner,Jayvontay caught at ECU11, for 3 yards to the ECU11 (Collins,Dax).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at ECU11</br>
+         </span>
+         <span>
+           (00:58) No Huddle-Shotgun Gunn Jr.,Marlon rush middle for 11 yards gain to the ECU22 (Collins,Dax; Williams,Zach), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU22</br>
+         </span>
+         <span>
+           (00:46) No Huddle-Shotgun Houser,Katin rush middle for 3 yards gain to the ECU25, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at ECU25</br>
+         </span>
+         <span>
+           (00:32) No Huddle-Shotgun Gunn Jr.,Marlon rush middle for 6 yards gain to the ECU31 (Collins,Dax).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at ECU31</br>
+         </span>
+         <span>
+           (00:16) No Huddle-Shotgun Gunn Jr.,Marlon rush middle for 3 yards gain to the ECU34 (Collins,Dax), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU34</br>
+         </span>
+         <span>
+           Timeout East Carolina, clock 00:14.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU34</br>
+         </span>
+         <span>
+           (00:12) No Huddle-Shotgun Houser,Katin pass incomplete short middle to Pettaway,Jaquaize thrown to TLS47.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at ECU34</br>
+         </span>
+         <span>
+           (00:06) No Huddle-Shotgun Houser,Katin pass complete short left to Engleman Jr.,TJ caught at ECU28, for 9 yards to the ECU43 (Robinson,Devin).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at ECU43</br>
+         </span>
+         <span>
+           End of game, clock 00:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS35</br>
+         </span>
+         <span>
+           ECU will receive; TLS will defend East end-zone.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS35</br>
+         </span>
+         <span>
+           Start of 3rd quarter, clock 15:00.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+</div>
+  <div style="border-bottom: 1px dotted #dcdddf;"><h1>3rd Quarter</h1></div>
+<div class="drives">
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="East Carolina" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//196.gif" /><span class='d-none d-sm-block'>East Carolina</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">15:00,ECU25, 3 plays, -10 yards, 00:28</span>
+        </div>
+        <div class="headerRight">14 - 24</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS35</br>
+         </span>
+         <span>
+           (15:00) Morgan,Seth kickoff 58 yards to the ECU07 fair catch by Pearson,Kyler at ECU07.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU25</br>
+         </span>
+         <span>
+           East Carolina drive start at 15:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU25</br>
+         </span>
+         <span>
+           (14:56) No Huddle-Shotgun Wright Jr.,Mike rush left for 11 yards gain to the ECU36, out of bounds at ECU36 PENALTY ECU Holding (Tarpeh,Jayson) 10 yards from ECU25 to ECU15. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 20 at ECU15</br>
+         </span>
+         <span>
+           (14:46) No Huddle-Shotgun Houser,Katin pass incomplete deep left to Gunn Jr.,Marlon thrown to ECU38.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 20 at ECU15</br>
+         </span>
+         <span>
+           (14:41) No Huddle-Shotgun Houser,Katin pass incomplete short right thrown to ECU20.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 20 at ECU15</br>
+         </span>
+         <span>
+           (14:34) No Huddle-Shotgun Houser,Katin pass incomplete short right thrown to ECU20.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 20 at ECU15</br>
+         </span>
+         <span>
+           (14:32) Leavy,Ryan punt 37 yards to the TLS48 fair catch by Booker,Zion at TLS48.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Tulsa" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//719.gif" /><span class='d-none d-sm-block'>Tulsa</span></div></div>
+        <div class="headerLeft">DOWNS <br/><span style="font-size: 8px;">14:32,TLS48, 4 plays, 3 yards, 01:14</span>
+        </div>
+        <div class="headerRight">14 - 24</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS48</br>
+         </span>
+         <span>
+           Tulsa drive start at 14:32.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS48</br>
+         </span>
+         <span>
+           (14:23) Shotgun Richardson,Dominic rush middle for 3 yards gain to the ECU49 (Riddle,Ja&#39;Marley; Robinson,Jasiyah).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at ECU49</br>
+         </span>
+         <span>
+           (14:01) Shotgun Hayes,Baylor pass incomplete short middle to Steptoe,Zion thrown to ECU44 broken up by Craig,Ryheem.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 7 at ECU49</br>
+         </span>
+         <span>
+           (13:59) Shotgun Hayes,Baylor pass complete short middle to Steptoe,Zion caught at ECU36, for 13 yards to the ECU36 (Wilk,Teagan) PENALTY TLS Holding (Hornsby,Codie) 10 yards from ECU49 to TLS41. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 17 at TLS41</br>
+         </span>
+         <span>
+           (13:41) Shotgun Hayes,Baylor pass complete short middle to Steptoe,Zion caught at TLS42, for 15 yards to the ECU44 (Jean,Jonathan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 2 at ECU44</br>
+         </span>
+         <span>
+           (13:18) Shotgun Richardson,Dominic rush middle for 5 yards loss to the ECU49 (Dankah,Samuel; Wilson,Zion), TURNOVER ON DOWNS.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="East Carolina" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//196.gif" /><span class='d-none d-sm-block'>East Carolina</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">13:18,ECU49, 1 plays, 51 yards, 00:09</span>
+        </div>
+        <div class="headerRight">14 - 31</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU49</br>
+         </span>
+         <span>
+           East Carolina drive start at 13:18.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU49</br>
+         </span>
+         <span>
+           (13:17) No Huddle-Shotgun Montgomery,London rush middle for 51 yards gain to the TLS00 TOUCHDOWN, clock 13:09, 1ST DOWN. The previous play is under automatic review - &quot;Runner broke the plane&quot;. PLAY STANDS.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS3</br>
+         </span>
+         <span>
+           Mazzie,Nick kick attempt good (H: Leavy,Ryan, LS: O&#39;Brien,Triston).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Tulsa" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//719.gif" /><span class='d-none d-sm-block'>Tulsa</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">13:06,TLS38, 3 plays, 8 yards, 01:24</span>
+        </div>
+        <div class="headerRight">14 - 31</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU35</br>
+         </span>
+         <span>
+           (13:08) Scott,Everett kickoff 27 yards to the TLS38 muffed by Ballard,Jeremiah at TLS38, out of bounds at TLS38.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS38</br>
+         </span>
+         <span>
+           Tulsa drive start at 13:06.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS38</br>
+         </span>
+         <span>
+           (13:00) Shotgun Washington,Kelvin rush right for 9 yards gain to the TLS47 (Johnson Jr.,DJ).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 1 at TLS47</br>
+         </span>
+         <span>
+           (12:27) Shotgun Hayes,Baylor pass incomplete short right to Richardson,Dominic thrown to TLS44.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at TLS47</br>
+         </span>
+         <span>
+           (12:21) Shotgun Richardson,Dominic rush right for 1 yard loss to the TLS46 (Benton,Josh).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 2 at TLS46</br>
+         </span>
+         <span>
+           (11:43) Davies,Angus punt 44 yards to the ECU10 fair catch by Pearson,Kyler at ECU10.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="East Carolina" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//196.gif" /><span class='d-none d-sm-block'>East Carolina</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">11:42,ECU10, 3 plays, 4 yards, 00:43</span>
+        </div>
+        <div class="headerRight">14 - 31</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU10</br>
+         </span>
+         <span>
+           East Carolina drive start at 11:42.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU10</br>
+         </span>
+         <span>
+           (11:40) No Huddle-Shotgun Engleman Jr.,TJ rush left for 4 yards gain to the ECU14 (Johnson,Nahki; Newhouse,Tai).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 6 at ECU14</br>
+         </span>
+         <span>
+           (11:18) No Huddle-Shotgun Houser,Katin pass incomplete short right to Mangrum,Payton thrown to ECU11.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at ECU14</br>
+         </span>
+         <span>
+           (11:13) No Huddle-Shotgun Houser,Katin pass incomplete short middle to Johnson,Tyler thrown to ECU30 broken up by Robinson,Devin.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 6 at ECU14</br>
+         </span>
+         <span>
+           (11:09) Leavy,Ryan punt 39 yards to the TLS47.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Tulsa" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//719.gif" /><span class='d-none d-sm-block'>Tulsa</span></div></div>
+        <div class="headerLeft">FG <br/><span style="font-size: 8px;">10:59,TLS47, 10 plays, 25 yards, 03:47</span>
+        </div>
+        <div class="headerRight">17 - 31</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS47</br>
+         </span>
+         <span>
+           Tulsa drive start at 10:59.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS47</br>
+         </span>
+         <span>
+           (10:57) Shotgun Hayes,Baylor pass complete short right to Booker,Zion caught at ECU49, for 9 yards to the ECU44 (Graves,Chance).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 1 at ECU44</br>
+         </span>
+         <span>
+           (10:11) Shotgun Hayes,Baylor rush middle for 5 yards loss to the ECU49, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at ECU49</br>
+         </span>
+         <span>
+           (09:55) Shotgun Richardson,Dominic rush right for 6 yards gain to the ECU43 (Merrell,Kevon), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU43</br>
+         </span>
+         <span>
+           (09:37) Shotgun Hayes,Baylor pass incomplete short middle to Tempest,Grayson thrown to ECU43 broken up by Craig,Ryheem.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at ECU43</br>
+         </span>
+         <span>
+           (09:33) Shotgun Hayes,Baylor pass complete short right to Tempest,Grayson caught at ECU38, for 7 yards to the ECU36, out of bounds at ECU36.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 3 at ECU36</br>
+         </span>
+         <span>
+           (09:02) Shotgun Hayes,Baylor pass complete short right to Booker,Zion caught at ECU31, for 13 yards to the ECU23 (Riddle,Ja&#39;Marley), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU23</br>
+         </span>
+         <span>
+           (08:38) Shotgun Hayes,Baylor pass incomplete short right to Roberts,Jewlyen thrown to ECU10 PENALTY TLS Illegal Formation declined.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at ECU23</br>
+         </span>
+         <span>
+           (08:32) Shotgun Hayes,Baylor rush left for 3 yards gain to the ECU20 (Wilson,Dameon).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 7 at ECU20</br>
+         </span>
+         <span>
+           (07:57) Shotgun Hayes,Baylor sacked for loss of 8 yards to the ECU28 (Carr,Preston).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 15 at ECU28</br>
+         </span>
+         <span>
+           (07:14) Morgan,Seth field goal attempt from 46 yards GOOD (H: Davies,Angus, LS: Fedigan,Aidan), clock 07:12.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="East Carolina" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//196.gif" /><span class='d-none d-sm-block'>East Carolina</span></div></div>
+        <div class="headerLeft">DOWNS <br/><span style="font-size: 8px;">07:12,ECU25, 11 plays, 40 yards, 04:53</span>
+        </div>
+        <div class="headerRight">17 - 31</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS35</br>
+         </span>
+         <span>
+           (07:12) Morgan,Seth kickoff 65 yards to the ECU00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU25</br>
+         </span>
+         <span>
+           East Carolina drive start at 07:12.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU25</br>
+         </span>
+         <span>
+           (07:10) No Huddle-Shotgun Montgomery,London rush right for 5 yards gain to the ECU30 (Williams,Zach).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 5 at ECU30</br>
+         </span>
+         <span>
+           (06:53) No Huddle-Shotgun Montgomery,London rush middle for 3 yards gain to the ECU33 (Hjelle,Joe).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at ECU33</br>
+         </span>
+         <span>
+           (06:22) No Huddle-Shotgun Houser,Katin pass complete short left to Montgomery,London caught at ECU28, for 1 yard to the ECU34 (Coney,Ray).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 1 at ECU34</br>
+         </span>
+         <span>
+           (05:43) No Huddle-Shotgun Montgomery,London rush middle for 5 yards gain to the ECU39 (Alexander,William), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU39</br>
+         </span>
+         <span>
+           (05:18) No Huddle-Shotgun Montgomery,London rush middle for 3 yards gain to the ECU42 (Hardiman,Tim).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at ECU42</br>
+         </span>
+         <span>
+           (04:56) No Huddle-Shotgun Houser,Katin sacked for loss of 4 yards to the ECU38 (Burnett,J&#39;Dan, Hjelle,Joe).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 11 at ECU38</br>
+         </span>
+         <span>
+           (04:20) No Huddle-Shotgun Houser,Katin pass complete short right to Mangrum,Payton caught at TLS46, for 18 yards to the TLS44 (Smith,Solento), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS44</br>
+         </span>
+         <span>
+           (03:37) No Huddle-Shotgun Engleman Jr.,TJ rush middle for 2 yards loss to the TLS46 (Turner Jr.,Byron; Cooper,Ty).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 12 at TLS46</br>
+         </span>
+         <span>
+           (03:19) No Huddle-Shotgun Engleman Jr.,TJ rush middle for 11 yards gain to the TLS35 (Williams,Zach).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at TLS35</br>
+         </span>
+         <span>
+           (03:08) No Huddle-Shotgun Engleman Jr.,TJ rush middle for 0 yards to the TLS35 (Potts,Eli).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 1 at TLS35</br>
+         </span>
+         <span>
+           (02:25) No Huddle-Shotgun Engleman Jr.,TJ rush middle for 0 yards to the TLS35 (Alexander,William; Williams,Zach), TURNOVER ON DOWNS. The previous play is under automatic review - &quot;Short of the line to gain&quot;. PLAY STANDS.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Tulsa" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//719.gif" /><span class='d-none d-sm-block'>Tulsa</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">02:19,TLS35, 8 plays, 65 yards, 02:32</span>
+        </div>
+        <div class="headerRight">24 - 31</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS35</br>
+         </span>
+         <span>
+           Tulsa drive start at 02:19.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS35</br>
+         </span>
+         <span>
+           (02:18) Shotgun Hayes,Baylor pass complete short middle to Foley,Brody caught at TLS40, for 6 yards to the TLS41 (McKinley,Kamaurri).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 4 at TLS41</br>
+         </span>
+         <span>
+           (01:59) Shotgun Hayes,Baylor pass incomplete short right to Foley,Brody thrown to TLS45 broken up by Dankah,Samuel.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 4 at TLS41</br>
+         </span>
+         <span>
+           (01:55) Shotgun Hayes,Baylor pass incomplete short middle to Booker,Zion thrown to TLS45.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 4 at TLS41</br>
+         </span>
+         <span>
+           (01:51) Shotgun Hayes,Baylor pass complete short left to Foley,Brody caught at TLS50, for 36 yards to the ECU23 (Lowery,Jordy), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU23</br>
+         </span>
+         <span>
+           (01:18) Shotgun Hayes,Baylor pass complete short left to Foley,Brody caught at ECU07, for 18 yards to the ECU05 QB hurried by Johnson Jr.,DJ (Lowery,Jordy), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 5 at ECU5</br>
+         </span>
+         <span>
+           (00:26) Shotgun Allen,Ajay rush middle for 0 yards to the ECU05 (Carr,Preston).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 5 at ECU5</br>
+         </span>
+         <span>
+           (15:00) Shotgun Hayes,Baylor rush middle for 4 yards gain to the ECU01 (Riddle,Ja&#39;Marley).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at ECU1</br>
+         </span>
+         <span>
+           Start of 4th quarter, clock 15:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at ECU1</br>
+         </span>
+         <span>
+           (14:58) Kittleman,Stephen rush middle for 1 yard gain to the ECU00 TOUCHDOWN, clock 14:47.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU3</br>
+         </span>
+         <span>
+           Morgan,Seth kick attempt good (H: Davies,Angus, LS: Fedigan,Aidan).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+</div>
+  <div style="border-bottom: 1px dotted #dcdddf;"><h1>4th Quarter</h1></div>
+<div class="drives">
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="East Carolina" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//196.gif" /><span class='d-none d-sm-block'>East Carolina</span></div></div>
+        <div class="headerLeft">FG <br/><span style="font-size: 8px;">14:47,ECU25, 11 plays, 61 yards, 03:56</span>
+        </div>
+        <div class="headerRight">24 - 34</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS35</br>
+         </span>
+         <span>
+           (14:47) Morgan,Seth kickoff 63 yards to the ECU02 fair catch by Pearson,Kyler at ECU02.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU25</br>
+         </span>
+         <span>
+           East Carolina drive start at 14:47.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU25</br>
+         </span>
+         <span>
+           (14:42) No Huddle-Shotgun Houser,Katin pass incomplete short right to Riles,Desirrio thrown to ECU30.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at ECU25</br>
+         </span>
+         <span>
+           (14:42) No Huddle-Shotgun Houser,Katin pass complete short middle to Riles,Desirrio caught at ECU29, for 10 yards to the ECU35 (Coney,Ray; Williams,Zach), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU35</br>
+         </span>
+         <span>
+           (14:19) No Huddle-Shotgun Montgomery,London rush middle for 4 yards gain to the ECU39 (Anglin,Josh).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 6 at ECU39</br>
+         </span>
+         <span>
+           (13:55) No Huddle-Shotgun Montgomery,London rush middle for 14 yards gain to the TLS47 (Williams,Zach), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS47</br>
+         </span>
+         <span>
+           (13:31) No Huddle-Shotgun Houser,Katin pass complete short left to Riles,Desirrio caught at TLS45, for 14 yards to the TLS33 (Williams,Zach), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS33</br>
+         </span>
+         <span>
+           (13:04) No Huddle-Shotgun Montgomery,London rush middle for 2 yards gain to the TLS31 (Hardiman,Tim).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 8 at TLS31</br>
+         </span>
+         <span>
+           (12:43) No Huddle-Shotgun Houser,Katin pass complete short middle to Riles,Desirrio caught at TLS26, for 11 yards to the TLS20 (Turner III,C.J.), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS20</br>
+         </span>
+         <span>
+           (11:59) No Huddle-Shotgun Wright Jr.,Mike rush middle for 2 yards gain to the TLS18 (Coney,Ray; Alexander,William).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 8 at TLS18</br>
+         </span>
+         <span>
+           (11:31) No Huddle-Shotgun Houser,Katin pass complete short right to Mangrum,Payton caught at TLS15, for 4 yards to the TLS14 (Smith,Solento).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 4 at TLS14</br>
+         </span>
+         <span>
+           (10:58) No Huddle-Shotgun Houser,Katin pass incomplete short middle to Mangrum,Payton thrown to TLS12.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 4 at TLS14</br>
+         </span>
+         <span>
+           (10:53) Mazzie,Nick field goal attempt from 32 yards GOOD (H: Leavy,Ryan, LS: O&#39;Brien,Triston), clock 10:51.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU35</br>
+         </span>
+         <span>
+           TLS ball on TLS30.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Tulsa" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//719.gif" /><span class='d-none d-sm-block'>Tulsa</span></div></div>
+        <div class="headerLeft">DOWNS <br/><span style="font-size: 8px;">10:51,TLS30, 7 plays, 11 yards, 02:16</span>
+        </div>
+        <div class="headerRight">24 - 34</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU35</br>
+         </span>
+         <span>
+           (10:51) Scott,Everett kickoff 65 yards to the TLS00, Touchback PENALTY ECU Offside (Benton,Josh) 5 yards from TLS25 to TLS30.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS30</br>
+         </span>
+         <span>
+           Tulsa drive start at 10:51.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS30</br>
+         </span>
+         <span>
+           (10:44) Shotgun Hayes,Baylor pass incomplete short middle to Booker,Zion thrown to TLS35 QB hurried by Benton,Justin.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at TLS30</br>
+         </span>
+         <span>
+           (10:42) Shotgun Hayes,Baylor pass incomplete deep right to Steptoe,Zion thrown to ECU25 PENALTY ECU Pass Interference (Lowery,Jordy) 15 yards from TLS30 to TLS45, 1ST DOWN. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS45</br>
+         </span>
+         <span>
+           (10:35) Shotgun Richardson,Dominic rush right for 6 yards gain to the ECU49 (Wilk,Teagan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 4 at ECU49</br>
+         </span>
+         <span>
+           (09:59) Shotgun Richardson,Dominic rush left for 5 yards gain to the ECU44 (Robinson,Jasiyah), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU44</br>
+         </span>
+         <span>
+           (09:26) Shotgun Hayes,Baylor pass incomplete short left to Booker,Zion thrown to ECU43.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at ECU44</br>
+         </span>
+         <span>
+           (09:21) Shotgun Hayes,Baylor sacked for loss of 5 yards to the ECU49 (Wilson,Zion, Dankah,Samuel).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 15 at ECU49</br>
+         </span>
+         <span>
+           (08:48) Shotgun Hayes,Baylor pass complete short middle to Booker,Zion caught at ECU47, for 0 yards to the ECU49 (Dankah,Samuel) PENALTY TLS Pass Interference declined.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 15 at ECU49</br>
+         </span>
+         <span>
+           (08:40) Shotgun Hayes,Baylor sacked for loss of 10 yards to the TLS41 (Roseborough,Rion), TURNOVER ON DOWNS. The previous play is under automatic review - &quot;Runner was down prior to losing the ball&quot;. PLAY OVERTURNED. (Original Play: (08:40) Shotgun #10 B.Hayes sacked for loss of 10 yards to the TLS41 (#93 R.Roseborough), fumble by #10 B.Hayes recovered by ECU #9 J.Lampley at TLS41 #9 J.Lampley return 41 yards to the TLS00 TOUCHDOWN, clock 08:35).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="East Carolina" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//196.gif" /><span class='d-none d-sm-block'>East Carolina</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">08:35,TLS41, 8 plays, 41 yards, 03:13</span>
+        </div>
+        <div class="headerRight">24 - 41</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS41</br>
+         </span>
+         <span>
+           East Carolina drive start at 08:35.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS41</br>
+         </span>
+         <span>
+           (08:33) No Huddle-Shotgun Gunn Jr.,Marlon rush middle for 3 yards gain to the TLS38 (Hjelle,Joe).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at TLS38</br>
+         </span>
+         <span>
+           (08:12) No Huddle-Shotgun Gunn Jr.,Marlon rush middle for 4 yards gain to the TLS34 (Alexander,William).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 3 at TLS34</br>
+         </span>
+         <span>
+           (07:45) No Huddle-Shotgun Gunn Jr.,Marlon rush left for 13 yards gain to the TLS21 (Williams,Zach), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS21</br>
+         </span>
+         <span>
+           (07:21) No Huddle-Shotgun Gunn Jr.,Marlon rush middle for 2 yards gain to the TLS19 (Burnett,J&#39;Dan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 8 at TLS19</br>
+         </span>
+         <span>
+           (06:50) No Huddle-Shotgun Houser,Katin rush middle for 14 yards gain to the TLS05 (Williams,Zach), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 5 at TLS5</br>
+         </span>
+         <span>
+           (06:14) No Huddle-Shotgun Gunn Jr.,Marlon rush middle for 1 yard loss to the TLS06 (Robinson,Devin).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 6 at TLS6</br>
+         </span>
+         <span>
+           (05:43) No Huddle-Shotgun Gunn Jr.,Marlon rush middle for 4 yards gain to the TLS02 (Alexander,William; Robinson,Devin).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at TLS2</br>
+         </span>
+         <span>
+           (05:25) No Huddle-Shotgun Houser,Katin rush middle for 2 yards gain to the TLS00 TOUCHDOWN, clock 05:22.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS3</br>
+         </span>
+         <span>
+           Mazzie,Nick kick attempt good (H: Leavy,Ryan, LS: O&#39;Brien,Triston).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Tulsa" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//719.gif" /><span class='d-none d-sm-block'>Tulsa</span></div></div>
+        <div class="headerLeft">FG <br/><span style="font-size: 8px;">05:19,TLS29, 11 plays, 63 yards, 03:30</span>
+        </div>
+        <div class="headerRight">27 - 41</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU35</br>
+         </span>
+         <span>
+           (05:22) Scott,Everett kickoff 41 yards to the TLS24 Lucas,Landen return 5 yards to the TLS29 (Duncanson,Ayden).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS29</br>
+         </span>
+         <span>
+           Tulsa drive start at 05:19.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS29</br>
+         </span>
+         <span>
+           (05:18) Shotgun Hayes,Baylor pass complete short middle to Booker,Zion caught at TLS34, for 5 yards to the TLS34 (Roseborough,Rion; Wilk,Teagan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 5 at TLS34</br>
+         </span>
+         <span>
+           (04:59) Shotgun Hayes,Baylor pass incomplete short middle to Steptoe,Zion thrown to ECU50.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 5 at TLS34</br>
+         </span>
+         <span>
+           (04:54) Shotgun Hayes,Baylor pass complete short right to Steptoe,Zion caught at TLS42, for 9 yards to the TLS43 (Merrell,Kevon), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS43</br>
+         </span>
+         <span>
+           (04:36) Shotgun Hayes,Baylor pass complete short right to Foley,Brody caught at TLS46, for 3 yards to the TLS46 (Horsley,Derrion).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at TLS46</br>
+         </span>
+         <span>
+           (04:08) Shotgun Richardson,Dominic rush left for 13 yards gain to the ECU41 (Wilk,Teagan), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU41</br>
+         </span>
+         <span>
+           (03:41) Shotgun Hayes,Baylor rush middle for 24 yards gain to the ECU17, out of bounds at ECU17, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU17</br>
+         </span>
+         <span>
+           (03:04) Shotgun Richardson,Dominic rush right for 13 yards gain to the ECU04 (Wilson,Dameon), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 4 at ECU4</br>
+         </span>
+         <span>
+           (02:35) Shotgun Richardson,Dominic rush middle for 1 yard loss to the ECU05 (Duncanson,Ayden; McKinley,Kamaurri).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 5 at ECU5</br>
+         </span>
+         <span>
+           Timeout East Carolina, clock 02:13.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 5 at ECU5</br>
+         </span>
+         <span>
+           (02:11) Shotgun Richardson,Dominic rush right for 3 yards loss to the ECU08 (Wilk,Teagan; Craig,Ryheem).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 8 at ECU8</br>
+         </span>
+         <span>
+           (01:59) Shotgun Hayes,Baylor pass incomplete short middle to Tempest,Grayson thrown to ECU00 QB hurried by Robinson,Jasiyah.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 8 at ECU8</br>
+         </span>
+         <span>
+           (01:49) Morgan,Seth field goal attempt from 26 yards GOOD (H: Davies,Angus, LS: Fedigan,Aidan), clock 01:49.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS45</br>
+         </span>
+         <span>
+           Timeout East Carolina, clock 01:49.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="East Carolina" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//196.gif" /><span class='d-none d-sm-block'>East Carolina</span></div></div>
+        <div class="headerLeft">DOWNS <br/><span style="font-size: 8px;">01:49,TLS45, 4 plays, 7 yards, 00:26</span>
+        </div>
+        <div class="headerRight">27 - 41</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS35</br>
+         </span>
+         <span>
+           (01:49) Zilmer,Carson onside kickoff 10 yards to the TLS45, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS45</br>
+         </span>
+         <span>
+           East Carolina drive start at 01:49.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS45</br>
+         </span>
+         <span>
+           (01:50) No Huddle-Shotgun Gunn Jr.,Marlon rush middle for 1 yard gain to the TLS44 (Alexander,William; Newhouse,Tai).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 9 at TLS44</br>
+         </span>
+         <span>
+           Timeout Tulsa, clock 01:44.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 9 at TLS44</br>
+         </span>
+         <span>
+           (01:36) No Huddle-Shotgun Gunn Jr.,Marlon rush left for 6 yards gain to the TLS38 (Burnett,J&#39;Dan; Smith,Solento).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 3 at TLS38</br>
+         </span>
+         <span>
+           Timeout Tulsa, clock 01:36.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 3 at TLS38</br>
+         </span>
+         <span>
+           (01:34) No Huddle-Shotgun Gunn Jr.,Marlon rush middle for 0 yards to the TLS38 (Coney,Ray; Drew,JD).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 3 at TLS38</br>
+         </span>
+         <span>
+           Timeout East Carolina, clock 01:30.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 3 at TLS38</br>
+         </span>
+         <span>
+           (01:28) No Huddle-Shotgun Wright Jr.,Mike rush middle for 0 yards to the TLS38 (Ball,Hudson), TURNOVER ON DOWNS.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Tulsa" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//719.gif" /><span class='d-none d-sm-block'>Tulsa</span></div></div>
+        <div class="headerLeft">DOWNS <br/><span style="font-size: 8px;">01:23,TLS38, 5 plays, 22 yards, 00:46</span>
+        </div>
+        <div class="headerRight">27 - 41</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS38</br>
+         </span>
+         <span>
+           Tulsa drive start at 01:23.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TLS38</br>
+         </span>
+         <span>
+           (01:23) Shotgun Hayes,Baylor pass complete short left to Steptoe,Zion caught at TLS45, for 14 yards to the ECU48 (Horsley,Derrion), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU48</br>
+         </span>
+         <span>
+           (01:10) Shotgun Hayes,Baylor pass complete short left to Booker,Zion caught at ECU46, for 2 yards to the ECU46, out of bounds at ECU46.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 8 at ECU46</br>
+         </span>
+         <span>
+           (01:06) Shotgun Hayes,Baylor pass complete short left to Presley,Braylin caught at ECU42, for 4 yards to the ECU42, out of bounds at ECU42.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 4 at ECU42</br>
+         </span>
+         <span>
+           (01:02) Shotgun Presley,Braylin rush right for 2 yards gain to the ECU40 (Dankah,Samuel).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 2 at ECU40</br>
+         </span>
+         <span>
+           (00:40) Shotgun Presley,Braylin rush right for 0 yards to the ECU40 (Jean,Jonathan), TURNOVER ON DOWNS.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="East Carolina" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//196.gif" /><span class='d-none d-sm-block'>East Carolina</span></div></div>
+        <div class="headerLeft"> <br/><span style="font-size: 8px;">00:37,ECU40, 1 plays, 0 yards, 00:37</span>
+        </div>
+        <div class="headerRight">27 - 41</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU40</br>
+         </span>
+         <span>
+           East Carolina drive start at 00:37.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at ECU40</br>
+         </span>
+         <span>
+           (00:33) Kneel down by Houser,Katin at ECU40 for loss of 0 yards.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at ECU40</br>
+         </span>
+         <span>
+           End of game, clock 00:00.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+</div>
+</div>
+
+
+
+       </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<footer>&copy; <script>document.write(new Date().getFullYear())</script> NCAA <a href="http://web1.ncaa.org/web_files/terms_and_conditions.html" title ="Terms and Conditions" target=_blank>Terms and Conditions</a> | <a href="http://web1.ncaa.org/web_files/privacy.html" target=_blank title="Our Privacy Policy">Privacy Policy</a> | <a href="mailto:ncaastats@ncaa.org">Contact Us</a> </footer>
+
+  <!-- /.container -->
+  <script type="text/javascript"  src="/QFrxqVkNu/zpMzxVZYg/LrV9L4r53Db3/PBxcAQ/GW/BCHRleLw0V?v=7618068e-1f1a-8726-648f-0d3e09941703" defer></script></body>
+
+  <script charset="utf-8">
+    $(document).ready(function() {
+      $('a.remote[data-toggle="tab"]').on('show.bs.tab', function (e) {
+        var tab_id = '#' + $(this).attr('aria-controls');
+        $(tab_id).html('<br/><br/><p style="text-align: center"><img style="vertical-align:middle; text-align: center" src="/assets/ajax-loader-6913acdbf4be7d6a2908a84bdecd6cad18110f5fc6d5a07cf8c9ce78d9548700.gif" /> Loading... </p><br/><br/>');
+        $.get($(this).data('remote'), function(data){
+          $(tab_id).html(data);
+        });
+      });
+    });
+
+    function skipMask(obj){
+      if (obj.hasClass('chosen-single') || obj.hasClass('skipMask') || obj.hasClass('ui-datepicker-prev') || obj.hasClass('ui-datepicker-next') || obj.hasClass('ui-corner-all') || obj.hasClass('paginate_button') || obj.hasClass('dt-button')){
+        return true;
+      }else{
+        return false;
+      }
+    }
+
+    $(document).ajaxComplete(function(){
+      unmask();
+    });
+/*
+    $("form").on('submit', function(event){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    */
+    $(document).on('click', 'a', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    $(document).on('click', 'input.green', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+
+  </script>
+</html>

--- a/tests/fixtures/cfb_ncaa/mfb_play_by_play_6386574.html
+++ b/tests/fixtures/cfb_ncaa/mfb_play_by_play_6386574.html
@@ -1,0 +1,2510 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<META HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=UTF-8">
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="">
+<meta name="author" content="">
+<meta name="version" content="321d28433e9f7a188596117e6f342ec4a84fb4ed">
+<META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<link rel="shortcut icon" href="/assets/favicon-405088046a5f2bab8eedeacfae7636975c095e9c8decd8c28e3fd0e65c2f51c4.ico" type="image/vnd.microsoft.icon">
+
+<title>NCAA Statistics</title>
+
+<!-- Bootstrap core CSS -->
+
+<!--
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+-->
+<!--
+<link rel="stylesheet" href="https://cdn.datatables.net/2.0.0/css/dataTables.bootstrap4.css" crossorigin="anonymous">
+-->
+<link rel="stylesheet" media="all" href="/assets/application-789c3971842ee3597428ccbebd021716b3231e9cbd0a00a184c3b2d6c8e5f152.css" />
+
+
+<script src="/assets/application-9232576bb3cb000ac0841ff2af81251908ec17312a3c5eb72bf1a32f9754800c.js"></script>
+<!--
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+-->
+<!--
+<script src="https://cdn.datatables.net/2.0.0/js/dataTables.bootstrap4.js" crossorigin="anonymous"></script>
+-->
+
+<meta name="csrf-param" content="authenticity_token" />
+<meta name="csrf-token" content="qNczNLMLGxTcGRn7fD9bpq7dS84iOA1snvxYzhXl6j0cB/wca2VV9IZH3bqFgvjM4y7rSmx0SAPh+3/HGC5YKA==" />
+
+<style>
+.grid {clear: all}
+.grid-item, .name {text-align: center;}
+h1 img {max-height: 33px;}
+
+</style>
+<!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+<!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+      <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+    <![endif]-->
+
+
+<script>(window.BOOMR_mq=window.BOOMR_mq||[]).push(["addVar",{"rua.upush":"false","rua.cpush":"false","rua.upre":"false","rua.cpre":"false","rua.uprl":"false","rua.cprl":"false","rua.cprf":"false","rua.trans":"","rua.cook":"false","rua.ims":"false","rua.ufprl":"false","rua.cfprl":"false","rua.isuxp":"false","rua.texp":"norulematch","rua.ceh":"false","rua.ueh":"false","rua.ieh.st":"0"}]);</script>
+                                <script>!function(e){var n="https://s.go-mpulse.net/boomerang/";if("False"=="True")e.BOOMR_config=e.BOOMR_config||{},e.BOOMR_config.PageParams=e.BOOMR_config.PageParams||{},e.BOOMR_config.PageParams.pci=!0,n="https://s2.go-mpulse.net/boomerang/";if(window.BOOMR_API_key="EVKJV-AGD2E-W66AE-NT84S-K5LTF",function(){function e(){if(!r){var e=document.createElement("script");e.id="boomr-scr-as",e.src=window.BOOMR.url,e.async=!0,o.appendChild(e),r=!0}}function t(e){r=!0;var n,t,a,i,d=document,O=window;if(window.BOOMR.snippetMethod=e?"if":"i",t=function(e,n){var t=d.createElement("script");t.id=n||"boomr-if-as",t.src=window.BOOMR.url,BOOMR_lstart=(new Date).getTime(),e=e||d.body,e.appendChild(t)},!window.addEventListener&&window.attachEvent&&navigator.userAgent.match(/MSIE [67]\./))return window.BOOMR.snippetMethod="s",void t(o,"boomr-async");a=document.createElement("IFRAME"),a.src="about:blank",a.title="",a.role="presentation",a.loading="eager",i=(a.frameElement||a).style,i.width=0,i.height=0,i.border=0,i.display="none",o.appendChild(a);try{O=a.contentWindow,d=O.document.open()}catch(_){n=document.domain,a.src="javascript:var d=document.open();d.domain='"+n+"';void 0;",O=a.contentWindow,d=O.document.open()}if(n)d._boomrl=function(){this.domain=n,t()},d.write("<bo"+"dy onload='document._boomrl();'>");else if(O._boomrl=function(){t()},O.addEventListener)O.addEventListener("load",O._boomrl,!1);else if(O.attachEvent)O.attachEvent("onload",O._boomrl);d.close()}function a(e){window.BOOMR_onload=e&&e.timeStamp||(new Date).getTime()}if(!window.BOOMR||!window.BOOMR.version&&!window.BOOMR.snippetExecuted){window.BOOMR=window.BOOMR||{},window.BOOMR.snippetStart=(new Date).getTime(),window.BOOMR.snippetExecuted=!0,window.BOOMR.snippetVersion=14,window.BOOMR.url=n+"EVKJV-AGD2E-W66AE-NT84S-K5LTF";var i=document.currentScript||document.getElementsByTagName("script")[0],o=i.parentNode,r=!1,d=document.createElement("link");if(d.relList&&"function"==typeof d.relList.supports&&d.relList.supports("preload")&&"as"in d)window.BOOMR.snippetMethod="p",d.href=window.BOOMR.url,d.rel="preload",d.as="script",d.addEventListener("load",e),d.addEventListener("error",function(){t(!0)}),setTimeout(function(){if(!r)t(!0)},3e3),BOOMR_lstart=(new Date).getTime(),o.appendChild(d);else t(!1);if(window.addEventListener)window.addEventListener("load",a,!1);else if(window.attachEvent)window.attachEvent("onload",a)}}(),"".length>0)if(e&&"performance"in e&&e.performance&&"function"==typeof e.performance.setResourceTimingBufferSize)e.performance.setResourceTimingBufferSize();!function(){if(BOOMR=e.BOOMR||{},BOOMR.plugins=BOOMR.plugins||{},!BOOMR.plugins.AK){var n=""=="true"?1:0,t="cookiepresent",a="jsi4mzyxjn7fy2ufvejq-f-6f8841b76-clientnsv4-s.akamaihd.net",i="false"=="true"?2:1,o={"ak.v":"41","ak.cp":"1168236","ak.ai":parseInt("215853",10),"ak.ol":"0","ak.cr":155,"ak.ipv":4,"ak.proto":"h2","ak.rid":"444f7cd0","ak.r":41112,"ak.a2":n,"ak.m":"a","ak.n":"essl","ak.cport":57194,"ak.gh":"104.120.208.208","ak.quicv":"","ak.tlsv":"tls1.3","ak.0rtt":"","ak.0rtt.ed":"","ak.csrc":"-","ak.acc":"","ak.t":"1787144467","ak.ak":"hOBiQwZUYzCg5VSAfCLimQ==pj/YmgsZ+J5wm/mGU2izvjUKSACtDmC2gf0efFj7pqvmrYdP4H2R8OToNhHl4K/gv3hT59s6p+5tC2U2jL5X1D8OIBpVmsF09OKLdcEz4P6RaslVgzkuEY12lNrv44fBtTPm1lTTPgmXB9Gtd1oSF+avIZ612aajCnfvLwmqRouBi+7C3yMZK/P45x+Dv0DSCykfNV+26tVxOc6CCM0+RcrR9hTgjII7ngiyoqgopFM8+nyZyfDRLgRPmUNDU7TtWzV05Qt9Qyl4ZVY7eNluxQRHBmARbj+HFzUwh9ck5dWOe9ChfDDg44Tvoj+ZnwM0UhwOAZcwStuN/5AHsTsVq3LgUMe4e6NQ8xrOGnLW32h1r+Lb9ajaeHS6fZ/YxDVeA3PoiDX2dszLHfk4s7d1E/892Y9EiucjAWhGzGy79Pk=","ak.pv":"93","ak.dpoabenc":"","ak.tf":i};if(""!==t)o["ak.ruds"]=t;var r={i:!1,av:function(n){var t="http.initiator";if(n&&(!n[t]||"spa_hard"===n[t]))o["ak.feo"]=void 0!==e.aFeoApplied?1:0,BOOMR.addVar(o)},rv:function(){var e=["ak.cport","ak.cr","ak.csrc","ak.gh","ak.ipv","ak.m","ak.n","ak.ol","ak.proto","ak.quicv","ak.tlsv","ak.0rtt","ak.0rtt.ed","ak.r","ak.acc","ak.t","ak.tf"];BOOMR.removeVar(e)}};BOOMR.plugins.AK={akVars:o,akDNSPreFetchDomain:a,init:function(){if(!r.i){var e=BOOMR.subscribe;e("before_beacon",r.av,null,null),e("onbeacon",r.rv,null,null),r.i=!0}return this},is_complete:function(){return!0}}}}()}(window);</script></head>
+
+  <script>
+
+    
+  //initialize tooltip
+  $(document).ready(function() {
+    //$("body").tooltip({ selector: '[data-toggle=tooltip]' });
+    $('[data-toggle="tooltip"]').tooltip();
+  });
+
+  $(document).ready(function() {
+    $( "#org_name" ).autocomplete({
+      source: '/team/search',
+      select: function( event, ui ) {
+        $("#org_id").val(ui.item.vid);
+        $("#id").val(ui.item.vid);
+        $('#sport_btn').click();
+      }
+    });
+  });
+
+  var body = 'body';
+
+  $.ajaxSetup ({
+    // Disable caching of AJAX responses
+    cache: false
+  });
+
+  function changeSport(field){
+    var el = $(field);
+    var tmList = el.parent().next().find('.new-team-year')[0];
+    if (tmList == null){
+      tmList = el.nextAll('.new-team-year')[0];
+    }
+    $.ajax({
+      url: "/game_sport_year_ctls/"+el.val()+"/available_teams",
+      dataType: "script",
+      success: function(data, status){
+        $(tmList).empty();
+        $(tmList).append(("<option value=''>Select team</option>"));
+        $.each(JSON.parse(data), function(k, v){
+          $(tmList).append($("<option></option>")
+              .attr("value", v["id"])
+              .text(v["member_org"]["name_tabular"]));
+        });
+        $(tmList).trigger("chosen:updated");
+      }
+    });
+  }
+
+    function set_process_styles(fld, start_color, end_color){
+       $('#'+fld).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    var downImage = "/assets/down12.gif";
+    var rightImage = "/assets/right12.gif";
+
+    function highlight(div_id){
+      $(div_id).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    function show_hide_rows(attr_val, link_id){
+      $('#'+attr_val).toggle();
+      if ($('#'+attr_val).is(':visible')) {
+        $('#'+link_id).attr('src', downImage);
+      }else{
+        $('#'+link_id).attr('src', rightImage);
+      }
+    }
+
+    function mask(label){
+      $('body').mask(label);
+    }
+    function unmask(){
+      $('body').unmask();
+    }
+
+    var winHeight = "auto";
+    var winWidth = "auto";
+    var maxHeight = 700;
+    var maxWidth = 1400;
+    var minHeight = 100;
+    var minWidth = 200;
+    
+    var modalOptions = {"width": winWidth,
+                        "height": winHeight,
+                        "maxHeight": maxHeight,
+                        "maxWidth": maxWidth,
+                        "minHeight": minHeight,
+                        "minWidth": minWidth};
+
+    function dialog(url, title){
+
+      $("#stats_app_dialog").dialog({modal:true, minWidth:minWidth, minHeight:minHeight, maxWidth:maxWidth, maxHeight:maxHeight, width:winWidth, height:winHeight, title:title, closeOnEscape: false});
+    
+      modalOptions.title = title;
+    
+      $("#stats_app_dialog").dialog("option", modalOptions);
+    
+      $("#stats_app_dialog").html("Loading...");
+      $("#stats_app_dialog").load(url).dialog('open');
+    }
+
+    function addDatePicker(){
+    $('.adddatepicker').each(function(i, obj){
+      $(obj).datepicker({ 
+        showOn: 'both', 
+        buttonImage: '/assets/calendar.gif', 
+        buttonImageOnly: true,
+      });
+    });
+    }
+
+   $(document).ready(function() {
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   });
+
+   function setClassInputFields(){
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   }
+
+   function isValidDateFormat(dateStr){
+     const regex = /^([1-9]|0[1-9]|1[0-2])\/([1-9]|0[1-9]|[12][0-9]|3[01])\/(19|20)\d{2}$/;
+     if (!regex.test(dateStr)) {
+       return false;
+     }else{
+       return true;
+     }
+   }
+
+  </script>
+
+
+<body style="font-size: .75rem;" onload="if (top != self) { top.location=self.location; }" >
+
+      <header>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0">
+        <a class="navbar-brand mr-0 mr-md-2" href="/" aria-label="statistics">
+                          <img alt="NCAA" style="margin-left: 24px; margin-right: 0; margin-top: 6px;" src="/assets/ncaa-fbc4d0406ae731b47babcc3fca53775b5955ef372bf8b8e998ca9a513e468b8f.svg" />
+                          <span class="title" class="dark-blue-font">Statistics</span>
+        </a>
+       </nav>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0" style="background-color: var(--color-dark-blue) !important;">
+  <button class="navbar-toggler bg-white" type="button" data-toggle="collapse" data-target="#navbarTogglerDemo01" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarTogglerDemo01">
+        <ul class="navbar-nav mr-auto mt-2 mt-lg-0 justify-content-center">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle skipMask" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Rankings
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+          <a class="dropdown-item" href="/rankings">National Rankings</a>
+          <a class="dropdown-item" href="/active_career_leaders">Active Career Leaders</a>
+        </div>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/contests/livestream_scoreboards">Scoreboard</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/selection_rankings/nitty_gritties">Selection Rankings</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/head_coaches">Head Coaches</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/search/players">Players</a>
+      </li>
+     </ul>
+
+    <form onsubmit="mask(&#39;Loading&#39;);" id="change_team_form" style="display:inline;" class="form-inline my-2 my-lg-0" action="/team/index" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="7AHfZ5FKlhfSD281q8mtduCT4zlS15Si1fIu95JJhoDWmpKxpBcUc158zmC1Fa9Vv0OSOQZW0wDlIFRJc/U6jg==" />
+  <div style="display:none;">
+  <input type="submit" name="commit" value="Submit" id="sport_btn" data-disable-with="Submit" />
+  </div>
+    <div id="team_autocomplete" class="ui-widget">
+      <input type="search" name="org_name" id="org_name" style="width:200px; font-size: 12px !important" class="form-control mr-sm-2" placeholder="Team Search" />
+      <input type="hidden" name="org_id" id="org_id" />
+    </div>
+</form>  </div>
+  </nav>
+</nav>
+      </header>
+
+       <div id="stats_app_dialog" style="display:none;">
+        </div>
+
+<div class="card p-1">
+  <div class="card-body application contests p-0">
+    <h3 class="card-title p-0"></h3>
+    <div class="container-fluid p-0">
+      <div class="row align-items-center justify-content-center p-0">
+        <div class="col-sm-12 p-0">
+          <br/>
+
+<br/>
+
+<style>
+.winner{
+  --display: flex;
+  vertical-align: middle;
+}
+.winner:before{
+  content: '\25BA';
+  --display: flex;
+  --align-items: center;
+  vertical-align: middle;
+}
+div.center {
+  margin: auto;
+  width: 50%;
+  --border: 3px solid green;
+  padding: 10px;
+}
+</style>
+
+   <div class="table-responsive">
+   <table align="center">
+     <tr>
+   <td>
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/606022"><img class="large_logo_image" alt="Rice" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//574.gif" /></a>
+   </td>
+   <td valign="center" class="grey_text d-none d-sm-table-cell" nowrap>
+     <span style="font-size:18px">
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/606022">Rice Owls</a>
+     </span><br/>
+       5-7, Conf 2-6
+   </td>
+   <td valign="center" class="">
+   </td>
+   <td valign="center" style="font-size:36px; color: grey">
+     3
+   </td>
+     <td style="padding: 0px 30px 0px 30px"  class="d-none d-md-table-cell">
+       <table style="border-collapse: collapse">
+         <tr>
+           <td class="grey_border_bottom"></td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">1</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">2</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">3</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">4</td>
+           <td width="20px" align="right" style="font-weight:bold" class="grey_border_bottom">S</td>
+         </tr>
+           <tr>
+             <td>Rice</td>
+               <td class="grey_text" align="right">0</td>
+               <td class="grey_text" align="right">3</td>
+               <td class="grey_text" align="right">0</td>
+               <td class="grey_text" align="right">0</td>
+             <td align="right" style="font-weight:bold">3</td>
+           </tr>
+           <tr>
+             <td>South Fla.</td>
+               <td class="grey_text" align="right">14</td>
+               <td class="grey_text" align="right">14</td>
+               <td class="grey_text" align="right">10</td>
+               <td class="grey_text" align="right">14</td>
+             <td align="right" style="font-weight:bold">52</td>
+           </tr>
+         <tr>
+           <td class="grey_text" colspan="6">11/29/2025 07:00 PM</td>
+         </tr>
+         <tr>
+           <td nowrap class="grey_text" colspan="6">Raymond James Stadium (Tampa, FL)</td>
+         </tr>
+         <tr>
+           <td nowrap class="grey_text" colspan="6">Attendance: 28,813</td>
+         </tr>
+       </table>
+     </td>
+   <td>
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/606031"><img class="large_logo_image" alt="South Fla." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//651.gif" /></a>
+   </td>
+   <td valign="center" class="grey_text d-none d-sm-table-cell" nowrap>
+     <span style="font-size:18px">
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/606031">South Fla. Bulls</a>
+     </span><br/>
+       9-3, Conf 6-2
+   </td>
+   <td valign="center" class="winner">
+   </td>
+   <td valign="center" style="font-size:36px; color: black">
+     52
+   </td>
+     </tr>
+     <tr>
+       <td colspan="10" class="grey_border_bottom grey_border_top">
+         <table cellpadding="10px">
+           <tr>
+             <td style="font-size: 16px;"><a href="/contests/6386574/box_score">Box Score</a></td>
+             <td style="font-size: 16px;"><a href="/contests/6386574/team_stats">Team Stats</a></td>
+             <td style="font-size: 16px;"><a href="/contests/6386574/individual_stats">Individual Stats</a></td>
+             <td style="font-size: 16px;">Play By Play</td>
+             <td style="font-size: 16px;"><a href="/contests/6386574/drives">Drives</a></td>
+             <td style="font-size: 16px;"><a href="/contests/6386574/officials">Officials</a></td>
+           </tr>
+         </table>
+       </td>
+     </tr>
+   </table>
+ </div>
+
+
+<br/>
+
+  <script>
+ $( function() {
+    $( ".drives" ).accordion({
+      collapsible: true,
+      heightStyle: "content",
+      header: "h5",
+      active: false
+    });
+  } );
+
+ function showScoringPlays(){
+   $('.non_scoring_play').hide();
+ }
+ function showAllPlays(){
+   $('.non_scoring_play').show();
+   $('.drives').accordion("refresh");
+   $('.drives').accordion("option", "active", false);
+ }
+</script>
+
+<style>
+ .ui-state-default, .ui-widget-content .ui-state-default, .ui-widget-header .ui-state-default {
+   overflow: auto;
+ }
+ .ui-state-default, .ui-widget-content .ui-state-default, .ui-widget-header .ui-state-default {
+    border: 1px solid #CCCCCC;
+    background: white;
+    background-image: none;
+    font-weight: normal;
+    color: #808080;
+}
+
+ .headerRight {
+  float: right;
+}
+.headerLeft {
+  float: left;
+}
+.under{
+text-decoration : underline;
+}
+</style>
+
+<div style="width: 50%; margin-left: auto; margin-right: auto;">
+  <div class="headerRight"><a class="skipMask" href="javascript:showAllPlays();">All Drives</a> | <a class="skipMask" href="javascript:showScoringPlays();">Scoring Drives</a></div>
+  <div style="border-bottom: 1px dotted #dcdddf;"><h1>1st Quarter</h1></div>
+<div class="drives">
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Rice" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//574.gif" /><span class='d-none d-sm-block'>Rice</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">15:00,Ric25, 3 plays, 2 yards, 02:11</span>
+        </div>
+        <div class="headerRight">0 - 0</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF35</br>
+         </span>
+         <span>
+           (15:00) Zouagui,Adam kickoff 65 yards to the Rice00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric25</br>
+         </span>
+         <span>
+           Rice drive start at 15:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric25</br>
+         </span>
+         <span>
+           (15:00) Shotgun Jenkins,Chase rush middle for 2 yards gain to the Rice27 (Shuler,Jhalyn; Harris,D.J.).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 8 at Ric27</br>
+         </span>
+         <span>
+           (14:25) No Huddle-Shotgun Jenkins,Chase sacked for loss of 7 yards to the Rice20 (Celiscar,Josh).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 15 at Ric20</br>
+         </span>
+         <span>
+           PENALTY Rice False Start (Fehoko,Netane) 5 yards from Rice20 to Rice15. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 20 at Ric15</br>
+         </span>
+         <span>
+           (13:37) No Huddle-Shotgun Jackson,Quinton rush right for 2 yards gain to the Rice17 (Harris,Mac).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 18 at Ric17</br>
+         </span>
+         <span>
+           (13:01) Bacchetta,Alex punt 41 yards to the USF42 PENALTY USF Holding (Jenkins,Gavin) 10 yards from USF42 to USF32.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 18 at Ric17</br>
+         </span>
+         <span>
+           USF ball on USF32.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="South Fla." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//651.gif" /><span class='d-none d-sm-block'>South Fla.</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">12:49,USF32, 12 plays, 68 yards, 03:24</span>
+        </div>
+        <div class="headerRight">0 - 7</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF32</br>
+         </span>
+         <span>
+           South Fla. drive start at 12:49.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF32</br>
+         </span>
+         <span>
+           (12:49) Shotgun Davenport,Nykahi rush left for 6 yards gain to the USF38 (Williams,Marcus; Boenisch,Blake).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 4 at USF38</br>
+         </span>
+         <span>
+           (12:30) No Huddle-Shotgun Davenport,Nykahi rush middle for 1 yard loss to the USF37 (Boenisch,Blake; Anyanwu,Tony).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 5 at USF37</br>
+         </span>
+         <span>
+           (11:59) No Huddle-Shotgun Brown,Byrum pass complete short left to Davenport,Nykahi caught at USF41, for 15 yards to the Rice48 (Awe,Andrew; Kane,Jack), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric48</br>
+         </span>
+         <span>
+           (11:33) No Huddle-Shotgun Brown,Byrum pass complete short right to Singleton,Keshaun caught at Rice47, for 4 yards to the Rice44 (Awe,Andrew; Chavez,Jo).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 6 at Ric44</br>
+         </span>
+         <span>
+           (11:09) No Huddle-Shotgun Davenport,Nykahi rush left for 4 yards gain to the Rice40 (Awe,Andrew; Anyanwu,Tony).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at Ric40</br>
+         </span>
+         <span>
+           (10:52) No Huddle-Shotgun Davenport,Nykahi rush middle for 5 yards gain to the Rice35 (Chavez,Jo; Anyanwu,Tony), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric35</br>
+         </span>
+         <span>
+           (10:37) No Huddle-Shotgun Brown,Byrum pass incomplete short left to Koger,Jeremiah thrown to Rice31 broken up by Harper,Jerrick.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at Ric35</br>
+         </span>
+         <span>
+           (10:34) No Huddle-Shotgun Brown,Byrum rush left for 21 yards gain to the Rice14 (Chavez,Jo), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric14</br>
+         </span>
+         <span>
+           (10:12) No Huddle-Shotgun Brown,Byrum pass incomplete short left to Koger,Jeremiah thrown to Rice00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at Ric14</br>
+         </span>
+         <span>
+           (10:07) No Huddle-Shotgun Davenport,Nykahi rush middle for 6 yards gain to the Rice08 (Harper,Jerrick; Morris,Ty).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 4 at Ric8</br>
+         </span>
+         <span>
+           (09:50) No Huddle-Shotgun Davenport,Nykahi rush middle for 3 yards gain to the Rice05 (Anyanwu,Tony; Awe,Andrew).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 1 at Ric5</br>
+         </span>
+         <span>
+           (09:30) No Huddle-Shotgun Brown,Byrum pass complete short left to Singleton,Keshaun caught at Rice00, for 5 yards to the Rice00 TOUCHDOWN, clock 09:25, 1ST DOWN, PENALTY Rice Holding declined.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric3</br>
+         </span>
+         <span>
+           Gramatica,Nico kick attempt good (H: Leon,Chase, LS: Cates,Garret).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Rice" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//574.gif" /><span class='d-none d-sm-block'>Rice</span></div></div>
+        <div class="headerLeft">DOWNS <br/><span style="font-size: 8px;">09:25,Ric25, 10 plays, 52 yards, 05:15</span>
+        </div>
+        <div class="headerRight">0 - 7</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF35</br>
+         </span>
+         <span>
+           (09:25) Zouagui,Adam kickoff 65 yards to the Rice00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric25</br>
+         </span>
+         <span>
+           Rice drive start at 09:25.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric25</br>
+         </span>
+         <span>
+           (09:22) Shotgun Turner,Aaron rush right for 7 yards gain to the Rice32 (Duclona,Jonas), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 3 at Ric32</br>
+         </span>
+         <span>
+           (08:51) No Huddle-Shotgun Jackson,Quinton rush right for 1 yard gain to the Rice33 (Shuler,Jhalyn; Gaskin,Fred).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at Ric33</br>
+         </span>
+         <span>
+           (08:14) No Huddle-Shotgun Jenkins,Chase rush right for 24 yards gain to the USF43 (Duclona,Jonas), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF43</br>
+         </span>
+         <span>
+           (07:38) No Huddle-Shotgun Jenkins,Chase pass incomplete short middle to Dickmann,Drayden thrown to USF30 broken up by Knox,Ben.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at USF43</br>
+         </span>
+         <span>
+           (07:33) No Huddle-Shotgun Jenkins,Chase rush right for 5 yards gain to the USF38 (Watson III,Rico).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 5 at USF38</br>
+         </span>
+         <span>
+           (06:52) No Huddle-Shotgun Turner,Aaron rush right for 6 yards gain to the USF32 (Watson III,Rico), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF32</br>
+         </span>
+         <span>
+           (06:11) No Huddle-Shotgun Hardemann,D&#39;Andre rush middle for 2 yards gain to the USF30 (Harris,Mac).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 8 at USF30</br>
+         </span>
+         <span>
+           (05:36) No Huddle-Shotgun Turner,Aaron rush left for 5 yards gain to the USF25 (Harris,Mac), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 3 at USF25</br>
+         </span>
+         <span>
+           (04:57) No Huddle-Shotgun Hardemann,D&#39;Andre rush middle for 2 yards gain to the USF23 (Rucker,De&#39;Shawn; Jenkins,Ryan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 1 at USF23</br>
+         </span>
+         <span>
+           (04:10) No Huddle-Shotgun Jenkins,Chase pass incomplete short right to Hardemann,D&#39;Andre thrown to USF30 QB hurried by Shuler,Jhalyn, TURNOVER ON DOWNS.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="South Fla." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//651.gif" /><span class='d-none d-sm-block'>South Fla.</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">04:10,USF23, 4 plays, 77 yards, 01:11</span>
+        </div>
+        <div class="headerRight">0 - 14</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF23</br>
+         </span>
+         <span>
+           South Fla. drive start at 04:10.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF23</br>
+         </span>
+         <span>
+           (04:10) Shotgun Brown,Byrum rush middle for 6 yards gain to the USF29 (Bays,Braden; Clemmons,Aquantis).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 4 at USF29</br>
+         </span>
+         <span>
+           (03:51) No Huddle-Shotgun Davenport,Nykahi rush middle for 6 yards gain to the USF35 (Morris,Ty; Stevenson,Peyton), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF35</br>
+         </span>
+         <span>
+           (03:32) No Huddle-Shotgun Brown,Byrum pass complete short left to Koger,Jeremiah caught at USF45, for 18 yards to the Rice47 (Kane,Jack; Harper,Jerrick), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric47</br>
+         </span>
+         <span>
+           (03:10) No Huddle-Shotgun Brown,Byrum pass complete deep right to Singleton,Keshaun caught at Rice26, for 47 yards to the Rice00 TOUCHDOWN, clock 02:59, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric3</br>
+         </span>
+         <span>
+           Gramatica,Nico kick attempt good (H: Leon,Chase, LS: Cates,Garret).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Rice" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//574.gif" /><span class='d-none d-sm-block'>Rice</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">02:59,Ric25, 8 plays, 30 yards, 05:11</span>
+        </div>
+        <div class="headerRight">0 - 14</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF35</br>
+         </span>
+         <span>
+           (02:59) Zouagui,Adam kickoff 65 yards to the Rice00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric25</br>
+         </span>
+         <span>
+           Rice drive start at 02:59.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric25</br>
+         </span>
+         <span>
+           (02:59) Shotgun Byars,Tyvonn rush middle for 8 yards gain to the Rice33 (Duclona,Jonas).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 2 at Ric33</br>
+         </span>
+         <span>
+           (02:26) No Huddle-Shotgun Jenkins,Chase rush left for 1 yard gain to the Rice34 (Harris,Mac).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at Ric34</br>
+         </span>
+         <span>
+           (01:46) No Huddle-Shotgun Byars,Tyvonn rush middle for 2 yards gain to the Rice36 (Celiscar,Josh; Harris,D.J.), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric36</br>
+         </span>
+         <span>
+           (01:05) No Huddle-Shotgun Turner,Aaron rush right for 0 yards to the Rice36 (Williams II,Michael), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at Ric36</br>
+         </span>
+         <span>
+           (00:28) No Huddle-Shotgun Jenkins,Chase pass complete short middle to Turner,Aaron caught at Rice34, for 18 yards to the USF46 (Duclona,Jonas), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF46</br>
+         </span>
+         <span>
+           Start of 2nd quarter, clock 15:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF46</br>
+         </span>
+         <span>
+           (15:00) Shotgun Byars,Tyvonn rush middle for 2 yards gain to the USF44 (Shuler,Jhalyn; Lee,Devin).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 8 at USF44</br>
+         </span>
+         <span>
+           (14:23) No Huddle-Shotgun Jenkins,Chase rush middle for 2 yards loss to the USF46 (Watson III,Rico).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 10 at USF46</br>
+         </span>
+         <span>
+           (13:40) No Huddle-Shotgun Jenkins,Chase rush middle for 1 yard gain to the USF45 (Shuler,Jhalyn).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 9 at USF45</br>
+         </span>
+         <span>
+           (12:54) Bacchetta,Alex punt 45 yards to the USF00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+</div>
+  <div style="border-bottom: 1px dotted #dcdddf;"><h1>2nd Quarter</h1></div>
+<div class="drives">
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="South Fla." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//651.gif" /><span class='d-none d-sm-block'>South Fla.</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">12:48,USF20, 6 plays, 80 yards, 01:27</span>
+        </div>
+        <div class="headerRight">0 - 21</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF20</br>
+         </span>
+         <span>
+           South Fla. drive start at 12:48.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF20</br>
+         </span>
+         <span>
+           (12:48) Shotgun Brown,Byrum pass incomplete short left to Smith,JeyQuan thrown to USF25.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at USF20</br>
+         </span>
+         <span>
+           (12:45) No Huddle-Shotgun Isaac,Alvon rush middle for 8 yards gain to the USF28 (Chavez,Jo).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at USF28</br>
+         </span>
+         <span>
+           (12:27) No Huddle-Shotgun Brown,Byrum rush right for 2 yards gain to the USF30 (Awe,Andrew), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF30</br>
+         </span>
+         <span>
+           (12:10) No Huddle-Shotgun Brown,Byrum rush middle for 0 yards to the USF30 (Awe,Andrew).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at USF30</br>
+         </span>
+         <span>
+           (11:53) No Huddle-Shotgun Brown,Byrum pass complete short left to Smith,JeyQuan caught at USF37, for 10 yards to the USF40 (Kane,Jack; Harper,Jerrick), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF40</br>
+         </span>
+         <span>
+           (11:32) No Huddle-Shotgun Brown,Byrum pass complete short middle to Reuben,Mudia caught at Rice44, for 60 yards to the Rice00 TOUCHDOWN, clock 11:21, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric3</br>
+         </span>
+         <span>
+           Gramatica,Nico kick attempt good (H: Leon,Chase, LS: Cates,Garret).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Rice" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//574.gif" /><span class='d-none d-sm-block'>Rice</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">11:21,Ric25, 3 plays, 4 yards, 02:03</span>
+        </div>
+        <div class="headerRight">0 - 21</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF35</br>
+         </span>
+         <span>
+           (11:21) Zouagui,Adam kickoff 65 yards to the Rice00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric25</br>
+         </span>
+         <span>
+           Rice drive start at 11:21.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric25</br>
+         </span>
+         <span>
+           (11:21) Shotgun Jenkins,Chase rush left for 0 yards to the Rice25 (Shuler,Jhalyn; Gaskin,Fred).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at Ric25</br>
+         </span>
+         <span>
+           (10:43) No Huddle-Shotgun Jenkins,Chase pass complete short middle to Turner,Aaron caught at Rice22, for 3 yards to the Rice28 (Rucker,De&#39;Shawn), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 7 at Ric28</br>
+         </span>
+         <span>
+           (10:02) No Huddle-Shotgun Jenkins,Chase pass complete short left to Falk,James caught at Rice26, for 1 yard to the Rice29 (Shuler,Jhalyn; Gaskin,Fred).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 6 at Ric29</br>
+         </span>
+         <span>
+           (09:27) Bacchetta,Alex punt 37 yards to the USF34 Porter,Joshua return for loss of 1 yard to the USF33 (Clark,Jordan; Freeman,Wyatt).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="South Fla." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//651.gif" /><span class='d-none d-sm-block'>South Fla.</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">09:18,USF33, 7 plays, 67 yards, 02:24</span>
+        </div>
+        <div class="headerRight">0 - 28</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF33</br>
+         </span>
+         <span>
+           South Fla. drive start at 09:18.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF33</br>
+         </span>
+         <span>
+           (09:13) No Huddle-Shotgun Brown,Byrum rush middle for 0 yards to the USF33 (Clark-Jolivet,Chris; Morris,Ty).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at USF33</br>
+         </span>
+         <span>
+           (08:49) No Huddle-Shotgun Brown,Byrum rush left for 22 yards gain to the Rice45, out of bounds at Rice45, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric45</br>
+         </span>
+         <span>
+           (08:20) No Huddle-Shotgun Davenport,Nykahi rush left for 1 yard loss to the Rice46 (Morris,Ty; Nwajuaku,Chibby).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 11 at Ric46</br>
+         </span>
+         <span>
+           (08:00) No Huddle-Shotgun Brown,Byrum pass incomplete short right to Singleton,Keshaun thrown to Rice35 broken up by Porter,Omari QB hurried by Awe,Andrew.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 11 at Ric46</br>
+         </span>
+         <span>
+           (07:54) No Huddle-Shotgun Brown,Byrum pass intercepted by Morris,Ty at Rice35 PENALTY Rice Offside (Bays,Braden) 5 yards from Rice46 to Rice41. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at Ric41</br>
+         </span>
+         <span>
+           (07:33) No Huddle-Shotgun Brown,Byrum pass complete deep right to Singleton,Keshaun caught at Rice10, for 34 yards to the Rice07 (Porter,Omari), 1ST DOWN, PENALTY Rice Offside declined Rice Pass Interference declined.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 7 at Ric7</br>
+         </span>
+         <span>
+           (07:13) No Huddle-Shotgun Brown,Byrum rush right for 5 yards gain to the Rice02 (Morris,Ty; Anyanwu,Tony).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 2 at Ric2</br>
+         </span>
+         <span>
+           (06:55) No Huddle-Shotgun Davenport,Nykahi rush left for 2 yards gain to the Rice00 TOUCHDOWN, clock 06:54.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric3</br>
+         </span>
+         <span>
+           Gramatica,Nico kick attempt good (H: Leon,Chase, LS: Cates,Garret).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Rice" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//574.gif" /><span class='d-none d-sm-block'>Rice</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">06:48,Ric15, 3 plays, 7 yards, 02:00</span>
+        </div>
+        <div class="headerRight">0 - 28</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF35</br>
+         </span>
+         <span>
+           (06:54) Zouagui,Adam kickoff 64 yards to the Rice01 Jackson,Quinton return 14 yards to the Rice15 (Leach,Gavin; Hamilton,Zavier).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric15</br>
+         </span>
+         <span>
+           Rice drive start at 06:48.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric15</br>
+         </span>
+         <span>
+           (06:48) Shotgun Byars,Tyvonn rush left for 3 yards gain to the Rice18 (Jenkins,Ryan; Lee,Devin).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at Ric18</br>
+         </span>
+         <span>
+           (06:19) No Huddle-Shotgun Jenkins,Chase pass complete short right to Dickmann,Drayden caught at Rice15, for 4 yards to the Rice22 (Lee,Jarvis).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 3 at Ric22</br>
+         </span>
+         <span>
+           (05:36) No Huddle-Shotgun Turner,Aaron rush right for 0 yards to the Rice22 (Knox,Ben).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 3 at Ric22</br>
+         </span>
+         <span>
+           (04:58) Bacchetta,Alex punt 46 yards to the USF32 Porter,Joshua return 1 yard to the USF33 (Chavez,Jo).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="South Fla." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//651.gif" /><span class='d-none d-sm-block'>South Fla.</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">04:48,USF33, 3 plays, 8 yards, 01:14</span>
+        </div>
+        <div class="headerRight">0 - 28</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF33</br>
+         </span>
+         <span>
+           South Fla. drive start at 04:48.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF33</br>
+         </span>
+         <span>
+           (04:48) Shotgun Franklin,Sam rush right for 5 yards gain to the USF38 (Fletcher,Bailey).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 5 at USF38</br>
+         </span>
+         <span>
+           (04:28) No Huddle-Shotgun Franklin,Sam rush right for 3 yards gain to the USF41 (Awe,Andrew; Boenisch,Blake).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at USF41</br>
+         </span>
+         <span>
+           (03:46) No Huddle-Shotgun Brown,Byrum pass incomplete deep right to Singleton,Keshaun thrown to Rice23 broken up by Porter,Omari.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 2 at USF41</br>
+         </span>
+         <span>
+           (03:40) Leon,Chase punt 39 yards to the Rice20 fair catch by Dickmann,Drayden at Rice20.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Rice" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//574.gif" /><span class='d-none d-sm-block'>Rice</span></div></div>
+        <div class="headerLeft">FG <br/><span style="font-size: 8px;">03:34,Ric20, 12 plays, 54 yards, 03:34</span>
+        </div>
+        <div class="headerRight">3 - 28</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric20</br>
+         </span>
+         <span>
+           Rice drive start at 03:34.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric20</br>
+         </span>
+         <span>
+           (03:34) Shotgun Jenkins,Chase pass complete short middle to Turner,Aaron caught at Rice16, for 10 yards to the Rice30 (Williams II,Michael; Rucker,De&#39;Shawn), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric30</br>
+         </span>
+         <span>
+           (02:57) No Huddle-Shotgun Jenkins,Chase rush left for 3 yards gain to the Rice33 (Rucker,De&#39;Shawn).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at Ric33</br>
+         </span>
+         <span>
+           (02:21) No Huddle-Shotgun Jenkins,Chase pass complete short middle to Turner,Aaron caught at Rice30, for 3 yards to the Rice36 (Harris,D.J.).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 4 at Ric36</br>
+         </span>
+         <span>
+           Timeout Other, clock 02:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 4 at Ric36</br>
+         </span>
+         <span>
+           (02:00) Shotgun Jenkins,Chase rush left for 3 yards gain to the Rice39 (Williams II,Michael).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 1 at Ric39</br>
+         </span>
+         <span>
+           (01:11) No Huddle-Shotgun Byars,Tyvonn rush middle for 5 yards gain to the Rice44 (Shuler,Jhalyn), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric44</br>
+         </span>
+         <span>
+           (00:50) No Huddle-Shotgun Jenkins,Chase pass incomplete deep right to Matthews,Payton thrown to USF30.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at Ric44</br>
+         </span>
+         <span>
+           (00:41) No Huddle-Shotgun Jenkins,Chase rush right for 4 yards gain to the Rice48 (Harris,Mac).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at Ric48</br>
+         </span>
+         <span>
+           Timeout Rice, clock 00:30.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at Ric48</br>
+         </span>
+         <span>
+           (00:29) Shotgun Jenkins,Chase pass incomplete short left to Barnett,Micah thrown to USF40 QB hurried by Harris,Mac PENALTY USF Targeting (Shuler,Jhalyn) 15 yards from Rice48 to USF37, 1ST DOWN. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF37</br>
+         </span>
+         <span>
+           (00:20) Shotgun Devillier,Drew pass incomplete short right to Dickmann,Drayden thrown to USF27 broken up by Rucker,De&#39;Shawn.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at USF37</br>
+         </span>
+         <span>
+           (00:17) No Huddle-Shotgun Devillier,Drew pass complete short left to Turner,Aaron caught at USF34, for 11 yards to the USF26 (Watson III,Rico), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF26</br>
+         </span>
+         <span>
+           Timeout Rice, clock 00:13.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF26</br>
+         </span>
+         <span>
+           (00:13) Shotgun Devillier,Drew pass incomplete short right to Guillo,Ryan thrown to USF14.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at USF26</br>
+         </span>
+         <span>
+           Timeout South Fla., clock 00:09.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at USF26</br>
+         </span>
+         <span>
+           (00:08) Shotgun Devillier,Drew pass incomplete deep left to Turner,Aaron thrown to USF00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 10 at USF26</br>
+         </span>
+         <span>
+           (00:02) Gota,Enock field goal attempt from 44 yards GOOD (H: Bacchetta,Alex, LS: Freeman,Wyatt), clock 00:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric35</br>
+         </span>
+         <span>
+           End of game, clock 00:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric35</br>
+         </span>
+         <span>
+           USF will receive; Ric will defend North end-zone.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric35</br>
+         </span>
+         <span>
+           Start of 3rd quarter, clock 15:00.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+</div>
+  <div style="border-bottom: 1px dotted #dcdddf;"><h1>3rd Quarter</h1></div>
+<div class="drives">
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="South Fla." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//651.gif" /><span class='d-none d-sm-block'>South Fla.</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">15:00,USF25, 11 plays, 75 yards, 04:47</span>
+        </div>
+        <div class="headerRight">3 - 35</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric35</br>
+         </span>
+         <span>
+           (15:00) Gota,Enock kickoff 65 yards to the USF00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF25</br>
+         </span>
+         <span>
+           South Fla. drive start at 15:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF25</br>
+         </span>
+         <span>
+           (15:00) Shotgun Brown,Byrum pass incomplete short left to Singleton,Keshaun thrown to USF30 broken up by Boenisch,Blake.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at USF25</br>
+         </span>
+         <span>
+           (14:56) No Huddle-Shotgun Brown,Byrum pass complete short left to Reuben,Mudia caught at USF28, for 3 yards to the USF28 (Fletcher,Bailey; Chavez,Jo).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 7 at USF28</br>
+         </span>
+         <span>
+           (14:21) No Huddle-Shotgun Brown,Byrum rush right for 3 yards gain to the USF31 (Morris,Ty; Anyanwu,Tony).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 4 at USF31</br>
+         </span>
+         <span>
+           (13:25) No Huddle Kinkle,Tray rush left for 15 yards gain to the USF46 (Kasemervisz,David), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF46</br>
+         </span>
+         <span>
+           (12:41) No Huddle-Shotgun Brown,Byrum pass complete short right to Reuben,Mudia caught at USF43, for 9 yards to the Rice45 (Porter,Omari; Stevenson,Peyton).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 1 at Ric45</br>
+         </span>
+         <span>
+           (12:24) No Huddle-Shotgun Davenport,Nykahi rush middle for 22 yards gain to the Rice23 (Chavez,Jo), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric23</br>
+         </span>
+         <span>
+           (12:01) No Huddle-Shotgun Brown,Byrum pass incomplete short left thrown to Rice20 PENALTY Rice Holding (Harper,Jerrick) 10 yards from Rice23 to Rice13, 1ST DOWN. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric13</br>
+         </span>
+         <span>
+           (11:55) No Huddle-Shotgun Davenport,Nykahi rush middle for 5 yards gain to the Rice08 (Chavez,Jo; Nwajuaku,Chibby).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 5 at Ric8</br>
+         </span>
+         <span>
+           (11:36) No Huddle-Shotgun Brown,Byrum pass incomplete short right to Singleton,Keshaun thrown to Rice00 broken up by Porter,Omari.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 5 at Ric8</br>
+         </span>
+         <span>
+           (11:30) No Huddle-Shotgun Brown,Byrum pass complete short left to Reuben,Mudia caught at Rice02, for 7 yards to the Rice01 (Awe,Andrew; Stevenson,Peyton), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 1 at Ric1</br>
+         </span>
+         <span>
+           (10:57) No Huddle-Shotgun Herring,Zane rush left for 6 yards loss to the Rice07 (Nwajuaku,Chibby; Harper,Jerrick).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at Ric7</br>
+         </span>
+         <span>
+           (10:13) No Huddle-Shotgun Brown,Byrum pass complete short left to Koger,Jeremiah caught at Rice00, for 7 yards to the Rice00 TOUCHDOWN, clock 10:13.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric3</br>
+         </span>
+         <span>
+           Gramatica,Nico kick attempt good (H: Leon,Chase, LS: Cates,Garret).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Rice" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//574.gif" /><span class='d-none d-sm-block'>Rice</span></div></div>
+        <div class="headerLeft">DOWNS <br/><span style="font-size: 8px;">10:13,Ric25, 7 plays, 61 yards, 03:16</span>
+        </div>
+        <div class="headerRight">3 - 35</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF35</br>
+         </span>
+         <span>
+           (10:13) Zouagui,Adam kickoff 65 yards to the Rice00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric25</br>
+         </span>
+         <span>
+           Rice drive start at 10:13.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric25</br>
+         </span>
+         <span>
+           (10:09) Shotgun Devillier,Drew rush left for 10 yards gain to the Rice35 (Stokes,Jaelen), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric35</br>
+         </span>
+         <span>
+           (09:39) No Huddle-Shotgun Devillier,Drew pass complete short middle to Turner,Aaron caught at Rice32, for 11 yards to the Rice46 (Hamilton,Zavier; Williams II,Michael) PENALTY Rice Holding (Sullivan,Sean) 10 yards from Rice35 to Rice25. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 20 at Ric25</br>
+         </span>
+         <span>
+           (09:13) No Huddle-Shotgun Devillier,Drew pass incomplete short left to Turner,Aaron thrown to Rice40.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 20 at Ric25</br>
+         </span>
+         <span>
+           (09:09) No Huddle-Shotgun Devillier,Drew pass complete short middle to Turner,Aaron caught at Rice22, for 55 yards to the USF20 (Stokes,Jaelen), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF20</br>
+         </span>
+         <span>
+           (08:49) Shotgun Dickmann,Drayden rush left for 0 yards to the USF20 (Gaskin,Fred).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at USF20</br>
+         </span>
+         <span>
+           (08:21) No Huddle-Shotgun Devillier,Drew rush middle for 6 yards gain to the USF14 (Hamilton,Zavier).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 4 at USF14</br>
+         </span>
+         <span>
+           (07:47) No Huddle-Shotgun Devillier,Drew rush left for 1 yard gain to the USF13 (Hamilton,Zavier; Singleton,Ira).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 3 at USF13</br>
+         </span>
+         <span>
+           (07:03) No Huddle-Shotgun Devillier,Drew pass complete short middle to Turner,Aaron caught at USF17, for 1 yard loss to the USF14, End Of Play, TURNOVER ON DOWNS.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="South Fla." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//651.gif" /><span class='d-none d-sm-block'>South Fla.</span></div></div>
+        <div class="headerLeft">FG <br/><span style="font-size: 8px;">06:57,USF14, 14 plays, 80 yards, 05:16</span>
+        </div>
+        <div class="headerRight">3 - 38</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF14</br>
+         </span>
+         <span>
+           South Fla. drive start at 06:57.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF14</br>
+         </span>
+         <span>
+           (06:56) Shotgun Brown,Byrum rush left for 1 yard gain to the USF15 (Fletcher,Bailey; Anyanwu,Tony).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 9 at USF15</br>
+         </span>
+         <span>
+           (06:35) No Huddle-Shotgun Brown,Byrum pass complete short right to Singleton,Keshaun caught at USF15, for 8 yards to the USF23 (Stevenson,Peyton; Porter,Omari).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at USF23</br>
+         </span>
+         <span>
+           (06:19) No Huddle-Shotgun Isaac,Alvon rush middle for 2 yards gain to the USF25 (Harper,Jerrick; Botts,Dillan), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF25</br>
+         </span>
+         <span>
+           (05:45) No Huddle-Shotgun Brown,Byrum rush middle for 12 yards gain to the USF37 (Awe,Andrew), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF37</br>
+         </span>
+         <span>
+           (05:06) No Huddle-Shotgun Franklin,Sam rush right for 2 yards gain to the USF39 (Morris,Ty; Morris,Elroyal).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 8 at USF39</br>
+         </span>
+         <span>
+           (04:47) No Huddle-Shotgun Brown,Byrum rush right for 6 yards gain to the USF45 (Awe,Andrew), out of bounds PENALTY Rice Holding (Fletcher,Bailey) 10 yards from USF45 to Rice45, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric45</br>
+         </span>
+         <span>
+           (04:20) No Huddle-Shotgun Brown,Byrum pass complete short left to Smith,JeyQuan caught at Rice48, for 10 yards to the Rice35 (Stevenson,Peyton), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric35</br>
+         </span>
+         <span>
+           (04:01) No Huddle-Shotgun Brown,Byrum rush right for 3 yards gain to the Rice32 (Bays,Braden) PENALTY Rice Holding (Porter,Omari) 10 yards from Rice32 to Rice22, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric22</br>
+         </span>
+         <span>
+           (03:31) No Huddle-Shotgun Franklin,Sam rush left for 7 yards gain to the Rice15 (Stevenson,Peyton).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 3 at Ric15</br>
+         </span>
+         <span>
+           (03:12) No Huddle-Shotgun Brown,Byrum pass complete short left to Reuben,Mudia caught at Rice17, for 11 yards to the Rice04 (Boenisch,Blake), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 4 at Ric4</br>
+         </span>
+         <span>
+           (02:49) No Huddle-Shotgun Franklin,Sam rush middle for 2 yards gain to the Rice02 (Awe,Andrew; Morris,Ty).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 2 at Ric2</br>
+         </span>
+         <span>
+           (02:32) No Huddle-Shotgun Brown,Byrum rush right for 2 yards gain to the Rice00 TOUCHDOWN nullified by penalty, clock 02:26 PENALTY Rice Holding offsetting USF Holding offsetting. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 2 at Ric2</br>
+         </span>
+         <span>
+           (02:26) No Huddle Franklin,Sam rush middle for 1 yard gain to the Rice01 (Awe,Andrew; Anyanwu,Tony).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at Ric1</br>
+         </span>
+         <span>
+           PENALTY USF False Start (Herring,Zane) 5 yards from Rice01 to Rice06. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at Ric6</br>
+         </span>
+         <span>
+           (01:49) No Huddle Brown,Byrum pass incomplete short left to Koger,Jeremiah thrown to Rice00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 6 at Ric6</br>
+         </span>
+         <span>
+           (01:44) Gramatica,Nico field goal attempt from 23 yards GOOD (H: Leon,Chase, LS: Cates,Garret), clock 01:41.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF35</br>
+         </span>
+         <span>
+           Ric ball on Ric12.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Rice" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//574.gif" /><span class='d-none d-sm-block'>Rice</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">01:41,Ric12, 3 plays, 1 yards, 00:57</span>
+        </div>
+        <div class="headerRight">3 - 38</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF35</br>
+         </span>
+         <span>
+           (01:41) Zouagui,Adam kickoff 65 yards to the Rice00, Touchback PENALTY Rice Personal Foul (Freeman,Wyatt) 13 yards from Rice25 to Rice12.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric12</br>
+         </span>
+         <span>
+           Rice drive start at 01:41.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric12</br>
+         </span>
+         <span>
+           (01:40) No Huddle-Shotgun Devillier,Drew pass incomplete short left to Matthews,Payton thrown to Rice17.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at Ric12</br>
+         </span>
+         <span>
+           (01:37) No Huddle-Shotgun Devillier,Drew rush right for 1 yard gain to the Rice13 (Mitchell,Traevon; Jenkins,Ryan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 9 at Ric13</br>
+         </span>
+         <span>
+           (00:57) No Huddle-Shotgun Devillier,Drew pass incomplete short left to Turner,Aaron thrown to Rice15.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 9 at Ric13</br>
+         </span>
+         <span>
+           (00:53) Bacchetta,Alex punt 51 yards to the USF36 Porter,Joshua return 14 yards to the Rice50, out of bounds at Rice50.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="South Fla." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//651.gif" /><span class='d-none d-sm-block'>South Fla.</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">00:44,Ric50, 4 plays, 50 yards, 01:05</span>
+        </div>
+        <div class="headerRight">3 - 45</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric50</br>
+         </span>
+         <span>
+           South Fla. drive start at 00:44.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric50</br>
+         </span>
+         <span>
+           (00:43) Brown,Byrum rush right for 12 yards gain to the Rice38 (Bays,Braden; Morris,Elroyal), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric38</br>
+         </span>
+         <span>
+           (00:20) No Huddle Brown,Byrum pass complete deep right to Singleton,Keshaun caught at Rice13, for 27 yards to the Rice11 (Stevenson,Peyton), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric11</br>
+         </span>
+         <span>
+           Start of 4th quarter, clock 15:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric11</br>
+         </span>
+         <span>
+           (15:00) Shotgun Brown,Byrum rush middle for 6 yards gain to the Rice05 (Boenisch,Blake; Bays,Braden).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 4 at Ric5</br>
+         </span>
+         <span>
+           (14:41) No Huddle-Shotgun Brown,Byrum rush middle for 5 yards gain to the Rice00 TOUCHDOWN, clock 14:39, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric3</br>
+         </span>
+         <span>
+           Gramatica,Nico kick attempt good (H: Leon,Chase, LS: Cates,Garret).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+</div>
+  <div style="border-bottom: 1px dotted #dcdddf;"><h1>4th Quarter</h1></div>
+<div class="drives">
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Rice" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//574.gif" /><span class='d-none d-sm-block'>Rice</span></div></div>
+        <div class="headerLeft">FUMB <br/><span style="font-size: 8px;">14:39,Ric25, 4 plays, 36 yards, 02:31</span>
+        </div>
+        <div class="headerRight">3 - 45</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF35</br>
+         </span>
+         <span>
+           (14:39) Leon,Chase kickoff 65 yards to the Rice00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric25</br>
+         </span>
+         <span>
+           Rice drive start at 14:39.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric25</br>
+         </span>
+         <span>
+           (14:32) Shotgun Scheerhorn,Lucas rush right for 0 yards to the Rice25 (Stokes,Jaelen; Hamilton,Zavier).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at Ric25</br>
+         </span>
+         <span>
+           PENALTY Rice False Start (Fehoko,Netane) 5 yards from Rice25 to Rice20. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 15 at Ric20</br>
+         </span>
+         <span>
+           (13:39) No Huddle-Shotgun Scheerhorn,Lucas rush left for 20 yards gain to the Rice40 (Hamilton,Zavier), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric40</br>
+         </span>
+         <span>
+           (12:56) No Huddle-Shotgun Byars,Tyvonn rush middle for 26 yards gain to the USF34 (Lee,Jarvis; Jenkins,Ryan), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF34</br>
+         </span>
+         <span>
+           (12:08) No Huddle-Shotgun Scheerhorn,Lucas rush middle for 5 yards loss to the USF39 fumbled by Scheerhorn,Lucas at USF39 recovered by USF Lee,Devin at USF39, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="South Fla." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//651.gif" /><span class='d-none d-sm-block'>South Fla.</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">12:08,USF39, 9 plays, 61 yards, 03:35</span>
+        </div>
+        <div class="headerRight">3 - 52</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF39</br>
+         </span>
+         <span>
+           South Fla. drive start at 12:08.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF39</br>
+         </span>
+         <span>
+           (12:07) Shotgun Franklin,Sam rush middle for 9 yards gain to the USF48 (Fletcher,Bailey).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 1 at USF48</br>
+         </span>
+         <span>
+           (11:20) No Huddle-Shotgun Franklin,Sam rush middle for 0 yards to the USF48 (Mutombo,Joseph; Nwajuaku,Chibby).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at USF48</br>
+         </span>
+         <span>
+           (10:59) No Huddle-Shotgun Franklin,Sam rush middle for 3 yards gain to the Rice49 (Boenisch,Blake; Chavez,Jo), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric49</br>
+         </span>
+         <span>
+           (10:30) No Huddle-Shotgun Moore,Gaston pass incomplete short right to Alexis,Jaden thrown to Rice40.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at Ric49</br>
+         </span>
+         <span>
+           (10:26) No Huddle-Shotgun Franklin,Sam rush right for 33 yards gain to the Rice16 (Morris,Ty), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric16</br>
+         </span>
+         <span>
+           (10:01) No Huddle-Shotgun Moore,Gaston pass complete short left to Porter,Joshua caught at Rice18, for 3 yards to the Rice13 (Stevenson,Peyton; Awe,Andrew).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at Ric13</br>
+         </span>
+         <span>
+           (09:26) No Huddle-Shotgun Moore,Gaston rush left for 8 yards gain to the Rice05 (Botts,Dillan), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 5 at Ric5</br>
+         </span>
+         <span>
+           (09:00) No Huddle-Shotgun Moore,Gaston rush right for 2 yards gain to the Rice03 (Botts,Dillan; Chavez,Jo).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 3 at Ric3</br>
+         </span>
+         <span>
+           (08:37) No Huddle-Shotgun Moore,Gaston pass complete short left to Helms,Christian caught at Rice05, for 3 yards to the Rice00 TOUCHDOWN, clock 08:33.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric3</br>
+         </span>
+         <span>
+           Zouagui,Adam kick attempt good (H: Leon,Chase, LS: McLaughlin,Turner).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Rice" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//574.gif" /><span class='d-none d-sm-block'>Rice</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">08:33,Ric25, 6 plays, 15 yards, 04:18</span>
+        </div>
+        <div class="headerRight">3 - 52</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF35</br>
+         </span>
+         <span>
+           (08:33) Zouagui,Adam kickoff 65 yards to the Rice00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric25</br>
+         </span>
+         <span>
+           Rice drive start at 08:33.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric25</br>
+         </span>
+         <span>
+           (08:32) Shotgun Hardemann,D&#39;Andre rush middle for 3 yards gain to the Rice28 (Smith,Jabari).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at Ric28</br>
+         </span>
+         <span>
+           (07:59) No Huddle-Shotgun Scheerhorn,Lucas rush middle for 0 yards to the Rice28 (Jones,Eli; Leach,Gavin).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 7 at Ric28</br>
+         </span>
+         <span>
+           (07:11) No Huddle-Shotgun Scheerhorn,Lucas rush left for 7 yards gain to the Rice35 (Hamilton,Zavier), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric35</br>
+         </span>
+         <span>
+           (06:30) No Huddle-Shotgun Scheerhorn,Lucas rush left for 1 yard gain to the Rice36 (Jenkins,Gavin), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 9 at Ric36</br>
+         </span>
+         <span>
+           (05:56) No Huddle-Shotgun Hardemann,D&#39;Andre rush middle for 2 yards gain to the Rice38 (Scott III,Richard; Jenkins,Gavin).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 7 at Ric38</br>
+         </span>
+         <span>
+           (05:13) No Huddle-Shotgun Turner,Aaron rush left for 2 yards gain to the Rice40 (Jenkins,Gavin; Leach,Gavin), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 5 at Ric40</br>
+         </span>
+         <span>
+           (04:24) Bacchetta,Alex punt 40 yards to the USF20, out of bounds at USF20.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="South Fla." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//651.gif" /><span class='d-none d-sm-block'>South Fla.</span></div></div>
+        <div class="headerLeft">HALF <br/><span style="font-size: 8px;">04:15,USF20, 8 plays, 32 yards, 04:15</span>
+        </div>
+        <div class="headerRight">3 - 52</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF20</br>
+         </span>
+         <span>
+           South Fla. drive start at 04:15.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF20</br>
+         </span>
+         <span>
+           (04:14) Shotgun Isaac,Alvon rush right for 3 yards gain to the USF23 (Bays,Braden; Chavez,Jo).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at USF23</br>
+         </span>
+         <span>
+           (03:51) No Huddle-Shotgun Moore,Gaston pass incomplete short right to Roberts,Cade thrown to USF21 broken up by Fletcher,Bailey.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 7 at USF23</br>
+         </span>
+         <span>
+           (03:49) No Huddle-Shotgun Moore,Gaston pass incomplete deep left to Helms,Christian thrown to Rice35 PENALTY Rice Pass Interference (Bility,Moh) 15 yards from USF23 to USF38, 1ST DOWN. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at USF38</br>
+         </span>
+         <span>
+           (03:42) No Huddle-Shotgun Isaac,Alvon rush middle for 3 yards gain to the USF41 (Stevenson,Peyton; Chavez,Jo).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at USF41</br>
+         </span>
+         <span>
+           (02:53) No Huddle-Shotgun Isaac,Alvon rush middle for 6 yards gain to the USF47 (Chavez,Jo).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at USF47</br>
+         </span>
+         <span>
+           (02:08) No Huddle-Shotgun Isaac,Alvon rush right for 0 yards to the USF47 (Awe,Andrew; Rooks,Robert).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 1 at USF47</br>
+         </span>
+         <span>
+           Timeout Other, clock 02:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 1 at USF47</br>
+         </span>
+         <span>
+           (01:59) Shotgun Moore,Gaston rush right for 7 yards gain to the Rice46 (Porter,Omari; Anyanwu,Tony), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at Ric46</br>
+         </span>
+         <span>
+           (01:11) Kneel down by Moore,Gaston at Rice47 for loss of 1 yard.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 11 at Ric47</br>
+         </span>
+         <span>
+           (00:30) Kneel down by Moore,Gaston at Rice48 for loss of 1 yard.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 12 at Ric48</br>
+         </span>
+         <span>
+           End of game, clock 00:00.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+</div>
+</div>
+
+
+
+       </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<footer>&copy; <script>document.write(new Date().getFullYear())</script> NCAA <a href="http://web1.ncaa.org/web_files/terms_and_conditions.html" title ="Terms and Conditions" target=_blank>Terms and Conditions</a> | <a href="http://web1.ncaa.org/web_files/privacy.html" target=_blank title="Our Privacy Policy">Privacy Policy</a> | <a href="mailto:ncaastats@ncaa.org">Contact Us</a> </footer>
+
+  <!-- /.container -->
+  <script type="text/javascript"  src="/QFrxqVkNu/zpMzxVZYg/LrV9L4r53Db3/PBxcAQ/GF/kteXRIKAwV?v=1b41474c-6c2d-fc17-a951-516413d46878" defer></script></body>
+
+  <script charset="utf-8">
+    $(document).ready(function() {
+      $('a.remote[data-toggle="tab"]').on('show.bs.tab', function (e) {
+        var tab_id = '#' + $(this).attr('aria-controls');
+        $(tab_id).html('<br/><br/><p style="text-align: center"><img style="vertical-align:middle; text-align: center" src="/assets/ajax-loader-6913acdbf4be7d6a2908a84bdecd6cad18110f5fc6d5a07cf8c9ce78d9548700.gif" /> Loading... </p><br/><br/>');
+        $.get($(this).data('remote'), function(data){
+          $(tab_id).html(data);
+        });
+      });
+    });
+
+    function skipMask(obj){
+      if (obj.hasClass('chosen-single') || obj.hasClass('skipMask') || obj.hasClass('ui-datepicker-prev') || obj.hasClass('ui-datepicker-next') || obj.hasClass('ui-corner-all') || obj.hasClass('paginate_button') || obj.hasClass('dt-button')){
+        return true;
+      }else{
+        return false;
+      }
+    }
+
+    $(document).ajaxComplete(function(){
+      unmask();
+    });
+/*
+    $("form").on('submit', function(event){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    */
+    $(document).on('click', 'a', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    $(document).on('click', 'input.green', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+
+  </script>
+</html>


### PR DESCRIPTION
## Summary

Graduates the NCAA MFB parser fixes and two new parsers from the `ncaa-mfb-football-raw` prototype (`python/mfb_cfbfastr.py`) into sdv-py. The prototype was validated against the **full 2025 season: 1,685 games, 1,685/1,685 exact-final QA** against the stats.ncaa.org linescore.

### Page variants found in the 2025 sweep (and fixed here)

| variant | symptom in the graduated parser | fix |
|---|---|---|
| Drive h5 title with **no result token** (some FCS/G5 pages) | lazy `(?P<team>.+?)\s+(?P<result>[A-Za-z/]+)` donated the last word of a multi-word team to `result`: `"East Carolina"` -> offense `"East"` | result is an OPTIONAL all-caps token `(?:\s+(?P<result>[A-Z/]{2,10}))?` |
| **Mixed-case / `&` yard-line side codes** (`Ric25` Rice, `W&M25` William & Mary, `Ore ball on Ore25`) | every `[A-Z]{1,4}` side-code class failed -> offense / `yard_line_side` / `end_yard_line` nulled for that team (120/203 rows in Rice @ USF) | one shared `_SIDE = [A-Za-z&]{1,4}` drives `_DRIVE_RE`, `_DD_RE`, `_YL_SPLIT_RE`, `_END_YL_RE`, `_POSSESSION_RE` |
| **Defense-labeled drive titles** (some FCS pages label every h5 with the defense) | silently wrong `offense` | not solvable in the parser alone -- `parse_cfb_ncaa_drive_titles()` exposes the raw title team + running-score checkpoints so a downstream builder can majority-vote against the `"X drive start"` markers (as the prototype does) |
| **OT omitted from the pbp page**; drives tab uses `1OT`/`2OT` | `parse_cfb_ncaa_drives` nulled `quarter` for OT rows; no OT scores anywhere | additive `period` Int64 column on drives (`"1OT"` -> 5, `quarter` semantics untouched) + new `parse_cfb_ncaa_scoring_summary()` on the box_score tab (OT as period 5+, running score checkpoints) |

### New public functions
- `sportsdataverse.cfb.parse_cfb_ncaa_drive_titles(html, contest_id=None, *, return_as_pandas=False)` -- one row per drive h5: `team/result/start_clock/start_yard_line/n_plays/yards/top/score_away/score_home` (+ `DRIVE_TITLES_SCHEMA`).
- `sportsdataverse.cfb.parse_cfb_ncaa_scoring_summary(html, contest_id=None, *, return_as_pandas=False)` -- the box_score `scoring_summary_table`, whose `tr`s concatenate logical rows: cells flattened, re-chunked by 9, dedup preserving order (+ `SCORING_SUMMARY_SCHEMA`).

Both follow the module conventions: zero-row documented-schema frame on empty input, never raise, Google-style docstrings with napoleon `Example:` blocks, in `__all__` (and `parsed/cfb.py` regenerated).

### Tests / fixtures
9 new offline tests on four single-tab fixtures extracted from the producer bundles (captured 2026-08-19; provenance table in `tests/fixtures/cfb_ncaa/README.md`):
- `mfb_play_by_play_6386335.html` Tulsa @ East Carolina -- multi-word team + missing result token; drive-title checkpoints end at the 27-41 final
- `mfb_play_by_play_6386574.html` Rice @ South Fla. -- `Ric25` mixed-case side code
- `mfb_drives_6386512.html` + `mfb_box_score_6386512.html` Houston @ Oregon St. (1OT) -- `period`=5 rows, scoring-summary OT row, running score ends 27-24

## Gates
- `uv run pytest tests/cfb/test_cfb_ncaa_pbp.py tests/cfb/test_cfb_ncaa_box.py -q` -> 41 passed
- `uv run python tools/codegen/generate.py` + `--check` -> "all generated files current"
- `uv run ruff check sportsdataverse/cfb/` + `ruff format --check` -> clean
- `uv run mypy sportsdataverse/cfb/cfb_ncaa_pbp.py sportsdataverse/cfb/cfb_ncaa_box.py` -> no issues
- no `uv.lock` change

## Summary by Sourcery

Harden NCAA football parsers against 2025 page variants and add drive-title and scoring-summary extraction.

New Features:
- Add public parsers for NCAA football drive-title checkpoints and box-score scoring summaries with documented schemas and pandas support.

Bug Fixes:
- Harden NCAA football parsing for missing drive-result tokens, mixed-case and ampersand yard-line codes, and overtime period labels.

Enhancements:
- Preserve overtime as numeric periods while retaining existing quarter semantics and expose running-score checkpoints for downstream reconciliation.

Documentation:
- Document the new parser behavior, schemas, public exports, and 2025-season fixture provenance.

Tests:
- Add regression coverage for 2025 NCAA page variants, overtime scoring, empty inputs, pandas output, and parser schema behavior.

Chores:
- Regenerate the parsed CFB exports for the new public functions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NCAA football scoring-summary parsing with plays, scoring details, game clocks, running scores, and normalized overtime periods.
  * Added drive-summary parsing with team, result, timing, field position, play count, yardage, possession time, and scores.
  * Added support for Polars and pandas output.
* **Bug Fixes**
  * Improved handling of overtime drives, mixed-case yard-line codes, ampersands, missing results, and multi-word team names.
* **Tests**
  * Added coverage for recent NCAA football page formats and overtime scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->