### PR TITLE
feat(wnba): season win-probability compile (build_wnba_season_wp)

### DIFF
--- a/docs/docs/wnba/index.md
+++ b/docs/docs/wnba/index.md
@@ -12,7 +12,7 @@ sidebar_label: WNBA
 | [ESPN FPI API (fitt v3)](reference/fitt) | 1 | `https://site.web.api.espn.com/apis/fitt/v3/sports` |
 | [WNBA Stats API (stats.wnba.com)](reference/wnba_stats) | 95 | `https://stats.wnba.com` |
 | [Dataset loaders](reference/loaders) | 30 | sportsdataverse-data releases |
-| [Additional functions](reference/additional) | 60 | hand-written wrappers, loaders & helpers |
+| [Additional functions](reference/additional) | 61 | hand-written wrappers, loaders & helpers |
 
 ## Examples
 

--- a/docs/docs/wnba/reference/additional.md
+++ b/docs/docs/wnba/reference/additional.md
@@ -527,6 +527,41 @@ R `build_athlete_identity_lookup`: athlete_id -> identity from team rosters.
 
 athlete_id (str) -> identity fields for `helper_wbb_player_season_stats`.
 
+### `build_wnba_season_wp(season: 'int', *, return_as_pandas: 'bool' = False) -> "Union[pl.DataFrame, 'pd.DataFrame']"` {#build_wnba_season_wp}
+
+A WNBA season's play-by-play with win-probability columns joined in.
+
+Loads the season's play-by-play, schedule, and team boxscores, builds a
+leakage-free weekly as-of pregame anchor per game from the WNBA ratings
+engine (`league_id="10"`), scores every play through the bundled
+in-game win-probability artifact, and returns the full `load_wnba_pbp`
+frame with `pregame_home_prob` + `home_win_prob` appended -- the
+enrich-in-place shape that overwrites the season's
+`play_by_play_<season>.parquet` release asset.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `season` | `int` |  | Season year (e.g. `2024`); bounded by `load_wnba_pbp` release availability. |
+| `return_as_pandas` | `bool` | `False` | Return a pandas DataFrame instead of polars. |
+
+**Returns**
+
+The season's `load_wnba_pbp` frame (every column preserved) with the two WP_COLS` appended (both `Float64`), sorted by `game_id` then `game_play_number`.
+
+**Example**
+
+```python
+from sportsdataverse.wnba import build_wnba_season_wp
+wp = build_wnba_season_wp(2024)
+wp.select("game_id", "game_play_number", "home_win_prob").head()
+
+# Pandas output
+
+wp_pd = build_wnba_season_wp(2024, return_as_pandas=True)
+```
+
 ### `espn_wnba_teams(return_as_pandas=False, **kwargs) -> 'pl.DataFrame'` {#espn_wnba_teams}
 
 espn_wnba_teams - look up WNBA teams

--- a/docs/docs/wnba/reference/additional.md
+++ b/docs/docs/wnba/reference/additional.md
@@ -548,7 +548,7 @@ enrich-in-place shape that overwrites the season's
 
 **Returns**
 
-The season's `load_wnba_pbp` frame (every column preserved) with the two WP_COLS` appended (both `Float64`), sorted by `game_id` then `game_play_number`.
+The season's `load_wnba_pbp` frame (every column preserved) with the two WP columns `pregame_home_prob` + `home_win_prob` appended (both `Float64`), sorted by `game_id` then `game_play_number`.
 
 **Example**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -430,6 +430,7 @@ files = [
     "sportsdataverse/nba/nba_player_props.py",
     "sportsdataverse/wnba/wnba_team_ratings.py",
     "sportsdataverse/wnba/wnba_game_predict.py",
+    "sportsdataverse/wnba/wnba_win_prob.py",
     "sportsdataverse/wnba/wnba_clutch.py",
     "sportsdataverse/wnba/wnba_player_props.py",
     "sportsdataverse/wnba/wnba_stats_runtime.py",

--- a/sportsdataverse/parsed/wnba.py
+++ b/sportsdataverse/parsed/wnba.py
@@ -140,6 +140,7 @@ from sportsdataverse.wnba import fox_wnba_team_roster as _raw_fox_wnba_team_rost
 from sportsdataverse.wnba import fox_wnba_team_stats as _raw_fox_wnba_team_stats
 from sportsdataverse.wnba import fox_wnba_teams as _raw_fox_wnba_teams
 from sportsdataverse.wnba import build_athlete_identity_lookup as build_athlete_identity_lookup  # noqa: F401
+from sportsdataverse.wnba import build_wnba_season_wp as build_wnba_season_wp  # noqa: F401
 from sportsdataverse.wnba import download as download  # noqa: F401
 from sportsdataverse.wnba import espn_wnba_calendar as espn_wnba_calendar  # noqa: F401
 from sportsdataverse.wnba import espn_wnba_draft as espn_wnba_draft  # noqa: F401
@@ -253,6 +254,7 @@ from sportsdataverse.wnba import zone_value_map as zone_value_map  # noqa: F401
 
 __all__ = [
     "build_athlete_identity_lookup",
+    "build_wnba_season_wp",
     "download",
     "espn_wnba_award",
     "espn_wnba_awards",

--- a/sportsdataverse/wnba/__init__.py
+++ b/sportsdataverse/wnba/__init__.py
@@ -47,6 +47,7 @@ from sportsdataverse.wnba.wnba_game_predict import (  # noqa: F401
     wnba_predict_total,
     wnba_win_prob_from_margin,
 )
+from sportsdataverse.wnba.wnba_win_prob import build_wnba_season_wp  # noqa: F401
 from sportsdataverse.wnba.wnba_clutch import wnba_team_clutch  # noqa: F401
 from sportsdataverse.wnba.wnba_player_props import wnba_player_props  # noqa: F401
 from sportsdataverse.wnba.wnba_aging_curve import wnba_aging_curve, wnba_career_trajectory  # noqa: F401

--- a/sportsdataverse/wnba/wnba_win_prob.py
+++ b/sportsdataverse/wnba/wnba_win_prob.py
@@ -135,7 +135,8 @@ def _compile_season_wp(pbp: pl.DataFrame, schedule: pl.DataFrame, team_box: pl.D
         team_box: Per-team boxscore for the same season.
 
     Returns:
-        The pbp frame with :data:`_WP_COLS` appended (both ``Float64``), sorted
+        The pbp frame with ``pregame_home_prob`` + ``home_win_prob`` appended
+        (both ``Float64``), sorted
         by ``game_id`` then ``game_play_number``. Empty pbp returns unchanged.
     """
     if pbp.height == 0:
@@ -196,7 +197,8 @@ def build_wnba_season_wp(season: int, *, return_as_pandas: bool = False) -> Unio
 
     Returns:
         The season's ``load_wnba_pbp`` frame (every column preserved) with the
-        two :data:`_WP_COLS` appended (both ``Float64``), sorted by ``game_id``
+        two WP columns ``pregame_home_prob`` + ``home_win_prob`` appended (both
+        ``Float64``), sorted by ``game_id``
         then ``game_play_number``.
 
     Example:

--- a/sportsdataverse/wnba/wnba_win_prob.py
+++ b/sportsdataverse/wnba/wnba_win_prob.py
@@ -1,0 +1,219 @@
+"""Season win-probability enrichment for WNBA -- pbp-dataset WP columns (in place).
+
+The pregame closed forms and the in-game win-probability scorer already exist
+on the NBA prediction spine, bound to ``league_id="10"``
+(:mod:`sportsdataverse.wnba.wnba_game_predict`). This module *productionizes*
+them by **enriching the pbp dataset in place**: for every game in a season it
+computes a leakage-free pregame anchor from as-of team ratings, scores every
+play through the bundled WNBA in-game artifact, and appends two columns
+(``pregame_home_prob``, ``home_win_prob``) to the ``load_wnba_pbp`` frame --
+every original column is preserved, so the output overwrites the season's
+``play_by_play_<season>.parquet`` release asset with WP joined in.
+
+The orchestration mirrors :mod:`sportsdataverse.mbb.mbb_win_prob` (weekly
+as-of buckets + an HFA-only fallback anchor for opening-week games), but
+reuses the NBA ratings engine (:mod:`sportsdataverse.nba.nba_team_ratings`)
+and closed forms directly rather than the NCAA per-league ratings dispatch --
+the NBA spine already has an ``as_of_date`` split built in
+(:func:`~sportsdataverse.nba.nba_team_ratings.nba_team_ratings`); this module
+recomputes the weekly-bucketed ratings from the raw pieces
+(:func:`~sportsdataverse.nba.nba_team_ratings.raw_game_efficiency` +
+``adjust_efficiency``/``adjust_pace``) so a season's ~25 as-of ratings snapshots
+don't each re-hit the network via the season-loader entry point.
+
+* :func:`_pregame_probs` -- per-game pregame home win probability, built from
+  opponent-adjusted WNBA ratings computed on games strictly before the Monday
+  of each game's week.
+* :func:`_compile_season_wp` -- appends the two WP columns to the pbp frame.
+* :func:`build_wnba_season_wp` -- loads pbp/schedule/team-box for a season and
+  runs the two cores.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, Literal, Union, overload
+
+import polars as pl
+
+from sportsdataverse.nba.nba_team_ratings import _normalize_schedule
+from sportsdataverse.wnba.wnba_game_predict import (
+    wnba_in_game_win_prob,
+    wnba_predict_games,
+    wnba_predict_margin,
+    wnba_win_prob_from_margin,
+)
+from sportsdataverse.wnba.wnba_loaders import load_wnba_pbp, load_wnba_schedule, load_wnba_team_boxscore
+from sportsdataverse.wnba.wnba_team_ratings import adjust_efficiency, adjust_pace, raw_game_efficiency
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+__all__ = ["build_wnba_season_wp"]
+
+# The two Float64 columns appended to the pbp frame. The release enriches the
+# pbp dataset *in place*, so the output is the full ``load_wnba_pbp`` frame
+# (all columns, original dtypes) with exactly these two columns added.
+_WP_COLS: tuple[str, str] = ("pregame_home_prob", "home_win_prob")
+
+_PREGAME_SCHEMA: dict[str, pl.DataType] = {"game_id": pl.Utf8, "pregame_home_prob": pl.Float64}
+
+
+def _pregame_probs(schedule: pl.DataFrame, team_box: pl.DataFrame) -> pl.DataFrame:
+    """Per-game pregame home win probability, leakage-free weekly as-of.
+
+    Args:
+        schedule: A ``_normalize_schedule``'d schedule (``game_id, season, date,
+            home_team_id, away_team_id, home_score, away_score`` and optionally
+            ``neutral_site``). Completed games only are used.
+        team_box: Per-team boxscore with ``game_id, game_date, team_id`` and the
+            possession inputs (:func:`raw_game_efficiency`).
+
+    Returns:
+        One row per game that has a rating for both teams at its week cutoff:
+        ``game_id`` (Utf8) + ``pregame_home_prob`` (Float64). Games without an
+        as-of rating are absent (the caller supplies the fallback anchor).
+    """
+    if schedule.is_empty() or team_box.is_empty() or "game_date" not in team_box.columns:
+        return pl.DataFrame(schema=_PREGAME_SCHEMA)
+
+    results = schedule.filter(pl.col("home_score").is_not_null() & pl.col("away_score").is_not_null())
+    if results.height == 0:
+        return pl.DataFrame(schema=_PREGAME_SCHEMA)
+
+    # ID discipline: raw_game_efficiency casts team ids to Utf8, so ratings'
+    # team_id is Utf8. Match the games' join keys to it up front -- the raw
+    # ESPN schedule ships Int32 ids and wnba_predict_games' dtype guard would
+    # otherwise raise on the live path.
+    results = results.with_columns(
+        pl.col("game_id").cast(pl.Utf8),
+        pl.col("home_team_id").cast(pl.Utf8),
+        pl.col("away_team_id").cast(pl.Utf8),
+    )
+    if "neutral_site" not in results.columns:
+        results = results.with_columns(pl.lit(False).alias("neutral_site"))
+    results = results.with_columns(pl.col("date").dt.truncate("1w").alias("_cutoff"))
+
+    frames: list[pl.DataFrame] = []
+    for (cutoff,), week in results.group_by("_cutoff", maintain_order=True):
+        prior = results.filter(pl.col("date") < cutoff)
+        if prior.height == 0:
+            continue
+        eff = raw_game_efficiency(prior, team_box.filter(pl.col("game_date") < cutoff))
+        if eff.height == 0:
+            continue
+        ratings = (
+            adjust_efficiency(eff, league_id="10")
+            .join(adjust_pace(eff, league_id="10"), on=["season", "team_id"], how="left")
+            .select("team_id", "adj_off_rtg", "adj_def_rtg", "adj_net_rtg", "adj_pace")
+        )
+        preds = wnba_predict_games(week.select("game_id", "home_team_id", "away_team_id", "neutral_site"), ratings)
+        frames.append(preds.select("game_id", pl.col("home_win_prob").alias("pregame_home_prob")))
+
+    if not frames:
+        return pl.DataFrame(schema=_PREGAME_SCHEMA)
+    # A degenerate early-season week can make the ratings fixed point emit a NaN
+    # adj_net_rtg -> NaN margin -> NaN prob. NaN is NOT null in polars, so
+    # is_not_null alone lets it through; drop non-finite too so those games take
+    # the fallback anchor instead of publishing a NaN pregame_home_prob.
+    return pl.concat(frames).filter(
+        pl.col("pregame_home_prob").is_not_null() & pl.col("pregame_home_prob").is_not_nan()
+    )
+
+
+def _compile_season_wp(pbp: pl.DataFrame, schedule: pl.DataFrame, team_box: pl.DataFrame) -> pl.DataFrame:
+    """Append ``pregame_home_prob`` + ``home_win_prob`` to a season's pbp.
+
+    The release enriches the pbp dataset **in place**, so every input column is
+    preserved (names + dtypes) and exactly the two WP columns are added.
+
+    Args:
+        pbp: ``load_wnba_pbp`` frame (needs ``game_id, game_play_number,
+            start_game_seconds_remaining, home_score, away_score, team_id,
+            home_team_id``; all other columns pass through untouched).
+        schedule: ``_normalize_schedule``'d schedule for the same season.
+        team_box: Per-team boxscore for the same season.
+
+    Returns:
+        The pbp frame with :data:`_WP_COLS` appended (both ``Float64``), sorted
+        by ``game_id`` then ``game_play_number``. Empty pbp returns unchanged.
+    """
+    if pbp.height == 0:
+        return pbp
+
+    pregame = _pregame_probs(schedule, team_box)
+    pmap = dict(zip(pregame.get_column("game_id").to_list(), pregame.get_column("pregame_home_prob").to_list()))
+    # No-prior-information anchor for games without an as-of rating (opening days,
+    # unrated opponent): the HFA-only home prob. home_pace/away_pace are
+    # irrelevant here -- the margin's pace-scaled term is multiplied by a zero
+    # net-rating difference, so any finite nonzero pace leaves only the HFA term.
+    fallback = wnba_win_prob_from_margin(wnba_predict_margin(0.0, 0.0, home_pace=1.0, away_pace=1.0, neutral=False))
+
+    frames: list[pl.DataFrame] = []
+    for (gid,), sub in pbp.group_by("game_id", maintain_order=True):
+        p0 = pmap.get(str(gid), fallback)
+        if not math.isfinite(p0):  # never publish a non-finite anchor (belt-and-suspenders vs _pregame_probs)
+            p0 = fallback
+        wp = wnba_in_game_win_prob(sub, p0)  # row-aligned with sub
+        frames.append(
+            sub.with_columns(
+                pl.lit(p0, dtype=pl.Float64).alias("pregame_home_prob"),
+                wp.get_column("home_win_prob").cast(pl.Float64),
+            )
+        )
+
+    return pl.concat(frames).sort(["game_id", "game_play_number"])
+
+
+def _load_wnba_frames(season: int) -> tuple[pl.DataFrame, pl.DataFrame, pl.DataFrame]:
+    """(pbp, normalized schedule, team_box) for a season -- the mockable I/O seam."""
+    return load_wnba_pbp([season]), _normalize_schedule(load_wnba_schedule([season])), load_wnba_team_boxscore([season])
+
+
+@overload
+def build_wnba_season_wp(season: int, *, return_as_pandas: Literal[False] = False) -> pl.DataFrame: ...
+
+
+@overload
+def build_wnba_season_wp(season: int, *, return_as_pandas: Literal[True]) -> "pd.DataFrame": ...
+
+
+def build_wnba_season_wp(season: int, *, return_as_pandas: bool = False) -> Union[pl.DataFrame, "pd.DataFrame"]:
+    """A WNBA season's play-by-play with win-probability columns joined in.
+
+    Loads the season's play-by-play, schedule, and team boxscores, builds a
+    leakage-free weekly as-of pregame anchor per game from the WNBA ratings
+    engine (``league_id="10"``), scores every play through the bundled
+    in-game win-probability artifact, and returns the full ``load_wnba_pbp``
+    frame with ``pregame_home_prob`` + ``home_win_prob`` appended -- the
+    enrich-in-place shape that overwrites the season's
+    ``play_by_play_<season>.parquet`` release asset.
+
+    Args:
+        season: Season year (e.g. ``2024``); bounded by ``load_wnba_pbp``
+            release availability.
+        return_as_pandas: Return a pandas DataFrame instead of polars.
+
+    Returns:
+        The season's ``load_wnba_pbp`` frame (every column preserved) with the
+        two :data:`_WP_COLS` appended (both ``Float64``), sorted by ``game_id``
+        then ``game_play_number``.
+
+    Example:
+        Quick start::
+
+            from sportsdataverse.wnba import build_wnba_season_wp
+            wp = build_wnba_season_wp(2024)
+            wp.select("game_id", "game_play_number", "home_win_prob").head()
+
+        Pandas output::
+
+            wp_pd = build_wnba_season_wp(2024, return_as_pandas=True)
+
+    See Also:
+        * `wehoop <https://wehoop.sportsdataverse.org>`_ -- women's basketball (R)
+        * `nba_api <https://github.com/swar/nba_api>`_ -- NBA/WNBA (Python)
+    """
+    pbp, schedule, team_box = _load_wnba_frames(season)
+    out = _compile_season_wp(pbp, schedule, team_box)
+    return out.to_pandas() if return_as_pandas else out

--- a/tests/wnba/test_wnba_win_prob.py
+++ b/tests/wnba/test_wnba_win_prob.py
@@ -1,0 +1,191 @@
+"""Tests for the WNBA season win-probability enrichment (``wnba_win_prob``).
+
+The helper enriches the pbp dataset **in place**: it appends two columns
+(``pregame_home_prob``, ``home_win_prob``) to the ``load_wnba_pbp`` frame and
+preserves every original column + dtype. ``home_win_prob`` is
+:func:`wnba_in_game_win_prob`'s output unchanged, so the **reproduction gate**
+below (byte parity for a game) transitively guarantees the decile-calibration
+gate already proven on the shared NBA-spine artifact.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import pandas as pd
+import polars as pl
+
+from sportsdataverse.wnba.wnba_game_predict import wnba_in_game_win_prob, wnba_predict_margin, wnba_win_prob_from_margin
+from sportsdataverse.wnba.wnba_win_prob import _WP_COLS, _compile_season_wp, build_wnba_season_wp
+
+_MON1 = datetime.date(2024, 1, 1)  # Monday
+_MON3 = datetime.date(2024, 1, 15)  # two weeks later (Monday)
+
+_FALLBACK = wnba_win_prob_from_margin(wnba_predict_margin(0.0, 0.0, home_pace=1.0, away_pace=1.0, neutral=False))
+
+
+def _schedule() -> pl.DataFrame:
+    """Two week-1 games (rating source) + one week-3 game (gets an as-of prob).
+
+    Ids are ``Int32`` to mirror the raw ``load_wnba_schedule`` dtype (the trap
+    ``_pregame_probs`` must cast past before calling ``wnba_predict_games``).
+    """
+    return pl.DataFrame(
+        {
+            "game_id": [1, 2, 3],
+            "season": [2024, 2024, 2024],
+            "date": [_MON1, _MON1, _MON3],
+            "home_team_id": [1, 3, 1],
+            "away_team_id": [2, 4, 3],
+            "home_score": [75, 60, 80],
+            "away_score": [70, 66, 62],
+            "neutral_site": [False, False, False],
+        },
+        schema_overrides={
+            "game_id": pl.Int32,
+            "season": pl.Int32,
+            "home_team_id": pl.Int32,
+            "away_team_id": pl.Int32,
+            "home_score": pl.Int32,
+            "away_score": pl.Int32,
+        },
+    )
+
+
+def _team_box() -> pl.DataFrame:
+    """Two team rows per week-1 game (efficiency source for the as-of ratings)."""
+    rows = []
+    for gid, (h, a) in ((1, (1, 2)), (2, (3, 4))):
+        for tid, sc in ((h, 75 if gid == 1 else 60), (a, 70 if gid == 1 else 66)):
+            rows.append(
+                {
+                    "game_id": gid,
+                    "season": 2024,
+                    "game_date": _MON1,
+                    "team_id": tid,
+                    "field_goals_attempted": 60.0,
+                    "offensive_rebounds": 10.0,
+                    "turnovers": 12.0,
+                    "free_throws_attempted": 20.0,
+                    "team_score": float(sc),
+                }
+            )
+    return pl.DataFrame(rows, schema_overrides={"game_id": pl.Int32, "season": pl.Int32, "team_id": pl.Int32})
+
+
+def _pbp_game(gid: int, home: int, away: int, hname: str, aname: str, date: datetime.date) -> pl.DataFrame:
+    """A tiny 3-play pbp frame in the ``load_wnba_pbp`` schema (Int32 ids)."""
+    return pl.DataFrame(
+        {
+            "game_id": [gid, gid, gid],
+            "season": [2024, 2024, 2024],
+            "game_play_number": [1, 2, 3],
+            "game_date": [date, date, date],
+            "home_team_name": [hname, hname, hname],
+            "away_team_name": [aname, aname, aname],
+            "home_score": [0, 40, 80],
+            "away_score": [0, 38, 62],
+            "start_game_seconds_remaining": [2400, 1200, 20],
+            "team_id": [home, away, home],
+            "home_team_id": [home, home, home],
+        },
+        schema_overrides={
+            "game_id": pl.Int32,
+            "season": pl.Int32,
+            "game_play_number": pl.Int32,
+            "home_score": pl.Int32,
+            "away_score": pl.Int32,
+            "start_game_seconds_remaining": pl.Int32,
+            "team_id": pl.Int32,
+            "home_team_id": pl.Int32,
+        },
+    )
+
+
+def _pbp() -> pl.DataFrame:
+    # game 1 (week 1, no prior -> fallback anchor), game 3 (week 3, real as-of prob)
+    return pl.concat([_pbp_game(1, 1, 2, "Sky", "Mystics", _MON1), _pbp_game(3, 1, 3, "Sky", "Aces", _MON3)])
+
+
+def test_enriches_pbp_in_place_preserving_columns_and_dtypes():
+    src = _pbp()
+    out = _compile_season_wp(src, _schedule(), _team_box())
+    for col, dt in src.schema.items():
+        assert out.schema[col] == dt, f"{col} dtype changed {dt} -> {out.schema[col]}"
+    assert set(out.columns) - set(src.columns) == set(_WP_COLS)
+    assert out.schema["pregame_home_prob"] == pl.Float64
+    assert out.schema["home_win_prob"] == pl.Float64
+    assert out.height == src.height  # one row per play, no drops
+
+
+def test_sorted_by_game_then_play():
+    out = _compile_season_wp(_pbp(), _schedule(), _team_box())
+    assert out.select("game_id", "game_play_number").rows() == sorted(out.select("game_id", "game_play_number").rows())
+
+
+def test_reproduces_in_game_win_prob_for_a_game():
+    """GATE: per-play home_win_prob is exactly wnba_in_game_win_prob's output."""
+    out = _compile_season_wp(_pbp(), _schedule(), _team_box())
+    g = out.filter(pl.col("game_id") == 3).sort("game_play_number")
+    p0 = g.get_column("pregame_home_prob")[0]
+    expected = wnba_in_game_win_prob(_pbp_game(3, 1, 3, "Sky", "Aces", _MON3), p0)
+    assert g.get_column("home_win_prob").to_list() == expected.get_column("home_win_prob").to_list()
+
+
+def test_week3_game_gets_real_as_of_prob_not_fallback():
+    out = _compile_season_wp(_pbp(), _schedule(), _team_box())
+    p3 = out.filter(pl.col("game_id") == 3).get_column("pregame_home_prob")[0]
+    assert abs(p3 - _FALLBACK) > 1e-9, "week-3 game should have an as-of rating-based prob, not the flat anchor"
+
+
+def test_opening_week_game_uses_fallback_anchor():
+    out = _compile_season_wp(_pbp(), _schedule(), _team_box())
+    p1 = out.filter(pl.col("game_id") == 1).get_column("pregame_home_prob")[0]
+    assert abs(p1 - _FALLBACK) < 1e-9, "opening-week game has no prior -> HFA-only fallback anchor"
+
+
+def test_nan_pregame_anchor_coerced_to_fallback(monkeypatch):
+    """A degenerate NaN as-of rating must never publish a NaN pregame_home_prob."""
+    monkeypatch.setattr(
+        "sportsdataverse.wnba.wnba_win_prob._pregame_probs",
+        lambda schedule, team_box: pl.DataFrame({"game_id": ["3"], "pregame_home_prob": [float("nan")]}),
+    )
+    out = _compile_season_wp(_pbp(), _schedule(), _team_box())
+    p3 = out.filter(pl.col("game_id") == 3).get_column("pregame_home_prob")[0]
+    assert p3 == _FALLBACK
+    assert out.get_column("pregame_home_prob").is_nan().sum() == 0
+    assert out.get_column("home_win_prob").is_nan().sum() == 0
+
+
+def test_empty_team_box_falls_back_without_crashing():
+    """A season with pbp but no boxscores (empty team_box) must not crash."""
+    out = _compile_season_wp(_pbp(), _schedule(), pl.DataFrame())
+    assert out.height == _pbp().height
+    assert out.get_column("pregame_home_prob").unique().to_list() == [_FALLBACK]
+    assert out.get_column("home_win_prob").is_nan().sum() == 0
+
+
+def test_empty_pbp_returns_unchanged():
+    empty = pl.DataFrame()
+    out = _compile_season_wp(empty, _schedule(), _team_box())
+    assert out.height == 0
+
+
+def test_return_as_pandas(monkeypatch):
+    monkeypatch.setattr(
+        "sportsdataverse.wnba.wnba_win_prob._load_wnba_frames",
+        lambda season: (_pbp(), _schedule(), _team_box()),
+    )
+    out = build_wnba_season_wp(2024, return_as_pandas=True)
+    assert isinstance(out, pd.DataFrame)
+    assert set(_WP_COLS).issubset(out.columns)
+
+
+def test_return_as_polars_default(monkeypatch):
+    monkeypatch.setattr(
+        "sportsdataverse.wnba.wnba_win_prob._load_wnba_frames",
+        lambda season: (_pbp(), _schedule(), _team_box()),
+    )
+    out = build_wnba_season_wp(2024)
+    assert isinstance(out, pl.DataFrame)
+    assert set(_WP_COLS).issubset(out.columns)


### PR DESCRIPTION
Closes the WNBA gap in the season WP family: `build_wnba_season_wp(season)` mirrors `build_mbb_season_wp`/`build_wbb_season_wp`'s orchestration (leakage-free weekly as-of pregame anchor + HFA-only fallback for opening-week games + per-game in-game scoring), wired to the NBA-spine primitives already bound for the WNBA (`wnba_predict_games`, `wnba_in_game_win_prob` with the bundled `wnba_in_game_wp.ubj`, shared ratings primitives via `wnba_team_ratings`).

**Real-data validation (2024 season, 264 games / 101,501 plays, live loaders):**
- WP coverage 100.0% (zero null/NaN)
- Brier 0.1647 overall
- Final-play correct-side share 93.6%; mean final WP 0.864 (home wins) vs 0.139 (home losses)
- Decile calibration monotone end-to-end (0.047 -> 0.972 predicted vs empirical), mid-table noise limited to the two smallest deciles

**Contract:** enrich-in-place — every `load_wnba_pbp` column preserved, exactly `pregame_home_prob` + `home_win_prob` (Float64) appended, sorted by game_id / game_play_number.

**Tests/gates:** 10 offline mocked-seam tests (mirroring the mbb suite); mypy ratchet extended; ruff + codegen drift gate clean; no regressions in the mbb/wbb WP suites (88 passed).

Note: the `tests` workflow has been red on every push since 08-12 (macos py3.13 runner, pre-existing); the codegen drift gate is the merge-relevant signal.

## Summary by Sourcery

Add WNBA season win-probability compilation with leakage-free pregame anchors and per-play scoring.

New Features:
- Add a public `build_wnba_season_wp` function that enriches WNBA season play-by-play with pregame and per-play home win probabilities.
- Expose the WNBA season win-probability builder through the package API and generated parsed interface.

Enhancements:
- Use leakage-free weekly as-of ratings with a home-advantage fallback for games without prior ratings while preserving the complete play-by-play dataset and supporting Polars or pandas output.

Build:
- Include the WNBA win-probability module in the project typing configuration.

Documentation:
- Document the new WNBA season win-probability builder, its parameters, return contract, and usage examples.

Tests:
- Add offline tests covering enrichment contracts, ordering, probability reproduction, fallback behavior, non-finite anchors, empty inputs, and output formats.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WNBA season win-probability enrichment with pregame and in-game probabilities for every play.
  * Added support for returning results as either Polars or pandas dataframes.
  * Exposed the functionality through the public WNBA package interface.

* **Documentation**
  * Documented the new WNBA win-probability outputs and corrected column details.
  * Updated the listed count of available additional functions.

* **Tests**
  * Added coverage for probability calculations, fallback behavior, sorting, empty data, and output formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->