### PR TITLE
chore(gitignore): ignore stray local debug.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ htmlcov/
 .omc/
 agent/
 .agents/
+
+# Stray local debug output (actively appended by local tooling)
+debug.log


### PR DESCRIPTION
Adds `debug.log` to .gitignore. A local tool appends to this file continuously in the repo root, which dirties the tree and breaks unattended workspace pulls (auto-stash races the appender and exits non-zero). One-line ignore; the file was never tracked.

## Summary by Sourcery

Chores:
- Ignore the local debug log file to prevent untracked workspace changes from interfering with automated pulls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project ignore settings so local `debug.log` files are not tracked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->