### PR TITLE
feat(baseball): NCAA reconciliation seam + sport-generic reference parsers

### DIFF
--- a/docs/docs/reference/python-helpers.md
+++ b/docs/docs/reference/python-helpers.md
@@ -267,6 +267,39 @@ wpa = cricket_wpa(cricket_win_probability(state))
 wpa.select("wpa_batting", "wpa_bowling").head()
 ```
 
+### `decompose_college_baseball_plays(rows: "'list[dict]'", *, return_as_pandas: 'bool' = False) -> "'Union[pl.DataFrame, pd.DataFrame]'"` {#decompose_college_baseball_plays}
+
+Decompose pre-extracted play rows into the full `PBP_SCHEMA` frame.
+
+The row-level half of `parse_college_baseball_ncaa_pbp` -- the play-text
+decomposition engine without the HTML extraction. This is the entry point
+for sources that already hold the base play fields, e.g. the legacy R-era
+`baseballr-data` trees (2012-2023: `description`/`inning`/
+`inning_top_bot`/`batting`/`fielding`/`score`), so legacy and
+freshly captured games resolve into IDENTICAL pbp columns.
+
+**Parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `rows` | `list[dict]` |  | One dict per play. Recognized keys (all optional except `description`): `contest_id`, `inning` (int), `inning_top_bot` (`"top"`/`"bot"`), `batting`, `fielding`, `play_number`, `score_away`/`score_home` (ints) or a combined `score` string (`"3-2"`, away-home), and `description`. Unrecognized keys are ignored; `play_number` defaults to the 1-based position in *rows*. |
+| `return_as_pandas` | `bool` | `False` | Return a `pandas.DataFrame` instead of `polars`. |
+
+**Returns**
+
+One row per input play with every text-derivable `PBP_SCHEMA` column populated (`play_type`, hit/out flags, `rbi`, `pitch_sequence`, runner movement, ...). Empty input returns a zero-row frame with the documented schema.
+
+**Example**
+
+```python
+from sportsdataverse.baseball.college_baseball import decompose_college_baseball_plays
+df = decompose_college_baseball_plays(
+    [{"inning": 1, "inning_top_bot": "top", "score": "0-0",
+      "description": "Jack Moss singled to left field (1-2 KBFX)."}]
+)
+print(df.select("play_type", "is_hit", "pitch_sequence").row(0))
+```
+
 ### `get_cache_mode() -> 'str'` {#get_cache_mode}
 
 Return the current cache mode.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -668,6 +668,7 @@ files = [
     "sportsdataverse/scrape/ncaa/__init__.py",
     "sportsdataverse/scrape/ncaa/league_config.py",
     "sportsdataverse/scrape/ncaa/bundle.py",
+    "sportsdataverse/scrape/ncaa/reference.py",
     "sportsdataverse/scrape/ncaa/espn_game_xwalk.py",
     "sportsdataverse/scrape/ncaa/rosters.py",
     "sportsdataverse/scrape/ncaa/discover.py",

--- a/sportsdataverse/baseball/college_baseball/college_baseball_ncaa_pbp.py
+++ b/sportsdataverse/baseball/college_baseball/college_baseball_ncaa_pbp.py
@@ -45,7 +45,10 @@ __all__ = [
 # NCAA batter/runner name. Baseball writes "Last, First" (Brooks, M.); softball
 # writes last-name only (Hasapis). The ", First" part is therefore OPTIONAL so one
 # parser handles both -- verified e2e against a real WSB game (contest 6548848).
-_NAME = r"[A-Z][A-Za-z'.\-]+(?:,\s*[A-Z][A-Za-z'.\-]*\.?)?"
+# Three era/site spellings: modern "Last, F." (Canci, A.), legacy R-era
+# "First Last" (Andres Canci -- multi-word, verbs are lowercase so additional
+# capitalized words are safely part of the name), softball bare "Last".
+_NAME = r"[A-Z][A-Za-z'.\-]+(?:\s+[A-Z][A-Za-z'.\-]+)*(?:,\s*[A-Z][A-Za-z'.\-]*\.?)?"
 
 # Clause separator inside a description (literal "3a", always followed by a
 # capital-led clause). Python re -> lookahead is fine here (not a polars expr).
@@ -65,8 +68,8 @@ _SCORED_RE = re.compile(rf"^({_NAME})\s+scored")
 _ADVANCED_RE = re.compile(rf"^({_NAME})\s+advanced to (\w+)")
 _OUT_RE = re.compile(r"\bout (?:at|on)\b")
 _POS_CODES = r"(?:p|1b|2b|3b|ss|lf|cf|rf|c|dh|ph|pr|dp|flex)"
-# A single "Last" or "Last, F" name (no intervening spaces/verbs).
-_SUB_NAME = r"[A-Z][A-Za-z'.\-]+(?:,\s*[A-Z][A-Za-z'.\-]*\.?)?"
+# A "Last", "Last, F", or legacy "First Last" name (no intervening verbs).
+_SUB_NAME = r"[A-Z][A-Za-z'.\-]+(?:\s+[A-Z][A-Za-z'.\-]+)*(?:,\s*[A-Z][A-Za-z'.\-]*\.?)?"
 # A substitution clause = "<player> to <pos>" (optionally "for <player>") and the
 # WHOLE clause is just that. The player name sits DIRECTLY before "to <pos>" -- no
 # action verb between -- which separates it both from a batted ball ("singled to

--- a/sportsdataverse/baseball/college_baseball/college_baseball_ncaa_pbp.py
+++ b/sportsdataverse/baseball/college_baseball/college_baseball_ncaa_pbp.py
@@ -35,7 +35,11 @@ from bs4 import BeautifulSoup
 if TYPE_CHECKING:
     import pandas as pd
 
-__all__ = ["PBP_SCHEMA", "parse_college_baseball_ncaa_pbp"]
+__all__ = [
+    "PBP_SCHEMA",
+    "decompose_college_baseball_plays",
+    "parse_college_baseball_ncaa_pbp",
+]
 
 # NCAA "Last, F" / "Last, First" incl. hyphens and apostrophes ("S-Johnson, C").
 # NCAA batter/runner name. Baseball writes "Last, First" (Brooks, M.); softball
@@ -265,6 +269,76 @@ PBP_SCHEMA: "dict[str, pl.DataType]" = {
 }
 
 
+def decompose_college_baseball_plays(
+    rows: "list[dict]",
+    *,
+    return_as_pandas: bool = False,
+) -> "Union[pl.DataFrame, pd.DataFrame]":
+    """Decompose pre-extracted play rows into the full :data:`PBP_SCHEMA` frame.
+
+    The row-level half of :func:`parse_college_baseball_ncaa_pbp` -- the play-text
+    decomposition engine without the HTML extraction. This is the entry point
+    for sources that already hold the base play fields, e.g. the legacy R-era
+    ``baseballr-data`` trees (2012-2023: ``description``/``inning``/
+    ``inning_top_bot``/``batting``/``fielding``/``score``), so legacy and
+    freshly captured games resolve into IDENTICAL pbp columns.
+
+    Args:
+        rows: One dict per play. Recognized keys (all optional except
+            ``description``): ``contest_id``, ``inning`` (int),
+            ``inning_top_bot`` (``"top"``/``"bot"``), ``batting``, ``fielding``,
+            ``play_number``, ``score_away``/``score_home`` (ints) or a combined
+            ``score`` string (``"3-2"``, away-home), and ``description``.
+            Unrecognized keys are ignored; ``play_number`` defaults to the
+            1-based position in *rows*.
+        return_as_pandas: Return a ``pandas.DataFrame`` instead of ``polars``.
+
+    Returns:
+        One row per input play with every text-derivable :data:`PBP_SCHEMA`
+        column populated (``play_type``, hit/out flags, ``rbi``,
+        ``pitch_sequence``, runner movement, ...). Empty input returns a
+        zero-row frame with the documented schema.
+
+    Example:
+        Quick start::
+
+            from sportsdataverse.baseball.college_baseball import decompose_college_baseball_plays
+            df = decompose_college_baseball_plays(
+                [{"inning": 1, "inning_top_bot": "top", "score": "0-0",
+                  "description": "Jack Moss singled to left field (1-2 KBFX)."}]
+            )
+            print(df.select("play_type", "is_hit", "pitch_sequence").row(0))
+
+        See Also:
+            * `baseballr`_ -- NCAA baseball via R (table-scrape pbp)
+
+        .. _baseballr: https://billpetti.github.io/baseballr/
+    """
+    out: "list[dict]" = []
+    for i, r in enumerate(rows, start=1):
+        sa, sh = r.get("score_away"), r.get("score_home")
+        if sa is None and sh is None:
+            sm = re.match(r"^\s*(\d+)\s*-\s*(\d+)\s*$", str(r.get("score") or ""))
+            if sm:
+                sa, sh = int(sm.group(1)), int(sm.group(2))
+        desc = r.get("description") or ""
+        row = {
+            "contest_id": str(r["contest_id"]) if r.get("contest_id") is not None else None,
+            "inning": int(r["inning"]) if r.get("inning") is not None else None,
+            "inning_top_bot": r.get("inning_top_bot"),
+            "batting": r.get("batting"),
+            "fielding": r.get("fielding"),
+            "play_number": int(r.get("play_number") or i),
+            "score_away": sa,
+            "score_home": sh,
+            "description": desc,
+        }
+        row.update(_decompose(desc))
+        out.append(row)
+    df = pl.DataFrame(out, schema=PBP_SCHEMA) if out else pl.DataFrame(schema=PBP_SCHEMA)
+    return df.to_pandas() if return_as_pandas else df
+
+
 def parse_college_baseball_ncaa_pbp(
     html: str,
     contest_id: "str | int | None" = None,
@@ -328,23 +402,19 @@ def parse_college_baseball_ncaa_pbp(
             else:
                 continue
             play_number += 1
-            sa, sh = None, None
-            sm = re.match(r"^\s*(\d+)\s*-\s*(\d+)\s*$", score or "")
-            if sm:
-                sa, sh = int(sm.group(1)), int(sm.group(2))
-            row = {
-                "contest_id": cid,
-                "inning": inning_idx,
-                "inning_top_bot": half,
-                "batting": batting,
-                "fielding": fielding,
-                "play_number": play_number,
-                "score_away": sa,
-                "score_home": sh,
-                "description": desc,
-            }
-            row.update(_decompose(desc))
-            rows.append(row)
+            rows.append(
+                {
+                    "contest_id": cid,
+                    "inning": inning_idx,
+                    "inning_top_bot": half,
+                    "batting": batting,
+                    "fielding": fielding,
+                    "play_number": play_number,
+                    "score": score,
+                    "description": desc,
+                }
+            )
 
-    df = pl.DataFrame(rows, schema=PBP_SCHEMA) if rows else pl.DataFrame(schema=PBP_SCHEMA)
-    return df.to_pandas() if return_as_pandas else df
+    # extraction above, decomposition below -- one engine for HTML captures and
+    # pre-extracted rows (the legacy R-era trees) alike
+    return decompose_college_baseball_plays(rows, return_as_pandas=return_as_pandas)

--- a/sportsdataverse/scrape/ncaa/reference.py
+++ b/sportsdataverse/scrape/ncaa/reference.py
@@ -1,0 +1,276 @@
+"""Sport-generic stats.ncaa.org reference-page parsers (team list / team
+schedule / roster).
+
+These pages share one platform layout across sports (verified on football
+``MFB`` and baseball ``MBA`` captures), so the parsers are sport-neutral:
+graduated from ``ncaa-mfb-football-raw``'s stage-05 builders and validated
+against real baseball fixtures (``tests/fixtures/ncaa_reference/``). The
+producer repos feed them the persisted HTML their capture stages write.
+
+* :func:`parse_ncaa_team_list` -- ``team/inst_team_list`` page -> one row per team.
+* :func:`parse_ncaa_team_schedule` -- a team page's schedule table -> one row per
+  game. Baseball doubleheaders print the date as ``MM/DD/YYYY(N)``; the raw
+  ``date`` is preserved and ``game_number`` carries the ``(N)`` (null when absent).
+* :func:`parse_ncaa_team_roster` -- a team roster page -> one row per player,
+  header-keyed (teams vary in which columns they publish).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Optional, Union
+
+import polars as pl
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+__all__ = [
+    "TEAM_LIST_SCHEMA",
+    "TEAM_ROSTER_SCHEMA",
+    "TEAM_SCHEDULE_SCHEMA",
+    "parse_ncaa_team_list",
+    "parse_ncaa_team_roster",
+    "parse_ncaa_team_schedule",
+]
+
+_RESULT_RE = re.compile(r"^([WLT])\s+(\d+)-(\d+)")
+_TEAM_HREF_RE = re.compile(r"/teams/(\d+)")
+_CONTEST_HREF_RE = re.compile(r"/contests/(\d+)/")
+_PLAYER_HREF_RE = re.compile(r"/players/(\d+)")
+_GAME_NUM_RE = re.compile(r"\((\d+)\)\s*$")
+
+TEAM_LIST_SCHEMA: "dict[str, pl.DataType]" = {
+    "team_id": pl.Utf8,
+    "team_name": pl.Utf8,
+}
+
+TEAM_SCHEDULE_SCHEMA: "dict[str, pl.DataType]" = {
+    "team_id": pl.Utf8,
+    "team_name": pl.Utf8,
+    "date": pl.Utf8,
+    "game_number": pl.Int64,
+    "opponent_id": pl.Utf8,
+    "opponent": pl.Utf8,
+    "result": pl.Utf8,
+    "outcome": pl.Utf8,
+    "team_score": pl.Int64,
+    "opponent_score": pl.Int64,
+    "contest_id": pl.Utf8,
+    "attendance": pl.Int64,
+}
+
+TEAM_ROSTER_SCHEMA: "dict[str, pl.DataType]" = {
+    "team_id": pl.Utf8,
+    "team_name": pl.Utf8,
+    "player_id": pl.Utf8,
+    "player_name": pl.Utf8,
+    "jersey": pl.Utf8,
+    "statcrew_jersey": pl.Utf8,
+    "player_class": pl.Utf8,
+    "position": pl.Utf8,
+    "height": pl.Utf8,
+    "weight": pl.Int64,
+    "hometown": pl.Utf8,
+    "high_school": pl.Utf8,
+    "games_played": pl.Int64,
+    "games_started": pl.Int64,
+}
+
+_ROSTER_COLMAP = {
+    "GP": "games_played",
+    "GS": "games_started",
+    "#": "jersey",
+    "StatCrew #": "statcrew_jersey",
+    "Name": "player_name",
+    "Class": "player_class",
+    "Position": "position",
+    "Height": "height",
+    "Weight": "weight",
+    "Hometown": "hometown",
+    "High School": "high_school",
+}
+
+
+def _finish(
+    rows: "list[dict]", schema: "dict[str, pl.DataType]", return_as_pandas: bool
+) -> "Union[pl.DataFrame, pd.DataFrame]":
+    df = pl.DataFrame(rows, schema=schema) if rows else pl.DataFrame(schema=schema)
+    return df.to_pandas() if return_as_pandas else df
+
+
+def parse_ncaa_team_list(html: str, *, return_as_pandas: bool = False) -> "Union[pl.DataFrame, pd.DataFrame]":
+    """Parse a ``team/inst_team_list`` page -> one row per team.
+
+    Args:
+        html: Raw HTML of the team-list page (any sport_code / division).
+        return_as_pandas: Return a ``pandas.DataFrame`` instead of ``polars``.
+
+    Returns:
+        ``team_id`` (Utf8) + ``team_name``, order preserved, de-duplicated.
+        Empty/unparseable input returns a zero-row frame with the schema.
+
+    Example:
+        Quick start::
+
+            from sportsdataverse.scrape.ncaa.reference import parse_ncaa_team_list
+            teams = parse_ncaa_team_list(open("inst_team_list.html").read())
+            print(teams.height)
+
+        See Also:
+            * `baseballr`_ -- NCAA baseball via R
+
+        .. _baseballr: https://billpetti.github.io/baseballr/
+    """
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(html or "", "html.parser")
+    rows: "list[dict]" = []
+    seen: "set[str]" = set()
+    for a in soup.select('a[href*="/teams/"]'):
+        m = _TEAM_HREF_RE.search(a.get("href") or "")
+        name = a.get_text(" ", strip=True)
+        if m and name and m.group(1) not in seen:
+            seen.add(m.group(1))
+            rows.append({"team_id": m.group(1), "team_name": name})
+    return _finish(rows, TEAM_LIST_SCHEMA, return_as_pandas)
+
+
+def parse_ncaa_team_schedule(
+    html: str,
+    team_id: "Optional[str]" = None,
+    *,
+    return_as_pandas: bool = False,
+) -> "Union[pl.DataFrame, pd.DataFrame]":
+    """Parse a team page's schedule table -> one row per game.
+
+    Args:
+        html: Raw HTML of the ``/teams/{id}`` page.
+        team_id: Stamped on every row (the page doesn't repeat its own id).
+        return_as_pandas: Return a ``pandas.DataFrame`` instead of ``polars``.
+
+    Returns:
+        One row per scheduled game: ``date`` exactly as printed (baseball
+        doubleheaders keep their ``(1)``/``(2)`` suffix, lifted into
+        ``game_number``), ``opponent_id``/``opponent``, the raw ``result``
+        (e.g. ``"W 11-1"``), ``outcome`` (W/L/T), scores, ``contest_id``,
+        ``attendance``. Unplayed/cancelled games keep null scores.
+
+    Example:
+        Quick start::
+
+            from sportsdataverse.scrape.ncaa.reference import parse_ncaa_team_schedule
+            games = parse_ncaa_team_schedule(open("team_page.html").read(), team_id="614839")
+            print(games.select("date", "opponent", "result").head())
+
+        See Also:
+            * `baseballr`_ -- NCAA baseball via R
+
+        .. _baseballr: https://billpetti.github.io/baseballr/
+    """
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(html or "", "html.parser")
+    header = soup.select_one("div.card-header")
+    team_name = None
+    if header:
+        team_name = re.sub(r"\s*\([\d\-]+\)\s*$", "", header.get_text(" ", strip=True)) or None
+    table = soup.find("table")
+    rows: "list[dict]" = []
+    if table is not None:
+        for tr in table.find_all("tr")[1:]:
+            cells = tr.find_all(["th", "td"])
+            if len(cells) < 3 or not cells[0].get_text(strip=True):
+                continue
+            opp_a = cells[1].find("a")
+            res_a = cells[2].find("a")
+            opp_m = _TEAM_HREF_RE.search(opp_a.get("href") or "") if opp_a else None
+            con_m = _CONTEST_HREF_RE.search(res_a.get("href") or "") if res_a else None
+            result = cells[2].get_text(" ", strip=True) or None
+            rm = _RESULT_RE.match(result or "")
+            date = cells[0].get_text(" ", strip=True)
+            gm = _GAME_NUM_RE.search(date)
+            att = (cells[3].get_text(strip=True) if len(cells) > 3 else "").replace(",", "")
+            rows.append(
+                {
+                    "team_id": team_id,
+                    "team_name": team_name,
+                    "date": date,
+                    "game_number": int(gm.group(1)) if gm else None,
+                    "opponent_id": opp_m.group(1) if opp_m else None,
+                    "opponent": cells[1].get_text(" ", strip=True) or None,
+                    "result": result,
+                    "outcome": rm.group(1) if rm else None,
+                    "team_score": int(rm.group(2)) if rm else None,
+                    "opponent_score": int(rm.group(3)) if rm else None,
+                    "contest_id": con_m.group(1) if con_m else None,
+                    "attendance": int(att) if att.isdigit() else None,
+                }
+            )
+    return _finish(rows, TEAM_SCHEDULE_SCHEMA, return_as_pandas)
+
+
+def parse_ncaa_team_roster(
+    html: str,
+    team_id: "Optional[str]" = None,
+    *,
+    return_as_pandas: bool = False,
+) -> "Union[pl.DataFrame, pd.DataFrame]":
+    """Parse a team roster page -> one row per player.
+
+    Header-keyed (teams vary in which columns they publish); ``player_id``
+    comes from the ``/players/{id}`` link and ``team_name`` from the card
+    header.
+
+    Args:
+        html: Raw HTML of the ``/teams/{id}/roster`` page.
+        team_id: Stamped on every row.
+        return_as_pandas: Return a ``pandas.DataFrame`` instead of ``polars``.
+
+    Returns:
+        One row per player with the documented schema; columns a team doesn't
+        publish are null. Empty input returns a zero-row frame with the schema.
+
+    Example:
+        Quick start::
+
+            from sportsdataverse.scrape.ncaa.reference import parse_ncaa_team_roster
+            roster = parse_ncaa_team_roster(open("roster.html").read(), team_id="614839")
+            print(roster.select("player_name", "position", "player_class").head())
+
+        See Also:
+            * `baseballr`_ -- NCAA baseball via R
+
+        .. _baseballr: https://billpetti.github.io/baseballr/
+    """
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(html or "", "html.parser")
+    header = soup.select_one("div.card-header")
+    team_name = None
+    if header:
+        team_name = re.sub(r"\s*\([\d\-]+\).*$", "", header.get_text(" ", strip=True)) or None
+    table = soup.find("table", id=re.compile(r"^rosters_form_players_.*_data_table$"))
+    rows: "list[dict]" = []
+    if table is not None:
+        trs = table.find_all("tr")
+        if trs:
+            head = [c.get_text(" ", strip=True) for c in trs[0].find_all(["th", "td"])]
+            for tr in trs[1:]:
+                cells = tr.find_all(["th", "td"])
+                if len(cells) != len(head):
+                    continue
+                rec: dict = {"team_id": team_id, "team_name": team_name}
+                for h, c in zip(head, cells):
+                    key = _ROSTER_COLMAP.get(h)
+                    if key:
+                        rec[key] = c.get_text(" ", strip=True) or None
+                a = tr.find("a", href=_PLAYER_HREF_RE)
+                pm = _PLAYER_HREF_RE.search(a["href"]) if a else None
+                rec["player_id"] = pm.group(1) if pm else None
+                for k in ("weight", "games_played", "games_started"):
+                    v = rec.get(k)
+                    rec[k] = int(v) if isinstance(v, str) and v.isdigit() else None
+                if rec.get("player_name"):
+                    rows.append(rec)
+    return _finish(rows, TEAM_ROSTER_SCHEMA, return_as_pandas)

--- a/sportsdataverse/scrape/ncaa/reference.py
+++ b/sportsdataverse/scrape/ncaa/reference.py
@@ -174,7 +174,11 @@ def parse_ncaa_team_schedule(
     header = soup.select_one("div.card-header")
     team_name = None
     if header:
-        team_name = re.sub(r"\s*\([\d\-]+\)\s*$", "", header.get_text(" ", strip=True)) or None
+        # strip from the W-L record on -- the header can continue past it
+        # ("A&M-Corpus Christi (23-28) RPI Ranking - 202"), so an end-anchored
+        # sub keeps the junk. Names with letter parentheticals (St. Thomas (MN))
+        # survive because the record marker requires digits.
+        team_name = re.sub(r"\s*\([\d\-]+\).*$", "", header.get_text(" ", strip=True)) or None
     table = soup.find("table")
     rows: "list[dict]" = []
     if table is not None:

--- a/tests/baseball/test_college_baseball_ncaa_pbp.py
+++ b/tests/baseball/test_college_baseball_ncaa_pbp.py
@@ -121,3 +121,47 @@ def test_return_as_pandas() -> None:
     df = parse_college_baseball_ncaa_pbp(GAMES[0].read_text(encoding="utf-8"), return_as_pandas=True)
     assert isinstance(df, pd.DataFrame)
     assert list(df.columns) == list(PBP_SCHEMA.keys())
+
+
+# --- decompose_college_baseball_plays (row-level entry point) --------------
+
+
+def test_decompose_rows_matches_html_parse() -> None:
+    """Legacy-shaped rows (combined ``score`` string) resolve into the same
+    columns/values the HTML path produces -- the reconciliation contract for
+    the R-era baseballr-data trees."""
+    from sportsdataverse.baseball.college_baseball import decompose_college_baseball_plays
+
+    rows = [
+        {
+            "inning": 1,
+            "inning_top_bot": "top",
+            "batting": "Texas A&M",
+            "fielding": "Florida",
+            "score": "0-0",
+            "description": "Moss, J. singled to left field (1-2 KBFX).",
+        },
+        {
+            "inning": 9,
+            "inning_top_bot": "bot",
+            "score": "3-2",
+            "description": "Langford struck out swinging (2-2 FBKS).",
+        },
+    ]
+    df = decompose_college_baseball_plays(rows)
+    assert df.columns == list(PBP_SCHEMA.keys())
+    assert df.get_column("play_number").to_list() == [1, 2]
+    r0 = df.row(0, named=True)
+    assert r0["play_type"] == "single" and r0["is_hit"] is True
+    assert (r0["score_away"], r0["score_home"]) == (0, 0)
+    assert r0["pitch_sequence"] == "KBFX"
+    r1 = df.row(1, named=True)
+    assert r1["play_type"] == "strikeout" and r1["strikeout_type"] == "swinging"
+    assert (r1["score_away"], r1["score_home"]) == (3, 2)
+
+
+def test_decompose_empty_is_zero_row_with_schema() -> None:
+    from sportsdataverse.baseball.college_baseball import decompose_college_baseball_plays
+
+    df = decompose_college_baseball_plays([])
+    assert df.height == 0 and df.columns == list(PBP_SCHEMA.keys())

--- a/tests/fixtures/ncaa_reference/README.md
+++ b/tests/fixtures/ncaa_reference/README.md
@@ -1,0 +1,11 @@
+# ncaa_reference fixtures
+
+Real stats.ncaa.org reference pages for the sport-generic parsers in
+`sportsdataverse/scrape/ncaa/reference.py`. Captured 2026-08-26 via the
+patchright browser transport (Decodo US residential).
+
+| file | page | why this capture | source |
+| --- | --- | --- | --- |
+| `mba_team_list_2026_d1.html` | `team/inst_team_list?academic_year=2026&division=1&sport_code=MBA` | 308 D-I baseball teams; proves the parser is sport-generic (graduated from MFB) | stats.ncaa.org |
+| `mba_team_page_614839.html` | `/teams/614839` (A&M-Corpus Christi 2026) | 51-game schedule incl. doubleheaders (`02/14/2026(1)`/`(2)` -> game_number) | stats.ncaa.org |
+| `mba_roster_614839.html` | `/teams/614839/roster` | 40-player roster, header-keyed columns | stats.ncaa.org |

--- a/tests/fixtures/ncaa_reference/mba_roster_614839.html
+++ b/tests/fixtures/ncaa_reference/mba_roster_614839.html
@@ -1,0 +1,1197 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<META HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=UTF-8">
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="">
+<meta name="author" content="">
+<meta name="version" content="321d28433e9f7a188596117e6f342ec4a84fb4ed">
+<META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<link rel="shortcut icon" href="/assets/favicon-405088046a5f2bab8eedeacfae7636975c095e9c8decd8c28e3fd0e65c2f51c4.ico" type="image/vnd.microsoft.icon">
+
+<title>NCAA Statistics</title>
+
+<!-- Bootstrap core CSS -->
+
+<!--
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+-->
+<!--
+<link rel="stylesheet" href="https://cdn.datatables.net/2.0.0/css/dataTables.bootstrap4.css" crossorigin="anonymous">
+-->
+<link rel="stylesheet" media="all" href="/assets/application-789c3971842ee3597428ccbebd021716b3231e9cbd0a00a184c3b2d6c8e5f152.css" />
+
+
+<script src="/assets/application-9232576bb3cb000ac0841ff2af81251908ec17312a3c5eb72bf1a32f9754800c.js"></script>
+<!--
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+-->
+<!--
+<script src="https://cdn.datatables.net/2.0.0/js/dataTables.bootstrap4.js" crossorigin="anonymous"></script>
+-->
+
+<meta name="csrf-param" content="authenticity_token" />
+<meta name="csrf-token" content="s9z7p/RTJyScHIdGZUyl9ASC5TL8jJW6rhBQNeYz7nRSUnlpu0fxbh2ZTfDOZUV5vkfv/PzvSGW4Rz35NPrrJQ==" />
+
+<style>
+.grid {clear: all}
+.grid-item, .name {text-align: center;}
+h1 img {max-height: 33px;}
+
+</style>
+<!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+<!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+      <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+    <![endif]-->
+
+
+<script>(window.BOOMR_mq=window.BOOMR_mq||[]).push(["addVar",{"rua.upush":"false","rua.cpush":"false","rua.upre":"false","rua.cpre":"false","rua.uprl":"false","rua.cprl":"false","rua.cprf":"false","rua.trans":"","rua.cook":"false","rua.ims":"false","rua.ufprl":"false","rua.cfprl":"false","rua.isuxp":"false","rua.texp":"norulematch","rua.ceh":"false","rua.ueh":"false","rua.ieh.st":"0"}]);</script>
+                                <script>!function(e){var n="https://s.go-mpulse.net/boomerang/";if("False"=="True")e.BOOMR_config=e.BOOMR_config||{},e.BOOMR_config.PageParams=e.BOOMR_config.PageParams||{},e.BOOMR_config.PageParams.pci=!0,n="https://s2.go-mpulse.net/boomerang/";if(window.BOOMR_API_key="EVKJV-AGD2E-W66AE-NT84S-K5LTF",function(){function e(){if(!r){var e=document.createElement("script");e.id="boomr-scr-as",e.src=window.BOOMR.url,e.async=!0,o.appendChild(e),r=!0}}function t(e){r=!0;var n,t,a,i,d=document,O=window;if(window.BOOMR.snippetMethod=e?"if":"i",t=function(e,n){var t=d.createElement("script");t.id=n||"boomr-if-as",t.src=window.BOOMR.url,BOOMR_lstart=(new Date).getTime(),e=e||d.body,e.appendChild(t)},!window.addEventListener&&window.attachEvent&&navigator.userAgent.match(/MSIE [67]\./))return window.BOOMR.snippetMethod="s",void t(o,"boomr-async");a=document.createElement("IFRAME"),a.src="about:blank",a.title="",a.role="presentation",a.loading="eager",i=(a.frameElement||a).style,i.width=0,i.height=0,i.border=0,i.display="none",o.appendChild(a);try{O=a.contentWindow,d=O.document.open()}catch(_){n=document.domain,a.src="javascript:var d=document.open();d.domain='"+n+"';void 0;",O=a.contentWindow,d=O.document.open()}if(n)d._boomrl=function(){this.domain=n,t()},d.write("<bo"+"dy onload='document._boomrl();'>");else if(O._boomrl=function(){t()},O.addEventListener)O.addEventListener("load",O._boomrl,!1);else if(O.attachEvent)O.attachEvent("onload",O._boomrl);d.close()}function a(e){window.BOOMR_onload=e&&e.timeStamp||(new Date).getTime()}if(!window.BOOMR||!window.BOOMR.version&&!window.BOOMR.snippetExecuted){window.BOOMR=window.BOOMR||{},window.BOOMR.snippetStart=(new Date).getTime(),window.BOOMR.snippetExecuted=!0,window.BOOMR.snippetVersion=14,window.BOOMR.url=n+"EVKJV-AGD2E-W66AE-NT84S-K5LTF";var i=document.currentScript||document.getElementsByTagName("script")[0],o=i.parentNode,r=!1,d=document.createElement("link");if(d.relList&&"function"==typeof d.relList.supports&&d.relList.supports("preload")&&"as"in d)window.BOOMR.snippetMethod="p",d.href=window.BOOMR.url,d.rel="preload",d.as="script",d.addEventListener("load",e),d.addEventListener("error",function(){t(!0)}),setTimeout(function(){if(!r)t(!0)},3e3),BOOMR_lstart=(new Date).getTime(),o.appendChild(d);else t(!1);if(window.addEventListener)window.addEventListener("load",a,!1);else if(window.attachEvent)window.attachEvent("onload",a)}}(),"".length>0)if(e&&"performance"in e&&e.performance&&"function"==typeof e.performance.setResourceTimingBufferSize)e.performance.setResourceTimingBufferSize();!function(){if(BOOMR=e.BOOMR||{},BOOMR.plugins=BOOMR.plugins||{},!BOOMR.plugins.AK){var n=""=="true"?1:0,t="cookiepresent",a="iwgbcjaxgslzw2upi6kq-f-9125d7f63-clientnsv4-s.akamaihd.net",i="false"=="true"?2:1,o={"ak.v":"41","ak.cp":"1168236","ak.ai":parseInt("215853",10),"ak.ol":"0","ak.cr":33,"ak.ipv":4,"ak.proto":"h2","ak.rid":"178c15c6","ak.r":51194,"ak.a2":n,"ak.m":"a","ak.n":"essl","ak.cport":56726,"ak.gh":"23.206.120.12","ak.quicv":"","ak.tlsv":"tls1.3","ak.0rtt":"","ak.0rtt.ed":"","ak.csrc":"-","ak.acc":"","ak.t":"1787774869","ak.ak":"hOBiQwZUYzCg5VSAfCLimQ==BJ0ju0hdaqgzsDdl0Ubluqqu5/ku7T1aztNEObJmf3fCH6vQhFxtBkYUMFat1anLX1eq8hvgBKrN3VG9XMNfd+74OMLrnP7SnN6c8lBnYJkf5Yzkryb9rnI60EptfWIaD+x+jEHSDbEnU2E2ZA7WC1OR9DeClVM6TX9BT+FZELJ/U1EWeiBxXR8SXIC/RiAGO80yd5M/3K+sWCN+A09rd2OjsYgE0yH6/aZTt4nY1phX+GhvpveVfml7mMOuskl0uIrOHAmmfW0TrBZ5/g8Ag1aFl21oLjFymWFjeDqHxQa2gHBrPMMYIPKZj31xQOFHdOs23gl19I/Cn2jD7m82UrNCguWYd3dFRHoFUHHB1Vu2ryWenV4d6c35wVH8+d2R0lHiIJIa6gZK2srXraoUw2OTIgqb/J5FUpFcmQHMHX0=","ak.pv":"93","ak.dpoabenc":"","ak.tf":i};if(""!==t)o["ak.ruds"]=t;var r={i:!1,av:function(n){var t="http.initiator";if(n&&(!n[t]||"spa_hard"===n[t]))o["ak.feo"]=void 0!==e.aFeoApplied?1:0,BOOMR.addVar(o)},rv:function(){var e=["ak.cport","ak.cr","ak.csrc","ak.gh","ak.ipv","ak.m","ak.n","ak.ol","ak.proto","ak.quicv","ak.tlsv","ak.0rtt","ak.0rtt.ed","ak.r","ak.acc","ak.t","ak.tf"];BOOMR.removeVar(e)}};BOOMR.plugins.AK={akVars:o,akDNSPreFetchDomain:a,init:function(){if(!r.i){var e=BOOMR.subscribe;e("before_beacon",r.av,null,null),e("onbeacon",r.rv,null,null),r.i=!0}return this},is_complete:function(){return!0}}}}()}(window);</script></head>
+
+  <script>
+
+    
+  //initialize tooltip
+  $(document).ready(function() {
+    //$("body").tooltip({ selector: '[data-toggle=tooltip]' });
+    $('[data-toggle="tooltip"]').tooltip();
+  });
+
+  $(document).ready(function() {
+    $( "#org_name" ).autocomplete({
+      source: '/team/search',
+      select: function( event, ui ) {
+        $("#org_id").val(ui.item.vid);
+        $("#id").val(ui.item.vid);
+        $('#sport_btn').click();
+      }
+    });
+  });
+
+  var body = 'body';
+
+  $.ajaxSetup ({
+    // Disable caching of AJAX responses
+    cache: false
+  });
+
+  function changeSport(field){
+    var el = $(field);
+    var tmList = el.parent().next().find('.new-team-year')[0];
+    if (tmList == null){
+      tmList = el.nextAll('.new-team-year')[0];
+    }
+    $.ajax({
+      url: "/game_sport_year_ctls/"+el.val()+"/available_teams",
+      dataType: "script",
+      success: function(data, status){
+        $(tmList).empty();
+        $(tmList).append(("<option value=''>Select team</option>"));
+        $.each(JSON.parse(data), function(k, v){
+          $(tmList).append($("<option></option>")
+              .attr("value", v["id"])
+              .text(v["member_org"]["name_tabular"]));
+        });
+        $(tmList).trigger("chosen:updated");
+      }
+    });
+  }
+
+    function set_process_styles(fld, start_color, end_color){
+       $('#'+fld).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    var downImage = "/assets/down12.gif";
+    var rightImage = "/assets/right12.gif";
+
+    function highlight(div_id){
+      $(div_id).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    function show_hide_rows(attr_val, link_id){
+      $('#'+attr_val).toggle();
+      if ($('#'+attr_val).is(':visible')) {
+        $('#'+link_id).attr('src', downImage);
+      }else{
+        $('#'+link_id).attr('src', rightImage);
+      }
+    }
+
+    function mask(label){
+      $('body').mask(label);
+    }
+    function unmask(){
+      $('body').unmask();
+    }
+
+    var winHeight = "auto";
+    var winWidth = "auto";
+    var maxHeight = 700;
+    var maxWidth = 1400;
+    var minHeight = 100;
+    var minWidth = 200;
+    
+    var modalOptions = {"width": winWidth,
+                        "height": winHeight,
+                        "maxHeight": maxHeight,
+                        "maxWidth": maxWidth,
+                        "minHeight": minHeight,
+                        "minWidth": minWidth};
+
+    function dialog(url, title){
+
+      $("#stats_app_dialog").dialog({modal:true, minWidth:minWidth, minHeight:minHeight, maxWidth:maxWidth, maxHeight:maxHeight, width:winWidth, height:winHeight, title:title, closeOnEscape: false});
+    
+      modalOptions.title = title;
+    
+      $("#stats_app_dialog").dialog("option", modalOptions);
+    
+      $("#stats_app_dialog").html("Loading...");
+      $("#stats_app_dialog").load(url).dialog('open');
+    }
+
+    function addDatePicker(){
+    $('.adddatepicker').each(function(i, obj){
+      $(obj).datepicker({ 
+        showOn: 'both', 
+        buttonImage: '/assets/calendar.gif', 
+        buttonImageOnly: true,
+      });
+    });
+    }
+
+   $(document).ready(function() {
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   });
+
+   function setClassInputFields(){
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   }
+
+   function isValidDateFormat(dateStr){
+     const regex = /^([1-9]|0[1-9]|1[0-2])\/([1-9]|0[1-9]|[12][0-9]|3[01])\/(19|20)\d{2}$/;
+     if (!regex.test(dateStr)) {
+       return false;
+     }else{
+       return true;
+     }
+   }
+
+  </script>
+
+
+<body style="font-size: .75rem;" onload="if (top != self) { top.location=self.location; }" >
+
+      <header>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0">
+        <a class="navbar-brand mr-0 mr-md-2" href="/" aria-label="statistics">
+                          <img alt="NCAA" style="margin-left: 24px; margin-right: 0; margin-top: 6px;" src="/assets/ncaa-fbc4d0406ae731b47babcc3fca53775b5955ef372bf8b8e998ca9a513e468b8f.svg" />
+                          <span class="title" class="dark-blue-font">Statistics</span>
+        </a>
+       </nav>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0" style="background-color: var(--color-dark-blue) !important;">
+  <button class="navbar-toggler bg-white" type="button" data-toggle="collapse" data-target="#navbarTogglerDemo01" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarTogglerDemo01">
+        <ul class="navbar-nav mr-auto mt-2 mt-lg-0 justify-content-center">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle skipMask" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Rankings
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+          <a class="dropdown-item" href="/rankings">National Rankings</a>
+          <a class="dropdown-item" href="/active_career_leaders">Active Career Leaders</a>
+        </div>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/contests/livestream_scoreboards">Scoreboard</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/selection_rankings/nitty_gritties">Selection Rankings</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/head_coaches">Head Coaches</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/search/players">Players</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link skipMask dropdown-toggle" data-toggle="collapse" href="#collapseSchoolTeams" role="button" aria-expanded="false" aria-controls="collapseSchoolTeams">
+          A&amp;M-Corpus Christi Sports
+        </a>
+      </li>
+     </ul>
+
+    <form onsubmit="mask(&#39;Loading&#39;);" id="change_team_form" style="display:inline;" class="form-inline my-2 my-lg-0" action="/team/index" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="I+M+aSu1EO0rQ+ugVaBUreb0VWwgzcD0PNCcDnISp0vlqtm0uTOc/Ypz0oogGoKLiq3y3pRTCbL4KYnJzthL3Q==" />
+  <div style="display:none;">
+  <input type="submit" name="commit" value="Submit" id="sport_btn" data-disable-with="Submit" />
+  </div>
+    <div id="team_autocomplete" class="ui-widget">
+      <input type="search" name="org_name" id="org_name" style="width:200px; font-size: 12px !important" class="form-control mr-sm-2" placeholder="Team Search" />
+      <input type="hidden" name="org_id" id="org_id" />
+    </div>
+</form>  </div>
+  </nav>
+    <div class="collapse pt-4" id="collapseSchoolTeams" style="width: 100%">
+      <div class="container-fluid">
+        <div class="row">
+          <div class="col-md">
+            <ul class="list-unstyled">
+              <li><strong>Fall</strong></li>
+                   <li><a href="/teams/625008">2026-27 Women&#39;s Soccer (2-0-1)</a></li>
+                   <li><a href="/teams/624921">2026-27 Women&#39;s Volleyball (0-0)</a></li>
+            </ul>
+          </div>
+          <div class="col-md">
+            <ul class="list-unstyled">
+              <li><strong>Winter</strong></li>
+                   <li><a href="/teams/627267">2026-27 Men&#39;s Basketball (0-0)</a></li>
+                   <li><a href="/teams/628770">2026-27 Women&#39;s Basketball (0-0)</a></li>
+            </ul>
+          </div>
+          <div class="col-md">
+            <ul class="list-unstyled">
+              <li><strong>Spring</strong></li>
+                   <li><a href="/teams/630967">2026-27 Baseball (0-0)</a></li>
+                   <li><a href="/teams/632565">2026-27 Softball (0-0)</a></li>
+                   <li><a href="/teams/633786">2026-27 Women&#39;s Beach Volleyball (0-0)</a></li>
+            </ul>
+          </div>
+      </div>
+    </div>
+</nav>
+      </header>
+
+       <div id="stats_app_dialog" style="display:none;">
+        </div>
+
+<div class="card p-1">
+  <div class="card-body application teams p-0">
+    <h3 class="card-title p-0"></h3>
+    <div class="container-fluid p-0">
+      <div class="row align-items-center justify-content-center p-0">
+        <div class="col-sm-12 p-0">
+        <script>
+  function submit_form(val){
+    curr_action = '/teams/';
+    $('#change_sport_form').attr("action", curr_action + val);
+    $('#team_sport_btn').click();
+  }
+  $(function() {
+    $( "#org_sport_name" ).autocomplete({
+      open: function(){
+        setTimeout(function () {
+            $('.ui-autocomplete').css('z-index', 99999999999999);
+        }, 0);
+      },
+      source: '/team/17040/sport_sponsored_search',
+      select: function( event, ui ) {
+        $("#sport_search_org_id").val(ui.item.vid);
+        //curr_action = '/teams/'.replace("26172", ui.item.vid);
+        curr_action = '/teams/'+ui.item.vid;
+        //$('#change_sport_form').attr("action", curr_action + $('#sport_list').val());
+        $('#change_sport_form').attr("action", curr_action);
+        $('#team_sport_btn').click();
+      }
+    });
+  });
+</script>
+
+  <div class="card">
+    <div class="card-header">
+    <img class="logo_image" alt="A&amp;M-Corpus Christi" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//26172.gif" /> <a target="ATHLETICS_URL" href="http://www.goislanders.com">A&amp;M-Corpus Christi Islanders</a> (23-28) <a class="skipMask" target="TEAM_SHEET_51849_614839_WIN" href="/selection_rankings/nitty_gritties/51849/teams/614839/team_sheet">RPI Ranking - 202</a>
+    </div>
+    <div class="card-body p-1">
+  <form onsubmit="mask(&#39;Loading&#39;);" id="change_sport_form" action="http://stats.ncaa.org" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+    <select name="year_id" id="year_list" onchange="submit_form(this.value);"><option value="630967">2026-27</option>
+<option selected="selected" value="614839">2025-26</option>
+<option value="596471">2024-25</option>
+<option value="573989">2023-24</option>
+<option value="548068">2022-23</option>
+<option value="526333">2021-22</option>
+<option value="508948">2020-21</option>
+<option value="494234">2019-20</option>
+<option value="471516">2018-19</option>
+<option value="197740">2017-18</option>
+<option value="65497">2016-17</option>
+<option value="85554">2015-16</option>
+<option value="18078">2014-15</option>
+<option value="80379">2013-14</option>
+<option value="78663">2012-13</option>
+<option value="13820">2011-12</option>
+<option value="96989">2010-11</option>
+<option value="27619">2009-10</option>
+<option value="320506">2008-09</option>
+<option value="236155">2007-08</option>
+<option value="235216">2006-07</option>
+<option value="197326">2005-06</option>
+<option value="349350">2004-05</option>
+<option value="280171">2003-04</option>
+<option value="319590">2002-03</option>
+<option value="165173">2001-02</option>
+<option value="390373">2000-01</option>
+<option value="164271">1999-00</option></select>
+    <select name="sport_id" id="sport_list" onchange="submit_form(this.value);"><option value="610016">Women&#39;s Basketball</option>
+<option value="602880">Women&#39;s Soccer</option>
+<option value="613770">Softball</option>
+<option value="605076">Women&#39;s Volleyball</option>
+<option value="620296">Women&#39;s Tennis</option>
+<option value="609609">Men&#39;s Basketball</option>
+<option value="613302">Women&#39;s Beach Volleyball</option>
+<option selected="selected" value="614839">Baseball</option>
+<option value="619404">Men&#39;s Tennis</option></select>
+    <a href="/teams/history/MBA/26172">Team History</a> |
+    <a href="/teams/coaches_summary/MBA/26172">Coaches Summary</a>
+
+    <div style="display:none;">
+    <input type="submit" name="commit" value="Submit" id="team_sport_btn" data-disable-with="Submit" />
+    </div>
+    <span id="tst" style="float:right;">
+      <div id="team_sport_autocomplete" class="ui-widget">
+      Teams Sponsoring Baseball:
+      <input type="text" name="org_sport_name" id="org_sport_name" style="width:200px" />
+      <input type="hidden" name="org_id" id="sport_search_org_id" />
+      </div>
+    </span>
+</form>    <!--
+  </div>
+ 
+  <div class="card">
+    <div class="card-body">
+      -->
+    <div class="row">
+      <div class="col p-0">
+          <div class="card m-2" id="team_venues_614839">
+    <div class="card-header">
+      Stadiums
+    </div>
+    <div class="card-body">
+    <div class="card m-2" id="team_page_season_venue_360452">
+  <div class="card-body">
+    <dl class="row mb-0 text-nowrap">
+      <dt class="col-sm-3 mb-0">Name:</dt>
+      <dd class="col-sm-9 mb-0">
+        Chapman Field
+      </dd>
+      <dt class="col-sm-3 mb-0">Capacity:</dt>
+      <dd class="col-sm-9 mb-0">
+        500
+      </dd>
+      <dt class="col-sm-3 mb-0">Year Built:</dt>
+      <dd class="col-sm-9 mb-0">
+        2002
+      </dd>
+      <dt class="col-sm-3 mb-0">Primary Venue:</dt>
+      <dd class="col-sm-9 mb-0">
+        true
+      </dd>
+    </dl>
+  </div>
+</div>
+
+      <br/>
+    <div class="card m-2" id="team_page_season_venue_360606">
+  <div class="card-body">
+    <dl class="row mb-0 text-nowrap">
+      <dt class="col-sm-3 mb-0">Name:</dt>
+      <dd class="col-sm-9 mb-0">
+        Whataburger Field
+      </dd>
+      <dt class="col-sm-3 mb-0">Capacity:</dt>
+      <dd class="col-sm-9 mb-0">
+        
+      </dd>
+      <dt class="col-sm-3 mb-0">Year Built:</dt>
+      <dd class="col-sm-9 mb-0">
+        
+      </dd>
+      <dt class="col-sm-3 mb-0">Primary Venue:</dt>
+      <dd class="col-sm-9 mb-0">
+        false
+      </dd>
+    </dl>
+  </div>
+</div>
+
+   </div>
+ </div>
+
+      </div>
+  
+        <div class="col p-0">
+        <div class="card m-2">
+  <div class="card-header">Coach</div>
+  <div class="card-body">
+      <div class="card">
+        <dl class="row mb-0 text-nowrap">
+          <dt class="col-sm-3 mb-0">Name:</dt>
+          <dd class="col-sm-9 mb-0">
+            <a href="/people/32546?sport_code=MBA">Scott Malone</a>
+          </dd>
+
+          <dt class="col-sm-3 mb-0">Alma Mater:</dt>
+          <dd class="col-sm-9 mb-0">
+            McMurry - 1998
+          </dd>
+          <dt class="col-sm-3 mb-0">Seasons:</dt>
+          <dd class="col-sm-9 mb-0">
+            19
+           <dt class="col-sm-3 mb-0">Record:</dt>
+          <dd class="col-sm-9 mb-0">
+            465-546-2
+          </dd>
+        </dl>
+      </div>
+  </div>
+</div>
+
+        </div>
+    </div>
+    <!--
+    don't close this here, but make sure to close it at the end of rosters, schedule results, game by game etc.
+  </div>
+  -->
+
+    <div class="row">
+      <div class="col p-0">
+  <div class="card mb-2 mx-2">
+  <div class="card-header">Season-to-date Records</div>
+  <div class="card-body p-0">
+       <div class="row">
+          <div class="card mx-2 my-2" style="min-width: 10em;">
+            <div class="card-header p-1">Overall</div>
+            <div class="card-body p-1"> 
+              <div class="row">
+                <span>23-28 (0.451)</span>
+              </div>
+              <div class="row">
+                <span> Streak: L4 </span>
+              </div>
+            </div>
+          </div>
+          <div class="card mx-2 my-2" style="min-width: 10em;">
+            <div class="card-header p-1">Conference</div>
+            <div class="card-body p-1"> 
+              <div class="row">
+                <span>11-19 (0.367)</span>
+              </div>
+              <div class="row">
+                <span> Streak: L3 </span>
+              </div>
+            </div>
+          </div>
+          <div class="card mx-2 my-2" style="min-width: 10em;">
+            <div class="card-header p-1">Home</div>
+            <div class="card-body p-1"> 
+              <div class="row">
+                <span>15-14 (0.517)</span>
+              </div>
+              <div class="row">
+                <span> Streak: W1 </span>
+              </div>
+            </div>
+          </div>
+          <div class="card mx-2 my-2" style="min-width: 10em;">
+            <div class="card-header p-1">Road</div>
+            <div class="card-body p-1"> 
+              <div class="row">
+                <span>8-14 (0.364)</span>
+              </div>
+              <div class="row">
+                <span> Streak: L4 </span>
+              </div>
+            </div>
+          </div>
+          <div class="card mx-2 my-2" style="min-width: 10em;">
+            <div class="card-header p-1">Neutral </div>
+            <div class="card-body p-1"> 
+              <div class="row">
+                <span>0-0 (0.000)</span>
+              </div>
+              <div class="row">
+                <span> Streak: L1 </span>
+              </div>
+            </div>
+          </div>
+          <div class="card mx-2 my-2" style="min-width: 10em;">
+            <div class="card-header p-1">Non-Division</div>
+            <div class="card-body p-1"> 
+              <div class="row">
+                <span>0-0 (0.000)</span>
+              </div>
+              <div class="row">
+                <span> Streak: W6 </span>
+              </div>
+            </div>
+          </div>
+    </div>
+  </div>
+</div>
+
+      </div>
+    </div>
+</div>
+
+
+  <nav>
+<ul class="nav nav-tabs padding-nav">
+  <li class="nav-item">
+    <a class="nav-link" href="/teams/614839">Schedule/Results</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link active" href="/teams/614839/roster">Roster</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="/teams/614839/season_to_date_stats">Team Statistics</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="/players/9708136">Game By Game</a>
+  </li>
+<!--
+<a href="/team/team_game_highs?org_id=26172&amp;sport_year_ctl_id=17040">Game Highs</a> 
+<a href="/team/conf_game_highs?org_id=26172&amp;sport_year_ctl_id=17040">Conf Game Highs</a> 
+<a href="/player/player_rank_history?game_sport_year_ctl_id=17040&amp;index_start=0&amp;org_id=26172&amp;stat_seq_to_chart=0&amp;stats_player_seq=-100">Ranking Trends</a> 
+<a href="/player/team_player_rank_yearly_history?game_sport_year_ctl_id=17040&amp;index_start=0&amp;org_id=26172&amp;stat_seq_to_chart=0&amp;stats_player_seq=-100">Team Final Trends</a> 
+-->
+      <li class="nav-item">
+        <a class="nav-link" href="/rankings/ranking_summary?academic_year=2026&amp;division=1&amp;org_id=26172&amp;ranking_period=111&amp;sport_code=MBA">Ranking Summary</a>
+      </li>
+</ul>
+</nav>
+
+
+<div id="team_614839_rosters_form">
+<script>
+      $(document).ready(function() {
+        oTable = $('#rosters_form_players_17040_data_table').dataTable({
+            "bStateSave": true,
+            "iCookieDuration" : 60*60*24*1000,
+            "paging": false,
+            "bProcessing": true,
+            "bServerSide": false,
+            "columnDefs": [{"type": "num-fmt", "targets": 2}],
+            "sScrollX": "100%",
+            "sScrollXInner": "100%",
+            "order": [[3, "asc"]] } );
+       });
+</script>
+
+<div class="card m-2">
+  <div class="card-header">Players</div>
+  <div class="card-body p-1">
+    <table id="rosters_form_players_17040_data_table" class="dataTable small_font no_padding" align="center">
+      <thead>
+        <tr>
+          <th width="33px;">GP</th>
+          <th width="33px;">GS</th>
+          <th width="33px;">#</th>
+          <th width="200px;">Name</th>
+          <th width="33px;">Class</th>
+          <th width="33px;">Position</th>
+          <th width="33px;">Height</th>
+          <th>Bats</th>
+          <th>Throws</th>
+          <th width="125px;">Hometown</th>
+          <th width="125px;">High School</th>
+      </tr>
+    </thead>
+    <tbody>
+
+      <tr>
+        <td>16</td>
+        <td>6</td>
+        <td>20</td>
+        <td data-order="Smith Easten"><a target="PLAYER_HISTORY" class="skipMask" href="/players/9677987">Easten Smith</a></td>
+        <td>Sr.</td>
+        <td>P</td>
+        <td>5-11</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>Glenn Heights, TX</td>
+        <td>Red Oak HS</td>
+      </tr>
+      <tr>
+        <td>2</td>
+        <td>0</td>
+        <td>40</td>
+        <td data-order="Pantoya Damian"><a target="PLAYER_HISTORY" class="skipMask" href="/players/9681888">Damian Pantoya</a></td>
+        <td>Fr.</td>
+        <td>P</td>
+        <td>6-2</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>Lubbock, TX</td>
+        <td>Lubbock-Cooper HS</td>
+      </tr>
+      <tr>
+        <td>26</td>
+        <td>13</td>
+        <td>2</td>
+        <td data-order="Stark Will"><a target="PLAYER_HISTORY" class="skipMask" href="/players/9682279">Will Stark</a></td>
+        <td>So.</td>
+        <td>OF</td>
+        <td>5-11</td>
+         <td>LEFT</td>
+         <td>RIGHT</td>
+        <td>Katy, TX</td>
+        <td>Obra D. Tompkins HS</td>
+      </tr>
+      <tr>
+        <td>3</td>
+        <td>0</td>
+        <td>30</td>
+        <td data-order="Pollard Pearson"><a target="PLAYER_HISTORY" class="skipMask" href="/players/9705034">Pearson Pollard</a></td>
+        <td>So.</td>
+        <td>P</td>
+        <td>5-10</td>
+         <td>LEFT</td>
+         <td>LEFT</td>
+        <td>Houston, TX</td>
+        <td>Cypress Christian School</td>
+      </tr>
+      <tr>
+        <td>49</td>
+        <td>46</td>
+        <td>33</td>
+        <td data-order="Smith Jackson"><a target="PLAYER_HISTORY" class="skipMask" href="/players/9705186">Jackson Smith</a></td>
+        <td>Sr.</td>
+        <td>1B</td>
+        <td>6-0</td>
+         <td>LEFT</td>
+         <td>RIGHT</td>
+        <td>Owasso, OK</td>
+        <td>Owasso HS</td>
+      </tr>
+      <tr>
+        <td>22</td>
+        <td>7</td>
+        <td>10</td>
+        <td data-order="Freeman Walker"><a target="PLAYER_HISTORY" class="skipMask" href="/players/11234904">Walker Freeman</a></td>
+        <td>Jr.</td>
+        <td>OF</td>
+        <td>-</td>
+         <td>LEFT</td>
+         <td>LEFT</td>
+        <td>Tyler, TX</td>
+        <td>Tyler Legacy HS</td>
+      </tr>
+      <tr>
+        <td>1</td>
+        <td>0</td>
+        <td>28</td>
+        <td data-order="Lange Bronson"><a target="PLAYER_HISTORY" class="skipMask" href="/players/11234926">Bronson Lange</a></td>
+        <td>Fr.</td>
+        <td>P</td>
+        <td>-</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>Floresville, TX</td>
+        <td>La Vernia HS</td>
+      </tr>
+      <tr>
+        <td>14</td>
+        <td>5</td>
+        <td>27</td>
+        <td data-order="Mayer Chase"><a target="PLAYER_HISTORY" class="skipMask" href="/players/11234927">Chase Mayer</a></td>
+        <td>Jr.</td>
+        <td>P</td>
+        <td>-</td>
+         <td>LEFT</td>
+         <td>LEFT</td>
+        <td>Amherst, OH</td>
+        <td>Marion L. Steele HS</td>
+      </tr>
+      <tr>
+        <td>47</td>
+        <td>35</td>
+        <td>3</td>
+        <td data-order="Reynolds Jayden"><a target="PLAYER_HISTORY" class="skipMask" href="/players/11234933">Jayden Reynolds</a></td>
+        <td>Jr.</td>
+        <td>INF</td>
+        <td>-</td>
+         <td>LEFT</td>
+         <td>RIGHT</td>
+        <td>Fair Oaks, CA</td>
+        <td>Bella Vista HS</td>
+      </tr>
+      <tr>
+        <td>39</td>
+        <td>29</td>
+        <td>15</td>
+        <td data-order="Russell Austin"><a target="PLAYER_HISTORY" class="skipMask" href="/players/11234934">Austin Russell</a></td>
+        <td>Sr.</td>
+        <td>1B</td>
+        <td>6-0</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>Flower Mound, TX</td>
+        <td>Flower Mound HS</td>
+      </tr>
+      <tr>
+        <td>5</td>
+        <td>1</td>
+        <td>38</td>
+        <td data-order="Chadwick Evan"><a target="PLAYER_HISTORY" class="skipMask" href="/players/9700536">Evan Chadwick</a></td>
+        <td>Jr.</td>
+        <td>C</td>
+        <td>5-11</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>La Palma, CA</td>
+        <td>Kennedy HS</td>
+      </tr>
+      <tr>
+        <td>14</td>
+        <td>2</td>
+        <td>39</td>
+        <td data-order="Molina Matthew"><a target="PLAYER_HISTORY" class="skipMask" href="/players/9687498">Matthew Molina</a></td>
+        <td>Jr.</td>
+        <td>P</td>
+        <td>6-0</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>Alice, TX</td>
+        <td>Alice HS</td>
+      </tr>
+      <tr>
+        <td>9</td>
+        <td>7</td>
+        <td>43</td>
+        <td data-order="Watkins Preston"><a target="PLAYER_HISTORY" class="skipMask" href="/players/9684975">Preston Watkins</a></td>
+        <td>Jr.</td>
+        <td>P</td>
+        <td>6-3</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>Deer Park, TX</td>
+        <td>Deer Park HS</td>
+      </tr>
+      <tr>
+        <td>31</td>
+        <td>22</td>
+        <td>9</td>
+        <td data-order="Evans Matt"><a target="PLAYER_HISTORY" class="skipMask" href="/players/11234895">Matt Evans</a></td>
+        <td>Jr.</td>
+        <td>OF</td>
+        <td>6-0</td>
+         <td>LEFT</td>
+         <td>LEFT</td>
+        <td>Tillsonburg, Canada</td>
+        <td>Glendale HS</td>
+      </tr>
+      <tr>
+        <td>12</td>
+        <td>7</td>
+        <td>23</td>
+        <td data-order="Shea Bryson"><a target="PLAYER_HISTORY" class="skipMask" href="/players/9698428">Bryson Shea</a></td>
+        <td>So.</td>
+        <td>P</td>
+        <td>6-2</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>Eagle, ID</td>
+        <td>Eagle HS</td>
+      </tr>
+      <tr>
+        <td>43</td>
+        <td>42</td>
+        <td>14</td>
+        <td data-order="Flaggert Jarrett"><a target="PLAYER_HISTORY" class="skipMask" href="/players/9685365">Jarrett Flaggert</a></td>
+        <td>Jr.</td>
+        <td>INF</td>
+        <td>6-5</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>Choctaw, OK</td>
+        <td>Choctaw HS</td>
+      </tr>
+      <tr>
+        <td>18</td>
+        <td>2</td>
+        <td>26</td>
+        <td data-order="Singleton Luke"><a target="PLAYER_HISTORY" class="skipMask" href="/players/9703907">Luke Singleton</a></td>
+        <td>Sr.</td>
+        <td>P</td>
+        <td>6-3</td>
+         <td>LEFT</td>
+         <td>LEFT</td>
+        <td>Colorado Springs, CO</td>
+        <td>Vista Ridge HS</td>
+      </tr>
+      <tr>
+        <td>11</td>
+        <td>0</td>
+        <td>34</td>
+        <td data-order="Robertson Luke"><a target="PLAYER_HISTORY" class="skipMask" href="/players/9693424">Luke Robertson</a></td>
+        <td>So.</td>
+        <td>P</td>
+        <td>6-5</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>Frisco, TX</td>
+        <td>Wakeland HS</td>
+      </tr>
+      <tr>
+        <td>48</td>
+        <td>46</td>
+        <td>1</td>
+        <td data-order="Smith-Johnson Christian"><a target="PLAYER_HISTORY" class="skipMask" href="/players/9692299">Christian Smith-Johnson</a></td>
+        <td>Sr.</td>
+        <td>OF</td>
+        <td>6-1</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>N Richland Hills, TX</td>
+        <td>Richland HS</td>
+      </tr>
+      <tr>
+        <td>19</td>
+        <td>0</td>
+        <td>6</td>
+        <td data-order="Budd Kade"><a target="PLAYER_HISTORY" class="skipMask" href="/players/11234866">Kade Budd</a></td>
+        <td>Jr.</td>
+        <td>P</td>
+        <td>-</td>
+         <td>LEFT</td>
+         <td>LEFT</td>
+        <td>Corpus Christi, TX</td>
+        <td>London HS</td>
+      </tr>
+      <tr>
+        <td>4</td>
+        <td>0</td>
+        <td>35</td>
+        <td data-order="Santos Tito"><a target="PLAYER_HISTORY" class="skipMask" href="/players/9702921">Tito Santos</a></td>
+        <td>So.</td>
+        <td>P</td>
+        <td>6-2</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>San Marcos, TX</td>
+        <td>San Marcos HS</td>
+      </tr>
+      <tr>
+        <td>31</td>
+        <td>28</td>
+        <td>44</td>
+        <td data-order="Afework Isaiah"><a target="PLAYER_HISTORY" class="skipMask" href="/players/11234856">Isaiah Afework</a></td>
+        <td>Jr.</td>
+        <td>OF</td>
+        <td>-</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>Federal Way, WA</td>
+        <td>Federal Way HS</td>
+      </tr>
+      <tr>
+        <td>41</td>
+        <td>33</td>
+        <td>19</td>
+        <td data-order="Azemar Hunter"><a target="PLAYER_HISTORY" class="skipMask" href="/players/11234858">Hunter Azemar</a></td>
+        <td>Jr.</td>
+        <td>C</td>
+        <td>-</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>Lafayette, LA</td>
+        <td>Southside HS</td>
+      </tr>
+      <tr>
+        <td>27</td>
+        <td>19</td>
+        <td>4</td>
+        <td data-order="Bergstrom Jack"><a target="PLAYER_HISTORY" class="skipMask" href="/players/11234862">Jack Bergstrom</a></td>
+        <td>Jr.</td>
+        <td>C</td>
+        <td>-</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>Federal Way, WA</td>
+        <td>Decatur HS</td>
+      </tr>
+      <tr>
+        <td>20</td>
+        <td>5</td>
+        <td>36</td>
+        <td data-order="Mueller Nathan"><a target="PLAYER_HISTORY" class="skipMask" href="/players/11234929">Nathan Mueller</a></td>
+        <td>Jr.</td>
+        <td>P</td>
+        <td>-</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>Fort Worth, TX</td>
+        <td>Timber Creek HS</td>
+      </tr>
+      <tr>
+        <td>2</td>
+        <td>0</td>
+        <td>11</td>
+        <td data-order="Quero Pedro"><a target="PLAYER_HISTORY" class="skipMask" href="/players/11234932">Pedro Quero</a></td>
+        <td>Jr.</td>
+        <td>C</td>
+        <td>-</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>Tempe, AZ</td>
+        <td>McClintock High School</td>
+      </tr>
+      <tr>
+        <td>20</td>
+        <td>15</td>
+        <td>17</td>
+        <td data-order="Cassie Noah"><a target="PLAYER_HISTORY" class="skipMask" href="/players/11234855">Noah Cassie</a></td>
+        <td>Jr.</td>
+        <td>OF</td>
+        <td>-</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>Vancouver, B.C., Canada</td>
+        <td>Sands HS</td>
+      </tr>
+      <tr>
+        <td>23</td>
+        <td>12</td>
+        <td>7</td>
+        <td data-order="Barron Jake"><a target="PLAYER_HISTORY" class="skipMask" href="/players/11234859">Jake Barron</a></td>
+        <td>Fr.</td>
+        <td>INF</td>
+        <td>-</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>Tomball, TX</td>
+        <td>Tomball Memorial HS</td>
+      </tr>
+      <tr>
+        <td>11</td>
+        <td>8</td>
+        <td>24</td>
+        <td data-order="Schlect Connor"><a target="PLAYER_HISTORY" class="skipMask" href="/players/11234938">Connor Schlect</a></td>
+        <td>Jr.</td>
+        <td>P</td>
+        <td>-</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>Yakima, WA</td>
+        <td>West Valley HS</td>
+      </tr>
+      <tr>
+        <td>0</td>
+        <td>0</td>
+        <td>13</td>
+        <td data-order="Hasche Gavin"><a target="PLAYER_HISTORY" class="skipMask" href="/players/11235094">Gavin Hasche</a></td>
+        <td>Jr.</td>
+        <td>P</td>
+        <td>6-0</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>Parker, CO</td>
+        <td>Legend</td>
+      </tr>
+      <tr>
+        <td>12</td>
+        <td>1</td>
+        <td>16</td>
+        <td data-order="Buckner John Paul"><a target="PLAYER_HISTORY" class="skipMask" href="/players/11234863">John Paul Buckner</a></td>
+        <td>Jr.</td>
+        <td>P</td>
+        <td>-</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>Starkville, MS</td>
+        <td>Starkville Academy</td>
+      </tr>
+      <tr>
+        <td>11</td>
+        <td>1</td>
+        <td>31</td>
+        <td data-order="Crowley Nicho"><a target="PLAYER_HISTORY" class="skipMask" href="/players/11234876">Nicho Crowley</a></td>
+        <td>Jr.</td>
+        <td>P</td>
+        <td>-</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>Port Orchard, WA</td>
+        <td>Bremerton HS</td>
+      </tr>
+      <tr>
+        <td>18</td>
+        <td>5</td>
+        <td>22</td>
+        <td data-order="Jacques Pierre-Luc"><a target="PLAYER_HISTORY" class="skipMask" href="/players/11234913">Pierre-Luc Jacques</a></td>
+        <td>Jr.</td>
+        <td>P</td>
+        <td>-</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>Saint-Nicolas, Canada</td>
+        <td>École Pointe-Lévy</td>
+      </tr>
+      <tr>
+        <td>9</td>
+        <td>0</td>
+        <td>32</td>
+        <td data-order="Schlehuber Jabe"><a target="PLAYER_HISTORY" class="skipMask" href="/players/11234939">Jabe Schlehuber</a></td>
+        <td>Jr.</td>
+        <td>P</td>
+        <td>-</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>Sand Springs, OK</td>
+        <td>Charles Page HS</td>
+      </tr>
+      <tr>
+        <td>4</td>
+        <td>0</td>
+        <td>41</td>
+        <td data-order="Thorndell Brock"><a target="PLAYER_HISTORY" class="skipMask" href="/players/11234944">Brock Thorndell</a></td>
+        <td>Jr.</td>
+        <td>P</td>
+        <td>-</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>Hockley, TX</td>
+        <td>Waller HS</td>
+      </tr>
+      <tr>
+        <td>34</td>
+        <td>25</td>
+        <td>18</td>
+        <td data-order="Towchik Max"><a target="PLAYER_HISTORY" class="skipMask" href="/players/11234946">Max Towchik</a></td>
+        <td>Jr.</td>
+        <td>INF</td>
+        <td>-</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>Colleyville, TX</td>
+        <td>Colleyville Heritage HS</td>
+      </tr>
+      <tr>
+        <td>47</td>
+        <td>47</td>
+        <td>12</td>
+        <td data-order="Sanchez Cade"><a target="PLAYER_HISTORY" class="skipMask" href="/players/11234948">Cade Sanchez</a></td>
+        <td>Sr.</td>
+        <td>INF</td>
+        <td>5-9</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>Houston, TX</td>
+        <td>Jersey Village HS</td>
+      </tr>
+      <tr>
+        <td>15</td>
+        <td>2</td>
+        <td>25</td>
+        <td data-order="Fowler Chandler"><a target="PLAYER_HISTORY" class="skipMask" href="/players/11234901">Chandler Fowler</a></td>
+        <td>Jr.</td>
+        <td>P</td>
+        <td>-</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>Jenks, OK</td>
+        <td>Jenks HS</td>
+      </tr>
+      <tr>
+        <td>47</td>
+        <td>38</td>
+        <td>5</td>
+        <td data-order="Krowka Karson"><a target="PLAYER_HISTORY" class="skipMask" href="/players/11234955">Karson Krowka</a></td>
+        <td>Sr.</td>
+        <td>INF</td>
+        <td>6-0</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>Heath, TX</td>
+        <td>Rockwall-Heath HS</td>
+      </tr>
+      <tr>
+        <td>9</td>
+        <td>1</td>
+        <td>8</td>
+        <td data-order="Schwing Nic"><a target="PLAYER_HISTORY" class="skipMask" href="/players/11234941">Nic Schwing</a></td>
+        <td>Jr.</td>
+        <td>INF</td>
+        <td>-</td>
+         <td>RIGHT</td>
+         <td>RIGHT</td>
+        <td>Madisonville, LA</td>
+        <td>Mandeville HS</td>
+      </tr>
+    </tbody>
+  </table>
+  </div>
+</div>
+</div>
+</div>
+
+</div>
+
+       </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<footer>&copy; <script>document.write(new Date().getFullYear())</script> NCAA <a href="http://web1.ncaa.org/web_files/terms_and_conditions.html" title ="Terms and Conditions" target=_blank>Terms and Conditions</a> | <a href="http://web1.ncaa.org/web_files/privacy.html" target=_blank title="Our Privacy Policy">Privacy Policy</a> | <a href="mailto:ncaastats@ncaa.org">Contact Us</a> </footer>
+
+  <!-- /.container -->
+  <script type="text/javascript"  src="/sXDpyF73OnZiV/4_nX4/vZg0RiRRg/DXf9fwurEzma/akwFfldRQQY/DSo0/LWZ8RSoX?v=8c96b7d3-5743-ecfc-4560-b8c6011c17ce" defer></script></body>
+
+  <script charset="utf-8">
+    $(document).ready(function() {
+      $('a.remote[data-toggle="tab"]').on('show.bs.tab', function (e) {
+        var tab_id = '#' + $(this).attr('aria-controls');
+        $(tab_id).html('<br/><br/><p style="text-align: center"><img style="vertical-align:middle; text-align: center" src="/assets/ajax-loader-6913acdbf4be7d6a2908a84bdecd6cad18110f5fc6d5a07cf8c9ce78d9548700.gif" /> Loading... </p><br/><br/>');
+        $.get($(this).data('remote'), function(data){
+          $(tab_id).html(data);
+        });
+      });
+    });
+
+    function skipMask(obj){
+      if (obj.hasClass('chosen-single') || obj.hasClass('skipMask') || obj.hasClass('ui-datepicker-prev') || obj.hasClass('ui-datepicker-next') || obj.hasClass('ui-corner-all') || obj.hasClass('paginate_button') || obj.hasClass('dt-button')){
+        return true;
+      }else{
+        return false;
+      }
+    }
+
+    $(document).ajaxComplete(function(){
+      unmask();
+    });
+/*
+    $("form").on('submit', function(event){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    */
+    $(document).on('click', 'a', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    $(document).on('click', 'input.green', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+
+  </script>
+</html>

--- a/tests/fixtures/ncaa_reference/mba_team_list_2026_d1.html
+++ b/tests/fixtures/ncaa_reference/mba_team_list_2026_d1.html
@@ -1,0 +1,2206 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<META HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=UTF-8">
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="">
+<meta name="author" content="">
+<meta name="version" content="321d28433e9f7a188596117e6f342ec4a84fb4ed">
+<META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<link rel="shortcut icon" href="/assets/favicon-405088046a5f2bab8eedeacfae7636975c095e9c8decd8c28e3fd0e65c2f51c4.ico" type="image/vnd.microsoft.icon">
+
+<title>NCAA Statistics</title>
+
+<!-- Bootstrap core CSS -->
+
+<!--
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+-->
+<!--
+<link rel="stylesheet" href="https://cdn.datatables.net/2.0.0/css/dataTables.bootstrap4.css" crossorigin="anonymous">
+-->
+<link rel="stylesheet" media="all" href="/assets/application-789c3971842ee3597428ccbebd021716b3231e9cbd0a00a184c3b2d6c8e5f152.css" />
+
+
+<script src="/assets/application-9232576bb3cb000ac0841ff2af81251908ec17312a3c5eb72bf1a32f9754800c.js"></script>
+<!--
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+-->
+<!--
+<script src="https://cdn.datatables.net/2.0.0/js/dataTables.bootstrap4.js" crossorigin="anonymous"></script>
+-->
+
+<meta name="csrf-param" content="authenticity_token" />
+<meta name="csrf-token" content="yKSGuiv/8zsWef1mR9uXeMEeI7OCh3quKlo0eaQ2LCkdFhG2d7s/uOVz0jfKk25A2RptHHTpKnmKGWQIgvzfeA==" />
+
+<style>
+.grid {clear: all}
+.grid-item, .name {text-align: center;}
+h1 img {max-height: 33px;}
+
+</style>
+<!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+<!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+      <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+    <![endif]-->
+
+
+<script>(window.BOOMR_mq=window.BOOMR_mq||[]).push(["addVar",{"rua.upush":"false","rua.cpush":"false","rua.upre":"false","rua.cpre":"false","rua.uprl":"false","rua.cprl":"false","rua.cprf":"false","rua.trans":"","rua.cook":"false","rua.ims":"false","rua.ufprl":"false","rua.cfprl":"false","rua.isuxp":"false","rua.texp":"norulematch","rua.ceh":"false","rua.ueh":"false","rua.ieh.st":"0"}]);</script>
+                                <script>!function(e){var n="https://s.go-mpulse.net/boomerang/";if("False"=="True")e.BOOMR_config=e.BOOMR_config||{},e.BOOMR_config.PageParams=e.BOOMR_config.PageParams||{},e.BOOMR_config.PageParams.pci=!0,n="https://s2.go-mpulse.net/boomerang/";if(window.BOOMR_API_key="EVKJV-AGD2E-W66AE-NT84S-K5LTF",function(){function e(){if(!r){var e=document.createElement("script");e.id="boomr-scr-as",e.src=window.BOOMR.url,e.async=!0,o.appendChild(e),r=!0}}function t(e){r=!0;var n,t,a,i,d=document,O=window;if(window.BOOMR.snippetMethod=e?"if":"i",t=function(e,n){var t=d.createElement("script");t.id=n||"boomr-if-as",t.src=window.BOOMR.url,BOOMR_lstart=(new Date).getTime(),e=e||d.body,e.appendChild(t)},!window.addEventListener&&window.attachEvent&&navigator.userAgent.match(/MSIE [67]\./))return window.BOOMR.snippetMethod="s",void t(o,"boomr-async");a=document.createElement("IFRAME"),a.src="about:blank",a.title="",a.role="presentation",a.loading="eager",i=(a.frameElement||a).style,i.width=0,i.height=0,i.border=0,i.display="none",o.appendChild(a);try{O=a.contentWindow,d=O.document.open()}catch(_){n=document.domain,a.src="javascript:var d=document.open();d.domain='"+n+"';void 0;",O=a.contentWindow,d=O.document.open()}if(n)d._boomrl=function(){this.domain=n,t()},d.write("<bo"+"dy onload='document._boomrl();'>");else if(O._boomrl=function(){t()},O.addEventListener)O.addEventListener("load",O._boomrl,!1);else if(O.attachEvent)O.attachEvent("onload",O._boomrl);d.close()}function a(e){window.BOOMR_onload=e&&e.timeStamp||(new Date).getTime()}if(!window.BOOMR||!window.BOOMR.version&&!window.BOOMR.snippetExecuted){window.BOOMR=window.BOOMR||{},window.BOOMR.snippetStart=(new Date).getTime(),window.BOOMR.snippetExecuted=!0,window.BOOMR.snippetVersion=14,window.BOOMR.url=n+"EVKJV-AGD2E-W66AE-NT84S-K5LTF";var i=document.currentScript||document.getElementsByTagName("script")[0],o=i.parentNode,r=!1,d=document.createElement("link");if(d.relList&&"function"==typeof d.relList.supports&&d.relList.supports("preload")&&"as"in d)window.BOOMR.snippetMethod="p",d.href=window.BOOMR.url,d.rel="preload",d.as="script",d.addEventListener("load",e),d.addEventListener("error",function(){t(!0)}),setTimeout(function(){if(!r)t(!0)},3e3),BOOMR_lstart=(new Date).getTime(),o.appendChild(d);else t(!1);if(window.addEventListener)window.addEventListener("load",a,!1);else if(window.attachEvent)window.attachEvent("onload",a)}}(),"".length>0)if(e&&"performance"in e&&e.performance&&"function"==typeof e.performance.setResourceTimingBufferSize)e.performance.setResourceTimingBufferSize();!function(){if(BOOMR=e.BOOMR||{},BOOMR.plugins=BOOMR.plugins||{},!BOOMR.plugins.AK){var n=""=="true"?1:0,t="cookiepresent",a="vq4kmwqxgslzw2upi5jq-f-b74b8d888-clientnsv4-s.akamaihd.net",i="false"=="true"?2:1,o={"ak.v":"41","ak.cp":"1168236","ak.ai":parseInt("215853",10),"ak.ol":"0","ak.cr":55,"ak.ipv":4,"ak.proto":"h2","ak.rid":"4e29646","ak.r":51194,"ak.a2":n,"ak.m":"a","ak.n":"essl","ak.cport":59277,"ak.gh":"23.206.120.23","ak.quicv":"","ak.tlsv":"tls1.3","ak.0rtt":"","ak.0rtt.ed":"","ak.csrc":"-","ak.acc":"","ak.t":"1787774803","ak.ak":"hOBiQwZUYzCg5VSAfCLimQ==5hqjOsMh2Rgw+Ue4BUNCbfcMVG1y704+hhMJriDV3gQggD3YjN+QfO45IqmsGcvk6dEkw59F9Chk4ggd2EVttFIa0m3zMm4lVzniWtKNlDo+wldsCWYah1fiNRJgncuWypzy+Vexaxg09mQExd1MwUCst0uITQtmhaf1s9xSPR6CKUo3xqrJgzWyvfZTdZa+Hm4loXKnOyx1TbpKBwrNoV+C8GmH637pMwCOFBpOMikNfI6I9qSTixCLtEYCo/rYpU3s8hGcf07AeZl+3CqUh1QWfG1QA1WCIAyH8Te3Ho7YjaVxqFwhn2bJu6PaDG5V6eOI6D5X+qsNiqDWzY6x3wuzoC9+c5Z9WGkjEloWjQPNY043EviqLddliqty4mPnvasBkEOCI+ufUMu6ZCIkgy5LeizLvu4q46nZOEe2nGQ=","ak.pv":"93","ak.dpoabenc":"","ak.tf":i};if(""!==t)o["ak.ruds"]=t;var r={i:!1,av:function(n){var t="http.initiator";if(n&&(!n[t]||"spa_hard"===n[t]))o["ak.feo"]=void 0!==e.aFeoApplied?1:0,BOOMR.addVar(o)},rv:function(){var e=["ak.cport","ak.cr","ak.csrc","ak.gh","ak.ipv","ak.m","ak.n","ak.ol","ak.proto","ak.quicv","ak.tlsv","ak.0rtt","ak.0rtt.ed","ak.r","ak.acc","ak.t","ak.tf"];BOOMR.removeVar(e)}};BOOMR.plugins.AK={akVars:o,akDNSPreFetchDomain:a,init:function(){if(!r.i){var e=BOOMR.subscribe;e("before_beacon",r.av,null,null),e("onbeacon",r.rv,null,null),r.i=!0}return this},is_complete:function(){return!0}}}}()}(window);</script></head>
+
+  <script>
+
+    
+  //initialize tooltip
+  $(document).ready(function() {
+    //$("body").tooltip({ selector: '[data-toggle=tooltip]' });
+    $('[data-toggle="tooltip"]').tooltip();
+  });
+
+  $(document).ready(function() {
+    $( "#org_name" ).autocomplete({
+      source: '/team/search',
+      select: function( event, ui ) {
+        $("#org_id").val(ui.item.vid);
+        $("#id").val(ui.item.vid);
+        $('#sport_btn').click();
+      }
+    });
+  });
+
+  var body = 'body';
+
+  $.ajaxSetup ({
+    // Disable caching of AJAX responses
+    cache: false
+  });
+
+  function changeSport(field){
+    var el = $(field);
+    var tmList = el.parent().next().find('.new-team-year')[0];
+    if (tmList == null){
+      tmList = el.nextAll('.new-team-year')[0];
+    }
+    $.ajax({
+      url: "/game_sport_year_ctls/"+el.val()+"/available_teams",
+      dataType: "script",
+      success: function(data, status){
+        $(tmList).empty();
+        $(tmList).append(("<option value=''>Select team</option>"));
+        $.each(JSON.parse(data), function(k, v){
+          $(tmList).append($("<option></option>")
+              .attr("value", v["id"])
+              .text(v["member_org"]["name_tabular"]));
+        });
+        $(tmList).trigger("chosen:updated");
+      }
+    });
+  }
+
+    function set_process_styles(fld, start_color, end_color){
+       $('#'+fld).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    var downImage = "/assets/down12.gif";
+    var rightImage = "/assets/right12.gif";
+
+    function highlight(div_id){
+      $(div_id).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    function show_hide_rows(attr_val, link_id){
+      $('#'+attr_val).toggle();
+      if ($('#'+attr_val).is(':visible')) {
+        $('#'+link_id).attr('src', downImage);
+      }else{
+        $('#'+link_id).attr('src', rightImage);
+      }
+    }
+
+    function mask(label){
+      $('body').mask(label);
+    }
+    function unmask(){
+      $('body').unmask();
+    }
+
+    var winHeight = "auto";
+    var winWidth = "auto";
+    var maxHeight = 700;
+    var maxWidth = 1400;
+    var minHeight = 100;
+    var minWidth = 200;
+    
+    var modalOptions = {"width": winWidth,
+                        "height": winHeight,
+                        "maxHeight": maxHeight,
+                        "maxWidth": maxWidth,
+                        "minHeight": minHeight,
+                        "minWidth": minWidth};
+
+    function dialog(url, title){
+
+      $("#stats_app_dialog").dialog({modal:true, minWidth:minWidth, minHeight:minHeight, maxWidth:maxWidth, maxHeight:maxHeight, width:winWidth, height:winHeight, title:title, closeOnEscape: false});
+    
+      modalOptions.title = title;
+    
+      $("#stats_app_dialog").dialog("option", modalOptions);
+    
+      $("#stats_app_dialog").html("Loading...");
+      $("#stats_app_dialog").load(url).dialog('open');
+    }
+
+    function addDatePicker(){
+    $('.adddatepicker').each(function(i, obj){
+      $(obj).datepicker({ 
+        showOn: 'both', 
+        buttonImage: '/assets/calendar.gif', 
+        buttonImageOnly: true,
+      });
+    });
+    }
+
+   $(document).ready(function() {
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   });
+
+   function setClassInputFields(){
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   }
+
+   function isValidDateFormat(dateStr){
+     const regex = /^([1-9]|0[1-9]|1[0-2])\/([1-9]|0[1-9]|[12][0-9]|3[01])\/(19|20)\d{2}$/;
+     if (!regex.test(dateStr)) {
+       return false;
+     }else{
+       return true;
+     }
+   }
+
+  </script>
+
+
+<body style="font-size: .75rem;" onload="if (top != self) { top.location=self.location; }" >
+
+      <header>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0">
+        <a class="navbar-brand mr-0 mr-md-2" href="/" aria-label="statistics">
+                          <img alt="NCAA" style="margin-left: 24px; margin-right: 0; margin-top: 6px;" src="/assets/ncaa-fbc4d0406ae731b47babcc3fca53775b5955ef372bf8b8e998ca9a513e468b8f.svg" />
+                          <span class="title" class="dark-blue-font">Statistics</span>
+        </a>
+       </nav>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0" style="background-color: var(--color-dark-blue) !important;">
+  <button class="navbar-toggler bg-white" type="button" data-toggle="collapse" data-target="#navbarTogglerDemo01" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarTogglerDemo01">
+        <ul class="navbar-nav mr-auto mt-2 mt-lg-0 justify-content-center">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle skipMask" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Rankings
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+          <a class="dropdown-item" href="/rankings">National Rankings</a>
+          <a class="dropdown-item" href="/active_career_leaders">Active Career Leaders</a>
+        </div>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/contests/livestream_scoreboards">Scoreboard</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/selection_rankings/nitty_gritties">Selection Rankings</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/head_coaches">Head Coaches</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/search/players">Players</a>
+      </li>
+     </ul>
+
+    <form onsubmit="mask(&#39;Loading&#39;);" id="change_team_form" style="display:inline;" class="form-inline my-2 my-lg-0" action="/team/index" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="WlAneWBbvaxUXf97/9dKVe9K6JGr4kU7DL7wJMC6K9Uz767PuLy7ry9xqcp+A2uFkNuHx2WedsqqTVIQzfXcIQ==" />
+  <div style="display:none;">
+  <input type="submit" name="commit" value="Submit" id="sport_btn" data-disable-with="Submit" />
+  </div>
+    <div id="team_autocomplete" class="ui-widget">
+      <input type="search" name="org_name" id="org_name" style="width:200px; font-size: 12px !important" class="form-control mr-sm-2" placeholder="Team Search" />
+      <input type="hidden" name="org_id" id="org_id" />
+    </div>
+</form>  </div>
+  </nav>
+</nav>
+      </header>
+
+       <div id="stats_app_dialog" style="display:none;">
+        </div>
+
+<div class="card p-1">
+  <div class="card-body application team p-0">
+    <h3 class="card-title p-0"></h3>
+    <div class="container-fluid p-0">
+      <div class="row align-items-center justify-content-center p-0">
+        <div class="col-sm-12 p-0">
+        
+<script language="javascript">
+      function changeDivisions(val){
+	     $('#params_form_division').val(val);
+	     document.params_form.submit();
+      }
+
+      function changeYears(val){
+         if ( $('#params_form_academic_year').val() != val ){
+	        $('#params_form_schedule_date').val('');
+         }
+	     $('#params_form_academic_year').val(val);
+	     document.params_form.submit();
+      }
+
+      function changeSports(val){
+	     $('#params_form_sport_code').val(val);
+	     document.params_form.submit();
+      }
+      function changeConference(val){
+	     $('#params_form_conf_id').val(val);
+	     document.params_form.submit();
+      }
+      function changeDate(val){
+	     $('#params_form_schedule_date').val(val);
+	     document.params_form.submit();
+      }
+</script>
+<form name="params_form" action="/team/schedule_list" method="post">
+  <input id="params_form_sport_code" type="hidden" name="sport_code" value="MBA">
+  <input id="params_form_academic_year" type="hidden" name="academic_year" value="2026">
+  <input id="params_form_division" type="hidden" name="division" value="1">
+  <input id="params_form_conf_id" type="hidden" name="conf_id" value="-1">
+  <input id="params_form_schedule_date" type="hidden" name="schedule_date" value="">
+</form>
+
+<div class="grey_header_menu">
+	
+<div id="nav_bar">
+  <div id="primary_nav_wrap">
+		<ul class="level1" id="root">
+		  <li>
+		    <a href="#" class="skipMask">Baseball</a>
+		    <ul class="level2">
+		 		    <li><a href="javascript:changeSports('MBA');">Baseball</a></li>
+		 		    <li><a href="javascript:changeSports('MBB');">Men&#39;s Basketball</a></li>
+		 		    <li><a href="javascript:changeSports('MFB');">Football</a></li>
+		 		    <li><a href="javascript:changeSports('MIH');">Men&#39;s Ice Hockey</a></li>
+		 		    <li><a href="javascript:changeSports('MLA');">Men&#39;s Lacrosse</a></li>
+		 		    <li><a href="javascript:changeSports('MSO');">Men&#39;s Soccer</a></li>
+		 		    <li><a href="javascript:changeSports('MVB');">Men&#39;s Volleyball</a></li>
+		 		    <li><a href="javascript:changeSports('MWP');">Men&#39;s Water Polo</a></li>
+		 		    <li><a href="javascript:changeSports('WBB');">Women&#39;s Basketball</a></li>
+		 		    <li><a href="javascript:changeSports('WBW');">Women&#39;s Bowling</a></li>
+		 		    <li><a href="javascript:changeSports('WFH');">Field Hockey</a></li>
+		 		    <li><a href="javascript:changeSports('WIH');">Women&#39;s Ice Hockey</a></li>
+		 		    <li><a href="javascript:changeSports('WLA');">Women&#39;s Lacrosse</a></li>
+		 		    <li><a href="javascript:changeSports('WSB');">Softball</a></li>
+		 		    <li><a href="javascript:changeSports('WSO');">Women&#39;s Soccer</a></li>
+		 		    <li><a href="javascript:changeSports('WSV');">Women&#39;s Beach Volleyball</a></li>
+		 		    <li><a href="javascript:changeSports('WVB');">Women&#39;s Volleyball</a></li>
+		 		    <li><a href="javascript:changeSports('WWP');">Women&#39;s Water Polo</a></li>
+		    </ul>
+		  </li>
+		  <li class="sep">|</li>
+ 		  <li>
+			<a href="#" class="skipMask">2025-26</a>
+			<ul class="level2">
+				<li><a href="javascript:changeYears(2027);">2026-27</a></li>
+				<li><a href="javascript:changeYears(2026);">2025-26</a></li>
+				<li><a href="javascript:changeYears(2025);">2024-25</a></li>
+				<li><a href="javascript:changeYears(2024);">2023-24</a></li>
+				<li><a href="javascript:changeYears(2023);">2022-23</a></li>
+				<li><a href="javascript:changeYears(2022);">2021-22</a></li>
+				<li><a href="javascript:changeYears(2021);">2020-21</a></li>
+				<li><a href="javascript:changeYears(2020);">2019-20</a></li>
+				<li><a href="javascript:changeYears(2019);">2018-19</a></li>
+				<li><a href="javascript:changeYears(2018);">2017-18</a></li>
+				<li><a href="javascript:changeYears(2017);">2016-17</a></li>
+				<li><a href="javascript:changeYears(2016);">2015-16</a></li>
+				<li><a href="javascript:changeYears(2015);">2014-15</a></li>
+				<li><a href="javascript:changeYears(2014);">2013-14</a></li>
+				<li><a href="javascript:changeYears(2013);">2012-13</a></li>
+				<li><a href="javascript:changeYears(2012);">2011-12</a></li>
+				<li><a href="javascript:changeYears(2011);">2010-11</a></li>
+				<li><a href="javascript:changeYears(2010);">2009-10</a></li>
+				<li><a href="javascript:changeYears(2009);">2008-09</a></li>
+				<li><a href="javascript:changeYears(2008);">2007-08</a></li>
+				<li><a href="javascript:changeYears(2007);">2006-07</a></li>
+				<li><a href="javascript:changeYears(2006);">2005-06</a></li>
+				<li><a href="javascript:changeYears(2005);">2004-05</a></li>
+				<li><a href="javascript:changeYears(2004);">2003-04</a></li>
+				<li><a href="javascript:changeYears(2003);">2002-03</a></li>
+				<li><a href="javascript:changeYears(2002);">2001-02</a></li>
+				<li><a href="javascript:changeYears(2001);">2000-01</a></li>
+				<li><a href="javascript:changeYears(2000);">1999-00</a></li>
+				<li><a href="javascript:changeYears(1999);">1998-99</a></li>
+				<li><a href="javascript:changeYears(1998);">1997-98</a></li>
+				<li><a href="javascript:changeYears(1997);">1996-97</a></li>
+				<li><a href="javascript:changeYears(1996);">1995-96</a></li>
+				<li><a href="javascript:changeYears(1995);">1994-95</a></li>
+				<li><a href="javascript:changeYears(1994);">1993-94</a></li>
+				<li><a href="javascript:changeYears(1993);">1992-93</a></li>
+				<li><a href="javascript:changeYears(1992);">1991-92</a></li>
+				<li><a href="javascript:changeYears(1991);">1990-91</a></li>
+				<li><a href="javascript:changeYears(1990);">1989-90</a></li>
+				<li><a href="javascript:changeYears(1989);">1988-89</a></li>
+				<li><a href="javascript:changeYears(1988);">1987-88</a></li>
+				<li><a href="javascript:changeYears(1987);">1986-87</a></li>
+				<li><a href="javascript:changeYears(1986);">1985-86</a></li>
+				<li><a href="javascript:changeYears(1985);">1984-85</a></li>
+				<li><a href="javascript:changeYears(1984);">1983-84</a></li>
+				<li><a href="javascript:changeYears(1983);">1982-83</a></li>
+				<li><a href="javascript:changeYears(1982);">1981-82</a></li>
+				<li><a href="javascript:changeYears(1981);">1980-81</a></li>
+				<li><a href="javascript:changeYears(1980);">1979-80</a></li>
+				<li><a href="javascript:changeYears(1979);">1978-79</a></li>
+				<li><a href="javascript:changeYears(1978);">1977-78</a></li>
+				<li><a href="javascript:changeYears(1977);">1976-77</a></li>
+				<li><a href="javascript:changeYears(1976);">1975-76</a></li>
+				<li><a href="javascript:changeYears(1975);">1974-75</a></li>
+				<li><a href="javascript:changeYears(1974);">1973-74</a></li>
+				<li><a href="javascript:changeYears(1973);">1972-73</a></li>
+				<li><a href="javascript:changeYears(1972);">1971-72</a></li>
+				<li><a href="javascript:changeYears(1971);">1970-71</a></li>
+				<li><a href="javascript:changeYears(1970);">1969-70</a></li>
+				<li><a href="javascript:changeYears(1969);">1968-69</a></li>
+				<li><a href="javascript:changeYears(1968);">1967-68</a></li>
+				<li><a href="javascript:changeYears(1967);">1966-67</a></li>
+				<li><a href="javascript:changeYears(1966);">1965-66</a></li>
+				<li><a href="javascript:changeYears(1965);">1964-65</a></li>
+				<li><a href="javascript:changeYears(1964);">1963-64</a></li>
+				<li><a href="javascript:changeYears(1963);">1962-63</a></li>
+				<li><a href="javascript:changeYears(1962);">1961-62</a></li>
+				<li><a href="javascript:changeYears(1961);">1960-61</a></li>
+				<li><a href="javascript:changeYears(1960);">1959-60</a></li>
+				<li><a href="javascript:changeYears(1959);">1958-59</a></li>
+				<li><a href="javascript:changeYears(1958);">1957-58</a></li>
+				<li><a href="javascript:changeYears(1957);">1956-57</a></li>
+				<li><a href="javascript:changeYears(1956);">1955-56</a></li>
+				<li><a href="javascript:changeYears(1955);">1954-55</a></li>
+				<li><a href="javascript:changeYears(1954);">1953-54</a></li>
+				<li><a href="javascript:changeYears(1953);">1952-53</a></li>
+				<li><a href="javascript:changeYears(1952);">1951-52</a></li>
+				<li><a href="javascript:changeYears(1951);">1950-51</a></li>
+				<li><a href="javascript:changeYears(1950);">1949-50</a></li>
+				<li><a href="javascript:changeYears(1949);">1948-49</a></li>
+				<li><a href="javascript:changeYears(1948);">1947-48</a></li>
+				<li><a href="javascript:changeYears(1947);">1946-47</a></li>
+				<li><a href="javascript:changeYears(1946);">1945-46</a></li>
+				<li><a href="javascript:changeYears(1945);">1944-45</a></li>
+				<li><a href="javascript:changeYears(1944);">1943-44</a></li>
+				<li><a href="javascript:changeYears(1943);">1942-43</a></li>
+				<li><a href="javascript:changeYears(1942);">1941-42</a></li>
+				<li><a href="javascript:changeYears(1941);">1940-41</a></li>
+				<li><a href="javascript:changeYears(1940);">1939-40</a></li>
+				<li><a href="javascript:changeYears(1939);">1938-39</a></li>
+				<li><a href="javascript:changeYears(1938);">1937-38</a></li>
+				<li><a href="javascript:changeYears(1937);">1936-37</a></li>
+				<li><a href="javascript:changeYears(1936);">1935-36</a></li>
+				<li><a href="javascript:changeYears(1935);">1934-35</a></li>
+				<li><a href="javascript:changeYears(1934);">1933-34</a></li>
+				<li><a href="javascript:changeYears(1933);">1932-33</a></li>
+				<li><a href="javascript:changeYears(1932);">1931-32</a></li>
+				<li><a href="javascript:changeYears(1931);">1930-31</a></li>
+				<li><a href="javascript:changeYears(1930);">1929-30</a></li>
+				<li><a href="javascript:changeYears(1929);">1928-29</a></li>
+				<li><a href="javascript:changeYears(1928);">1927-28</a></li>
+				<li><a href="javascript:changeYears(1927);">1926-27</a></li>
+				<li><a href="javascript:changeYears(1926);">1925-26</a></li>
+				<li><a href="javascript:changeYears(1925);">1924-25</a></li>
+				<li><a href="javascript:changeYears(1924);">1923-24</a></li>
+				<li><a href="javascript:changeYears(1923);">1922-23</a></li>
+				<li><a href="javascript:changeYears(1922);">1921-22</a></li>
+				<li><a href="javascript:changeYears(1921);">1920-21</a></li>
+				<li><a href="javascript:changeYears(1920);">1919-20</a></li>
+				<li><a href="javascript:changeYears(1919);">1918-19</a></li>
+				<li><a href="javascript:changeYears(1918);">1917-18</a></li>
+				<li><a href="javascript:changeYears(1917);">1916-17</a></li>
+				<li><a href="javascript:changeYears(1916);">1915-16</a></li>
+				<li><a href="javascript:changeYears(1915);">1914-15</a></li>
+				<li><a href="javascript:changeYears(1914);">1913-14</a></li>
+				<li><a href="javascript:changeYears(1913);">1912-13</a></li>
+				<li><a href="javascript:changeYears(1912);">1911-12</a></li>
+				<li><a href="javascript:changeYears(1911);">1910-11</a></li>
+				<li><a href="javascript:changeYears(1910);">1909-10</a></li>
+				<li><a href="javascript:changeYears(1909);">1908-09</a></li>
+				<li><a href="javascript:changeYears(1908);">1907-08</a></li>
+				<li><a href="javascript:changeYears(1907);">1906-07</a></li>
+				<li><a href="javascript:changeYears(1906);">1905-06</a></li>
+				<li><a href="javascript:changeYears(1905);">1904-05</a></li>
+				<li><a href="javascript:changeYears(1904);">1903-04</a></li>
+				<li><a href="javascript:changeYears(1903);">1902-03</a></li>
+				<li><a href="javascript:changeYears(1902);">1901-02</a></li>
+				<li><a href="javascript:changeYears(1901);">1900-01</a></li>
+				<li><a href="javascript:changeYears(1900);">1899-00</a></li>
+				<li><a href="javascript:changeYears(1899);">1898-99</a></li>
+				<li><a href="javascript:changeYears(1898);">1897-98</a></li>
+				<li><a href="javascript:changeYears(1897);">1896-97</a></li>
+				<li><a href="javascript:changeYears(1896);">1895-96</a></li>
+				<li><a href="javascript:changeYears(1895);">1894-95</a></li>
+				<li><a href="javascript:changeYears(1894);">1893-94</a></li>
+				<li><a href="javascript:changeYears(1893);">1892-93</a></li>
+				<li><a href="javascript:changeYears(1892);">1891-92</a></li>
+				<li><a href="javascript:changeYears(1891);">1890-91</a></li>
+				<li><a href="javascript:changeYears(1890);">1889-90</a></li>
+				<li><a href="javascript:changeYears(1889);">1888-89</a></li>
+				<li><a href="javascript:changeYears(1888);">1887-88</a></li>
+				<li><a href="javascript:changeYears(1887);">1886-87</a></li>
+				<li><a href="javascript:changeYears(1886);">1885-86</a></li>
+				<li><a href="javascript:changeYears(1885);">1884-85</a></li>
+				<li><a href="javascript:changeYears(1884);">1883-84</a></li>
+				<li><a href="javascript:changeYears(1883);">1882-83</a></li>
+				<li><a href="javascript:changeYears(1882);">1881-82</a></li>
+				<li><a href="javascript:changeYears(1881);">1880-81</a></li>
+				<li><a href="javascript:changeYears(1880);">1879-80</a></li>
+				<li><a href="javascript:changeYears(1879);">1878-79</a></li>
+				<li><a href="javascript:changeYears(1878);">1877-78</a></li>
+				<li><a href="javascript:changeYears(1877);">1876-77</a></li>
+				<li><a href="javascript:changeYears(1876);">1875-76</a></li>
+				<li><a href="javascript:changeYears(1875);">1874-75</a></li>
+				<li><a href="javascript:changeYears(1874);">1873-74</a></li>
+				<li><a href="javascript:changeYears(1873);">1872-73</a></li>
+				<li><a href="javascript:changeYears(1872);">1871-72</a></li>
+				<li><a href="javascript:changeYears(1871);">1870-71</a></li>
+				<li><a href="javascript:changeYears(1870);">1869-70</a></li>
+				<li><a href="javascript:changeYears(1869);">1868-69</a></li>
+				<li><a href="javascript:changeYears(1868);">1867-68</a></li>
+				<li><a href="javascript:changeYears(1867);">1866-67</a></li>
+				<li><a href="javascript:changeYears(1866);">1865-66</a></li>
+				<li><a href="javascript:changeYears(1865);">1864-65</a></li>
+				<li><a href="javascript:changeYears(1864);">1863-64</a></li>
+				<li><a href="javascript:changeYears(1863);">1862-63</a></li>
+				<li><a href="javascript:changeYears(1862);">1861-62</a></li>
+				<li><a href="javascript:changeYears(1861);">1860-61</a></li>
+				<li><a href="javascript:changeYears(1860);">1859-60</a></li>
+				<li><a href="javascript:changeYears(1859);">1858-59</a></li>
+			</ul>
+		  </li>
+  	      <li class="sep">|</li>
+ 		  <li>
+			<a href="#" class="skipMask">I</a>
+			<ul class="level2">
+				<li><a href="javascript:changeDivisions(1);">I</a></li>
+				<li><a href="javascript:changeDivisions(2);">II</a></li>
+				<li><a href="javascript:changeDivisions(3);">III</a></li>
+			</ul>
+		  </li>
+		  </li>
+  	      <li class="sep">|</li>
+ 		  <li>
+			<a href="#" class="skipMask">ALL TEAMS</a>
+			<ul class="level2">
+			   <li><a href="javascript:changeConference(-1);">ALL TEAMS</a></li>
+				<li><a href="javascript:changeConference(821);">ACC</a></li>
+				<li><a href="javascript:changeConference(920);">ASUN</a></li>
+				<li><a href="javascript:changeConference(845);">America East</a></li>
+				<li><a href="javascript:changeConference(823);">American</a></li>
+				<li><a href="javascript:changeConference(820);">Atlantic 10</a></li>
+				<li><a href="javascript:changeConference(25354);">Big 12</a></li>
+				<li><a href="javascript:changeConference(30184);">Big East</a></li>
+				<li><a href="javascript:changeConference(826);">Big South</a></li>
+				<li><a href="javascript:changeConference(827);">Big Ten</a></li>
+				<li><a href="javascript:changeConference(904);">Big West</a></li>
+				<li><a href="javascript:changeConference(837);">CAA</a></li>
+				<li><a href="javascript:changeConference(24312);">CUSA</a></li>
+				<li><a href="javascript:changeConference(99000);">DI Independent</a></li>
+				<li><a href="javascript:changeConference(881);">Horizon</a></li>
+				<li><a href="javascript:changeConference(865);">Ivy League</a></li>
+				<li><a href="javascript:changeConference(875);">MAC</a></li>
+				<li><a href="javascript:changeConference(884);">MVC</a></li>
+				<li><a href="javascript:changeConference(871);">Metro</a></li>
+				<li><a href="javascript:changeConference(5486);">Mountain West</a></li>
+				<li><a href="javascript:changeConference(846);">NEC</a></li>
+				<li><a href="javascript:changeConference(902);">OVC</a></li>
+				<li><a href="javascript:changeConference(838);">Patriot</a></li>
+				<li><a href="javascript:changeConference(911);">SEC</a></li>
+				<li><a href="javascript:changeConference(916);">SWAC</a></li>
+				<li><a href="javascript:changeConference(912);">SoCon</a></li>
+				<li><a href="javascript:changeConference(914);">Southland</a></li>
+				<li><a href="javascript:changeConference(819);">Summit League</a></li>
+				<li><a href="javascript:changeConference(818);">Sun Belt</a></li>
+				<li><a href="javascript:changeConference(923);">UAC </a></li>
+				<li><a href="javascript:changeConference(922);">WCC</a></li>
+			</ul>
+		  </li>
+		  </li>
+  	 </ul>
+  </div>
+</div>
+</div>
+
+
+<br/>
+<br/>
+<!-- tabs -->
+<ul class="css-tabs">
+  <li><a id="available_teams_tab" href="/team/inst_team_list?academic_year=2026&amp;conf_id=-1&amp;division=1&amp;sport_code=MBA">Available Teams</a></li>
+  <li><a id="scoreboard_tab" href="/team/schedule_list?academic_year=2026&amp;conf_id=-1&amp;division=1&amp;sport_code=MBA">Scoreboard</a></li>
+</ul>
+
+
+
+
+<!-- single pane. it is always visible -->
+<div class="css-panes">
+  <div style="display:block">
+<table width="95%" align="center">
+	<tr>
+       <td valign="top">
+	      <table width="100%">
+             <tr>
+	            <td>
+                <a href="/teams/614839">A&amp;M-Corpus Christi</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614845">Abilene Christian</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614798">Air Force</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614787">Akron</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614848">Alabama</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614846">Alabama A&amp;M</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614847">Alabama St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614851">Alcorn</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614852">App State</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614767">Arizona</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614853">Arizona St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614834">Ark.-Pine Bluff</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614855">Arkansas</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614854">Arkansas St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614763">Army West Point</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614857">Auburn</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614858">Austin Peay</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614867">BYU</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614859">Ball St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614861">Baylor</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614754">Bellarmine</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614838">Belmont</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614862">Bethune-Cookman</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614863">Binghamton</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614864">Boston College</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614865">Bowling Green</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614866">Bradley</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614868">Brown</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614869">Bryant</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614563">Bucknell</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614564">Butler</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614566">CSU Bakersfield</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614569">CSUN</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614565">Cal Poly</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614567">Cal St. Fullerton</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614572">California</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614844">California Baptist</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614577">Campbell</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614578">Canisius</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614825">Central Ark.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614579">Central Conn. St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614581">Central Mich.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614860">Charleston So.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614676">Charlotte</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614582">Cincinnati</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614584">Clemson</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614585">Coastal Carolina</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614827">Col. of Charleston</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614586">Columbia</a>
+                </td>
+             </tr>
+         </table>
+     </td>
+       <td valign="top">
+	      <table width="100%">
+             <tr>
+	            <td>
+                <a href="/teams/614588">Coppin St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614589">Cornell</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614590">Creighton</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614764">DBU</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614591">Dartmouth</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614592">Davidson</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614593">Dayton</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614595">Delaware</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614594">Delaware St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614769">Duke</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614597">ETSU</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614596">East Carolina</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614598">Eastern Ill.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614599">Eastern Ky.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614600">Eastern Mich.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614828">Elon</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614770">Evansville</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614602">FDU</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614841">FGCU</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614605">FIU</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614601">Fairfield</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614604">Fla. Atlantic</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614607">Florida</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614603">Florida A&amp;M</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614606">Florida St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614608">Fordham</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614768">Fresno St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614612">Ga. Southern</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614829">Gardner-Webb</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614609">George Mason</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614610">George Washington</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614611">Georgetown</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614615">Georgia</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614613">Georgia St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614614">Georgia Tech</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614616">Gonzaga</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614771">Grambling</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614830">Grand Canyon</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614617">Harvard</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614618">Hawaii</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614766">High Point</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614619">Hofstra</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614620">Holy Cross</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614622">Houston</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614621">Houston Christian</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614624">Illinois</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614623">Illinois St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614627">Indiana</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614626">Indiana St.</a>
+                </td>
+             </tr>
+         </table>
+     </td>
+       <td valign="top">
+	      <table width="100%">
+             <tr>
+	            <td>
+                <a href="/teams/614629">Iona</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614630">Iowa</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614631">Jackson St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614633">Jacksonville</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614632">Jacksonville St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614634">James Madison</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614636">Kansas</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614635">Kansas St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614831">Kennesaw St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614637">Kent St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614638">Kentucky</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614772">LIU</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614648">LMU (CA)</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614644">LSU</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614685">LSU New Orleans </a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/621265">La Salle</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614639">Lafayette</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614640">Lamar University</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614760">Le Moyne</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614641">Lehigh</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614642">Liberty</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614756">Lindenwood</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614840">Lipscomb</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614856">Little Rock</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614568">Long Beach St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614643">Longwood</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614748">Louisiana</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614645">Louisiana Tech</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614646">Louisville</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614649">Maine</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614650">Manhattan</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614651">Marist</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614652">Marshall</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614654">Maryland</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614656">Massachusetts</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614657">McNeese</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614658">Memphis</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614659">Mercer</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614783">Mercyhurst</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614826">Merrimack</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614661">Miami (FL)</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614660">Miami (OH)</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614663">Michigan</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614662">Michigan St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614664">Middle Tenn.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614820">Milwaukee</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614665">Minnesota</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614666">Mississippi St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614667">Mississippi Val.</a>
+                </td>
+             </tr>
+         </table>
+     </td>
+       <td valign="top">
+	      <table width="100%">
+             <tr>
+	            <td>
+                <a href="/teams/614669">Missouri</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614746">Missouri St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614670">Monmouth</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614671">Morehead St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614672">Mount St. Mary&#39;s</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614673">Murray St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614688">N.C. A&amp;T</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614689">NC State</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614694">NIU</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614682">NJIT</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614799">Navy</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614773">Nebraska</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614681">Nevada</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/615065">New Haven</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614684">New Mexico</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614683">New Mexico St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614686">Niagara</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614774">Nicholls</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614687">Norfolk St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614843">North Ala.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614675">North Carolina</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614690">North Dakota St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614835">North Florida</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614692">Northeastern</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614693">Northern Colo.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614695">Northern Ky.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614697">Northwestern</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614696">Northwestern St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614698">Notre Dame</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614699">Oakland</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614701">Ohio</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614700">Ohio St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614702">Oklahoma</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614775">Oklahoma St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614703">Old Dominion</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614668">Ole Miss</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614679">Omaha</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614776">Oral Roberts</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614705">Oregon</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614704">Oregon St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614706">Pacific</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614777">Penn</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614708">Penn St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614709">Pepperdine</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614710">Pittsburgh</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614711">Portland</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614712">Prairie View</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614832">Presbyterian</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614713">Princeton</a>
+                </td>
+             </tr>
+         </table>
+     </td>
+       <td valign="top">
+	      <table width="100%">
+             <tr>
+	            <td>
+                <a href="/teams/614714">Purdue</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614757">Queens (NC)</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614715">Quinnipiac</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614716">Radford</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614717">Rhode Island</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614718">Rice</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614719">Richmond</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614720">Rider</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614721">Rutgers</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614750">SFA</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614744">SIUE</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614570">Sacramento St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614722">Sacred Heart</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614724">Saint Joseph&#39;s</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614725">Saint Louis</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614726">Saint Mary&#39;s (CA)</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614727">Saint Peter&#39;s</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614728">Sam Houston</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614729">Samford</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614731">San Diego</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614730">San Diego St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614732">San Francisco</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614733">San Jose St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614734">Santa Clara</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614833">Seattle U</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614735">Seton Hall</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614736">Siena</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614737">South Alabama</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614738">South Carolina</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614739">South Dakota St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614740">South Fla.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614779">Southeast Mo. St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614741">Southeastern La.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614742">Southern California</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614743">Southern Ill.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614758">Southern Ind.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614780">Southern Miss.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614745">Southern U.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614723">St. Bonaventure</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614778">St. John&#39;s (NY)</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614785">St. Thomas (MN)</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614749">Stanford</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614781">Stetson</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614759">Stonehill</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614751">Stony Brook</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614789">TCU</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614761">Tarleton St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614782">Tennessee</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614752">Tennessee Tech</a>
+                </td>
+             </tr>
+         </table>
+     </td>
+       <td valign="top">
+	      <table width="100%">
+             <tr>
+	            <td>
+                <a href="/teams/614793">Texas</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614788">Texas A&amp;M</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614790">Texas Southern</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614747">Texas St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614791">Texas Tech</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614583">The Citadel</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614795">Toledo</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614796">Towson</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614797">Troy</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614762">Tulane</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614849">UAB</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614850">UAlbany</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614573">UC Davis</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614574">UC Irvine</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614576">UC Riverside</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614755">UC San Diego</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614571">UC Santa Barbara</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614580">UCF</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614575">UCLA</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614587">UConn</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614625">UIC</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614836">UIW</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614691">ULM</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614653">UMBC</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614655">UMES</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614647">UMass Lowell</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614674">UNC Asheville</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614677">UNC Greensboro</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614678">UNCW</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614680">UNLV</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614837">USC Upstate</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614792">UT Arlington</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614753">UT Martin</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614707">UTRGV</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614794">UTSA</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614800">Utah</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614786">Utah Tech</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614842">Utah Valley</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614804">VCU</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614805">VMI</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614801">Valparaiso</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614802">Vanderbilt</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614803">Villanova</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614807">Virginia</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614806">Virginia Tech</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614808">Wagner</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614809">Wake Forest</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614811">Washington</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614810">Washington St.</a>
+                </td>
+             </tr>
+         </table>
+     </td>
+       <td valign="top">
+	      <table width="100%">
+             <tr>
+	            <td>
+                <a href="/teams/614784">West Ga.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614812">West Virginia</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614813">Western Caro.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614814">Western Ill.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614815">Western Ky.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614816">Western Mich.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614817">Wichita St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614818">William &amp; Mary</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614819">Winthrop</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614765">Wofford</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614821">Wright St.</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614822">Xavier</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614823">Yale</a>
+                </td>
+             </tr>
+             <tr>
+	            <td>
+                <a href="/teams/614824">Youngstown St.</a>
+                </td>
+             </tr>
+      </table>
+     </td>
+   </tr>
+</table>
+  </div>
+</div>
+
+<script>
+
+
+$("#available_teams_tab").addClass("current");
+
+$(function() {
+
+	$("ul.css-tabs").tabs("div.css-panes > div", {effect: 'ajax'});
+
+});
+</script>
+
+<br/>
+
+       </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<footer>&copy; <script>document.write(new Date().getFullYear())</script> NCAA <a href="http://web1.ncaa.org/web_files/terms_and_conditions.html" title ="Terms and Conditions" target=_blank>Terms and Conditions</a> | <a href="http://web1.ncaa.org/web_files/privacy.html" target=_blank title="Our Privacy Policy">Privacy Policy</a> | <a href="mailto:ncaastats@ncaa.org">Contact Us</a> </footer>
+
+  <!-- /.container -->
+  </body>
+
+  <script charset="utf-8">
+    $(document).ready(function() {
+      $('a.remote[data-toggle="tab"]').on('show.bs.tab', function (e) {
+        var tab_id = '#' + $(this).attr('aria-controls');
+        $(tab_id).html('<br/><br/><p style="text-align: center"><img style="vertical-align:middle; text-align: center" src="/assets/ajax-loader-6913acdbf4be7d6a2908a84bdecd6cad18110f5fc6d5a07cf8c9ce78d9548700.gif" /> Loading... </p><br/><br/>');
+        $.get($(this).data('remote'), function(data){
+          $(tab_id).html(data);
+        });
+      });
+    });
+
+    function skipMask(obj){
+      if (obj.hasClass('chosen-single') || obj.hasClass('skipMask') || obj.hasClass('ui-datepicker-prev') || obj.hasClass('ui-datepicker-next') || obj.hasClass('ui-corner-all') || obj.hasClass('paginate_button') || obj.hasClass('dt-button')){
+        return true;
+      }else{
+        return false;
+      }
+    }
+
+    $(document).ajaxComplete(function(){
+      unmask();
+    });
+/*
+    $("form").on('submit', function(event){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    */
+    $(document).on('click', 'a', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    $(document).on('click', 'input.green', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+
+  </script>
+</html>

--- a/tests/fixtures/ncaa_reference/mba_team_page_614839.html
+++ b/tests/fixtures/ncaa_reference/mba_team_page_614839.html
@@ -1,0 +1,1637 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<META HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=UTF-8">
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="">
+<meta name="author" content="">
+<meta name="version" content="321d28433e9f7a188596117e6f342ec4a84fb4ed">
+<META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<link rel="shortcut icon" href="/assets/favicon-405088046a5f2bab8eedeacfae7636975c095e9c8decd8c28e3fd0e65c2f51c4.ico" type="image/vnd.microsoft.icon">
+
+<title>NCAA Statistics</title>
+
+<!-- Bootstrap core CSS -->
+
+<!--
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+-->
+<!--
+<link rel="stylesheet" href="https://cdn.datatables.net/2.0.0/css/dataTables.bootstrap4.css" crossorigin="anonymous">
+-->
+<link rel="stylesheet" media="all" href="/assets/application-789c3971842ee3597428ccbebd021716b3231e9cbd0a00a184c3b2d6c8e5f152.css" />
+
+
+<script src="/assets/application-9232576bb3cb000ac0841ff2af81251908ec17312a3c5eb72bf1a32f9754800c.js"></script>
+<!--
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+-->
+<!--
+<script src="https://cdn.datatables.net/2.0.0/js/dataTables.bootstrap4.js" crossorigin="anonymous"></script>
+-->
+
+<meta name="csrf-param" content="authenticity_token" />
+<meta name="csrf-token" content="U3QxTFDb8zStI4cIIYVDSmOYXKGW4dqSPKwH1Mcazgyy+rOCH88lfiymTb6KrKPH2V1Wb5aCB00q+2oYFdPLXQ==" />
+
+<style>
+.grid {clear: all}
+.grid-item, .name {text-align: center;}
+h1 img {max-height: 33px;}
+
+</style>
+<!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+<!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+      <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+    <![endif]-->
+
+
+<script>(window.BOOMR_mq=window.BOOMR_mq||[]).push(["addVar",{"rua.upush":"false","rua.cpush":"false","rua.upre":"false","rua.cpre":"false","rua.uprl":"false","rua.cprl":"false","rua.cprf":"false","rua.trans":"","rua.cook":"false","rua.ims":"false","rua.ufprl":"false","rua.cfprl":"false","rua.isuxp":"false","rua.texp":"norulematch","rua.ceh":"false","rua.ueh":"false","rua.ieh.st":"0"}]);</script>
+                                <script>!function(e){var n="https://s.go-mpulse.net/boomerang/";if("False"=="True")e.BOOMR_config=e.BOOMR_config||{},e.BOOMR_config.PageParams=e.BOOMR_config.PageParams||{},e.BOOMR_config.PageParams.pci=!0,n="https://s2.go-mpulse.net/boomerang/";if(window.BOOMR_API_key="EVKJV-AGD2E-W66AE-NT84S-K5LTF",function(){function e(){if(!r){var e=document.createElement("script");e.id="boomr-scr-as",e.src=window.BOOMR.url,e.async=!0,o.appendChild(e),r=!0}}function t(e){r=!0;var n,t,a,i,d=document,O=window;if(window.BOOMR.snippetMethod=e?"if":"i",t=function(e,n){var t=d.createElement("script");t.id=n||"boomr-if-as",t.src=window.BOOMR.url,BOOMR_lstart=(new Date).getTime(),e=e||d.body,e.appendChild(t)},!window.addEventListener&&window.attachEvent&&navigator.userAgent.match(/MSIE [67]\./))return window.BOOMR.snippetMethod="s",void t(o,"boomr-async");a=document.createElement("IFRAME"),a.src="about:blank",a.title="",a.role="presentation",a.loading="eager",i=(a.frameElement||a).style,i.width=0,i.height=0,i.border=0,i.display="none",o.appendChild(a);try{O=a.contentWindow,d=O.document.open()}catch(_){n=document.domain,a.src="javascript:var d=document.open();d.domain='"+n+"';void 0;",O=a.contentWindow,d=O.document.open()}if(n)d._boomrl=function(){this.domain=n,t()},d.write("<bo"+"dy onload='document._boomrl();'>");else if(O._boomrl=function(){t()},O.addEventListener)O.addEventListener("load",O._boomrl,!1);else if(O.attachEvent)O.attachEvent("onload",O._boomrl);d.close()}function a(e){window.BOOMR_onload=e&&e.timeStamp||(new Date).getTime()}if(!window.BOOMR||!window.BOOMR.version&&!window.BOOMR.snippetExecuted){window.BOOMR=window.BOOMR||{},window.BOOMR.snippetStart=(new Date).getTime(),window.BOOMR.snippetExecuted=!0,window.BOOMR.snippetVersion=14,window.BOOMR.url=n+"EVKJV-AGD2E-W66AE-NT84S-K5LTF";var i=document.currentScript||document.getElementsByTagName("script")[0],o=i.parentNode,r=!1,d=document.createElement("link");if(d.relList&&"function"==typeof d.relList.supports&&d.relList.supports("preload")&&"as"in d)window.BOOMR.snippetMethod="p",d.href=window.BOOMR.url,d.rel="preload",d.as="script",d.addEventListener("load",e),d.addEventListener("error",function(){t(!0)}),setTimeout(function(){if(!r)t(!0)},3e3),BOOMR_lstart=(new Date).getTime(),o.appendChild(d);else t(!1);if(window.addEventListener)window.addEventListener("load",a,!1);else if(window.attachEvent)window.attachEvent("onload",a)}}(),"".length>0)if(e&&"performance"in e&&e.performance&&"function"==typeof e.performance.setResourceTimingBufferSize)e.performance.setResourceTimingBufferSize();!function(){if(BOOMR=e.BOOMR||{},BOOMR.plugins=BOOMR.plugins||{},!BOOMR.plugins.AK){var n=""=="true"?1:0,t="cookiepresent",a="iwgbcjaxgslzw2upi6ka-f-7b027a414-clientnsv4-s.akamaihd.net",i="false"=="true"?2:1,o={"ak.v":"41","ak.cp":"1168236","ak.ai":parseInt("215853",10),"ak.ol":"0","ak.cr":35,"ak.ipv":4,"ak.proto":"h2","ak.rid":"178c0320","ak.r":51194,"ak.a2":n,"ak.m":"a","ak.n":"essl","ak.cport":56726,"ak.gh":"23.206.120.12","ak.quicv":"","ak.tlsv":"tls1.3","ak.0rtt":"","ak.0rtt.ed":"","ak.csrc":"-","ak.acc":"","ak.t":"1787774868","ak.ak":"hOBiQwZUYzCg5VSAfCLimQ==+yBMZEColr7qDuob7Jv6LUYPbaXEl5PMWztrbHACJq+3oCe//xl5aWxEUO8WpfDP74FPSNPkW4qmc2KzLnbxb62rGv7BB8sc9PPSQieiQi3+fRCI+rv+bpz8cU302mskn/io25RAVRK1wv/agcJj99+XNFchrOixCyn0jmBmi5b9XVRYfS6L/nbVWr0xYE98BCBvxO5Z9a/a7V7EnA6T4wxyQT8OrTPu5odjcE7TYj/2carwcyEy+GzK3DKWh60FCRNDGzr5q3OvEatC3ZNVI7IRaYYrkpAItCzC5YYjmFDtbA9C7X8HXT5JphuHG6XiOdRrvfCmtBT4vw9GSAs96CnEfhljT6zbMbQjbVYUG62/wjyE+XzXOtkDxzH7yMBdTQ2kQdKkbYSf71elSAuTlMnaDfu+O87B6bP4Vx9aKQ8=","ak.pv":"93","ak.dpoabenc":"","ak.tf":i};if(""!==t)o["ak.ruds"]=t;var r={i:!1,av:function(n){var t="http.initiator";if(n&&(!n[t]||"spa_hard"===n[t]))o["ak.feo"]=void 0!==e.aFeoApplied?1:0,BOOMR.addVar(o)},rv:function(){var e=["ak.cport","ak.cr","ak.csrc","ak.gh","ak.ipv","ak.m","ak.n","ak.ol","ak.proto","ak.quicv","ak.tlsv","ak.0rtt","ak.0rtt.ed","ak.r","ak.acc","ak.t","ak.tf"];BOOMR.removeVar(e)}};BOOMR.plugins.AK={akVars:o,akDNSPreFetchDomain:a,init:function(){if(!r.i){var e=BOOMR.subscribe;e("before_beacon",r.av,null,null),e("onbeacon",r.rv,null,null),r.i=!0}return this},is_complete:function(){return!0}}}}()}(window);</script></head>
+
+  <script>
+
+    
+  //initialize tooltip
+  $(document).ready(function() {
+    //$("body").tooltip({ selector: '[data-toggle=tooltip]' });
+    $('[data-toggle="tooltip"]').tooltip();
+  });
+
+  $(document).ready(function() {
+    $( "#org_name" ).autocomplete({
+      source: '/team/search',
+      select: function( event, ui ) {
+        $("#org_id").val(ui.item.vid);
+        $("#id").val(ui.item.vid);
+        $('#sport_btn').click();
+      }
+    });
+  });
+
+  var body = 'body';
+
+  $.ajaxSetup ({
+    // Disable caching of AJAX responses
+    cache: false
+  });
+
+  function changeSport(field){
+    var el = $(field);
+    var tmList = el.parent().next().find('.new-team-year')[0];
+    if (tmList == null){
+      tmList = el.nextAll('.new-team-year')[0];
+    }
+    $.ajax({
+      url: "/game_sport_year_ctls/"+el.val()+"/available_teams",
+      dataType: "script",
+      success: function(data, status){
+        $(tmList).empty();
+        $(tmList).append(("<option value=''>Select team</option>"));
+        $.each(JSON.parse(data), function(k, v){
+          $(tmList).append($("<option></option>")
+              .attr("value", v["id"])
+              .text(v["member_org"]["name_tabular"]));
+        });
+        $(tmList).trigger("chosen:updated");
+      }
+    });
+  }
+
+    function set_process_styles(fld, start_color, end_color){
+       $('#'+fld).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    var downImage = "/assets/down12.gif";
+    var rightImage = "/assets/right12.gif";
+
+    function highlight(div_id){
+      $(div_id).effect('highlight', {color: '#99CC99'}, 6000);
+    }
+
+    function show_hide_rows(attr_val, link_id){
+      $('#'+attr_val).toggle();
+      if ($('#'+attr_val).is(':visible')) {
+        $('#'+link_id).attr('src', downImage);
+      }else{
+        $('#'+link_id).attr('src', rightImage);
+      }
+    }
+
+    function mask(label){
+      $('body').mask(label);
+    }
+    function unmask(){
+      $('body').unmask();
+    }
+
+    var winHeight = "auto";
+    var winWidth = "auto";
+    var maxHeight = 700;
+    var maxWidth = 1400;
+    var minHeight = 100;
+    var minWidth = 200;
+    
+    var modalOptions = {"width": winWidth,
+                        "height": winHeight,
+                        "maxHeight": maxHeight,
+                        "maxWidth": maxWidth,
+                        "minHeight": minHeight,
+                        "minWidth": minWidth};
+
+    function dialog(url, title){
+
+      $("#stats_app_dialog").dialog({modal:true, minWidth:minWidth, minHeight:minHeight, maxWidth:maxWidth, maxHeight:maxHeight, width:winWidth, height:winHeight, title:title, closeOnEscape: false});
+    
+      modalOptions.title = title;
+    
+      $("#stats_app_dialog").dialog("option", modalOptions);
+    
+      $("#stats_app_dialog").html("Loading...");
+      $("#stats_app_dialog").load(url).dialog('open');
+    }
+
+    function addDatePicker(){
+    $('.adddatepicker').each(function(i, obj){
+      $(obj).datepicker({ 
+        showOn: 'both', 
+        buttonImage: '/assets/calendar.gif', 
+        buttonImageOnly: true,
+      });
+    });
+    }
+
+   $(document).ready(function() {
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   });
+
+   function setClassInputFields(){
+     addDatePicker();
+     $('.chosen-select').chosen({allow_single_deselect: true, search_contains: true, width: '250px'});
+     $('.chosen-select-wide').chosen({allow_single_deselect: true, search_contains: true, width: '400px'});
+   }
+
+   function isValidDateFormat(dateStr){
+     const regex = /^([1-9]|0[1-9]|1[0-2])\/([1-9]|0[1-9]|[12][0-9]|3[01])\/(19|20)\d{2}$/;
+     if (!regex.test(dateStr)) {
+       return false;
+     }else{
+       return true;
+     }
+   }
+
+  </script>
+
+
+<body style="font-size: .75rem;" onload="if (top != self) { top.location=self.location; }" >
+
+      <header>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0">
+        <a class="navbar-brand mr-0 mr-md-2" href="/" aria-label="statistics">
+                          <img alt="NCAA" style="margin-left: 24px; margin-right: 0; margin-top: 6px;" src="/assets/ncaa-fbc4d0406ae731b47babcc3fca53775b5955ef372bf8b8e998ca9a513e468b8f.svg" />
+                          <span class="title" class="dark-blue-font">Statistics</span>
+        </a>
+       </nav>
+        <nav class="navbar navbar-expand-lg navbar-light bg-light header-dark-border-color py-0" style="background-color: var(--color-dark-blue) !important;">
+  <button class="navbar-toggler bg-white" type="button" data-toggle="collapse" data-target="#navbarTogglerDemo01" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarTogglerDemo01">
+        <ul class="navbar-nav mr-auto mt-2 mt-lg-0 justify-content-center">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle skipMask" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Rankings
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+          <a class="dropdown-item" href="/rankings">National Rankings</a>
+          <a class="dropdown-item" href="/active_career_leaders">Active Career Leaders</a>
+        </div>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/contests/livestream_scoreboards">Scoreboard</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/selection_rankings/nitty_gritties">Selection Rankings</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/head_coaches">Head Coaches</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/search/players">Players</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link skipMask dropdown-toggle" data-toggle="collapse" href="#collapseSchoolTeams" role="button" aria-expanded="false" aria-controls="collapseSchoolTeams">
+          A&amp;M-Corpus Christi Sports
+        </a>
+      </li>
+     </ul>
+
+    <form onsubmit="mask(&#39;Loading&#39;);" id="change_team_form" style="display:inline;" class="form-inline my-2 my-lg-0" action="/team/index" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="pt/vxjtvYLtGTfEjzWqoPu9xIa5dg9jbAPIeGJ+ANipglggbqensq+d9yAm40H4YgyiGHOkdEZ3ECwvfI0ravA==" />
+  <div style="display:none;">
+  <input type="submit" name="commit" value="Submit" id="sport_btn" data-disable-with="Submit" />
+  </div>
+    <div id="team_autocomplete" class="ui-widget">
+      <input type="search" name="org_name" id="org_name" style="width:200px; font-size: 12px !important" class="form-control mr-sm-2" placeholder="Team Search" />
+      <input type="hidden" name="org_id" id="org_id" />
+    </div>
+</form>  </div>
+  </nav>
+    <div class="collapse pt-4" id="collapseSchoolTeams" style="width: 100%">
+      <div class="container-fluid">
+        <div class="row">
+          <div class="col-md">
+            <ul class="list-unstyled">
+              <li><strong>Fall</strong></li>
+                   <li><a href="/teams/625008">2026-27 Women&#39;s Soccer (2-0-1)</a></li>
+                   <li><a href="/teams/624921">2026-27 Women&#39;s Volleyball (0-0)</a></li>
+            </ul>
+          </div>
+          <div class="col-md">
+            <ul class="list-unstyled">
+              <li><strong>Winter</strong></li>
+                   <li><a href="/teams/627267">2026-27 Men&#39;s Basketball (0-0)</a></li>
+                   <li><a href="/teams/628770">2026-27 Women&#39;s Basketball (0-0)</a></li>
+            </ul>
+          </div>
+          <div class="col-md">
+            <ul class="list-unstyled">
+              <li><strong>Spring</strong></li>
+                   <li><a href="/teams/630967">2026-27 Baseball (0-0)</a></li>
+                   <li><a href="/teams/632565">2026-27 Softball (0-0)</a></li>
+                   <li><a href="/teams/633786">2026-27 Women&#39;s Beach Volleyball (0-0)</a></li>
+            </ul>
+          </div>
+      </div>
+    </div>
+</nav>
+      </header>
+
+       <div id="stats_app_dialog" style="display:none;">
+        </div>
+
+<div class="card p-1">
+  <div class="card-body application teams p-0">
+    <h3 class="card-title p-0"></h3>
+    <div class="container-fluid p-0">
+      <div class="row align-items-center justify-content-center p-0">
+        <div class="col-sm-12 p-0">
+        <script>
+  function submit_form(val){
+    curr_action = '/teams/';
+    $('#change_sport_form').attr("action", curr_action + val);
+    $('#team_sport_btn').click();
+  }
+  $(function() {
+    $( "#org_sport_name" ).autocomplete({
+      open: function(){
+        setTimeout(function () {
+            $('.ui-autocomplete').css('z-index', 99999999999999);
+        }, 0);
+      },
+      source: '/team/17040/sport_sponsored_search',
+      select: function( event, ui ) {
+        $("#sport_search_org_id").val(ui.item.vid);
+        //curr_action = '/teams/'.replace("26172", ui.item.vid);
+        curr_action = '/teams/'+ui.item.vid;
+        //$('#change_sport_form').attr("action", curr_action + $('#sport_list').val());
+        $('#change_sport_form').attr("action", curr_action);
+        $('#team_sport_btn').click();
+      }
+    });
+  });
+</script>
+
+  <div class="card">
+    <div class="card-header">
+    <img class="logo_image" alt="A&amp;M-Corpus Christi" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//26172.gif" /> <a target="ATHLETICS_URL" href="http://www.goislanders.com">A&amp;M-Corpus Christi Islanders</a> (23-28) <a class="skipMask" target="TEAM_SHEET_51849_614839_WIN" href="/selection_rankings/nitty_gritties/51849/teams/614839/team_sheet">RPI Ranking - 202</a>
+    </div>
+    <div class="card-body p-1">
+  <form onsubmit="mask(&#39;Loading&#39;);" id="change_sport_form" action="http://stats.ncaa.org" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+    <select name="year_id" id="year_list" onchange="submit_form(this.value);"><option value="630967">2026-27</option>
+<option selected="selected" value="614839">2025-26</option>
+<option value="596471">2024-25</option>
+<option value="573989">2023-24</option>
+<option value="548068">2022-23</option>
+<option value="526333">2021-22</option>
+<option value="508948">2020-21</option>
+<option value="494234">2019-20</option>
+<option value="471516">2018-19</option>
+<option value="197740">2017-18</option>
+<option value="65497">2016-17</option>
+<option value="85554">2015-16</option>
+<option value="18078">2014-15</option>
+<option value="80379">2013-14</option>
+<option value="78663">2012-13</option>
+<option value="13820">2011-12</option>
+<option value="96989">2010-11</option>
+<option value="27619">2009-10</option>
+<option value="320506">2008-09</option>
+<option value="236155">2007-08</option>
+<option value="235216">2006-07</option>
+<option value="197326">2005-06</option>
+<option value="349350">2004-05</option>
+<option value="280171">2003-04</option>
+<option value="319590">2002-03</option>
+<option value="165173">2001-02</option>
+<option value="390373">2000-01</option>
+<option value="164271">1999-00</option></select>
+    <select name="sport_id" id="sport_list" onchange="submit_form(this.value);"><option value="610016">Women&#39;s Basketball</option>
+<option value="602880">Women&#39;s Soccer</option>
+<option value="613770">Softball</option>
+<option value="605076">Women&#39;s Volleyball</option>
+<option value="620296">Women&#39;s Tennis</option>
+<option value="609609">Men&#39;s Basketball</option>
+<option value="613302">Women&#39;s Beach Volleyball</option>
+<option selected="selected" value="614839">Baseball</option>
+<option value="619404">Men&#39;s Tennis</option></select>
+    <a href="/teams/history/MBA/26172">Team History</a> |
+    <a href="/teams/coaches_summary/MBA/26172">Coaches Summary</a>
+
+    <div style="display:none;">
+    <input type="submit" name="commit" value="Submit" id="team_sport_btn" data-disable-with="Submit" />
+    </div>
+    <span id="tst" style="float:right;">
+      <div id="team_sport_autocomplete" class="ui-widget">
+      Teams Sponsoring Baseball:
+      <input type="text" name="org_sport_name" id="org_sport_name" style="width:200px" />
+      <input type="hidden" name="org_id" id="sport_search_org_id" />
+      </div>
+    </span>
+</form>    <!--
+  </div>
+ 
+  <div class="card">
+    <div class="card-body">
+      -->
+    <div class="row">
+      <div class="col p-0">
+          <div class="card m-2" id="team_venues_614839">
+    <div class="card-header">
+      Stadiums
+    </div>
+    <div class="card-body">
+    <div class="card m-2" id="team_page_season_venue_360452">
+  <div class="card-body">
+    <dl class="row mb-0 text-nowrap">
+      <dt class="col-sm-3 mb-0">Name:</dt>
+      <dd class="col-sm-9 mb-0">
+        Chapman Field
+      </dd>
+      <dt class="col-sm-3 mb-0">Capacity:</dt>
+      <dd class="col-sm-9 mb-0">
+        500
+      </dd>
+      <dt class="col-sm-3 mb-0">Year Built:</dt>
+      <dd class="col-sm-9 mb-0">
+        2002
+      </dd>
+      <dt class="col-sm-3 mb-0">Primary Venue:</dt>
+      <dd class="col-sm-9 mb-0">
+        true
+      </dd>
+    </dl>
+  </div>
+</div>
+
+      <br/>
+    <div class="card m-2" id="team_page_season_venue_360606">
+  <div class="card-body">
+    <dl class="row mb-0 text-nowrap">
+      <dt class="col-sm-3 mb-0">Name:</dt>
+      <dd class="col-sm-9 mb-0">
+        Whataburger Field
+      </dd>
+      <dt class="col-sm-3 mb-0">Capacity:</dt>
+      <dd class="col-sm-9 mb-0">
+        
+      </dd>
+      <dt class="col-sm-3 mb-0">Year Built:</dt>
+      <dd class="col-sm-9 mb-0">
+        
+      </dd>
+      <dt class="col-sm-3 mb-0">Primary Venue:</dt>
+      <dd class="col-sm-9 mb-0">
+        false
+      </dd>
+    </dl>
+  </div>
+</div>
+
+   </div>
+ </div>
+
+      </div>
+  
+        <div class="col p-0">
+        <div class="card m-2">
+  <div class="card-header">Coach</div>
+  <div class="card-body">
+      <div class="card">
+        <dl class="row mb-0 text-nowrap">
+          <dt class="col-sm-3 mb-0">Name:</dt>
+          <dd class="col-sm-9 mb-0">
+            <a href="/people/32546?sport_code=MBA">Scott Malone</a>
+          </dd>
+
+          <dt class="col-sm-3 mb-0">Alma Mater:</dt>
+          <dd class="col-sm-9 mb-0">
+            McMurry - 1998
+          </dd>
+          <dt class="col-sm-3 mb-0">Seasons:</dt>
+          <dd class="col-sm-9 mb-0">
+            19
+           <dt class="col-sm-3 mb-0">Record:</dt>
+          <dd class="col-sm-9 mb-0">
+            465-546-2
+          </dd>
+        </dl>
+      </div>
+  </div>
+</div>
+
+        </div>
+    </div>
+    <!--
+    don't close this here, but make sure to close it at the end of rosters, schedule results, game by game etc.
+  </div>
+  -->
+
+    <div class="row">
+      <div class="col p-0">
+  <div class="card mb-2 mx-2">
+  <div class="card-header">Season-to-date Records</div>
+  <div class="card-body p-0">
+       <div class="row">
+          <div class="card mx-2 my-2" style="min-width: 10em;">
+            <div class="card-header p-1">Overall</div>
+            <div class="card-body p-1"> 
+              <div class="row">
+                <span>23-28 (0.451)</span>
+              </div>
+              <div class="row">
+                <span> Streak: L4 </span>
+              </div>
+            </div>
+          </div>
+          <div class="card mx-2 my-2" style="min-width: 10em;">
+            <div class="card-header p-1">Conference</div>
+            <div class="card-body p-1"> 
+              <div class="row">
+                <span>11-19 (0.367)</span>
+              </div>
+              <div class="row">
+                <span> Streak: L3 </span>
+              </div>
+            </div>
+          </div>
+          <div class="card mx-2 my-2" style="min-width: 10em;">
+            <div class="card-header p-1">Home</div>
+            <div class="card-body p-1"> 
+              <div class="row">
+                <span>15-14 (0.517)</span>
+              </div>
+              <div class="row">
+                <span> Streak: W1 </span>
+              </div>
+            </div>
+          </div>
+          <div class="card mx-2 my-2" style="min-width: 10em;">
+            <div class="card-header p-1">Road</div>
+            <div class="card-body p-1"> 
+              <div class="row">
+                <span>8-14 (0.364)</span>
+              </div>
+              <div class="row">
+                <span> Streak: L4 </span>
+              </div>
+            </div>
+          </div>
+          <div class="card mx-2 my-2" style="min-width: 10em;">
+            <div class="card-header p-1">Neutral </div>
+            <div class="card-body p-1"> 
+              <div class="row">
+                <span>0-0 (0.000)</span>
+              </div>
+              <div class="row">
+                <span> Streak: L1 </span>
+              </div>
+            </div>
+          </div>
+          <div class="card mx-2 my-2" style="min-width: 10em;">
+            <div class="card-header p-1">Non-Division</div>
+            <div class="card-body p-1"> 
+              <div class="row">
+                <span>0-0 (0.000)</span>
+              </div>
+              <div class="row">
+                <span> Streak: W6 </span>
+              </div>
+            </div>
+          </div>
+    </div>
+  </div>
+</div>
+
+      </div>
+    </div>
+</div>
+
+
+  <nav>
+<ul class="nav nav-tabs padding-nav">
+  <li class="nav-item">
+    <a class="nav-link active" href="/teams/614839">Schedule/Results</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="/teams/614839/roster">Roster</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="/teams/614839/season_to_date_stats">Team Statistics</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="/players/9708136">Game By Game</a>
+  </li>
+<!--
+<a href="/team/team_game_highs?org_id=26172&amp;sport_year_ctl_id=17040">Game Highs</a> 
+<a href="/team/conf_game_highs?org_id=26172&amp;sport_year_ctl_id=17040">Conf Game Highs</a> 
+<a href="/player/player_rank_history?game_sport_year_ctl_id=17040&amp;index_start=0&amp;org_id=26172&amp;stat_seq_to_chart=0&amp;stats_player_seq=-100">Ranking Trends</a> 
+<a href="/player/team_player_rank_yearly_history?game_sport_year_ctl_id=17040&amp;index_start=0&amp;org_id=26172&amp;stat_seq_to_chart=0&amp;stats_player_seq=-100">Team Final Trends</a> 
+-->
+      <li class="nav-item">
+        <a class="nav-link" href="/rankings/ranking_summary?academic_year=2026&amp;division=1&amp;org_id=26172&amp;ranking_period=111&amp;sport_code=MBA">Ranking Summary</a>
+      </li>
+</ul>
+</nav>
+
+
+<!--
+
+  <div class="row">
+  <tr>
+    <td colspan="2">
+    </td>
+  </tr>
+</div>
+-->
+      <div class="row">
+        <div class="col p-0" style="min-width: 400px;">
+          <div class="card m-2">
+  <div class="card-header">Schedule/Results</div>
+  <div class="card-body">
+    <table style="border-collapse: collapse" width="80%">
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th>Opponent</th>
+          <th>Result</th>
+          <th align="right" style="text-align: right !important">Attendance</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="underline_rows">
+          <td>02/13/2026</td>
+          <td>
+        <a href="/teams/614759"><img class="logo_image" alt="Stonehill" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//682.gif" /> Stonehill</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6526442/box_score">W 11-1 </a>
+          </td>
+          <td align="right">
+        378
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>02/14/2026(1)</td>
+          <td>
+        <a href="/teams/614759"><img class="logo_image" alt="Stonehill" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//682.gif" /> Stonehill</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6526445/box_score">W 12-5 </a>
+          </td>
+          <td align="right">
+        281
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>02/14/2026(2)</td>
+          <td>
+        <a href="/teams/614759"><img class="logo_image" alt="Stonehill" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//682.gif" /> Stonehill</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6526447/box_score">W 11-8 </a>
+          </td>
+          <td align="right">
+        265
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>02/15/2026</td>
+          <td>
+        <a href="/teams/614759"><img class="logo_image" alt="Stonehill" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//682.gif" /> Stonehill</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6526450/box_score">W 11-1 </a>
+          </td>
+          <td align="right">
+        291
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>02/17/2026</td>
+          <td>
+        @<a href="/teams/614788"><img class="logo_image" alt="Texas A&amp;M" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//697.gif" /> Texas A&amp;M</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6549903/box_score">L 3-8 </a>
+          </td>
+          <td align="right">
+        5,385
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>02/20/2026</td>
+          <td>
+        <a href="/teams/614566"><img class="logo_image" alt="CSU Bakersfield" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//94.gif" /> CSU Bakersfield</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6498814/box_score">L 4-7 </a>
+          </td>
+          <td align="right">
+        771
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>02/21/2026</td>
+          <td>
+        <a href="/teams/614568"><img class="logo_image" alt="Long Beach St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//99.gif" /> Long Beach St.</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6500378/box_score">L 5-10 </a>
+          </td>
+          <td align="right">
+        808
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>02/22/2026</td>
+          <td>
+        <a href="/teams/614710"><img class="logo_image" alt="Pittsburgh" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//545.gif" /> Pittsburgh</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6549905/box_score">W 5-2 </a>
+          </td>
+          <td align="right">
+        847
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>02/24/2026</td>
+          <td>
+        <a href="/teams/614712"><img class="logo_image" alt="Prairie View" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//553.gif" /> Prairie View</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6549906/box_score">W 9-2 </a>
+          </td>
+          <td align="right">
+        308
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>02/27/2026</td>
+          <td>
+        <a href="/teams/614790"><img class="logo_image" alt="Texas Southern" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//699.gif" /> Texas Southern</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6549907/box_score">W 5-4 </a>
+          </td>
+          <td align="right">
+        259
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>02/28/2026</td>
+          <td>
+        <a href="/teams/614790"><img class="logo_image" alt="Texas Southern" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//699.gif" /> Texas Southern</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6549910/box_score">W 4-3 </a>
+          </td>
+          <td align="right">
+        281
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>03/01/2026</td>
+          <td>
+        <a href="/teams/614790"><img class="logo_image" alt="Texas Southern" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//699.gif" /> Texas Southern</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6549911/box_score">L 4-16 </a>
+          </td>
+          <td align="right">
+        231
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>03/03/2026</td>
+          <td>
+        <a href="/teams/614794"><img class="logo_image" alt="UTSA" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//706.gif" /> UTSA</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6549915/box_score">L 5-7 </a>
+          </td>
+          <td align="right">
+        410
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>03/06/2026</td>
+          <td>
+        <a href="/teams/614774"><img class="logo_image" alt="Nicholls" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//483.gif" /> Nicholls</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6549916/box_score">L 1-6 </a>
+          </td>
+          <td align="right">
+        0
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>03/07/2026(1)</td>
+          <td>
+        <a href="/teams/614774"><img class="logo_image" alt="Nicholls" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//483.gif" /> Nicholls</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6558914/box_score">L 3-8 </a>
+          </td>
+          <td align="right">
+        276
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>03/07/2026(2)</td>
+          <td>
+        <a href="/teams/614774"><img class="logo_image" alt="Nicholls" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//483.gif" /> Nicholls</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6558986/box_score">L 5-14 </a>
+          </td>
+          <td align="right">
+        288
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>03/10/2026</td>
+          <td>
+        <a href="/teams/614790"><img class="logo_image" alt="Texas Southern" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//699.gif" /> Texas Southern</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6549923/box_score">W 2-1 </a>
+          </td>
+          <td align="right">
+        258
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>03/11/2026</td>
+          <td>
+        <a href="/teams/614790"><img class="logo_image" alt="Texas Southern" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//699.gif" /> Texas Southern</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6549925/box_score">W 5-4 </a>
+          </td>
+          <td align="right">
+        317
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>03/13/2026</td>
+          <td>
+        @<a href="/teams/614696"><img class="logo_image" alt="Northwestern St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//508.gif" /> Northwestern St.</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6489272/box_score">L 1-5 </a>
+          </td>
+          <td align="right">
+        843
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>03/14/2026</td>
+          <td>
+        @<a href="/teams/614696"><img class="logo_image" alt="Northwestern St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//508.gif" /> Northwestern St.</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6489273/box_score">L 4-10 </a>
+          </td>
+          <td align="right">
+        789
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>03/15/2026</td>
+          <td>
+        @<a href="/teams/614696"><img class="logo_image" alt="Northwestern St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//508.gif" /> Northwestern St.</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6489274/box_score">L 3-4 </a>
+          </td>
+          <td align="right">
+        233
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>03/20/2026</td>
+          <td>
+        <a href="/teams/614640"><img class="logo_image" alt="Lamar University" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//346.gif" /> Lamar University</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6503392/box_score">W 6-1 </a>
+          </td>
+          <td align="right">
+        321
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>03/21/2026</td>
+          <td>
+        <a href="/teams/614640"><img class="logo_image" alt="Lamar University" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//346.gif" /> Lamar University</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6503394/box_score">L 3-7 </a>
+          </td>
+          <td align="right">
+        308
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>03/22/2026</td>
+          <td>
+        <a href="/teams/614640"><img class="logo_image" alt="Lamar University" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//346.gif" /> Lamar University</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6503395/box_score">L 15-18 (10)</a>
+          </td>
+          <td align="right">
+        358
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>03/24/2026</td>
+          <td>
+        @<a href="/teams/614794"><img class="logo_image" alt="UTSA" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//706.gif" /> UTSA</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6551514/box_score">L 1-3 </a>
+          </td>
+          <td align="right">
+        1,140
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>03/27/2026</td>
+          <td>
+        @<a href="/teams/614707"><img class="logo_image" alt="UTRGV" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//536.gif" /> UTRGV</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6525711/box_score">W 9-6 </a>
+          </td>
+          <td align="right">
+        3,618
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>03/28/2026</td>
+          <td>
+        @<a href="/teams/614707"><img class="logo_image" alt="UTRGV" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//536.gif" /> UTRGV</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6525714/box_score">L 1-5 </a>
+          </td>
+          <td align="right">
+        5,213
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>03/29/2026</td>
+          <td>
+        @<a href="/teams/614707"><img class="logo_image" alt="UTRGV" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//536.gif" /> UTRGV</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6525717/box_score">W 5-2 </a>
+          </td>
+          <td align="right">
+        1,887
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>04/02/2026</td>
+          <td>
+        <a href="/teams/614750"><img class="logo_image" alt="SFA" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//676.gif" /> SFA</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6532140/box_score">L 3-8 </a>
+          </td>
+          <td align="right">
+        316
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>04/03/2026</td>
+          <td>
+        <a href="/teams/614750"><img class="logo_image" alt="SFA" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//676.gif" /> SFA</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6532145/box_score">L 9-13 </a>
+          </td>
+          <td align="right">
+        0
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>04/04/2026</td>
+          <td>
+        <a href="/teams/614750"><img class="logo_image" alt="SFA" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//676.gif" /> SFA</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6532151/box_score">W 8-3 </a>
+          </td>
+          <td align="right">
+        362
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>04/07/2026</td>
+          <td>
+        @<a href="/teams/614718"><img class="logo_image" alt="Rice" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//574.gif" /> Rice</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6549424/box_score">L 4-18 </a>
+          </td>
+          <td align="right">
+        1,543
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>04/08/2026</td>
+          <td>
+        @<a href="/teams/614712"><img class="logo_image" alt="Prairie View" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//553.gif" /> Prairie View</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6549939/box_score">W 14-4 </a>
+          </td>
+          <td align="right">
+        115
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>04/10/2026</td>
+          <td>
+        @<a href="/teams/614741"><img class="logo_image" alt="Southeastern La." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//655.gif" /> Southeastern La.</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6498116/box_score">W 7-5 </a>
+          </td>
+          <td align="right">
+        1,233
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>04/11/2026</td>
+          <td>
+        @<a href="/teams/614741"><img class="logo_image" alt="Southeastern La." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//655.gif" /> Southeastern La.</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6498117/box_score">L 5-10 </a>
+          </td>
+          <td align="right">
+        1,188
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>04/12/2026</td>
+          <td>
+        @<a href="/teams/614741"><img class="logo_image" alt="Southeastern La." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//655.gif" /> Southeastern La.</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6498119/box_score">L 4-5 </a>
+          </td>
+          <td align="right">
+        1,309
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>04/14/2026</td>
+          <td>
+        @<a href="/teams/614793"><img class="logo_image" alt="Texas" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//703.gif" /> Texas</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6539332/box_score">L 7-14 </a>
+          </td>
+          <td align="right">
+        6,726
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>04/17/2026</td>
+          <td>
+        <a href="/teams/614657"><img class="logo_image" alt="McNeese" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//402.gif" /> McNeese</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6509831/box_score">L 4-9 </a>
+          </td>
+          <td align="right">
+        242
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>04/18/2026</td>
+          <td>
+        <a href="/teams/614657"><img class="logo_image" alt="McNeese" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//402.gif" /> McNeese</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6509834/box_score">W 7-6 </a>
+          </td>
+          <td align="right">
+        267
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>04/19/2026</td>
+          <td>
+        <a href="/teams/614657"><img class="logo_image" alt="McNeese" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//402.gif" /> McNeese</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6509835/box_score">W 9-5 </a>
+          </td>
+          <td align="right">
+        244
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>04/24/2026</td>
+          <td>
+        @<a href="/teams/614836"><img class="logo_image" alt="UIW" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//2743.gif" /> UIW</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6532957/box_score">W 14-3 </a>
+          </td>
+          <td align="right">
+        118
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>04/25/2026</td>
+          <td>
+        @<a href="/teams/614836"><img class="logo_image" alt="UIW" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//2743.gif" /> UIW</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6532959/box_score">W 6-4 </a>
+          </td>
+          <td align="right">
+        0
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>04/26/2026</td>
+          <td>
+        @<a href="/teams/614836"><img class="logo_image" alt="UIW" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//2743.gif" /> UIW</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6532961/box_score">W 11-4 </a>
+          </td>
+          <td align="right">
+        144
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>04/28/2026</td>
+          <td>
+        @<a href="/teams/614747"><img class="logo_image" alt="Texas St." src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//670.gif" /> Texas St.</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6499391/box_score">W 7-2 </a>
+          </td>
+          <td align="right">
+        1,256
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>05/02/2026(1)</td>
+          <td>
+        <a href="/teams/614621"><img class="logo_image" alt="Houston Christian" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//287.gif" /> Houston Christian</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6529988/box_score">L 4-5 </a>
+          </td>
+          <td align="right">
+        345
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>05/02/2026(2)</td>
+          <td>
+        <a href="/teams/614621"><img class="logo_image" alt="Houston Christian" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//287.gif" /> Houston Christian</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6529990/box_score">L 4-15 </a>
+          </td>
+          <td align="right">
+        362
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>05/03/2026</td>
+          <td>
+        <a href="/teams/614621"><img class="logo_image" alt="Houston Christian" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//287.gif" /> Houston Christian</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6529991/box_score">W 3-2 </a>
+          </td>
+          <td align="right">
+        288
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>05/05/2026</td>
+          <td>
+        @<a href="/teams/614622"><img class="logo_image" alt="Houston" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//288.gif" /> Houston</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6526979/box_score">L 1-10 </a>
+          </td>
+          <td align="right">
+        699
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>05/07/2026</td>
+          <td>
+        @<a href="/teams/614685"><img class="logo_image" alt="New Orleans" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//474.gif" /> New Orleans</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6515627/box_score">L 2-9 </a>
+          </td>
+          <td align="right">
+        575
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>05/08/2026</td>
+          <td>
+        @<a href="/teams/614685"><img class="logo_image" alt="New Orleans" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//474.gif" /> New Orleans</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6515628/box_score">L 4-6 </a>
+          </td>
+          <td align="right">
+        477
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+        <tr class="underline_rows">
+          <td>05/09/2026</td>
+          <td>
+        @<a href="/teams/614685"><img class="logo_image" alt="New Orleans" src="https://web2.ncaa.org/ncaa_style/img/All_Logos/sm//474.gif" /> New Orleans</a> 
+          </td>
+          <td nowrap>
+          <a target="BOX_SCORE_WINDOW" class="skipMask" href="/contests/6515629/box_score">L 4-7 </a>
+          </td>
+          <td align="right">
+        659
+          </td>
+       </tr>
+       <tr>
+         <td colspan="4"></td>
+       </tr>
+    </tbody>
+	 </table>
+ </div>
+</div>
+
+        </div>
+        <div class="col p-0">
+            <div class="card m-2">
+    <div class="card-header">Team Stats - Through games 06/22/2026</div>
+    <div class="card-body">
+      <table class="" style="border-collapse: collapse" width="50%">
+        <thead>
+          <tr>
+            <th align="left">Stat</th>
+            <th align="right" sytle="text-align: right !important">Rank</th>
+            <th align="rigth" style="text-align: right !important">Value</th>
+          </tr>
+        </thead>
+        <tbody>
+              <tr class="underline_rows">
+            <td nowrap><a target="Rankings" class="skipMask" href="/rankings/MBA/2026/1/210/111">Batting Average</a></td>
+            <td align="right">215</td>
+            <td align="right">
+              0.267
+            </td>
+          </tr>
+              <tr class="underline_rows">
+            <td nowrap><a target="Rankings" class="skipMask" href="/rankings/MBA/2026/1/323/111">Home Runs Per Game</a></td>
+            <td align="right">253</td>
+            <td align="right">
+              0.69
+            </td>
+          </tr>
+              <tr class="underline_rows">
+            <td nowrap><a target="Rankings" class="skipMask" href="/rankings/MBA/2026/1/324/111">Doubles Per Game</a></td>
+            <td align="right">292</td>
+            <td align="right">
+              1.37
+            </td>
+          </tr>
+              <tr class="underline_rows">
+            <td nowrap><a target="Rankings" class="skipMask" href="/rankings/MBA/2026/1/325/111">Triples Per Game</a></td>
+            <td align="right">106</td>
+            <td align="right">
+              0.22
+            </td>
+          </tr>
+              <tr class="underline_rows">
+            <td nowrap><a target="Rankings" class="skipMask" href="/rankings/MBA/2026/1/327/111">Slugging Percentage</a></td>
+            <td align="right">255</td>
+            <td align="right">
+              0.385
+            </td>
+          </tr>
+              <tr class="underline_rows">
+            <td nowrap><a target="Rankings" class="skipMask" href="/rankings/MBA/2026/1/589/111">On Base Percentage</a></td>
+            <td align="right">257</td>
+            <td align="right">
+              0.359
+            </td>
+          </tr>
+              <tr class="underline_rows">
+            <td nowrap><a target="Rankings" class="skipMask" href="/rankings/MBA/2026/1/213/111">Scoring</a></td>
+            <td align="right">239</td>
+            <td align="right">
+              5.8
+            </td>
+          </tr>
+              <tr class="underline_rows">
+            <td nowrap><a target="Rankings" class="skipMask" href="/rankings/MBA/2026/1/326/111">Stolen Bases Per Game</a></td>
+            <td align="right">121</td>
+            <td align="right">
+              1.37
+            </td>
+          </tr>
+              <tr class="underline_rows">
+            <td nowrap><a target="Rankings" class="skipMask" href="/rankings/MBA/2026/1/211/111">Earned Run Average</a></td>
+            <td align="right">186</td>
+            <td align="right">
+              6.28
+            </td>
+          </tr>
+              <tr class="underline_rows">
+            <td nowrap><a target="Rankings" class="skipMask" href="/rankings/MBA/2026/1/328/111">Double Plays Per Game</a></td>
+            <td align="right">207</td>
+            <td align="right">
+              0.61
+            </td>
+          </tr>
+              <tr class="underline_rows">
+            <td nowrap><a target="Rankings" class="skipMask" href="/rankings/MBA/2026/1/591/111">Strikeout-to-Walk Ratio</a></td>
+            <td align="right">154</td>
+            <td align="right">
+              1.75
+            </td>
+          </tr>
+              <tr class="underline_rows">
+            <td nowrap><a target="Rankings" class="skipMask" href="/rankings/MBA/2026/1/212/111">Fielding Percentage</a></td>
+            <td align="right">107</td>
+            <td align="right">
+              0.973
+            </td>
+          </tr>
+        </tbody>
+        <tfoot>
+          <tr>
+            <td colspan="3">
+              <a target="RANKINGS_WIN" class="skipMask" href="/rankings/ranking_summary?academic_year=2026.0&amp;division=1.0&amp;game_high=N&amp;org_id=26172&amp;ranking_period=111&amp;sport_code=MBA&amp;team_individual=T">View Complete Ranking Summary</a>
+            </td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  </div>
+</table>
+<br/>
+
+            <div class="card m-2">
+    <div class="card-header">Individual Leaders</div>
+    <div class="card-body">
+      <table style="border-collapse: collapse" width="50%">
+        <thead>
+          <tr>
+            <th align="left">Stat</th>
+            <th align="left">Player</th>
+            <th align="right" style="text-align: right !important;">Value</th>
+            <th align="right" style="text-align: right !important;">PG</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="underline_rows">
+            <td>BA</td>
+            <td>
+              <a href="/players/11234932">Pedro Quero</a>
+            </td>
+            <td align="right">0.500</td>
+            <td align="right">-</td>
+          </tr>
+          <tr class="underline_rows">
+            <td>R</td>
+            <td>
+              <a href="/players/9692299">Christian Smith-Johnson</a>
+            </td>
+            <td align="right">35</td>
+            <td align="right">0.73</td>
+          </tr>
+          <tr class="underline_rows">
+            <td>HR</td>
+            <td>
+              <a href="/players/11234856">Isaiah Afework</a>
+            </td>
+            <td align="right">5</td>
+            <td align="right">0.16</td>
+          </tr>
+          <tr class="underline_rows">
+            <td>RBI</td>
+            <td>
+              <a href="/players/9685365">Jarrett Flaggert</a>
+            </td>
+            <td align="right">31</td>
+            <td align="right">0.72</td>
+          </tr>
+          <tr class="underline_rows">
+            <td>SB</td>
+            <td>
+              <a href="/players/9692299">Christian Smith-Johnson</a>
+            </td>
+            <td align="right">22</td>
+            <td align="right">0.46</td>
+          </tr>
+          <tr class="underline_rows">
+            <td>IP</td>
+            <td>
+              <a href="/players/9677987">Easten Smith</a>
+            </td>
+            <td align="right">50.0</td>
+            <td align="right">3.13</td>
+          </tr>
+          <tr class="underline_rows">
+            <td>ERA</td>
+            <td>
+              <a href="/players/11234926">Bronson Lange</a>
+            </td>
+            <td align="right">0.00</td>
+            <td align="right">-</td>
+          </tr>
+          <tr class="underline_rows">
+            <td>W</td>
+            <td>
+              <a href="/players/9677987">Easten Smith</a>
+            </td>
+            <td align="right">6</td>
+            <td align="right">-</td>
+          </tr>
+          <tr class="underline_rows">
+            <td>SV</td>
+            <td>
+              <a href="/players/11234927">Chase Mayer</a>
+            </td>
+            <td align="right">3</td>
+            <td align="right">-</td>
+          </tr>
+        </tbody>
+        <tfoot>
+          <tr>
+            <td colspan="3">
+              <a href="/team/26172/stats/17040">Team Stats</a>
+            </td>
+        </tfoot>
+      </table>
+    </div>
+  </div>
+
+        </div>
+    </div>
+</div>
+
+       </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<footer>&copy; <script>document.write(new Date().getFullYear())</script> NCAA <a href="http://web1.ncaa.org/web_files/terms_and_conditions.html" title ="Terms and Conditions" target=_blank>Terms and Conditions</a> | <a href="http://web1.ncaa.org/web_files/privacy.html" target=_blank title="Our Privacy Policy">Privacy Policy</a> | <a href="mailto:ncaastats@ncaa.org">Contact Us</a> </footer>
+
+  <!-- /.container -->
+  <script type="text/javascript"  src="/sXDpyF73OnZiV/4_nX4/vZg0RiRRg/DXf9fwurEzma/akwFfldRQQY/DSo0/LWZ8RSoX?v=8c96b7d3-5743-ecfc-4560-b8c6011c17ce" defer></script></body>
+
+  <script charset="utf-8">
+    $(document).ready(function() {
+      $('a.remote[data-toggle="tab"]').on('show.bs.tab', function (e) {
+        var tab_id = '#' + $(this).attr('aria-controls');
+        $(tab_id).html('<br/><br/><p style="text-align: center"><img style="vertical-align:middle; text-align: center" src="/assets/ajax-loader-6913acdbf4be7d6a2908a84bdecd6cad18110f5fc6d5a07cf8c9ce78d9548700.gif" /> Loading... </p><br/><br/>');
+        $.get($(this).data('remote'), function(data){
+          $(tab_id).html(data);
+        });
+      });
+    });
+
+    function skipMask(obj){
+      if (obj.hasClass('chosen-single') || obj.hasClass('skipMask') || obj.hasClass('ui-datepicker-prev') || obj.hasClass('ui-datepicker-next') || obj.hasClass('ui-corner-all') || obj.hasClass('paginate_button') || obj.hasClass('dt-button')){
+        return true;
+      }else{
+        return false;
+      }
+    }
+
+    $(document).ajaxComplete(function(){
+      unmask();
+    });
+/*
+    $("form").on('submit', function(event){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    */
+    $(document).on('click', 'a', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+    $(document).on('click', 'input.green', function(){
+      if (skipMask($(this))){
+        return;
+      }else{
+        mask('Loading');
+      }
+    });
+
+  </script>
+</html>

--- a/tests/scrape/test_ncaa_reference.py
+++ b/tests/scrape/test_ncaa_reference.py
@@ -1,0 +1,59 @@
+"""Offline tests for the sport-generic stats.ncaa.org reference parsers.
+
+Fixtures are real baseball (MBA) captures -- the parsers graduated from the
+MFB producer, so passing on a second sport is the sport-generic proof.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+
+from sportsdataverse.scrape.ncaa.reference import (
+    TEAM_LIST_SCHEMA,
+    TEAM_ROSTER_SCHEMA,
+    TEAM_SCHEDULE_SCHEMA,
+    parse_ncaa_team_list,
+    parse_ncaa_team_roster,
+    parse_ncaa_team_schedule,
+)
+
+FIX = Path(__file__).resolve().parents[1] / "fixtures" / "ncaa_reference"
+
+
+def _rd(name: str) -> str:
+    return (FIX / f"{name}.html").read_text(encoding="utf-8")
+
+
+def test_team_list_schema_and_rows() -> None:
+    df = parse_ncaa_team_list(_rd("mba_team_list_2026_d1"))
+    assert df.columns == list(TEAM_LIST_SCHEMA.keys())
+    assert df.height == 308  # 2026 D-I baseball
+    assert df.get_column("team_id").str.contains(r"^\d+$").all()
+
+
+def test_team_schedule_doubleheaders_and_results() -> None:
+    df = parse_ncaa_team_schedule(_rd("mba_team_page_614839"), team_id="614839")
+    assert df.columns == list(TEAM_SCHEDULE_SCHEMA.keys())
+    assert df.height >= 50  # full baseball season
+    dh = df.filter(pl.col("game_number").is_not_null())
+    assert dh.height >= 2  # doubleheader pairs
+    assert set(dh.get_column("game_number").unique().to_list()) <= {1, 2}
+    played = df.filter(pl.col("outcome").is_not_null())
+    assert (played.get_column("team_score") >= 0).all()
+    assert played.get_column("contest_id").str.contains(r"^\d+$").all()
+
+
+def test_team_roster_header_keyed() -> None:
+    df = parse_ncaa_team_roster(_rd("mba_roster_614839"), team_id="614839")
+    assert df.columns == list(TEAM_ROSTER_SCHEMA.keys())
+    assert df.height >= 30
+    assert df.get_column("player_name").is_not_null().all()
+    assert "P" in df.get_column("position").to_list()
+
+
+def test_empty_inputs_zero_row_with_schema() -> None:
+    assert parse_ncaa_team_list("").columns == list(TEAM_LIST_SCHEMA.keys())
+    assert parse_ncaa_team_schedule("").height == 0
+    assert parse_ncaa_team_roster("").height == 0

--- a/tests/scrape/test_ncaa_reference.py
+++ b/tests/scrape/test_ncaa_reference.py
@@ -57,3 +57,12 @@ def test_empty_inputs_zero_row_with_schema() -> None:
     assert parse_ncaa_team_list("").columns == list(TEAM_LIST_SCHEMA.keys())
     assert parse_ncaa_team_schedule("").height == 0
     assert parse_ncaa_team_roster("").height == 0
+
+
+def test_team_name_strips_record_and_trailing_junk() -> None:
+    # CodeRabbit PR #390: header continues past the W-L record
+    # ("A&M-Corpus Christi (23-28) RPI Ranking - 202") -- name only survives
+    df = parse_ncaa_team_schedule(_rd("mba_team_page_614839"), team_id="614839")
+    assert df.get_column("team_name").unique().to_list() == ["A&M-Corpus Christi Islanders"]
+    ro = parse_ncaa_team_roster(_rd("mba_roster_614839"), team_id="614839")
+    assert ro.get_column("team_name").unique().to_list() == ["A&M-Corpus Christi Islanders"]


### PR DESCRIPTION
Foundation PR for the NCAA baseball data program (baseballr-data Python standardization).

1. **decompose_college_baseball_plays** — row-level pbp decomposition entry point. parse_college_baseball_ncaa_pbp is now extract-then-decompose; sources that already hold base play fields (the legacy R-era baseballr-data trees, 2012-2023: description/inning/top-bot/batting/fielding/score) feed the same engine, so legacy and freshly captured games resolve into IDENTICAL PBP_SCHEMA columns. Behavior-preserving for the HTML path (all pre-existing baseball/softball tests pass unchanged).

2. **scrape/ncaa/reference.py** — sport-generic stats.ncaa.org reference parsers (team list / team schedule / roster), graduated from ncaa-mfb-football-raw's stage-05 builders. Validated on real baseball (MBA) captures — passing on a second sport is the sport-generic proof: 308 D-I teams, 51-game schedule incl. doubleheaders (new game_number column from the "(N)" date suffix, null for sports without it), 40-player header-keyed roster. Three real fixtures vendored under tests/fixtures/ncaa_reference/ with a provenance README.

Tests: 216 passed (scrape + baseball); mypy clean (398 files, reference.py added to the ratchet); ruff clean; codegen --check clean.

Downstream (baseballr-data, follow-up work): stage-03 legacy adapter re-parses the 102,963 R-era games through the decomposition seam with zero re-scraping; the reference parsers drive the new capture stages for 2024+.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NCAA reference-page parsers for team lists, schedules, and rosters.
  * Added optional Pandas output alongside Polars DataFrames.
  * Added reusable college baseball play-data processing, including scores, play details, and empty-result handling.

* **Bug Fixes**
  * Improved parsing of legacy player-name formats and NCAA baseball data consistency.

* **Tests**
  * Added offline coverage for team, schedule, roster, and play parsing, including empty inputs and doubleheaders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->