### PR TITLE
fix(cfb): correct the fourth-down end-game clamps and the input contract

### DIFF
--- a/docs/docs/cfb/reference/additional.md
+++ b/docs/docs/cfb/reference/additional.md
@@ -2466,6 +2466,34 @@ A pandas copy of `pbp_df` with the decision columns added. Empty input returns t
 
 ```python
 from sportsdataverse.cfb.cfb_fourth_down import get_4th_down_probs
+
+import polars as pl
+
+# The `start.*` state contract -- a 4th & 10 from midfield, tied,
+# early in the 2nd quarter. Every column here is required; a missing
+# one raises KeyError naming it.
+fourth_down_rows = pl.DataFrame(
+    [
+        {
+            "start.down": 4,
+            "start.distance": 10,
+            "start.yardsToEndzone": 50,
+            "start.pos_team_spread": 3.0,
+            "pos_score_diff_start": 0,
+            "start.TimeSecsRem": 900,
+            "start.adj_TimeSecsRem": 1800,
+            "start.pos_team_receives_2H_kickoff": 1,
+            "start.posTeamTimeouts": 3,
+            "start.defPosTeamTimeouts": 3,
+            "start.is_home": 1,
+            "period": 2,
+            "season": 2023,
+            "overUnder": 55.5,
+            "homeTeamSpread": -3.0,
+        }
+    ]
+)
+
 out = get_4th_down_probs(fourth_down_rows)
 print(out[["go_wp", "punt_wp", "fg_wp", "fourth_down_recommendation"]].head())
 ```
@@ -2536,6 +2564,34 @@ A pandas copy of `pbp_df` plus `fg_make_prob`, `make_fg_wp`, `miss_fg_wp` and `f
 
 ```python
 from sportsdataverse.cfb.cfb_fourth_down import get_fg_wp
+
+import polars as pl
+
+# The `start.*` state contract -- a 4th & 10 from midfield, tied,
+# early in the 2nd quarter. Every column here is required; a missing
+# one raises KeyError naming it.
+fourth_down_rows = pl.DataFrame(
+    [
+        {
+            "start.down": 4,
+            "start.distance": 10,
+            "start.yardsToEndzone": 50,
+            "start.pos_team_spread": 3.0,
+            "pos_score_diff_start": 0,
+            "start.TimeSecsRem": 900,
+            "start.adj_TimeSecsRem": 1800,
+            "start.pos_team_receives_2H_kickoff": 1,
+            "start.posTeamTimeouts": 3,
+            "start.defPosTeamTimeouts": 3,
+            "start.is_home": 1,
+            "period": 2,
+            "season": 2023,
+            "overUnder": 55.5,
+            "homeTeamSpread": -3.0,
+        }
+    ]
+)
+
 out = get_fg_wp(fourth_down_rows)
 print(out[["fg_make_prob", "fg_wp"]].head())
 ```
@@ -2558,6 +2614,34 @@ A pandas copy of `pbp_df` plus `go_wp` (prob-weighted WP of going for it), `firs
 
 ```python
 from sportsdataverse.cfb.cfb_fourth_down import get_go_wp
+
+import polars as pl
+
+# The `start.*` state contract -- a 4th & 10 from midfield, tied,
+# early in the 2nd quarter. Every column here is required; a missing
+# one raises KeyError naming it.
+fourth_down_rows = pl.DataFrame(
+    [
+        {
+            "start.down": 4,
+            "start.distance": 10,
+            "start.yardsToEndzone": 50,
+            "start.pos_team_spread": 3.0,
+            "pos_score_diff_start": 0,
+            "start.TimeSecsRem": 900,
+            "start.adj_TimeSecsRem": 1800,
+            "start.pos_team_receives_2H_kickoff": 1,
+            "start.posTeamTimeouts": 3,
+            "start.defPosTeamTimeouts": 3,
+            "start.is_home": 1,
+            "period": 2,
+            "season": 2023,
+            "overUnder": 55.5,
+            "homeTeamSpread": -3.0,
+        }
+    ]
+)
+
 out = get_go_wp(fourth_down_rows)
 print(out[["go_wp", "first_down_prob"]].head())
 ```
@@ -2580,8 +2664,36 @@ A pandas copy of `pbp_df` plus `punt_wp` (prob-weighted WP of punting, from the 
 
 ```python
 from sportsdataverse.cfb.cfb_fourth_down import get_punt_wp
+
+import polars as pl
+
+# The `start.*` state contract -- a 4th & 10 from midfield, tied,
+# early in the 2nd quarter. Every column here is required; a missing
+# one raises KeyError naming it.
+fourth_down_rows = pl.DataFrame(
+    [
+        {
+            "start.down": 4,
+            "start.distance": 10,
+            "start.yardsToEndzone": 50,
+            "start.pos_team_spread": 3.0,
+            "pos_score_diff_start": 0,
+            "start.TimeSecsRem": 900,
+            "start.adj_TimeSecsRem": 1800,
+            "start.pos_team_receives_2H_kickoff": 1,
+            "start.posTeamTimeouts": 3,
+            "start.defPosTeamTimeouts": 3,
+            "start.is_home": 1,
+            "period": 2,
+            "season": 2023,
+            "overUnder": 55.5,
+            "homeTeamSpread": -3.0,
+        }
+    ]
+)
+
 out = get_punt_wp(fourth_down_rows)
-print(out[["yards_to_goal", "punt_wp"]].head())
+print(out[["punt_wp"]].head())
 ```
 
 ### `make_ratings_compute_results(ratings: 'pl.DataFrame', *, era: 'str' = 'modern') -> 'ComputeResultsFn'` {#make_ratings_compute_results}

--- a/docs/docs/cfb/reference/additional.md
+++ b/docs/docs/cfb/reference/additional.md
@@ -2532,6 +2532,14 @@ Expected win probability of attempting a field goal (cfb4th `get_fg_wp`).
 
 A pandas copy of `pbp_df` plus `fg_make_prob`, `make_fg_wp`, `miss_fg_wp` and `fg_wp` (= make_prob*make_wp + (1-make_prob)*miss_wp, from the kicking team's perspective). All four are NaN when the FG model is not bundled (`FG_MODEL_AVAILABLE` is False) -- probabilities are never fabricated.
 
+**Example**
+
+```python
+from sportsdataverse.cfb.cfb_fourth_down import get_fg_wp
+out = get_fg_wp(fourth_down_rows)
+print(out[["fg_make_prob", "fg_wp"]].head())
+```
+
 ### `get_go_wp(pbp_df) -> 'pd.DataFrame'` {#get_go_wp}
 
 Expected win probability of going for it on 4th down (cfb4th `get_go_wp`).
@@ -2567,6 +2575,14 @@ Expected win probability of punting on 4th down (cfb4th `get_punt_wp`).
 **Returns**
 
 A pandas copy of `pbp_df` plus `punt_wp` (prob-weighted WP of punting, from the punting team's perspective). `punt_wp` is NaN where the punt end-yardline distribution has no support for the play's `yards_to_goal` (e.g. inside the 31, where punting is dominated and the cfb4th table is empty -- matching the R reference's left-join NA behavior).
+
+**Example**
+
+```python
+from sportsdataverse.cfb.cfb_fourth_down import get_punt_wp
+out = get_punt_wp(fourth_down_rows)
+print(out[["yards_to_goal", "punt_wp"]].head())
+```
 
 ### `make_ratings_compute_results(ratings: 'pl.DataFrame', *, era: 'str' = 'modern') -> 'ComputeResultsFn'` {#make_ratings_compute_results}
 

--- a/sportsdataverse/cfb/cfb_fourth_down.py
+++ b/sportsdataverse/cfb/cfb_fourth_down.py
@@ -425,6 +425,34 @@ def get_go_wp(pbp_df) -> pd.DataFrame:
         Quick start::
 
             from sportsdataverse.cfb.cfb_fourth_down import get_go_wp
+
+            import polars as pl
+
+            # The `start.*` state contract -- a 4th & 10 from midfield, tied,
+            # early in the 2nd quarter. Every column here is required; a missing
+            # one raises KeyError naming it.
+            fourth_down_rows = pl.DataFrame(
+                [
+                    {
+                        "start.down": 4,
+                        "start.distance": 10,
+                        "start.yardsToEndzone": 50,
+                        "start.pos_team_spread": 3.0,
+                        "pos_score_diff_start": 0,
+                        "start.TimeSecsRem": 900,
+                        "start.adj_TimeSecsRem": 1800,
+                        "start.pos_team_receives_2H_kickoff": 1,
+                        "start.posTeamTimeouts": 3,
+                        "start.defPosTeamTimeouts": 3,
+                        "start.is_home": 1,
+                        "period": 2,
+                        "season": 2023,
+                        "overUnder": 55.5,
+                        "homeTeamSpread": -3.0,
+                    }
+                ]
+            )
+
             out = get_go_wp(fourth_down_rows)
             print(out[["go_wp", "first_down_prob"]].head())
     """
@@ -624,8 +652,36 @@ def get_punt_wp(pbp_df) -> pd.DataFrame:
         Quick start::
 
             from sportsdataverse.cfb.cfb_fourth_down import get_punt_wp
+
+            import polars as pl
+
+            # The `start.*` state contract -- a 4th & 10 from midfield, tied,
+            # early in the 2nd quarter. Every column here is required; a missing
+            # one raises KeyError naming it.
+            fourth_down_rows = pl.DataFrame(
+                [
+                    {
+                        "start.down": 4,
+                        "start.distance": 10,
+                        "start.yardsToEndzone": 50,
+                        "start.pos_team_spread": 3.0,
+                        "pos_score_diff_start": 0,
+                        "start.TimeSecsRem": 900,
+                        "start.adj_TimeSecsRem": 1800,
+                        "start.pos_team_receives_2H_kickoff": 1,
+                        "start.posTeamTimeouts": 3,
+                        "start.defPosTeamTimeouts": 3,
+                        "start.is_home": 1,
+                        "period": 2,
+                        "season": 2023,
+                        "overUnder": 55.5,
+                        "homeTeamSpread": -3.0,
+                    }
+                ]
+            )
+
             out = get_punt_wp(fourth_down_rows)
-            print(out[["yards_to_goal", "punt_wp"]].head())
+            print(out[["punt_wp"]].head())
     """
     n_plays = len(pbp_df)
     base = (pbp_df.to_pandas() if hasattr(pbp_df, "to_pandas") else pd.DataFrame(pbp_df)).reset_index(drop=True)
@@ -801,6 +857,34 @@ def get_fg_wp(pbp_df) -> pd.DataFrame:
         Quick start::
 
             from sportsdataverse.cfb.cfb_fourth_down import get_fg_wp
+
+            import polars as pl
+
+            # The `start.*` state contract -- a 4th & 10 from midfield, tied,
+            # early in the 2nd quarter. Every column here is required; a missing
+            # one raises KeyError naming it.
+            fourth_down_rows = pl.DataFrame(
+                [
+                    {
+                        "start.down": 4,
+                        "start.distance": 10,
+                        "start.yardsToEndzone": 50,
+                        "start.pos_team_spread": 3.0,
+                        "pos_score_diff_start": 0,
+                        "start.TimeSecsRem": 900,
+                        "start.adj_TimeSecsRem": 1800,
+                        "start.pos_team_receives_2H_kickoff": 1,
+                        "start.posTeamTimeouts": 3,
+                        "start.defPosTeamTimeouts": 3,
+                        "start.is_home": 1,
+                        "period": 2,
+                        "season": 2023,
+                        "overUnder": 55.5,
+                        "homeTeamSpread": -3.0,
+                    }
+                ]
+            )
+
             out = get_fg_wp(fourth_down_rows)
             print(out[["fg_make_prob", "fg_wp"]].head())
     """
@@ -912,6 +996,34 @@ def get_4th_down_probs(pbp_df) -> pd.DataFrame:
         Quick start::
 
             from sportsdataverse.cfb.cfb_fourth_down import get_4th_down_probs
+
+            import polars as pl
+
+            # The `start.*` state contract -- a 4th & 10 from midfield, tied,
+            # early in the 2nd quarter. Every column here is required; a missing
+            # one raises KeyError naming it.
+            fourth_down_rows = pl.DataFrame(
+                [
+                    {
+                        "start.down": 4,
+                        "start.distance": 10,
+                        "start.yardsToEndzone": 50,
+                        "start.pos_team_spread": 3.0,
+                        "pos_score_diff_start": 0,
+                        "start.TimeSecsRem": 900,
+                        "start.adj_TimeSecsRem": 1800,
+                        "start.pos_team_receives_2H_kickoff": 1,
+                        "start.posTeamTimeouts": 3,
+                        "start.defPosTeamTimeouts": 3,
+                        "start.is_home": 1,
+                        "period": 2,
+                        "season": 2023,
+                        "overUnder": 55.5,
+                        "homeTeamSpread": -3.0,
+                    }
+                ]
+            )
+
             out = get_4th_down_probs(fourth_down_rows)
             print(out[["go_wp", "punt_wp", "fg_wp", "fourth_down_recommendation"]].head())
     """

--- a/sportsdataverse/cfb/cfb_fourth_down.py
+++ b/sportsdataverse/cfb/cfb_fourth_down.py
@@ -338,6 +338,7 @@ def _end_game_clamp(
     adj: np.ndarray,
     period: np.ndarray,
     def_to: np.ndarray,
+    value: float = 0.0,
 ) -> np.ndarray:
     """cfb4th ``end_game_fn``: leading + late + defense out of timeouts -> WP clamps.
 
@@ -350,12 +351,19 @@ def _end_game_clamp(
 
     Feeding the original team's own columns inverts the rule -- it pins the win
     probability of the team that is AHEAD to zero. See #395.
+
+    ``value`` is what a clamped row is pinned to, and it depends on WHOSE win
+    probability ``wp`` holds. When possession changed, ``wp`` belongs to the team
+    that gave the ball up, so the kneel-out is a loss (``0.0``, the default).
+    When possession did not change -- a punt return touchdown hands the ball
+    straight back -- ``wp`` belongs to the team doing the kneeling, so the same
+    situation is a win (``1.0``).
     """
     lead = pos_diff > 0
     p4 = period == 4
-    wp = np.where(lead & (adj < 120) & p4 & (def_to == 0), 0.0, wp)
-    wp = np.where(lead & (adj < 80) & p4 & (def_to == 1), 0.0, wp)
-    wp = np.where(lead & (adj < 40) & p4 & (def_to == 2), 0.0, wp)
+    wp = np.where(lead & (adj < 120) & p4 & (def_to == 0), value, wp)
+    wp = np.where(lead & (adj < 80) & p4 & (def_to == 1), value, wp)
+    wp = np.where(lead & (adj < 40) & p4 & (def_to == 2), value, wp)
     return wp
 
 
@@ -403,6 +411,15 @@ def get_go_wp(pbp_df) -> pd.DataFrame:
         ``go_wp`` is always in [0, 1]; the conditional columns are in [0, 1] but
         can be NaN for degenerate goal-line plays where one outcome bucket is
         empty (matches the R reference ``pivot_wider`` NA behavior).
+
+    Raises:
+        KeyError: If ``pbp_df`` is missing a required state column from
+            :data:`_PBP_COLS`. The frame is validated up front rather than
+            substituting ``NaN``, which used to surface far downstream as
+            ``AttributeError: 'float' object has no attribute 'to_numpy'``.
+        ValueError: If ``season`` is absent or all-null. The era-aware models
+            would otherwise score against an all-zero one-hot -- a rule era that
+            never existed -- and return a plausible number.
 
     Example:
         Quick start::
@@ -596,6 +613,12 @@ def get_punt_wp(pbp_df) -> pd.DataFrame:
         end-yardline distribution has no support for the play's ``yards_to_goal``
         (e.g. inside the 31, where punting is dominated and the cfb4th table is
         empty -- matching the R reference's left-join NA behavior).
+
+    Raises:
+        KeyError: If ``pbp_df`` is missing a required state column from
+            :data:`_PBP_COLS`. The frame is validated up front rather than
+            substituting ``NaN``, which used to surface far downstream as
+            ``AttributeError: 'float' object has no attribute 'to_numpy'``.
     """
     n_plays = len(pbp_df)
     base = (pbp_df.to_pandas() if hasattr(pbp_df, "to_pandas") else pd.DataFrame(pbp_df)).reset_index(drop=True)
@@ -675,12 +698,24 @@ def get_punt_wp(pbp_df) -> pd.DataFrame:
     # receiving team leads and the punting team is out of timeouts, so the
     # punting team's win probability is zero. Passing `orig`'s differential here
     # inverted it and pinned the team that was AHEAD to zero (#395).
-    wp = _end_game_clamp(
-        wp,
+    #
+    # The kneel-out is only a LOSS for the team being asked about when the ball
+    # actually changed hands. A punt return touchdown hands it straight back, so
+    # on those rows `wp` already belongs to the kneeling team and the same
+    # situation is a WIN. cfb4th clamps both to zero, which pins a punting team
+    # still leading after conceding the score to a certain loss; return-TD rows
+    # carry under 0.2% of the mass, so this is a small deliberate divergence
+    # rather than a faithful port.
+    clamp_args = (
         flipped_state["pos_score_diff_start"].to_numpy().astype(float),
         flipped_state["adj_TimeSecsRem"].to_numpy().astype(float),
         flipped_state["period"].to_numpy().astype(float),
         flipped_state["def_pos_team_timeouts_rem_before"].to_numpy().astype(float),
+    )
+    wp = np.where(
+        possession_changed,
+        _end_game_clamp(wp, *clamp_args, value=0.0),
+        _end_game_clamp(wp, *clamp_args, value=1.0),
     )
 
     agg = (
@@ -745,6 +780,15 @@ def get_fg_wp(pbp_df) -> pd.DataFrame:
         from the kicking team's perspective). All four are NaN when the FG model
         is not bundled (:data:`FG_MODEL_AVAILABLE` is False) -- probabilities are
         never fabricated.
+
+    Raises:
+        KeyError: If ``pbp_df`` is missing a required state column from
+            :data:`_PBP_COLS`. The frame is validated up front rather than
+            substituting ``NaN``, which used to surface far downstream as
+            ``AttributeError: 'float' object has no attribute 'to_numpy'``.
+        ValueError: If ``season`` is absent or all-null. The era-aware models
+            would otherwise score against an all-zero one-hot -- a rule era that
+            never existed -- and return a plausible number.
     """
     n_plays = len(pbp_df)
     base = (pbp_df.to_pandas() if hasattr(pbp_df, "to_pandas") else pd.DataFrame(pbp_df)).reset_index(drop=True)
@@ -840,6 +884,15 @@ def get_4th_down_probs(pbp_df) -> pd.DataFrame:
     Returns:
         A pandas copy of ``pbp_df`` with the decision columns added. Empty input
         returns the input plus empty decision columns.
+
+    Raises:
+        KeyError: If ``pbp_df`` is missing a required state column from
+            :data:`_PBP_COLS`. The frame is validated up front rather than
+            substituting ``NaN``, which used to surface far downstream as
+            ``AttributeError: 'float' object has no attribute 'to_numpy'``.
+        ValueError: If ``season`` is absent or all-null. The era-aware models
+            would otherwise score against an all-zero one-hot -- a rule era that
+            never existed -- and return a plausible number.
 
     Example:
         Quick start::

--- a/sportsdataverse/cfb/cfb_fourth_down.py
+++ b/sportsdataverse/cfb/cfb_fourth_down.py
@@ -619,6 +619,13 @@ def get_punt_wp(pbp_df) -> pd.DataFrame:
             :data:`_PBP_COLS`. The frame is validated up front rather than
             substituting ``NaN``, which used to surface far downstream as
             ``AttributeError: 'float' object has no attribute 'to_numpy'``.
+
+    Example:
+        Quick start::
+
+            from sportsdataverse.cfb.cfb_fourth_down import get_punt_wp
+            out = get_punt_wp(fourth_down_rows)
+            print(out[["yards_to_goal", "punt_wp"]].head())
     """
     n_plays = len(pbp_df)
     base = (pbp_df.to_pandas() if hasattr(pbp_df, "to_pandas") else pd.DataFrame(pbp_df)).reset_index(drop=True)
@@ -789,6 +796,13 @@ def get_fg_wp(pbp_df) -> pd.DataFrame:
         ValueError: If ``season`` is absent or all-null. The era-aware models
             would otherwise score against an all-zero one-hot -- a rule era that
             never existed -- and return a plausible number.
+
+    Example:
+        Quick start::
+
+            from sportsdataverse.cfb.cfb_fourth_down import get_fg_wp
+            out = get_fg_wp(fourth_down_rows)
+            print(out[["fg_make_prob", "fg_wp"]].head())
     """
     n_plays = len(pbp_df)
     base = (pbp_df.to_pandas() if hasattr(pbp_df, "to_pandas") else pd.DataFrame(pbp_df)).reset_index(drop=True)

--- a/sportsdataverse/cfb/cfb_fourth_down.py
+++ b/sportsdataverse/cfb/cfb_fourth_down.py
@@ -202,10 +202,55 @@ FG_MODEL_AVAILABLE: bool = fg_model is not None
 # --------------------------------------------------------------------------- #
 # state -> EP / WP scorers (shared by go / punt / fg paths)
 # --------------------------------------------------------------------------- #
+#: Source columns of :data:`_PBP_COLS` the models cannot be scored without.
+#:
+#: ``overUnder`` / ``homeTeamSpread`` are excluded because :func:`_posteam_total`
+#: has a documented fallback for them. ``season`` is excluded because both model
+#: paths already raise their own, more specific error naming the era features it
+#: feeds -- see :func:`_require_season`.
+_REQUIRED_PBP_COLS = tuple(
+    src for short, src in _PBP_COLS.items() if short not in ("overUnder", "homeTeamSpread", "season")
+)
+
+
+def _require_season(st: pd.DataFrame, model: str) -> np.ndarray:
+    """The season column, or a loud error naming what it feeds.
+
+    A missing ``season`` makes every era dummy zero, which is not a valid
+    one-hot -- the model then scores against a rule era that never existed and
+    returns a plausible number. The field-goal path has always failed loudly
+    here; the go-for-it path did not, and silently degraded instead.
+    """
+    if "season" not in st.columns or st["season"].isna().all():
+        raise ValueError(
+            f"the era-aware {model} requires a non-null 'season' column "
+            "(era features would otherwise silently degrade to all-zero); pass "
+            "'season' in the input frame -- see "
+            "sportsdataverse.cfb.cfb_fourth_down._PBP_COLS"
+        )
+    return st["season"].to_numpy().astype(float)
+
+
 def _to_pandas(df) -> pd.DataFrame:
-    """Accept polars or pandas; return a pandas copy with the cfb4th-named state cols."""
+    """Accept polars or pandas; return a pandas copy with the cfb4th-named state cols.
+
+    Raises:
+        KeyError: when a required source column is absent. Substituting ``NaN``
+            instead -- the previous behaviour -- did not fail anywhere near the
+            mistake: the NaN poisoned the turnover bucketing, the pivot came back
+            missing a bucket, and the caller died several frames later with
+            ``AttributeError: 'float' object has no attribute 'to_numpy'``, which
+            names neither the column nor the frame. See #395.
+    """
     if hasattr(df, "to_pandas"):  # polars.DataFrame
         df = df.to_pandas()
+    missing = [src for src in _REQUIRED_PBP_COLS if src not in df.columns]
+    if missing:
+        raise KeyError(
+            "cfb_fourth_down: play-by-play frame is missing required column(s) "
+            f"{missing}. Expected the cfb4th state contract "
+            "(sportsdataverse.cfb.cfb_fourth_down._PBP_COLS)."
+        )
     out = pd.DataFrame(index=range(len(df)))
     for short, src in _PBP_COLS.items():
         out[short] = df[src].to_numpy() if src in df.columns else np.nan
@@ -296,10 +341,15 @@ def _end_game_clamp(
 ) -> np.ndarray:
     """cfb4th ``end_game_fn``: leading + late + defense out of timeouts -> WP clamps.
 
-    When the *possessing* team is leading and the defense can no longer stop the
-    clock, WP is pinned to the kneel-out outcome. Note this is the WP from the
-    perspective of whoever holds the ball in ``state`` (already possession-correct
-    for the punt / fg ensuing-drive frames before the final flip back).
+    Every argument must come from the **resulting** (already-flipped) frame, not
+    from the pre-play one. cfb4th applies this after ``flip_team()``, so
+    ``pos_diff`` belongs to the team that just *received* the ball and ``def_to``
+    to the team that just gave it up: *the team now holding the ball leads, and
+    the team it took the ball from cannot stop the clock, so whoever is asking
+    loses.*
+
+    Feeding the original team's own columns inverts the rule -- it pins the win
+    probability of the team that is AHEAD to zero. See #395.
     """
     lead = pos_diff > 0
     p4 = period == 4
@@ -379,7 +429,7 @@ def get_go_wp(pbp_df) -> pd.DataFrame:
             "yards_to_goal": st["yards_to_goal"].to_numpy().astype(float),
             "posteam_total": _posteam_total(st),
             "posteam_spread": st["pos_team_spread"].to_numpy().astype(float),
-            **_era_onehot(st["season"].to_numpy().astype(float)),
+            **_era_onehot(_require_season(st, "fd_model")),
         }
     )[FD_FEATURES]
     fd_probs = _load_fd_model().predict(DMatrix(fd_X))
@@ -477,7 +527,12 @@ def get_go_wp(pbp_df) -> pd.DataFrame:
     wp = np.where(succ_alive & (adj < 120) & (new_def_to == 0), 1.0, wp)
     wp = np.where(succ_alive & (adj < 80) & (new_def_to == 1), 1.0, wp)
     wp = np.where(succ_alive & (adj < 40) & (new_def_to == 2), 1.0, wp)
-    fail_lead = (turnover == 1) & (pos_diff < 0)
+    # `pos_diff` here is the POST-turnover value, already negated above, so
+    # `> 0` means the team that just TOOK the ball leads and can kneel it out --
+    # which is why the offence's win probability goes to zero. `< 0` inverted
+    # it and pinned a team that turned the ball over while LEADING to a certain
+    # loss (cfb4th decision_functions.R:365-367, #395).
+    fail_lead = (turnover == 1) & (pos_diff > 0)
     wp = np.where(fail_lead & (adj < 120) & (new_def_to == 0), 0.0, wp)
     wp = np.where(fail_lead & (adj < 80) & (new_def_to == 1), 0.0, wp)
     wp = np.where(fail_lead & (adj < 40) & (new_def_to == 2), 0.0, wp)
@@ -497,9 +552,21 @@ def get_go_wp(pbp_df) -> pd.DataFrame:
     wp0 = piv["wp"].get(0)
     wp1 = piv["wp"].get(1)
     report = pd.DataFrame({"play_idx": piv.index})
-    report["first_down_prob"] = (pct0 if pct0 is not None else 0.0).to_numpy()
-    report["wp_succeed"] = (wp0 if wp0 is not None else np.nan).to_numpy()
-    report["wp_fail"] = (wp1 if wp1 is not None else np.nan).to_numpy()
+
+    def _bucket(col, fill):
+        """A turnover bucket that no outcome landed in, as a full-length column.
+
+        `.to_numpy()` used to be applied to the scalar fallback rather than to
+        the Series, so an absent bucket raised `AttributeError: 'float' object
+        has no attribute 'to_numpy'` instead of filling (#395).
+        """
+        if col is None:
+            return np.full(len(piv.index), fill, dtype=float)
+        return col.to_numpy()
+
+    report["first_down_prob"] = _bucket(pct0, 0.0)
+    report["wp_succeed"] = _bucket(wp0, np.nan)
+    report["wp_fail"] = _bucket(wp1, np.nan)
 
     merged = (
         pd.DataFrame({"play_idx": np.arange(n_plays)})
@@ -572,9 +639,12 @@ def get_punt_wp(pbp_df) -> pd.DataFrame:
     # punt distance distribution already excludes muffs; on a return TD undo the
     # one flip so the punting team is the possessing team again (receives kickoff)
     pos_diff_flipped = flipped_state["pos_score_diff_start"].to_numpy().astype(float)
-    # return TD: receiving team got 7; from punting-team perspective score diff is
-    # -(orig_pos_diff) - 7. orig pos_diff (punting team) = -pos_diff_flipped.
-    rtd_pos_diff = -(-pos_diff_flipped) - 7.0
+    # cfb4th negates the ALREADY-FLIPPED differential and then subtracts seven,
+    # which leaves the punting team's own lead minus the return touchdown:
+    # -(-orig) - 7 == orig - 7. The previous `-(-pos_diff_flipped) - 7` was a
+    # double negation that reduced to `-orig - 7`, turning a 10-point lead into
+    # a 17-point deficit (#395).
+    rtd_pos_diff = -pos_diff_flipped - 7.0
     flipped_state["pos_score_diff_start"] = np.where(return_td, rtd_pos_diff, pos_diff_flipped)
     # on a return TD restore is_home / spread / timeouts / kickoff to the punting team
     orig = state[list(_PBP_COLS.keys())]
@@ -601,13 +671,16 @@ def get_punt_wp(pbp_df) -> pd.DataFrame:
     possession_changed = new_is_home != orig_is_home
     wp = np.where(possession_changed, 1.0 - wp, wp)
 
-    # end_game_fn clamp from the punting team's perspective
+    # end_game_fn, read off the RESULTING frame exactly as cfb4th does: the
+    # receiving team leads and the punting team is out of timeouts, so the
+    # punting team's win probability is zero. Passing `orig`'s differential here
+    # inverted it and pinned the team that was AHEAD to zero (#395).
     wp = _end_game_clamp(
         wp,
-        orig["pos_score_diff_start"].to_numpy().astype(float),
-        np.maximum(orig["adj_TimeSecsRem"].to_numpy().astype(float) - 6.0, 0.0),
-        orig["period"].to_numpy().astype(float),
-        flipped_state["pos_team_timeouts_rem_before"].to_numpy().astype(float),
+        flipped_state["pos_score_diff_start"].to_numpy().astype(float),
+        flipped_state["adj_TimeSecsRem"].to_numpy().astype(float),
+        flipped_state["period"].to_numpy().astype(float),
+        flipped_state["def_pos_team_timeouts_rem_before"].to_numpy().astype(float),
     )
 
     agg = (
@@ -704,12 +777,14 @@ def get_fg_wp(pbp_df) -> pd.DataFrame:
     wp_make = _predict_wp(make_state, ep_make)
     make_changed = make_state["is_home"].to_numpy().astype(float) != orig_is_home
     wp_make = np.where(make_changed, 1.0 - wp_make, wp_make)
+    # Read off the RESULTING frame, as cfb4th does -- see _end_game_clamp. The
+    # pre-play columns pinned a team kicking while AHEAD to zero (#395).
     wp_make = _end_game_clamp(
         wp_make,
-        orig["pos_score_diff_start"].to_numpy().astype(float),
-        np.maximum(orig["adj_TimeSecsRem"].to_numpy().astype(float) - 6.0, 0.0),
-        orig["period"].to_numpy().astype(float),
-        make_state["pos_team_timeouts_rem_before"].to_numpy().astype(float),
+        make_state["pos_score_diff_start"].to_numpy().astype(float),
+        make_state["adj_TimeSecsRem"].to_numpy().astype(float),
+        make_state["period"].to_numpy().astype(float),
+        make_state["def_pos_team_timeouts_rem_before"].to_numpy().astype(float),
     )
 
     # missed FG: opponent takes over at the spot (ytg = 100 - kicking ytg, capped 80).
@@ -725,10 +800,10 @@ def get_fg_wp(pbp_df) -> pd.DataFrame:
     wp_miss = np.where(miss_changed, 1.0 - wp_miss, wp_miss)
     wp_miss = _end_game_clamp(
         wp_miss,
-        orig["pos_score_diff_start"].to_numpy().astype(float),
-        np.maximum(orig["adj_TimeSecsRem"].to_numpy().astype(float) - 6.0, 0.0),
-        orig["period"].to_numpy().astype(float),
-        miss_state["pos_team_timeouts_rem_before"].to_numpy().astype(float),
+        miss_state["pos_score_diff_start"].to_numpy().astype(float),
+        miss_state["adj_TimeSecsRem"].to_numpy().astype(float),
+        miss_state["period"].to_numpy().astype(float),
+        miss_state["def_pos_team_timeouts_rem_before"].to_numpy().astype(float),
     )
 
     fg_wp = make_prob * wp_make + (1.0 - make_prob) * wp_miss

--- a/tests/cfb/test_cfb_fourth_down.py
+++ b/tests/cfb/test_cfb_fourth_down.py
@@ -382,3 +382,27 @@ def test_go_path_requires_season_like_the_fg_path_does():
     rows = pl.DataFrame([_row(4, 2, 45)]).drop("season")
     with pytest.raises(ValueError, match="season"):
         get_go_wp(rows)
+
+
+def test_return_touchdown_rows_clamp_toward_a_win_not_a_loss():
+    # A punt return TD hands the ball straight back, so on those rows `wp` is
+    # already the punting team's and possession never changed. cfb4th clamps
+    # every row to 0, which pins a punting team still LEADING after conceding
+    # the score to a certain loss. Those rows must clamp to 1 instead.
+    #
+    # Asserted through the clamp helper directly: return-TD rows carry under
+    # 0.2% of the punt distribution's mass, so an aggregate would hide the sign.
+    from sportsdataverse.cfb.cfb_fourth_down import _end_game_clamp
+
+    wp = np.array([0.5])
+    lead, adj, period, def_to = (
+        np.array([3.0]),
+        np.array([60.0]),
+        np.array([4.0]),
+        np.array([0.0]),
+    )
+    assert _end_game_clamp(wp, lead, adj, period, def_to) == pytest.approx(0.0)
+    assert _end_game_clamp(wp, lead, adj, period, def_to, value=1.0) == pytest.approx(1.0)
+    # Trailing is not a kneel-out for anyone, whichever value is passed.
+    trailing = np.array([-3.0])
+    assert _end_game_clamp(wp, trailing, adj, period, def_to, value=1.0) == pytest.approx(0.5)

--- a/tests/cfb/test_cfb_fourth_down.py
+++ b/tests/cfb/test_cfb_fourth_down.py
@@ -260,3 +260,125 @@ def test_fg_make_prob_requires_season_when_era_aware():
     rows = pl.DataFrame([_row(4, 2, 45)]).drop("season")
     with pytest.raises(ValueError, match="season"):
         get_fg_wp(rows)
+
+
+# --------------------------------------------------------------------------- #
+# End-game clamp perspective (#395)
+#
+# cfb4th applies end_game_fn to the ALREADY-FLIPPED frame, so the rule reads
+# "the team now holding the ball leads, and the team it took the ball from is
+# out of timeouts, so whoever is asking loses". Feeding the pre-play team's own
+# columns inverts it and pins the team that is AHEAD to zero.
+#
+# None of these raise when inverted -- they return a confident wrong number, so
+# each is asserted directionally rather than against a fixture value.
+# --------------------------------------------------------------------------- #
+
+
+def _late(**kw):
+    """A Q4 row with a minute left, the possessing team out of timeouts."""
+    base = dict(period=4, tsr=60, adj=60, pto=0, dto=3)
+    base.update(kw)
+    return pl.DataFrame([_row(**base)])
+
+
+def test_punt_clamp_pins_the_trailing_team_not_the_leading_one():
+    # Punting team out of timeouts, 60s left in Q4. Trailing: you punt, they
+    # kneel it out, you lose. Leading: you are still winning.
+    trailing = get_punt_wp(_late(dist=10, ytg=50, sd=-3))["punt_wp"].to_numpy()[0]
+    leading = get_punt_wp(_late(dist=10, ytg=50, sd=3))["punt_wp"].to_numpy()[0]
+    assert trailing < 0.01, trailing
+    assert leading > 0.5, leading
+    # The inverted form produced exactly this pair the other way round:
+    # trailing 0.0999 (unclamped) and leading 0.0 (pinned).
+    assert leading > trailing
+
+
+def test_punt_clamp_does_not_fire_with_timeouts_or_outside_the_fourth():
+    trailing_no_to = get_punt_wp(_late(dist=10, ytg=50, sd=-3))["punt_wp"].to_numpy()[0]
+    # Timeouts in hand: still a game.
+    with_to = get_punt_wp(_late(dist=10, ytg=50, sd=-3, pto=3))["punt_wp"].to_numpy()[0]
+    assert with_to > trailing_no_to
+    # cfb4th's end_game_fn is gated on period == 4.
+    second_qtr = get_punt_wp(pl.DataFrame([_row(dist=10, ytg=50, sd=-3, period=2, tsr=60, adj=1860, pto=0)]))[
+        "punt_wp"
+    ].to_numpy()[0]
+    assert second_qtr > trailing_no_to
+
+
+@pytest.mark.skipif(not FG_MODEL_AVAILABLE, reason="fg_model not bundled")
+def test_fg_clamp_does_not_zero_a_team_that_is_ahead():
+    # A team kicking a field goal while up 3 with a minute left is not a team
+    # with zero chance of winning. The inverted clamp collapsed BOTH branches
+    # (make and miss) to 0, so fg_wp was 0 as well.
+    leading = get_fg_wp(_late(dist=10, ytg=20, sd=3))
+    assert leading["make_fg_wp"].to_numpy()[0] > 0.5
+    assert leading["miss_fg_wp"].to_numpy()[0] > 0.5
+    assert leading["fg_wp"].to_numpy()[0] > 0.5
+
+    # Trailing by 3, a MISS hands it over to a team that can kneel it out.
+    trailing = get_fg_wp(_late(dist=10, ytg=20, sd=-3))
+    assert trailing["miss_fg_wp"].to_numpy()[0] < 0.01
+    # ...but making it ties the game, so that branch must not be clamped.
+    assert trailing["make_fg_wp"].to_numpy()[0] > 0.1
+
+
+@requires_fd
+def test_go_fail_clamp_pins_the_turnover_that_loses_the_lead():
+    # After a turnover the resulting frame's differential is already negated, so
+    # `> 0` means the team that just TOOK the ball leads. Reading it as `< 0`
+    # pinned a team that turned it over WHILE AHEAD to a certain loss.
+    #
+    # The clamp needs the OFFENCE's own timeouts at 0: after the turnover
+    # new_def_to is the offence's pre-play count. Setting dto=0 instead leaves
+    # new_def_to == 3 and the clamp never fires at all -- a test written that
+    # way passes with either sign.
+    leading = get_go_wp(_late(dist=1, ytg=50, sd=3, pto=0, dto=3))
+    trailing = get_go_wp(_late(dist=1, ytg=50, sd=-3, pto=0, dto=3))
+    assert leading["wp_fail"].to_numpy()[0] > 0.5
+    assert trailing["wp_fail"].to_numpy()[0] == pytest.approx(0.0, abs=1e-9)
+
+
+def test_return_touchdown_keeps_the_punting_teams_own_lead():
+    # cfb4th: -(flipped) - 7 == orig - 7. The double negation reduced to
+    # -orig - 7, turning a 10-point lead into a 17-point deficit. Return-TD rows
+    # carry <0.2% of the mass, so this is asserted on the arithmetic directly
+    # rather than through an aggregate that would hide it.
+    orig = np.array([10.0, -4.0, 0.0])
+    flipped = -orig
+    assert np.allclose(-flipped - 7.0, orig - 7.0)
+    assert not np.allclose(-(-flipped) - 7.0, orig - 7.0)
+
+
+# --------------------------------------------------------------------------- #
+# Input contract (#395)
+# --------------------------------------------------------------------------- #
+
+
+def test_missing_required_column_names_itself():
+    # _to_pandas used to substitute NaN for an absent column. The NaN poisoned
+    # the turnover bucketing, the pivot came back missing a bucket, and the
+    # caller died several frames later with "'float' object has no attribute
+    # 'to_numpy'" -- naming neither the column nor the frame.
+    frame = pl.DataFrame([_row()]).drop("start.distance")
+    with pytest.raises(KeyError, match="start.distance"):
+        get_go_wp(frame)
+
+
+def test_optional_odds_columns_are_still_optional():
+    # overUnder / homeTeamSpread have a documented fallback in _posteam_total,
+    # so they must NOT be caught by the required-column check.
+    frame = pl.DataFrame([_row()]).drop(["overUnder", "homeTeamSpread"])
+    out = get_punt_wp(frame)
+    assert "punt_wp" in out.columns
+
+
+@requires_fd
+def test_go_path_requires_season_like_the_fg_path_does():
+    # The FG path has always raised here. The GO path fed the same NaN straight
+    # into _era_onehot, so every era dummy came out 0 -- not a valid one-hot --
+    # and fd_model scored against a rule era that never existed, returning a
+    # plausible 76-class distribution with nothing to flag it.
+    rows = pl.DataFrame([_row(4, 2, 45)]).drop("season")
+    with pytest.raises(ValueError, match="season"):
+        get_go_wp(rows)

--- a/tests/cfb/test_cfb_fourth_down.py
+++ b/tests/cfb/test_cfb_fourth_down.py
@@ -406,3 +406,28 @@ def test_return_touchdown_rows_clamp_toward_a_win_not_a_loss():
     # Trailing is not a kneel-out for anyone, whichever value is passed.
     trailing = np.array([-3.0])
     assert _end_game_clamp(wp, trailing, adj, period, def_to, value=1.0) == pytest.approx(0.5)
+
+
+def test_punt_path_itself_routes_return_touchdowns_to_the_winning_clamp(monkeypatch):
+    # The helper-level test above pins the clamp's arithmetic but never runs the
+    # `return_td` selector inside get_punt_wp, so a regression to value=0.0
+    # there would not fail it. Swap the empirical distribution for a certain
+    # return touchdown: punt_wp is then decided entirely by that branch, and the
+    # 0.2%-of-the-mass problem that forced the helper-level test disappears.
+    from sportsdataverse.cfb import cfb_fourth_down as m
+
+    monkeypatch.setattr(
+        m,
+        "punt_distribution",
+        pl.DataFrame({"yards_to_goal": [50], "yards_to_goal_end": [100], "pct": [1.0]}),
+    )
+    late = dict(period=4, tsr=60, adj=60, dist=10, ytg=50, dto=0)
+
+    # Up 10, concede the return TD -> still up 3, and the receiving team has no
+    # timeouts left to stop the clock, so the punting team kneels out a win.
+    lead = get_punt_wp(pl.DataFrame([_row(sd=10, pto=3, **late)]))
+    assert lead["punt_wp"].to_numpy()[0] == pytest.approx(1.0)
+
+    # Up only 3, the same return TD puts them behind, so nothing is clamped.
+    behind = get_punt_wp(pl.DataFrame([_row(sd=3, pto=3, **late)]))
+    assert behind["punt_wp"].to_numpy()[0] < 1.0


### PR DESCRIPTION
Closes #395.

Four defects in `sportsdataverse/cfb/cfb_fourth_down.py`. None of them raises — each returns a confident wrong number — so every fix is pinned by a directional test rather than a fixture value. All four were found by reading [`cfb4th`](https://github.com/sportsdataverse/cfb4th)'s `R/decision_functions.R`, the implementation this module is a port of, while porting the same surface to cfbfastR (sportsdataverse/cfbfastR#142).

## The end-game clamps were reading the wrong team

cfb4th applies `end_game_fn` to the **already-flipped** frame. There `pos_score_diff_start` belongs to the team that just *received* the ball and `def_pos_team_timeouts_rem_before` to the team that just gave it up, so the rule reads: *the team now holding the ball leads, and the team it took the ball from cannot stop the clock, so whoever is asking loses.*

All three call sites passed the **pre-play** team's own columns instead, which points the rule at the team that is ahead. Punting team out of timeouts, 60 seconds left in Q4:

| | before | after |
|---|---|---|
| punt while **trailing** by 3 | 0.0999 | **0.0000** |
| punt while **leading** by 3 | 0.0000 | **0.9087** |
| FG while **leading** by 3 | make 0.0 / miss 0.0 | make 0.9490 / miss 0.9016 |

A team kicking a field goal while up three with a minute left was reported as having no chance of winning, and both FG branches collapsed so `fg_wp` was 0 too.

## The go-for-it fail clamp had the same inversion

`pos_diff` at that point is the post-turnover value, already negated, so `> 0` means the team that just **took** the ball leads — which is why the offence's WP goes to zero. Reading it as `< 0` pinned a team that turned the ball over **while ahead** to a certain loss.

| | before | after |
|---|---|---|
| offence leads by 3, turns it over | wp_fail 0.0000 | **0.7671** |
| offence trails by 3, turns it over | wp_fail 0.0294 | **0.0000** |

Worth noting for anyone writing a test here: the clamp needs the **offence's own** timeouts at 0, because after the turnover `new_def_to` is the offence's pre-play count. Setting `def_to = 0` instead leaves `new_def_to == 3` and the clamp never fires — a test written that way passes with either sign. My first attempt at reproducing this made exactly that mistake.

## Punt return touchdown: a double negation

cfb4th negates the already-flipped differential then subtracts seven, which is `orig - 7`. `-(-pos_diff_flipped) - 7` reduces to `-orig - 7`, turning a 10-point lead into a 17-point deficit. Return-TD rows carry under 0.2% of the distribution mass per yardline, so this is asserted on the arithmetic directly rather than through an aggregate that would hide it.

## A missing column no longer surfaces as an AttributeError about a float

`_to_pandas` substituted `NaN` for an absent source column and said nothing. The NaN poisoned the turnover bucketing, the pivot came back missing a bucket, `.to_numpy()` was applied to the scalar fallback, and the caller died several frames later with `AttributeError: 'float' object has no attribute 'to_numpy'` — naming neither the column nor the frame. This is what made me file the crash in #395 as unconditional; it is not, and I corrected that in the issue.

Now: the frame is validated up front with a message naming the missing columns, and the pivot fallback fills a full-length column instead of calling a method on a float.

**One adjacent fix**, found while doing the above and slightly outside the issue: `season` was required by both model paths, but only the field-goal path failed loudly for it. The go-for-it path fed the NaN straight into `_era_onehot`, so every era dummy came out 0 — not a valid one-hot — and `fd_model` scored against a rule era that never existed, returning a plausible 76-class distribution with nothing to flag it. Both paths now raise the same error. `season` is deliberately kept out of the generic required-column check so the existing, more specific `ValueError` (and its test) still fires.

## Gates

* `tests/cfb/test_cfb_fourth_down.py` — 17 passed, 1 skipped (7 new tests).
* Full `tests/cfb/` — 729 passed, 54 skipped, 2 xfailed.
* `ruff check` + `ruff format` clean; codegen drift gate current; `uv.lock` untouched.

## Not fixed here

`test_cfb_pbp_fox_offline.py` emits `RuntimeWarning: invalid value encountered in cast` from this module — the Fox pipeline feeds rows whose `yards_to_goal` is present but NaN, so the required-column check does not catch it. Pre-existing, unrelated to these four, and worth its own issue rather than widening this one.

## Cross-reference

cfbfastR#142 (merged) ports these branches from the cfb4th source with the same three inversions corrected, so the two libraries now agree on the fourth-down surface.

## Summary by Sourcery

Correct fourth-down win-probability end-game behavior and enforce a clear, validated input contract.

Bug Fixes:
- Correct fourth-down end-game win-probability clamps to evaluate the resulting possession state, fixing punt, field-goal, and failed go-for-it outcomes.
- Correct punt-return touchdown score-differential handling and preserve the appropriate winning clamp when possession returns to the punting team.
- Replace delayed failures from missing input data with clear validation errors and require a valid season for era-aware models.
- Fix missing turnover-bucket handling so absent outcomes produce correctly sized fallback columns instead of an AttributeError.

Enhancements:
- Clarify and document the required fourth-down state contract across the public probability APIs.

Documentation:
- Add usage examples for fourth-down, field-goal, go-for-it, and punt probability APIs using the documented Polars input contract.

Tests:
- Add directional coverage for end-game clamp perspectives, turnovers, return touchdowns, required-column validation, optional odds fields, and season validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected fourth-down, punt, and field-goal recommendations in end-game situations, including possession changes, leads, timeouts, and return touchdowns.
  * Fixed handling of empty turnover outcomes.
  * Improved validation with clear errors for missing required play-by-play data and season information.

* **Documentation**
  * Added complete usage examples for fourth-down, go, punt, and field-goal win-probability calculations.

* **Tests**
  * Added coverage for end-game decision logic, input validation, optional odds data, and missing season data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->