### PR TITLE
fix(pbp): era-aware half/clock columns for pre-2006 WNBA and pre-2016 NCAA WBB

### DIFF
--- a/docs/docs/wbb/reference/loaders.md
+++ b/docs/docs/wbb/reference/loaders.md
@@ -43,7 +43,7 @@ Release: [espn_womens_college_basketball_pbp](https://github.com/sportsdataverse
 | `id` | Int64 | Unique play identification number |
 | `sequence_number` | Int32 | Sequence number representing a shot-possession (V3 PBP). |
 | `type_id` | Int32 | Type identifier (numeric). |
-| `type_text` | String | Display text for the type field. |
+| `type_text` | String | Play type text, passed through verbatim from ESPN. ESPN labels the free-throw play type "MadeFreeThrow" for made AND missed free throws; filter makes vs. misses with scoring_play, not type_text. |
 | `text` | String | Text description of the play / record. |
 | `away_score` | Int32 | Away team score at the time of the play. |
 | `home_score` | Int32 | Home team score at the time of the play. |
@@ -51,7 +51,7 @@ Release: [espn_womens_college_basketball_pbp](https://github.com/sportsdataverse
 | `period_display_value` | String | Period display label (e.g. '1st Quarter', 'OT'). |
 | `clock_display_value` | String | Game clock display string (e.g. '8:32'). |
 | `scoring_play` | Boolean | TRUE if the play resulted in points scored. |
-| `score_value` | Int32 | Point value of the play (2 / 3 / 1). |
+| `score_value` | Int32 | Point value of the attempt (1 / 2 / 3), carried even on misses (a missed free throw still shows 1); use scoring_play to identify points actually scored. |
 | `wallclock` | String | Wallclock. |
 | `shooting_play` | Boolean | TRUE if the play was a shooting attempt. |
 | `coordinate_x_raw` | Float64 | X coordinate as returned by the API before any adjustment. |

--- a/docs/docs/wnba/reference/loaders.md
+++ b/docs/docs/wnba/reference/loaders.md
@@ -56,7 +56,7 @@ Release: [espn_wnba_pbp](https://github.com/sportsdataverse/sportsdataverse-data
 | `id` | Int64 | Unique play identification number |
 | `sequence_number` | Int32 | Sequence number representing a shot-possession (V3 PBP). |
 | `type_id` | Int32 | Type identifier (numeric). |
-| `type_text` | String | Display text for the type field. |
+| `type_text` | String | Play type text, passed through verbatim from ESPN. ESPN labels the free-throw play type "MadeFreeThrow" for made AND missed free throws; filter makes vs. misses with scoring_play, not type_text. |
 | `text` | String | Text description of the play / record. |
 | `away_score` | Int32 | Away team score at the time of the play. |
 | `home_score` | Int32 | Home team score at the time of the play. |
@@ -64,7 +64,7 @@ Release: [espn_wnba_pbp](https://github.com/sportsdataverse/sportsdataverse-data
 | `period_display_value` | String | Period display label (e.g. '1st Quarter', 'OT'). |
 | `clock_display_value` | String | Game clock display string (e.g. '8:32'). |
 | `scoring_play` | Boolean | TRUE if the play resulted in points scored. |
-| `score_value` | Int32 | Point value of the play (2 / 3 / 1). |
+| `score_value` | Int32 | Point value of the attempt (1 / 2 / 3), carried even on misses (a missed free throw still shows 1); use scoring_play to identify points actually scored. |
 | `team_id` | Int32 | Unique team identifier. |
 | `athlete_id_1` | Int32 | Primary athlete identifier (e.g. shooter). |
 | `athlete_id_2` | Int32 | Secondary athlete identifier (e.g. assister / fouler). |

--- a/sportsdataverse/wbb/wbb_pbp.py
+++ b/sportsdataverse/wbb/wbb_pbp.py
@@ -267,7 +267,12 @@ def helper_wbb_pbp_features(game_id, pbp_txt, init):
     # switched to 10-minute quarters in 2015-16 (ESPN season year 2016; OT is
     # 5:00 in both eras). Pre-2016 ESPN's period IS the half, so the
     # half/seconds-remaining columns need era-aware math.
-    is_halves_era = int(pbp_txt["header"]["season"]["year"]) < 2016
+    fmt = pbp_txt.get("format")
+    reg_periods = (fmt.get("regulation") or {}).get("periods") if isinstance(fmt, dict) else None
+    if reg_periods in (2, 4):
+        is_halves_era = reg_periods == 2
+    else:
+        is_halves_era = int(pbp_txt["header"]["season"]["year"]) < 2016
     first_half_periods = 1 if is_halves_era else 2
     clock_sec = 60 * pl.col("clock.minutes") + pl.col("clock.seconds")
     if is_halves_era:

--- a/sportsdataverse/wbb/wbb_pbp.py
+++ b/sportsdataverse/wbb/wbb_pbp.py
@@ -263,6 +263,29 @@ def helper_wbb_pbp_features(game_id, pbp_txt, init):
         p = flatten_json_iterative(play)
         pbp_txt["plays_mod"].append(p)
     pbp_txt["plays"] = pl.from_pandas(pd.json_normalize(pbp_txt, "plays_mod"))
+    # NCAA women's basketball played 2x20-minute halves through 2014-15 and
+    # switched to 10-minute quarters in 2015-16 (ESPN season year 2016; OT is
+    # 5:00 in both eras). Pre-2016 ESPN's period IS the half, so the
+    # half/seconds-remaining columns need era-aware math.
+    is_halves_era = int(pbp_txt["header"]["season"]["year"]) < 2016
+    first_half_periods = 1 if is_halves_era else 2
+    clock_sec = 60 * pl.col("clock.minutes") + pl.col("clock.seconds")
+    if is_halves_era:
+        half_expr = pl.when(pl.col("qtr") <= 1).then(1).otherwise(2)
+        start_half_expr = clock_sec
+        start_game_expr = pl.when(pl.col("qtr") == 1).then(1200 + clock_sec).otherwise(clock_sec)
+    else:
+        half_expr = pl.when(pl.col("qtr") <= 2).then(1).otherwise(2)
+        start_half_expr = pl.when(pl.col("qtr").is_in([1, 3])).then(600 + clock_sec).otherwise(clock_sec)
+        start_game_expr = (
+            pl.when(pl.col("qtr") == 1)
+            .then(1800 + clock_sec)
+            .when(pl.col("qtr") == 2)
+            .then(1200 + clock_sec)
+            .when(pl.col("qtr") == 3)
+            .then(600 + clock_sec)
+            .otherwise(clock_sec)
+        )
     pbp_txt["plays"] = (
         pbp_txt["plays"]
         .with_columns(
@@ -352,8 +375,8 @@ def helper_wbb_pbp_features(game_id, pbp_txt, init):
             .alias("awayTimeoutCalled"),
         )
         .with_columns(
-            half=pl.when(pl.col("qtr") <= 2).then(1).otherwise(2),
-            game_half=pl.when(pl.col("qtr") <= 2).then(1).otherwise(2),
+            half=half_expr,
+            game_half=half_expr,
         )
         .with_columns(
             lag_qtr=pl.col("qtr").shift(1),
@@ -362,19 +385,9 @@ def helper_wbb_pbp_features(game_id, pbp_txt, init):
             lead_half=pl.col("half").shift(-1),
         )
         .with_columns(
-            (60 * pl.col("clock.minutes") + pl.col("clock.seconds")).alias("start.quarter_seconds_remaining"),
-            pl.when(pl.col("qtr").is_in([1, 3]))
-            .then(600 + 60 * pl.col("clock.minutes") + pl.col("clock.seconds"))
-            .otherwise(60 * pl.col("clock.minutes") + pl.col("clock.seconds"))
-            .alias("start.half_seconds_remaining"),
-            pl.when(pl.col("qtr") == 1)
-            .then(1800 + 60 * pl.col("clock.minutes") + pl.col("clock.seconds"))
-            .when(pl.col("qtr") == 2)
-            .then(1200 + 60 * pl.col("clock.minutes") + pl.col("clock.seconds"))
-            .when(pl.col("qtr") == 3)
-            .then(600 + 60 * pl.col("clock.minutes") + pl.col("clock.seconds"))
-            .otherwise(60 * pl.col("clock.minutes") + pl.col("clock.seconds"))
-            .alias("start.game_seconds_remaining"),
+            clock_sec.alias("start.quarter_seconds_remaining"),
+            start_half_expr.alias("start.half_seconds_remaining"),
+            start_game_expr.alias("start.game_seconds_remaining"),
         )
         .with_columns(
             pl.col("start.quarter_seconds_remaining").shift(-1).alias("end.quarter_seconds_remaining"),
@@ -390,67 +403,96 @@ def helper_wbb_pbp_features(game_id, pbp_txt, init):
     }
     pbp_txt["timeouts"][init["homeTeamId"]]["1"] = (
         pbp_txt["plays"]
-        .filter((pl.col("homeTimeoutCalled") == True).and_(pl.col("period.number") <= 2))
+        .filter((pl.col("homeTimeoutCalled") == True).and_(pl.col("period.number") <= first_half_periods))
         .get_column("id")
         .to_list()
     )
     pbp_txt["timeouts"][init["homeTeamId"]]["2"] = (
         pbp_txt["plays"]
-        .filter((pl.col("homeTimeoutCalled") == True).and_(pl.col("period.number") > 2))
+        .filter((pl.col("homeTimeoutCalled") == True).and_(pl.col("period.number") > first_half_periods))
         .get_column("id")
         .to_list()
     )
     pbp_txt["timeouts"][init["awayTeamId"]]["1"] = (
         pbp_txt["plays"]
-        .filter((pl.col("awayTimeoutCalled") == True).and_(pl.col("period.number") <= 2))
+        .filter((pl.col("awayTimeoutCalled") == True).and_(pl.col("period.number") <= first_half_periods))
         .get_column("id")
         .to_list()
     )
     pbp_txt["timeouts"][init["awayTeamId"]]["2"] = (
         pbp_txt["plays"]
-        .filter((pl.col("awayTimeoutCalled") == True).and_(pl.col("period.number") > 2))
+        .filter((pl.col("awayTimeoutCalled") == True).and_(pl.col("period.number") > first_half_periods))
         .get_column("id")
         .to_list()
     )
     # Pos Team - Start and End Id
-    pbp_txt["plays"] = pbp_txt["plays"].with_columns(
-        pl.when(
-            (pl.col("game_play_number") == 1)
-            .or_((pl.col("lag_qtr") == 1).and_(pl.col("period.number") == 2))
-            .or_((pl.col("lag_qtr") == 2).and_(pl.col("period.number") == 3))
-            .or_((pl.col("lag_qtr") == 3).and_(pl.col("period.number") == 4)),
+    if is_halves_era:
+        pbp_txt["plays"] = pbp_txt["plays"].with_columns(
+            pl.when(
+                (pl.col("game_play_number") == 1).or_((pl.col("lag_qtr") == 1).and_(pl.col("period.number") == 2)),
+            )
+            .then(1200)
+            .when((pl.col("lag_qtr") == (pl.col("period.number") - 1)).and_(pl.col("period.number") >= 3))
+            .then(300)
+            .otherwise(pl.col("end.quarter_seconds_remaining"))
+            .alias("end.quarter_seconds_remaining"),
+            pl.when((pl.col("game_play_number") == 1))
+            .then(1200)
+            .when((pl.col("lag_half") == 1).and_(pl.col("half") == 2))
+            .then(1200)
+            .when((pl.col("lag_qtr") == (pl.col("period.number") - 1)).and_(pl.col("period.number") >= 3))
+            .then(300)
+            .otherwise(pl.col("end.half_seconds_remaining"))
+            .alias("end.half_seconds_remaining"),
+            pl.when((pl.col("game_play_number") == 1))
+            .then(2400)
+            .when((pl.col("lag_qtr") == 1).and_(pl.col("period.number") == 2))
+            .then(1200)
+            .when((pl.col("lag_qtr") == (pl.col("period.number") - 1)).and_(pl.col("period.number") >= 3))
+            .then(300)
+            .otherwise(pl.col("end.game_seconds_remaining"))
+            .alias("end.game_seconds_remaining"),
+            pl.col("qtr").cast(pl.Int32).alias("period"),
         )
-        .then(600)
-        .when((pl.col("lag_qtr") == (pl.col("period.number") - 1)).and_(pl.col("period.number") >= 5))
-        .then(300)
-        .otherwise(pl.col("end.quarter_seconds_remaining"))
-        .alias("end.quarter_seconds_remaining"),
-        pl.when((pl.col("game_play_number") == 1))
-        .then(1200)
-        .when((pl.col("lag_half") == 1).and_(pl.col("half") == 2))
-        .then(1200)
-        .when((pl.col("lag_qtr") == 1).and_(pl.col("period.number") == 2))
-        .then(600)
-        .when((pl.col("lag_qtr") == 2).and_(pl.col("period.number") == 3))
-        .then(1200)
-        .when((pl.col("lag_qtr") == 3).and_(pl.col("period.number") == 4))
-        .then(600)
-        .when((pl.col("lag_qtr") == (pl.col("period.number") - 1)).and_(pl.col("period.number") >= 5))
-        .then(300)
-        .otherwise(pl.col("end.half_seconds_remaining"))
-        .alias("end.half_seconds_remaining"),
-        pl.when((pl.col("game_play_number") == 1))
-        .then(2400)
-        .when((pl.col("lag_qtr") == 1).and_(pl.col("period.number") == 2))
-        .then(1800)
-        .when((pl.col("lag_qtr") == 2).and_(pl.col("period.number") == 3))
-        .then(1200)
-        .when((pl.col("lag_qtr") == 3).and_(pl.col("period.number") == 4))
-        .then(600)
-        .when((pl.col("lag_qtr") == (pl.col("period.number") - 1)).and_(pl.col("period.number") >= 5))
-        .then(300)
-        .otherwise(pl.col("end.game_seconds_remaining"))
-        .alias("end.game_seconds_remaining"),
-        pl.col("qtr").cast(pl.Int32).alias("period"),
-    )
+    else:
+        pbp_txt["plays"] = pbp_txt["plays"].with_columns(
+            pl.when(
+                (pl.col("game_play_number") == 1)
+                .or_((pl.col("lag_qtr") == 1).and_(pl.col("period.number") == 2))
+                .or_((pl.col("lag_qtr") == 2).and_(pl.col("period.number") == 3))
+                .or_((pl.col("lag_qtr") == 3).and_(pl.col("period.number") == 4)),
+            )
+            .then(600)
+            .when((pl.col("lag_qtr") == (pl.col("period.number") - 1)).and_(pl.col("period.number") >= 5))
+            .then(300)
+            .otherwise(pl.col("end.quarter_seconds_remaining"))
+            .alias("end.quarter_seconds_remaining"),
+            pl.when((pl.col("game_play_number") == 1))
+            .then(1200)
+            .when((pl.col("lag_half") == 1).and_(pl.col("half") == 2))
+            .then(1200)
+            .when((pl.col("lag_qtr") == 1).and_(pl.col("period.number") == 2))
+            .then(600)
+            .when((pl.col("lag_qtr") == 2).and_(pl.col("period.number") == 3))
+            .then(1200)
+            .when((pl.col("lag_qtr") == 3).and_(pl.col("period.number") == 4))
+            .then(600)
+            .when((pl.col("lag_qtr") == (pl.col("period.number") - 1)).and_(pl.col("period.number") >= 5))
+            .then(300)
+            .otherwise(pl.col("end.half_seconds_remaining"))
+            .alias("end.half_seconds_remaining"),
+            pl.when((pl.col("game_play_number") == 1))
+            .then(2400)
+            .when((pl.col("lag_qtr") == 1).and_(pl.col("period.number") == 2))
+            .then(1800)
+            .when((pl.col("lag_qtr") == 2).and_(pl.col("period.number") == 3))
+            .then(1200)
+            .when((pl.col("lag_qtr") == 3).and_(pl.col("period.number") == 4))
+            .then(600)
+            .when((pl.col("lag_qtr") == (pl.col("period.number") - 1)).and_(pl.col("period.number") >= 5))
+            .then(300)
+            .otherwise(pl.col("end.game_seconds_remaining"))
+            .alias("end.game_seconds_remaining"),
+            pl.col("qtr").cast(pl.Int32).alias("period"),
+        )
     return pbp_txt

--- a/sportsdataverse/wnba/wnba_pbp.py
+++ b/sportsdataverse/wnba/wnba_pbp.py
@@ -221,6 +221,28 @@ def helper_wnba_pbp_features(game_id, pbp_txt, init):
         p = flatten_json_iterative(play)
         pbp_txt["plays_mod"].append(p)
     pbp_txt["plays"] = pl.from_pandas(pd.json_normalize(pbp_txt, "plays_mod"))
+    # WNBA played 2x20-minute halves through 2005 and switched to 10-minute
+    # quarters in 2006 (OT is 5:00 in both eras). Pre-2006 ESPN's period IS
+    # the half, so the half/seconds-remaining columns need era-aware math.
+    is_halves_era = int(pbp_txt["header"]["season"]["year"]) < 2006
+    first_half_periods = 1 if is_halves_era else 2
+    clock_sec = 60 * pl.col("clock.minutes") + pl.col("clock.seconds")
+    if is_halves_era:
+        half_expr = pl.when(pl.col("qtr") <= 1).then(1).otherwise(2)
+        start_half_expr = clock_sec
+        start_game_expr = pl.when(pl.col("qtr") == 1).then(1200 + clock_sec).otherwise(clock_sec)
+    else:
+        half_expr = pl.when(pl.col("qtr") <= 2).then(1).otherwise(2)
+        start_half_expr = pl.when(pl.col("qtr").is_in([1, 3])).then(600 + clock_sec).otherwise(clock_sec)
+        start_game_expr = (
+            pl.when(pl.col("qtr") == 1)
+            .then(1800 + clock_sec)
+            .when(pl.col("qtr") == 2)
+            .then(1200 + clock_sec)
+            .when(pl.col("qtr") == 3)
+            .then(600 + clock_sec)
+            .otherwise(clock_sec)
+        )
     pbp_txt["plays"] = (
         pbp_txt["plays"]
         .with_columns(
@@ -310,8 +332,8 @@ def helper_wnba_pbp_features(game_id, pbp_txt, init):
             .alias("awayTimeoutCalled"),
         )
         .with_columns(
-            half=pl.when(pl.col("qtr") <= 2).then(1).otherwise(2),
-            game_half=pl.when(pl.col("qtr") <= 2).then(1).otherwise(2),
+            half=half_expr,
+            game_half=half_expr,
         )
         .with_columns(
             lag_qtr=pl.col("qtr").shift(1),
@@ -320,19 +342,9 @@ def helper_wnba_pbp_features(game_id, pbp_txt, init):
             lead_half=pl.col("half").shift(-1),
         )
         .with_columns(
-            (60 * pl.col("clock.minutes") + pl.col("clock.seconds")).alias("start.quarter_seconds_remaining"),
-            pl.when(pl.col("qtr").is_in([1, 3]))
-            .then(600 + 60 * pl.col("clock.minutes") + pl.col("clock.seconds"))
-            .otherwise(60 * pl.col("clock.minutes") + pl.col("clock.seconds"))
-            .alias("start.half_seconds_remaining"),
-            pl.when(pl.col("qtr") == 1)
-            .then(1800 + 60 * pl.col("clock.minutes") + pl.col("clock.seconds"))
-            .when(pl.col("qtr") == 2)
-            .then(1200 + 60 * pl.col("clock.minutes") + pl.col("clock.seconds"))
-            .when(pl.col("qtr") == 3)
-            .then(600 + 60 * pl.col("clock.minutes") + pl.col("clock.seconds"))
-            .otherwise(60 * pl.col("clock.minutes") + pl.col("clock.seconds"))
-            .alias("start.game_seconds_remaining"),
+            clock_sec.alias("start.quarter_seconds_remaining"),
+            start_half_expr.alias("start.half_seconds_remaining"),
+            start_game_expr.alias("start.game_seconds_remaining"),
         )
         .with_columns(
             pl.col("start.quarter_seconds_remaining").shift(-1).alias("end.quarter_seconds_remaining"),
@@ -348,69 +360,98 @@ def helper_wnba_pbp_features(game_id, pbp_txt, init):
     }
     pbp_txt["timeouts"][init["homeTeamId"]]["1"] = (
         pbp_txt["plays"]
-        .filter((pl.col("homeTimeoutCalled") == True).and_(pl.col("period.number") <= 2))
+        .filter((pl.col("homeTimeoutCalled") == True).and_(pl.col("period.number") <= first_half_periods))
         .get_column("id")
         .to_list()
     )
     pbp_txt["timeouts"][init["homeTeamId"]]["2"] = (
         pbp_txt["plays"]
-        .filter((pl.col("homeTimeoutCalled") == True).and_(pl.col("period.number") > 2))
+        .filter((pl.col("homeTimeoutCalled") == True).and_(pl.col("period.number") > first_half_periods))
         .get_column("id")
         .to_list()
     )
     pbp_txt["timeouts"][init["awayTeamId"]]["1"] = (
         pbp_txt["plays"]
-        .filter((pl.col("awayTimeoutCalled") == True).and_(pl.col("period.number") <= 2))
+        .filter((pl.col("awayTimeoutCalled") == True).and_(pl.col("period.number") <= first_half_periods))
         .get_column("id")
         .to_list()
     )
     pbp_txt["timeouts"][init["awayTeamId"]]["2"] = (
         pbp_txt["plays"]
-        .filter((pl.col("awayTimeoutCalled") == True).and_(pl.col("period.number") > 2))
+        .filter((pl.col("awayTimeoutCalled") == True).and_(pl.col("period.number") > first_half_periods))
         .get_column("id")
         .to_list()
     )
     # Pos Team - Start and End Id
-    pbp_txt["plays"] = pbp_txt["plays"].with_columns(
-        pl.when(
-            (pl.col("game_play_number") == 1)
-            .or_((pl.col("lag_qtr") == 1).and_(pl.col("period.number") == 2))
-            .or_((pl.col("lag_qtr") == 2).and_(pl.col("period.number") == 3))
-            .or_((pl.col("lag_qtr") == 3).and_(pl.col("period.number") == 4)),
+    if is_halves_era:
+        pbp_txt["plays"] = pbp_txt["plays"].with_columns(
+            pl.when(
+                (pl.col("game_play_number") == 1).or_((pl.col("lag_qtr") == 1).and_(pl.col("period.number") == 2)),
+            )
+            .then(1200)
+            .when((pl.col("lag_qtr") == (pl.col("period.number") - 1)).and_(pl.col("period.number") >= 3))
+            .then(300)
+            .otherwise(pl.col("end.quarter_seconds_remaining"))
+            .alias("end.quarter_seconds_remaining"),
+            pl.when((pl.col("game_play_number") == 1))
+            .then(1200)
+            .when((pl.col("lag_half") == 1).and_(pl.col("half") == 2))
+            .then(1200)
+            .when((pl.col("lag_qtr") == (pl.col("period.number") - 1)).and_(pl.col("period.number") >= 3))
+            .then(300)
+            .otherwise(pl.col("end.half_seconds_remaining"))
+            .alias("end.half_seconds_remaining"),
+            pl.when((pl.col("game_play_number") == 1))
+            .then(2400)
+            .when((pl.col("lag_qtr") == 1).and_(pl.col("period.number") == 2))
+            .then(1200)
+            .when((pl.col("lag_qtr") == (pl.col("period.number") - 1)).and_(pl.col("period.number") >= 3))
+            .then(300)
+            .otherwise(pl.col("end.game_seconds_remaining"))
+            .alias("end.game_seconds_remaining"),
+            pl.col("qtr").cast(pl.Int32).alias("period"),
         )
-        .then(600)
-        .when((pl.col("lag_qtr") == (pl.col("period.number") - 1)).and_(pl.col("period.number") >= 5))
-        .then(300)
-        .otherwise(pl.col("end.quarter_seconds_remaining"))
-        .alias("end.quarter_seconds_remaining"),
-        pl.when((pl.col("game_play_number") == 1))
-        .then(1200)
-        .when((pl.col("lag_half") == 1).and_(pl.col("half") == 2))
-        .then(1200)
-        .when((pl.col("lag_qtr") == 1).and_(pl.col("period.number") == 2))
-        .then(600)
-        .when((pl.col("lag_qtr") == 2).and_(pl.col("period.number") == 3))
-        .then(1200)
-        .when((pl.col("lag_qtr") == 3).and_(pl.col("period.number") == 4))
-        .then(600)
-        .when((pl.col("lag_qtr") == (pl.col("period.number") - 1)).and_(pl.col("period.number") >= 5))
-        .then(300)
-        .otherwise(pl.col("end.half_seconds_remaining"))
-        .alias("end.half_seconds_remaining"),
-        pl.when((pl.col("game_play_number") == 1))
-        .then(2400)
-        .when((pl.col("lag_qtr") == 1).and_(pl.col("period.number") == 2))
-        .then(1800)
-        .when((pl.col("lag_qtr") == 2).and_(pl.col("period.number") == 3))
-        .then(1200)
-        .when((pl.col("lag_qtr") == 3).and_(pl.col("period.number") == 4))
-        .then(600)
-        .when((pl.col("lag_qtr") == (pl.col("period.number") - 1)).and_(pl.col("period.number") >= 5))
-        .then(300)
-        .otherwise(pl.col("end.game_seconds_remaining"))
-        .alias("end.game_seconds_remaining"),
-        pl.col("qtr").cast(pl.Int32).alias("period"),
-    )
+    else:
+        pbp_txt["plays"] = pbp_txt["plays"].with_columns(
+            pl.when(
+                (pl.col("game_play_number") == 1)
+                .or_((pl.col("lag_qtr") == 1).and_(pl.col("period.number") == 2))
+                .or_((pl.col("lag_qtr") == 2).and_(pl.col("period.number") == 3))
+                .or_((pl.col("lag_qtr") == 3).and_(pl.col("period.number") == 4)),
+            )
+            .then(600)
+            .when((pl.col("lag_qtr") == (pl.col("period.number") - 1)).and_(pl.col("period.number") >= 5))
+            .then(300)
+            .otherwise(pl.col("end.quarter_seconds_remaining"))
+            .alias("end.quarter_seconds_remaining"),
+            pl.when((pl.col("game_play_number") == 1))
+            .then(1200)
+            .when((pl.col("lag_half") == 1).and_(pl.col("half") == 2))
+            .then(1200)
+            .when((pl.col("lag_qtr") == 1).and_(pl.col("period.number") == 2))
+            .then(600)
+            .when((pl.col("lag_qtr") == 2).and_(pl.col("period.number") == 3))
+            .then(1200)
+            .when((pl.col("lag_qtr") == 3).and_(pl.col("period.number") == 4))
+            .then(600)
+            .when((pl.col("lag_qtr") == (pl.col("period.number") - 1)).and_(pl.col("period.number") >= 5))
+            .then(300)
+            .otherwise(pl.col("end.half_seconds_remaining"))
+            .alias("end.half_seconds_remaining"),
+            pl.when((pl.col("game_play_number") == 1))
+            .then(2400)
+            .when((pl.col("lag_qtr") == 1).and_(pl.col("period.number") == 2))
+            .then(1800)
+            .when((pl.col("lag_qtr") == 2).and_(pl.col("period.number") == 3))
+            .then(1200)
+            .when((pl.col("lag_qtr") == 3).and_(pl.col("period.number") == 4))
+            .then(600)
+            .when((pl.col("lag_qtr") == (pl.col("period.number") - 1)).and_(pl.col("period.number") >= 5))
+            .then(300)
+            .otherwise(pl.col("end.game_seconds_remaining"))
+            .alias("end.game_seconds_remaining"),
+            pl.col("qtr").cast(pl.Int32).alias("period"),
+        )
 
     return pbp_txt
 

--- a/sportsdataverse/wnba/wnba_pbp.py
+++ b/sportsdataverse/wnba/wnba_pbp.py
@@ -223,8 +223,15 @@ def helper_wnba_pbp_features(game_id, pbp_txt, init):
     pbp_txt["plays"] = pl.from_pandas(pd.json_normalize(pbp_txt, "plays_mod"))
     # WNBA played 2x20-minute halves through 2005 and switched to 10-minute
     # quarters in 2006 (OT is 5:00 in both eras). Pre-2006 ESPN's period IS
-    # the half, so the half/seconds-remaining columns need era-aware math.
-    is_halves_era = int(pbp_txt["header"]["season"]["year"]) < 2006
+    # the half, so the half/seconds-remaining columns need era-aware math. The summary
+    # format.regulation.periods field (2 = halves, 4 = quarters) is authoritative
+    # when present; the season-year cutoff is the fallback.
+    fmt = pbp_txt.get("format")
+    reg_periods = (fmt.get("regulation") or {}).get("periods") if isinstance(fmt, dict) else None
+    if reg_periods in (2, 4):
+        is_halves_era = reg_periods == 2
+    else:
+        is_halves_era = int(pbp_txt["header"]["season"]["year"]) < 2006
     first_half_periods = 1 if is_halves_era else 2
     clock_sec = 60 * pl.col("clock.minutes") + pl.col("clock.seconds")
     if is_halves_era:

--- a/tests/wbb/test_wbb_pbp_era.py
+++ b/tests/wbb/test_wbb_pbp_era.py
@@ -11,7 +11,7 @@ from sportsdataverse.wbb import espn_wbb_pbp
 from tests.conftest import skip_if_no_live
 
 
-def _plays(game_id):
+def _plays(game_id: int) -> pl.DataFrame:
     plays = espn_wbb_pbp(game_id=game_id)["plays"]
     if not plays:
         pytest.skip(f"ESPN returned no plays for {game_id}")
@@ -19,7 +19,7 @@ def _plays(game_id):
 
 
 @skip_if_no_live
-def test_wbb_pre2016_halves_model():
+def test_wbb_pre2016_halves_model() -> None:
     df = _plays(400595044)  # 2014-15 season game
     p1 = df.filter(pl.col("period.number") == 1)
     p2 = df.filter(pl.col("period.number") == 2)
@@ -32,7 +32,7 @@ def test_wbb_pre2016_halves_model():
 
 
 @skip_if_no_live
-def test_wbb_2016plus_quarters_model_unchanged():
+def test_wbb_2016plus_quarters_model_unchanged() -> None:
     df = _plays(401596715)  # 2023-24 season game
     p2 = df.filter(pl.col("period.number") == 2)
     assert p2.get_column("half").unique().to_list() == [1]

--- a/tests/wbb/test_wbb_pbp_era.py
+++ b/tests/wbb/test_wbb_pbp_era.py
@@ -1,0 +1,39 @@
+"""Era-aware clock/half regression tests for espn_wbb_pbp (wehoop#39 sibling).
+
+NCAA women's basketball played 2x20-minute halves through 2014-15 and
+10-minute quarters from 2015-16 (ESPN season year 2016).
+"""
+
+import polars as pl
+import pytest
+
+from sportsdataverse.wbb import espn_wbb_pbp
+from tests.conftest import skip_if_no_live
+
+
+def _plays(game_id):
+    plays = espn_wbb_pbp(game_id=game_id)["plays"]
+    if not plays:
+        pytest.skip(f"ESPN returned no plays for {game_id}")
+    return pl.from_dicts(plays)
+
+
+@skip_if_no_live
+def test_wbb_pre2016_halves_model():
+    df = _plays(400595044)  # 2014-15 season game
+    p1 = df.filter(pl.col("period.number") == 1)
+    p2 = df.filter(pl.col("period.number") == 2)
+    assert p1.get_column("half").unique().to_list() == [1]
+    assert p2.get_column("half").unique().to_list() == [2]
+    assert p1.get_column("start.game_seconds_remaining").max() == 2400
+    assert p2.get_column("start.game_seconds_remaining").max() <= 1200
+    assert p1.get_column("start.half_seconds_remaining").max() <= 1200
+    assert p1.get_column("start.quarter_seconds_remaining").max() <= 1200
+
+
+@skip_if_no_live
+def test_wbb_2016plus_quarters_model_unchanged():
+    df = _plays(401596715)  # 2023-24 season game
+    p2 = df.filter(pl.col("period.number") == 2)
+    assert p2.get_column("half").unique().to_list() == [1]
+    assert p2.get_column("start.game_seconds_remaining").max() <= 1800

--- a/tests/wnba/test_wnba_pbp_era.py
+++ b/tests/wnba/test_wnba_pbp_era.py
@@ -10,7 +10,7 @@ from sportsdataverse.wnba import espn_wnba_pbp
 from tests.conftest import skip_if_no_live
 
 
-def _plays(game_id):
+def _plays(game_id: int) -> pl.DataFrame:
     plays = espn_wnba_pbp(game_id=game_id)["plays"]
     if not plays:
         pytest.skip(f"ESPN returned no plays for {game_id}")
@@ -18,7 +18,7 @@ def _plays(game_id):
 
 
 @skip_if_no_live
-def test_wnba_pre2006_halves_model():
+def test_wnba_pre2006_halves_model() -> None:
     df = _plays(250506017)  # 2005 regular-season game
     p1 = df.filter(pl.col("period.number") == 1)
     p2 = df.filter(pl.col("period.number") == 2)
@@ -31,7 +31,7 @@ def test_wnba_pre2006_halves_model():
 
 
 @skip_if_no_live
-def test_wnba_2006plus_quarters_model_unchanged():
+def test_wnba_2006plus_quarters_model_unchanged() -> None:
     df = _plays(401649378)  # 2024 regular-season game
     p2 = df.filter(pl.col("period.number") == 2)
     assert p2.get_column("half").unique().to_list() == [1]

--- a/tests/wnba/test_wnba_pbp_era.py
+++ b/tests/wnba/test_wnba_pbp_era.py
@@ -1,0 +1,38 @@
+"""Era-aware clock/half regression tests for espn_wnba_pbp (wehoop#39).
+
+WNBA played 2x20-minute halves through 2005 and 10-minute quarters from 2006.
+"""
+
+import polars as pl
+import pytest
+
+from sportsdataverse.wnba import espn_wnba_pbp
+from tests.conftest import skip_if_no_live
+
+
+def _plays(game_id):
+    plays = espn_wnba_pbp(game_id=game_id)["plays"]
+    if not plays:
+        pytest.skip(f"ESPN returned no plays for {game_id}")
+    return pl.from_dicts(plays)
+
+
+@skip_if_no_live
+def test_wnba_pre2006_halves_model():
+    df = _plays(250506017)  # 2005 regular-season game
+    p1 = df.filter(pl.col("period.number") == 1)
+    p2 = df.filter(pl.col("period.number") == 2)
+    assert p1.get_column("half").unique().to_list() == [1]
+    assert p2.get_column("half").unique().to_list() == [2]
+    assert p1.get_column("start.game_seconds_remaining").max() == 2400
+    assert p2.get_column("start.game_seconds_remaining").max() <= 1200
+    assert p1.get_column("start.half_seconds_remaining").max() <= 1200
+    assert p1.get_column("start.quarter_seconds_remaining").max() <= 1200
+
+
+@skip_if_no_live
+def test_wnba_2006plus_quarters_model_unchanged():
+    df = _plays(401649378)  # 2024 regular-season game
+    p2 = df.filter(pl.col("period.number") == 2)
+    assert p2.get_column("half").unique().to_list() == [1]
+    assert p2.get_column("start.game_seconds_remaining").max() <= 1800

--- a/tools/codegen/manual_column_descriptions.yaml
+++ b/tools/codegen/manual_column_descriptions.yaml
@@ -4847,6 +4847,24 @@ load_phf_team_boxscores:
   successful_power_play: Number of power plays on which the team scored.
   total_scoring: Goals the team scored in the game.
   total_shots: Shots the team took in the game.
+load_wbb_pbp:
+  type_text: >-
+    Play type text, passed through verbatim from ESPN. ESPN labels the
+    free-throw play type "MadeFreeThrow" for made AND missed free throws;
+    filter makes vs. misses with scoring_play, not type_text.
+  score_value: >-
+    Point value of the attempt (1 / 2 / 3), carried even on misses (a missed
+    free throw still shows 1); use scoring_play to identify points actually
+    scored.
+load_wnba_pbp:
+  type_text: >-
+    Play type text, passed through verbatim from ESPN. ESPN labels the
+    free-throw play type "MadeFreeThrow" for made AND missed free throws;
+    filter makes vs. misses with scoring_play, not type_text.
+  score_value: >-
+    Point value of the attempt (1 / 2 / 3), carried even on misses (a missed
+    free throw still shows 1); use scoring_play to identify points actually
+    scored.
 load_wnba_stats_pbp:
 load_wnba_stats_player_game_logs:
   ast: Assists credited.


### PR DESCRIPTION
Addresses sportsdataverse/wehoop#39 at its root: the producer hard-coded the 4x10-minute quarters model for every season, so pre-2006 WNBA (2x20-minute halves) and pre-2015-16 NCAA WBB games shipped wrong `half`, `start/end.{quarter,half,game}_seconds_remaining`, OT detection (period >= 5 instead of >= 3), and timeout first/second-half buckets.

**Changes**
- `helper_wnba_pbp_features` / `helper_wbb_pbp_features` derive `is_halves_era` from the summary header season year (WNBA < 2006, WBB < 2016) and branch the half mapping (period IS the half), seconds-remaining offsets (half 1200 / game 2400, H2 from 1200), period-boundary resets (OT at period >= 3), and the timeout split (first half = period 1). Quarters-era output is unchanged.
- Live-gated regression tests for all four cases (2005 + 2024 WNBA, 2014-15 + 2023-24 WBB).
- Sister docs change to wehoop#18 / sportsdataverse/wehoop#73: `type_text` / `score_value` free-throw semantics documented for `load_wbb_pbp` / `load_wnba_pbp` (`manual_column_descriptions.yaml` + regenerated reference docs).

**Validated on real ESPN games** — 2005 WNBA game 250506017 and 2014-15 WBB game 400595044 now emit half 1/2 by period with game seconds 2400 -> 1200 at the break; 2024 controls for both leagues are unchanged vs. the old code path.

**Follow-up (not in this PR):** the published pre-2006 `espn_wnba_pbp` and pre-2016 `espn_wbb_pbp` season assets were built with the quarters model and need a reprocess + republish once this merges — tracked in the session ledger.

Note: the `tests` workflow has been red on every push since 08-12 (macos py3.13 runner issue, pre-existing); the codegen drift gate is the merge-relevant signal.

## Summary by Sourcery

Make WNBA and NCAA women's basketball play-by-play period features aware of the sport's historical halves and quarters eras.

Bug Fixes:
- Correct half assignments, clock-derived remaining-seconds fields, overtime boundaries, and timeout half buckets for pre-2006 WNBA and pre-2016 NCAA women's basketball games while preserving the modern quarters-era behavior.

Documentation:
- Document ESPN free-throw semantics for the WNBA and NCAA women's basketball play-by-play loaders, including how to distinguish attempted value from points scored.

Tests:
- Add live-gated regression coverage for historical halves-era and modern quarters-era WNBA and NCAA women's basketball games.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved women’s basketball play-by-play timing and period assignments for historical two-half games.
  * Preserved accurate quarter-based timing for modern games.
  * Improved timeout grouping and period transitions across historical formats.

* **Documentation**
  * Clarified ESPN play-type labels and free-throw handling.
  * Documented that `scoring_play` identifies made free throws and points scored, while `score_value` reflects the attempted value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->