### PR TITLE
feat(cfb): graduate NCAA->cfbfastR mapper + drive totals (n_plays/yards)

### DIFF
--- a/docs/docs/cfb/index.md
+++ b/docs/docs/cfb/index.md
@@ -14,7 +14,7 @@ sidebar_label: CFB
 | [247Sports Recruit Database (ipa.247sports.com)](reference/sports247) | 12 | `https://ipa.247sports.com` |
 | [247Sports Site Pages (247sports.com)](reference/sports247_site_pages) | 35 | `https://247sports.com` |
 | [Dataset loaders](reference/loaders) | 40 | sportsdataverse raw data / sportsdataverse-data releases |
-| [Additional functions](reference/additional) | 75 | hand-written wrappers, loaders & helpers |
+| [Additional functions](reference/additional) | 76 | hand-written wrappers, loaders & helpers |
 
 ## Examples
 

--- a/docs/docs/cfb/reference/additional.md
+++ b/docs/docs/cfb/reference/additional.md
@@ -2910,6 +2910,41 @@ st = special_teams_ratings(pbp)
 st.sort("adj_st_epa", descending=True).head()
 ```
 
+### `to_cfbfastr(pbp: 'pl.DataFrame', *, season: "'Optional[int]'" = None, week: "'Optional[int]'" = None, drives: "'Optional[pl.DataFrame]'" = None, linescore: "'Optional[pl.DataFrame]'" = None, drive_titles: "'Optional[pl.DataFrame]'" = None, ot_drives: "'Optional[pl.DataFrame]'" = None, scoring_summary: "'Optional[pl.DataFrame]'" = None, return_as_pandas: 'bool' = False) -> "'Union[pl.DataFrame, pd.DataFrame]'"` {#to_cfbfastr}
+
+cfbfastR-named play frame from the NCAA structural pbp frame.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `pbp` | `DataFrame` |  | Output of `sportsdataverse.cfb.cfb_ncaa_pbp.parse_cfb_ncaa_pbp` (one game). |
+| `season` | `Optional[int]` | `None` | Season year (2025 = fall-2025), written to `season`/`year`. |
+| `week` | `Optional[int]` | `None` | Optional week number (from the schedule master). |
+| `drives` | `Optional[DataFrame]` | `None` | Optional `sportsdataverse.cfb.cfb_ncaa_box.parse_cfb_ncaa_drives` frame -- refines `period` per drive when quarter markers are missing from the pbp page. |
+| `linescore` | `Optional[DataFrame]` | `None` | Optional `sportsdataverse.cfb.cfb_ncaa_box.parse_cfb_ncaa_linescore` frame -- provides `home`/`away` team names and the official per-team finals. |
+| `drive_titles` | `Optional[DataFrame]` | `None` | Optional `sportsdataverse.cfb.cfb_ncaa_pbp.parse_cfb_ncaa_drive_titles` frame -- authoritative per-drive team labels (fixes graduated-parser team truncation) and running-score checkpoints the play-level score snaps to at each drive boundary (self-heals OT scoring rules + missed events). |
+| `ot_drives` | `Optional[DataFrame]` | `None` | Optional `sportsdataverse.cfb.cfb_ncaa_box.parse_cfb_ncaa_drives` frame for the OT-synthesis pass -- overtime rows (`period > 4`) are selected internally, so the full drives frame can be passed as-is. |
+| `scoring_summary` | `Optional[DataFrame]` | `None` | Optional `sportsdataverse.cfb.cfb_ncaa_box.parse_cfb_ncaa_scoring_summary` frame -- running-score checkpoints for the synthesized OT rows and the final-drive snap. |
+| `return_as_pandas` | `bool` | `False` | Return a `pandas.DataFrame` instead of `polars`. |
+
+**Returns**
+
+A `polars.DataFrame` (or `pandas.DataFrame` when `return_as_pandas`) with one row per play (markers/furniture dropped) and the columns of `CFBFASTR_SCHEMA`. Empty input returns a **zero-row frame carrying the documented schema**.
+
+**Example**
+
+```python
+from sportsdataverse.cfb import parse_cfb_ncaa_pbp, to_cfbfastr
+pbp = parse_cfb_ncaa_pbp(open("play_by_play_5362431.html").read(), contest_id=5362431)
+df = to_cfbfastr(pbp, season=2024)
+print(df.shape)
+
+# Final score from the running-score columns
+
+df.select("pos_team", "pos_team_score", "def_pos_team", "def_pos_team_score").row(-1)
+```
+
 ### `win_prob_from_margin(exp_margin: 'float', *, era: 'str' = 'modern') -> 'float'` {#win_prob_from_margin}
 
 Home win probability from an expected margin via the Gaussian CDF.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -312,6 +312,7 @@ files = [
     "sportsdataverse/cfb/cfb_field_position.py",
     "sportsdataverse/cfb/cfb_ncaa_pbp.py",
     "sportsdataverse/cfb/cfb_ncaa_box.py",
+    "sportsdataverse/cfb/cfb_ncaa_cfbfastr.py",
     "sportsdataverse/cfb/cfb_opponent_adjust.py",
     "sportsdataverse/cfb/cfb_crosswalk.py",
     "sportsdataverse/_common_crosswalk_basketball.py",

--- a/sportsdataverse/cfb/__init__.py
+++ b/sportsdataverse/cfb/__init__.py
@@ -8,6 +8,7 @@ from sportsdataverse.cfb.cfb_loaders_extra import *
 from sportsdataverse.cfb.cfb_pbp import *
 from sportsdataverse.cfb.cfb_ncaa_pbp import *
 from sportsdataverse.cfb.cfb_ncaa_box import *
+from sportsdataverse.cfb.cfb_ncaa_cfbfastr import *
 from sportsdataverse.cfb.cfb_adjusted_epa import *
 from sportsdataverse.cfb.cfb_advanced_stats import *
 from sportsdataverse.cfb.cfb_field_position import *

--- a/sportsdataverse/cfb/cfb_ncaa_box.py
+++ b/sportsdataverse/cfb/cfb_ncaa_box.py
@@ -113,6 +113,8 @@ DRIVES_SCHEMA: "dict[str, pl.DataType]" = {
     "end_how": pl.Utf8,
     "end_clock": pl.Utf8,
     "end_yard_line": pl.Utf8,
+    "n_plays": pl.Int64,
+    "yards": pl.Int64,
 }
 
 
@@ -140,8 +142,9 @@ def parse_cfb_ncaa_drives(
 
     Columns: ``drive_number``, ``quarter``, ``period``, ``team``,
     ``start_period``/``start_how`` (KO/PUNT/DOWNS/…)/``start_clock``/
-    ``start_yard_line``, and the ``end_*`` equivalents (``end_how`` =
-    TD/FGA/PUNT/DOWNS/…).
+    ``start_yard_line``, the ``end_*`` equivalents (``end_how`` =
+    TD/FGA/PUNT/DOWNS/…), and the drive totals ``n_plays`` / ``yards``
+    (``yards`` keeps its sign; both null when the page omits the cells).
 
     ``quarter`` is the page's Quarter cell as an int and is **null for overtime
     drives** (the cell reads ``"1OT"``/``"2OT"``); ``period`` preserves those as
@@ -170,6 +173,8 @@ def parse_cfb_ncaa_drives(
                     "end_how": r[8] or None,
                     "end_clock": r[9] or None,
                     "end_yard_line": r[10] or None,
+                    "n_plays": _int(r[11]) if len(r) > 11 else None,
+                    "yards": _int(r[12]) if len(r) > 12 else None,
                 }
             )
     return _finish(rows, DRIVES_SCHEMA, return_as_pandas)

--- a/sportsdataverse/cfb/cfb_ncaa_cfbfastr.py
+++ b/sportsdataverse/cfb/cfb_ncaa_cfbfastr.py
@@ -1,0 +1,871 @@
+"""Map stats.ncaa.org MFB pbp (``parse_cfb_ncaa_pbp`` output) to cfbfastR-named columns.
+
+Takes the 49-column NCAA structural frame and emits as many of the ~330
+cfbfastR ``cfb_pbp`` columns as a raw-text parser can honestly produce -- ids,
+pos/def teams, period/clock, down/distance/yards_to_goal, running scores,
+participant names (cfbfastR "First Last" naming), play-type labels, and the
+flag family. Model outputs (EPA/WP/...) and ESPN-participant columns are out
+of scope by design.
+
+Stateful derivations (period from quarter markers, running scores, play
+numbering) run in one ordered pass; window/lag columns are polars ops on top.
+
+Input: the frame from :func:`sportsdataverse.cfb.cfb_ncaa_pbp.parse_cfb_ncaa_pbp`.
+Optional ``drives`` / ``linescore`` frames (from
+:mod:`sportsdataverse.cfb.cfb_ncaa_box`) refine period + home/away when the
+full bundle is available; ``ot_drives`` takes a
+:func:`sportsdataverse.cfb.cfb_ncaa_box.parse_cfb_ncaa_drives` frame (overtime
+rows are selected internally via ``period > 4``).
+
+**Provenance.** Graduated from the ``ncaa-mfb-football-raw`` producer's
+``python/mfb_cfbfastr.py`` (behavior-preserving port; the four heuristics --
+FCS defense-labelled-drive majority vote, away/home checkpoint-slot vote,
+linescore-arbitrated score snapping, OT synthesis -- are unchanged).
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from typing import TYPE_CHECKING, Any, Optional, Union
+
+import polars as pl
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+__all__ = [
+    "CFBFASTR_SCHEMA",
+    "to_cfbfastr",
+]
+
+_TRAILING_CLOCK_RE = re.compile(r"clock (\d{1,2}:\d{2})")
+_QTR_MARKER_RE = re.compile(r"start of (\d)(?:st|nd|rd|th) quarter", re.I)
+_INT_BY_RE = re.compile(r"intercepted by ([A-Z][\w'.\- ]*,[\w'.\- ]+?)(?: at| return| for|\.|,|$)")
+_RET_YDS_RE = re.compile(r"return (\d+) yards", re.I)
+# XP/FG result: "good" appears in both cases and "NO GOOD"/"no good" must not match.
+_KICK_GOOD_RE = re.compile(r"(?<!no )good", re.I)
+
+#: play rows that are game furniture, not plays (dropped from the cfbfastR frame
+#: after they've fed the stateful pass).
+_MARKER_TYPES = {"drive_start", "coin_toss"}
+
+#: end_how -> approximate cfbfastR play_type label for synthesized OT rows.
+_OT_END_HOW_LABEL = {
+    "TD": "Touchdown",
+    "FG": "Field Goal Good",
+    "FGA": "Field Goal Missed",
+    "PUNT": "Punt",
+    "INT": "Pass Interception Return",
+    "FUMB": "Fumble Recovery (Opponent)",
+    "DOWNS": "Turnover on Downs",
+    "HALF": "End of Game",
+    "END": "End of Game",
+}
+
+#: every emitted column, in order. The stateful pass builds the leading
+#: columns; the trailing window/lag columns (from ``lag_pos_team`` on) are
+#: polars ops appended after frame construction. Dtypes were frozen from the
+#: mapper's output on the committed real-game fixture corpus.
+CFBFASTR_SCHEMA: "dict[str, pl.DataType]" = {
+    # ids / context
+    "game_id": pl.Int64,
+    "id_play": pl.Int64,
+    "drive_id": pl.Int64,
+    "game_play_number": pl.Int64,
+    "half_play_number": pl.Int64,
+    "drive_play_number": pl.Int64,
+    "drive_number": pl.Int64,
+    "season": pl.Int64,
+    "year": pl.Int64,
+    "week": pl.Int64,
+    "period": pl.Int64,
+    "half": pl.Int64,
+    "clock.minutes": pl.Int64,
+    "clock.seconds": pl.Int64,
+    "TimeSecsRem": pl.Int64,
+    "Under_two": pl.Boolean,
+    # teams
+    "pos_team": pl.Utf8,
+    "def_pos_team": pl.Utf8,
+    "offense_play": pl.Utf8,
+    "defense_play": pl.Utf8,
+    "home": pl.Utf8,
+    "away": pl.Utf8,
+    # score (after the play, cfbfastR convention for offense/defense_score)
+    "pos_team_score": pl.Int64,
+    "def_pos_team_score": pl.Int64,
+    "offense_score": pl.Int64,
+    "defense_score": pl.Int64,
+    "pos_score_diff": pl.Int64,
+    "score_pts": pl.Int64,
+    "scoring_play": pl.Boolean,
+    "scoring": pl.Boolean,
+    # situation
+    "down": pl.Int64,
+    "distance": pl.Int64,
+    "yard_line": pl.Utf8,
+    "yards_to_goal": pl.Int64,
+    "yards_to_goal_end": pl.Int64,
+    "Goal_To_Go": pl.Boolean,
+    "log_ydstogo": pl.Float64,
+    "yards_gained": pl.Int64,
+    # typing
+    "play_type": pl.Utf8,
+    "orig_play_type": pl.Utf8,
+    "play_text": pl.Utf8,
+    "rush": pl.Boolean,
+    "rush_td": pl.Boolean,
+    "pass": pl.Boolean,
+    "pass_td": pl.Boolean,
+    "pass_attempt": pl.Boolean,
+    "completion": pl.Boolean,
+    "target": pl.Boolean,
+    "sack": pl.Boolean,
+    "sack_vec": pl.Boolean,
+    "int": pl.Boolean,
+    "int_td": pl.Boolean,
+    "turnover_vec": pl.Boolean,
+    "downs_turnover": pl.Boolean,
+    "touchdown": pl.Boolean,
+    "td_play": pl.Boolean,
+    "safety": pl.Boolean,
+    "fumble_vec": pl.Boolean,
+    "punt": pl.Boolean,
+    "punt_play": pl.Boolean,
+    "kickoff_play": pl.Boolean,
+    "kick_play": pl.Boolean,
+    "fg_inds": pl.Boolean,
+    "fg_made": pl.Boolean,
+    "punt_blocked": pl.Boolean,
+    "punt_fair_catch": pl.Boolean,
+    "firstD_by_yards": pl.Boolean,
+    "firstD_by_penalty": pl.Boolean,
+    # penalties
+    "penalty_flag": pl.Boolean,
+    "penalty_no_play": pl.Boolean,
+    "penalty_declined": pl.Boolean,
+    "penalty_offset": pl.Boolean,
+    "penalty_text": pl.Utf8,
+    "yds_penalty": pl.Int64,
+    # participants (cfbfastR "First Last")
+    "rusher_player_name": pl.Utf8,
+    "passer_player_name": pl.Utf8,
+    "receiver_player_name": pl.Utf8,
+    "interception_player_name": pl.Utf8,
+    "punter_player_name": pl.Utf8,
+    "punt_returner_player_name": pl.Utf8,
+    "fg_kicker_player_name": pl.Utf8,
+    "kickoff_player_name": pl.Utf8,
+    "kickoff_returner_player_name": pl.Utf8,
+    "yds_rushed": pl.Int64,
+    "yds_receiving": pl.Int64,
+    "yds_sacked": pl.Int64,
+    "yds_punted": pl.Int64,
+    "yds_punt_return": pl.Int64,
+    "yds_kickoff": pl.Int64,
+    "yds_kickoff_return": pl.Int64,
+    "yds_int_return": pl.Int64,
+    "yds_fg": pl.Int64,
+    "drive_result": pl.Utf8,
+    "drive_scoring": pl.Boolean,
+    "ot_synthesized": pl.Boolean,
+    # window/lag bookkeeping (appended after the stateful pass)
+    "lag_pos_team": pl.Utf8,
+    "lead_pos_team": pl.Utf8,
+    "lag_play_type": pl.Utf8,
+    "lead_play_type": pl.Utf8,
+    "lag_play_text": pl.Utf8,
+    "lead_play_text": pl.Utf8,
+    "change_of_pos_team": pl.Boolean,
+    "play_after_turnover": pl.Boolean,
+    "n_plays_in_game": pl.UInt32,
+}
+
+#: columns appended by the window/lag pass (not part of the row dicts).
+_WINDOW_COLS = (
+    "lag_pos_team",
+    "lead_pos_team",
+    "lag_play_type",
+    "lead_play_type",
+    "lag_play_text",
+    "lead_play_text",
+    "change_of_pos_team",
+    "play_after_turnover",
+    "n_plays_in_game",
+)
+
+_ROW_SCHEMA: "dict[str, pl.DataType]" = {k: t for k, t in CFBFASTR_SCHEMA.items() if k not in _WINDOW_COLS}
+
+
+def _norm_team(name: "str | None") -> str:
+    """Normalize a team label for cross-surface matching: the linescore and the
+    drive titles can disagree on variant spellings ('Saint Anselm' vs
+    'St. Anselm')."""
+    s = (name or "").lower().strip()
+    s = re.sub(r"\bsaint\b", "st.", s)
+    return re.sub(r"[^a-z0-9&]+", " ", s).strip()
+
+
+def _first_last(name: "str | None") -> "str | None":
+    """NCAA 'Last[ Suffix],First' -> cfbfastR 'First Last[ Suffix]'."""
+    if not name or "," not in name:
+        return name
+    last, first = name.split(",", 1)
+    return f"{first.strip()} {last.strip()}"
+
+
+def _clock_secs(clock: "str | None") -> "int | None":
+    if not clock or ":" not in clock:
+        return None
+    mm, ss = clock.split(":", 1)
+    try:
+        return int(mm) * 60 + int(ss)
+    except ValueError:
+        return None
+
+
+def _own_side(df: pl.DataFrame) -> "dict[str, str]":
+    """Infer each offense's own yard-line side code (e.g. Merrimack -> 'MC').
+
+    Drives overwhelmingly start in the offense's own territory, so of the two
+    possible (team name -> side code) assignments, pick the one under which
+    more first-plays-of-drive sit on the offense's own side.
+    """
+    teams = [t for t in df.get_column("offense").unique().to_list() if t]
+    sides = [s for s in df.get_column("yard_line_side").unique().to_list() if s]
+    if len(teams) != 2 or len(sides) != 2:
+        return {}
+    firsts = (
+        df.filter(pl.col("yard_line_side").is_not_null())
+        .group_by("drive_number", maintain_order=True)
+        .first()
+        .select("offense", "yard_line_side")
+        .to_dicts()
+    )
+    a = {teams[0]: sides[0], teams[1]: sides[1]}
+    b = {teams[0]: sides[1], teams[1]: sides[0]}
+    score_a = sum(1 for r in firsts if a.get(r["offense"]) == r["yard_line_side"])
+    score_b = sum(1 for r in firsts if b.get(r["offense"]) == r["yard_line_side"])
+    return a if score_a >= score_b else b
+
+
+def _play_type_label(r: "dict[str, Any]") -> str:
+    """Map the NCAA structural play_type to the cfbfastR play_type vocabulary."""
+    pt, td = r["play_type"], bool(r["is_touchdown"])
+    if pt == "rush" or pt == "kneel":
+        return "Rushing Touchdown" if td else "Rush"
+    if pt == "pass":
+        if r["turnover_type"] == "interception":
+            return "Interception Return Touchdown" if td else "Pass Interception Return"
+        if r["pass_complete"]:
+            return "Passing Touchdown" if td else "Pass Reception"
+        return "Pass Incompletion"
+    if pt == "sack":
+        return "Sack"
+    if pt == "punt":
+        return "Blocked Punt" if "blocked" in (r["play_text"] or "").lower() else "Punt"
+    if pt == "kickoff":
+        return "Kickoff Return Touchdown" if td else "Kickoff"
+    if pt == "field_goal":
+        return "Field Goal Good" if r["fg_made"] else "Field Goal Missed"
+    if pt == "extra_point":
+        return "Extra Point Good" if _KICK_GOOD_RE.search(r["play_text"] or "") else "Extra Point Missed"
+    if pt == "two_point":
+        return "Two Point Pass" if r["passer"] else "Two Point Rush"
+    if pt == "penalty":
+        return "Penalty"
+    if pt == "timeout":
+        return "Timeout"
+    if pt == "period_marker":
+        return "End Period"
+    return str(pt)
+
+
+def to_cfbfastr(
+    pbp: pl.DataFrame,
+    *,
+    season: "Optional[int]" = None,
+    week: "Optional[int]" = None,
+    drives: "Optional[pl.DataFrame]" = None,
+    linescore: "Optional[pl.DataFrame]" = None,
+    drive_titles: "Optional[pl.DataFrame]" = None,
+    ot_drives: "Optional[pl.DataFrame]" = None,
+    scoring_summary: "Optional[pl.DataFrame]" = None,
+    return_as_pandas: bool = False,
+) -> "Union[pl.DataFrame, pd.DataFrame]":
+    """cfbfastR-named play frame from the NCAA structural pbp frame.
+
+    Args:
+        pbp: Output of :func:`sportsdataverse.cfb.cfb_ncaa_pbp.parse_cfb_ncaa_pbp`
+            (one game).
+        season: Season year (2025 = fall-2025), written to ``season``/``year``.
+        week: Optional week number (from the schedule master).
+        drives: Optional :func:`sportsdataverse.cfb.cfb_ncaa_box.parse_cfb_ncaa_drives`
+            frame -- refines ``period`` per drive when quarter markers are
+            missing from the pbp page.
+        linescore: Optional
+            :func:`sportsdataverse.cfb.cfb_ncaa_box.parse_cfb_ncaa_linescore`
+            frame -- provides ``home``/``away`` team names and the official
+            per-team finals.
+        drive_titles: Optional
+            :func:`sportsdataverse.cfb.cfb_ncaa_pbp.parse_cfb_ncaa_drive_titles`
+            frame -- authoritative per-drive team labels (fixes graduated-parser
+            team truncation) and running-score checkpoints the play-level score
+            snaps to at each drive boundary (self-heals OT scoring rules +
+            missed events).
+        ot_drives: Optional
+            :func:`sportsdataverse.cfb.cfb_ncaa_box.parse_cfb_ncaa_drives`
+            frame for the OT-synthesis pass -- overtime rows (``period > 4``)
+            are selected internally, so the full drives frame can be passed
+            as-is.
+        scoring_summary: Optional
+            :func:`sportsdataverse.cfb.cfb_ncaa_box.parse_cfb_ncaa_scoring_summary`
+            frame -- running-score checkpoints for the synthesized OT rows and
+            the final-drive snap.
+        return_as_pandas: Return a ``pandas.DataFrame`` instead of ``polars``.
+
+    Returns:
+        A ``polars.DataFrame`` (or ``pandas.DataFrame`` when
+        ``return_as_pandas``) with one row per play (markers/furniture dropped)
+        and the columns of :data:`CFBFASTR_SCHEMA`. Empty input returns a
+        **zero-row frame carrying the documented schema**.
+
+    Example:
+        Quick start::
+
+            from sportsdataverse.cfb import parse_cfb_ncaa_pbp, to_cfbfastr
+            pbp = parse_cfb_ncaa_pbp(open("play_by_play_5362431.html").read(), contest_id=5362431)
+            df = to_cfbfastr(pbp, season=2024)
+            print(df.shape)
+
+        Final score from the running-score columns::
+
+            df.select("pos_team", "pos_team_score", "def_pos_team", "def_pos_team_score").row(-1)
+
+        See Also:
+            * `cfbfastR`_ -- the ESPN-sourced college-football ``cfb_pbp``
+              frame (R) whose column vocabulary this mapper targets
+
+        .. _cfbfastR: https://cfbfastR.sportsdataverse.org
+    """
+    if pbp.height == 0:
+        empty = pl.DataFrame(schema=CFBFASTR_SCHEMA)
+        return empty.to_pandas() if return_as_pandas else empty
+    title_team: "dict[int, str]" = {}
+    checkpoint: "dict[int, tuple[int, int]]" = {}  # drive -> (score_away, score_home)
+    title_result: "dict[int, str]" = {}
+    if drive_titles is not None and drive_titles.height:
+        for t in drive_titles.to_dicts():
+            dn = t["drive_number"]
+            if t["team"]:
+                title_team[dn] = t["team"]
+            if t["result"]:
+                title_result[dn] = t["result"]
+            if t["score_away"] is not None and t["score_home"] is not None:
+                checkpoint[dn] = (t["score_away"], t["score_home"])
+    # Some (FCS) pages label every drive h5 with the DEFENSE. The per-drive
+    # "X drive start at MM:SS" markers name the true offense, so majority-vote
+    # the markers against the titles (prefix-matched -- markers use name
+    # variants like "Southern (La.)" for title "Southern U.") and flip the
+    # whole page's title assignment when the majority disagree.
+    if title_team and len(set(title_team.values())) == 2:
+        two = sorted(set(title_team.values()))
+
+        def _match(marker: str) -> "Optional[str]":
+            scores = {t: 0 for t in two}
+            for t in two:
+                n = 0
+                for a, b in zip(marker.lower(), t.lower()):
+                    if a != b:
+                        break
+                    n += 1
+                scores[t] = n
+            best = max(two, key=lambda t: scores[t])
+            other = next(t for t in two if t != best)
+            return best if scores[best] >= 4 and scores[best] > scores[other] else None
+
+        agree = disagree = 0
+        for r in pbp.filter(pl.col("play_type") == "drive_start").to_dicts():
+            m = re.match(r"^(.+?) drive start at", r["play_text"] or "")
+            marker_team = _match(m.group(1)) if m else None
+            titled = title_team.get(r["drive_number"])
+            if marker_team and titled in two:
+                agree += marker_team == titled
+                disagree += marker_team != titled
+        if disagree > agree:
+            flip = {two[0]: two[1], two[1]: two[0]}
+            title_team = {dn: flip[t] for dn, t in title_team.items()}
+    if title_team:
+        # authoritative per-drive team labels fix truncated offense values
+        pbp = pbp.with_columns(
+            pl.col("drive_number")
+            .replace_strict(title_team, default=None, return_dtype=pl.Utf8)
+            .fill_null(pl.col("offense"))
+            .alias("offense")
+        )
+    own_side = _own_side(pbp)
+    teams = (
+        sorted(set(title_team.values()))
+        if len(set(title_team.values())) == 2
+        else [t for t in pbp.get_column("offense").unique().to_list() if t]
+    )
+    home = away = None
+    if linescore is not None and linescore.height:
+        ls = linescore.group_by("team", "home_away").len()
+        for r in ls.to_dicts():
+            if r["home_away"] == "home":
+                home = r["team"]
+            elif r["home_away"] == "away":
+                away = r["team"]
+    # Checkpoint slot -> team mapping. The title score pair is USUALLY
+    # "away - home", but some (mostly FCS) pages emit it "home - away", so
+    # trusting the linescore's away/home for SNAPPING swaps the whole game.
+    # MAJORITY VOTE over every scoring drive whose checkpoint moved exactly one
+    # slot (the mover is almost always the drive's own team; defensive TDs are
+    # rare) decides which team owns the first slot. The linescore still
+    # supplies the emitted home/away columns.
+    snap_first, snap_second = away, home
+    if checkpoint and len(teams) == 2:
+        tally = dict.fromkeys(teams, 0)
+        prev = (0, 0)
+        for dn in sorted(checkpoint):
+            ca, ch = checkpoint[dn]
+            team = title_team.get(dn)
+            if team in teams and title_result.get(dn) in ("TD", "FG"):
+                if ca > prev[0] and ch == prev[1]:
+                    tally[team] += 1
+                elif ch > prev[1] and ca == prev[0]:
+                    tally[team] -= 1
+            prev = (ca, ch)
+        if any(tally.values()):
+            snap_first = max(teams, key=lambda t: tally[t])
+            snap_second = next(t for t in teams if t != snap_first)
+    if away not in teams or home not in teams:
+        away, home = snap_first, snap_second
+    drive_period: "dict[int, int]" = {}
+    if drives is not None and drives.height:
+        drive_period = {
+            r["drive_number"]: r["quarter"]
+            for r in drives.select("drive_number", "quarter").to_dicts()
+            if r["drive_number"] is not None and r["quarter"] is not None
+        }
+
+    game_id = pbp.get_column("contest_id")[0]
+    gid = int(game_id) if game_id and str(game_id).isdigit() else None
+
+    period = 1
+    last_td_team: "Optional[str]" = None
+    score: "dict[str, int]" = {t: 0 for t in teams}
+    game_play_number = 0
+    half_play_number = 0
+    prev_half = 1
+    prev_drive: "Optional[int]" = None
+    rows: "list[dict[str, Any]]" = []
+    drive_play_counter: "dict[int, int]" = {}
+
+    # the scoring summary is a SUPERSET of the drive-title checkpoints (some
+    # pages score plays the final drive title never checkpoints -- e.g. a late
+    # TD after the last titled drive), so the game's last drive snaps to its
+    # final regulation running-score instead.
+    last_reg_summary: "Optional[tuple[int, int]]" = None
+    if scoring_summary is not None and scoring_summary.height:
+        reg = scoring_summary.filter(
+            (pl.col("period") <= 4) & pl.col("score_away").is_not_null() & pl.col("score_home").is_not_null()
+        )
+        if reg.height:
+            last_reg_summary = (reg["score_away"][-1], reg["score_home"][-1])
+    last_drive_number = max(checkpoint) if checkpoint else None
+    # official per-team finals from the linescore (name-normalized onto the
+    # title team labels) -- the arbiter when the titles and the scoring
+    # summary disagree at game end (source self-inconsistencies exist:
+    # Mercyhurst 5366186 titles say 55, the official book says 48).
+    official_final: "dict[str, int]" = {}
+    if linescore is not None and linescore.height and len(teams) == 2:
+        for r in linescore.group_by("team").agg(pl.col("final").max()).to_dicts():
+            if r["final"] is None or not r["team"]:
+                continue
+            match = next((t for t in teams if _norm_team(t) == _norm_team(r["team"])), None)
+            if match:
+                official_final[match] = r["final"]
+        if len(official_final) != 2:
+            official_final = {}
+
+    def _final_matches(cand: "tuple[int, int]") -> bool:
+        return (
+            bool(official_final)
+            and (
+                official_final.get(snap_first or ""),
+                official_final.get(snap_second or ""),
+            )
+            == cand
+        )
+
+    def _snap(drive: "Optional[int]") -> None:
+        """Snap the running score to the checkpoint of a finished drive."""
+        if snap_first not in score or snap_second not in score:
+            return
+        if drive == last_drive_number and last_reg_summary is not None:
+            cp = checkpoint.get(drive) if drive is not None else None
+            # candidates: title checkpoint vs summary final. The official
+            # linescore arbitrates; without its vote, take the further-along
+            # one (the summary trails on OT pages).
+            if cp is not None and _final_matches(cp):
+                score[snap_first], score[snap_second] = cp
+                return
+            if _final_matches(last_reg_summary) or sum(last_reg_summary) >= sum(cp or (0, 0)):
+                score[snap_first], score[snap_second] = last_reg_summary
+                return
+        if drive in checkpoint:
+            score[snap_first], score[snap_second] = checkpoint[drive]
+
+    all_rows = pbp.to_dicts()
+    # the checkpoint is the score AFTER a drive, so the drive's LAST play must
+    # emit exactly it (event-sourcing can't see OT-shootout scoring rules).
+    last_play_of_drive: "dict[int, int]" = {
+        r["drive_number"]: i for i, r in enumerate(all_rows) if r["drive_number"] is not None
+    }
+
+    for i, r in enumerate(all_rows):
+        text = r["play_text"] or ""
+        qm = _QTR_MARKER_RE.search(text.lower())
+        if qm:
+            period = int(qm.group(1))
+        if r["drive_number"] in drive_period:
+            period = drive_period[r["drive_number"]]
+        half = 1 if period <= 2 else 2
+        if half != prev_half:
+            half_play_number = 0
+            prev_half = half
+
+        if r["drive_number"] != prev_drive:
+            _snap(prev_drive)
+            prev_drive = r["drive_number"]
+
+        offense = title_team.get(r["drive_number"]) or r["offense"]
+        defense = next((t for t in teams if t != offense), None) if offense else None
+
+        # running score -- award points to the right side of the ball
+        pts_off = pts_def = 0
+        if r["play_type"] not in (
+            "timeout",
+            "period_marker",
+            "drive_start",
+            "coin_toss",
+        ):
+            if r["is_touchdown"]:
+                # a fumble-return TD has turnover_type set WITHOUT is_turnover
+                to_defense = r["turnover_type"] in ("interception", "fumble")
+                if to_defense:
+                    pts_def += 6
+                    last_td_team = defense
+                else:
+                    pts_off += 6
+                    last_td_team = offense
+            if r["play_type"] == "field_goal" and r["fg_made"]:
+                pts_off += 3
+            # XP/2pt belong to whoever scored the preceding TD (a defensive TD's
+            # try is kicked by the drive's DEFENSE, so drive offense is wrong).
+            if r["play_type"] == "extra_point" and _KICK_GOOD_RE.search(text):
+                if (last_td_team or offense) == defense:
+                    pts_def += 1
+                else:
+                    pts_off += 1
+            if r["play_type"] == "two_point" and "successful" in text.lower():
+                if (last_td_team or offense) == defense:
+                    pts_def += 2
+                else:
+                    pts_off += 2
+            if r["is_safety"]:
+                pts_def += 2
+        if offense and pts_off:
+            score[offense] = score.get(offense, 0) + pts_off
+        if defense and pts_def:
+            score[defense] = score.get(defense, 0) + pts_def
+        if last_play_of_drive.get(r["drive_number"]) == i:
+            _snap(r["drive_number"])
+
+        if r["play_type"] in _MARKER_TYPES:
+            continue
+        game_play_number += 1
+        half_play_number += 1
+        dn = r["drive_number"]
+        drive_play_counter[dn] = drive_play_counter.get(dn, 0) + 1
+
+        clock = r["clock"]
+        if not clock:
+            cm = _TRAILING_CLOCK_RE.search(text)
+            clock = cm.group(1) if cm else None
+        secs = _clock_secs(clock)
+        time_secs_rem = (4 - period) * 900 + secs if secs is not None and period <= 4 else None
+
+        side, num = r["yard_line_side"], r["yard_line_number"]
+        ytg = None
+        if side is not None and num is not None and offense in own_side:
+            ytg = 100 - num if own_side[offense] == side else num
+        end_ytg = None
+        eyl = r["end_yard_line"] or ""
+        em = re.match(r"([A-Za-z&]{1,4})(\d+)$", eyl)
+        if em and offense in own_side:
+            end_ytg = 100 - int(em.group(2)) if own_side[offense] == em.group(1) else int(em.group(2))
+
+        pt = r["play_type"]
+        is_rush = pt in ("rush", "kneel")
+        is_pass_att = pt == "pass"
+        is_sack = pt == "sack"
+        completion = bool(r["pass_complete"]) if is_pass_att else False
+        interception = r["turnover_type"] == "interception"
+        scoring_play = bool(pts_off or pts_def)
+        int_m = _INT_BY_RE.search(text)
+        ret_m = _RET_YDS_RE.search(text)
+
+        pos_score = score.get(offense, 0) if offense else None
+        def_score = score.get(defense, 0) if defense else None
+        rows.append(
+            {
+                # ids / context
+                "game_id": gid,
+                "id_play": gid * 10_000 + game_play_number if gid else None,
+                "drive_id": gid * 100 + dn if gid and dn else None,
+                "game_play_number": game_play_number,
+                "half_play_number": half_play_number,
+                "drive_play_number": drive_play_counter[dn],
+                "drive_number": dn,
+                "season": season,
+                "year": season,
+                "week": week,
+                "period": period,
+                "half": half,
+                "clock.minutes": secs // 60 if secs is not None else None,
+                "clock.seconds": secs % 60 if secs is not None else None,
+                "TimeSecsRem": time_secs_rem,
+                "Under_two": time_secs_rem is not None and time_secs_rem <= 120,
+                # teams
+                "pos_team": offense,
+                "def_pos_team": defense,
+                "offense_play": offense,
+                "defense_play": defense,
+                "home": home,
+                "away": away,
+                # score (after the play, cfbfastR convention for offense/defense_score)
+                "pos_team_score": pos_score,
+                "def_pos_team_score": def_score,
+                "offense_score": pos_score,
+                "defense_score": def_score,
+                "pos_score_diff": pos_score - def_score if pos_score is not None and def_score is not None else None,
+                "score_pts": pts_off - pts_def,
+                "scoring_play": scoring_play,
+                "scoring": scoring_play,
+                # situation
+                "down": r["down"],
+                "distance": r["distance"],
+                "yard_line": r["yard_line"],
+                "yards_to_goal": ytg,
+                "yards_to_goal_end": end_ytg,
+                "Goal_To_Go": (r["distance"] is not None and ytg is not None and ytg <= r["distance"]),
+                "log_ydstogo": math.log(r["distance"]) if r["distance"] else None,
+                "yards_gained": r["yards_gained"],
+                # typing
+                "play_type": _play_type_label(r),
+                "orig_play_type": pt,
+                "play_text": r["play_text"],
+                "rush": is_rush,
+                "rush_td": is_rush and bool(r["is_touchdown"]),
+                "pass": is_pass_att or is_sack,
+                "pass_td": is_pass_att and completion and bool(r["is_touchdown"]),
+                "pass_attempt": is_pass_att,
+                "completion": completion,
+                "target": is_pass_att and r["receiver"] is not None,
+                "sack": is_sack,
+                "sack_vec": is_sack,
+                "int": interception,
+                "int_td": interception and bool(r["is_touchdown"]),
+                "turnover_vec": bool(r["is_turnover"]) or r["turnover_type"] == "fumble",
+                "downs_turnover": r["turnover_type"] == "downs",
+                "touchdown": bool(r["is_touchdown"]),
+                "td_play": bool(r["is_touchdown"]),
+                "safety": bool(r["is_safety"]),
+                "fumble_vec": bool(r["is_fumble"]),
+                "punt": pt == "punt",
+                "punt_play": pt == "punt",
+                "kickoff_play": pt == "kickoff",
+                "kick_play": pt == "field_goal" or pt == "extra_point",
+                "fg_inds": pt == "field_goal",
+                "fg_made": r["fg_made"],
+                "punt_blocked": pt == "punt" and "blocked" in text.lower(),
+                "punt_fair_catch": pt == "punt" and bool(r["fair_catch"]),
+                "firstD_by_yards": bool(r["is_first_down"]) and not bool(r["penalty_flag"]),
+                "firstD_by_penalty": bool(r["is_first_down"]) and bool(r["penalty_flag"]),
+                # penalties
+                "penalty_flag": bool(r["penalty_flag"]),
+                "penalty_no_play": bool(r["no_play"]),
+                "penalty_declined": "declined" in text.lower(),
+                "penalty_offset": "off-setting" in text.lower() or "offsetting" in text.lower(),
+                "penalty_text": r["penalty_type"],
+                "yds_penalty": r["penalty_yards"],
+                # participants (cfbfastR "First Last")
+                "rusher_player_name": _first_last(r["rusher"]) if is_rush else None,
+                "passer_player_name": _first_last(r["passer"]) if (is_pass_att or is_sack) else None,
+                "receiver_player_name": _first_last(r["receiver"]),
+                "interception_player_name": _first_last(int_m.group(1)) if int_m and interception else None,
+                "punter_player_name": _first_last(r["punter"]),
+                "punt_returner_player_name": _first_last(r["returner"]) if pt == "punt" else None,
+                "fg_kicker_player_name": _first_last(r["kicker"]) if pt in ("field_goal", "extra_point") else None,
+                "kickoff_player_name": _first_last(r["kicker"]) if pt == "kickoff" else None,
+                "kickoff_returner_player_name": _first_last(r["returner"]) if pt == "kickoff" else None,
+                "yds_rushed": r["yards_gained"] if is_rush else None,
+                "yds_receiving": r["yards_gained"] if completion else None,
+                "yds_sacked": -r["yards_gained"] if is_sack and r["yards_gained"] is not None else None,
+                "yds_punted": r["punt_yards"],
+                "yds_punt_return": r["return_yards"] if pt == "punt" else None,
+                "yds_kickoff": r["kick_yards"],
+                "yds_kickoff_return": r["return_yards"] if pt == "kickoff" else None,
+                "yds_int_return": int(ret_m.group(1)) if ret_m and interception else None,
+                "yds_fg": r["fg_distance"],
+                "drive_result": r["drive_result"],
+                "drive_scoring": r["drive_scored"],
+                "ot_synthesized": False,
+            }
+        )
+
+    # --- OT synthesis: stats.ncaa.org pbp pages omit OT drives. Rebuild them
+    # (one row per drive) from the drives tab, with scores walked through the
+    # scoring-summary running-score checkpoints. Rows are flagged
+    # ot_synthesized=True; play_text is the summary's real description when it
+    # ships one, else an honest synthesized descriptor.
+    max_pbp_drive = max((r["drive_number"] for r in rows if r["drive_number"]), default=0)
+    # official_final (built above, name-normalized) also serves as the mop-up
+    # for OT tails no surface checkpoints (2-pt shootouts, walk-off return TDs).
+    # Page-wise: does the pbp already reach the final (its titles include OT,
+    # like some FBS pages do)? Then synthesize nothing. Drive numbers can NOT
+    # be compared across the pbp and drives tabs (they misalign by one on some
+    # pages), so the decision is score-based and synthesized drives renumber
+    # from max_pbp_drive + 1.
+    pbp_reaches_final = bool(
+        checkpoint and official_final and sum(checkpoint[max(checkpoint)]) >= sum(official_final.values())
+    )
+    # the graduated parse_cfb_ncaa_drives frame carries the whole game; only
+    # its overtime rows (period 5+) feed the synthesis.
+    ot_rows = ot_drives.filter(pl.col("period") > 4) if ot_drives is not None and ot_drives.height else None
+    if rows and not pbp_reaches_final and ot_rows is not None and ot_rows.height:
+        ot_checkpoints = (
+            scoring_summary.filter(pl.col("period") > 4).to_dicts()
+            if scoring_summary is not None and scoring_summary.height
+            else []
+        )
+        template = dict.fromkeys(rows[-1].keys())
+        n_synth = 0
+        for od in sorted(ot_rows.to_dicts(), key=lambda d: d["drive_number"]):
+            n_synth += 1
+            od = dict(od)
+            od["drive_number"] = max_pbp_drive + n_synth
+            offense = od["team"]
+            defense = next((t for t in teams if t != offense), None)
+            scoring = od["end_how"] in ("TD", "FG", "SAF")
+            summary_text = None
+            if scoring and ot_checkpoints:
+                cp = ot_checkpoints.pop(0)
+                summary_text = cp["play_text"]
+                if snap_first in score and snap_second in score and cp["score_away"] is not None:
+                    # scoring-summary slots follow the same per-page order
+                    score[snap_first], score[snap_second] = (
+                        cp["score_away"],
+                        cp["score_home"],
+                    )
+            elif scoring and offense in score:
+                score[offense] += 3 if od["end_how"] == "FG" else 6
+            game_play_number += 1
+            half_play_number += 1
+            pos_s = score.get(offense) if offense else None
+            def_s = score.get(defense) if defense else None
+            row = dict(template)
+            row.update(
+                {
+                    "game_id": gid,
+                    "id_play": gid * 10_000 + game_play_number if gid else None,
+                    "drive_id": gid * 100 + od["drive_number"] if gid else None,
+                    "game_play_number": game_play_number,
+                    "half_play_number": half_play_number,
+                    "drive_play_number": 1,
+                    "drive_number": od["drive_number"],
+                    "season": season,
+                    "year": season,
+                    "week": week,
+                    "period": od["period"],
+                    "half": 3,
+                    "pos_team": offense,
+                    "def_pos_team": defense,
+                    "offense_play": offense,
+                    "defense_play": defense,
+                    "home": home,
+                    "away": away,
+                    "pos_team_score": pos_s,
+                    "def_pos_team_score": def_s,
+                    "offense_score": pos_s,
+                    "defense_score": def_s,
+                    "pos_score_diff": pos_s - def_s if pos_s is not None and def_s is not None else None,
+                    "scoring_play": scoring,
+                    "scoring": scoring,
+                    "yard_line": od["start_yard_line"],
+                    "play_type": _OT_END_HOW_LABEL.get(od["end_how"], od["end_how"]),
+                    "orig_play_type": "ot_drive",
+                    "play_text": summary_text
+                    or (
+                        f"{offense} OT drive ({od['end_how']}): "
+                        f"{od['n_plays']} plays, {od['yards']} yards, "
+                        f"{od['start_yard_line']} to {od['end_yard_line']}"
+                    ),
+                    "touchdown": od["end_how"] == "TD",
+                    "td_play": od["end_how"] == "TD",
+                    "fg_inds": od["end_how"] in ("FG", "FGA"),
+                    "fg_made": od["end_how"] == "FG" if od["end_how"] in ("FG", "FGA") else None,
+                    "punt": od["end_how"] == "PUNT",
+                    "punt_play": od["end_how"] == "PUNT",
+                    "int": od["end_how"] == "INT",
+                    "turnover_vec": od["end_how"] in ("INT", "FUMB", "DOWNS"),
+                    "downs_turnover": od["end_how"] == "DOWNS",
+                    "drive_result": od["end_how"],
+                    "drive_scoring": scoring,
+                    "ot_synthesized": True,
+                }
+            )
+            rows.append(row)
+
+        # mop-up: OT tails no surface checkpoints (3OT+ two-point shootouts,
+        # walk-off return TDs) leave the last synthesized row short of the
+        # official final -- reconcile it against the linescore per-team finals.
+        if (
+            rows
+            and rows[-1].get("ot_synthesized")
+            and official_final
+            and rows[-1]["pos_team"] in official_final
+            and rows[-1]["def_pos_team"] in official_final
+        ):
+            last = rows[-1]
+            want_pos = official_final[last["pos_team"]]
+            want_def = official_final[last["def_pos_team"]]
+            if (last["pos_team_score"], last["def_pos_team_score"]) != (
+                want_pos,
+                want_def,
+            ):
+                last["pos_team_score"], last["def_pos_team_score"] = want_pos, want_def
+                last["offense_score"], last["defense_score"] = want_pos, want_def
+                last["pos_score_diff"] = want_pos - want_def
+                last["scoring_play"] = last["scoring"] = True
+                score[last["pos_team"]] = want_pos
+                score[last["def_pos_team"]] = want_def
+
+    df = pl.DataFrame(rows, schema=_ROW_SCHEMA)
+    # window/lag bookkeeping over the ordered game
+    df = df.with_columns(
+        pl.col("pos_team").shift(1).alias("lag_pos_team"),
+        pl.col("pos_team").shift(-1).alias("lead_pos_team"),
+        pl.col("play_type").shift(1).alias("lag_play_type"),
+        pl.col("play_type").shift(-1).alias("lead_play_type"),
+        pl.col("play_text").shift(1).alias("lag_play_text"),
+        pl.col("play_text").shift(-1).alias("lead_play_text"),
+        (pl.col("pos_team") != pl.col("pos_team").shift(1)).alias("change_of_pos_team"),
+        (pl.col("turnover_vec").shift(1) == True).alias("play_after_turnover"),  # noqa: E712
+        pl.len().alias("n_plays_in_game"),
+    )
+    return df.to_pandas() if return_as_pandas else df

--- a/sportsdataverse/parsed/cfb.py
+++ b/sportsdataverse/parsed/cfb.py
@@ -452,6 +452,7 @@ from sportsdataverse.cfb import predict_total as predict_total  # noqa: F401
 from sportsdataverse.cfb import scoreboard_event_parsing as scoreboard_event_parsing  # noqa: F401
 from sportsdataverse.cfb import slope_for_games as slope_for_games  # noqa: F401
 from sportsdataverse.cfb import special_teams_ratings as special_teams_ratings  # noqa: F401
+from sportsdataverse.cfb import to_cfbfastr as to_cfbfastr  # noqa: F401
 from sportsdataverse.cfb import underscore as underscore  # noqa: F401
 from sportsdataverse.cfb import win_prob_from_margin as win_prob_from_margin  # noqa: F401
 
@@ -834,6 +835,7 @@ __all__ = [
     "sports247_transfer_portal_player_feed",
     "sports247_transfer_portal_team_feed",
     "sports247_transfers",
+    "to_cfbfastr",
     "underscore",
     "win_prob_from_margin",
     "yahoo_cfb_boxscore",

--- a/tests/cfb/test_cfb_ncaa_box.py
+++ b/tests/cfb/test_cfb_ncaa_box.py
@@ -54,6 +54,15 @@ def test_drives_start_end_vocab() -> None:
     assert yl.get_column("start_yard_line").str.contains(r"^[A-Z]{2,4}\d+$").all()
 
 
+def test_drives_totals_populated() -> None:
+    df = parse_cfb_ncaa_drives(_rd("drives"), contest_id="5362283")
+    # the drives table's trailing "# Plays"/"Yards" cells; a lost-yardage
+    # drive keeps its sign, so only n_plays is strictly positive
+    assert df.get_column("n_plays").is_not_null().all()
+    assert (df.get_column("n_plays") >= 1).all()
+    assert df.get_column("yards").is_not_null().all()
+
+
 def test_drives_empty() -> None:
     df = parse_cfb_ncaa_drives("")
     assert df.height == 0 and df.columns == list(DRIVES_SCHEMA.keys())

--- a/tests/cfb/test_cfb_ncaa_cfbfastr.py
+++ b/tests/cfb/test_cfb_ncaa_cfbfastr.py
@@ -1,0 +1,104 @@
+"""Offline tests for the NCAA -> cfbfastR column mapper (``to_cfbfastr``).
+
+Runs on the committed real stats.ncaa.org pbp captures under
+``tests/fixtures/cfb_ncaa/`` (contests 5336803, 5361446, 5362431, 5362535 --
+two FBS blowouts, an FBS shootout, and an FCS-at-FBS game). The running-score
+assertions pin REAL 2024 final scores (verified against the public record), so
+a scoring-attribution regression (defensive TDs, XP after a pick-six,
+lowercase "kick attempt good") fails loudly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from sportsdataverse.cfb.cfb_ncaa_cfbfastr import (
+    CFBFASTR_SCHEMA,
+    _first_last,
+    to_cfbfastr,
+)
+from sportsdataverse.cfb.cfb_ncaa_pbp import parse_cfb_ncaa_pbp
+
+FIX = Path(__file__).resolve().parents[1] / "fixtures" / "cfb_ncaa"
+
+#: fixture -> (last-row pos_team, its score, def_pos_team, its score); real finals.
+FINALS = {
+    "5336803": ("Ohio St.", 52, "Akron", 6),
+    "5361446": ("Boise St.", 56, "Ga. Southern", 45),
+    "5362431": ("Cincinnati", 38, "Towson", 20),
+    "5362535": ("Merrimack", 6, "Air Force", 21),
+}
+
+
+def _frame(cid: str) -> "pl.DataFrame":
+    """The mapped frame for one committed pbp fixture (either vendored name)."""
+    path = FIX / f"mfb_pbp_{cid}.html"
+    if not path.exists():
+        path = FIX / f"cfb_ncaa_pbp_{cid}.html"
+    html = path.read_text(encoding="utf-8")
+    df = to_cfbfastr(parse_cfb_ncaa_pbp(html, contest_id=cid), season=2024)
+    assert isinstance(df, pl.DataFrame)
+    return df
+
+
+def test_returns_documented_schema() -> None:
+    df = _frame("5336803")
+    assert df.columns == list(CFBFASTR_SCHEMA.keys())
+    assert df.schema == pl.Schema(CFBFASTR_SCHEMA)
+
+
+def test_empty_input_zero_row_with_schema() -> None:
+    df = to_cfbfastr(parse_cfb_ncaa_pbp("", contest_id=None))
+    assert isinstance(df, pl.DataFrame)
+    assert df.height == 0
+    assert df.columns == list(CFBFASTR_SCHEMA.keys())
+    assert df.schema == pl.Schema(CFBFASTR_SCHEMA)
+
+
+def test_return_as_pandas() -> None:
+    pdf = to_cfbfastr(parse_cfb_ncaa_pbp("", contest_id=None), return_as_pandas=True)
+    assert not isinstance(pdf, pl.DataFrame)
+    assert list(pdf.columns) == list(CFBFASTR_SCHEMA.keys())
+
+
+@pytest.mark.parametrize("cid", sorted(FINALS))
+def test_running_score_matches_real_final(cid: str) -> None:
+    df = _frame(cid)
+    pos, pos_s, dpos, dpos_s = df.select("pos_team", "pos_team_score", "def_pos_team", "def_pos_team_score").row(-1)
+    assert {pos: pos_s, dpos: dpos_s} == {
+        FINALS[cid][0]: FINALS[cid][1],
+        FINALS[cid][2]: FINALS[cid][3],
+    }
+
+
+def test_structure_and_columns() -> None:
+    df = _frame("5336803")
+    assert df.height > 100
+    assert df.get_column("period").max() >= 4
+    assert df.get_column("id_play").n_unique() == df.height
+    # cfbfastR flag family present and boolean
+    for c in (
+        "rush",
+        "pass",
+        "completion",
+        "sack",
+        "int",
+        "touchdown",
+        "punt",
+        "kickoff_play",
+    ):
+        assert df.schema[c] == pl.Boolean, c
+    # participant naming converted to "First Last"
+    rushers = df.filter(pl.col("rusher_player_name").is_not_null())
+    assert rushers.height > 0
+    assert not rushers.get_column("rusher_player_name").str.contains(",").any()
+
+
+def test_first_last_suffixes() -> None:
+    assert _first_last("Wilborn Jr.,James") == "James Wilborn Jr."
+    assert _first_last("Jordan III,Tre") == "Tre Jordan III"
+    assert _first_last("Anthony,Malakai") == "Malakai Anthony"
+    assert _first_last(None) is None

--- a/tests/fixtures/cfb_ncaa/README.md
+++ b/tests/fixtures/cfb_ncaa/README.md
@@ -4,6 +4,8 @@
 
 - [cfb_ncaa fixtures](#cfb_ncaa-fixtures)
   - [Box-score tabs (contest 5362283 — California @ Auburn, 2024-09-07)](#box-score-tabs-contest-5362283--california--auburn-2024-09-07)
+  - [cfbfastR-mapper pbp fixtures (vendored from `ncaa-mfb-football-raw`)](#cfbfastr-mapper-pbp-fixtures-vendored-from-ncaa-mfb-football-raw)
+  - [2025-season page variants (captured 2026-08-19)](#2025-season-page-variants-captured-2026-08-19)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -38,6 +40,19 @@ game, for the box/drives/officials parsers in `cfb/cfb_ncaa_box.py`:
 | `mfb_individual_stats_5362283.html` | Individual Stats | <https://stats.ncaa.org/contests/5362283/individual_stats> |
 | `mfb_officials_5362283.html` | Officials | <https://stats.ncaa.org/contests/5362283/officials> |
 | `mfb_box_score_5362283.html` | Box Score (linescore + game info) | <https://stats.ncaa.org/contests/5362283/box_score> |
+
+## cfbfastR-mapper pbp fixtures (vendored from `ncaa-mfb-football-raw`)
+
+Consumed by `tests/cfb/test_cfb_ncaa_cfbfastr.py` (`to_cfbfastr` running-score
+finals). Copied byte-for-byte from the producer repo's
+`tests/fixtures/mfb_pbp_{id}.html` corpus (same browser transport); the tests
+also reuse `cfb_ncaa_pbp_5361446.html` / `cfb_ncaa_pbp_5362535.html` above for
+their pinned finals (Boise St. 56-45 Ga. Southern; Air Force 21-6 Merrimack).
+
+| file | contest_id | game | why this game | source URL |
+|---|---|---|---|---|
+| `mfb_pbp_5336803.html` | 5336803 | Akron @ Ohio St., 2024-08-31 (52-6) | pick-six (Powers 29-yd INT return TD) + the XP after it -- pins defensive-TD scoring attribution and XP-credited-to-the-scoring-defense; lowercase `"kick attempt good"` XPs | <https://stats.ncaa.org/contests/5336803/play_by_play> |
+| `mfb_pbp_5362431.html` | 5362431 | Towson @ Cincinnati, 2024-08-31 (20-38) | fumble-laden game (own-team recoveries that must NOT flip possession/score, plus forced-turnover fumbles); lowercase `"kick attempt good"` XPs | <https://stats.ncaa.org/contests/5362431/play_by_play> |
 
 ## 2025-season page variants (captured 2026-08-19)
 

--- a/tests/fixtures/cfb_ncaa/mfb_pbp_5336803.html
+++ b/tests/fixtures/cfb_ncaa/mfb_pbp_5336803.html
@@ -1,0 +1,2604 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<META HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=UTF-8">
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="">
+<meta name="author" content="">
+<meta name="version" content="321d28433e9f7a188596117e6f342ec4a84fb4ed">
+<META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<link rel="shortcut icon" href="/assets/favicon-405088046a5f2bab8eedeacfae7636975c095e9c8decd8c28e3fd0e65c2f51c4.ico" type="image/vnd.microsoft.icon">
+
+<title>NCAA Statistics</title>
+
+<!-- Bootstrap core CSS -->
+
+<!--
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+-->
+<!--
+<link rel="stylesheet" href="https://cdn.datatables.net/2.0.0/css/dataTables.bootstrap4.css" crossorigin="anonymous">
+-->
+<link rel="stylesheet" media="all" href="/assets/application-789c3971842ee3597428ccbebd021716b3231e9cbd0a00a184c3b2d6c8e5f152.css" />
+
+
+<script src="/assets/application-9232576bb3cb000ac0841ff2af81251908ec17312a3c5eb72bf1a32f9754800c.js"></script>
+<!--
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+-->
+<!--
+<script src="https://cdn.datatables.net/2.0.0/js/dataTables.bootstrap4.js" crossorigin="anonymous"></script>
+-->
+
+<meta name="csrf-param" content="authenticity_token" />
+<meta name="csrf-token" content="rjMh8Y2C/Zzk+BuH7YWTFhPzGbshBB8l6NVXWn6B42a8xaDU8idwMAVnvlig/kUGGNfOxc0UEhgPzpLSg/1Xqg==" />
+
+<style>
+.grid {clear: all}
+.grid-item, .name {text-align: center;}
+h1 img {max-height: 33px;}
+
+</style>
+<!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+<!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+      <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+    <![endif]-->
+
+
+<script>(window.BOOMR_mq=window.BOOMR_mq||[]).push(["addVar",{"rua.upush":"false","rua.cpush":"false","rua.upre":"false","rua.cpre":"false","rua.uprl":"false","rua.cprl":"false","rua.cprf":"false","rua.trans":"","rua.cook":"false","rua.ims":"false","rua.ufprl":"false","rua.cfprl":"false","rua.isuxp":"false","rua.texp":"norulematch","rua.ceh":"false","rua.ueh":"false","rua.ieh.st":"0"}]);</script>
+                                <script>!function(e){var n="https://s.go-mpulse.net/boomerang/";if("False"=="True")e.BOOMR_config=e.BOOMR_config||{},e.BOOMR_config.PageParams=e.BOOMR_config.PageParams||{},e.BOOMR_config.PageParams.pci=!0,n="https://s2.go-mpulse.net/boomerang/";if(window.BOOMR_API_key="EVKJV-AGD2E-W66AE-NT84S-K5LTF",function(){function e(){if(!r){var e=document.createElement("script");e.id="boomr-scr-as",e.src=window.BOOMR.url,e.async=!0,o.appendChild(e),r=!0}}function t(e){r=!0;var n,t,a,i,d=document,O=window;if(window.BOOMR.snippetMethod=e?"if":"i",t=function(e,n){var t=d.createElement("script");t.id=n||"boomr-if-as",t.src=window.BOOMR.url,BOOMR_lstart=(new Date).getTime(),e=e||d.body,e.appendChild(t)},!window.addEventListener&&window.attachEvent&&navigator.userAgent.match(/MSIE [67]\./))return window.BOOMR.snippetMethod="s",void t(o,"boomr-async");a=document.createElement("IFRAME"),a.src="about:blank",a.title="",a.role="presentation",a.loading="eager",i=(a.frameElement||a).style,i.width=0,i.height=0,i.border=0,i.display="none",o.appendChild(a);try{O=a.contentWindow,d=O.document.open()}catch(_){n=document.domain,a.src="javascript:var d=document.open();d.domain='"+n+"';void 0;",O=a.contentWindow,d=O.document.open()}if(n)d._boomrl=function(){this.domain=n,t()},d.write("<bo"+"dy onload='document._boomrl();'>");else if(O._boomrl=function(){t()},O.addEventListener)O.addEventListener("load",O._boomrl,!1);else if(O.attachEvent)O.attachEvent("onload",O._boomrl);d.close()}function a(e){window.BOOMR_onload=e&&e.timeStamp||(new Date).getTime()}if(!window.BOOMR||!window.BOOMR.version&&!window.BOOMR.snippetExecuted){window.BOOMR=window.BOOMR||{},window.BOOMR.snippetStart=(new Date).getTime(),window.BOOMR.snippetExecuted=!0,window.BOOMR.snippetVersion=14,window.BOOMR.url=n+"EVKJV-AGD2E-W66AE-NT84S-K5LTF";var i=document.currentScript||document.getElementsByTagName("script")[0],o=i.parentNode,r=!1,d=document.createElement("link");if(d.relList&&"function"==typeof d.relList.supports&&d.relList.supports("preload")&&"as"in d)window.BOOMR.snippetMethod="p",d.href=window.BOOMR.url,d.rel="preload",d.as="script",d.addEventListener("load",e),d.addEventListener("error",function(){t(!0)}),setTimeout(function(){if(!r)t(!0)},3e3),BOOMR_lstart=(new Date).getTime(),o.appendChild(d);else t(!1);if(window.addEventListener)window.addEventListener("load",a,!1);else if(window.attachEvent)window.attachEvent("onload",a)}}(),"".length>0)if(e&&"performance"in e&&e.performance&&"function"==typeof e.performance.setResourceTimingBufferSize)e.performance.setResourceTimingBufferSize();!function(){if(BOOMR=e.BOOMR||{},BOOMR.plugins=BOOMR.plugins||{},!BOOMR.plugins.AK){var n=""=="true"?1:0,t="",a="vq5hssix2kdgi2sztkga-f-8a79ea43b-clientnsv4-s.akamaihd.net",i="false"=="true"?2:1,o={"ak.v":"41","ak.cp":"1168236","ak.ai":parseInt("215853",10),"ak.ol":"0","ak.cr":49,"ak.ipv":4,"ak.proto":"h2","ak.rid":"4e5aad12","ak.r":47358,"ak.a2":n,"ak.m":"a","ak.n":"essl","ak.cport":14824,"ak.gh":"23.208.24.235","ak.quicv":"","ak.tlsv":"tls1.3","ak.0rtt":"","ak.0rtt.ed":"","ak.csrc":"-","ak.acc":"","ak.t":"1784257164","ak.ak":"hOBiQwZUYzCg5VSAfCLimQ==7nkOj75lsUatQZD0jLAvXPkunJ+5IudoNXfl85/nuhVnlZaIw3gAQdmFvoJYnTRO4krhz2ucNOBnXrFDUJYxNabvnOmcshPH6pTa8kxTB5XgOHSspO6Zm0qgrC3GkH37sd3w/dSmgEt+B1cb80mbXIg/irC3taTeFCpxZMHjDCUM8mXuOqeiRbUWmG4YRyDrawxlGi82xsVEA8CLaCYq/c8Rs7SmE4giKNOCy4W/6JkeLEY3llrZQ/Z6Peuz3IyG0pvHl64eDw0B07QGzTHAqiOQ0/B+w7s9E6WgDs3VfNIIPo2ll4ykCNAipgtKr0cGmsC8cuRRgNxQutFqmhWw+IrmBpzH3UBojUrX1yoGsa2A21TDS8z5wIKe1DKdmlfSHETQALnHzlagJZnKu4KjZ/7LM36syoRsFMfNz0Gz0Zs=","ak.pv":"93","ak.dpoabenc":"","ak.tf":i};if(""!==t)o["ak.ruds"]=t;var r={i:!1,av:function(n){var t="http.initiator";if(n&&(!n[t]||"spa_hard"===n[t]))o["ak.feo"]=void 0!==e.aFeoApplied?1:0,BOOMR.addVar(o)},rv:function(){var e=["ak.cport","ak.cr","ak.csrc","ak.gh","ak.ipv","ak.m","ak.n","ak.ol","ak.proto","ak.quicv","ak.tlsv","ak.0rtt","ak.0rtt.ed","ak.r","ak.acc","ak.t","ak.tf"];BOOMR.removeVar(e)}};BOOMR.plugins.AK={akVars:o,akDNSPreFetchDomain:a,init:function(){if(!r.i){var e=BOOMR.subscribe;e("before_beacon",r.av,null,null),e("onbeacon",r.rv,null,null),r.i=!0}return this},is_complete:function(){return!0}}}}()}(window);</script></head>
+
+  <script>
+
+    
+  //initialize tooltip
+  $(document).ready(function() {
+    //$("body").tooltip({ selector: '[data-toggle=tooltip]' });
+    $('[data-toggle="tooltip"]').tooltip();
+  });
+
+  $(document).ready(function() {
+    $( "#org_name" ).autocomplete({
+      source: '/team/search',
+      select: function( event, ui ) {
+        $("#org_id").val(ui.item.vid);
+        $("#id").val(ui.item.vid);
+        $('#sport_btn').click();
+      }
+    });
+  });
+
+  var body = 'body';
+
+  $.ajaxSetup ({
+    // Disable caching of AJAX responses
+    cache: false
+  });
+
+  function changeSport(field){
+    var el = $(field);
+    var tmList = el.parent().next().find('.new-team-year')[0];
+    if (tmList == null){
+      tmList = el.nextAll('.new-team-year')[0];
+    }
+    $.ajax({
+      url: "/game_sport_year_ctls/"+el.val()+"/available_teams",
+      dataType: "script",
+      success: function(data, status){
+        $(tmList).empty();
+        $(tmList).append(("<option value=''>Select team</option>"));
+        $.each(JSON.parse(data), function(k, v){
+          $(tmList).append($("<option></option>")
+              .attr("value", v["id"])
+              .text(v["member_org"]["name_tabular"]));
+        });
+        $(tmList).trigger("chosen:updated");
+      }
+    });
+  }
+
+    function set_process_styles(fld, start_color, end_color){
+       $('#'+fld).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    var downImage = "/assets/down12.gif";
+    var rightImage = "/assets/right12.gif";
+
+    function highlight(div_id){
+      $(div_id).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    function show_hide_rows(attr_val, link_id){
+      $('#'+attr_val).toggle();
+      if ($('#'+attr_val).is(':visible')) {
+        $('#'+link_id).attr('src', downImage);
+      }else{
+        $('#'+link_id).attr('src', rightImage);
+      }
+    }
+
+    function mask(label){
+      $('body').mask(label);
+    }
+    function unmask(){
+      $('body').unmask();
+    }
+
+    var winHeight = "auto";
+    var winWidth = "auto";
+    var maxHeight = 700;
+    var maxWidth = 1400;
+    var minHeight = 100;
+    var minWidth = 200;
+    
+    var modalOptions = {"width": winWidth,
+                        "height": winHeight,
+                        "maxHeight": maxHeight,
+                        "maxWidth": maxWidth,
+                        "minHeight": minHeight,
+                        "minWidth": minWidth};
+
+    function dialog(url, title){
+
+      $("#stats_app_dialog").dialog({modal:true, minWidth:minWidth, minHeight:minHeight, maxWidth:maxWidth, maxHeight:maxHeight, width:winWidth, height:winHeight, title:title, closeOnEscape: false});
+    
+      modalOptions.title = title;
+    
+      $("#stats_app_dialog").dialog("option", modalOptions);
+    
+      $("#stats_app_dialog").html("Loading...");
+      $("#stats_app_dialog").load(url).dialog('open');
+    }
+
+    function addDatePicker(){
+    $('.adddatepicker').each(function(i, obj){
+      $(obj).datepicker({ 
+        showOn: 'both', 
+        buttonImage: '/assets/calendar.gif', 
+        buttonImageOnly: true,
+      });
+    });
+    }
+
+   $(document).ready(function() {
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   });
+
+   function setClassInputFields(){
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   }
+
+   function isValidDateFormat(dateStr){
+     const regex = /^([1-9]|0[1-9]|1[0-2])\/([1-9]|0[1-9]|[12][0-9]|3[01])\/(19|20)\d{2}$/;
+     if (!regex.test(dateStr)) {
+       return false;
+     }else{
+       return true;
+     }
+   }
+
+  </script>
+
+
+<body style="font-size: .75rem;" onload="if (top != self) { top.location=self.location; }" >
+
+      <header>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0">
+        <a class="navbar-brand mr-0 mr-md-2" href="/" aria-label="statistics">
+                          <img alt="NCAA" style="margin-left: 24px; margin-right: 0; margin-top: 6px;" src="/assets/ncaa-fbc4d0406ae731b47babcc3fca53775b5955ef372bf8b8e998ca9a513e468b8f.svg" />
+                          <span class="title" class="dark-blue-font">Statistics</span>
+        </a>
+       </nav>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0" style="background-color: var(--color-dark-blue) !important;">
+  <button class="navbar-toggler bg-white" type="button" data-toggle="collapse" data-target="#navbarTogglerDemo01" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarTogglerDemo01">
+        <ul class="navbar-nav mr-auto mt-2 mt-lg-0 justify-content-center">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle skipMask" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Rankings
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+          <a class="dropdown-item" href="/rankings">National Rankings</a>
+          <a class="dropdown-item" href="/active_career_leaders">Active Career Leaders</a>
+        </div>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/contests/livestream_scoreboards">Scoreboard</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/selection_rankings/nitty_gritties">Selection Rankings</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/head_coaches">Head Coaches</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/search/players">Players</a>
+      </li>
+     </ul>
+
+    <form onsubmit="mask(&#39;Loading&#39;);" id="change_team_form" style="display:inline;" class="form-inline my-2 my-lg-0" action="/team/index" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="9mN1hWtu9Ifi+1WotKMYKWxZUFWWbQEIwE3xkqM0qGutRJtjpQ9Iyqqr3V8AGSAj3W/0P+33iZtfOIqq1M+N0w==" />
+  <div style="display:none;">
+  <input type="submit" name="commit" value="Submit" id="sport_btn" data-disable-with="Submit" />
+  </div>
+    <div id="team_autocomplete" class="ui-widget">
+      <input type="search" name="org_name" id="org_name" style="width:200px; font-size: 12px !important" class="form-control mr-sm-2" placeholder="Team Search" />
+      <input type="hidden" name="org_id" id="org_id" />
+    </div>
+</form>  </div>
+  </nav>
+</nav>
+      </header>
+
+       <div id="stats_app_dialog" style="display:none;">
+        </div>
+
+<div class="card p-1">
+  <div class="card-body application contests p-0">
+    <h3 class="card-title p-0"></h3>
+    <div class="container-fluid p-0">
+      <div class="row align-items-center justify-content-center p-0">
+        <div class="col-sm-12 p-0">
+          <br/>
+
+<br/>
+
+<style>
+.winner{
+  --display: flex;
+  vertical-align: middle;
+}
+.winner:before{
+  content: '\25BA';
+  --display: flex;
+  --align-items: center;
+  vertical-align: middle;
+}
+div.center {
+  margin: auto;
+  width: 50%;
+  --border: 3px solid green;
+  padding: 10px;
+}
+</style>
+
+   <div class="table-responsive">
+   <table align="center">
+     <tr>
+   <td>
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589020"><img class="large_logo_image" alt="Akron" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//5.gif" /></a>
+   </td>
+   <td valign="center" class="grey_text d-none d-sm-table-cell" nowrap>
+     <span style="font-size:18px">
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589020">Akron Zips</a>
+     </span><br/>
+       0-1, Conf 0-0
+   </td>
+   <td valign="center" class="">
+   </td>
+   <td valign="center" style="font-size:36px; color: grey">
+     6
+   </td>
+     <td style="padding: 0px 30px 0px 30px"  class="d-none d-md-table-cell">
+       <table style="border-collapse: collapse">
+         <tr>
+           <td class="grey_border_bottom"></td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">1</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">2</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">3</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">4</td>
+           <td width="20px" align="right" style="font-weight:bold" class="grey_border_bottom">S</td>
+         </tr>
+           <tr>
+             <td>Akron</td>
+               <td class="grey_text" align="right">3</td>
+               <td class="grey_text" align="right">0</td>
+               <td class="grey_text" align="right">3</td>
+               <td class="grey_text" align="right">0</td>
+             <td align="right" style="font-weight:bold">6</td>
+           </tr>
+           <tr>
+             <td>Ohio St.</td>
+               <td class="grey_text" align="right">7</td>
+               <td class="grey_text" align="right">10</td>
+               <td class="grey_text" align="right">21</td>
+               <td class="grey_text" align="right">14</td>
+             <td align="right" style="font-weight:bold">52</td>
+           </tr>
+         <tr>
+           <td class="grey_text" colspan="6">08/31/2024 03:30 PM</td>
+         </tr>
+         <tr>
+           <td nowrap class="grey_text" colspan="6">Ohio Stadium (Columbus, OH)</td>
+         </tr>
+         <tr>
+           <td nowrap class="grey_text" colspan="6">Attendance: 102,011</td>
+         </tr>
+       </table>
+     </td>
+   <td>
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/588963"><img class="large_logo_image" alt="Ohio St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//518.gif" /></a>
+   </td>
+   <td valign="center" class="grey_text d-none d-sm-table-cell" nowrap>
+     <span style="font-size:18px">
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/588963">Ohio St. Buckeyes</a>
+     </span><br/>
+       1-0, Conf 0-0
+   </td>
+   <td valign="center" class="winner">
+   </td>
+   <td valign="center" style="font-size:36px; color: black">
+     52
+   </td>
+     </tr>
+     <tr>
+       <td colspan="10" class="grey_border_bottom grey_border_top">
+         <table cellpadding="10px">
+           <tr>
+             <td style="font-size: 16px;"><a href="/contests/5336803/box_score">Box Score</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5336803/team_stats">Team Stats</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5336803/individual_stats">Individual Stats</a></td>
+             <td style="font-size: 16px;">Play By Play</td>
+             <td style="font-size: 16px;"><a href="/contests/5336803/drives">Drives</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5336803/officials">Officials</a></td>
+           </tr>
+         </table>
+       </td>
+     </tr>
+   </table>
+ </div>
+
+
+<br/>
+
+  <script>
+ $( function() {
+    $( ".drives" ).accordion({
+      collapsible: true,
+      heightStyle: "content",
+      header: "h5",
+      active: false
+    });
+  } );
+
+ function showScoringPlays(){
+   $('.non_scoring_play').hide();
+ }
+ function showAllPlays(){
+   $('.non_scoring_play').show();
+   $('.drives').accordion("refresh");
+   $('.drives').accordion("option", "active", false);
+ }
+</script>
+
+<style>
+ .ui-state-default, .ui-widget-content .ui-state-default, .ui-widget-header .ui-state-default {
+   overflow: auto;
+ }
+ .ui-state-default, .ui-widget-content .ui-state-default, .ui-widget-header .ui-state-default {
+    border: 1px solid #CCCCCC;
+    background: white;
+    background-image: none;
+    font-weight: normal;
+    color: #808080;
+}
+
+ .headerRight {
+  float: right;
+}
+.headerLeft {
+  float: left;
+}
+.under{
+text-decoration : underline;
+}
+</style>
+
+<div style="width: 50%; margin-left: auto; margin-right: auto;">
+  <div class="headerRight"><a class="skipMask" href="javascript:showAllPlays();">All Drives</a> | <a class="skipMask" href="javascript:showScoringPlays();">Scoring Drives</a></div>
+  <div style="border-bottom: 1px dotted #dcdddf;"><h1>1st Quarter</h1></div>
+<div class="drives">
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ohio St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//518.gif" /><span class='d-none d-sm-block'>Ohio St.</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">14:53,OSU32, 3 plays, 4 yards, 00:51</span>
+        </div>
+        <div class="headerRight">0 - 0</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR35</br>
+         </span>
+         <span>
+           Jackson,Dante kickoff 61 yards to the OSU04 Ballard,Jayden return 23 yards to the OSU27 (Jackson,Dante; Roach,Noel) PENALTY AKRON Offside 5 yards from OSU27 to OSU32.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU32</br>
+         </span>
+         <span>
+           Ohio State drive start at 14:53.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU32</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Henderson,TreVeyon rush right for 9 yards gain to the OSU41 (Nunnally,CJ).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 1 at OSU41</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass incomplete short left to Smith,Jeremiah thrown to OSU39.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at OSU41</br>
+         </span>
+         <span>
+           PENALTY OSU False Start (Tshabola,Tegra) 5 yards from OSU41 to OSU36. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at OSU36</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass incomplete short right to Egbuka,Emeka thrown to OSU41 broken up by McCoy,Bryan.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 6 at OSU36</br>
+         </span>
+         <span>
+           McGuire,Joe punt 42 yards to the AKRON22, TURNOVER ON DOWNS.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Akron" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//5.gif" /><span class='d-none d-sm-block'>Akron</span></div></div>
+        <div class="headerLeft">FG <br/><span style="font-size: 8px;">14:02,AKR22, 10 plays, 47 yards, 05:18</span>
+        </div>
+        <div class="headerRight">3 - 0</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR22</br>
+         </span>
+         <span>
+           Akron drive start at 14:02.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR22</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben rush left for 5 yards gain to the AKRON27, End Of Play PENALTY OSU Personal Foul (Igbinosun,Davison) 15 yards from AKRON27 to AKRON42, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR42</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj pass complete short right to Simmons,Jordon caught at AKRON38, for 6 yards to the AKRON48 (Hancock,Jordan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 4 at AKR48</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Simmons,Jordon rush middle for 2 yards gain to the AKRON50 (Hamilton,Ty; Ransom,Lathan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at AKR50</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj pass complete short right to Newell,Jake caught at OSU49, for 12 yards to the OSU38 (Burke,Denzel), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU38</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj rush middle for 3 yards gain to the OSU35 (Williams,Tyleik).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at OSU35</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj rush right for 12 yards gain to the OSU23 (Burke,Denzel), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU23</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Akron rush middle for 14 yards loss to the OSU37, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 24 at OSU37</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj sacked for loss of 4 yards to the OSU41 (Tuimoloau,JT).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 28 at OSU41</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj pass complete short left to Golden,Bobby caught at OSU44, for 10 yards to the OSU31 (Williams,Tyleik; Styles,Sonny).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 18 at OSU31</br>
+         </span>
+         <span>
+           Smith,Garrison field goal attempt from 48 yards GOOD (H: Castle,Joseph, LS: Reardon,Liam), clock 08:44.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ohio St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//518.gif" /><span class='d-none d-sm-block'>Ohio St.</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">08:44,OSU25, 14 plays, 75 yards, 06:00</span>
+        </div>
+        <div class="headerRight">3 - 7</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR35</br>
+         </span>
+         <span>
+           Jackson,Dante kickoff 51 yards to the OSU14 fair catch by Ballard,Jayden at OSU14.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU25</br>
+         </span>
+         <span>
+           Ohio State drive start at 08:44.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass incomplete short right to Tate,Carnell thrown to OSU32.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at OSU25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass incomplete short middle to Judkins,Quinshon thrown to OSU27 broken up by Cooper,Shammond.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 10 at OSU25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short right to Smith,Jeremiah caught at OSU36, for 11 yards to the OSU36 (Golden-Nelson,Devonte), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU36</br>
+         </span>
+         <span>
+           Shotgun Judkins,Quinshon rush left for 1 yard gain to the OSU37 (Dall,Bruno).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 9 at OSU37</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short right to Egbuka,Emeka caught at AKRON44, for 19 yards to the AKRON44 (David,Daymon), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR44</br>
+         </span>
+         <span>
+           Shotgun Judkins,Quinshon rush middle for 1 yard gain to the AKRON43 (Fish,Antavious; Murphy,Kiawan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 9 at AKR43</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will rush right for 8 yards gain to the AKRON35, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at AKR35</br>
+         </span>
+         <span>
+           Timeout Other, clock 05:41.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at AKR35</br>
+         </span>
+         <span>
+           Howard,Will rush middle for 1 yard gain to the AKRON34 (Lewis,Darrian), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR34</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short right to Tate,Carnell caught at AKRON29, for 6 yards to the AKRON28 (Golden-Nelson,Devonte), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 4 at AKR28</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Judkins,Quinshon rush right for 0 yards to the AKRON28 (Nunnally,CJ).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 4 at AKR28</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short right to Smith,Jeremiah caught at AKRON20, for 8 yards to the AKRON20, out of bounds at AKRON20, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR20</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass incomplete deep right to Egbuka,Emeka thrown to AKRON00 broken up by Golden-Nelson,Devonte. The previous play is under automatic review - &quot;Incomplete pass&quot;. PLAY CONFIRMED.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at AKR20</br>
+         </span>
+         <span>
+           Shotgun Judkins,Quinshon rush middle for 4 yards gain to the AKRON16 (Lewis,Darrian; Fish,Antavious).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at AKR16</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short left to Smith,Jeremiah caught at AKRON00, for 16 yards to the AKRON00 TOUCHDOWN, clock 02:44, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR3</br>
+         </span>
+         <span>
+           Fielding,Jayden kick attempt good (H: McGuire,Joe, LS: Ferlmann,John).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Akron" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//5.gif" /><span class='d-none d-sm-block'>Akron</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">02:44,AKR25, 5 plays, 9 yards, 02:36</span>
+        </div>
+        <div class="headerRight">3 - 7</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU35</br>
+         </span>
+         <span>
+           Fielding,Jayden kickoff 65 yards to the AKRON00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           Akron drive start at 02:44.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben pass complete short right to Kellom,Charles caught at AKRON25, for 9 yards to the AKRON34 (Ransom,Lathan), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 1 at AKR34</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben pass complete short right to Bullock,Tahj caught at AKRON34, for 5 yards to the AKRON39 (Hicks,C.J.), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR39</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj pass complete short right to Kellom,Charles caught at AKRON38, for 3 yards to the AKRON42 (Hicks,C.J.; Ransom,Lathan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at AKR42</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben sacked for loss of 8 yards to the AKRON34 (Hicks,C.J.).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 15 at AKR34</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben pass incomplete short right to Kellom,Charles thrown to AKRON35.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 15 at AKR34</br>
+         </span>
+         <span>
+           Book,Avery punt 25 yards to the OSU41, out of bounds at OSU41.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ohio St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//518.gif" /><span class='d-none d-sm-block'>Ohio St.</span></div></div>
+        <div class="headerLeft">DOWNS <br/><span style="font-size: 8px;">00:08,OSU41, 6 plays, 34 yards, 02:09</span>
+        </div>
+        <div class="headerRight">3 - 7</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU41</br>
+         </span>
+         <span>
+           Ohio State drive start at 00:08.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU41</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Henderson,TreVeyon rush right for 13 yards gain to the AKRON46 (Lewis,Darrian), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR46</br>
+         </span>
+         <span>
+           Start of 2nd quarter, clock 15:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR46</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short left to Egbuka,Emeka caught at AKRON41, for 16 yards to the AKRON30 (Lewis,Darrian), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR30</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass incomplete short right thrown to AKRON22.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at AKR30</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Henderson,TreVeyon rush left for 3 yards gain to the AKRON27 (Nunnally,CJ; Kapongo,Nate).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 7 at AKR27</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Henderson,TreVeyon rush left for 2 yards gain to the AKRON25 (McCoy,Bryan; Fish,Antavious).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 5 at AKR25</br>
+         </span>
+         <span>
+           Timeout Other, clock 13:11.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 5 at AKR25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass incomplete short right to Egbuka,Emeka thrown to AKRON23 broken up by Greenwood,Aman, TURNOVER ON DOWNS.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+</div>
+  <div style="border-bottom: 1px dotted #dcdddf;"><h1>2nd Quarter</h1></div>
+<div class="drives">
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Akron" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//5.gif" /><span class='d-none d-sm-block'>Akron</span></div></div>
+        <div class="headerLeft">INT <br/><span style="font-size: 8px;">12:59,AKR25, 2 plays, -2 yards, 00:56</span>
+        </div>
+        <div class="headerRight">3 - 7</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           Akron drive start at 12:59.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Simmons,Jordon rush middle for 2 yards loss to the AKRON23 (Ransom,Lathan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 12 at AKR23</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben pass intercepted by Burke,Denzel at AKRON33, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ohio St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//518.gif" /><span class='d-none d-sm-block'>Ohio St.</span></div></div>
+        <div class="headerLeft">FG <br/><span style="font-size: 8px;">12:03,AKR33, 5 plays, 11 yards, 00:40</span>
+        </div>
+        <div class="headerRight">3 - 10</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR33</br>
+         </span>
+         <span>
+           Ohio State drive start at 12:03.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR33</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Henderson,TreVeyon rush middle for 11 yards gain to the AKRON22 (Fish,Antavious; David,Daymon), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR22</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass incomplete short right to Inniss,Brandon thrown to AKRON25 broken up by Greenwood,Aman.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at AKR22</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass incomplete short left to Kacmarek,Will thrown to AKRON05.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 10 at AKR22</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass incomplete deep left to Smith,Jeremiah thrown to AKRON00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 10 at AKR22</br>
+         </span>
+         <span>
+           Fielding,Jayden field goal attempt from 40 yards GOOD (H: McGuire,Joe, LS: Ferlmann,John), clock 11:23.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Akron" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//5.gif" /><span class='d-none d-sm-block'>Akron</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">11:23,AKR25, 3 plays, -3 yards, 02:23</span>
+        </div>
+        <div class="headerRight">3 - 10</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU35</br>
+         </span>
+         <span>
+           Fielding,Jayden kickoff 65 yards to the AKRON00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           Akron drive start at 11:23.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj rush left for 0 yards to the AKRON25 (Tuimoloau,JT).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at AKR25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Kellom,Charles rush middle for 2 yards gain to the AKRON27 (Williams,Tyleik; Sawyer,Jack).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 8 at AKR27</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben sacked for loss of 5 yards to the AKRON22 (Tuimoloau,JT, Downs,Caleb).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 13 at AKR22</br>
+         </span>
+         <span>
+           Book,Avery punt 60 yards to the OSU18 Inniss,Brandon return 6 yards to the OSU24 (Thomas,Terence; Reardon,Liam).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ohio St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//518.gif" /><span class='d-none d-sm-block'>Ohio St.</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">09:00,OSU24, 9 plays, 76 yards, 04:30</span>
+        </div>
+        <div class="headerRight">3 - 17</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU24</br>
+         </span>
+         <span>
+           Ohio State drive start at 09:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU24</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Judkins,Quinshon rush right for 5 yards gain to the OSU29 (Greenwood,Aman).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 5 at OSU29</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short right to Egbuka,Emeka caught at OSU29, for 12 yards to the OSU41 (Greenwood,Aman), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU41</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Judkins,Quinshon rush left for 12 yards gain to the AKRON47 (Lewis III,Paul), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR47</br>
+         </span>
+         <span>
+           Timeout Other, clock 07:39.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR47</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Judkins,Quinshon rush left for 2 yards gain to the AKRON45 (David,Daymon).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 8 at AKR45</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Henderson,TreVeyon rush left for 5 yards gain to the AKRON40, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 3 at AKR40</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short left to Egbuka,Emeka caught at AKRON40, for 14 yards to the AKRON26 (Nunnally,CJ) PENALTY OSU Illegal Formation 5 yards from AKRON40 to AKRON45. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 8 at AKR45</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short right to Tate,Carnell caught at AKRON29, for 16 yards to the AKRON29 (Lewis III,Paul), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR29</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will rush right for 19 yards gain to the AKRON10 (Fish,Antavious; Golden-Nelson,Devonte), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR10</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Henderson,TreVeyon rush middle for 1 yard gain to the AKRON09 (Spriggs,Melvin).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 9 at AKR9</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short middle to Smith,Jeremiah caught at AKRON00, for 9 yards to the AKRON00 TOUCHDOWN, clock 04:30, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR3</br>
+         </span>
+         <span>
+           Fielding,Jayden kick attempt good (H: McGuire,Joe, LS: Ferlmann,John).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU35</br>
+         </span>
+         <span>
+           AKR ball on AKR20.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Akron" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//5.gif" /><span class='d-none d-sm-block'>Akron</span></div></div>
+        <div class="headerLeft">DOWNS <br/><span style="font-size: 8px;">04:30,AKR20, 12 plays, 45 yards, 03:26</span>
+        </div>
+        <div class="headerRight">3 - 17</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU35</br>
+         </span>
+         <span>
+           Fielding,Jayden kickoff 65 yards to the AKRON00, Touchback PENALTY AKRON Illegal Substitution 5 yards from AKRON25 to AKRON20.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR20</br>
+         </span>
+         <span>
+           Akron drive start at 04:30.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR20</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben pass complete short right to Golden,Bobby caught at AKRON24, for 19 yards to the AKRON39 (Hancock,Jordan), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR39</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben rush middle for 5 yards gain to the AKRON44 (Hamilton,Ty).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 5 at AKR44</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben pass incomplete short left to Golden,Bobby thrown to OSU45.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 5 at AKR44</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben pass complete short right to Simmons,Jordon caught at AKRON40, for 6 yards to the AKRON50 (Hicks,C.J.), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR50</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben pass incomplete deep left to Golden,Bobby thrown to OSU25 QB hurried by Sawyer,Jack.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at AKR50</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben pass complete short left to Simmons,Jordon caught at AKRON45, for 8 yards to the OSU42 (Styles,Sonny; Igbinosun,Davison).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at OSU42</br>
+         </span>
+         <span>
+           Timeout Akron, clock 02:02.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at OSU42</br>
+         </span>
+         <span>
+           No Huddle Bullock,Tahj rush middle for 1 yard gain to the OSU41 (Williams,Tyleik; Sawyer,Jack).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 1 at OSU41</br>
+         </span>
+         <span>
+           Timeout Other, clock 01:56.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 1 at OSU41</br>
+         </span>
+         <span>
+           No Huddle Bullock,Tahj rush right for 2 yards gain to the OSU39 (Styles,Sonny; Burke,Denzel), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU39</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben pass incomplete short right to Polk,Israel thrown to OSU23 broken up by Hancock,Jordan.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at OSU39</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben pass complete short left to Polk,Israel caught at OSU40, for 5 yards to the OSU34 (Reese,Arvell), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 5 at OSU34</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben pass incomplete short left to Newell,Jake thrown to OSU32.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 5 at OSU34</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben sacked for loss of 1 yard to the OSU35 (Williams,Tyleik), TURNOVER ON DOWNS.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ohio St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//518.gif" /><span class='d-none d-sm-block'>Ohio St.</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">01:04,OSU35, 3 plays, -7 yards, 00:34</span>
+        </div>
+        <div class="headerRight">3 - 17</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU35</br>
+         </span>
+         <span>
+           Ohio State drive start at 01:04.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU35</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass incomplete short right to Smith,Jeremiah thrown to AKRON48.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at OSU35</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short right to Smith,Jeremiah caught at OSU38, for 3 yards to the OSU38, out of bounds at OSU38.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 7 at OSU38</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will rush middle for 10 yards loss to the OSU28 fumbled by Howard,Will at OSU30 recovered by OSU Henderson,TreVeyon at OSU28, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 17 at OSU28</br>
+         </span>
+         <span>
+           Timeout Akron, clock 00:37.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 17 at OSU28</br>
+         </span>
+         <span>
+           McGuire,Joe punt 51 yards to the AKRON21 fair catch by Granger,Ahmarian at AKRON21.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Akron" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//5.gif" /><span class='d-none d-sm-block'>Akron</span></div></div>
+        <div class="headerLeft">HALF <br/><span style="font-size: 8px;">00:30,AKR21, 1 plays, 2 yards, 00:30</span>
+        </div>
+        <div class="headerRight">3 - 17</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR21</br>
+         </span>
+         <span>
+           Akron drive start at 00:30.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR21</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben pass complete short right to Rush,Jarvis caught at AKRON20, for 2 yards to the AKRON23 (Hancock,Jordan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 8 at AKR23</br>
+         </span>
+         <span>
+           End of game, clock 00:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU35</br>
+         </span>
+         <span>
+           AKR will receive; OSU will defend South end-zone.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU35</br>
+         </span>
+         <span>
+           Start of 3rd quarter, clock 15:00.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+</div>
+  <div style="border-bottom: 1px dotted #dcdddf;"><h1>3rd Quarter</h1></div>
+<div class="drives">
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Akron" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//5.gif" /><span class='d-none d-sm-block'>Akron</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">15:00,AKR25, 10 plays, 19 yards, 06:15</span>
+        </div>
+        <div class="headerRight">3 - 17</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU35</br>
+         </span>
+         <span>
+           Fielding,Jayden kickoff 65 yards to the AKRON00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           Akron drive start at 15:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben rush middle for 5 yards gain to the AKRON30 (Ransom,Lathan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 5 at AKR30</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben pass complete short right to Bullock,Tahj caught at AKRON29, for 1 yard loss to the AKRON29 (Ransom,Lathan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at AKR29</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben pass complete short right to Newell,Jake caught at AKRON34, for 5 yards to the AKRON34 (Burke,Denzel), out of bounds PENALTY OSU Offside (Tuimoloau,JT) 5 yards from AKRON29 to AKRON34. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at AKR34</br>
+         </span>
+         <span>
+           Timeout Akron, clock 13:20.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at AKR34</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Simmons,Jordon rush middle for 0 yards to the AKRON34 (Hamilton,Ty; Williams,Tyleik).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 1 at AKR34</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Simmons,Jordon rush middle for 2 yards gain to the AKRON36 (Downs,Caleb; Hamilton,Ty), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR36</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Finley,Ben rush left for 1 yard loss to the AKRON35 (Reese,Arvell).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 11 at AKR35</br>
+         </span>
+         <span>
+           Timeout Other, clock 11:46.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 11 at AKR35</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj pass complete short left to Simmons,Jordon caught at AKRON31, for 5 yards to the AKRON40 (Hancock,Jordan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at AKR40</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj rush left for 6 yards gain to the AKRON46 (Ransom,Lathan), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR46</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Simmons,Jordon rush left for 5 yards loss to the AKRON41 (Williams,Tyleik; Melton,Mitchell).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 15 at AKR41</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj pass incomplete short left thrown to AKRON45.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 15 at AKR41</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj pass complete short right to Golden,Bobby caught at AKRON37, for 3 yards to the AKRON44 (Burke,Denzel; Reese,Arvell), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 12 at AKR44</br>
+         </span>
+         <span>
+           Book,Avery punt 52 yards to the OSU04 Inniss,Brandon return 36 yards to the OSU40 (Kellom,Charles).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ohio St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//518.gif" /><span class='d-none d-sm-block'>Ohio St.</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">08:45,OSU40, 3 plays, 60 yards, 00:52</span>
+        </div>
+        <div class="headerRight">3 - 24</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU40</br>
+         </span>
+         <span>
+           Ohio State drive start at 08:45.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU40</br>
+         </span>
+         <span>
+           Shotgun Judkins,Quinshon rush middle for 13 yards gain to the AKRON47 (David,Daymon), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR47</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete deep left to Smith,Jeremiah caught at AKRON02, for 45 yards to the AKRON02 (David,Daymon), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 2 at AKR2</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Judkins,Quinshon rush middle for 2 yards gain to the AKRON00 TOUCHDOWN, clock 07:53.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR3</br>
+         </span>
+         <span>
+           Fielding,Jayden kick attempt good (H: McGuire,Joe, LS: Ferlmann,John).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Akron" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//5.gif" /><span class='d-none d-sm-block'>Akron</span></div></div>
+        <div class="headerLeft">FUMB <br/><span style="font-size: 8px;">07:53,AKR25, 3 plays, 2 yards, 00:18</span>
+        </div>
+        <div class="headerRight">3 - 31</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU35</br>
+         </span>
+         <span>
+           Fielding,Jayden kickoff 65 yards to the AKRON00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           Akron drive start at 07:53.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj pass incomplete short left to Rush,Jarvis thrown to AKRON24.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at AKR25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj pass incomplete short left to Rush,Jarvis thrown to AKRON26.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 10 at AKR25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj rush middle for 2 yards gain to the AKRON27 fumbled by Bullock,Tahj at AKRON25 forced by Curry,Caden recovered by OSU Ransom,Lathan at AKRON27 Ransom,Lathan return 27 yards to the AKRON00 TOUCHDOWN, clock 07:35.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR3</br>
+         </span>
+         <span>
+           Fielding,Jayden kick attempt good (H: McGuire,Joe, LS: Ferlmann,John).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Akron" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//5.gif" /><span class='d-none d-sm-block'>Akron</span></div></div>
+        <div class="headerLeft">FG <br/><span style="font-size: 8px;">07:35,AKR25, 7 plays, 44 yards, 03:38</span>
+        </div>
+        <div class="headerRight">6 - 31</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU35</br>
+         </span>
+         <span>
+           Fielding,Jayden kickoff 65 yards to the AKRON00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           Akron drive start at 07:35.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Simmons,Jordon rush middle for 3 yards gain to the AKRON28 (Hicks,C.J.; Ransom,Lathan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at AKR28</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj rush left for 3 yards gain to the AKRON31 (Styles,Sonny).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 4 at AKR31</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj pass complete short left to Newell,Jake caught at AKRON42, for 29 yards to the OSU40 (Styles,Sonny; Ransom,Lathan), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU40</br>
+         </span>
+         <span>
+           PENALTY AKRON False Start (Burrell,Jerrod) 5 yards from OSU40 to OSU45. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 15 at OSU45</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj rush middle for 8 yards gain to the OSU37, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at OSU37</br>
+         </span>
+         <span>
+           Timeout Other, clock 05:11.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at OSU37</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj rush middle for 5 yards gain to the OSU32 (Malone,Tywone; Styles,Sonny).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at OSU32</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Kellom,Charles rush middle for 1 yard gain to the OSU31 (Jackson Jr.,Kenyatta).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 1 at OSU31</br>
+         </span>
+         <span>
+           Smith,Garrison field goal attempt from 49 yards GOOD (H: Castle,Joseph, LS: Reardon,Liam), clock 03:57.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ohio St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//518.gif" /><span class='d-none d-sm-block'>Ohio St.</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">03:57,OSU25, 8 plays, 75 yards, 03:56</span>
+        </div>
+        <div class="headerRight">6 - 38</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR35</br>
+         </span>
+         <span>
+           Jackson,Dante kickoff 65 yards to the OSU00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU25</br>
+         </span>
+         <span>
+           Ohio State drive start at 03:57.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short right to Henderson,TreVeyon caught at OSU22, for 12 yards to the OSU37 (Golden-Nelson,Devonte; Cooper,Shammond), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU37</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Henderson,TreVeyon rush middle for 21 yards gain to the AKRON42 (David,Daymon), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR42</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short left to Henderson,TreVeyon caught at AKRON46, for 6 yards to the AKRON36 (Cooper,Shammond), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 4 at AKR36</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Judkins,Quinshon rush middle for 2 yards gain to the AKRON34 (McCoy,Bryan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at AKR34</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Judkins,Quinshon rush left for 6 yards gain to the AKRON28 (Lewis III,Paul; McCoy,Bryan), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR28</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Judkins,Quinshon rush left for 0 yards to the AKRON28 (Lewis III,Paul).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at AKR28</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass incomplete deep middle to Egbuka,Emeka thrown to AKRON02 PENALTY AKRON Pass Interference (Hunter,Joey) 15 yards from AKRON28 to AKRON13, 1ST DOWN. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR13</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short left to Rodgers,Bryson caught at AKRON07, for 9 yards to the AKRON04 (Spriggs,Melvin; White,Catrell).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 1 at AKR4</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Peoples,James rush left for 4 yards gain to the AKRON00 TOUCHDOWN, clock 00:01, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR3</br>
+         </span>
+         <span>
+           Fielding,Jayden kick attempt good (H: McGuire,Joe, LS: Ferlmann,John).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           Start of 4th quarter, clock 15:00.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+</div>
+  <div style="border-bottom: 1px dotted #dcdddf;"><h1>4th Quarter</h1></div>
+<div class="drives">
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Akron" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//5.gif" /><span class='d-none d-sm-block'>Akron</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">15:00,AKR25, 3 plays, -8 yards, 02:51</span>
+        </div>
+        <div class="headerRight">6 - 38</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU35</br>
+         </span>
+         <span>
+           Fielding,Jayden kickoff 65 yards to the AKRON00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           Akron drive start at 15:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Simmons,Jordon rush right for 2 yards gain to the AKRON27 (Jackson Jr.,Kenyatta).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 8 at AKR27</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj pass complete short left to Davis,Paul caught at AKRON25, for 2 yards to the AKRON29 (Reese,Arvell).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at AKR29</br>
+         </span>
+         <span>
+           PENALTY AKRON False Start (Blanchard,Joshua) 5 yards from AKRON29 to AKRON24. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 11 at AKR24</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj sacked for loss of 7 yards to the AKRON17 (Jackson Jr.,Kenyatta, Melton,Mitchell).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 18 at AKR17</br>
+         </span>
+         <span>
+           Book,Avery punt 42 yards to the OSU41 Inniss,Brandon return 12 yards to the AKRON47 (Roach,Noel).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ohio St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//518.gif" /><span class='d-none d-sm-block'>Ohio St.</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">12:09,AKR47, 4 plays, 47 yards, 01:53</span>
+        </div>
+        <div class="headerRight">6 - 45</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR47</br>
+         </span>
+         <span>
+           Ohio State drive start at 12:09.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR47</br>
+         </span>
+         <span>
+           Shotgun Howard,Will pass complete short right to Egbuka,Emeka caught at AKRON49, for 4 yards to the AKRON43 (Lavea,Lama; Nunnally,CJ).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 6 at AKR43</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short left to Tate,Carnell caught at AKRON46, for 2 yards to the AKRON41 (DeWalt IV,Malcom).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 4 at AKR41</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Judkins,Quinshon rush middle for 7 yards gain to the AKRON34 (Roach,Noel), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR34</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Howard,Will pass complete short right to Tate,Carnell caught at AKRON22, for 34 yards to the AKRON00 TOUCHDOWN, clock 10:16, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR3</br>
+         </span>
+         <span>
+           Fielding,Jayden kick attempt good (H: McGuire,Joe, LS: Ferlmann,John).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Akron" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//5.gif" /><span class='d-none d-sm-block'>Akron</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">10:16,AKR25, 5 plays, 15 yards, 03:03</span>
+        </div>
+        <div class="headerRight">6 - 45</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU35</br>
+         </span>
+         <span>
+           Fielding,Jayden kickoff 65 yards to the AKRON00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           Akron drive start at 10:16.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj rush middle for 5 yards gain to the AKRON30 (Hicks,C.J.; Styles Jr.,Lorenzo).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 5 at AKR30</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Kellom,Charles rush middle for 6 yards gain to the AKRON36 (McClain,Jaylen), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR36</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj pass incomplete short left to Kellom,Charles thrown to AKRON35 broken up by Houston,Eddrick.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at AKR36</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj rush left for 6 yards gain to the AKRON42 (Matthews Jr.,Jermaine), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 4 at AKR42</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Bullock,Tahj pass complete short right to Kellom,Charles caught at AKRON38, for 2 yards loss to the AKRON40 (Matthews Jr.,Jermaine).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 6 at AKR40</br>
+         </span>
+         <span>
+           Book,Avery punt 56 yards to the OSU04 Inniss,Brandon return 27 yards to the OSU31 (Conroy,Sean) PENALTY OSU Holding (Simpson-Hunt,Calvin) 5 yards from OSU10 to OSU05.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 6 at AKR40</br>
+         </span>
+         <span>
+           OSU ball on OSU5.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ohio St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//518.gif" /><span class='d-none d-sm-block'>Ohio St.</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">07:13,OSU5, 9 plays, 31 yards, 04:03</span>
+        </div>
+        <div class="headerRight">6 - 45</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU5</br>
+         </span>
+         <span>
+           Ohio State drive start at 07:13.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU5</br>
+         </span>
+         <span>
+           Shotgun Peoples,James rush middle for 3 yards gain to the OSU08 (Adler,Bennett).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at OSU8</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Peoples,James rush middle for 6 yards gain to the OSU14 (Cheatom,Kam).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at OSU14</br>
+         </span>
+         <span>
+           PENALTY OSU Illegal Snap (McLaughlin,Seth) 5 yards from OSU14 to OSU09. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at OSU9</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Brown,Devin pass complete short right to Ballard,Jayden caught at OSU15, for 6 yards to the OSU15 (DeWalt IV,Malcom), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU15</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Peoples,James rush middle for 3 yards gain to the OSU18 (Nunnally,CJ; Benenge,Rich).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at OSU18</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Peoples,James rush middle for 5 yards gain to the OSU23 (Benenge,Rich; Hunter,Rodrick).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at OSU23</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Peoples,James rush middle for 9 yards gain to the OSU32 (Benenge,Rich; DeWalt IV,Malcom), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU32</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Brown,Devin pass incomplete deep middle to Ballard,Jayden thrown to AKRON25.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at OSU32</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Williams-Dixon,Sam rush left for 4 yards gain to the OSU36 (Anderson,Justin).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at OSU36</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Brown,Devin pass incomplete short left to Ballard,Jayden thrown to OSU43.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 6 at OSU36</br>
+         </span>
+         <span>
+           McGuire,Joe punt 41 yards to the AKRON23 fair catch by Granger,Ahmarian at AKRON23.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Akron" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//5.gif" /><span class='d-none d-sm-block'>Akron</span></div></div>
+        <div class="headerLeft">INT <br/><span style="font-size: 8px;">03:10,AKR23, 2 plays, 9 yards, 00:45</span>
+        </div>
+        <div class="headerRight">6 - 52</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR23</br>
+         </span>
+         <span>
+           Akron drive start at 03:10.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR23</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Roggow,Brayden pass complete short right to Cravaack,Conner caught at AKRON23, for 9 yards to the AKRON32 (Matthews Jr.,Jermaine).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 1 at AKR32</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Roggow,Brayden pass intercepted by Powers,Gabe at AKRON29 broken up by Houston,Eddrick Powers,Gabe return 29 yards to the AKRON00 TOUCHDOWN, clock 02:25.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR3</br>
+         </span>
+         <span>
+           PENALTY OSU Delay Of Game  5 yards from AKRON03 to AKRON08. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR8</br>
+         </span>
+         <span>
+           Fielding,Jayden kick attempt good (H: McGuire,Joe, LS: Ferlmann,John).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Akron" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//5.gif" /><span class='d-none d-sm-block'>Akron</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">02:25,AKR25, 3 plays, 8 yards, 02:04</span>
+        </div>
+        <div class="headerRight">6 - 52</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU35</br>
+         </span>
+         <span>
+           Fielding,Jayden kickoff 65 yards to the AKRON00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           Akron drive start at 02:25.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at AKR25</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Williams,Marquese rush right for 7 yards gain to the AKRON32 (Powers,Gabe), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 3 at AKR32</br>
+         </span>
+         <span>
+           Timeout Other, clock 02:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 3 at AKR32</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Williams,Marquese rush middle for 0 yards to the AKRON32 (Styles Jr.,Lorenzo).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 3 at AKR32</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Williams,Marquese rush middle for 1 yard gain to the AKRON33 (Mickens,Joshua; McDonald,Kayden).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 2 at AKR33</br>
+         </span>
+         <span>
+           Book,Avery punt 54 yards to the OSU13 fair catch by Inniss,Brandon at OSU13.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Ohio St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//518.gif" /><span class='d-none d-sm-block'>Ohio St.</span></div></div>
+        <div class="headerLeft">HALF <br/><span style="font-size: 8px;">00:21,OSU13, 1 plays, -2 yards, 00:21</span>
+        </div>
+        <div class="headerRight">6 - 52</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU13</br>
+         </span>
+         <span>
+           Ohio State drive start at 00:21.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at OSU13</br>
+         </span>
+         <span>
+           Kneel down by Brown,Devin at OSU11 for loss of 2 yards.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 12 at OSU11</br>
+         </span>
+         <span>
+           End of game, clock 00:00.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+</div>
+</div>
+
+
+
+       </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<footer>&copy; <script>document.write(new Date().getFullYear())</script> NCAA <a href="http://web1.ncaa.org/web_files/terms_and_conditions.html" title ="Terms and Conditions" target=_blank>Terms and Conditions</a> | <a href="http://web1.ncaa.org/web_files/privacy.html" target=_blank title="Our Privacy Policy">Privacy Policy</a> | <a href="mailto:ncaa_stats@ncaa.org">Contact Us</a> </footer>
+
+  <!-- /.container -->
+  <script type="text/javascript"  src="/sU0joiPwv/zplvN/xFxji/wmgXJnBU/whimQww3k9OS/ZXgTG2MrBg/bA4YBlB/oDERZ?v=94743442-ba56-a24e-40df-7388407117d0" defer></script></body>
+
+  <script charset="utf-8">
+    $(document).ready(function() {
+      $('a.remote[data-toggle="tab"]').on('show.bs.tab', function (e) {
+        var tab_id = '#' + $(this).attr('aria-controls');
+        $(tab_id).html('<br/><br/><p style="text-align: center"><img style="vertical-align:middle; text-align: center" src="/assets/ajax-loader-6913acdbf4be7d6a2908a84bdecd6cad18110f5fc6d5a07cf8c9ce78d9548700.gif" /> Loading... </p><br/><br/>');
+        $.get($(this).data('remote'), function(data){
+          $(tab_id).html(data);
+        });
+      });
+    });
+
+    function skipMask(obj){
+      if (obj.hasClass('chosen-single') || obj.hasClass('skipMask') || obj.hasClass('ui-datepicker-prev') || obj.hasClass('ui-datepicker-next') || obj.hasClass('ui-corner-all') || obj.hasClass('paginate_button') || obj.hasClass('dt-button')){
+        return true;
+      }else{
+        return false;
+      }
+    }
+
+    $(document).ajaxComplete(function(){
+      unmask();
+    });
+/*
+    $("form").on('submit', function(event){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    */
+    $(document).on('click', 'a', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    $(document).on('click', 'input.green', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+
+  </script>
+</html>

--- a/tests/fixtures/cfb_ncaa/mfb_pbp_5362431.html
+++ b/tests/fixtures/cfb_ncaa/mfb_pbp_5362431.html
@@ -1,0 +1,2677 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<META HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=UTF-8">
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="">
+<meta name="author" content="">
+<meta name="version" content="321d28433e9f7a188596117e6f342ec4a84fb4ed">
+<META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<link rel="shortcut icon" href="/assets/favicon-405088046a5f2bab8eedeacfae7636975c095e9c8decd8c28e3fd0e65c2f51c4.ico" type="image/vnd.microsoft.icon">
+
+<title>NCAA Statistics</title>
+
+<!-- Bootstrap core CSS -->
+
+<!--
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+-->
+<!--
+<link rel="stylesheet" href="https://cdn.datatables.net/2.0.0/css/dataTables.bootstrap4.css" crossorigin="anonymous">
+-->
+<link rel="stylesheet" media="all" href="/assets/application-789c3971842ee3597428ccbebd021716b3231e9cbd0a00a184c3b2d6c8e5f152.css" />
+
+
+<script src="/assets/application-9232576bb3cb000ac0841ff2af81251908ec17312a3c5eb72bf1a32f9754800c.js"></script>
+<!--
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+-->
+<!--
+<script src="https://cdn.datatables.net/2.0.0/js/dataTables.bootstrap4.js" crossorigin="anonymous"></script>
+-->
+
+<meta name="csrf-param" content="authenticity_token" />
+<meta name="csrf-token" content="CbIWP37DltJdYe+uBLXd+Auq4PlQfSF8QiWwA9sAticbRJcaAWYbfrz+SnFJzgvoAI43h7xtLEGlPnWLJnwC6w==" />
+
+<style>
+.grid {clear: all}
+.grid-item, .name {text-align: center;}
+h1 img {max-height: 33px;}
+
+</style>
+<!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+<!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+      <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+    <![endif]-->
+
+
+<script>(window.BOOMR_mq=window.BOOMR_mq||[]).push(["addVar",{"rua.upush":"false","rua.cpush":"false","rua.upre":"false","rua.cpre":"false","rua.uprl":"false","rua.cprl":"false","rua.cprf":"false","rua.trans":"","rua.cook":"false","rua.ims":"false","rua.ufprl":"false","rua.cfprl":"false","rua.isuxp":"false","rua.texp":"norulematch","rua.ceh":"false","rua.ueh":"false","rua.ieh.st":"0"}]);</script>
+                                <script>!function(e){var n="https://s.go-mpulse.net/boomerang/";if("False"=="True")e.BOOMR_config=e.BOOMR_config||{},e.BOOMR_config.PageParams=e.BOOMR_config.PageParams||{},e.BOOMR_config.PageParams.pci=!0,n="https://s2.go-mpulse.net/boomerang/";if(window.BOOMR_API_key="EVKJV-AGD2E-W66AE-NT84S-K5LTF",function(){function e(){if(!r){var e=document.createElement("script");e.id="boomr-scr-as",e.src=window.BOOMR.url,e.async=!0,o.appendChild(e),r=!0}}function t(e){r=!0;var n,t,a,i,d=document,O=window;if(window.BOOMR.snippetMethod=e?"if":"i",t=function(e,n){var t=d.createElement("script");t.id=n||"boomr-if-as",t.src=window.BOOMR.url,BOOMR_lstart=(new Date).getTime(),e=e||d.body,e.appendChild(t)},!window.addEventListener&&window.attachEvent&&navigator.userAgent.match(/MSIE [67]\./))return window.BOOMR.snippetMethod="s",void t(o,"boomr-async");a=document.createElement("IFRAME"),a.src="about:blank",a.title="",a.role="presentation",a.loading="eager",i=(a.frameElement||a).style,i.width=0,i.height=0,i.border=0,i.display="none",o.appendChild(a);try{O=a.contentWindow,d=O.document.open()}catch(_){n=document.domain,a.src="javascript:var d=document.open();d.domain='"+n+"';void 0;",O=a.contentWindow,d=O.document.open()}if(n)d._boomrl=function(){this.domain=n,t()},d.write("<bo"+"dy onload='document._boomrl();'>");else if(O._boomrl=function(){t()},O.addEventListener)O.addEventListener("load",O._boomrl,!1);else if(O.attachEvent)O.attachEvent("onload",O._boomrl);d.close()}function a(e){window.BOOMR_onload=e&&e.timeStamp||(new Date).getTime()}if(!window.BOOMR||!window.BOOMR.version&&!window.BOOMR.snippetExecuted){window.BOOMR=window.BOOMR||{},window.BOOMR.snippetStart=(new Date).getTime(),window.BOOMR.snippetExecuted=!0,window.BOOMR.snippetVersion=14,window.BOOMR.url=n+"EVKJV-AGD2E-W66AE-NT84S-K5LTF";var i=document.currentScript||document.getElementsByTagName("script")[0],o=i.parentNode,r=!1,d=document.createElement("link");if(d.relList&&"function"==typeof d.relList.supports&&d.relList.supports("preload")&&"as"in d)window.BOOMR.snippetMethod="p",d.href=window.BOOMR.url,d.rel="preload",d.as="script",d.addEventListener("load",e),d.addEventListener("error",function(){t(!0)}),setTimeout(function(){if(!r)t(!0)},3e3),BOOMR_lstart=(new Date).getTime(),o.appendChild(d);else t(!1);if(window.addEventListener)window.addEventListener("load",a,!1);else if(window.attachEvent)window.attachEvent("onload",a)}}(),"".length>0)if(e&&"performance"in e&&e.performance&&"function"==typeof e.performance.setResourceTimingBufferSize)e.performance.setResourceTimingBufferSize();!function(){if(BOOMR=e.BOOMR||{},BOOMR.plugins=BOOMR.plugins||{},!BOOMR.plugins.AK){var n=""=="true"?1:0,t="",a="vq5hssnyk4sly2sztlcq-f-842b5914b-clientnsv4-s.akamaihd.net",i="false"=="true"?2:1,o={"ak.v":"41","ak.cp":"1168236","ak.ai":parseInt("215853",10),"ak.ol":"0","ak.cr":192,"ak.ipv":4,"ak.proto":"h2","ak.rid":"1ebb9d0c","ak.r":40932,"ak.a2":n,"ak.m":"","ak.n":"essl","ak.cport":45122,"ak.gh":"23.56.236.47","ak.quicv":"","ak.tlsv":"tls1.3","ak.0rtt":"","ak.0rtt.ed":"","ak.csrc":"-","ak.acc":"","ak.t":"1784257221","ak.ak":"hOBiQwZUYzCg5VSAfCLimQ==IPzgyyn3VE6YBnLX/Sj6yfDIhdhIMflpKGpZ1qfr+T9l0wF42/9juN2121LfU60r6KOYOnzTMILHLo2WfTLZXT+07uHexvM1rHSLnwqR8h7A06/MfKEVP0KybKVTv0isthJ8fD6bT1qmvoZsOsQLBi13zZVMd+C3+Pk/AE41zML7S8x45ER+e0Q/b9gaNNN+8sV9veKTGDZqBx+8JbitytR6Vv8e13drtDpqRjYzTlJLDC+xQRk1c7Z8BtPfnIwhY9o6zAbgUf6bfNBGwogKhjuHsmkhpxDfP4zd/OFl9qgyHLqbFYeb0uW/VZRk1j5Cc4yCUNIIMUwSgxgF/8d2AudLNv/M2ktiLk2MM2KGaORaGZ7SGgHsYSFg3BqMpeyLEL+1PZnM/f5YjbYaWtDmpk4rK8s632bP7CVlM7laXx0=","ak.pv":"93","ak.dpoabenc":"","ak.tf":i};if(""!==t)o["ak.ruds"]=t;var r={i:!1,av:function(n){var t="http.initiator";if(n&&(!n[t]||"spa_hard"===n[t]))o["ak.feo"]=void 0!==e.aFeoApplied?1:0,BOOMR.addVar(o)},rv:function(){var e=["ak.cport","ak.cr","ak.csrc","ak.gh","ak.ipv","ak.m","ak.n","ak.ol","ak.proto","ak.quicv","ak.tlsv","ak.0rtt","ak.0rtt.ed","ak.r","ak.acc","ak.t","ak.tf"];BOOMR.removeVar(e)}};BOOMR.plugins.AK={akVars:o,akDNSPreFetchDomain:a,init:function(){if(!r.i){var e=BOOMR.subscribe;e("before_beacon",r.av,null,null),e("onbeacon",r.rv,null,null),r.i=!0}return this},is_complete:function(){return!0}}}}()}(window);</script></head>
+
+  <script>
+
+    
+  //initialize tooltip
+  $(document).ready(function() {
+    //$("body").tooltip({ selector: '[data-toggle=tooltip]' });
+    $('[data-toggle="tooltip"]').tooltip();
+  });
+
+  $(document).ready(function() {
+    $( "#org_name" ).autocomplete({
+      source: '/team/search',
+      select: function( event, ui ) {
+        $("#org_id").val(ui.item.vid);
+        $("#id").val(ui.item.vid);
+        $('#sport_btn').click();
+      }
+    });
+  });
+
+  var body = 'body';
+
+  $.ajaxSetup ({
+    // Disable caching of AJAX responses
+    cache: false
+  });
+
+  function changeSport(field){
+    var el = $(field);
+    var tmList = el.parent().next().find('.new-team-year')[0];
+    if (tmList == null){
+      tmList = el.nextAll('.new-team-year')[0];
+    }
+    $.ajax({
+      url: "/game_sport_year_ctls/"+el.val()+"/available_teams",
+      dataType: "script",
+      success: function(data, status){
+        $(tmList).empty();
+        $(tmList).append(("<option value=''>Select team</option>"));
+        $.each(JSON.parse(data), function(k, v){
+          $(tmList).append($("<option></option>")
+              .attr("value", v["id"])
+              .text(v["member_org"]["name_tabular"]));
+        });
+        $(tmList).trigger("chosen:updated");
+      }
+    });
+  }
+
+    function set_process_styles(fld, start_color, end_color){
+       $('#'+fld).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    var downImage = "/assets/down12.gif";
+    var rightImage = "/assets/right12.gif";
+
+    function highlight(div_id){
+      $(div_id).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    function show_hide_rows(attr_val, link_id){
+      $('#'+attr_val).toggle();
+      if ($('#'+attr_val).is(':visible')) {
+        $('#'+link_id).attr('src', downImage);
+      }else{
+        $('#'+link_id).attr('src', rightImage);
+      }
+    }
+
+    function mask(label){
+      $('body').mask(label);
+    }
+    function unmask(){
+      $('body').unmask();
+    }
+
+    var winHeight = "auto";
+    var winWidth = "auto";
+    var maxHeight = 700;
+    var maxWidth = 1400;
+    var minHeight = 100;
+    var minWidth = 200;
+    
+    var modalOptions = {"width": winWidth,
+                        "height": winHeight,
+                        "maxHeight": maxHeight,
+                        "maxWidth": maxWidth,
+                        "minHeight": minHeight,
+                        "minWidth": minWidth};
+
+    function dialog(url, title){
+
+      $("#stats_app_dialog").dialog({modal:true, minWidth:minWidth, minHeight:minHeight, maxWidth:maxWidth, maxHeight:maxHeight, width:winWidth, height:winHeight, title:title, closeOnEscape: false});
+    
+      modalOptions.title = title;
+    
+      $("#stats_app_dialog").dialog("option", modalOptions);
+    
+      $("#stats_app_dialog").html("Loading...");
+      $("#stats_app_dialog").load(url).dialog('open');
+    }
+
+    function addDatePicker(){
+    $('.adddatepicker').each(function(i, obj){
+      $(obj).datepicker({ 
+        showOn: 'both', 
+        buttonImage: '/assets/calendar.gif', 
+        buttonImageOnly: true,
+      });
+    });
+    }
+
+   $(document).ready(function() {
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   });
+
+   function setClassInputFields(){
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   }
+
+   function isValidDateFormat(dateStr){
+     const regex = /^([1-9]|0[1-9]|1[0-2])\/([1-9]|0[1-9]|[12][0-9]|3[01])\/(19|20)\d{2}$/;
+     if (!regex.test(dateStr)) {
+       return false;
+     }else{
+       return true;
+     }
+   }
+
+  </script>
+
+
+<body style="font-size: .75rem;" onload="if (top != self) { top.location=self.location; }" >
+
+      <header>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0">
+        <a class="navbar-brand mr-0 mr-md-2" href="/" aria-label="statistics">
+                          <img alt="NCAA" style="margin-left: 24px; margin-right: 0; margin-top: 6px;" src="/assets/ncaa-fbc4d0406ae731b47babcc3fca53775b5955ef372bf8b8e998ca9a513e468b8f.svg" />
+                          <span class="title" class="dark-blue-font">Statistics</span>
+        </a>
+       </nav>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0" style="background-color: var(--color-dark-blue) !important;">
+  <button class="navbar-toggler bg-white" type="button" data-toggle="collapse" data-target="#navbarTogglerDemo01" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarTogglerDemo01">
+        <ul class="navbar-nav mr-auto mt-2 mt-lg-0 justify-content-center">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle skipMask" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Rankings
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+          <a class="dropdown-item" href="/rankings">National Rankings</a>
+          <a class="dropdown-item" href="/active_career_leaders">Active Career Leaders</a>
+        </div>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/contests/livestream_scoreboards">Scoreboard</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/selection_rankings/nitty_gritties">Selection Rankings</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/head_coaches">Head Coaches</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/search/players">Players</a>
+      </li>
+     </ul>
+
+    <form onsubmit="mask(&#39;Loading&#39;);" id="change_team_form" style="display:inline;" class="form-inline my-2 my-lg-0" action="/team/index" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="rOoEmhuTzlaoznWltrpCy76hyMVBpseKiippWjMuakz3zep81fJyG+Ce/VICAHrBD5dsrzo8TxkVXxJiRNVP9A==" />
+  <div style="display:none;">
+  <input type="submit" name="commit" value="Submit" id="sport_btn" data-disable-with="Submit" />
+  </div>
+    <div id="team_autocomplete" class="ui-widget">
+      <input type="search" name="org_name" id="org_name" style="width:200px; font-size: 12px !important" class="form-control mr-sm-2" placeholder="Team Search" />
+      <input type="hidden" name="org_id" id="org_id" />
+    </div>
+</form>  </div>
+  </nav>
+</nav>
+      </header>
+
+       <div id="stats_app_dialog" style="display:none;">
+        </div>
+
+<div class="card p-1">
+  <div class="card-body application contests p-0">
+    <h3 class="card-title p-0"></h3>
+    <div class="container-fluid p-0">
+      <div class="row align-items-center justify-content-center p-0">
+        <div class="col-sm-12 p-0">
+          <br/>
+
+<br/>
+
+<style>
+.winner{
+  --display: flex;
+  vertical-align: middle;
+}
+.winner:before{
+  content: '\25BA';
+  --display: flex;
+  --align-items: center;
+  vertical-align: middle;
+}
+div.center {
+  margin: auto;
+  width: 50%;
+  --border: 3px solid green;
+  padding: 10px;
+}
+</style>
+
+   <div class="table-responsive">
+   <table align="center">
+     <tr>
+   <td>
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589176"><img class="large_logo_image" alt="Towson" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//711.gif" /></a>
+   </td>
+   <td valign="center" class="grey_text d-none d-sm-table-cell" nowrap>
+     <span style="font-size:18px">
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589176">Towson Tigers</a>
+     </span><br/>
+       0-1, Conf 0-0
+   </td>
+   <td valign="center" class="">
+   </td>
+   <td valign="center" style="font-size:36px; color: grey">
+     20
+   </td>
+     <td style="padding: 0px 30px 0px 30px"  class="d-none d-md-table-cell">
+       <table style="border-collapse: collapse">
+         <tr>
+           <td class="grey_border_bottom"></td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">1</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">2</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">3</td>
+             <td width="20px" nowrap class="grey_text grey_border_bottom" align="right">4</td>
+           <td width="20px" align="right" style="font-weight:bold" class="grey_border_bottom">S</td>
+         </tr>
+           <tr>
+             <td>Towson</td>
+               <td class="grey_text" align="right">3</td>
+               <td class="grey_text" align="right">14</td>
+               <td class="grey_text" align="right">3</td>
+               <td class="grey_text" align="right">0</td>
+             <td align="right" style="font-weight:bold">20</td>
+           </tr>
+           <tr>
+             <td>Cincinnati</td>
+               <td class="grey_text" align="right">21</td>
+               <td class="grey_text" align="right">7</td>
+               <td class="grey_text" align="right">10</td>
+               <td class="grey_text" align="right">0</td>
+             <td align="right" style="font-weight:bold">38</td>
+           </tr>
+         <tr>
+           <td class="grey_text" colspan="6">08/31/2024 02:30 PM</td>
+         </tr>
+         <tr>
+           <td nowrap class="grey_text" colspan="6">Nippert Stadium (Cincinnati, OH)</td>
+         </tr>
+         <tr>
+           <td nowrap class="grey_text" colspan="6">Attendance: 37,654</td>
+         </tr>
+       </table>
+     </td>
+   <td>
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589040"><img class="large_logo_image" alt="Cincinnati" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//140.gif" /></a>
+   </td>
+   <td valign="center" class="grey_text d-none d-sm-table-cell" nowrap>
+     <span style="font-size:18px">
+     <a target="TEAMS_WIN" class="skipMask" href="/teams/589040">Cincinnati Bearcats</a>
+     </span><br/>
+       1-0, Conf 0-0
+   </td>
+   <td valign="center" class="winner">
+   </td>
+   <td valign="center" style="font-size:36px; color: black">
+     38
+   </td>
+     </tr>
+     <tr>
+       <td colspan="10" class="grey_border_bottom grey_border_top">
+         <table cellpadding="10px">
+           <tr>
+             <td style="font-size: 16px;"><a href="/contests/5362431/box_score">Box Score</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5362431/team_stats">Team Stats</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5362431/individual_stats">Individual Stats</a></td>
+             <td style="font-size: 16px;">Play By Play</td>
+             <td style="font-size: 16px;"><a href="/contests/5362431/drives">Drives</a></td>
+             <td style="font-size: 16px;"><a href="/contests/5362431/officials">Officials</a></td>
+           </tr>
+         </table>
+       </td>
+     </tr>
+   </table>
+ </div>
+
+
+<br/>
+
+  <script>
+ $( function() {
+    $( ".drives" ).accordion({
+      collapsible: true,
+      heightStyle: "content",
+      header: "h5",
+      active: false
+    });
+  } );
+
+ function showScoringPlays(){
+   $('.non_scoring_play').hide();
+ }
+ function showAllPlays(){
+   $('.non_scoring_play').show();
+   $('.drives').accordion("refresh");
+   $('.drives').accordion("option", "active", false);
+ }
+</script>
+
+<style>
+ .ui-state-default, .ui-widget-content .ui-state-default, .ui-widget-header .ui-state-default {
+   overflow: auto;
+ }
+ .ui-state-default, .ui-widget-content .ui-state-default, .ui-widget-header .ui-state-default {
+    border: 1px solid #CCCCCC;
+    background: white;
+    background-image: none;
+    font-weight: normal;
+    color: #808080;
+}
+
+ .headerRight {
+  float: right;
+}
+.headerLeft {
+  float: left;
+}
+.under{
+text-decoration : underline;
+}
+</style>
+
+<div style="width: 50%; margin-left: auto; margin-right: auto;">
+  <div class="headerRight"><a class="skipMask" href="javascript:showAllPlays();">All Drives</a> | <a class="skipMask" href="javascript:showScoringPlays();">Scoring Drives</a></div>
+  <div style="border-bottom: 1px dotted #dcdddf;"><h1>1st Quarter</h1></div>
+<div class="drives">
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Cincinnati" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//140.gif" /><span class='d-none d-sm-block'>Cincinnati</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">15:00,CIN25, 7 plays, 75 yards, 03:43</span>
+        </div>
+        <div class="headerRight">0 - 7</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW35</br>
+         </span>
+         <span>
+           (15:00) Vaughan,Keegan kickoff 47 yards to the CIN18 fair catch by Golday,Jake at CIN18.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN25</br>
+         </span>
+         <span>
+           Cincinnati drive start at 15:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN25</br>
+         </span>
+         <span>
+           (14:59) No Huddle-Shotgun Sorsby,Brendan pass complete short middle to Jackson Jr.,Barry caught at CIN22, for 5 yards to the CIN30 (Johnson,Myles), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 5 at CIN30</br>
+         </span>
+         <span>
+           (14:29) No Huddle-Shotgun Kiner,Corey rush middle for 5 yards gain to the CIN35 (Middleton,Will), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN35</br>
+         </span>
+         <span>
+           (13:56) No Huddle-Shotgun Sorsby,Brendan pass complete short left to Turner,Aaron caught at CIN35, for 49 yards to the TOW16 (Smith,Shafeek), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW16</br>
+         </span>
+         <span>
+           (13:14) Shotgun Kiner,Corey rush right for 3 yards gain to the TOW13 (Dunbar,Jurnee).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at TOW13</br>
+         </span>
+         <span>
+           (12:37) No Huddle-Shotgun Sorsby,Brendan pass complete short right to Henderson,Xzavier caught at TOW14, for 2 yards to the TOW11 (Terry,Xavier; Smith,Shafeek).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 5 at TOW11</br>
+         </span>
+         <span>
+           (11:54) No Huddle-Shotgun Sorsby,Brendan pass complete short middle to Mayes,Jamoi caught at TOW03, for 9 yards to the TOW02 (Terry,Xavier), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 2 at TOW2</br>
+         </span>
+         <span>
+           (11:18) Shotgun Sorsby,Brendan rush middle for 2 yards gain to the TOW00 TOUCHDOWN, clock 11:17.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW3</br>
+         </span>
+         <span>
+           Brown,Carter kick attempt good (H: Fletcher,Mason, LS: Perry,Jayden).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Towson" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//711.gif" /><span class='d-none d-sm-block'>Towson</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">11:17,TOW25, 3 plays, -1 yards, 01:30</span>
+        </div>
+        <div class="headerRight">0 - 7</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN35</br>
+         </span>
+         <span>
+           (11:17) Hawks,Nathan kickoff 65 yards to the TOW00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW25</br>
+         </span>
+         <span>
+           Towson drive start at 11:17.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW25</br>
+         </span>
+         <span>
+           (11:16) No Huddle-Shotgun Davis,Carlos sacked for loss of 4 yards to the TOW21 (Bartlett,Jared).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 14 at TOW21</br>
+         </span>
+         <span>
+           (10:40) No Huddle-Shotgun Matthews,Devin rush middle for 3 yards gain to the TOW24 (Dingle,Jack; Sanks,Jiquan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 11 at TOW24</br>
+         </span>
+         <span>
+           (09:57) No Huddle-Shotgun Davis,Carlos pass incomplete deep left to Dunmore,John thrown to TOW48 broken up by Young,Jordan.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 11 at TOW24</br>
+         </span>
+         <span>
+           (09:51) LaFollette,Bryce punt 54 yards to the CIN22 muffed by Mussari,Michael at CIN22 recovered by TOW Raymond,Daniel at CIN20, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Towson" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//711.gif" /><span class='d-none d-sm-block'>Towson</span></div></div>
+        <div class="headerLeft">FG <br/><span style="font-size: 8px;">09:47,CIN20, 4 plays, 5 yards, 01:44</span>
+        </div>
+        <div class="headerRight">3 - 7</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN20</br>
+         </span>
+         <span>
+           Towson drive start at 09:47.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN20</br>
+         </span>
+         <span>
+           (09:41) No Huddle-Shotgun Davis,Carlos pass incomplete deep right to Runyon,Carter thrown to CIN00 PENALTY CIN Holding (Young,Jordan) 10 yards from CIN20 to CIN10, 1ST DOWN. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN10</br>
+         </span>
+         <span>
+           Timeout Towson, clock 09:35.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN10</br>
+         </span>
+         <span>
+           (09:35) No Huddle-Shotgun Davis,Carlos pass incomplete short left to James,Da&#39;Kendall thrown to CIN10 QB hurried by Phillips,Eric.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at CIN10</br>
+         </span>
+         <span>
+           (09:30) No Huddle-Shotgun Matthews,Devin rush middle for 5 yards gain to the CIN05 (Sanks,Jiquan; Roetherford,Cameron).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 5 at CIN5</br>
+         </span>
+         <span>
+           PENALTY TOW False Start (Staehler,Florian) 5 yards from CIN05 to CIN10. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 10 at CIN10</br>
+         </span>
+         <span>
+           PENALTY TOW Delay Of Game  5 yards from CIN10 to CIN15. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 15 at CIN15</br>
+         </span>
+         <span>
+           (08:14) No Huddle-Shotgun Davis,Carlos pass incomplete short middle to Londono,Lukkas thrown to CIN00 broken up by Minkins,Josh.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 15 at CIN15</br>
+         </span>
+         <span>
+           (08:05) Vaughan,Keegan field goal attempt from 32 yards GOOD (H: Ritter,Justin, LS: Coyle,Patrick), clock 08:03.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Cincinnati" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//140.gif" /><span class='d-none d-sm-block'>Cincinnati</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">07:58,CIN35, 4 plays, 65 yards, 01:08</span>
+        </div>
+        <div class="headerRight">3 - 14</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW35</br>
+         </span>
+         <span>
+           (08:03) Vaughan,Keegan kickoff 44 yards to the CIN21 Wilson,Logan return 14 yards to the CIN35 (Johnson,Myles; Middleton,Will).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN35</br>
+         </span>
+         <span>
+           Cincinnati drive start at 07:58.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN35</br>
+         </span>
+         <span>
+           (07:57) No Huddle-Shotgun Kiner,Corey rush left for 2 yards gain to the CIN37 (Shiggs,Jasin; Roane Jr.,Rodney).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 8 at CIN37</br>
+         </span>
+         <span>
+           (07:22) Shotgun Sorsby,Brendan pass complete short middle to Royer,Joe caught at TOW44, for 21 yards to the TOW42 (White,Kaden), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW42</br>
+         </span>
+         <span>
+           (07:00) No Huddle-Shotgun Sorsby,Brendan pass incomplete short right to Henderson,Xzavier thrown to TOW36.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at TOW42</br>
+         </span>
+         <span>
+           (06:56) Shotgun Sorsby,Brendan pass complete deep middle to Henderson,Xzavier caught at TOW01, for 42 yards to the TOW00 TOUCHDOWN, clock 06:50, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW3</br>
+         </span>
+         <span>
+           Brown,Carter kick attempt good (H: Fletcher,Mason, LS: Perry,Jayden).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Towson" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//711.gif" /><span class='d-none d-sm-block'>Towson</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">06:50,TOW25, 5 plays, 25 yards, 02:14</span>
+        </div>
+        <div class="headerRight">3 - 14</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN35</br>
+         </span>
+         <span>
+           (06:50) Hawks,Nathan kickoff 65 yards to the TOW00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW25</br>
+         </span>
+         <span>
+           Towson drive start at 06:50.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW25</br>
+         </span>
+         <span>
+           (06:49) No Huddle-Shotgun Greene Jr.,Tyrell rush middle for 6 yards gain to the TOW31 (Bartlett,Jared; Wilson,Logan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 4 at TOW31</br>
+         </span>
+         <span>
+           (06:24) No Huddle-Shotgun Davis,Carlos pass complete short middle to Londono,Lukkas caught at TOW44, for 22 yards to the CIN47 (Stokes,Kye), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN47</br>
+         </span>
+         <span>
+           (06:02) No Huddle-Shotgun Greene Jr.,Tyrell rush middle for 2 yards gain to the CIN45 (Thompson,Jonathan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 8 at CIN45</br>
+         </span>
+         <span>
+           (05:31) No Huddle-Shotgun Davis,Carlos pass incomplete short right to Londono,Lukkas thrown to CIN40 QB hurried by Adams,Harris.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 8 at CIN45</br>
+         </span>
+         <span>
+           (05:23) No Huddle-Shotgun Davis,Carlos rush left for 0 yards to the CIN45 (Wilson,Kam; Coleman,Simeon).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 8 at CIN45</br>
+         </span>
+         <span>
+           (04:49) LaFollette,Bryce punt 45 yards to the CIN00, Touchback PENALTY TOW Illegal Formation 5 yards from CIN20 to CIN25, TURNOVER ON DOWNS.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 8 at CIN45</br>
+         </span>
+         <span>
+           CIN ball on CIN25.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Cincinnati" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//140.gif" /><span class='d-none d-sm-block'>Cincinnati</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">04:36,CIN25, 3 plays, 75 yards, 01:23</span>
+        </div>
+        <div class="headerRight">3 - 21</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN25</br>
+         </span>
+         <span>
+           Cincinnati drive start at 04:36.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN25</br>
+         </span>
+         <span>
+           (04:35) No Huddle-Shotgun Williams,Chance rush middle for 3 yards gain to the CIN28 (Middleton,Will; Crews-Harris,Dion).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 7 at CIN28</br>
+         </span>
+         <span>
+           (04:00) Shotgun Sorsby,Brendan pass complete short right to Royer,Joe caught at CIN34, for 11 yards to the CIN39 (Snell,Kam), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN39</br>
+         </span>
+         <span>
+           (03:22) Shotgun Sorsby,Brendan pass complete deep left to Berkhalter,Sterling caught at TOW17, for 61 yards to the TOW00 TOUCHDOWN, clock 03:13, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW3</br>
+         </span>
+         <span>
+           Brown,Carter kick attempt good (H: Fletcher,Mason, LS: Perry,Jayden).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN35</br>
+         </span>
+         <span>
+           TOW ball on TOW35.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Towson" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//711.gif" /><span class='d-none d-sm-block'>Towson</span></div></div>
+        <div class="headerLeft">DOWNS <br/><span style="font-size: 8px;">03:13,TOW35, 11 plays, 62 yards, 03:57</span>
+        </div>
+        <div class="headerRight">3 - 21</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN35</br>
+         </span>
+         <span>
+           (03:13) Hawks,Nathan kickoff 61 yards to the TOW04, out of bounds at TOW04.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW35</br>
+         </span>
+         <span>
+           Towson drive start at 03:13.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW35</br>
+         </span>
+         <span>
+           (03:03) No Huddle-Shotgun Davis,Carlos pass complete short right to Londono,Lukkas caught at TOW37, for 4 yards to the TOW39 (Minkins,Josh).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 6 at TOW39</br>
+         </span>
+         <span>
+           (02:52) No Huddle-Shotgun Davis,Carlos pass complete short right to Londono,Lukkas caught at TOW45, for 8 yards to the TOW47 (Young,Jordan; Coleman,Simeon), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW47</br>
+         </span>
+         <span>
+           (02:35) No Huddle-Shotgun Matthews,Devin rush middle for 2 yards loss to the TOW45 fumbled by Matthews,Devin at TOW44 recovered by TOW Matthews,Devin at TOW44, Matthews,Devin for 1 yard to the TOW45, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 12 at TOW45</br>
+         </span>
+         <span>
+           (01:44) No Huddle-Shotgun Greene Jr.,Tyrell rush right for 18 yards gain to the CIN37 (Peek Jr.,Antwan), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN37</br>
+         </span>
+         <span>
+           (01:30) PENALTY TOW False Start (Staehler,Florian) 5 yards from CIN37 to CIN42. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 15 at CIN42</br>
+         </span>
+         <span>
+           (01:08) No Huddle-Shotgun Davis,Carlos pass incomplete short left to Watkins,Christopher thrown to CIN47.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 15 at CIN42</br>
+         </span>
+         <span>
+           (01:03) No Huddle-Shotgun Davis,Carlos pass complete short right to James,Da&#39;Kendall caught at CIN24, for 21 yards to the CIN21 (Minkins,Josh), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN21</br>
+         </span>
+         <span>
+           (00:27) No Huddle-Shotgun Davis,Carlos pass complete short left to Runyon,Carter caught at CIN11, for 10 yards to the CIN11 (Canteen,Derrick; Peek Jr.,Antwan), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN11</br>
+         </span>
+         <span>
+           (00:00) No Huddle-Shotgun Watkins,Christopher rush middle for 7 yards gain to the CIN04 (Peek Jr.,Antwan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 3 at CIN4</br>
+         </span>
+         <span>
+           Start of 2nd quarter, clock 15:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 3 at CIN4</br>
+         </span>
+         <span>
+           (15:00) No Huddle-Shotgun Matthews,Devin rush middle for 2 yards gain to the CIN02 (Bartlett,Jared; Sanks,Jiquan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at CIN2</br>
+         </span>
+         <span>
+           (14:35) No Huddle Matthews,Devin rush middle for 0 yards to the CIN02 (Canteen,Derrick).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 1 at CIN2</br>
+         </span>
+         <span>
+           (14:20) No Huddle Matthews,Devin rush middle for 1 yard loss to the CIN03 (Bartlett,Jared), TURNOVER ON DOWNS.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+</div>
+  <div style="border-bottom: 1px dotted #dcdddf;"><h1>2nd Quarter</h1></div>
+<div class="drives">
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Cincinnati" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//140.gif" /><span class='d-none d-sm-block'>Cincinnati</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">14:16,CIN3, 6 plays, 39 yards, 03:23</span>
+        </div>
+        <div class="headerRight">3 - 21</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN3</br>
+         </span>
+         <span>
+           Cincinnati drive start at 14:16.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN3</br>
+         </span>
+         <span>
+           (14:16) No Huddle-Shotgun Johnson,Tony rush right for 13 yards gain to the CIN16 (Snell,Kam; Gant,Emiril), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN16</br>
+         </span>
+         <span>
+           (13:40) No Huddle-Shotgun Sorsby,Brendan pass complete short right to Henderson,Xzavier caught at CIN20, for 5 yards to the CIN21 (Smith,Shafeek).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 5 at CIN21</br>
+         </span>
+         <span>
+           (13:10) Shotgun Kiner,Corey rush middle for 18 yards gain to the CIN39 (Johnson,Myles), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN39</br>
+         </span>
+         <span>
+           (12:36) Shotgun Sorsby,Brendan pass incomplete short left to Henderson,Xzavier thrown to CIN38.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at CIN39</br>
+         </span>
+         <span>
+           (12:31) Shotgun Covey,Manny rush right for 4 yards loss to the CIN35 (Crews-Harris,Dion; Raymond,Daniel).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 14 at CIN35</br>
+         </span>
+         <span>
+           (11:49) No Huddle-Shotgun Sorsby,Brendan pass complete short left to Covey,Manny caught at CIN42, for 7 yards to the CIN42, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 7 at CIN42</br>
+         </span>
+         <span>
+           (10:59) Fletcher,Mason punt 51 yards to the TOW07 fair catch by Dunmore,John at TOW07 PENALTY TOW Holding (Haynes,Nick) 3 yards from TOW07 to TOW04.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 7 at CIN42</br>
+         </span>
+         <span>
+           TOW ball on TOW4.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Towson" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//711.gif" /><span class='d-none d-sm-block'>Towson</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">10:53,TOW4, 4 plays, 96 yards, 00:59</span>
+        </div>
+        <div class="headerRight">10 - 21</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW4</br>
+         </span>
+         <span>
+           Towson drive start at 10:53.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW4</br>
+         </span>
+         <span>
+           (10:53) No Huddle-Shotgun Davis,Carlos pass complete short right to Matthews,Devin caught at TOW06, for 14 yards to the TOW18 (Miller,Mehki), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW18</br>
+         </span>
+         <span>
+           (10:34) No Huddle-Shotgun Matthews,Devin rush middle for 6 yards gain to the TOW24 (Miller,Mehki; Coleman,Simeon).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 4 at TOW24</br>
+         </span>
+         <span>
+           (10:09) No Huddle-Shotgun Davis,Carlos pass incomplete short left to Reynolds,Sam thrown to TOW28 broken up by Thompson,Jonathan.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 4 at TOW24</br>
+         </span>
+         <span>
+           (10:05) No Huddle-Shotgun Davis,Carlos pass complete short middle to Doss,Jaceon caught at TOW32, for 76 yards to the CIN00 TOUCHDOWN, clock 09:54, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN3</br>
+         </span>
+         <span>
+           Vaughan,Keegan kick attempt good (H: Ritter,Justin, LS: Coyle,Patrick).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Cincinnati" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//140.gif" /><span class='d-none d-sm-block'>Cincinnati</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">09:49,CIN37, 5 plays, 63 yards, 02:53</span>
+        </div>
+        <div class="headerRight">10 - 28</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW35</br>
+         </span>
+         <span>
+           (09:54) Vaughan,Keegan kickoff 43 yards to the CIN22 Wilson,Logan return 15 yards to the CIN37 (Thomas,Alfred).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN37</br>
+         </span>
+         <span>
+           Cincinnati drive start at 09:49.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN37</br>
+         </span>
+         <span>
+           (09:49) No Huddle-Shotgun Sorsby,Brendan pass complete short right to Henderson,Xzavier caught at CIN47, for 18 yards to the TOW45 (Haynes,Nick), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW45</br>
+         </span>
+         <span>
+           (09:10) Shotgun Sorsby,Brendan pass complete short right to Royer,Joe caught at TOW46, for 38 yards to the TOW07 (Smith,Shafeek), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 7 at TOW7</br>
+         </span>
+         <span>
+           (08:26) Shotgun Williams,Chance rush left for 4 yards gain to the TOW03 (Roane Jr.,Rodney).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 3 at TOW3</br>
+         </span>
+         <span>
+           (07:47) Shotgun Sorsby,Brendan rush right for 9 yards loss to the TOW12 (Crews-Harris,Dion; Swain,Mike).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 12 at TOW12</br>
+         </span>
+         <span>
+           (07:01) Shotgun Sorsby,Brendan rush middle for 12 yards gain to the TOW00 TOUCHDOWN, clock 06:56.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW3</br>
+         </span>
+         <span>
+           Brown,Carter kick attempt good (H: Fletcher,Mason, LS: Perry,Jayden).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Towson" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//711.gif" /><span class='d-none d-sm-block'>Towson</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">06:56,TOW25, 3 plays, 8 yards, 01:09</span>
+        </div>
+        <div class="headerRight">10 - 28</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN35</br>
+         </span>
+         <span>
+           (06:56) Hawks,Nathan kickoff 65 yards to the TOW00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW25</br>
+         </span>
+         <span>
+           Towson drive start at 06:56.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW25</br>
+         </span>
+         <span>
+           (06:56) No Huddle-Shotgun Greene Jr.,Tyrell rush middle for 6 yards gain to the TOW31 (Minkins,Josh).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 4 at TOW31</br>
+         </span>
+         <span>
+           (06:25) No Huddle-Shotgun Davis,Carlos pass complete short right to Runyon,Carter caught at TOW29, for 2 yards to the TOW33 (Young,Jordan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at TOW33</br>
+         </span>
+         <span>
+           (06:01) No Huddle-Shotgun Davis,Carlos pass incomplete short right to Londono,Lukkas thrown to TOW40 broken up by Peek Jr.,Antwan.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 2 at TOW33</br>
+         </span>
+         <span>
+           (05:55) LaFollette,Bryce punt 45 yards to the CIN22 Mussari,Michael return 12 yards to the CIN34, out of bounds at CIN34.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Cincinnati" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//140.gif" /><span class='d-none d-sm-block'>Cincinnati</span></div></div>
+        <div class="headerLeft">FGA <br/><span style="font-size: 8px;">05:47,CIN34, 10 plays, 53 yards, 04:01</span>
+        </div>
+        <div class="headerRight">10 - 28</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN34</br>
+         </span>
+         <span>
+           Cincinnati drive start at 05:47.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN34</br>
+         </span>
+         <span>
+           (05:46) No Huddle-Shotgun Kiner,Corey rush middle for 12 yards gain to the CIN46 (Raymond,Daniel), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN46</br>
+         </span>
+         <span>
+           (05:11) No Huddle-Shotgun Sorsby,Brendan pass complete short left to Berkhalter,Sterling caught at TOW45, for 9 yards to the TOW45, out of bounds at TOW45.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 1 at TOW45</br>
+         </span>
+         <span>
+           (04:36) Shotgun Kiner,Corey rush middle for 10 yards gain to the TOW35 (McClendon,CJ; Idehen,Dumkele), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW35</br>
+         </span>
+         <span>
+           (03:55) Shotgun Sorsby,Brendan pass incomplete deep middle to Berkhalter,Sterling thrown to TOW00 PENALTY TOW Pass Interference (Gant,Emiril) 15 yards from TOW35 to TOW20, 1ST DOWN. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW20</br>
+         </span>
+         <span>
+           (03:49) Shotgun Sorsby,Brendan pass incomplete short right to Kiner,Corey thrown to TOW20.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at TOW20</br>
+         </span>
+         <span>
+           (03:46) Shotgun Kiner,Corey rush middle for 1 yard gain to the TOW19 (Raymond,Daniel), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 9 at TOW19</br>
+         </span>
+         <span>
+           (03:04) Shotgun Sorsby,Brendan pass complete short right to Royer,Joe caught at TOW08, for 11 yards to the TOW08 (Terry,Xavier), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 8 at TOW8</br>
+         </span>
+         <span>
+           (02:20) Shotgun Cincinnati rush middle for 5 yards loss to the TOW13 fumbled by Cincinnati at TOW18 recovered by CIN Kiner,Corey at TOW18 (Crews-Harris,Dion; Peters,Branson).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 13 at TOW13</br>
+         </span>
+         <span>
+           (02:00) No Huddle-Shotgun Sorsby,Brendan pass incomplete short left to Henderson,Xzavier thrown to TOW00 broken up by Gant,Emiril.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 13 at TOW13</br>
+         </span>
+         <span>
+           (01:54) Shotgun Sorsby,Brendan pass incomplete short right to Sherman,Francis thrown to TOW00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 13 at TOW13</br>
+         </span>
+         <span>
+           (01:49) Brown,Carter field goal attempt from 31 yards NO GOOD (H: Fletcher,Mason, LS: Perry,Jayden), clock 01:46.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Towson" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//711.gif" /><span class='d-none d-sm-block'>Towson</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">01:46,TOW20, 8 plays, 80 yards, 01:27</span>
+        </div>
+        <div class="headerRight">17 - 28</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW20</br>
+         </span>
+         <span>
+           Towson drive start at 01:46.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW20</br>
+         </span>
+         <span>
+           (01:44) No Huddle-Shotgun Watkins,Christopher rush middle for 39 yards gain to the CIN41 (Young,Jordan), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN41</br>
+         </span>
+         <span>
+           PENALTY TOW False Start (Staehler,Florian) 5 yards from CIN41 to CIN46. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 15 at CIN46</br>
+         </span>
+         <span>
+           Timeout Towson, clock 01:25.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 15 at CIN46</br>
+         </span>
+         <span>
+           (01:24) No Huddle-Shotgun Davis,Carlos sacked for loss of 4 yards to the CIN50 (Phillips,Eric).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 19 at CIN50</br>
+         </span>
+         <span>
+           Timeout Cincinnati, clock 01:20.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 19 at CIN50</br>
+         </span>
+         <span>
+           (01:17) No Huddle-Shotgun Davis,Carlos pass complete short right to Runyon,Carter caught at TOW48, for 7 yards to the CIN43 (Sanks,Jiquan), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 12 at CIN43</br>
+         </span>
+         <span>
+           PENALTY TOW False Start (Doss,Jaceon) 5 yards from CIN43 to CIN48. NO PLAY.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 17 at CIN48</br>
+         </span>
+         <span>
+           (01:11) No Huddle-Shotgun Davis,Carlos rush middle for 12 yards gain to the CIN36 (Minkins,Josh).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 5 at CIN36</br>
+         </span>
+         <span>
+           (01:00) No Huddle-Shotgun Davis,Carlos rush middle for 8 yards gain to the CIN28 (Jackson,Rob), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN28</br>
+         </span>
+         <span>
+           (00:39) No Huddle-Shotgun Davis,Carlos pass incomplete deep middle to Doss,Jaceon thrown to CIN00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at CIN28</br>
+         </span>
+         <span>
+           (00:33) No Huddle-Shotgun Davis,Carlos pass incomplete deep left to Dunmore,John thrown to CIN02.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 10 at CIN28</br>
+         </span>
+         <span>
+           (00:28) No Huddle-Shotgun Davis,Carlos pass complete deep left to Dunmore,John caught at CIN00, for 28 yards to the CIN00 TOUCHDOWN, clock 00:19, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN3</br>
+         </span>
+         <span>
+           Vaughan,Keegan kick attempt good (H: Ritter,Justin, LS: Coyle,Patrick).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Cincinnati" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//140.gif" /><span class='d-none d-sm-block'>Cincinnati</span></div></div>
+        <div class="headerLeft">HALF <br/><span style="font-size: 8px;">00:19,CIN30, 4 plays, 40 yards, 00:19</span>
+        </div>
+        <div class="headerRight">17 - 28</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW35</br>
+         </span>
+         <span>
+           (00:19) Vaughan,Keegan kickoff 35 yards to the CIN30 fair catch by Golday,Jake at CIN30.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN30</br>
+         </span>
+         <span>
+           Cincinnati drive start at 00:19.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN30</br>
+         </span>
+         <span>
+           (00:18) No Huddle-Shotgun Sorsby,Brendan pass complete short right to Royer,Joe caught at CIN36, for 8 yards to the CIN38 (Gant,Emiril), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 2 at CIN38</br>
+         </span>
+         <span>
+           (00:15) Shotgun Sorsby,Brendan pass incomplete short middle to Smith,Tyrin thrown to TOW45.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at CIN38</br>
+         </span>
+         <span>
+           (00:10) Shotgun Sorsby,Brendan pass complete short left to Pryor,Evan caught at CIN31, for 13 yards to the TOW49 (Shiggs,Jasin), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW49</br>
+         </span>
+         <span>
+           (00:03) Shotgun Sorsby,Brendan pass complete short middle to Henderson,Xzavier caught at TOW45, for 19 yards to the TOW30 (Snell,Kam), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW30</br>
+         </span>
+         <span>
+           End of game, clock 00:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN35</br>
+         </span>
+         <span>
+           TOW will receive; CIN will defend South end-zone.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN35</br>
+         </span>
+         <span>
+           Start of 3rd quarter, clock 15:00.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+</div>
+  <div style="border-bottom: 1px dotted #dcdddf;"><h1>3rd Quarter</h1></div>
+<div class="drives">
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Towson" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//711.gif" /><span class='d-none d-sm-block'>Towson</span></div></div>
+        <div class="headerLeft">FG <br/><span style="font-size: 8px;">15:00,TOW25, 12 plays, 59 yards, 04:50</span>
+        </div>
+        <div class="headerRight">20 - 28</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN35</br>
+         </span>
+         <span>
+           (15:00) Hawks,Nathan kickoff 65 yards to the TOW00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW25</br>
+         </span>
+         <span>
+           Towson drive start at 15:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW25</br>
+         </span>
+         <span>
+           (15:00) No Huddle-Shotgun Greene Jr.,Tyrell rush middle for 4 yards gain to the TOW29 (Bartlett,Jared).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 6 at TOW29</br>
+         </span>
+         <span>
+           (14:37) No Huddle-Shotgun Davis,Carlos pass incomplete short right thrown to TOW30 QB hurried by Wilson,Kam PENALTY TOW Intentional Grounding (Davis,Carlos).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 13 at TOW22</br>
+         </span>
+         <span>
+           (14:27) No Huddle-Shotgun Davis,Carlos pass complete short middle to Runyon,Carter caught at TOW20, for 2 yards to the TOW24 (Wilson,Kam) PENALTY CIN Roughing The Passer (Roetherford,Cameron) 15 yards from TOW24 to TOW39, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW39</br>
+         </span>
+         <span>
+           (14:19) No Huddle-Shotgun Matthews,Devin rush middle for 2 yards gain to the TOW41 (Varner,Darian; Dingle,Jack).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 8 at TOW41</br>
+         </span>
+         <span>
+           (13:43) No Huddle-Shotgun Matthews,Devin rush middle for 2 yards gain to the TOW43 (Bartlett,Jared; Young,Jordan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 6 at TOW43</br>
+         </span>
+         <span>
+           (12:59) No Huddle-Shotgun Davis,Carlos pass complete short middle to Matthews,Devin caught at TOW50, for 11 yards to the CIN46 (Golday,Jake), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN46</br>
+         </span>
+         <span>
+           (12:23) No Huddle-Shotgun Matthews,Devin rush middle for 8 yards gain to the CIN38 (Golday,Jake).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 2 at CIN38</br>
+         </span>
+         <span>
+           (11:38) No Huddle-Shotgun Matthews,Devin rush middle for 15 yards gain to the CIN23 (Young,Jordan; Minkins,Josh), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN23</br>
+         </span>
+         <span>
+           (10:56) No Huddle-Shotgun Watkins,Christopher rush right for 7 yards gain to the CIN16 (Varner,Darian).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 3 at CIN16</br>
+         </span>
+         <span>
+           (10:23) No Huddle-Shotgun Davis,Carlos pass incomplete short right to Runyon,Carter thrown to CIN00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 3 at CIN16</br>
+         </span>
+         <span>
+           (10:18) No Huddle-Shotgun Davis,Carlos pass incomplete short left to McElhaney,Brady thrown to CIN00 broken up by Minkins,Josh.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 3 at CIN16</br>
+         </span>
+         <span>
+           (10:13) Vaughan,Keegan field goal attempt from 33 yards GOOD (H: Ritter,Justin, LS: Coyle,Patrick), clock 10:10.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Cincinnati" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//140.gif" /><span class='d-none d-sm-block'>Cincinnati</span></div></div>
+        <div class="headerLeft">TD <br/><span style="font-size: 8px;">10:02,CIN36, 1 plays, 64 yards, 00:10</span>
+        </div>
+        <div class="headerRight">20 - 35</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW35</br>
+         </span>
+         <span>
+           (10:10) Vaughan,Keegan kickoff 41 yards to the CIN24 Golday,Jake return 12 yards to the CIN36 (Thomas,Alfred).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN36</br>
+         </span>
+         <span>
+           Cincinnati drive start at 10:02.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN36</br>
+         </span>
+         <span>
+           (10:02) No Huddle-Shotgun Pryor,Evan rush right for 64 yards gain to the TOW00 TOUCHDOWN, clock 09:52, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW3</br>
+         </span>
+         <span>
+           Brown,Carter kick attempt good (H: Fletcher,Mason, LS: Perry,Jayden).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Towson" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//711.gif" /><span class='d-none d-sm-block'>Towson</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">09:52,TOW25, 3 plays, 8 yards, 01:33</span>
+        </div>
+        <div class="headerRight">20 - 35</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN35</br>
+         </span>
+         <span>
+           (09:52) Hawks,Nathan kickoff 58 yards to the TOW07 fair catch by Doss,Jaceon at TOW07.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW25</br>
+         </span>
+         <span>
+           Towson drive start at 09:52.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW25</br>
+         </span>
+         <span>
+           (09:52) No Huddle-Shotgun Greene Jr.,Tyrell rush middle for 8 yards gain to the TOW33 (Miller,Mehki; Simms III,Brian).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 2 at TOW33</br>
+         </span>
+         <span>
+           (09:24) No Huddle-Shotgun Davis,Carlos pass incomplete short right to Perkins,Zay thrown to TOW38 broken up by Adams,Trevor.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 2 at TOW33</br>
+         </span>
+         <span>
+           (09:15) No Huddle-Shotgun Davis,Carlos rush right for 0 yards to the TOW33 (Miller,Mehki; Stokes,Kye).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 2 at TOW33</br>
+         </span>
+         <span>
+           (08:25) LaFollette,Bryce punt 48 yards to the CIN19 fair catch by Mussari,Michael at CIN19.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="scoring_play">
+      <div class="scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Cincinnati" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//140.gif" /><span class='d-none d-sm-block'>Cincinnati</span></div></div>
+        <div class="headerLeft">FG <br/><span style="font-size: 8px;">08:19,CIN19, 11 plays, 63 yards, 03:41</span>
+        </div>
+        <div class="headerRight">20 - 38</div>
+      </div>
+    </h5>
+      <div class="scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN19</br>
+         </span>
+         <span>
+           Cincinnati drive start at 08:19.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN19</br>
+         </span>
+         <span>
+           (08:19) No Huddle-Shotgun Sorsby,Brendan pass complete short left to Henderson,Xzavier caught at CIN28, for 9 yards to the CIN28 (Smith,Shafeek).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 1 at CIN28</br>
+         </span>
+         <span>
+           (07:50) Shotgun Covey,Manny rush left for 5 yards gain to the CIN33 (White,Kaden; Smith,Shafeek), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN33</br>
+         </span>
+         <span>
+           (07:25) No Huddle-Shotgun Sorsby,Brendan pass complete short middle to Turner,Aaron caught at TOW48, for 19 yards to the TOW48 (Shiggs,Jasin), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW48</br>
+         </span>
+         <span>
+           (06:51) Shotgun Covey,Manny rush left for 5 yards gain to the TOW43 (Smith,Shafeek).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 5 at TOW43</br>
+         </span>
+         <span>
+           (06:30) No Huddle-Shotgun Sorsby,Brendan pass complete short left to Henderson,Xzavier caught at TOW37, for 6 yards to the TOW37 (Smith,Shafeek), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW37</br>
+         </span>
+         <span>
+           (05:57) Shotgun Williams,Chance rush middle for 7 yards gain to the TOW30 (Terry,Xavier).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 3 at TOW30</br>
+         </span>
+         <span>
+           (05:17) Shotgun Sorsby,Brendan pass complete short right to Mayes,Jamoi caught at TOW23, for 7 yards to the TOW23 (Raymond,Daniel), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW23</br>
+         </span>
+         <span>
+           (05:08) Shotgun Jackson Jr.,Barry rush left for 5 yards gain to the TOW18 (Bivans,Alijah).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 5 at TOW18</br>
+         </span>
+         <span>
+           (04:54) Shotgun Sorsby,Brendan pass incomplete short right to Royer,Joe thrown to TOW00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 5 at TOW18</br>
+         </span>
+         <span>
+           (04:47) Shotgun Sorsby,Brendan pass incomplete short left to Henderson,Xzavier thrown to TOW06 broken up by Smith,Shafeek.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 5 at TOW18</br>
+         </span>
+         <span>
+           (04:41) Brown,Carter field goal attempt from 36 yards GOOD (H: Fletcher,Mason, LS: Perry,Jayden), clock 04:38.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Towson" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//711.gif" /><span class='d-none d-sm-block'>Towson</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">04:38,TOW25, 5 plays, 16 yards, 02:34</span>
+        </div>
+        <div class="headerRight">20 - 38</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN35</br>
+         </span>
+         <span>
+           (04:38) Hawks,Nathan kickoff 65 yards to the TOW00, Touchback.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW25</br>
+         </span>
+         <span>
+           Towson drive start at 04:38.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW25</br>
+         </span>
+         <span>
+           (04:38) No Huddle-Shotgun Matthews,Devin rush middle for 7 yards gain to the TOW32 (Stokes,Kye; Simms III,Brian).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 3 at TOW32</br>
+         </span>
+         <span>
+           (04:14) No Huddle-Shotgun Matthews,Devin rush middle for 4 yards gain to the TOW36 (Simms III,Brian; Thompson,Jonathan), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW36</br>
+         </span>
+         <span>
+           (03:43) No Huddle-Shotgun Matthews,Devin rush middle for 6 yards gain to the TOW42 (Adams,Trevor).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 4 at TOW42</br>
+         </span>
+         <span>
+           (02:58) No Huddle-Shotgun Davis,Carlos pass complete short left to Watkins,Christopher caught at TOW37, for 1 yard loss to the TOW41 (Peek Jr.,Antwan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 5 at TOW41</br>
+         </span>
+         <span>
+           Timeout Towson, clock 02:50.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 5 at TOW41</br>
+         </span>
+         <span>
+           (02:15) No Huddle-Shotgun Davis,Carlos pass incomplete short middle to Londono,Lukkas thrown to TOW46.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 5 at TOW41</br>
+         </span>
+         <span>
+           (02:10) LaFollette,Bryce punt 39 yards to the CIN20 fair catch by Mussari,Michael at CIN20.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Cincinnati" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//140.gif" /><span class='d-none d-sm-block'>Cincinnati</span></div></div>
+        <div class="headerLeft">FUMB <br/><span style="font-size: 8px;">02:04,CIN20, 5 plays, 68 yards, 02:16</span>
+        </div>
+        <div class="headerRight">20 - 38</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN20</br>
+         </span>
+         <span>
+           Cincinnati drive start at 02:04.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN20</br>
+         </span>
+         <span>
+           (02:04) No Huddle-Shotgun Sorsby,Brendan rush left for 0 yards to the CIN20 (McClendon,CJ).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at CIN20</br>
+         </span>
+         <span>
+           (01:28) No Huddle-Shotgun Sorsby,Brendan pass complete short right to Sherman,Francis caught at CIN20, for 14 yards to the CIN34 (Terry,Xavier), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN34</br>
+         </span>
+         <span>
+           (00:48) No Huddle-Shotgun Sorsby,Brendan pass incomplete short left to Berkhalter,Sterling thrown to CIN39 QB hurried by Crews-Harris,Dion.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at CIN34</br>
+         </span>
+         <span>
+           (00:41) No Huddle-Shotgun Dawson,Victor rush middle for 7 yards gain to the CIN41 (Dunbar,Jurnee; Idehen,Dumkele).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 3 at CIN41</br>
+         </span>
+         <span>
+           Start of 4th quarter, clock 15:00.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 3 at CIN41</br>
+         </span>
+         <span>
+           (14:57) No Huddle-Shotgun Dawson,Victor rush middle for 47 yards gain to the TOW12 fumbled by Dawson,Victor at TOW17 forced by Raymond,Daniel recovered by TOW Terry,Xavier at TOW12, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+</div>
+  <div style="border-bottom: 1px dotted #dcdddf;"><h1>4th Quarter</h1></div>
+<div class="drives">
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Towson" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//711.gif" /><span class='d-none d-sm-block'>Towson</span></div></div>
+        <div class="headerLeft">FUMB <br/><span style="font-size: 8px;">14:48,TOW12, 4 plays, 30 yards, 02:10</span>
+        </div>
+        <div class="headerRight">20 - 38</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW12</br>
+         </span>
+         <span>
+           Towson drive start at 14:48.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW12</br>
+         </span>
+         <span>
+           (14:47) No Huddle-Shotgun Greene Jr.,Tyrell rush middle for 4 yards gain to the TOW16 (Willis,Ken).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 6 at TOW16</br>
+         </span>
+         <span>
+           (14:17) No Huddle-Shotgun Davis,Carlos pass complete short right to James,Da&#39;Kendall caught at TOW22, for 6 yards to the TOW22 (Willis,Ken), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW22</br>
+         </span>
+         <span>
+           (13:39) No Huddle-Shotgun Davis,Carlos pass complete short right to Greene Jr.,Tyrell caught at TOW23, for 8 yards to the TOW30 (Dingle,Jack), out of bounds.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 2 at TOW30</br>
+         </span>
+         <span>
+           (13:04) No Huddle-Shotgun Greene Jr.,Tyrell rush left for 12 yards gain to the TOW42 fumbled by Greene Jr.,Tyrell at TOW42 forced by Weedon,Montay recovered by CIN Varner,Darian at TOW42 Varner,Darian return 6 yards to the TOW41 fumbled by Varner,Darian at TOW41 forced by James,Da&#39;Kendall recovered by TOW Runyon,Carter at TOW36, End Of Play, 1ST DOWN. The previous play is under automatic review - &quot;Fumble&quot;. PLAY STANDS.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Towson" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//711.gif" /><span class='d-none d-sm-block'>Towson</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">12:38,TOW36, 6 plays, 14 yards, 03:18</span>
+        </div>
+        <div class="headerRight">20 - 38</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW36</br>
+         </span>
+         <span>
+           Towson drive start at 12:38.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW36</br>
+         </span>
+         <span>
+           (12:31) No Huddle-Shotgun Watkins,Christopher rush right for 4 yards gain to the TOW40 (Robinson,Jordan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 6 at TOW40</br>
+         </span>
+         <span>
+           (11:48) No Huddle-Shotgun Watkins,Christopher rush middle for 2 yards gain to the TOW42 (Wilson,Kam).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 4 at TOW42</br>
+         </span>
+         <span>
+           Timeout Towson, clock 11:42.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 4 at TOW42</br>
+         </span>
+         <span>
+           No Huddle-Shotgun Davis,Carlos pass complete short middle to James,Da&#39;Kendall caught at TOW49, for 9 yards to the CIN49 (Minkins,Josh; Roetherford,Cameron), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN49</br>
+         </span>
+         <span>
+           (10:21) No Huddle-Shotgun Davis,Carlos pass incomplete short right to Watkins,Christopher thrown to CIN37 broken up by Minkins,Josh.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 10 at CIN49</br>
+         </span>
+         <span>
+           (10:15) No Huddle-Shotgun Matthews,Devin rush middle for 1 yard loss to the CIN50 (Simms III,Brian; Coleman,Simeon).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 11 at CIN50</br>
+         </span>
+         <span>
+           (09:33) No Huddle-Shotgun Davis,Carlos pass incomplete short left to Doss,Jaceon thrown to CIN40.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 11 at CIN50</br>
+         </span>
+         <span>
+           (09:27) LaFollette,Bryce punt 39 yards to the CIN11 muffed by Mussari,Michael at CIN11 recovered by CIN Mussari,Michael at CIN13, End Of Play.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Cincinnati" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//140.gif" /><span class='d-none d-sm-block'>Cincinnati</span></div></div>
+        <div class="headerLeft">PUNT <br/><span style="font-size: 8px;">09:20,CIN13, 3 plays, 9 yards, 02:05</span>
+        </div>
+        <div class="headerRight">20 - 38</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN13</br>
+         </span>
+         <span>
+           Cincinnati drive start at 09:20.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN13</br>
+         </span>
+         <span>
+           (09:19) No Huddle-Shotgun Williams,Chance rush left for 8 yards gain to the CIN21 (Terry,Xavier).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 2 at CIN21</br>
+         </span>
+         <span>
+           (08:45) Shotgun Williams,Chance rush middle for 1 yard gain to the CIN22 (Terry,Xavier).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at CIN22</br>
+         </span>
+         <span>
+           (08:18) No Huddle Sorsby,Brendan rush middle for 0 yards to the CIN22 (Roane Jr.,Rodney; McClendon,CJ).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 1 at CIN22</br>
+         </span>
+         <span>
+           Timeout Cincinnati, clock 08:13.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 1 at CIN22</br>
+         </span>
+         <span>
+           (07:25) Fletcher,Mason punt 54 yards to the TOW24 Dunmore,John return for loss of 2 yards to the TOW22 (Perry,Jayden).</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Towson" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//711.gif" /><span class='d-none d-sm-block'>Towson</span></div></div>
+        <div class="headerLeft">DOWNS <br/><span style="font-size: 8px;">07:15,TOW22, 8 plays, 46 yards, 04:38</span>
+        </div>
+        <div class="headerRight">20 - 38</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW22</br>
+         </span>
+         <span>
+           Towson drive start at 07:15.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW22</br>
+         </span>
+         <span>
+           (07:14) No Huddle-Shotgun Matthews,Devin rush right for 12 yards gain to the TOW34 (Peek Jr.,Antwan), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW34</br>
+         </span>
+         <span>
+           (06:43) No Huddle-Shotgun Matthews,Devin rush middle for 2 yards gain to the TOW36 (Peek Jr.,Antwan; Burns,Kamari).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 8 at TOW36</br>
+         </span>
+         <span>
+           (06:07) No Huddle-Shotgun Davis,Carlos pass complete short left to Runyon,Carter caught at TOW36, for 0 yards to the TOW36 (Weedon,Montay).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 8 at TOW36</br>
+         </span>
+         <span>
+           (05:25) No Huddle-Shotgun Davis,Carlos pass complete short right to Doss,Jaceon caught at TOW49, for 13 yards to the TOW49 (Carroll,Kalen), 1ST DOWN, PENALTY CIN Roughing The Passer (Simms III,Brian) 15 yards from TOW49 to CIN36, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN36</br>
+         </span>
+         <span>
+           (04:43) No Huddle-Shotgun Davis,Carlos pass complete short right to Watkins,Christopher caught at CIN37, for 1 yard loss to the CIN37 (Robinson,Jordan; Coleman,Simeon).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 11 at CIN37</br>
+         </span>
+         <span>
+           (04:02) No Huddle-Shotgun Davis,Carlos pass complete short left to Doss,Jaceon caught at CIN38, for 2 yards loss to the CIN39 (Wilson,Logan; Thompson,Jonathan).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 13 at CIN39</br>
+         </span>
+         <span>
+           (03:14) No Huddle-Shotgun Davis,Carlos pass complete short right to Dunmore,John caught at CIN34, for 7 yards to the CIN32 (Dingle,Jack).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 6 at CIN32</br>
+         </span>
+         <span>
+           Timeout Towson, clock 03:05.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           4th & 6 at CIN32</br>
+         </span>
+         <span>
+           (02:38) No Huddle-Shotgun Davis,Carlos pass incomplete deep left to Dunmore,John thrown to CIN10, TURNOVER ON DOWNS.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+    <h5 class="non_scoring_play">
+      <div class="non_scoring_play">
+        <div class="headerLeft" style="width: 300px; color: black"><div class='row'><img class="logo_image" alt="Cincinnati" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//140.gif" /><span class='d-none d-sm-block'>Cincinnati</span></div></div>
+        <div class="headerLeft">HALF <br/><span style="font-size: 8px;">02:37,CIN32, 6 plays, 59 yards, 02:37</span>
+        </div>
+        <div class="headerRight">20 - 38</div>
+      </div>
+    </h5>
+      <div class="non_scoring_play">
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN32</br>
+         </span>
+         <span>
+           Cincinnati drive start at 02:37.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN32</br>
+         </span>
+         <span>
+           (02:36) No Huddle-Shotgun Pryor,Evan rush left for 4 yards gain to the CIN36 (Middleton,Will).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 6 at CIN36</br>
+         </span>
+         <span>
+           (02:00) No Huddle-Shotgun Pryor,Evan rush left for 5 yards gain to the CIN41 (Smith,Shafeek; White,Kaden).</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           3rd & 1 at CIN41</br>
+         </span>
+         <span>
+           (01:39) Shotgun Covey,Manny rush middle for 9 yards gain to the CIN50 (White,Kaden; Shiggs,Jasin), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at CIN50</br>
+         </span>
+         <span>
+           (01:06) Shotgun Covey,Manny rush right for 11 yards gain to the TOW39 (White,Kaden; Crews-Harris,Dion), 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 10 at TOW39</br>
+         </span>
+         <span>
+           (00:35) Shotgun Pryor,Evan rush right for 32 yards gain to the TOW07 (Shiggs,Jasin), out of bounds, 1ST DOWN.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           1st & 7 at TOW7</br>
+         </span>
+         <span>
+           Kneel down by Cincinnati at TOW09 for loss of 2 yards.</br>
+         </span>
+         </div>
+         </br>
+         <div style="border-bottom: 1px dotted #dcdddf;">
+         <span style="font-weight: bold;">
+           2nd & 9 at TOW9</br>
+         </span>
+         <span>
+           End of game, clock 00:00.</br>
+         </span>
+         </div>
+         </br>
+     </div>
+</div>
+</div>
+
+
+
+       </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<footer>&copy; <script>document.write(new Date().getFullYear())</script> NCAA <a href="http://web1.ncaa.org/web_files/terms_and_conditions.html" title ="Terms and Conditions" target=_blank>Terms and Conditions</a> | <a href="http://web1.ncaa.org/web_files/privacy.html" target=_blank title="Our Privacy Policy">Privacy Policy</a> | <a href="mailto:ncaa_stats@ncaa.org">Contact Us</a> </footer>
+
+  <!-- /.container -->
+  <script type="text/javascript"  src="/sU0joiPwv/zplvN/xFxji/wmgXJnBU/whimQww3k9OS/ZXgTG2MrBg/bA4YBlB/oDERZ?v=94743442-ba56-a24e-40df-7388407117d0" defer></script></body>
+
+  <script charset="utf-8">
+    $(document).ready(function() {
+      $('a.remote[data-toggle="tab"]').on('show.bs.tab', function (e) {
+        var tab_id = '#' + $(this).attr('aria-controls');
+        $(tab_id).html('<br/><br/><p style="text-align: center"><img style="vertical-align:middle; text-align: center" src="/assets/ajax-loader-6913acdbf4be7d6a2908a84bdecd6cad18110f5fc6d5a07cf8c9ce78d9548700.gif" /> Loading... </p><br/><br/>');
+        $.get($(this).data('remote'), function(data){
+          $(tab_id).html(data);
+        });
+      });
+    });
+
+    function skipMask(obj){
+      if (obj.hasClass('chosen-single') || obj.hasClass('skipMask') || obj.hasClass('ui-datepicker-prev') || obj.hasClass('ui-datepicker-next') || obj.hasClass('ui-corner-all') || obj.hasClass('paginate_button') || obj.hasClass('dt-button')){
+        return true;
+      }else{
+        return false;
+      }
+    }
+
+    $(document).ajaxComplete(function(){
+      unmask();
+    });
+/*
+    $("form").on('submit', function(event){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    */
+    $(document).on('click', 'a', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    $(document).on('click', 'input.green', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+
+  </script>
+</html>


### PR DESCRIPTION
Graduates the last two NCAA MFB backlog items from ncaa-mfb-football-raw:

1. **parse_cfb_ncaa_drives carries the drives table's trailing "# Plays"/"Yards" cells** as n_plays / yards (signed; null when the page omits them). This unblocks the OT-synthesis path, which needs drive totals for synthesized OT play_text.

2. **to_cfbfastr — the NCAA→cfbfastR column mapper** (sportsdataverse/cfb/cfb_ncaa_cfbfastr.py), ported behavior-preserving from ncaa-mfb-football-raw/python/mfb_cfbfastr.py:
   - frozen CFBFASTR_SCHEMA (104 columns, raw column order)
   - the four load-bearing heuristics kept with their comments: FCS defense-labelled-drive majority vote, away/home checkpoint-slot vote, linescore-arbitrated score snapping, OT synthesis (now fed by the graduated parse_cfb_ncaa_drives period>4 rows instead of a local parser)
   - house module contract: zero-row-with-schema on empty input, return_as_pandas, mypy-ratcheted

**Parity evidence:** scripted full-frame comparison (columns, dtypes, every value) of graduated vs raw to_cfbfastr across all five real mfb_pbp_* fixtures — identical, including the un-pinned 5362546. OT-drives replacement verified value-identical on the 1OT fixture mfb_drives_6386512.html.

Tests: tests/cfb 710 passed / 54 skipped / 2 xfailed; ruff clean; mypy clean (396 files). Fixtures mfb_pbp_5336803 / mfb_pbp_5362431 vendored byte-for-byte from the raw repo with README table rows. Codegen regenerated (parsed/cfb.py + cfb reference docs), --check clean.

Validated at scale downstream: this mapper (raw twin) built pbp_cfbfastr for all 13 seasons (2014-2026, ~4.3M plays) with >=99.2% exact-final QA per season.

Follow-up (raw repo, post-merge): point mfb_cfbfastr.py imports at the graduated module and delete the local copy.