### PR TITLE
feat(mbb): league-wide NCAA RAPM solver (Path B) -- stint ridge + Torvik-gated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Unreleased](#unreleased)
+  - [Added — league-wide NCAA RAPM solver (`mbb_ncaa_rapm_league`, #389)](#added--league-wide-ncaa-rapm-solver-mbb_ncaa_rapm_league-389)
   - [Deprecated — the three NBA `*_v3` loaders now read the production releases](#deprecated--the-three-nba-_v3-loaders-now-read-the-production-releases)
   - [Docs — NBA shifted loaders: the `season` COLUMN is the END year](#docs--nba-shifted-loaders-the-season-column-is-the-end-year)
   - [New — `sportsdataverse.wexp`: win-expectancy bake-off harness (NFL + CFB)](#new--sportsdataversewexp-win-expectancy-bake-off-harness-nfl--cfb)
@@ -232,6 +233,34 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Unreleased
+
+### Added — league-wide NCAA RAPM solver (`mbb_ncaa_rapm_league`, #389)
+
+The league-wide half of the NCAA RAPM program ("Path B"): one joint
+offense/defense ridge per (league, season) putting every Division-I player on
+a common scale — complementing the published `ncaa_{lg}_rapm_within_team`
+datasets, which estimate a DIFFERENT quantity (value relative to teammates)
+and must never be cross-joined with these.
+
+- `aggregate_stints` collapses id-resolved possessions (the #382
+  `mbb_ncaa_rapm_input` adapter output) into matchup stints; a
+  possession-weighted stint ridge is mathematically identical to the
+  per-possession ridge at ~1/3 the rows. Possessions with any unresolved
+  on-floor slot are dropped, never imputed.
+- `solve_rapm_league` runs the sparse joint solve (per-100 scale, positive
+  `drapm` = good defense, ±1 home-offense column). `DEFAULT_RIDGE_LAMBDA =
+  1000` was fitted by game-grouped 5-fold CV on the real 2024 corpora — both
+  leagues minimize there independently. Non-converged solves raise instead
+  of returning a partial iterate.
+- `team_aggregate` produces the model-implied team ratings used by the
+  external oracle gate. Validated on the full corpus: Torvik AdjEM Spearman
+  ≥ 0.9434 (MBB 2011–2026, median 0.9653) and ≥ 0.9723 (WBB 2022–2026;
+  0.9039 in the COVID 2021 season).
+
+The module is league-blind (frames in, frames out) — WBB passes its own
+frames; there is deliberately no `wbb_` twin. Companion `sportsdataverse.mbb`
+adapter fixes from the same program: cross-season `person_id` resolution
+(#382) and the canonical `display_name_to_roster_key` (#388).
 
 ### Deprecated — the three NBA `*_v3` loaders now read the production releases
 

--- a/docs/src/pages/CHANGELOG.md
+++ b/docs/src/pages/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Unreleased](#unreleased)
+  - [Added — league-wide NCAA RAPM solver (`mbb_ncaa_rapm_league`, #389)](#added--league-wide-ncaa-rapm-solver-mbb_ncaa_rapm_league-389)
   - [Deprecated — the three NBA `*_v3` loaders now read the production releases](#deprecated--the-three-nba-_v3-loaders-now-read-the-production-releases)
   - [Docs — NBA shifted loaders: the `season` COLUMN is the END year](#docs--nba-shifted-loaders-the-season-column-is-the-end-year)
   - [New — `sportsdataverse.wexp`: win-expectancy bake-off harness (NFL + CFB)](#new--sportsdataversewexp-win-expectancy-bake-off-harness-nfl--cfb)
@@ -232,6 +233,34 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Unreleased
+
+### Added — league-wide NCAA RAPM solver (`mbb_ncaa_rapm_league`, #389)
+
+The league-wide half of the NCAA RAPM program ("Path B"): one joint
+offense/defense ridge per (league, season) putting every Division-I player on
+a common scale — complementing the published `ncaa_{lg}_rapm_within_team`
+datasets, which estimate a DIFFERENT quantity (value relative to teammates)
+and must never be cross-joined with these.
+
+- `aggregate_stints` collapses id-resolved possessions (the #382
+  `mbb_ncaa_rapm_input` adapter output) into matchup stints; a
+  possession-weighted stint ridge is mathematically identical to the
+  per-possession ridge at ~1/3 the rows. Possessions with any unresolved
+  on-floor slot are dropped, never imputed.
+- `solve_rapm_league` runs the sparse joint solve (per-100 scale, positive
+  `drapm` = good defense, ±1 home-offense column). `DEFAULT_RIDGE_LAMBDA =
+  1000` was fitted by game-grouped 5-fold CV on the real 2024 corpora — both
+  leagues minimize there independently. Non-converged solves raise instead
+  of returning a partial iterate.
+- `team_aggregate` produces the model-implied team ratings used by the
+  external oracle gate. Validated on the full corpus: Torvik AdjEM Spearman
+  ≥ 0.9434 (MBB 2011–2026, median 0.9653) and ≥ 0.9723 (WBB 2022–2026;
+  0.9039 in the COVID 2021 season).
+
+The module is league-blind (frames in, frames out) — WBB passes its own
+frames; there is deliberately no `wbb_` twin. Companion `sportsdataverse.mbb`
+adapter fixes from the same program: cross-season `person_id` resolution
+(#382) and the canonical `display_name_to_roster_key` (#388).
 
 ### Deprecated — the three NBA `*_v3` loaders now read the production releases
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -453,6 +453,8 @@ files = [
     "sportsdataverse/mbb/mbb_ratings.py",
     "sportsdataverse/mbb/mbb_luck.py",
     "sportsdataverse/mbb/mbb_rapm.py",
+    "sportsdataverse/mbb/mbb_ncaa_rapm_input.py",
+    "sportsdataverse/mbb/mbb_ncaa_rapm_league.py",
     "sportsdataverse/mbb/mbb_positions.py",
     "sportsdataverse/mbb/mbb_prediction_constants.py",
     "sportsdataverse/mbb/mbb_team_ratings.py",

--- a/sportsdataverse/mbb/mbb_ncaa_rapm_league.py
+++ b/sportsdataverse/mbb/mbb_ncaa_rapm_league.py
@@ -212,6 +212,16 @@ def team_aggregate(stints: pl.DataFrame, players: pl.DataFrame) -> pl.DataFrame:
     """
     if stints.height == 0:
         return pl.DataFrame(schema=_TEAM_AGG_SCHEMA)
+    if players.schema["player_id"] != pl.Utf8:
+        # A wrong-dtype key would left-join to all-null, fill_null(0.0) every
+        # coefficient, and emit all-zero team ratings with no error.
+        raise TypeError(f"players.player_id must be Utf8, got {players.schema['player_id']}")
+    on_floor = set(stints["off_ids"].explode().to_list()) | set(stints["def_ids"].explode().to_list())
+    if players.height and not (set(players["player_id"].to_list()) & on_floor):
+        raise ValueError(
+            "zero player_id overlap between stints and players -- wrong frames "
+            "or an upstream id mismatch; refusing to emit all-zero team ratings"
+        )
     off = _side_aggregate(stints, players, "off_ids", "off_team", "orapm", "team_orapm")
     dfn = _side_aggregate(stints, players, "def_ids", "def_team", "drapm", "team_drapm")
     return (
@@ -233,7 +243,7 @@ def solve_rapm_league(
     *,
     ridge_lambda: float = DEFAULT_RIDGE_LAMBDA,
     return_as_pandas: bool = False,
-) -> "tuple[pl.DataFrame, dict[str, float]]":
+) -> tuple[pl.DataFrame, dict[str, float]]:
     """Weighted sparse joint O/D ridge over matchup stints.
 
     Args:
@@ -300,8 +310,8 @@ def solve_rapm_league(
     # entries (so positive drapm = fewer points allowed), hca column at 2P.
     off_rows = off["_row"].to_numpy().astype(np.int64)
     dfn_rows = dfn["_row"].to_numpy().astype(np.int64)
-    off_cols: "np.ndarray" = np.fromiter((idx[p] for p in off["pid"].to_list()), np.int64, len(off_rows))
-    dfn_cols: "np.ndarray" = np.fromiter((n_players + idx[p] for p in dfn["pid"].to_list()), np.int64, len(dfn_rows))
+    off_cols: np.ndarray = np.fromiter((idx[p] for p in off["pid"].to_list()), np.int64, len(off_rows))
+    dfn_cols: np.ndarray = np.fromiter((n_players + idx[p] for p in dfn["pid"].to_list()), np.int64, len(dfn_rows))
     side = np.where(s["is_home_offense"].to_numpy(), 1.0, -1.0)
 
     rows = np.concatenate([off_rows, dfn_rows, np.arange(n_stints)])
@@ -309,7 +319,11 @@ def solve_rapm_league(
     vals = np.concatenate([sw[off_rows], -sw[dfn_rows], side * sw])
     x = coo_matrix((vals, (rows, cols)), shape=(n_stints, 2 * n_players + 1)).tocsr()
 
-    beta = lsqr(x, (y - mu) * sw, damp=float(np.sqrt(ridge_lambda)))[0]
+    beta, istop, itn = lsqr(x, (y - mu) * sw, damp=float(np.sqrt(ridge_lambda)))[:3]
+    if istop not in (0, 1, 2):
+        # istop=7 is the iteration limit: lsqr hands back a PARTIAL iterate
+        # with no error, which must never flow silently into the gate.
+        raise RuntimeError(f"lsqr did not converge (istop={istop}, itn={itn}) -- refusing to return a partial solve")
     orapm = beta[:n_players]
     drapm = beta[n_players : 2 * n_players]
     hca = float(beta[2 * n_players])
@@ -351,5 +365,7 @@ def solve_rapm_league(
         "ridge_lambda": float(ridge_lambda),
         "n_stints": n_stints,
         "n_poss": int(w.sum()),
+        "lsqr_istop": int(istop),
+        "lsqr_itn": int(itn),
     }
     return (out.to_pandas() if return_as_pandas else out), info

--- a/sportsdataverse/mbb/mbb_ncaa_rapm_league.py
+++ b/sportsdataverse/mbb/mbb_ncaa_rapm_league.py
@@ -49,13 +49,15 @@ __all__ = [
     "STINT_SCHEMA",
     "aggregate_stints",
     "solve_rapm_league",
+    "team_aggregate",
 ]
 
-#: Ridge penalty on the possession-weighted per-100 scale. Placeholder pending
-#: the Phase-4 fitting script (game-grouped CV on real 2024 seasons, both
-#: leagues); the gate phase overwrites this with the fitted value and cites
-#: the script. Do not tune ad hoc.
-DEFAULT_RIDGE_LAMBDA = 500.0
+#: Ridge penalty on the possession-weighted per-100 scale. Fitted by
+#: game-grouped 5-fold CV (``dev/ncaa_rapm/fit_lambda_league.py``) on the
+#: real 2024 seasons: BOTH leagues minimize weighted OOS MSE at 1000
+#: (mbb 5145.33 over a 50..5000 grid; wbb 4910.74). Refit with that script;
+#: do not tune ad hoc.
+DEFAULT_RIDGE_LAMBDA = 1000.0
 
 #: The ten id slots emitted by ``resolve_possessions`` (``"<slot>_id"``).
 _SLOT_IDS = [f"{side}_{i}_id" for side in ("home", "away") for i in range(1, 6)]
@@ -149,6 +151,80 @@ def aggregate_stints(resolved: pl.DataFrame) -> pl.DataFrame:
             pl.col("pts").cast(pl.Int64).sum().alias("pts"),
         )
         .select(list(STINT_SCHEMA))
+    )
+
+
+_TEAM_AGG_SCHEMA: dict[str, pl.DataType] = {
+    "team": pl.Utf8,
+    "team_orapm": pl.Float64,
+    "team_drapm": pl.Float64,
+    "team_net": pl.Float64,
+    "off_poss": pl.Int64,
+    "def_poss": pl.Int64,
+}
+
+
+def _side_aggregate(
+    stints: pl.DataFrame, players: pl.DataFrame, ids: str, team: str, coef: str, out: str
+) -> pl.DataFrame:
+    per_stint = (
+        stints.with_row_index("_r")
+        .select("_r", pl.col(team).alias("team"), "n_poss", pl.col(ids).alias("player_id"))
+        .explode("player_id", empty_as_null=False)
+        .join(players.select("player_id", coef), on="player_id", how="left")
+        .group_by("_r", "team", "n_poss")
+        .agg(pl.col(coef).fill_null(0.0).sum().alias("_sum"))
+    )
+    poss_col = "off_poss" if ids == "off_ids" else "def_poss"
+    return per_stint.group_by("team").agg(
+        ((pl.col("_sum") * pl.col("n_poss")).sum() / pl.col("n_poss").sum()).alias(out),
+        pl.col("n_poss").sum().cast(pl.Int64).alias(poss_col),
+    )
+
+
+def team_aggregate(stints: pl.DataFrame, players: pl.DataFrame) -> pl.DataFrame:
+    """Model-implied team ratings from player coefficients.
+
+    For each team: ``team_orapm`` is the possession-weighted mean over its
+    offensive stints of the on-floor five's ``orapm`` sum; ``team_drapm``
+    likewise with ``drapm`` over its defensive stints; ``team_net`` is their
+    sum. This is exactly what the fitted model predicts for the team's
+    average possession (excluding opponent terms and home-court), so it is
+    the faithful aggregate to hold against an external team rating (Torvik
+    AdjEM) in the oracle gate.
+
+    Args:
+        stints: Output of :func:`aggregate_stints`.
+        players: Players frame from :func:`solve_rapm_league` (needs
+            ``player_id``, ``orapm``, ``drapm``). A player absent from it
+            contributes 0 -- the model's own convention for an unrated
+            column.
+
+    Returns:
+        One row per team: ``team``, ``team_orapm``, ``team_drapm``,
+        ``team_net``, ``off_poss``, ``def_poss``.
+
+    Example:
+        Gate a season against Torvik::
+
+            teams = team_aggregate(stints, players)
+            joined = teams.join(torvik, on="team", how="inner")
+    """
+    if stints.height == 0:
+        return pl.DataFrame(schema=_TEAM_AGG_SCHEMA)
+    off = _side_aggregate(stints, players, "off_ids", "off_team", "orapm", "team_orapm")
+    dfn = _side_aggregate(stints, players, "def_ids", "def_team", "drapm", "team_drapm")
+    return (
+        off.join(dfn, on="team", how="full", coalesce=True)
+        .with_columns(
+            pl.col("team_orapm").fill_null(0.0),
+            pl.col("team_drapm").fill_null(0.0),
+            pl.col("off_poss").fill_null(0).cast(pl.Int64),
+            pl.col("def_poss").fill_null(0).cast(pl.Int64),
+        )
+        .with_columns((pl.col("team_orapm") + pl.col("team_drapm")).alias("team_net"))
+        .select(list(_TEAM_AGG_SCHEMA))
+        .sort("team")
     )
 
 

--- a/sportsdataverse/mbb/mbb_ncaa_rapm_league.py
+++ b/sportsdataverse/mbb/mbb_ncaa_rapm_league.py
@@ -41,8 +41,17 @@ imputed. Callers should report the usable fraction.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+
 import numpy as np
 import polars as pl
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+if TYPE_CHECKING:
+    pass
 
 __all__ = [
     "DEFAULT_RIDGE_LAMBDA",
@@ -243,7 +252,7 @@ def solve_rapm_league(
     *,
     ridge_lambda: float = DEFAULT_RIDGE_LAMBDA,
     return_as_pandas: bool = False,
-) -> tuple[pl.DataFrame, dict[str, float]]:
+) -> "tuple[pl.DataFrame | pd.DataFrame, dict[str, float]]":
     """Weighted sparse joint O/D ridge over matchup stints.
 
     Args:

--- a/sportsdataverse/mbb/mbb_ncaa_rapm_league.py
+++ b/sportsdataverse/mbb/mbb_ncaa_rapm_league.py
@@ -1,0 +1,279 @@
+"""League-wide NCAA RAPM: one joint O/D ridge per (league, season).
+
+This is "Path B" of the NCAA RAPM program. The published
+``ncaa_{lg}_rapm_within_team`` datasets estimate each player RELATIVE TO
+TEAMMATES (the hoop-explorer engine solves one team at a time); this module
+estimates every Division-I player on a COMMON league scale by regressing all
+possessions jointly, which is what makes a team-aggregate external gate
+(Torvik AdjEM Spearman) meaningful.
+
+Like :mod:`sportsdataverse.mbb.mbb_ncaa_rapm_input`, this module is
+league-blind -- frames in, frames out. WBB passes its own frames; there is
+deliberately no ``wbb_ncaa_rapm_league`` twin.
+
+The pipeline:
+
+1. :func:`mbb_ncaa_rapm_input.resolve_possessions` attaches a ``player_id``
+   to each of the ten on-floor slots (identity is the hard part and lives
+   there, not here).
+2. :func:`aggregate_stints` collapses those possessions to matchup stints --
+   one row per unique (offense five, defense five, home/away offense). A
+   possession-count-weighted ridge on stints is mathematically identical to
+   the per-possession ridge (same ``X'WX`` / ``X'Wy``) while keeping the
+   design matrix ~300k sparse rows instead of ~870k.
+3. :func:`solve_rapm_league` runs the weighted sparse joint O/D ridge.
+
+The model, on the per-100-possession scale::
+
+    pts_per_100 = mu + sum(orapm_j, offense five) - sum(drapm_k, defense five)
+                  + hca * side          (side = +1 home offense, -1 away)
+
+``mu`` is the possession-weighted league mean, removed by centering (so it is
+unpenalized); the player coefficients and ``hca`` are L2-penalized. With the
+minus sign on the defense block, POSITIVE ``drapm`` means good defense. The
+``hca`` coefficient is half the home-minus-away offensive gap; its shrinkage
+under the shared penalty is negligible because every possession loads it.
+
+A null slot id (an unresolved player, or the ``TEAM`` pseudo-slot) marks the
+possession unusable and it is DROPPED -- "not a rated player" must never be
+imputed. Callers should report the usable fraction.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+
+__all__ = [
+    "DEFAULT_RIDGE_LAMBDA",
+    "STINT_SCHEMA",
+    "aggregate_stints",
+    "solve_rapm_league",
+]
+
+#: Ridge penalty on the possession-weighted per-100 scale. Placeholder pending
+#: the Phase-4 fitting script (game-grouped CV on real 2024 seasons, both
+#: leagues); the gate phase overwrites this with the fitted value and cites
+#: the script. Do not tune ad hoc.
+DEFAULT_RIDGE_LAMBDA = 500.0
+
+#: The ten id slots emitted by ``resolve_possessions`` (``"<slot>_id"``).
+_SLOT_IDS = [f"{side}_{i}_id" for side in ("home", "away") for i in range(1, 6)]
+_HOME_IDS = _SLOT_IDS[:5]
+_AWAY_IDS = _SLOT_IDS[5:]
+
+#: Documented output schema of :func:`aggregate_stints`.
+STINT_SCHEMA: dict[str, pl.DataType] = {
+    "off_ids": pl.List(pl.Utf8),
+    "def_ids": pl.List(pl.Utf8),
+    "off_team": pl.Utf8,
+    "def_team": pl.Utf8,
+    "is_home_offense": pl.Boolean,
+    "n_poss": pl.Int64,
+    "pts": pl.Int64,
+}
+
+_PLAYERS_SCHEMA: dict[str, pl.DataType] = {
+    "player_id": pl.Utf8,
+    "orapm": pl.Float64,
+    "drapm": pl.Float64,
+    "rapm_net": pl.Float64,
+    "off_poss": pl.Int64,
+    "def_poss": pl.Int64,
+}
+
+
+def aggregate_stints(resolved: pl.DataFrame) -> pl.DataFrame:
+    """Collapse id-resolved possessions into matchup stints.
+
+    Args:
+        resolved: Output of ``resolve_possessions`` -- needs ``home``,
+            ``away``, ``poss_team``, ``pts`` and the ten ``{slot}_id``
+            columns. Extra columns are ignored.
+
+    Returns:
+        One row per unique ``(offense five, defense five, home/away
+        offense)`` with ``n_poss`` and total ``pts`` (schema
+        :data:`STINT_SCHEMA`). Possessions with ANY null slot id are dropped
+        (unresolved player or ``TEAM`` pseudo-slot -- never imputed), as are
+        possessions whose ``poss_team`` matches neither side.
+
+    Raises:
+        ValueError: A required column is missing.
+
+    Example:
+        Season pipeline::
+
+            from sportsdataverse.mbb.mbb_ncaa_rapm_input import (
+                build_player_xwalk, resolve_possessions,
+            )
+            from sportsdataverse.mbb.mbb_ncaa_rapm_league import aggregate_stints
+
+            resolved = resolve_possessions(possessions, build_player_xwalk(rosters))
+            stints = aggregate_stints(resolved)
+    """
+    required = ["home", "away", "poss_team", "pts", *_SLOT_IDS]
+    missing = [c for c in required if c not in resolved.columns]
+    if missing:
+        raise ValueError(f"aggregate_stints: missing required columns {missing}")
+
+    usable = resolved.filter(
+        pl.all_horizontal([pl.col(c).is_not_null() for c in _SLOT_IDS])
+        & ((pl.col("poss_team") == pl.col("home")) | (pl.col("poss_team") == pl.col("away")))
+    )
+    if usable.height == 0:
+        return pl.DataFrame(schema=STINT_SCHEMA)
+
+    is_home = pl.col("poss_team") == pl.col("home")
+    home_ids = pl.concat_list([pl.col(c) for c in _HOME_IDS]).list.sort()
+    away_ids = pl.concat_list([pl.col(c) for c in _AWAY_IDS]).list.sort()
+    shaped = usable.with_columns(
+        pl.when(is_home).then(home_ids).otherwise(away_ids).alias("off_ids"),
+        pl.when(is_home).then(away_ids).otherwise(home_ids).alias("def_ids"),
+        pl.when(is_home).then(pl.col("away")).otherwise(pl.col("home")).alias("def_team"),
+        pl.col("poss_team").alias("off_team"),
+        is_home.alias("is_home_offense"),
+    )
+    return (
+        shaped.with_columns(
+            pl.col("off_ids").list.join("|").alias("_ok"),
+            pl.col("def_ids").list.join("|").alias("_dk"),
+        )
+        .group_by(["_ok", "_dk", "is_home_offense"], maintain_order=True)
+        .agg(
+            pl.col("off_ids").first(),
+            pl.col("def_ids").first(),
+            pl.col("off_team").first(),
+            pl.col("def_team").first(),
+            pl.len().cast(pl.Int64).alias("n_poss"),
+            pl.col("pts").cast(pl.Int64).sum().alias("pts"),
+        )
+        .select(list(STINT_SCHEMA))
+    )
+
+
+def solve_rapm_league(
+    stints: pl.DataFrame,
+    *,
+    ridge_lambda: float = DEFAULT_RIDGE_LAMBDA,
+    return_as_pandas: bool = False,
+) -> "tuple[pl.DataFrame, dict[str, float]]":
+    """Weighted sparse joint O/D ridge over matchup stints.
+
+    Args:
+        stints: Output of :func:`aggregate_stints`.
+        ridge_lambda: L2 penalty on the possession-weighted normal equations.
+            Because rows are weighted by possessions, the same ``lambda`` is
+            exactly equivalent to a per-possession ridge with that penalty.
+        return_as_pandas: Return the players frame as pandas.
+
+    Returns:
+        ``(players, info)``. ``players`` has one row per rated player:
+        ``player_id``, ``orapm``, ``drapm`` (positive = good defense),
+        ``rapm_net = orapm + drapm`` (all per 100 possessions), ``off_poss``,
+        ``def_poss``. ``info`` carries ``intercept`` (possession-weighted
+        league mean pts/100), ``hca`` (half the home-minus-away offensive
+        gap), ``ridge_lambda``, ``n_stints``, ``n_poss``.
+
+    Example:
+        Solve a season::
+
+            from sportsdataverse.mbb.mbb_ncaa_rapm_league import (
+                aggregate_stints, solve_rapm_league,
+            )
+
+            players, info = solve_rapm_league(aggregate_stints(resolved))
+            players.sort("rapm_net", descending=True).head()
+
+    See Also:
+        * `hoopR <https://hoopR.sportsdataverse.org>`_ -- men's college
+          basketball companion (R)
+        * `wehoop <https://wehoop.sportsdataverse.org>`_ -- women's college
+          basketball companion (R)
+    """
+    from scipy.sparse import coo_matrix
+    from scipy.sparse.linalg import lsqr
+
+    empty = pl.DataFrame(schema=_PLAYERS_SCHEMA)
+    if stints.height == 0:
+        info = {
+            "intercept": 0.0,
+            "hca": 0.0,
+            "ridge_lambda": float(ridge_lambda),
+            "n_stints": 0,
+            "n_poss": 0,
+        }
+        return (empty.to_pandas() if return_as_pandas else empty), info
+
+    s = stints.with_row_index("_row")
+    # empty_as_null=False is the polars-2.0 default; the lists are always
+    # exactly five ids so the choice is behavior-neutral here.
+    off = s.select("_row", "n_poss", pl.col("off_ids").alias("pid")).explode("pid", empty_as_null=False)
+    dfn = s.select("_row", "n_poss", pl.col("def_ids").alias("pid")).explode("pid", empty_as_null=False)
+    players = sorted(set(off["pid"].to_list()) | set(dfn["pid"].to_list()))
+    idx = {p: i for i, p in enumerate(players)}
+    n_players = len(players)
+    n_stints = s.height
+
+    w = s["n_poss"].to_numpy().astype(np.float64)
+    sw = np.sqrt(w)
+    y = 100.0 * s["pts"].to_numpy().astype(np.float64) / w
+    mu = float(np.average(y, weights=w))
+
+    # Sparse design: offense block [0, P), defense block [P, 2P) with -1
+    # entries (so positive drapm = fewer points allowed), hca column at 2P.
+    off_rows = off["_row"].to_numpy().astype(np.int64)
+    dfn_rows = dfn["_row"].to_numpy().astype(np.int64)
+    off_cols = np.fromiter((idx[p] for p in off["pid"].to_list()), np.int64, len(off_rows))
+    dfn_cols = np.fromiter((n_players + idx[p] for p in dfn["pid"].to_list()), np.int64, len(dfn_rows))
+    side = np.where(s["is_home_offense"].to_numpy(), 1.0, -1.0)
+
+    rows = np.concatenate([off_rows, dfn_rows, np.arange(n_stints)])
+    cols = np.concatenate([off_cols, dfn_cols, np.full(n_stints, 2 * n_players)])
+    vals = np.concatenate([sw[off_rows], -sw[dfn_rows], side * sw])
+    x = coo_matrix((vals, (rows, cols)), shape=(n_stints, 2 * n_players + 1)).tocsr()
+
+    beta = lsqr(x, (y - mu) * sw, damp=float(np.sqrt(ridge_lambda)))[0]
+    orapm = beta[:n_players]
+    drapm = beta[n_players : 2 * n_players]
+    hca = float(beta[2 * n_players])
+
+    exposure = (
+        pl.concat(
+            [
+                off.select("pid", pl.col("n_poss").alias("off_poss")),
+                dfn.select("pid", pl.col("n_poss").alias("def_poss")),
+            ],
+            how="diagonal",
+        )
+        .group_by("pid")
+        .agg(
+            pl.col("off_poss").sum().fill_null(0).cast(pl.Int64),
+            pl.col("def_poss").sum().fill_null(0).cast(pl.Int64),
+        )
+    )
+    out = (
+        pl.DataFrame(
+            {
+                "player_id": pl.Series(players, dtype=pl.Utf8),
+                "orapm": orapm.astype(np.float64),
+                "drapm": drapm.astype(np.float64),
+            }
+        )
+        .with_columns((pl.col("orapm") + pl.col("drapm")).alias("rapm_net"))
+        .join(exposure.rename({"pid": "player_id"}), on="player_id", how="left")
+        .with_columns(
+            pl.col("off_poss").fill_null(0).cast(pl.Int64),
+            pl.col("def_poss").fill_null(0).cast(pl.Int64),
+        )
+        .select(list(_PLAYERS_SCHEMA))
+        .sort("player_id")
+    )
+    info = {
+        "intercept": mu,
+        "hca": hca,
+        "ridge_lambda": float(ridge_lambda),
+        "n_stints": n_stints,
+        "n_poss": int(w.sum()),
+    }
+    return (out.to_pandas() if return_as_pandas else out), info

--- a/sportsdataverse/mbb/mbb_ncaa_rapm_league.py
+++ b/sportsdataverse/mbb/mbb_ncaa_rapm_league.py
@@ -300,8 +300,8 @@ def solve_rapm_league(
     # entries (so positive drapm = fewer points allowed), hca column at 2P.
     off_rows = off["_row"].to_numpy().astype(np.int64)
     dfn_rows = dfn["_row"].to_numpy().astype(np.int64)
-    off_cols = np.fromiter((idx[p] for p in off["pid"].to_list()), np.int64, len(off_rows))
-    dfn_cols = np.fromiter((n_players + idx[p] for p in dfn["pid"].to_list()), np.int64, len(dfn_rows))
+    off_cols: "np.ndarray" = np.fromiter((idx[p] for p in off["pid"].to_list()), np.int64, len(off_rows))
+    dfn_cols: "np.ndarray" = np.fromiter((n_players + idx[p] for p in dfn["pid"].to_list()), np.int64, len(dfn_rows))
     side = np.where(s["is_home_offense"].to_numpy(), 1.0, -1.0)
 
     rows = np.concatenate([off_rows, dfn_rows, np.arange(n_stints)])

--- a/tests/mbb/test_mbb_ncaa_rapm_league.py
+++ b/tests/mbb/test_mbb_ncaa_rapm_league.py
@@ -238,6 +238,31 @@ class TestSolveRapmLeague:
         }
         assert info["n_stints"] == 0
 
+    def test_nonconverged_solve_raises_not_returns_partial(self, monkeypatch):
+        # lsqr can hit iter_lim (istop=7) and hand back a partial iterate with
+        # no error; that must never flow silently into the gate.
+        import scipy.sparse.linalg as sla
+
+        real = sla.lsqr
+
+        def fake(*a, **k):
+            out = list(real(*a, **k))
+            out[1] = 7  # istop: iteration limit reached
+            return tuple(out)
+
+        monkeypatch.setattr("scipy.sparse.linalg.lsqr", fake)
+        s = _balanced_stints(n=5)
+        with pytest.raises(RuntimeError, match="istop"):
+            solve_rapm_league(s, ridge_lambda=100.0)
+
+    def test_info_reports_solver_diagnostics(self):
+        s = _balanced_stints(n=5)
+        _players_frame, info = solve_rapm_league(s, ridge_lambda=100.0)
+        # 0 = x=0 is the exact solution (this fixture has zero centered
+        # signal), 1/2 = converged.
+        assert info["lsqr_istop"] in (0, 1, 2)
+        assert info["lsqr_itn"] >= 0
+
     def test_net_is_o_plus_d(self):
         s = _balanced_stints(ppp_starter=2.0, ppp_sub=1.0, n=50)
         players, _ = solve_rapm_league(s, ridge_lambda=50.0)
@@ -308,6 +333,20 @@ class TestTeamAggregate:
         t = team_aggregate(s, players)
         duke = t.filter(pl.col("team") == "Duke")
         assert abs(duke["team_orapm"][0] - 5.0) < 1e-12
+
+    def test_non_utf8_player_id_raises_not_silently_zeroes(self):
+        # An Int64-keyed players frame would left-join to all-null -> every
+        # coefficient fill_null(0.0) -> all-zero team ratings with no error.
+        s = aggregate_stints(_poss([("Duke", "Iowa", "Duke", 2, _H, _A)]))
+        bad = _players(h1=1).with_columns(pl.lit(1).alias("player_id"))
+        with pytest.raises(TypeError, match="player_id"):
+            team_aggregate(s, bad)
+
+    def test_zero_overlap_between_stints_and_players_raises(self):
+        s = aggregate_stints(_poss([("Duke", "Iowa", "Duke", 2, _H, _A)]))
+        strangers = _players(x1=1, x2=2)
+        with pytest.raises(ValueError, match="overlap"):
+            team_aggregate(s, strangers)
 
     def test_empty_stints_return_documented_schema(self):
         t = team_aggregate(aggregate_stints(_poss([])), _players())

--- a/tests/mbb/test_mbb_ncaa_rapm_league.py
+++ b/tests/mbb/test_mbb_ncaa_rapm_league.py
@@ -1,0 +1,250 @@
+"""Tests for the league-wide NCAA RAPM solver (Path B).
+
+``aggregate_stints`` collapses id-resolved possessions (the output of
+``mbb_ncaa_rapm_input.resolve_possessions``) into matchup stints;
+``solve_rapm_league`` runs one weighted sparse joint O/D ridge over them.
+
+The solver tests assert IDENTIFIABLE quantities (within-lineup differences,
+orderings, sign conventions, weighting equivalences) rather than absolute
+coefficient values -- under a ridge penalty absolute values are shrunk, but
+the difference between two players who swap into an otherwise identical
+lineup is pinned by the data. The external correctness contract (Torvik
+team-aggregate Spearman) runs on real seasons in the gate phase, not here.
+"""
+
+import polars as pl
+import pytest
+
+from sportsdataverse.mbb.mbb_ncaa_rapm_league import (
+    STINT_SCHEMA,
+    aggregate_stints,
+    solve_rapm_league,
+)
+
+# Ten id slots in resolve_possessions' output naming: "<slot>_id".
+_SLOT_IDS = [f"{side}_{i}_id" for side in ("home", "away") for i in range(1, 6)]
+
+
+def _poss(rows):
+    """Build a minimal id-resolved possessions frame.
+
+    Each row: (home, away, poss_team, pts, home_ids[5], away_ids[5]).
+    """
+    out = {
+        "home": [],
+        "away": [],
+        "poss_team": [],
+        "pts": [],
+        **{c: [] for c in _SLOT_IDS},
+    }
+    for home, away, poss_team, pts, home_ids, away_ids in rows:
+        out["home"].append(home)
+        out["away"].append(away)
+        out["poss_team"].append(poss_team)
+        out["pts"].append(pts)
+        for i in range(5):
+            out[f"home_{i + 1}_id"].append(home_ids[i])
+            out[f"away_{i + 1}_id"].append(away_ids[i])
+    return pl.DataFrame(
+        out,
+        schema_overrides={c: pl.Utf8 for c in _SLOT_IDS},
+    )
+
+
+_H = ["h1", "h2", "h3", "h4", "h5"]
+_A = ["a1", "a2", "a3", "a4", "a5"]
+
+
+class TestAggregateStints:
+    def test_collapses_identical_matchups(self):
+        d = _poss(
+            [
+                ("Duke", "Iowa", "Duke", 2, _H, _A),
+                ("Duke", "Iowa", "Duke", 0, _H, _A),
+            ]
+        )
+        s = aggregate_stints(d)
+        assert s.height == 1
+        assert s["n_poss"][0] == 2
+        assert s["pts"][0] == 2
+
+    def test_offense_is_the_poss_team_side(self):
+        d = _poss([("Duke", "Iowa", "Iowa", 3, _H, _A)])
+        s = aggregate_stints(d)
+        assert sorted(s["off_ids"][0].to_list()) == _A
+        assert sorted(s["def_ids"][0].to_list()) == _H
+        assert s["is_home_offense"][0] is False
+        assert s["off_team"][0] == "Iowa"
+        assert s["def_team"][0] == "Duke"
+
+    def test_slot_order_does_not_split_a_lineup(self):
+        d = _poss(
+            [
+                ("Duke", "Iowa", "Duke", 2, _H, _A),
+                ("Duke", "Iowa", "Duke", 1, list(reversed(_H)), list(reversed(_A))),
+            ]
+        )
+        s = aggregate_stints(d)
+        assert s.height == 1
+        assert s["n_poss"][0] == 2
+
+    def test_home_and_away_offense_are_separate_stints(self):
+        d = _poss(
+            [
+                ("Duke", "Iowa", "Duke", 2, _H, _A),
+                ("Duke", "Iowa", "Iowa", 2, _H, _A),
+            ]
+        )
+        s = aggregate_stints(d)
+        assert s.height == 2
+        assert set(s["is_home_offense"].to_list()) == {True, False}
+
+    def test_null_slot_id_drops_the_possession(self):
+        broken = _H[:4] + [None]
+        d = _poss(
+            [
+                ("Duke", "Iowa", "Duke", 2, broken, _A),
+                ("Duke", "Iowa", "Duke", 1, _H, _A),
+            ]
+        )
+        s = aggregate_stints(d)
+        assert s["n_poss"].sum() == 1
+
+    def test_poss_team_matching_neither_side_is_dropped(self):
+        d = _poss([("Duke", "Iowa", "Kansas", 2, _H, _A)])
+        s = aggregate_stints(d)
+        assert s.height == 0
+
+    def test_empty_input_returns_documented_schema(self):
+        s = aggregate_stints(_poss([]))
+        assert s.height == 0
+        assert dict(s.schema) == dict(STINT_SCHEMA)
+
+    def test_ids_stay_utf8_lists(self):
+        d = _poss([("Duke", "Iowa", "Duke", 2, _H, _A)])
+        s = aggregate_stints(d)
+        assert s.schema["off_ids"] == pl.List(pl.Utf8)
+        assert s.schema["def_ids"] == pl.List(pl.Utf8)
+
+    def test_missing_required_column_raises(self):
+        with pytest.raises(ValueError, match="poss_team"):
+            aggregate_stints(pl.DataFrame({"home": ["Duke"]}))
+
+
+def _balanced_stints(ppp_starter=1.0, ppp_sub=1.0, n=200):
+    """Two Duke lineups (h5 vs h6 swapped) against the same Iowa five.
+
+    Every stint is away-offense-free and home-offense-only, so the ONLY
+    contrast in the design is h5-vs-h6; their orapm difference is pinned by
+    ``ppp_starter - ppp_sub`` (per 100: x100) while everything shared shrinks
+    identically.
+    """
+    starters = _H
+    subbed = _H[:4] + ["h6"]
+    rows = []
+    for _ in range(n):
+        rows.append(("Duke", "Iowa", "Duke", None, starters, _A))
+        rows.append(("Duke", "Iowa", "Duke", None, subbed, _A))
+    d = _poss([(h, a, p, 0, hi, ai) for h, a, p, _, hi, ai in rows])
+    s = aggregate_stints(d)
+    # overwrite pts to the generative model: pts = ppp * n_poss
+    return s.with_columns(
+        pl.when(pl.col("off_ids").list.contains("h6"))
+        .then(pl.col("n_poss") * ppp_sub)
+        .otherwise(pl.col("n_poss") * ppp_starter)
+        .cast(pl.Int64)
+        .alias("pts")
+    )
+
+
+class TestSolveRapmLeague:
+    def test_recovers_a_known_within_lineup_contrast(self):
+        # h5's lineups score 2.0 ppp, h6's 1.0 ppp -> orapm(h5) - orapm(h6)
+        # approaches 100 per 100 possessions as lambda -> 0.
+        s = _balanced_stints(ppp_starter=2.0, ppp_sub=1.0)
+        players, _info = solve_rapm_league(s, ridge_lambda=1e-6)
+        o = dict(zip(players["player_id"].to_list(), players["orapm"].to_list()))
+        assert o["h5"] > o["h6"]
+        assert abs((o["h5"] - o["h6"]) - 100.0) < 1.0
+
+    def test_defense_sign_convention_positive_is_good(self):
+        # Same offense, two defenses: the one allowing fewer points must get
+        # the HIGHER drapm.
+        good_def = _A
+        bad_def = _A[:4] + ["a6"]
+        rows = []
+        for _ in range(200):
+            rows.append(("Duke", "Iowa", "Duke", 1, _H, good_def))
+            rows.append(("Duke", "Iowa", "Duke", 2, _H, bad_def))
+        s = aggregate_stints(_poss(rows))
+        players, _info = solve_rapm_league(s, ridge_lambda=1e-6)
+        d = dict(zip(players["player_id"].to_list(), players["drapm"].to_list()))
+        assert d["a5"] > d["a6"]
+        assert abs((d["a5"] - d["a6"]) - 100.0) < 1.0
+
+    def test_weighting_equivalence_duplicated_stint_equals_doubled_n_poss(self):
+        s1 = _balanced_stints(ppp_starter=1.5, ppp_sub=0.5, n=50)
+        # doubling every stint's weight...
+        s2 = s1.with_columns((pl.col("n_poss") * 2).alias("n_poss"), (pl.col("pts") * 2).alias("pts"))
+        p1, _ = solve_rapm_league(s1, ridge_lambda=100.0)
+        p2, _ = solve_rapm_league(s2, ridge_lambda=200.0)
+        # lambda scales with total weight for exact equivalence
+        j = p1.join(p2, on="player_id", suffix="_2")
+        assert (j["orapm"] - j["orapm_2"]).abs().max() < 1e-6
+
+    def test_larger_lambda_shrinks_coefficients(self):
+        s = _balanced_stints(ppp_starter=2.0, ppp_sub=1.0)
+        loose, _ = solve_rapm_league(s, ridge_lambda=1.0)
+        tight, _ = solve_rapm_league(s, ridge_lambda=1e5)
+        assert tight["orapm"].abs().max() < loose["orapm"].abs().max()
+
+    def test_hca_column_absorbs_a_home_offense_boost(self):
+        # identical matchup, home offense scores more -> hca > 0.
+        rows = []
+        for _ in range(200):
+            rows.append(("Duke", "Iowa", "Duke", 2, _H, _A))
+            rows.append(("Duke", "Iowa", "Iowa", 1, _H, _A))
+        s = aggregate_stints(_poss(rows))
+        _players, info = solve_rapm_league(s, ridge_lambda=1e-6)
+        assert info["hca"] > 0
+
+    def test_info_reports_scale_and_size(self):
+        s = _balanced_stints(ppp_starter=1.0, ppp_sub=1.0, n=10)
+        _players, info = solve_rapm_league(s, ridge_lambda=100.0)
+        assert info["n_poss"] == s["n_poss"].sum()
+        assert info["n_stints"] == s.height
+        assert abs(info["intercept"] - 100.0) < 1e-9  # 1.0 ppp -> 100 per 100
+        assert info["ridge_lambda"] == 100.0
+
+    def test_possession_exposure_columns(self):
+        s = _balanced_stints(n=10)
+        players, _ = solve_rapm_league(s, ridge_lambda=100.0)
+        row = players.filter(pl.col("player_id") == "a1")
+        # a1 defends every possession and never attacks
+        assert row["def_poss"][0] == s["n_poss"].sum()
+        assert row["off_poss"][0] == 0
+
+    def test_empty_stints_return_empty_frame(self):
+        players, info = solve_rapm_league(aggregate_stints(_poss([])), ridge_lambda=100.0)
+        assert players.height == 0
+        assert set(players.columns) == {
+            "player_id",
+            "orapm",
+            "drapm",
+            "rapm_net",
+            "off_poss",
+            "def_poss",
+        }
+        assert info["n_stints"] == 0
+
+    def test_net_is_o_plus_d(self):
+        s = _balanced_stints(ppp_starter=2.0, ppp_sub=1.0, n=50)
+        players, _ = solve_rapm_league(s, ridge_lambda=50.0)
+        assert (players["rapm_net"] - (players["orapm"] + players["drapm"])).abs().max() < 1e-12
+
+    def test_return_as_pandas(self):
+        import pandas as pd
+
+        s = _balanced_stints(n=5)
+        players, _ = solve_rapm_league(s, ridge_lambda=100.0, return_as_pandas=True)
+        assert isinstance(players, pd.DataFrame)

--- a/tests/mbb/test_mbb_ncaa_rapm_league.py
+++ b/tests/mbb/test_mbb_ncaa_rapm_league.py
@@ -19,6 +19,7 @@ from sportsdataverse.mbb.mbb_ncaa_rapm_league import (
     STINT_SCHEMA,
     aggregate_stints,
     solve_rapm_league,
+    team_aggregate,
 )
 
 # Ten id slots in resolve_possessions' output naming: "<slot>_id".
@@ -248,3 +249,74 @@ class TestSolveRapmLeague:
         s = _balanced_stints(n=5)
         players, _ = solve_rapm_league(s, ridge_lambda=100.0, return_as_pandas=True)
         assert isinstance(players, pd.DataFrame)
+
+
+def _players(**net):
+    """players frame with orapm = value, drapm = 0 for each id."""
+    ids = sorted(net)
+    return pl.DataFrame(
+        {
+            "player_id": ids,
+            "orapm": [float(net[p]) for p in ids],
+            "drapm": [0.0] * len(ids),
+            "rapm_net": [float(net[p]) for p in ids],
+            "off_poss": [0] * len(ids),
+            "def_poss": [0] * len(ids),
+        }
+    )
+
+
+class TestTeamAggregate:
+    def test_weighted_mean_of_on_floor_sums(self):
+        # Duke offense: stint A (sum orapm 5.0, 30 poss), stint B (sum 0.0,
+        # 10 poss) -> team_orapm = (5*30 + 0*10) / 40 = 3.75.
+        rows = [("Duke", "Iowa", "Duke", 0, _H, _A)] * 30 + [("Duke", "Iowa", "Duke", 0, _H[:4] + ["h6"], _A)] * 10
+        s = aggregate_stints(_poss(rows))
+        players = _players(h1=1, h2=1, h3=1, h4=1, h5=1, h6=-4)
+        t = team_aggregate(s, players)
+        duke = t.filter(pl.col("team") == "Duke")
+        assert abs(duke["team_orapm"][0] - 3.75) < 1e-12
+
+    def test_defense_side_uses_drapm(self):
+        rows = [("Duke", "Iowa", "Duke", 0, _H, _A)] * 10
+        s = aggregate_stints(_poss(rows))
+        players = _players(h1=0, h2=0, h3=0, h4=0, h5=0)
+        players = pl.concat(
+            [
+                players,
+                pl.DataFrame(
+                    {
+                        "player_id": _A,
+                        "orapm": [0.0] * 5,
+                        "drapm": [2.0] * 5,
+                        "rapm_net": [2.0] * 5,
+                        "off_poss": [0] * 5,
+                        "def_poss": [0] * 5,
+                    }
+                ),
+            ]
+        )
+        t = team_aggregate(s, players)
+        iowa = t.filter(pl.col("team") == "Iowa")
+        assert abs(iowa["team_drapm"][0] - 10.0) < 1e-12
+        assert abs(iowa["team_net"][0] - 10.0) < 1e-12
+
+    def test_player_missing_from_ratings_counts_zero(self):
+        rows = [("Duke", "Iowa", "Duke", 0, _H, _A)] * 5
+        s = aggregate_stints(_poss(rows))
+        players = _players(h1=5)  # h2..h5, a1..a5 absent
+        t = team_aggregate(s, players)
+        duke = t.filter(pl.col("team") == "Duke")
+        assert abs(duke["team_orapm"][0] - 5.0) < 1e-12
+
+    def test_empty_stints_return_documented_schema(self):
+        t = team_aggregate(aggregate_stints(_poss([])), _players())
+        assert t.height == 0
+        assert set(t.columns) == {
+            "team",
+            "team_orapm",
+            "team_drapm",
+            "team_net",
+            "off_poss",
+            "def_poss",
+        }


### PR DESCRIPTION
## What

The league-wide half of the NCAA RAPM program ("Path B"): one joint O/D ridge per (league, season) on a common D-I scale, complementing the published `ncaa_{lg}_rapm_within_team` (a DIFFERENT estimand -- relative-to-teammates).

New module `sportsdataverse/mbb/mbb_ncaa_rapm_league.py` (league-blind, frames-in/frames-out like `mbb_ncaa_rapm_input`; WBB passes its own frames, no twin):

- `aggregate_stints` -- id-resolved possessions -> matchup stints. Possession-weighted stint ridge is exactly the per-possession ridge (same X'WX / X'Wy) at ~1/3 the rows; any-null-slot possessions are dropped, never imputed.
- `solve_rapm_league` -- sparse joint O/D ridge (scipy lsqr, damp=sqrt(lambda)); per-100 scale, positive drapm = good defense, +-1 home-offense column, weighted-centered unpenalized intercept. Raises on non-converged solves (istop outside 0/1/2); reports lsqr diagnostics in info.
- `team_aggregate` -- model-implied team ratings for the external gate; refuses non-Utf8 keys and zero-overlap frames (would otherwise fill_null into all-zero ratings silently).
- `DEFAULT_RIDGE_LAMBDA = 1000` -- game-grouped 5-fold CV on the real 2024 corpora (dev/ncaa_rapm/fit_lambda_league.py): BOTH leagues minimize OOS weighted MSE at 1000 independently.

## Gate evidence (full 17-season runs, both leagues, non_di=drop)

- Torvik AdjEM team-aggregate Spearman: MBB 2011-2026 min 0.9434 / median 0.9653 / max 0.9783 (n=332..356 teams/season); WBB (oracle 2021+) 0.9039 (COVID) then 0.9723-0.9864.
- HCA ~2.4-3.0 per-100 every season EXCEPT ~1.8-2.0 in 2021 -- the model found the empty-arena COVID effect unprompted.
- Face validity, MBB 2024 top-3 by rapm_net (>=1000 poss): Edey (NPOY), Shead (DPOY, top drapm), Sheppard.
- non_di=pool measured: keeps ~4pp more possessions, uniformly slightly worse on the gate -> drop stays default.
- 2010 is degenerate in both leagues (corpus limitation, MBB 4.6% usable) -- excluded from the publish plan; the -data publishers will encode this as a usable-fraction floor.

## Review

`sdv-model-reviewer` pass done; the silent-no-op findings (lsqr partial solve, all-zero team_aggregate) are fixed in this PR with regression tests. The gate-encoding findings land in the -data publishers (floors from the observed values above, never lowered; NaN/absent-oracle = FAIL).

27 offline tests; module + `mbb_ncaa_rapm_input` added to the mypy ratchet (both clean). Codegen regen produced no diff.

## Summary by Sourcery

Add a league-wide NCAA RAPM pipeline that produces common-scale player ratings and validated team aggregates from resolved possession data.

New Features:
- Add a league-wide NCAA RAPM solver that estimates Division-I player offense and defense ratings on a common league-season scale.
- Add possession-to-stint aggregation and model-implied team rating aggregation for external validation.
- Support returning solved player ratings as either Polars or pandas data frames.

Bug Fixes:
- Reject non-converged sparse solves and invalid or zero-overlap rating inputs instead of silently producing partial or all-zero results.
- Drop possessions with unresolved lineup slots rather than imputing missing player identities.

Enhancements:
- Tune and establish a default ridge penalty of 1000 using game-grouped cross-validation for both men's and women's college basketball.
- Expose solver diagnostics, player exposure counts, home-court advantage, and intercept metadata.
- Add the new RAPM module and adapter to the mypy ratchet.

Documentation:
- Document the league-wide NCAA RAPM solver, its distinct estimand, usage, validation results, and shared MBB/WBB design in the changelogs.

Tests:
- Add comprehensive offline coverage for stint aggregation, weighted ridge behavior, coefficient signs and contrasts, solver diagnostics, convergence failures, output formats, and team aggregation validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NCAA league-wide RAPM analysis with possession aggregation, player ratings, team summaries, exposure counts, and model diagnostics.
  * Added support for weighted offense/defense modeling, ridge regularization, home-court effects, and configurable output formats.

* **Quality Improvements**
  * Expanded validation for inputs, outputs, weighting, convergence, and team aggregation scenarios.
  * Improved reliability through broader automated coverage and stricter type checking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->