### PR TITLE
fix(cfb): make cfb_season_odds bit-reproducible under seed= (#392)

### DIFF
--- a/sportsdataverse/cfb/cfb_season_odds.py
+++ b/sportsdataverse/cfb/cfb_season_odds.py
@@ -287,6 +287,12 @@ def cfb_season_odds(
     games = cfb_games_from_schedule(schedule).select(
         "season", "week", "game_type", "home_team", "away_team", "result", "neutral"
     )
+    # Canonical order, for the same reason `teams` is sorted below: the sampler draws
+    # `rng.normal(..., n)` ACROSS THIS FRAME, so row order decides which game gets
+    # which number out of the seeded stream. Whatever order the schedule arrived in
+    # would otherwise leak into the results, and `seed=` would not survive a loader
+    # change or a re-sorted input. (season, week, home, away) is unique per game.
+    games = games.sort("season", "week", "home_team", "away_team")
     if as_of_date is not None:
         # A postseason MATCHUP is itself an outcome of the season, so an unplayed
         # conf-champ / bowl / CFP row would leak the real bracket into the forecast.
@@ -297,6 +303,14 @@ def cfb_season_odds(
         .vstack(schedule.select(team=pl.col("away_team"), conference=pl.col("away_conference")))
         .drop_nulls("team")
         .unique(subset=["team"], keep="first")
+        # polars `.unique()` gives NO order guarantee, and this frame's row order is
+        # what the seeded RNG draws map onto (`sims.join(teams, how="cross")` below).
+        # So `seed=` made the DRAWS reproducible while leaving the ORDERING free, and
+        # a tiebreak-sensitive team could move by ~1/n_sims between two identical
+        # calls. `team` is unique here, so sorting on it is a total, stable order and
+        # makes `seed=` mean what callers -- backtests, published season odds --
+        # already assume it means.
+        .sort("team")
     )
     # Restrict the SIMULATED UNIVERSE to the FBS field (issue #333). The schedule carries
     # every opponent an FBS team played, and the sampler scores a team absent from

--- a/tests/cfb/test_cfb_season_odds.py
+++ b/tests/cfb/test_cfb_season_odds.py
@@ -436,3 +436,29 @@ def test_as_of_date_drops_unplayed_postseason_matchups(monkeypatch: pytest.Monke
     assert set(out["team_id"].to_list()) == set(_FBS_IDS)
     assert out["cfp_champ_prob"].sum() == pytest.approx(1.0, abs=1e-9)
     assert out.filter((pl.col("playoff_prob") > 0.02) & (pl.col("playoff_prob") < 0.98)).height > 0
+
+
+def test_season_odds_is_bit_reproducible_under_row_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Same seed + same teams + DIFFERENT schedule row order => identical odds.
+
+    The team universe is built with polars `.unique()`, which carries no order
+    guarantee, and that row order is what the seeded RNG draws map onto. So the
+    seed makes the DRAWS reproducible while the ORDERING stays free, and a
+    tiebreak-sensitive team can move by ~1/n_sims between identical calls.
+
+    Shuffling the input rows is a deterministic stand-in for that: it changes
+    what `.unique(keep='first')` sees first, exactly as a different scan order
+    would. Reproducibility is what `seed=` promises callers."""
+    sched = _fake_schedule()
+
+    monkeypatch.setattr(_mod, "cfb_ratings", lambda *a, **k: _fake_ratings())
+    monkeypatch.setattr(_mod, "load_cfb_schedule", lambda *a, **k: sched)
+    first = cfb_season_odds(2023, n_sims=200, playoff_seeds=4, seed=7)
+
+    reversed_sched = sched.reverse()
+    monkeypatch.setattr(_mod, "load_cfb_schedule", lambda *a, **k: reversed_sched)
+    second = cfb_season_odds(2023, n_sims=200, playoff_seeds=4, seed=7)
+
+    assert first.sort("team_id").equals(second.sort("team_id")), (
+        "identical seed produced different odds under a different input row order"
+    )


### PR DESCRIPTION
Closes #392.

`seed=` promised reproducibility it could not deliver: it fixed the **draws** while leaving the **row order** those draws map onto free, so two identical calls could move a tiebreak-sensitive team by ~`1/n_sims`. Callers that assume otherwise include backtests and the published season-odds board.

## Two ordering sources, not one

The issue named `teams`, built with polars `.unique()` (no order guarantee) and consumed through `sims.join(teams, how="cross")`.

**Sorting `teams` alone did not fix the test.** `games` inherits the schedule's row order, and the sampler draws `rng.normal(..., n)` *across that frame*, so each game takes a different number out of the seeded stream. Both are now canonically ordered:

- `teams` by `team` — unique here, so it is a total order
- `games` by `(season, week, home_team, away_team)` — unique per game

Writing the failing test **first** is what caught the second source. Fixing only the reported mechanism would have closed #392 on a partial fix that still drifted, and the symptom is intermittent enough that it would not have resurfaced quickly.

## The test asserts the stronger property

It shuffles the input row order rather than hoping `.unique()` returns something different on a rerun — same seed, same teams, reversed schedule must produce identical odds.

That is deliberately stronger than the reported bug, and it is the property `seed=` should actually carry: reproducibility has to survive a loader change or a re-sorted input, not just a lucky scan order. Verified it fails before the fix and passes after.

## Gates

- `tests/cfb`: **732 passed**, 54 skipped, 2 xfailed
- ruff clean
- codegen drift gate: all generated files current

## Summary by Sourcery

Ensure `seed=` provides bit-reproducible college football season odds across changes in input ordering.

Bug Fixes:
- Make seeded college football season-odds simulations produce identical results regardless of team or schedule input row order.

Tests:
- Add coverage verifying bit-reproducible season odds under reversed schedule input order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured college football season odds remain consistent when schedule data arrives in a different row order.
  - Improved reproducibility for repeated calculations using the same seed and teams.

- **Tests**
  - Added coverage confirming identical odds across reordered schedule inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->