### PR TITLE
fix(cfb): allow team-nickname yard-line side codes (up to 8 letters)

### DIFF
--- a/sportsdataverse/cfb/cfb_ncaa_pbp.py
+++ b/sportsdataverse/cfb/cfb_ncaa_pbp.py
@@ -36,7 +36,7 @@ _NAME = r"[A-Z][\w.'\-]+(?:\s(?:Jr|Sr|II|III|IV)\.?)?,\s?[A-Z][\w.'\-]+"
 
 # Yard-line side code. NOT upper-case only: "Ric25" (Rice), "W&M25" (William &
 # Mary) -- an [A-Z]-only class silently drops every such team's drives/plays.
-_SIDE = r"[A-Za-z&]{1,4}"
+_SIDE = r"[A-Za-z&]{1,8}"  # abbrev/mixed-case/&, or a nickname ("BEARS38", "SPARTANS25")
 
 # h5 drive title: "{team} {RESULT} {clock},{yardline}, {n} plays, {yards} yards, {top} {a} - {h}".
 # RESULT is an OPTIONAL all-caps token (TD/FG/FGA/PUNT/INT/FUMB/DOWNS/HALF/...);

--- a/tests/cfb/test_cfb_ncaa_pbp.py
+++ b/tests/cfb/test_cfb_ncaa_pbp.py
@@ -261,3 +261,17 @@ def test_drive_titles_mixed_case_side_and_pandas() -> None:
 def test_drive_titles_empty() -> None:
     df = parse_cfb_ncaa_drive_titles("")
     assert df.height == 0 and df.columns == list(DRIVE_TITLES_SCHEMA.keys())
+
+
+def test_drive_titles_nickname_side_codes() -> None:
+    """Some pages use team NICKNAMES as yard-line side codes (up to 8 letters)."""
+    html = (
+        '<div class="drives">'
+        '<h5 class="non_scoring_play">Morgan St. FUMB 15:00,BEARS38, 2 plays, -7 yards, 1:29 0 - 0</h5>'
+        '<h5 class="non_scoring_play">Norfolk St. FG 13:31,SPARTANS25, 16 plays, 3 yards, 8:10 3 - 3</h5>'
+        "</div>"
+    )
+    df = parse_cfb_ncaa_drive_titles(html)
+    assert df.get_column("team").to_list() == ["Morgan St.", "Norfolk St."]
+    assert df.get_column("start_yard_line").to_list() == ["BEARS38", "SPARTANS25"]
+    assert df.get_column("yards").to_list() == [-7, 3]


### PR DESCRIPTION
The ay2025 (fall-2024) backfill surfaced stats.ncaa.org pages that key yard lines by team NICKNAME — `BEARS38`, `SPARTANS25` (Morgan St. @ Norfolk St., contest 5367229) — which the `{1,4}` cap in the shared `_SIDE` class silently dropped: every drive title on such a page parsed with a null team.

One-constant fix (`{1,4}` → `{1,8}`) applied to all five side-code regexes via `_SIDE`, plus a regression test on the real title strings.

Gates: 27 pbp + 16 box tests pass, ruff clean.

## Summary by Sourcery

Allow NCAA football drive parsing to recognize longer team-based yard-line side codes.

Bug Fixes:
- Support NCAA football drive titles that use team nicknames of up to eight letters in yard-line side codes, preserving team and starting yard-line parsing.

Tests:
- Add regression coverage for nickname-based yard-line side codes from real NCAA drive title formats.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved college football play-by-play parsing for longer team abbreviations and nicknames in yard-line data.
  * Drive details now correctly identify teams, starting yard lines, and yardage totals for supported nickname formats.

* **Tests**
  * Added regression coverage for Morgan State and Norfolk State drive-title parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->