### PR TITLE
fix(torvik): reject an HTML body instead of parsing it as a CSV

### DIFF
--- a/sportsdataverse/mbb/torvik_parsers.py
+++ b/sportsdataverse/mbb/torvik_parsers.py
@@ -24,6 +24,12 @@ from sportsdataverse.dl_utils import underscore
 __all__ = ["parse_torvik_csv"]
 
 
+#: Document markers that mean "this body is markup, not a data file". Matched
+#: against the start of the payload, so a CSV cell containing "<html>" mid-file
+#: is unaffected.
+_HTML_MARKERS = ("<!doctype", "<html", "<?xml", "<head", "<body")
+
+
 def _clean_col(name: str) -> str:
     """janitor::make_clean_names-style cleaner for a single Torvik CSV header."""
     s = str(name).strip().replace("%", " percent ")
@@ -97,7 +103,10 @@ def parse_torvik_csv(payload: object, return_as_pandas: bool = False) -> Union[p
     # from here. The crosswalk builders wrap this in require_source(), whose
     # contract is exactly that a payload which will not render is a build
     # failure rather than a silently empty source.
-    if text.lstrip()[:1] == "<":
+    # Match real document markers, not a bare "<": a CSV whose first header
+    # cell is "<team>" is still a CSV, and a lone "<" belongs on the zero-row
+    # path below. A UTF-8 BOM ahead of the DOCTYPE is stripped first.
+    if text.lstrip("﻿").lstrip()[:200].lower().startswith(_HTML_MARKERS):
         snippet = " ".join(text.split())[:120]
         raise ValueError(
             "expected a barttorvik.com CSV data file but received an HTML "

--- a/sportsdataverse/mbb/torvik_parsers.py
+++ b/sportsdataverse/mbb/torvik_parsers.py
@@ -62,10 +62,17 @@ def parse_torvik_csv(payload: object, return_as_pandas: bool = False) -> Union[p
         de-duplicated column names; zero rows on empty/malformed input.
 
     Raises:
-        None: malformed input (non-text payload, header-only body, unterminated
-            quoted field) yields a zero-row frame rather than raising, so callers
-            can chain without a null-check. Only a ``pandas`` import failure under
-            ``return_as_pandas=True`` propagates.
+        ValueError: The payload is an HTML document rather than a data file.
+            barttorvik.com answers a transient outage with an HTML page and
+            HTTP 200, and an HTML body parses as a one-column CSV whose header
+            is the DOCTYPE -- which reaches the caller as a baffling
+            ``ColumnNotFoundError: unable to find column "team"`` several
+            frames away. Say what actually happened instead.
+        None: other malformed input (non-text payload, header-only body,
+            unterminated quoted field) yields a zero-row frame rather than
+            raising, so callers can chain without a null-check. Only a
+            ``pandas`` import failure under ``return_as_pandas=True``
+            propagates.
 
     Example:
         Quick start::
@@ -84,6 +91,20 @@ def parse_torvik_csv(payload: object, return_as_pandas: bool = False) -> Union[p
         .. _Bart Torvik: https://barttorvik.com
     """
     text = payload if isinstance(payload, str) else ""
+    # An HTML body is not an empty data file and must not be read as one.
+    # barttorvik.com serves an HTML page with HTTP 200 during an outage; the
+    # DOCTYPE then becomes the sole column name and the failure surfaces far
+    # from here. The crosswalk builders wrap this in require_source(), whose
+    # contract is exactly that a payload which will not render is a build
+    # failure rather than a silently empty source.
+    if text.lstrip()[:1] == "<":
+        snippet = " ".join(text.split())[:120]
+        raise ValueError(
+            "expected a barttorvik.com CSV data file but received an HTML "
+            f"document (starts: {snippet!r}). The host answers a transient "
+            "outage with an HTML page and HTTP 200; retry, or check the "
+            "endpoint URL for that season."
+        )
     if not text.strip() or "\n" not in text.strip():
         df = pl.DataFrame()
     else:

--- a/tests/mbb/test_mbb_torvik.py
+++ b/tests/mbb/test_mbb_torvik.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import polars as pl
+import pytest
 
 from sportsdataverse.mbb.torvik_parsers import parse_torvik_csv
 
@@ -58,6 +59,31 @@ def test_parse_malformed_csv_returns_zero_rows():
     df = parse_torvik_csv('team,conf\nHouston,"B12\n')
     assert isinstance(df, pl.DataFrame)
     assert len(df) == 0
+
+
+def test_parse_html_outage_page_raises_rather_than_pretending_to_be_data():
+    """An HTML body must not be read as a one-column CSV named after the DOCTYPE.
+
+    barttorvik.com answers a transient outage with an HTML page and HTTP 200.
+    Parsing it produced a frame whose only columns were the snake-cased
+    DOCTYPE, so the failure surfaced far away as
+    ``ColumnNotFoundError: unable to find column "team"`` inside
+    ``wbb_team_crosswalk`` -- which is how the nightly wehoop-wbb-data build
+    broke on 2026-08-24.
+    """
+    html = (
+        '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"'
+        ' "http://www.w3.org/TR/html4/loose.dtd">\n'
+        "<html><body>Service Unavailable</body></html>\n"
+    )
+    with pytest.raises(ValueError, match="HTML document"):
+        parse_torvik_csv(html)
+
+
+def test_parse_leading_whitespace_html_also_raises():
+    """The guard looks past leading whitespace, as a real body may have some."""
+    with pytest.raises(ValueError, match="HTML document"):
+        parse_torvik_csv("\n  <!DOCTYPE html>\n<html><body>nope</body></html>\n")
 
 
 def test_wrapper_routes_through_parser(monkeypatch):

--- a/tests/mbb/test_mbb_torvik.py
+++ b/tests/mbb/test_mbb_torvik.py
@@ -86,6 +86,29 @@ def test_parse_leading_whitespace_html_also_raises():
         parse_torvik_csv("\n  <!DOCTYPE html>\n<html><body>nope</body></html>\n")
 
 
+def test_parse_html_detection_does_not_swallow_a_csv_starting_with_a_bracket():
+    """Only document markers count as HTML -- a bare "<" is not one.
+
+    A CSV whose first header cell is ``<team>`` is still a CSV, and a lone
+    ``<`` belongs on the documented zero-row path, not the raising one.
+    """
+    df = parse_torvik_csv("<team>,conf\nHouston,B12\n")
+    assert df.columns == ["team", "conf"]
+    assert df.height == 1
+    assert parse_torvik_csv("<").height == 0
+
+
+def test_parse_html_detection_sees_past_a_utf8_bom():
+    """A BOM ahead of the DOCTYPE must not hide the markup."""
+    with pytest.raises(ValueError, match="HTML document"):
+        parse_torvik_csv("\ufeff<!DOCTYPE html>\n<html><body>x</body></html>\n")
+
+
+def test_parse_xml_error_document_also_raises():
+    with pytest.raises(ValueError, match="HTML document"):
+        parse_torvik_csv('<?xml version="1.0"?>\n<error/>\n')
+
+
 def test_wrapper_routes_through_parser(monkeypatch):
     import sportsdataverse.mbb.torvik as gen
 


### PR DESCRIPTION
Found while fixing the nightly `wehoop-wbb-data` build, which failed on 2026-08-24 in `team_crosswalk`, `schedule_crosswalk` **and** `player_crosswalk` at once with:

```
polars.exceptions.ColumnNotFoundError: unable to find column "team";
valid columns: ["doctype_html_public_w3c_dtd_html_4_01_transitional_en_http_www_w3_org_tr_html4_loose_dtd",
                "unnamed"]
  ...
  File "sportsdataverse/wbb/wbb_crosswalk.py", line 231, in _assemble_team_crosswalk
    bart2 = bart.select(
```

That column name is a snake-cased HTML DOCTYPE. barttorvik.com answers a transient outage with an **HTML page and HTTP 200**, `torvik_runtime._get` correctly returns the body as text for a non-JSON content type, and `parse_torvik_csv` then read the HTML as a headed CSV — so the DOCTYPE became the only column. The real failure surfaced several frames away, in a function that had nothing to do with it.

The existing guard in `_assemble_team_crosswalk` is `bart is None or bart.height == 0`, which an HTML frame passes: it has rows, just not the right ones.

**Change:** `parse_torvik_csv` raises when the payload is an HTML document, naming what actually arrived. The crosswalk builders already wrap the fetch in `require_source()`, whose docstring states the contract exactly — *"a provider that cannot be produced — the module is missing, the import fails, the request errors, the payload will not render — is a build failure"* — so this routes into machinery that was already designed for it, and the caller gets `CrosswalkSourceError: bart_wbb_ratings(year=2026) ...` instead of a `ColumnNotFoundError`.

The documented zero-row contract is unchanged for genuinely empty input:

```
  PASS  HTML rejected: expected a barttorvik.com CSV data file but received an HTML document...
  PASS  real CSV still parses: (2, 3) cols=[rank, team, conf]
  PASS  empty        -> zero-row frame (contract unchanged)
  PASS  header only  -> zero-row frame (contract unchanged)
  PASS  non-text     -> zero-row frame (contract unchanged)
```

Two regression tests added. `216 passed, 19 skipped, 1 xfailed` across `tests/mbb/test_mbb_torvik.py` + `tests/wbb/`; `codegen --check: all generated files current`.

Note the endpoint is healthy again today (both `2025_team_results.csv` and `2026_team_results.csv` return `text/csv`, HTTP 200), so this is hardening against a recurrence rather than a currently-broken source.

## Summary by Sourcery

Reject markup responses from Torvik CSV endpoints so transient outages produce clear source errors instead of downstream column failures.

Bug Fixes:
- Reject HTML and XML outage responses instead of parsing them as CSV data, allowing source-fetch failures to surface with an actionable error.
- Preserve the existing zero-row behavior for empty and other malformed non-HTML input.

Enhancements:
- Add focused regression coverage for markup detection, leading whitespace, UTF-8 BOMs, and CSV inputs beginning with angle brackets.

Documentation:
- Document the parser's HTML rejection behavior and retained malformed-input contract.

Tests:
- Add regression tests ensuring HTML outage pages raise clear errors without changing valid CSV parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of HTML error pages returned where Torvik CSV data is expected.
  * Raises a clear error instead of incorrectly parsing the HTML as CSV data.
  * Handles HTML responses with leading whitespace consistently.

* **Tests**
  * Added coverage for HTML outage pages and malformed responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->