### PR TITLE
feat(cfb): serve load_cfb_team_info from the cfb_team_info release

### DIFF
--- a/docs/docs/cfb/reference/loaders.md
+++ b/docs/docs/cfb/reference/loaders.md
@@ -21,7 +21,7 @@ flowchart LR
 | `load_cfb_returning_production` | [cfb_returning_production](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_returning_production) | — |
 | `load_cfb_rosters` | [cfbfastR-data](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfbfastR-data) | — |
 | `load_cfb_schedule` | [cfb_schedules](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_schedules) | — |
-| `load_cfb_team_info` | [cfbfastR-data](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfbfastR-data) | — |
+| `load_cfb_team_info` | [cfb_team_info](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_team_info) | — |
 | `load_cfb_team_talent` | [cfb_team_talent](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_team_talent) | — |
 | `load_cfb_teams_crosswalk` | [cfb_crosswalk](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_crosswalk) | — |
 | `load_cfb_schedule_crosswalk` | [cfb_crosswalk](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_crosswalk) | — |
@@ -699,7 +699,7 @@ load_cfb_schedule(seasons=2024)
 
 ## `load_cfb_team_info`
 
-Release: [cfbfastR-data](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfbfastR-data) · asset `https://raw.githubusercontent.com/sportsdataverse/cfbfastR-data/main/team_info/parquet/cfb_team_info_{season}.parquet`
+Release: [cfb_team_info](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_team_info) · asset `https://github.com/sportsdataverse/sportsdataverse-data/releases/download/cfb_team_info/cfb_team_info_{season}.parquet`
 ### Returns
 
 | col_name | type | description |
@@ -718,6 +718,20 @@ Release: [cfbfastR-data](https://github.com/sportsdataverse/sportsdataverse-data
 | `alt_color` | String | Team color (alternate). |
 | `logo` | String | Team or league logo URL. |
 | `logo_2` | String | URL of the team's alternate dark-background 500-pixel logo on ESPN's CDN, null for programs with no dark variant. |
+| `logos_3` | String |  |
+| `logos_4` | String |  |
+| `logos_5` | String |  |
+| `logos_6` | String |  |
+| `logos_7` | String |  |
+| `logos_8` | String |  |
+| `logos_9` | String |  |
+| `logos_10` | String |  |
+| `logos_11` | String |  |
+| `logos_12` | String |  |
+| `logos_13` | String |  |
+| `logos_14` | String |  |
+| `logos_15` | String |  |
+| `logos_16` | String |  |
 | `twitter` | String | The football program's Twitter/X handle including the leading at sign, populated for only a minority of listed teams. |
 | `venue_id` | Int32 | Referencing venue id. |
 | `venue_name` | String | Full name of the franchise's venue. |

--- a/sportsdataverse/cfb/cfb_loaders.py
+++ b/sportsdataverse/cfb/cfb_loaders.py
@@ -930,12 +930,12 @@ def load_cfb_schedule(seasons, return_as_pandas: bool = False):
 
 
 def load_cfb_team_info(seasons, return_as_pandas: bool = False):
-    """Load cfbfastR-data (sportsdataverse-data release).
+    """Load cfb_team_info (sportsdataverse-data release).
 
-    Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfbfastR-data
+    Source: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_team_info
 
     Args:
-        seasons: an int or iterable of seasons (>= 2003).
+        seasons: an int or iterable of seasons (>= 2001).
         return_as_pandas: return a pandas DataFrame instead of polars.
 
     Returns:
@@ -958,6 +958,20 @@ def load_cfb_team_info(seasons, return_as_pandas: bool = False):
         |alt_color        |String  |
         |logo             |String  |
         |logo_2           |String  |
+        |logos_3          |String  |
+        |logos_4          |String  |
+        |logos_5          |String  |
+        |logos_6          |String  |
+        |logos_7          |String  |
+        |logos_8          |String  |
+        |logos_9          |String  |
+        |logos_10         |String  |
+        |logos_11         |String  |
+        |logos_12         |String  |
+        |logos_13         |String  |
+        |logos_14         |String  |
+        |logos_15         |String  |
+        |logos_16         |String  |
         |twitter          |String  |
         |venue_id         |Int32   |
         |venue_name       |String  |
@@ -975,7 +989,7 @@ def load_cfb_team_info(seasons, return_as_pandas: bool = False):
         |dome             |Boolean |
 
     Raises:
-        SeasonNotFoundError: if a requested season is below 2003.
+        SeasonNotFoundError: if a requested season is below 2001.
 
     Example:
         Quick start::
@@ -984,10 +998,10 @@ def load_cfb_team_info(seasons, return_as_pandas: bool = False):
     """
     frames, missing = [], []
     for season in _as_season_list(seasons):
-        if int(season) < 2003:
-            raise SeasonNotFoundError("season cannot be less than 2003")
+        if int(season) < 2001:
+            raise SeasonNotFoundError("season cannot be less than 2001")
         df = _read_release_parquet(
-            f"https://raw.githubusercontent.com/sportsdataverse/cfbfastR-data/main/team_info/parquet/cfb_team_info_{season}.parquet"
+            f"https://github.com/sportsdataverse/sportsdataverse-data/releases/download/cfb_team_info/cfb_team_info_{season}.parquet"
         )
         if df is None:
             missing.append(season)

--- a/tools/codegen/endpoints/releases.yaml
+++ b/tools/codegen/endpoints/releases.yaml
@@ -69,10 +69,10 @@ loaders:
     seasons: 2024
 - fn: load_cfb_team_info
   league: cfb
-  base: raw_data
-  url: cfbfastR-data/main/team_info/parquet/cfb_team_info_{season}.parquet
-  tag: cfbfastR-data
-  min_season: 2003
+  base: sdv_releases
+  url: cfb_team_info/cfb_team_info_{season}.parquet
+  tag: cfb_team_info
+  min_season: 2001
   example_args:
     seasons: 2024
   id_int64:

--- a/tools/codegen/schemas/loader_schemas.yaml
+++ b/tools/codegen/schemas/loader_schemas.yaml
@@ -3744,6 +3744,34 @@ load_cfb_team_info:
   type: String
 - name: logo_2
   type: String
+- name: logos_3
+  type: String
+- name: logos_4
+  type: String
+- name: logos_5
+  type: String
+- name: logos_6
+  type: String
+- name: logos_7
+  type: String
+- name: logos_8
+  type: String
+- name: logos_9
+  type: String
+- name: logos_10
+  type: String
+- name: logos_11
+  type: String
+- name: logos_12
+  type: String
+- name: logos_13
+  type: String
+- name: logos_14
+  type: String
+- name: logos_15
+  type: String
+- name: logos_16
+  type: String
 - name: twitter
   type: String
 - name: venue_id


### PR DESCRIPTION
## What

`load_cfb_team_info` now reads the new **`cfb_team_info`** release on
`sportsdataverse/sportsdataverse-data` instead of `cfbfastR-data/main/team_info/parquet/`.

## Why

The `cfbfastR-data` files were **not per-season**. Every year 2001-2024 was the same
all-time CFBD snapshot written under a per-season filename:

| | rows | id-set fingerprint | `classification` null |
|---|---:|---|---:|
| before, 2001-2024 (each) | 1,840 | identical (symmetric difference 0) | 62.9% |
| before, 2025 | 683 | — | 0% |

So `load_cfb_team_info(2023)` returned teams classified by where they play **today** —
Kennesaw State read FBS in the 2023 file because of its 2024 move — and `classification`
was two-thirds null because the snapshot carried every team that has ever existed.

The producer (`cfbfastR-data/add_team_info.R` → `cfbd_team_info(year, only_fbs = FALSE)`)
was always correct; only the published data was stale. It has been re-run per season
(cfbfastR-data `c1af1a0`) and published as a proper dataset release, so this PR points the
loader at the release the same way `load_cfb_schedule` moved to `cfb_schedules`.

## After

Genuine per-season output, 26 seasons, **23 distinct id-set fingerprints**,
`classification` **0% null** everywhere:

`2001=246  2004=256  2013=265  2014=687  2015=687  2019=682  2020=637  2023=672  2025=681  2026=684`

`min_season` drops `2003 → 2001` (the release covers 2001-2026).

## Returns table

Gains `logos_3` .. `logos_16` — CFBD now serves the full 16-entry logo ladder
(8 sizes × light/dark). `logo` / `logo_2` keep their existing 500px light/dark meaning,
so no existing column changed.

## Verification

- Loader exercised live against the release: 2001/2014/2023/2026 return 246/687/672/684
  rows × 43 cols, `team_id` `Int64`, `classification` 0 nulls; a multi-season call
  (2015+2020+2023) concatenates to 1,996.
- `uv run python tools/codegen/generate.py --check` — green.
- `uv run pytest tests/codegen` — 158 passed, 11 skipped.
- Release: https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_team_info
  (52 assets, parquet + rds per season).

## Summary by Sourcery

Serve accurate historical college football team information from the dedicated per-season `cfb_team_info` release.

New Features:
- Serve per-season college football team information from the dedicated `cfb_team_info` release, including coverage from 2001 onward.
- Expose the expanded CFBD logo fields `logos_3` through `logos_16` while retaining existing logo columns.

Bug Fixes:
- Replace stale all-time team snapshots with season-specific team data so historical classifications and team membership are accurate.

Documentation:
- Update loader documentation to reference the `cfb_team_info` release, its expanded schema, and the new season range.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added additional team logo fields, from `logos_3` through `logos_16`, to team information results.
  * Added support for loading college football team information beginning with the 2001 season.

* **Bug Fixes**
  * Updated team information data sourcing to improve reliability and align with the current release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->