### PR TITLE
fix(mbb): close the team-alias flaw class and name the colliding players

### DIFF
--- a/sportsdataverse/mbb/mbb_ncaa_boxscore_parser.py
+++ b/sportsdataverse/mbb/mbb_ncaa_boxscore_parser.py
@@ -540,7 +540,21 @@ def validate_box_score(team: TeamId, lineup: list[str]) -> Union[list[PlayerCode
     if len(codes) != len({c.code for c in codes}):
         codes = _disambiguate_sibling_codes(codes)
     if len(codes) != len({c.code for c in codes}):
-        return build_sub_error(error=f"Duplicate players: [{codes}]")
+        # Report ONLY the colliding players. Dumping the whole roster (the
+        # previous behaviour) buries the one thing the reader needs -- and
+        # the parse-stage skip ledger clips messages to 160 chars, so the
+        # actual duplicate fell off the end every time.
+        seen: "dict[str, list[str]]" = {}
+        for c in codes:
+            seen.setdefault(c.code, []).append(c.id.name)
+        collisions = {code: names for code, names in seen.items() if len(names) > 1}
+        return build_sub_error(
+            error=(
+                "Duplicate players after widening: "
+                + "; ".join(f"{code} <- {names}" for code, names in sorted(collisions.items()))
+                + f" (roster of {len(codes)})"
+            )
+        )
     return codes
 
 

--- a/sportsdataverse/mbb/mbb_ncaa_data_quality.py
+++ b/sportsdataverse/mbb/mbb_ncaa_data_quality.py
@@ -296,6 +296,7 @@ team_aliases: dict[Year, dict[TeamId, TeamId]] = {
 team_name_equivalents: tuple[frozenset[str], ...] = (
     frozenset({"New Orleans", "LSU New Orleans"}),
     frozenset({"NIU", "Northern Ill."}),
+    frozenset({"UAH", "Alabama Huntsville"}),
 )
 """Names that denote the SAME school, as an equivalence -- not a rewrite.
 
@@ -334,6 +335,10 @@ Both targets occur in the SAME season, so no directional rewrite can be
 right. The class is ADDITIVE: the rewrite still fires and `same_school` then
 matches the rewritten name against either spelling, so the inherited entry is
 left untouched rather than diverging further from the Scala oracle.
+
+`UAH` / `Alabama Huntsville` was the last team-name failure left in the WBB
+corpus after the NIU fix -- one event, a D-II school playing a D-I opponent
+(`Alabama Huntsville/Troy` against target `UAH`).
 
 Surfaced by the skip ledger during the corpus re-parse -- 6 events, all NIU,
 all with BOTH titles present and one exactly equal to the target.

--- a/tests/mbb/test_mbb_ncaa_team_alias_guard.py
+++ b/tests/mbb/test_mbb_ncaa_team_alias_guard.py
@@ -46,6 +46,40 @@ def test_the_guard_can_actually_fail() -> None:
     assert team_name_equivalents, "team_name_equivalents is empty"
 
 
+def test_every_equivalence_class_resolves_in_both_directions() -> None:
+    """Each declared class must actually work, in either argument order.
+
+    The alias guard above only inspects pairs drawn from `team_aliases`, so an
+    equivalence added for a school that is NOT in that table -- `UAH` /
+    `Alabama Huntsville`, the last WBB team-name failure -- would be silently
+    unprotected: deleting it would leave every other test green.
+
+    Driven off `team_name_equivalents` itself, so a class added later is
+    covered without touching this test.
+    """
+    from itertools import permutations
+
+    assert team_name_equivalents, "no classes declared"
+    for cls in team_name_equivalents:
+        assert len(cls) >= 2, f"a one-name class equates nothing: {cls}"
+        for a, b in permutations(sorted(cls), 2):
+            assert same_school(a, b), f"{a} / {b} declared equivalent but same_school says no"
+
+
+def test_the_known_equivalences_are_present() -> None:
+    """Pin the three measured pairs by name, so a deletion is loud.
+
+    Each was found by the skip ledger during the corpus re-parse, not guessed.
+    """
+    for a, b in (
+        ("UAH", "Alabama Huntsville"),
+        ("NIU", "Northern Ill."),
+        ("New Orleans", "LSU New Orleans"),
+    ):
+        assert same_school(a, b), f"{a} / {b} equivalence missing"
+        assert same_school(b, a), f"{b} / {a} not symmetric"
+
+
 def test_distinct_schools_stay_distinct() -> None:
     """The constraint the whole equivalence approach rests on.
 

--- a/tests/mbb/test_mbb_ncaa_team_alias_guard.py
+++ b/tests/mbb/test_mbb_ncaa_team_alias_guard.py
@@ -1,0 +1,62 @@
+"""A directional `team_aliases` rewrite fixes one spelling by breaking the other.
+
+`team_aliases` REWRITES a page name to a canonical one. That only works while
+every game in the season targets the canonical spelling -- and both spellings
+occur in the SAME season, so the rewrite is a perfect trade. Measured on the
+inherited `Year(2021): {NIU -> Northern Ill.}` entry:
+
+    season 2021-22 (alias active)  target `NIU` FAIL x3  `Northern Ill.` OK x3
+    season 2015    (no alias)      target `NIU` OK       `Northern Ill.` FAIL
+
+Six of those reached the skip ledger during the corpus re-parse (#374), every
+one with BOTH titles present and one exactly equal to the target.
+
+`team_name_equivalents` is symmetric and has no direction, so it holds in both
+eras. The guard below makes the failure mode impossible to reintroduce
+silently: any NEW alias pair must also be declared as an equivalence.
+"""
+
+from __future__ import annotations
+
+from sportsdataverse.mbb.mbb_ncaa_data_quality import (
+    same_school,
+    team_aliases,
+    team_name_equivalents,
+)
+
+
+def test_every_alias_pair_is_also_an_equivalence() -> None:
+    """A rewrite without a matching equivalence breaks the other direction."""
+    missing = []
+    for year, mapping in team_aliases.items():
+        for src, dst in mapping.items():
+            if not same_school(src.name, dst.name):
+                missing.append((year.value, src.name, dst.name))
+    assert not missing, (
+        "team_aliases entries with no team_name_equivalents class: "
+        f"{missing}. A directional rewrite alone fails in the season whose "
+        "target uses the OTHER spelling -- add a frozenset to "
+        "team_name_equivalents so both directions resolve."
+    )
+
+
+def test_the_guard_can_actually_fail() -> None:
+    """A guard over an empty table would pass vacuously."""
+    assert team_aliases, "team_aliases is empty -- the guard checks nothing"
+    assert team_name_equivalents, "team_name_equivalents is empty"
+
+
+def test_distinct_schools_stay_distinct() -> None:
+    """The constraint the whole equivalence approach rests on.
+
+    A silently wrong team is far worse than a dropped game, and these differ
+    by less than a typo.
+    """
+    for a, b in (
+        ("Miami (FL)", "Miami (OH)"),
+        ("New Orleans", "Southern-N.O."),
+        ("Loyola (IL)", "Loyola (MD)"),
+        ("NIU", "Northern Colo."),
+        ("UAH", "Alabama A&M"),
+    ):
+        assert not same_school(a, b), f"{a} and {b} must not be merged"


### PR DESCRIPTION
Closes the remaining follow-ups from the NCAA lineup investigation (#371-#376).

## 1. `UAH` / `Alabama Huntsville` equivalence

The last team-name failure left in the WBB corpus after #374 — one event, a D-II school playing a D-I opponent (`Alabama Huntsville/Troy` against target `UAH`).

## 2. A guard so the directional-alias flaw cannot return

`team_aliases` **rewrites** a page name to a canonical one. That works only while every game that season targets the canonical spelling — and both spellings occur in the **same** season, so the rewrite is a perfect trade:

| season | target `NIU` | target `Northern Ill.` |
|---|---|---|
| 2021-22 (alias active) | **FAIL** x3 | OK x3 |
| 2015 (no alias) | OK | **FAIL** |

Six of those reached the skip ledger during the corpus re-parse.

The table holds only that one entry today, so the "audit every entry" follow-up is **closed by inspection** — but any *new* pair would carry the identical latent failure. The guard asserts every `team_aliases` pair also resolves through `same_school`.

Verified by injecting a fresh directional alias (`St. Bonaventure -> Bonaventure`) and watching it fail, rather than trusting a green run. A second test pins that near-identical **different** schools stay distinct — `Miami (FL)`/`Miami (OH)`, `Loyola (IL)`/`Loyola (MD)`, `New Orleans`/`Southern-N.O.`, `UAH`/`Alabama A&M`. A silently wrong team is far worse than a dropped game.

## 3. Report the colliding players, not the whole roster

The duplicate-code error dumped every `PlayerCodeId` on the team. The parse-stage skip ledger clips to 160 chars, so it truncated **before** reaching the actual duplicate — diagnosing Lamar 2014 required a separate script to recover information the message already had. Now:

```
Duplicate players after widening: NimrodHilliard <- ['Nimrod Hilliard', 'Nimrod Hilliard'] (roster of 4)
```

## Why those games stay rejected

Investigated rather than assumed. Lamar 2014 and Sam Houston 2011 each carry **two different players with the same full name** (`Nimrod Hilliard` #01 / 9 min / id 4342948, and #11 / 32 min / id 4286584). The box row *could* separate them via jersey or NCAA id — but the play-by-play carries only `HILLIARD,NIMROD`, with **no jersey, no id, no discriminator** (verified on contest 717719, zero alternative forms).

So no roster-side widening can attribute an event, and guessing would be silently wrong attribution. The rejection is correct by design, and I deliberately did **not** build the jersey/id widening — it would add complexity and recover nothing.

## Gates

ruff, mypy (395 files), codegen drift clean, `tests/mbb` + `tests/wbb` + `tests/scrape` 1315 passed.

## Summary by Sourcery

Close the remaining NCAA team-name resolution gap and make alias handling and duplicate-player diagnostics safer and more actionable.

Bug Fixes:
- Add the missing UAH and Alabama Huntsville team-name equivalence so games using either spelling resolve to the same school.
- Improve duplicate-player validation errors to identify only the colliding players and preserve actionable details within skip-ledger limits.

Enhancements:
- Add regression guards ensuring directional team aliases have symmetric school equivalences and that distinct similarly named schools remain separate.

Tests:
- Add coverage for known team equivalences, bidirectional resolution, alias/equivalence consistency, and protection against merging distinct schools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate-player error messages to identify only the conflicting players, making parsing issues easier to diagnose.
  * Recognized “UAH” and “Alabama Huntsville” as equivalent team names.

* **Tests**
  * Added safeguards for team-name aliases and equivalences.
  * Confirmed distinct schools remain correctly separated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->