### PR TITLE
fix(mbb): derive NCAA shots period/sec_left instead of shipping them null

### DIFF
--- a/sportsdataverse/mbb/mbb_shots_adapter.py
+++ b/sportsdataverse/mbb/mbb_shots_adapter.py
@@ -139,6 +139,83 @@ def classify_zone_type(type_text: "str | None") -> "str | None":
     return None
 
 
+def period_and_sec_left(minute: float, *, league: str, season: int) -> "tuple[int | None, float | None]":
+    """Derive ``(period, sec_left)`` from a shot's ascending game-clock minute.
+
+    ``ShotEvent.min`` is ascending ELAPSED minutes for the whole game, so the
+    period has to be recovered from the era's period schedule -- and the era is
+    not a constant.
+
+    **WBB is HALVES before season 2016**, quarters from 2016; MBB has always
+    been halves. :func:`~sportsdataverse.mbb.mbb_ncaa_stints.start_time_from_period`
+    takes a BOOLEAN ``is_women_game`` and unconditionally assumes quarters for
+    women, so using it here would silently label a pre-2016 WBB game's first
+    half as "quarter 1" and put ``sec_left`` on a 10-minute clock that ran for
+    20. The season-aware model is resolved through
+    :func:`~sportsdataverse.scrape.ncaa.parse.wbb_period_model` instead.
+
+    Args:
+        minute: Ascending elapsed game time in minutes (``ShotEvent.min``).
+        league: ``"mbb"`` or ``"wbb"``.
+        season: Season-ending year.
+
+    Returns:
+        ``(period, sec_left)`` -- 1-indexed period and seconds remaining IN that
+        period. ``(None, None)`` when ``minute`` is missing or negative, so a
+        bad clock stays unresolved rather than becoming a confident wrong period.
+
+    **Seconds-left-in-PERIOD, matching the ESPN path.** This is not an
+    assumption: :func:`espn_shots_to_canonical` builds ``sec_left`` from
+    ESPN's ``clock_display_value`` (``"12:34"`` -> ``12*60 + 34``), which is the
+    DESCENDING clock within the current period, paired with ``period_number``.
+    Both sources land in the same frame distinguished only by ``source``, so a
+    consumer filtering across ESPN and NCAA rows would silently mix two
+    definitions if these disagreed.
+
+    Example:
+        Quick start::
+
+            from sportsdataverse.mbb.mbb_shots_adapter import period_and_sec_left
+            period_and_sec_left(25.0, league="mbb", season=2024)   # (2, 900.0)
+            period_and_sec_left(25.0, league="wbb", season=2024)   # (3, 300.0)
+            period_and_sec_left(25.0, league="wbb", season=2014)   # (2, 900.0) -- halves era
+    """
+    if minute is None:
+        return None, None
+    try:
+        m = float(minute)
+    except (TypeError, ValueError):
+        return None, None
+    if m < 0:
+        return None, None
+
+    # This module speaks "mens"/"womens"; the release/league layer speaks
+    # "mbb"/"wbb". Accept BOTH -- matching only one vocabulary would silently
+    # give women's games the men's halves schedule and mislabel every quarter.
+    if str(league).lower() in ("wbb", "womens", "women", "w"):
+        from sportsdataverse.scrape.ncaa.parse import wbb_period_model
+
+        periods, reg_seconds, ot_seconds = wbb_period_model(str(season))
+    else:
+        periods, reg_seconds, ot_seconds = 2, 1200, 300
+
+    reg_len = reg_seconds / 60.0
+    ot_len = ot_seconds / 60.0
+    reg_total = periods * reg_len
+
+    if m < reg_total:
+        idx = int(m // reg_len)
+        period = idx + 1
+        start = idx * reg_len
+        return period, round((reg_len - (m - start)) * 60.0, 1)
+
+    over = m - reg_total
+    ot_idx = int(over // ot_len)
+    period = periods + ot_idx + 1
+    start = reg_total + ot_idx * ot_len
+    return period, round((ot_len - (m - start)) * 60.0, 1)
+
+
 def shot_events_to_frame(
     events: list[ShotEvent],
     *,
@@ -190,8 +267,12 @@ def shot_events_to_frame(
                 "shot_type": "unknown",
                 "made": e.pts == 1,
                 "point_value": classify_point_value(dist, x, y, league=league, season=season),
-                "period": None,
-                "sec_left": None,
+                **dict(
+                    zip(
+                        ("period", "sec_left"),
+                        period_and_sec_left(e.min, league=league, season=season),
+                    )
+                ),
                 "source": "ncaa",
             }
         )

--- a/sportsdataverse/mbb/mbb_shots_adapter.py
+++ b/sportsdataverse/mbb/mbb_shots_adapter.py
@@ -9,6 +9,8 @@ shot_type, made, point_value, period, sec_left, source``).
 
 from __future__ import annotations
 
+import math
+
 from typing import TYPE_CHECKING
 
 import pandas as pd
@@ -186,7 +188,9 @@ def period_and_sec_left(minute: float, *, league: str, season: int) -> "tuple[in
         m = float(minute)
     except (TypeError, ValueError):
         return None, None
-    if m < 0:
+    # NaN passes `m < 0` and then explodes in the floor division; +inf
+    # overflows. Both must honour the (None, None) contract, not crash.
+    if not math.isfinite(m) or m < 0:
         return None, None
 
     # This module speaks "mens"/"womens"; the release/league layer speaks
@@ -203,16 +207,22 @@ def period_and_sec_left(minute: float, *, league: str, season: int) -> "tuple[in
     ot_len = ot_seconds / 60.0
     reg_total = periods * reg_len
 
-    if m < reg_total:
-        idx = int(m // reg_len)
-        period = idx + 1
-        start = idx * reg_len
+    # A period BOUNDARY belongs to the period that just ended, at 0 seconds --
+    # a buzzer-beater at 0:00 of the first half is period 1 / 0.0, not period 2
+    # with a full clock. `ceil` puts the boundary on the closing period;
+    # `m == 0` is the only tip-off case and needs the explicit branch.
+    if m == 0.0:
+        return 1, round(reg_len * 60.0, 1)
+
+    if m <= reg_total:
+        period = math.ceil(m / reg_len)
+        start = (period - 1) * reg_len
         return period, round((reg_len - (m - start)) * 60.0, 1)
 
     over = m - reg_total
-    ot_idx = int(over // ot_len)
-    period = periods + ot_idx + 1
-    start = reg_total + ot_idx * ot_len
+    ot_idx = math.ceil(over / ot_len)
+    period = periods + ot_idx
+    start = reg_total + (ot_idx - 1) * ot_len
     return period, round((ot_len - (m - start)) * 60.0, 1)
 
 

--- a/tests/mbb/test_mbb_shots_period.py
+++ b/tests/mbb/test_mbb_shots_period.py
@@ -20,16 +20,18 @@ class TestMensHalves:
         "minute,period,sec_left",
         [
             (0.0, 1, 1200.0),  # tip
-            (19.99, 1, 0.6),  # end of the 1st half
-            (20.0, 2, 1200.0),  # start of the 2nd
+            (19.99, 1, 0.6),  # just before the horn
+            (20.0, 1, 0.0),  # ON the horn -- the period that ENDED
+            (20.01, 2, 1199.4),  # start of the 2nd
             (25.0, 2, 900.0),
             (39.5, 2, 30.0),
+            (40.0, 2, 0.0),  # end of regulation, NOT overtime
         ],
     )
     def test_regulation(self, minute: float, period: int, sec_left: float) -> None:
         assert period_and_sec_left(minute, league="mbb", season=2024) == (period, sec_left)
 
-    @pytest.mark.parametrize("minute,period", [(40.0, 3), (44.9, 3), (45.0, 4), (50.0, 5)])
+    @pytest.mark.parametrize("minute,period", [(40.01, 3), (44.9, 3), (45.0, 3), (45.01, 4), (50.0, 4)])
     def test_overtimes_are_five_minutes(self, minute: float, period: int) -> None:
         assert period_and_sec_left(minute, league="mbb", season=2024)[0] == period
 
@@ -61,9 +63,14 @@ class TestWomensEraSplit:
         assert halves != quarters
 
     def test_womens_regulation_still_ends_at_40_minutes(self) -> None:
-        """Both eras play 40 minutes; only the subdivision changed."""
-        for season in (2014, 2024):
-            assert period_and_sec_left(40.0, league="wbb", season=season)[0] > (2 if season < 2016 else 4)
+        """Both eras play 40 minutes; only the subdivision changed.
+
+        40.0 is the END of regulation, so it belongs to the LAST regulation
+        period at 0 seconds -- half 2 pre-2016, quarter 4 after.
+        """
+        assert period_and_sec_left(40.0, league="wbb", season=2014) == (2, 0.0)
+        assert period_and_sec_left(40.0, league="wbb", season=2024) == (4, 0.0)
+        assert period_and_sec_left(40.01, league="wbb", season=2024)[0] == 5
 
 
 class TestBadClockStaysUnresolved:
@@ -94,3 +101,38 @@ class TestLeagueVocabulary:
         assert period_and_sec_left(25.0, league="womens", season=2024) != period_and_sec_left(
             25.0, league="mens", season=2024
         )
+
+
+class TestPeriodBoundaries:
+    """A shot ON the horn belongs to the period that ENDED, at 0 seconds.
+
+    The naive floor-division put 20.0 in period 2 with a full 1200s clock, so
+    every buzzer-beater was attributed to the following period as though it had
+    just started. Caught in review; these pin it.
+    """
+
+    @pytest.mark.parametrize(
+        "minute,expected",
+        [
+            (20.0, (1, 0.0)),  # end of the men's 1st half
+            (40.0, (2, 0.0)),  # end of men's regulation, NOT overtime
+            (45.0, (3, 0.0)),  # end of OT1, NOT OT2
+        ],
+    )
+    def test_mens_boundaries_close_the_period(self, minute, expected) -> None:
+        assert period_and_sec_left(minute, league="mbb", season=2024) == expected
+
+    @pytest.mark.parametrize("minute,expected", [(10.0, (1, 0.0)), (30.0, (3, 0.0))])
+    def test_womens_quarter_boundaries(self, minute, expected) -> None:
+        assert period_and_sec_left(minute, league="wbb", season=2024) == expected
+
+    def test_a_hair_past_the_boundary_opens_the_next_period(self) -> None:
+        assert period_and_sec_left(20.01, league="mbb", season=2024) == (2, 1199.4)
+
+
+class TestNonFiniteClock:
+    """NaN passed the ``< 0`` guard and then crashed the floor division."""
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+    def test_non_finite_returns_none_rather_than_raising(self, bad: float) -> None:
+        assert period_and_sec_left(bad, league="mbb", season=2024) == (None, None)

--- a/tests/mbb/test_mbb_shots_period.py
+++ b/tests/mbb/test_mbb_shots_period.py
@@ -1,0 +1,96 @@
+"""``period`` / ``sec_left`` derivation for NCAA shot events.
+
+Both columns were hardcoded ``None`` on the NCAA path, so every published
+``ncaa_{mbb,wbb}_shots`` season shipped them entirely null (~2.8M rows per
+league). They are derivable from ``ShotEvent.min``, the ascending elapsed
+game-clock minute.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sportsdataverse.mbb.mbb_shots_adapter import period_and_sec_left
+
+
+class TestMensHalves:
+    """MBB has always played two 20-minute halves."""
+
+    @pytest.mark.parametrize(
+        "minute,period,sec_left",
+        [
+            (0.0, 1, 1200.0),  # tip
+            (19.99, 1, 0.6),  # end of the 1st half
+            (20.0, 2, 1200.0),  # start of the 2nd
+            (25.0, 2, 900.0),
+            (39.5, 2, 30.0),
+        ],
+    )
+    def test_regulation(self, minute: float, period: int, sec_left: float) -> None:
+        assert period_and_sec_left(minute, league="mbb", season=2024) == (period, sec_left)
+
+    @pytest.mark.parametrize("minute,period", [(40.0, 3), (44.9, 3), (45.0, 4), (50.0, 5)])
+    def test_overtimes_are_five_minutes(self, minute: float, period: int) -> None:
+        assert period_and_sec_left(minute, league="mbb", season=2024)[0] == period
+
+
+class TestWomensEraSplit:
+    """WBB is HALVES before season 2016 and quarters from 2016.
+
+    This is the trap that silently emptied six WBB seasons during the first
+    publish. ``start_time_from_period`` takes a BOOLEAN ``is_women_game`` and
+    unconditionally assumes quarters, so deriving through it would label a
+    2014 first half as "quarter 1" and put ``sec_left`` on a 10-minute clock
+    that actually ran for 20.
+    """
+
+    def test_quarters_from_2016(self) -> None:
+        assert period_and_sec_left(25.0, league="wbb", season=2024) == (3, 300.0)
+        assert period_and_sec_left(0.0, league="wbb", season=2016) == (1, 600.0)
+
+    def test_halves_before_2016(self) -> None:
+        assert period_and_sec_left(25.0, league="wbb", season=2014) == (2, 900.0)
+        assert period_and_sec_left(0.0, league="wbb", season=2010) == (1, 1200.0)
+
+    def test_the_same_minute_differs_across_the_era_boundary(self) -> None:
+        """The regression this guards: one minute, two correct answers."""
+        halves = period_and_sec_left(25.0, league="wbb", season=2015)
+        quarters = period_and_sec_left(25.0, league="wbb", season=2016)
+        assert halves == (2, 900.0)
+        assert quarters == (3, 300.0)
+        assert halves != quarters
+
+    def test_womens_regulation_still_ends_at_40_minutes(self) -> None:
+        """Both eras play 40 minutes; only the subdivision changed."""
+        for season in (2014, 2024):
+            assert period_and_sec_left(40.0, league="wbb", season=season)[0] > (2 if season < 2016 else 4)
+
+
+class TestBadClockStaysUnresolved:
+    """A missing or nonsense clock must NOT become a confident wrong period."""
+
+    @pytest.mark.parametrize("bad", [None, -1.0, "abc"])
+    def test_returns_none(self, bad: object) -> None:
+        assert period_and_sec_left(bad, league="mbb", season=2024) == (None, None)  # type: ignore[arg-type]
+
+
+class TestLeagueVocabulary:
+    """The adapter says "mens"/"womens"; the release layer says "mbb"/"wbb".
+
+    Matching only one vocabulary is a SILENT failure: a women's game passed as
+    "womens" would fall through to the men's halves schedule and every quarter
+    would be mislabelled, with no error anywhere. Caught exactly that way.
+    """
+
+    @pytest.mark.parametrize("womens", ["wbb", "womens", "Womens", "W"])
+    def test_all_womens_spellings_get_the_womens_schedule(self, womens: str) -> None:
+        assert period_and_sec_left(25.0, league=womens, season=2024) == (3, 300.0)
+
+    @pytest.mark.parametrize("mens", ["mbb", "mens", "Mens"])
+    def test_all_mens_spellings_get_the_mens_schedule(self, mens: str) -> None:
+        assert period_and_sec_left(25.0, league=mens, season=2024) == (2, 900.0)
+
+    def test_the_two_leagues_disagree_at_the_same_minute(self) -> None:
+        assert period_and_sec_left(25.0, league="womens", season=2024) != period_and_sec_left(
+            25.0, league="mens", season=2024
+        )


### PR DESCRIPTION
`shot_events_to_frame` hardcoded `"period": None, "sec_left": None` on the NCAA
path, so **both columns are entirely null in every published
`ncaa_{mbb,wbb}_shots` season** — ~2.8M rows per league across 2019–2026:

    ncaa_mbb_shots 2019: 257,291 rows  ALL-NULL: period, sec_left, espn_game_id
    ncaa_mbb_shots 2024: 729,580 rows  ALL-NULL: period, sec_left
    ncaa_wbb_shots 2026: 708,038 rows  ALL-NULL: period, sec_left

The ESPN path populated them all along; only the NCAA path did not.

### They were always derivable

`ShotEvent.min` is the ascending elapsed game-clock minute, and the era's period
schedule recovers the rest.

### Two traps, both hit

**WBB is HALVES before season 2016**, quarters from 2016. The obvious helper,
`start_time_from_period`, takes a BOOLEAN `is_women_game` and unconditionally
assumes quarters (`n < 4 -> n * 10.0`), so deriving through it would label a
2014 first half as "quarter 1" and put `sec_left` on a 10-minute clock that
actually ran for 20 — silently, for six seasons. This is the same era trap that
emptied six WBB seasons during the first publish. The era is resolved through
`wbb_period_model` instead.

**The league vocabulary is dual.** This module speaks `"mens"`/`"womens"`; the
release layer speaks `"mbb"`/`"wbb"`. My first cut matched only `"wbb"`, which
would have given every women's game the men's halves schedule **with no error
anywhere** — caught only because an end-to-end call raised on the other
vocabulary. Both spellings are accepted and pinned by tests.

### `sec_left` means seconds-left-in-PERIOD — verified, not assumed

`espn_shots_to_canonical` builds it from ESPN's `clock_display_value`
(`"12:34"` -> `12*60 + 34`), the within-period descending clock, paired with
`period_number`. Both sources land in the same frame distinguished only by
`source`, so disagreeing definitions would corrupt any cross-source filter.

A missing or nonsense clock yields `(None, None)` — unresolved beats a
confident wrong period.

### Tests

24 new (`tests/mbb/test_mbb_shots_period.py`), 106 shot tests pass. The era test
asserts the same minute gives two different correct answers either side of 2016.

### Scope

This fixes the **builder**. The published seasons stay null until `shots` is
rebuilt and republished — that is a separate, much larger job (~2.8M rows ×
2 leagues × 17 seasons from raw HTML) and is not part of this PR.

## Summary by Sourcery

Populate NCAA shot period and in-period clock metadata using season-aware game-clock derivation.

New Features:
- Derive NCAA shot periods and seconds remaining from elapsed game-clock values for both men's and women's basketball.

Bug Fixes:
- Populate NCAA shot metadata instead of publishing null period and sec_left values.
- Correctly handle women's basketball halves before 2016 and quarters from 2016, including period boundaries, overtime, league-name variants, and invalid clocks.

Tests:
- Add coverage for men's and women's era-specific schedules, overtime, period boundaries, league vocabularies, and invalid or non-finite clocks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * NCAA basketball shot events now include accurate period and seconds-remaining values.
  * Clock interpretation accounts for men’s halves, women’s basketball eras, quarters, and overtime.
  * Invalid or negative clock values remain safely unassigned instead of producing incorrect timing data.

* **Tests**
  * Added coverage for league formats, season-based rules, overtime, clock boundaries, and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->