### PR TITLE
fix(cfb): sync load_cfb_passing's declared schema with the published asset

### DIFF
--- a/docs/docs/cfb/reference/loaders.md
+++ b/docs/docs/cfb/reference/loaders.md
@@ -1734,7 +1734,7 @@ Release: [espn_cfb_passing](https://github.com/sportsdataverse/sportsdataverse-d
 | `team_games` | UInt32 | Games the team played, used as the per-game denominator. |
 | `TEPA` | Float64 | Total EPA summed over every play. |
 | `EPAplay` | Float64 | EPA generated per play. |
-| `yards` | Int64 | Total yards gained on the drive. |
+| `yards` | Float64 | Total yards gained on the drive. |
 | `success` | Float64 | Success rate across the team plays. |
 | `comp` | Float64 | Completed passes. |
 | `att` | Float64 | Pass attempts thrown. |
@@ -1746,11 +1746,13 @@ Release: [espn_cfb_passing](https://github.com/sportsdataverse/sportsdataverse-d
 | `yardsgame` | Float64 | Yards per game. |
 | `sacked` | UInt32 | Times the passer was sacked. |
 | `sack_yds` | Int64 | Yards lost to sacks. |
+| `sack_epa` | Float64 |  |
 | `pass_int` | UInt32 | Interceptions thrown. |
+| `int_epa` | Float64 |  |
 | `detmer` | Float64 | Detmer rating -- the composite passing-efficiency measure this pipeline publishes, named for the college passing-efficiency tradition. |
 | `detmergame` | Float64 | Detmer rating expressed per game. |
 | `dropbacks` | Float64 | Dropbacks taken by the passer. |
-| `sack_adj_yards` | Int64 | Passing yards adjusted for sack yardage lost. |
+| `sack_adj_yards` | Float64 | Passing yards adjusted for sack yardage lost. |
 | `yardsdropback` | Float64 | Yards per dropback. |
 | `TEPA_rank` | Float64 | National rank of the team's total EPA summed over every play, where 1 is best. |
 | `EPAgame_rank` | Float64 | National rank of the team's EPA generated per game, where 1 is best. |

--- a/docs/docs/cfb/reference/loaders.md
+++ b/docs/docs/cfb/reference/loaders.md
@@ -1746,9 +1746,9 @@ Release: [espn_cfb_passing](https://github.com/sportsdataverse/sportsdataverse-d
 | `yardsgame` | Float64 | Yards per game. |
 | `sacked` | UInt32 | Times the passer was sacked. |
 | `sack_yds` | Int64 | Yards lost to sacks. |
-| `sack_epa` | Float64 |  |
+| `sack_epa` | Float64 | EPA lost on the sacks the team's passers took -- the expected-points cost of those plays. |
 | `pass_int` | UInt32 | Interceptions thrown. |
-| `int_epa` | Float64 |  |
+| `int_epa` | Float64 | EPA lost on the team's interceptions thrown -- the expected-points cost of the turnovers, not a count. |
 | `detmer` | Float64 | Detmer rating -- the composite passing-efficiency measure this pipeline publishes, named for the college passing-efficiency tradition. |
 | `detmergame` | Float64 | Detmer rating expressed per game. |
 | `dropbacks` | Float64 | Dropbacks taken by the passer. |

--- a/sportsdataverse/cfb/cfb_loaders.py
+++ b/sportsdataverse/cfb/cfb_loaders.py
@@ -2730,7 +2730,7 @@ def load_cfb_passing(seasons, return_as_pandas: bool = False):
         |team_games          |UInt32  |
         |TEPA                |Float64 |
         |EPAplay             |Float64 |
-        |yards               |Int64   |
+        |yards               |Float64 |
         |success             |Float64 |
         |comp                |Float64 |
         |att                 |Float64 |
@@ -2742,11 +2742,13 @@ def load_cfb_passing(seasons, return_as_pandas: bool = False):
         |yardsgame           |Float64 |
         |sacked              |UInt32  |
         |sack_yds            |Int64   |
+        |sack_epa            |Float64 |
         |pass_int            |UInt32  |
+        |int_epa             |Float64 |
         |detmer              |Float64 |
         |detmergame          |Float64 |
         |dropbacks           |Float64 |
-        |sack_adj_yards      |Int64   |
+        |sack_adj_yards      |Float64 |
         |yardsdropback       |Float64 |
         |TEPA_rank           |Float64 |
         |EPAgame_rank        |Float64 |

--- a/tools/codegen/manual_column_descriptions.yaml
+++ b/tools/codegen/manual_column_descriptions.yaml
@@ -2627,11 +2627,13 @@ load_cfb_passing:
   dropbacks: Dropbacks taken by the passer.
   fbs_class: 'Power/Group classification for the season: P4 or G6 from 2024 on, P5 or G5 through 2023, derived from conference
     membership. Null for teams outside FBS.'
+  int_epa: EPA lost on the team's interceptions thrown -- the expected-points cost of the turnovers, not a count.
   pass_int: Interceptions thrown.
   passer_player_name: Display name of the passer -- the FIRST participant in that role on the play.
   playsgame: Plays per game.
   sack_adj_yards: Passing yards adjusted for sack yardage lost.
   sack_adj_yards_rank: National rank of the team's passing yards adjusted for sack yardage lost, where 1 is best.
+  sack_epa: EPA lost on the sacks the team's passers took -- the expected-points cost of those plays.
   sack_yds: Yards lost to sacks.
   sacked: Times the passer was sacked.
   success: Success rate across the team plays.

--- a/tools/codegen/schemas/loader_schemas.yaml
+++ b/tools/codegen/schemas/loader_schemas.yaml
@@ -1243,7 +1243,7 @@ load_cfb_passing:
 - name: EPAplay
   type: Float64
 - name: yards
-  type: Int64
+  type: Float64
 - name: success
   type: Float64
 - name: comp
@@ -1266,8 +1266,12 @@ load_cfb_passing:
   type: UInt32
 - name: sack_yds
   type: Int64
+- name: sack_epa
+  type: Float64
 - name: pass_int
   type: UInt32
+- name: int_epa
+  type: Float64
 - name: detmer
   type: Float64
 - name: detmergame
@@ -1275,7 +1279,7 @@ load_cfb_passing:
 - name: dropbacks
   type: Float64
 - name: sack_adj_yards
-  type: Int64
+  type: Float64
 - name: yardsdropback
   type: Float64
 - name: TEPA_rank


### PR DESCRIPTION
`tests` has been red on **every push since 2026-08-12** — always the same job, `pytest (macos-latest / py3.13.2)`. That means no sdv-py PR has had a usable CI signal in eleven days.

It is **one test out of 5,748**, and it is neither flaky nor macOS-specific:

```
FAILED test_declared_schema_matches_the_published_parquet[load_cfb_passing-2023]
  declared-vs-published column mismatch; missing=[] extra=['int_epa', 'sack_epa']
1 failed, 5748 passed, 87 skipped, 11 xfailed, 1 xpassed
```

macOS is simply the only matrix leg that runs live API tests (`Run tests (live API tests included)`).

## Cause

The published parquet gained `int_epa` / `sack_epa` when the CFB passing-EPA work shipped (`cfbfastR-cfb-raw` #30/#33, 2026-08-06). The declared returns-schema was never updated, so the **shipped returns-table has been misdescribing the dataset for eleven days**.

This test exists precisely to catch producer-side drift — it worked, and the signal went unread.

## Fixing the reported error alone would have left CI red

The column assert fires first and **masks a second, pre-existing drift**:

| column | declared | published |
|---|---|---|
| `yards` | `Int64` | `Float64` |
| `sack_adj_yards` | `Int64` | `Float64` |

Assertions short-circuit, so "make the reported error go away" is not the same as "make the test pass." I checked the whole declared-vs-published contract instead.

Confirmed stable across **2015 / 2019 / 2023 / 2024** — 45 columns, both fields `Float64` in every one — so this is the dataset's real dtype, not a one-season null artifact. Published data is the source of truth here; the schemas were introspected from it, which is the premise the test states.

## Verification

| check | result |
|---|---|
| the exact failing CI test, `SDV_PY_LIVE_TESTS=1` | **passes** |
| full live loader-schema suite | **30 passed** |
| `generate.py --check` | clean |
| ruff / mypy ratchet / codegen pre-push hooks | pass |

## Summary by Sourcery

Align the CFB passing loader schema and documentation with the published parquet data.

Bug Fixes:
- Synchronize the CFB passing loader’s declared schema with the published dataset by adding `int_epa` and `sack_epa` and correcting the numeric types for `yards` and `sack_adj_yards`.

Documentation:
- Update the CFB passing loader reference documentation and column descriptions for the added EPA fields and corrected data types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added sack EPA and interception EPA fields to college football passing data.
- **Bug Fixes**
  - Improved precision for passing yards and sack-adjusted yards by representing them as decimal values.
- **Documentation**
  - Updated passing-data schema documentation and field descriptions to reflect the new fields and data types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->