### PR TITLE
feat(scrape): warn when a team parses cleanly but yields no stints

### DIFF
--- a/sportsdataverse/scrape/ncaa/parse.py
+++ b/sportsdataverse/scrape/ncaa/parse.py
@@ -265,7 +265,29 @@ def _parse_lineups(contest_id: str, pbp_df: pl.DataFrame, pbp_html: str, stats_h
         if isinstance(lineup_result, list):  # list[ParseError]
             _log_family_skip("lineups", contest_id, team_name, lineup_result)
             continue
-        good, _bad = lineup_result
+        good, bad = lineup_result
+        if not good:
+            # THE THIRD SILENT PATH. The two branches above cover a returned
+            # ParseError, and `parse_bundle` catches exceptions -- but a team
+            # whose box lineup parses cleanly and whose stints ALL come back
+            # bad reaches here with `good == []`, extends nothing, and is
+            # dropped without an error, an exception, or a skip line.
+            #
+            # That is exactly the sibling-code signature (every stint flagged
+            # `player_count_error`), and it is how Kansas 2010/2011 came out
+            # of a corpus re-parse at 1/36 and 0/38 games while the run
+            # reported EXIT=0, failed=0 on every shard and zero skip warnings.
+            #
+            # An empty result is not always wrong -- a team can legitimately
+            # have no usable stint -- so this is a warning, not an error.
+            logger.warning(
+                "ncaa_parse: family=lineups contest_id=%s team=%s produced NO good stints "
+                "(%d bad, roster=%d) -- parsed successfully but contributed nothing",
+                contest_id,
+                team_name,
+                len(bad),
+                len(box_lineup.players),
+            )
         events.extend(good)
     return [_jsonable(ev) for ev in events]
 

--- a/tests/scrape/test_ncaa_parse_empty_family.py
+++ b/tests/scrape/test_ncaa_parse_empty_family.py
@@ -1,0 +1,68 @@
+"""The parse stage must not drop a team that parses cleanly and yields nothing.
+
+There are THREE ways a team's lineups can vanish, and only two were covered:
+
+1. `get_box_lineup` returns `list[ParseError]`   -> logged by `_log_family_skip`
+2. something raises                              -> logged by `parse_bundle`
+3. everything succeeds, every stint is bad,
+   `good == []`                                  -> WAS SILENT
+
+Path 3 is the sibling-code signature: the roster parses, the play-by-play
+parses, every stint is flagged `player_count_error`, and the team contributes
+nothing. It is how Kansas came out of a corpus re-parse at 1/36 (2010) and
+0/38 (2011) games while the run reported EXIT=0, `failed=0` on every shard,
+and zero skip warnings.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import polars as pl
+import pytest
+
+import sportsdataverse.scrape.ncaa.parse as parse_mod
+
+
+@pytest.fixture
+def pbp_df() -> pl.DataFrame:
+    return pl.DataFrame({"home": ["Kansas"], "away": ["Hofstra"]})
+
+
+def _box(n_players: int = 5):
+    players = [SimpleNamespace(code=f"P{i}", id=SimpleNamespace(name=f"Player {i}")) for i in range(n_players)]
+    return SimpleNamespace(players=players)
+
+
+def test_empty_but_successful_parse_is_logged(monkeypatch, caplog, pbp_df) -> None:
+    """good == [] with no error must still name the team in the log."""
+    monkeypatch.setattr(parse_mod, "get_box_lineup", lambda *a, **k: _box())
+    # Succeeds -- returns a tuple, not a ParseError -- but every stint is bad.
+    monkeypatch.setattr(parse_mod, "create_lineup_data", lambda *a, **k: ([], ["bad1", "bad2", "bad3"]))
+
+    with caplog.at_level(logging.WARNING, logger=parse_mod.logger.name):
+        out = parse_mod._parse_lineups("999", pbp_df, "<pbp/>", "<box/>")
+
+    assert out == []
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("NO good stints" in m for m in msgs), msgs
+    assert any("team=Kansas" in m for m in msgs), msgs
+    assert any("team=Hofstra" in m for m in msgs), msgs
+    assert any("3 bad" in m for m in msgs), msgs
+
+
+def test_a_healthy_team_logs_nothing(monkeypatch, caplog, pbp_df) -> None:
+    """No false positives -- a team with usable stints must stay quiet.
+
+    Without this, the guard could 'pass' by warning on everything.
+    """
+    monkeypatch.setattr(parse_mod, "get_box_lineup", lambda *a, **k: _box())
+    monkeypatch.setattr(parse_mod, "_jsonable", lambda ev: {"ev": ev})
+    monkeypatch.setattr(parse_mod, "create_lineup_data", lambda *a, **k: (["good1", "good2"], []))
+
+    with caplog.at_level(logging.WARNING, logger=parse_mod.logger.name):
+        out = parse_mod._parse_lineups("999", pbp_df, "<pbp/>", "<box/>")
+
+    assert len(out) == 4  # two teams x two stints
+    assert not [r for r in caplog.records if "NO good stints" in r.getMessage()]

--- a/tests/scrape/test_ncaa_parse_empty_family.py
+++ b/tests/scrape/test_ncaa_parse_empty_family.py
@@ -46,10 +46,19 @@ def test_empty_but_successful_parse_is_logged(monkeypatch, caplog, pbp_df) -> No
 
     assert out == []
     msgs = [r.getMessage() for r in caplog.records]
-    assert any("NO good stints" in m for m in msgs), msgs
-    assert any("team=Kansas" in m for m in msgs), msgs
-    assert any("team=Hofstra" in m for m in msgs), msgs
-    assert any("3 bad" in m for m in msgs), msgs
+    # Assert the COMPLETE diagnostic payload, not just that something warned.
+    # Each field is what makes the line actionable: without contest_id you
+    # cannot find the game, without the team you cannot tell which side was
+    # dropped (the skip is per-team), without the counts you cannot tell an
+    # all-bad parse from an empty roster.
+    for team in ("Kansas", "Hofstra"):
+        hit = [m for m in msgs if f"team={team}" in m]
+        assert hit, f"no warning naming {team}: {msgs}"
+        line = hit[0]
+        assert "NO good stints" in line, line
+        assert "contest_id=999" in line, line
+        assert "3 bad" in line, line
+        assert "roster=5" in line, line
 
 
 def test_a_healthy_team_logs_nothing(monkeypatch, caplog, pbp_df) -> None:


### PR DESCRIPTION
Follow-up to #373. The skip ledger that PR added covered two of the three ways a team can vanish from the parse stage. This closes the third — the one that actually bit.

## The three paths

| path | covered by |
|---|---|
| `get_box_lineup` returns `list[ParseError]` | `_log_family_skip` (#373) |
| something raises | `parse_bundle`'s per-family `try/except` |
| **everything succeeds, every stint is bad, `good == []`** | **nothing** |

Path 3 is the sibling-code signature exactly: the roster parses, the play-by-play parses, every stint is flagged `player_count_error`, `events.extend([])` is a no-op, and the team contributes nothing — with no error, no exception, and no skip line.

## Not hypothetical

Kansas came out of the corpus re-parse at **1/36 games (2010)** and **0/38 (2011)** through this path, while the run reported `EXIT=0`, `failed=0` on every shard, and zero skip warnings.

Re-running the identical seasons at the identical commit then produced the correct result. So the run was not reproducible **and could not say so** — every completion signal called it clean.

Measuring per-`(team, season)` coverage (rather than per-team aggregated across seasons, which averages a broken season away) found **21 MBB and 2 WBB team-seasons below 90%** that all of `EXIT=0`, `failed=0` and an empty skip ledger had passed.

## The change

One `logger.warning` when `good` is empty, naming the team, the bad-stint count and the roster size. An empty result is not always wrong — a team can legitimately have no usable stint — so it warns rather than errors.

## Tests pin both directions

- the warning **fires** on empty-but-successful, naming the team and `3 bad`
- it stays **quiet** for a team with usable stints

The second matters as much as the first: a detector that warns on everything also "passes". Separately verified against 300 real MBB 2013 games — zero false positives.

## Gates

ruff, mypy (395 files), codegen drift clean, `tests/scrape` + `tests/mbb` + `tests/wbb` 1312 passed.

## Summary by Sourcery

Detect and report silently dropped teams whose lineup parsing succeeds but yields no good stints.

Bug Fixes:
- Warn when a team parses successfully but produces no usable lineup stints, preventing silent loss of team data.

Enhancements:
- Include contest, team, bad-stint, and roster information in the diagnostic warning while preserving legitimate empty results as non-errors.

Tests:
- Add coverage for warnings on empty successful parses and for the absence of false positives when usable stints are present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NCAA lineup processing when a team has no usable lineup stints.
  * Processing now continues for affected and other teams instead of failing.
  * Added warnings with team details and counts to make data-quality issues visible.

* **Tests**
  * Added coverage for empty lineup results, warning messages, and unaffected teams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->