### PR TITLE
fix(transport): classify release-asset read failures via download() (#397)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -778,12 +778,28 @@ publish/download helpers plus a pure-Python **byte-parity RDS writer**
 
 ### HTTP / retry layer
 
-All HTTP goes through `sportsdataverse.dl_utils.download()`. As of May 2026
-it's type-hinted, iterative (no recursion), initializes `response = None`
-defensively, and re-raises the most recent exception when the retry budget
-is exhausted (instead of returning an unbound variable). Wrappers do NOT
-wrap the call in try/except — they trust `download()` to either return a
-usable `requests.Response` or raise.
+All **payload HTTP** goes through `sportsdataverse.dl_utils.download()` — the
+JSON-fetching wrapper layer (ESPN, MLB, NHL, NFL.com, HockeyTech, stats.ncaa.org)
+and every hand-rolled `requests` call. As of May 2026 it's type-hinted, iterative
+(no recursion), initializes `response = None` defensively, and re-raises the most
+recent exception when the retry budget is exhausted (instead of returning an
+unbound variable). Wrappers do NOT wrap the call in try/except — they trust
+`download()` to either return a usable `requests.Response` or raise.
+
+**Exception — remote columnar reads.** `_read_release_parquet()` in
+`_codegen_runtime.py` (backing 226 generated-loader call sites) hands the release
+URL straight to Arrow rather than buffering it through `download()`. This is
+deliberate and measured, not an oversight: Arrow overlaps the fetch with decoding
+and range-reads column chunks, while any fetch-then-parse path serializes the two
+and holds an extra copy of the compressed asset. On the 59 MB
+`play_by_play_2025.parquet` the buffered variant cost **+7% peak RSS and +75% wall**
+(1010 MB / 6.0s → 1081 MB / 10.5s); temp-file and zero-copy `pa.py_buffer` variants
+were no better. `download()` is still used there to **classify** a failed read — a
+404 becomes `NoDataError` (skip the season), any other non-200 becomes
+`AssetFetchError` (surface it), so a fetch that FAILED is never recorded as a
+season that is EMPTY. Don't "fix" this to route the bytes through `download()`;
+`tests/codegen/test_runtime_release.py::test_success_path_never_calls_the_transport`
+guards it. See issue #397.
 
 ### Polars version
 

--- a/sportsdataverse/_codegen_runtime.py
+++ b/sportsdataverse/_codegen_runtime.py
@@ -112,28 +112,56 @@ def cli_warn(msg: str) -> None:
 def _read_release_parquet(url: str) -> Optional[pl.DataFrame]:
     """Read a release parquet; return ``None`` on 404 / missing asset (404-safe loaders).
 
-    Re-raises anything that isn't a missing-asset error so genuine parse/schema bugs
-    aren't silently swallowed. The token list is deliberately narrow: ``403/forbidden``
-    (rate-limit / auth) and generic ``could not`` (parse/type failures) are NOT treated
-    as missing assets, so they surface instead of being masked as "no data".
+    The read itself stays a direct Arrow fetch, and the bytes deliberately do NOT go
+    through the HTTP gateway. Arrow overlaps the fetch with decoding and range-reads
+    column chunks; buffering the asset first serializes the two and holds an extra copy
+    of the compressed file. Measured on the 59 MB ``play_by_play_2025.parquet`` (best of
+    3, one read per process, identical imports): direct 1010 MB / 6.0s versus buffered
+    1081 MB / 10.5s -- +7% peak RSS and +75% wall. Routing through a temp file or a
+    zero-copy ``pa.py_buffer`` was no better. See issue #397.
+
+    What DOES go through the gateway is the *classification* of a failure. When the
+    direct read fails we ask ``download`` what the server actually said instead of
+    pattern-matching the reader's exception message:
+
+    * a 404 (``NoDataError``) means the asset is genuinely absent -- return ``None``
+      so the caller skips that season;
+    * any other non-200 -- notably a 403 or a rate-limit that outlived the retry
+      budget -- raises :class:`~sportsdataverse.errors.AssetFetchError`, so a fetch
+      that FAILED is never recorded as a season that is EMPTY;
+    * a reachable, readable asset means the failure was a genuine parse/schema error,
+      which is re-raised untouched.
+
+    The extra round trip happens only on the failure path and costs ~0.1s per missing
+    season, versus the several seconds a buffered success path would cost every time.
 
     R-producer assets can carry an ``arrow.r.vctrs`` field-extension whose metadata is
-    raw RDS bytes (not UTF-8) — e.g. a ``glue`` character column. polars' arrow-FFI
-    import panics on that metadata (``pyo3 PanicException``, a ``BaseException`` the
-    404 classifier never sees), so on panic we re-read via pyarrow with all
-    field/schema metadata stripped; the storage types are plain, so this is lossless.
+    raw RDS bytes (not UTF-8) -- e.g. a ``glue`` character column. polars' arrow-FFI
+    import panics on that metadata (``pyo3 PanicException``, a ``BaseException`` that
+    an ``except Exception`` handler never sees), so on panic we re-read via pyarrow
+    with all field/schema metadata stripped; the storage types are plain, so this is
+    lossless.
     """
+    from sportsdataverse.errors import AssetFetchError, NoDataError
+
     try:
         return pl.read_parquet(url, use_pyarrow=True)
-    except Exception as e:  # noqa: BLE001 -- classify fetch/parse failures
-        msg = str(e).lower()
-        if any(tok in msg for tok in ("404", "not found", "no such")):
-            return None
-        raise
+    except Exception as e:  # noqa: BLE001 -- classified below, by the server not the message
+        original: BaseException = e
     except BaseException as e:  # pyo3 PanicException does not subclass Exception
         if type(e).__name__ != "PanicException":
-            raise
+            raise  # never swallow KeyboardInterrupt / SystemExit into an HTTP call
         return _read_parquet_stripped_metadata(url)
+
+    try:
+        resp = download(url)
+    except NoDataError:
+        return None
+
+    status = getattr(resp, "status_code", None)
+    if status is not None and status != 200:
+        raise AssetFetchError(f"release asset fetch failed with HTTP {status}: {url}") from original
+    raise original
 
 
 def _read_parquet_stripped_metadata(url: str) -> pl.DataFrame:

--- a/sportsdataverse/_common_espn_player_stats.py
+++ b/sportsdataverse/_common_espn_player_stats.py
@@ -135,7 +135,7 @@ def _espn_player_stats(
 
     Raises:
         ValueError: ``season_type`` is not ``"regular"``/``"postseason"``.
-        sportsdataverse.errors.NoESPNDataError: ESPN returned 404 for the
+        sportsdataverse.errors.NoDataError: ESPN returned 404 for the
             statistics node (no season line for that athlete/season).
     """
     st = season_type.strip().lower()
@@ -148,7 +148,7 @@ def _espn_player_stats(
     stats_url = f"{base}/{season}/types/{s_type}/athletes/{athlete_id}/statistics/{totals}"
     athlete_url = f"{base}/{season}/athletes/{athlete_id}"
 
-    # Statistics node is authoritative: a 404 here raises (NoESPNDataError).
+    # Statistics node is authoritative: a 404 here raises (NoDataError).
     stats_payload: dict[str, Any] = download(stats_url, **kwargs).json()
 
     if raw:

--- a/sportsdataverse/cfb/cfb_game_rosters.py
+++ b/sportsdataverse/cfb/cfb_game_rosters.py
@@ -183,7 +183,7 @@ def helper_cfb_roster_items(items, summary_url, **kwargs):
             from sportsdataverse.cfb import espn_cfb_game_rosters
             rosters = espn_cfb_game_rosters(game_id=401628334)
     """
-    from sportsdataverse.errors import NoESPNDataError
+    from sportsdataverse.errors import NoDataError
 
     team_ids = list(items["team_id"])
     game_rosters = pl.DataFrame()
@@ -191,7 +191,7 @@ def helper_cfb_roster_items(items, summary_url, **kwargs):
         team_roster_url = "{x}/{t}/roster".format(x=summary_url, t=tm)
         try:
             team_roster_resp = download(team_roster_url, **kwargs)
-        except NoESPNDataError:
+        except NoDataError:
             # ESPN has no roster resource for this team in this game (a 404 —
             # common for older games and FCS opponents). Skip it so the other
             # team's roster is still recovered instead of failing the whole game.
@@ -206,7 +206,7 @@ def helper_cfb_roster_items(items, summary_url, **kwargs):
         game_rosters = pl.concat([game_rosters, team_roster], how="diagonal")
     if game_rosters.is_empty():
         # No team in this game exposes a roster resource — genuinely no data.
-        raise NoESPNDataError(f"NoESPNDataError: No roster data found for any team at {summary_url}")
+        raise NoDataError(f"NoDataError: No roster data found for any team at {summary_url}")
     game_rosters = game_rosters.drop([c for c in ["period", "for_player_id", "active"] if c in game_rosters.columns])
     game_rosters = game_rosters.with_columns(
         player_id=pl.col("player_id").cast(pl.Int64),

--- a/sportsdataverse/cfb/cfb_pbp.py
+++ b/sportsdataverse/cfb/cfb_pbp.py
@@ -1647,15 +1647,15 @@ class CFBPlayProcess(object):
     def __helper_cfb_pbp(self, pbp_txt):
         # ESPN's summary endpoint intermittently returns a payload with no
         # `header.competitions` (transient gap / a game not yet ingested).
-        # Short-circuit with a clear, catchable NoESPNDataError *before* pickcenter
+        # Short-circuit with a clear, catchable NoDataError *before* pickcenter
         # resolution (which would otherwise make a fallback odds network hop) and
         # before the deep `KeyError: 'competitions'` in __helper_cfb_game_data.
         # Local import so the error class doesn't leak into the package namespace
         # (it is not a public wrapper) and trip the codegen autodoc/parsed gates.
-        from sportsdataverse.errors import NoESPNDataError
+        from sportsdataverse.errors import NoDataError
 
         if not ((pbp_txt.get("header") or {}).get("competitions") or []):
-            raise NoESPNDataError(
+            raise NoDataError(
                 f"ESPN summary for game {self.gameId} has no header.competitions; cannot build play-by-play.",
             )
         init = self.__helper_cfb_pickcenter(pbp_txt)

--- a/sportsdataverse/cfb/cfb_play_participants.py
+++ b/sportsdataverse/cfb/cfb_play_participants.py
@@ -153,7 +153,7 @@ def espn_cfb_play_participants(
         If ``raw=True``, returns the parsed JSON list of play dicts.
 
     Raises:
-        sportsdataverse.errors.NoESPNDataError: ESPN returned 404.
+        sportsdataverse.errors.NoDataError: ESPN returned 404.
         requests.exceptions.RequestException: Other network failures after retries.
 
     Example:

--- a/sportsdataverse/cfb/cfb_player_stats.py
+++ b/sportsdataverse/cfb/cfb_player_stats.py
@@ -88,7 +88,7 @@ def espn_cfb_player_stats(
 
     Raises:
         ValueError: ``season_type`` is not ``"regular"``/``"postseason"``.
-        sportsdataverse.errors.NoESPNDataError: ESPN returned 404.
+        sportsdataverse.errors.NoDataError: ESPN returned 404.
 
     Example:
         Pull a player's 2023 season line as a single wide row::

--- a/sportsdataverse/cfb/on3_runtime.py
+++ b/sportsdataverse/cfb/on3_runtime.py
@@ -28,7 +28,7 @@ continuity. The RDB natives are the forward path.
   rankings HTML page and cached at module level for the process lifetime.
 * **stale-buildId retry** — a rotated buildId makes the data route return
   HTTP 404 (which :func:`sportsdataverse.dl_utils.download` surfaces as
-  :class:`~sportsdataverse.errors.NoESPNDataError`). ``_scrape_get`` treats that
+  :class:`~sportsdataverse.errors.NoDataError`). ``_scrape_get`` treats that
   as "re-discover the buildId and retry once", so a deploy mid-process degrades
   to one extra page fetch instead of an error.
 
@@ -43,7 +43,7 @@ import re
 from typing import Any, Dict, Optional
 
 from sportsdataverse.dl_utils import download
-from sportsdataverse.errors import NoESPNDataError
+from sportsdataverse.errors import NoDataError
 
 _HOST = "https://www.on3.com"
 _BUILD_ID_RE = re.compile(r'"buildId":"([A-Za-z0-9_-]+)"')
@@ -89,7 +89,7 @@ def _discover_build_id(page_url: str, **kwargs: Any) -> Optional[str]:
     headers = {**_headers(), **kwargs.pop("headers", {})}
     try:
         resp = download(url=page_url, headers=headers, **kwargs)
-    except NoESPNDataError:
+    except NoDataError:
         return None
     return _extract_build_id(getattr(resp, "text", "") or "")
 
@@ -110,13 +110,13 @@ def _get(url: str, params: Optional[Dict[str, Any]] = None, **kwargs: Any) -> An
 
     Returns:
         The parsed JSON ``dict`` or ``list``; ``{}`` when the route is
-        unreachable (``NoESPNDataError``) or the body is not JSON.
+        unreachable (``NoDataError``) or the body is not JSON.
     """
     headers = {**_headers(), **kwargs.pop("headers", {})}
     query = {k: v for k, v in (params or {}).items() if v is not None}
     try:
         resp = download(url=url, params=query, headers=headers, **kwargs)
-    except NoESPNDataError:
+    except NoDataError:
         return {}
     try:
         body = resp.json()
@@ -176,7 +176,7 @@ def _scrape_get(url: str, params: Optional[Dict[str, Any]] = None, **kwargs: Any
         data_url = f"{_HOST}/_next/data/{_build_id}{path}"
         try:
             resp = download(url=data_url, params=query, headers=headers, **kwargs)
-        except NoESPNDataError:
+        except NoDataError:
             if attempt == 1:
                 return {}
             # 404 on the data route == buildId rotated (On3 deployed). Refresh once;

--- a/sportsdataverse/dl_utils.py
+++ b/sportsdataverse/dl_utils.py
@@ -14,7 +14,7 @@ import polars as pl
 import requests
 from requests.adapters import HTTPAdapter
 
-from sportsdataverse.errors import NoESPNDataError, no_espn_data
+from sportsdataverse.errors import NoDataError, no_espn_data
 
 logger = logging.getLogger("sdv.dl_utils")
 logger.addHandler(logging.NullHandler())
@@ -125,7 +125,8 @@ def download(
 
     Canonical HTTP gateway used by every wrapper in the package. Wraps
     :mod:`requests` with an exponential-style retry loop, raises
-    :class:`~sportsdataverse.errors.NoESPNDataError` on ESPN 404 payloads,
+    :class:`~sportsdataverse.errors.NoDataError` on any 404 -- an ESPN
+    200-with-``code:404`` body included, and release assets on GitHub too --
     and surfaces transient failures through the supplied ``logger`` rather
     than raising.
 
@@ -277,7 +278,7 @@ def download(
                 except Exception:  # noqa: BLE001
                     pass
             return response
-        except NoESPNDataError:
+        except NoDataError:
             # A 404 (or ESPN's 200-with-`code:404` body) is a definitive "no data"
             # answer — retrying cannot change it and only amplifies load against a
             # rate-limited host. Fail fast instead of burning the retry budget.

--- a/sportsdataverse/errors.py
+++ b/sportsdataverse/errors.py
@@ -15,7 +15,7 @@ class SportsDataverseError(Exception):
 
     Catch this to handle any package-specific failure with one ``except``
     clause, while still being able to catch the narrower subclasses
-    (:class:`SeasonNotFoundError`, :class:`NoESPNDataError`) individually::
+    (:class:`SeasonNotFoundError`, :class:`NoDataError`) individually::
 
         from sportsdataverse.errors import SportsDataverseError
 
@@ -111,23 +111,55 @@ class RawStoreMissError(SportsDataverseError):
     """
 
 
-class NoESPNDataError(SportsDataverseError):
-    """Raised when an ESPN endpoint has no payload for the request.
+class AssetFetchError(SportsDataverseError):
+    """Raised when fetching a published data asset returns an unusable response.
 
-    Triggered both by a raw HTTP 404 and by the legacy ESPN convention of
-    returning a JSON body with ``{"code": 404, ...}`` and a 200 status.
-    Both cases mean the same thing for callers: there is no data for the
-    requested game / team / season.
+    Covers any hosted artifact the package reads over HTTP -- a release parquet,
+    a producer-repo file, a bundled JSON capture -- when the transport comes back
+    with a status that is neither success nor a definitive "no data". The common
+    cases are a 403 that outlived the retry budget (rate limit, or a private
+    asset) and a 5xx the host never recovered from.
+
+    Deliberately distinct from :class:`NoDataError`, which means the asset is
+    genuinely absent and the caller should skip it. This one means the fetch
+    FAILED and the answer is unknown, so it must never be swallowed into an empty
+    frame: a rate-limited season is not an empty season.
+
+    Example:
+        Tell a missing season apart from a failed fetch::
+
+            from sportsdataverse.errors import AssetFetchError
+            from sportsdataverse.cfb import load_cfb_schedule
+
+            try:
+                sched = load_cfb_schedule([2024])
+            except AssetFetchError as exc:
+                print(f"fetch failed, retry later: {exc}")
+    """
+
+
+class NoDataError(SportsDataverseError):
+    """Raised when a source has no payload for the request.
+
+    Means the fetch SUCCEEDED and the answer is "nothing here" -- the game,
+    team, season or asset does not exist upstream. Triggered by a raw HTTP 404
+    from any host (an ESPN endpoint, a published release asset, a producer-repo
+    file) and by the legacy ESPN convention of returning ``{"code": 404, ...}``
+    with a 200 status. Callers treat all of these the same way: skip it.
+
+    Contrast :class:`AssetFetchError`, which means the fetch FAILED and the
+    answer is unknown. Keeping them apart is what stops a rate-limited season
+    from being recorded as an empty one.
 
     Example:
         Catch missing-data responses around an ESPN call::
 
-            from sportsdataverse.errors import NoESPNDataError
+            from sportsdataverse.errors import NoDataError
             from sportsdataverse.cfb import espn_cfb_pbp
 
             try:
                 pbp = espn_cfb_pbp(game_id=1)  # not a real ESPN game id
-            except NoESPNDataError as exc:
+            except NoDataError as exc:
                 print(f"no data: {exc}")
                 pbp = None
     """
@@ -135,8 +167,15 @@ class NoESPNDataError(SportsDataverseError):
     pass
 
 
+#: Back-compat alias. The error was ESPN-only when it was named, but
+#: :func:`sportsdataverse.dl_utils.download` raises it for any 404 -- including
+#: release assets on GitHub -- so the name misdescribes it. Existing
+#: ``raise``/``except NoESPNDataError`` code keeps working unchanged.
+NoESPNDataError = NoDataError
+
+
 def no_espn_data(response: "requests.Response") -> "requests.Response":
-    """Validate an ESPN response, raising :class:`NoESPNDataError` if empty.
+    """Validate an ESPN response, raising :class:`NoDataError` if empty.
 
     Used by :func:`sportsdataverse.dl_utils.download` to normalize ESPN's
     two flavors of "no data" (HTTP 404 and 200-with-``code=404``-body)
@@ -151,24 +190,24 @@ def no_espn_data(response: "requests.Response") -> "requests.Response":
         The same ``response`` object unchanged when the payload is valid.
 
     Raises:
-        NoESPNDataError: When the response is a 404 or carries a
+        NoDataError: When the response is a 404 or carries a
             ``code: 404`` JSON body.
 
     Example:
         Use directly when you have a hand-rolled ``requests`` call::
 
             import requests
-            from sportsdataverse.errors import NoESPNDataError, no_espn_data
+            from sportsdataverse.errors import NoDataError, no_espn_data
 
             try:
                 resp = no_espn_data(
                     requests.get("https://site.api.espn.com/apis/site/v2/sports/football/college-football/scoreboard")
                 )
-            except NoESPNDataError:
+            except NoDataError:
                 resp = None
     """
     if response.status_code == 404:
-        raise NoESPNDataError(_format_404(response.url))
+        raise NoDataError(_format_404(response.url))
 
     # ESPN's "200-but-empty" envelope is `{"code": 404, ...}`. Other
     # endpoints (e.g. jsonplaceholder.typicode.com/posts, stats.wnba.com
@@ -184,7 +223,7 @@ def no_espn_data(response: "requests.Response") -> "requests.Response":
         return response
 
     if isinstance(body, dict) and body.get("code") == 404:
-        raise NoESPNDataError(_format_404(response.url, body=body))
+        raise NoDataError(_format_404(response.url, body=body))
     return response
 
 
@@ -277,8 +316,8 @@ def suggest_next_action(url: str) -> str | None:
 
 
 def _format_404(url: str, body: object | None = None) -> str:
-    """Build a NoESPNDataError message with an optional next-action hint."""
-    base = f"NoESPNDataError: No data found for {url}"
+    """Build a NoDataError message with an optional next-action hint."""
+    base = f"NoDataError: No data found for {url}"
     if body is not None:
         base += f", response: {body}"
     hint = suggest_next_action(url)

--- a/sportsdataverse/mbb/mbb_fox_ext.py
+++ b/sportsdataverse/mbb/mbb_fox_ext.py
@@ -28,7 +28,7 @@ from sportsdataverse._fox_layout import (
     parse_team_stats,
     parse_teams,
 )
-from sportsdataverse.errors import NoESPNDataError
+from sportsdataverse.errors import NoDataError
 
 __all__ = [
     "fox_mbb_pbp",
@@ -479,7 +479,7 @@ def fox_mbb_teams(
         ``return_parsed=False``.
 
     Raises:
-        sportsdataverse.errors.NoESPNDataError: Fox returned 404 for the requested id.
+        sportsdataverse.errors.NoDataError: Fox returned 404 for the requested id.
         requests.exceptions.RequestException: Connection-level failure after
             ``dl_utils.download`` exhausts its retries.
 
@@ -530,7 +530,7 @@ def fox_mbb_teams_all(
     Raises:
         requests.exceptions.RequestException: Connection-level failure after
             ``dl_utils.download`` exhausts its retries. A 404 on an individual
-            candidate id (``NoESPNDataError``) is expected during the scan and is
+            candidate id (``NoDataError``) is expected during the scan and is
             skipped; every other failure propagates rather than silently
             truncating the directory.
 
@@ -563,7 +563,7 @@ def fox_mbb_teams_all(
             continue
         try:
             part = parse_teams(fox_get(f"{_SPORT}/team/{cand}/standings", **kwargs))
-        except NoESPNDataError:
+        except NoDataError:
             # Only "this candidate id does not exist" is expected while scanning.
             # Transport / auth / rate-limit failures must NOT be laundered into an
             # empty directory the caller can't tell apart from a valid scan.

--- a/sportsdataverse/mbb/mbb_game_rosters.py
+++ b/sportsdataverse/mbb/mbb_game_rosters.py
@@ -136,7 +136,7 @@ def helper_mbb_team_items(items, **kwargs):
 
 
 def helper_mbb_roster_items(items, summary_url, **kwargs):
-    from sportsdataverse.errors import NoESPNDataError
+    from sportsdataverse.errors import NoDataError
 
     team_ids = list(items["team_id"])
     game_rosters = pl.DataFrame()
@@ -144,7 +144,7 @@ def helper_mbb_roster_items(items, summary_url, **kwargs):
         team_roster_url = "{x}/{t}/roster".format(x=summary_url, t=tm)
         try:
             team_roster_resp = download(team_roster_url, **kwargs)
-        except NoESPNDataError:
+        except NoDataError:
             # ESPN has no roster resource for this team in this game (a 404 —
             # common for older games and non-D1 opponents). Skip it so the other
             # team's roster is still recovered instead of failing the whole game.
@@ -159,7 +159,7 @@ def helper_mbb_roster_items(items, summary_url, **kwargs):
         game_rosters = pl.concat([game_rosters, team_roster], how="diagonal")
     if game_rosters.is_empty():
         # No team in this game exposes a roster resource — genuinely no data.
-        raise NoESPNDataError(f"NoESPNDataError: No roster data found for any team at {summary_url}")
+        raise NoDataError(f"NoDataError: No roster data found for any team at {summary_url}")
     game_rosters = game_rosters.drop([c for c in ["period", "for_player_id", "active"] if c in game_rosters.columns])
     game_rosters = game_rosters.with_columns(
         player_id=pl.col("player_id").cast(pl.Int64),

--- a/sportsdataverse/mbb/mbb_player_stats.py
+++ b/sportsdataverse/mbb/mbb_player_stats.py
@@ -87,7 +87,7 @@ def espn_mbb_player_stats(
 
     Raises:
         ValueError: ``season_type`` is not ``"regular"``/``"postseason"``.
-        sportsdataverse.errors.NoESPNDataError: ESPN returned 404.
+        sportsdataverse.errors.NoDataError: ESPN returned 404.
 
     Example:
         Pull a player's 2023 season line as a single wide row::

--- a/sportsdataverse/mbb/mbb_recruiting_projection.py
+++ b/sportsdataverse/mbb/mbb_recruiting_projection.py
@@ -47,7 +47,7 @@ def _load_recruits(seasons: "list[int]", league: str = "mens") -> pl.DataFrame:
     bogus low ranks), so it is nulled there.
     """
     from sportsdataverse.dl_utils import download  # noqa: PLC0415
-    from sportsdataverse.errors import NoESPNDataError  # noqa: PLC0415
+    from sportsdataverse.errors import NoDataError  # noqa: PLC0415
 
     if league == "womens":
         from sportsdataverse.wbb import espn_wbb_season_recruits as season_recruits  # noqa: PLC0415
@@ -61,7 +61,7 @@ def _load_recruits(seasons: "list[int]", league: str = "mens") -> pl.DataFrame:
         for url in ref_list:
             try:
                 payload = download(url).json()
-            except NoESPNDataError:  # $ref resolves to no data — skip this recruit
+            except NoDataError:  # $ref resolves to no data — skip this recruit
                 continue
             ath = payload.get("athlete") or {}
             school_ref = ((payload.get("schools") or [{}])[0].get("team") or {}).get("$ref", "")

--- a/sportsdataverse/mlb/mlb_player_stats.py
+++ b/sportsdataverse/mlb/mlb_player_stats.py
@@ -89,7 +89,7 @@ def espn_mlb_player_stats(
 
     Raises:
         ValueError: ``season_type`` is not ``"regular"``/``"postseason"``.
-        sportsdataverse.errors.NoESPNDataError: ESPN returned 404.
+        sportsdataverse.errors.NoDataError: ESPN returned 404.
 
     Example:
         Pull Aaron Judge's 2023 season line as a single wide row::

--- a/sportsdataverse/nba/nba_fox_ext.py
+++ b/sportsdataverse/nba/nba_fox_ext.py
@@ -496,7 +496,7 @@ def fox_nba_teams(
         ``return_parsed=False``.
 
     Raises:
-        sportsdataverse.errors.NoESPNDataError: Fox returned 404 for the requested id.
+        sportsdataverse.errors.NoDataError: Fox returned 404 for the requested id.
         requests.exceptions.RequestException: Connection-level failure after
             ``dl_utils.download`` exhausts its retries.
 

--- a/sportsdataverse/nba/nba_game_rosters.py
+++ b/sportsdataverse/nba/nba_game_rosters.py
@@ -185,7 +185,7 @@ def helper_nba_roster_items(items, summary_url, **kwargs):
             from sportsdataverse.nba import espn_nba_game_rosters
             rosters = espn_nba_game_rosters(game_id=401585183)
     """
-    from sportsdataverse.errors import NoESPNDataError
+    from sportsdataverse.errors import NoDataError
 
     team_ids = list(items["team_id"])
     game_rosters = pl.DataFrame()
@@ -193,7 +193,7 @@ def helper_nba_roster_items(items, summary_url, **kwargs):
         team_roster_url = "{x}/{t}/roster".format(x=summary_url, t=tm)
         try:
             team_roster_resp = download(team_roster_url, **kwargs)
-        except NoESPNDataError:
+        except NoDataError:
             # ESPN has no roster resource for this team in this game (a 404 —
             # common for older games). Skip it so the other team's roster is
             # still recovered instead of failing the whole game.
@@ -208,7 +208,7 @@ def helper_nba_roster_items(items, summary_url, **kwargs):
         game_rosters = pl.concat([game_rosters, team_roster], how="diagonal")
     if game_rosters.is_empty():
         # No team in this game exposes a roster resource — genuinely no data.
-        raise NoESPNDataError(f"NoESPNDataError: No roster data found for any team at {summary_url}")
+        raise NoDataError(f"NoDataError: No roster data found for any team at {summary_url}")
     game_rosters = game_rosters.drop([c for c in ["period", "for_player_id", "active"] if c in game_rosters.columns])
     game_rosters = game_rosters.with_columns(
         player_id=pl.col("player_id").cast(pl.Int64),

--- a/sportsdataverse/nba/nba_player_stats.py
+++ b/sportsdataverse/nba/nba_player_stats.py
@@ -88,7 +88,7 @@ def espn_nba_player_stats(
 
     Raises:
         ValueError: ``season_type`` is not ``"regular"``/``"postseason"``.
-        sportsdataverse.errors.NoESPNDataError: ESPN returned 404.
+        sportsdataverse.errors.NoDataError: ESPN returned 404.
 
     Example:
         Pull LeBron James' 2023 season line as a single wide row::

--- a/sportsdataverse/nfl/nfl_game_rosters.py
+++ b/sportsdataverse/nfl/nfl_game_rosters.py
@@ -171,7 +171,7 @@ def helper_nfl_roster_items(items, summary_url, **kwargs):
             from sportsdataverse.nfl import espn_nfl_game_rosters
             rosters = espn_nfl_game_rosters(game_id=401220403)
     """
-    from sportsdataverse.errors import NoESPNDataError
+    from sportsdataverse.errors import NoDataError
 
     team_ids = list(items["team_id"])
     game_rosters = pl.DataFrame()
@@ -179,7 +179,7 @@ def helper_nfl_roster_items(items, summary_url, **kwargs):
         team_roster_url = "{x}/{t}/roster".format(x=summary_url, t=tm)
         try:
             team_roster_resp = download(team_roster_url, **kwargs)
-        except NoESPNDataError:
+        except NoDataError:
             # ESPN has no roster resource for this team in this game (a 404 —
             # common for older games). Skip it so the other team's roster is
             # still recovered instead of failing the whole game.
@@ -194,7 +194,7 @@ def helper_nfl_roster_items(items, summary_url, **kwargs):
         game_rosters = pl.concat([game_rosters, team_roster], how="diagonal")
     if game_rosters.is_empty():
         # No team in this game exposes a roster resource — genuinely no data.
-        raise NoESPNDataError(f"NoESPNDataError: No roster data found for any team at {summary_url}")
+        raise NoDataError(f"NoDataError: No roster data found for any team at {summary_url}")
     game_rosters = game_rosters.drop([c for c in ["period", "for_player_id", "active"] if c in game_rosters.columns])
     game_rosters = game_rosters.with_columns(
         player_id=pl.col("player_id").cast(pl.Int64),

--- a/sportsdataverse/nfl/nfl_pbp.py
+++ b/sportsdataverse/nfl/nfl_pbp.py
@@ -824,15 +824,15 @@ class NFLPlayProcess(object):
     def __helper_nfl_pbp(self, pbp_txt):
         # ESPN's summary endpoint intermittently returns a payload with no
         # `header.competitions` (transient gap / a game not yet ingested).
-        # Short-circuit with a clear, catchable NoESPNDataError *before* pickcenter
+        # Short-circuit with a clear, catchable NoDataError *before* pickcenter
         # resolution (which would otherwise make a fallback odds network hop) and
         # before the deep `KeyError: 'competitions'` in __helper_nfl_game_data.
         # Local import so the error class doesn't leak into the package namespace
         # (it is not a public wrapper) and trip the codegen autodoc/parsed gates.
-        from sportsdataverse.errors import NoESPNDataError
+        from sportsdataverse.errors import NoDataError
 
         if not ((pbp_txt.get("header") or {}).get("competitions") or []):
-            raise NoESPNDataError(
+            raise NoDataError(
                 f"ESPN summary for game {self.gameId} has no header.competitions; cannot build play-by-play.",
             )
         init = self.__helper_nfl_pickcenter(pbp_txt)

--- a/sportsdataverse/nfl/nfl_player_stats.py
+++ b/sportsdataverse/nfl/nfl_player_stats.py
@@ -89,7 +89,7 @@ def espn_nfl_player_stats(
 
     Raises:
         ValueError: ``season_type`` is not ``"regular"``/``"postseason"``.
-        sportsdataverse.errors.NoESPNDataError: ESPN returned 404.
+        sportsdataverse.errors.NoDataError: ESPN returned 404.
 
     Example:
         Pull Patrick Mahomes' 2023 season line as a single wide row::

--- a/sportsdataverse/nhl/nhl_game_rosters.py
+++ b/sportsdataverse/nhl/nhl_game_rosters.py
@@ -141,7 +141,7 @@ def helper_nhl_team_items(items, **kwargs):
 
 
 def helper_nhl_roster_items(items, summary_url, **kwargs):
-    from sportsdataverse.errors import NoESPNDataError
+    from sportsdataverse.errors import NoDataError
 
     team_ids = list(items["team_id"])
     game_rosters = pl.DataFrame()
@@ -149,7 +149,7 @@ def helper_nhl_roster_items(items, summary_url, **kwargs):
         team_roster_url = "{x}/{t}/roster".format(x=summary_url, t=tm)
         try:
             team_roster_resp = download(team_roster_url, **kwargs)
-        except NoESPNDataError:
+        except NoDataError:
             # ESPN has no roster resource for this team in this game (a 404 —
             # common for older games). Skip it so the other team's roster is
             # still recovered instead of failing the whole game.
@@ -164,7 +164,7 @@ def helper_nhl_roster_items(items, summary_url, **kwargs):
         game_rosters = pl.concat([game_rosters, team_roster], how="diagonal")
     if game_rosters.is_empty():
         # No team in this game exposes a roster resource — genuinely no data.
-        raise NoESPNDataError(f"NoESPNDataError: No roster data found for any team at {summary_url}")
+        raise NoDataError(f"NoDataError: No roster data found for any team at {summary_url}")
     game_rosters = game_rosters.with_columns(
         player_id=pl.col("player_id").cast(pl.Int64),
         team_id=pl.col("team_id").cast(pl.Int32),

--- a/sportsdataverse/nhl/nhl_player_stats.py
+++ b/sportsdataverse/nhl/nhl_player_stats.py
@@ -89,7 +89,7 @@ def espn_nhl_player_stats(
 
     Raises:
         ValueError: ``season_type`` is not ``"regular"``/``"postseason"``.
-        sportsdataverse.errors.NoESPNDataError: ESPN returned 404.
+        sportsdataverse.errors.NoDataError: ESPN returned 404.
 
     Example:
         Pull Connor McDavid's 2023 season line as a single wide row::

--- a/sportsdataverse/wbb/wbb_fox_ext.py
+++ b/sportsdataverse/wbb/wbb_fox_ext.py
@@ -28,7 +28,7 @@ from sportsdataverse._fox_layout import (
     parse_team_stats,
     parse_teams,
 )
-from sportsdataverse.errors import NoESPNDataError
+from sportsdataverse.errors import NoDataError
 
 __all__ = [
     "fox_wbb_pbp",
@@ -81,7 +81,7 @@ def fox_wbb_pbp(
         ``return_parsed=False``.
 
     Raises:
-        sportsdataverse.errors.NoESPNDataError: Fox returned 404 for the requested id.
+        sportsdataverse.errors.NoDataError: Fox returned 404 for the requested id.
         requests.exceptions.RequestException: Connection-level failure after
             ``dl_utils.download`` exhausts its retries.
 
@@ -139,7 +139,7 @@ def fox_wbb_boxscore(
         ``return_parsed=False``.
 
     Raises:
-        sportsdataverse.errors.NoESPNDataError: Fox returned 404 for the requested id.
+        sportsdataverse.errors.NoDataError: Fox returned 404 for the requested id.
         requests.exceptions.RequestException: Connection-level failure after
             ``dl_utils.download`` exhausts its retries.
 
@@ -197,7 +197,7 @@ def fox_wbb_odds(
         ``return_parsed=False``.
 
     Raises:
-        sportsdataverse.errors.NoESPNDataError: Fox returned 404 for the requested id.
+        sportsdataverse.errors.NoDataError: Fox returned 404 for the requested id.
         requests.exceptions.RequestException: Connection-level failure after
             ``dl_utils.download`` exhausts its retries.
 
@@ -255,7 +255,7 @@ def fox_wbb_team_roster(
         ``return_parsed=False``.
 
     Raises:
-        sportsdataverse.errors.NoESPNDataError: Fox returned 404 for the requested id.
+        sportsdataverse.errors.NoDataError: Fox returned 404 for the requested id.
         requests.exceptions.RequestException: Connection-level failure after
             ``dl_utils.download`` exhausts its retries.
 
@@ -313,7 +313,7 @@ def fox_wbb_team_stats(
         ``return_parsed=False``.
 
     Raises:
-        sportsdataverse.errors.NoESPNDataError: Fox returned 404 for the requested id.
+        sportsdataverse.errors.NoDataError: Fox returned 404 for the requested id.
         requests.exceptions.RequestException: Connection-level failure after
             ``dl_utils.download`` exhausts its retries.
 
@@ -371,7 +371,7 @@ def fox_wbb_team_gamelog(
         ``return_parsed=False``.
 
     Raises:
-        sportsdataverse.errors.NoESPNDataError: Fox returned 404 for the requested id.
+        sportsdataverse.errors.NoDataError: Fox returned 404 for the requested id.
         requests.exceptions.RequestException: Connection-level failure after
             ``dl_utils.download`` exhausts its retries.
 
@@ -429,7 +429,7 @@ def fox_wbb_standings(
         ``return_parsed=False``.
 
     Raises:
-        sportsdataverse.errors.NoESPNDataError: Fox returned 404 for the requested id.
+        sportsdataverse.errors.NoDataError: Fox returned 404 for the requested id.
         requests.exceptions.RequestException: Connection-level failure after
             ``dl_utils.download`` exhausts its retries.
 
@@ -509,7 +509,7 @@ def fox_wbb_league_leaders(
         ``return_parsed=False``.
 
     Raises:
-        sportsdataverse.errors.NoESPNDataError: Fox returned 404 for the requested id.
+        sportsdataverse.errors.NoDataError: Fox returned 404 for the requested id.
         requests.exceptions.RequestException: Connection-level failure after
             ``dl_utils.download`` exhausts its retries.
 
@@ -591,7 +591,7 @@ def fox_wbb_teams(
         ``return_parsed=False``.
 
     Raises:
-        sportsdataverse.errors.NoESPNDataError: Fox returned 404 for the requested id.
+        sportsdataverse.errors.NoDataError: Fox returned 404 for the requested id.
         requests.exceptions.RequestException: Connection-level failure after
             ``dl_utils.download`` exhausts its retries.
 
@@ -642,7 +642,7 @@ def fox_wbb_teams_all(
     Raises:
         requests.exceptions.RequestException: Connection-level failure after
             ``dl_utils.download`` exhausts its retries. A 404 on an individual
-            candidate id (``NoESPNDataError``) is expected during the scan and is
+            candidate id (``NoDataError``) is expected during the scan and is
             skipped; every other failure propagates rather than silently
             truncating the directory.
 
@@ -671,7 +671,7 @@ def fox_wbb_teams_all(
             continue
         try:
             part = parse_teams(fox_get(f"{_SPORT}/team/{cand}/standings", **kwargs))
-        except NoESPNDataError:
+        except NoDataError:
             # Only "this candidate id does not exist" is expected while scanning.
             # Transport / auth / rate-limit failures must NOT be laundered into an
             # empty directory the caller can't tell apart from a valid scan.

--- a/sportsdataverse/wbb/wbb_game_officials.py
+++ b/sportsdataverse/wbb/wbb_game_officials.py
@@ -110,7 +110,7 @@ def espn_wbb_game_officials(
         If ``raw=True``, returns the raw response dict.
 
     Raises:
-        sportsdataverse.errors.NoESPNDataError: ESPN returned 404.
+        sportsdataverse.errors.NoDataError: ESPN returned 404.
         requests.exceptions.RequestException: Other network failures after retries.
 
     Example:

--- a/sportsdataverse/wbb/wbb_game_rosters.py
+++ b/sportsdataverse/wbb/wbb_game_rosters.py
@@ -136,7 +136,7 @@ def helper_wbb_team_items(items, **kwargs):
 
 
 def helper_wbb_roster_items(items, summary_url, **kwargs):
-    from sportsdataverse.errors import NoESPNDataError
+    from sportsdataverse.errors import NoDataError
 
     team_ids = list(items["team_id"])
     game_rosters = pl.DataFrame()
@@ -144,7 +144,7 @@ def helper_wbb_roster_items(items, summary_url, **kwargs):
         team_roster_url = "{x}/{t}/roster".format(x=summary_url, t=tm)
         try:
             team_roster_resp = download(team_roster_url, **kwargs)
-        except NoESPNDataError:
+        except NoDataError:
             # ESPN has no roster resource for this team in this game (a 404 —
             # common for older games and non-D1 opponents). Skip it so the other
             # team's roster is still recovered instead of failing the whole game.
@@ -159,7 +159,7 @@ def helper_wbb_roster_items(items, summary_url, **kwargs):
         game_rosters = pl.concat([game_rosters, team_roster], how="diagonal")
     if game_rosters.is_empty():
         # No team in this game exposes a roster resource — genuinely no data.
-        raise NoESPNDataError(f"NoESPNDataError: No roster data found for any team at {summary_url}")
+        raise NoDataError(f"NoDataError: No roster data found for any team at {summary_url}")
     game_rosters = game_rosters.drop([c for c in ["period", "for_player_id", "active"] if c in game_rosters.columns])
     game_rosters = game_rosters.with_columns(
         player_id=pl.col("player_id").cast(pl.Int64),

--- a/sportsdataverse/wbb/wbb_player_stats.py
+++ b/sportsdataverse/wbb/wbb_player_stats.py
@@ -94,7 +94,7 @@ def espn_wbb_player_stats(
 
     Raises:
         ValueError: ``season_type`` is not ``"regular"``/``"postseason"``.
-        sportsdataverse.errors.NoESPNDataError: ESPN returned 404 (no season
+        sportsdataverse.errors.NoDataError: ESPN returned 404 (no season
             line for that athlete/season).
 
     Example:

--- a/sportsdataverse/wbb/wbb_standings.py
+++ b/sportsdataverse/wbb/wbb_standings.py
@@ -148,7 +148,7 @@ def espn_wbb_standings(
         If ``raw=True``, returns the raw response dict.
 
     Raises:
-        sportsdataverse.errors.NoESPNDataError: ESPN returned 404.
+        sportsdataverse.errors.NoDataError: ESPN returned 404.
         requests.exceptions.RequestException: Other network failures after
             retries.
 

--- a/sportsdataverse/wbb/wbb_team_roster.py
+++ b/sportsdataverse/wbb/wbb_team_roster.py
@@ -108,7 +108,7 @@ def espn_wbb_team_roster(
         If ``raw=True``, returns the raw response dict.
 
     Raises:
-        sportsdataverse.errors.NoESPNDataError: ESPN returned 404.
+        sportsdataverse.errors.NoDataError: ESPN returned 404.
         requests.exceptions.RequestException: Other network failures after retries.
 
     Example:

--- a/sportsdataverse/wbb/wbb_team_stats.py
+++ b/sportsdataverse/wbb/wbb_team_stats.py
@@ -141,7 +141,7 @@ def espn_wbb_team_stats(
         If ``raw=True``, returns the raw response dict.
 
     Raises:
-        sportsdataverse.errors.NoESPNDataError: ESPN returned 404.
+        sportsdataverse.errors.NoDataError: ESPN returned 404.
         requests.exceptions.RequestException: Other network failures after
             retries.
 

--- a/sportsdataverse/wnba/wnba_draft.py
+++ b/sportsdataverse/wnba/wnba_draft.py
@@ -117,7 +117,7 @@ def espn_wnba_draft(
         If ``raw=True``, returns the raw response dict.
 
     Raises:
-        sportsdataverse.errors.NoESPNDataError: ESPN returned 404.
+        sportsdataverse.errors.NoDataError: ESPN returned 404.
         requests.exceptions.RequestException: Other network failures after
             retries.
 

--- a/sportsdataverse/wnba/wnba_fox_ext.py
+++ b/sportsdataverse/wnba/wnba_fox_ext.py
@@ -83,7 +83,7 @@ def fox_wnba_pbp(
         ``return_parsed=False``.
 
     Raises:
-        sportsdataverse.errors.NoESPNDataError: Fox returned 404 for the requested id.
+        sportsdataverse.errors.NoDataError: Fox returned 404 for the requested id.
         requests.exceptions.RequestException: Connection-level failure after
             ``dl_utils.download`` exhausts its retries.
 
@@ -145,7 +145,7 @@ def fox_wnba_boxscore(
         ``return_parsed=False``.
 
     Raises:
-        sportsdataverse.errors.NoESPNDataError: Fox returned 404 for the requested id.
+        sportsdataverse.errors.NoDataError: Fox returned 404 for the requested id.
         requests.exceptions.RequestException: Connection-level failure after
             ``dl_utils.download`` exhausts its retries.
 
@@ -207,7 +207,7 @@ def fox_wnba_odds(
         ``return_parsed=False``.
 
     Raises:
-        sportsdataverse.errors.NoESPNDataError: Fox returned 404 for the requested id.
+        sportsdataverse.errors.NoDataError: Fox returned 404 for the requested id.
         requests.exceptions.RequestException: Connection-level failure after
             ``dl_utils.download`` exhausts its retries.
 
@@ -269,7 +269,7 @@ def fox_wnba_team_roster(
         ``return_parsed=False``.
 
     Raises:
-        sportsdataverse.errors.NoESPNDataError: Fox returned 404 for the requested id.
+        sportsdataverse.errors.NoDataError: Fox returned 404 for the requested id.
         requests.exceptions.RequestException: Connection-level failure after
             ``dl_utils.download`` exhausts its retries.
 
@@ -331,7 +331,7 @@ def fox_wnba_team_stats(
         ``return_parsed=False``.
 
     Raises:
-        sportsdataverse.errors.NoESPNDataError: Fox returned 404 for the requested id.
+        sportsdataverse.errors.NoDataError: Fox returned 404 for the requested id.
         requests.exceptions.RequestException: Connection-level failure after
             ``dl_utils.download`` exhausts its retries.
 
@@ -393,7 +393,7 @@ def fox_wnba_team_gamelog(
         ``return_parsed=False``.
 
     Raises:
-        sportsdataverse.errors.NoESPNDataError: Fox returned 404 for the requested id.
+        sportsdataverse.errors.NoDataError: Fox returned 404 for the requested id.
         requests.exceptions.RequestException: Connection-level failure after
             ``dl_utils.download`` exhausts its retries.
 
@@ -455,7 +455,7 @@ def fox_wnba_standings(
         ``return_parsed=False``.
 
     Raises:
-        sportsdataverse.errors.NoESPNDataError: Fox returned 404 for the requested id.
+        sportsdataverse.errors.NoDataError: Fox returned 404 for the requested id.
         requests.exceptions.RequestException: Connection-level failure after
             ``dl_utils.download`` exhausts its retries.
 
@@ -535,7 +535,7 @@ def fox_wnba_league_leaders(
         ``return_parsed=False``.
 
     Raises:
-        sportsdataverse.errors.NoESPNDataError: Fox returned 404 for the requested id.
+        sportsdataverse.errors.NoDataError: Fox returned 404 for the requested id.
         requests.exceptions.RequestException: Connection-level failure after
             ``dl_utils.download`` exhausts its retries.
 
@@ -608,7 +608,7 @@ def fox_wnba_teams(
         ``return_parsed=False``.
 
     Raises:
-        sportsdataverse.errors.NoESPNDataError: Fox returned 404 for the requested id.
+        sportsdataverse.errors.NoDataError: Fox returned 404 for the requested id.
         requests.exceptions.RequestException: Connection-level failure after
             ``dl_utils.download`` exhausts its retries.
 

--- a/sportsdataverse/wnba/wnba_game_officials.py
+++ b/sportsdataverse/wnba/wnba_game_officials.py
@@ -74,7 +74,7 @@ def espn_wnba_game_officials(
         ``raw=True``, returns the raw response dict.
 
     Raises:
-        sportsdataverse.errors.NoESPNDataError: ESPN returned 404.
+        sportsdataverse.errors.NoDataError: ESPN returned 404.
         requests.exceptions.RequestException: Other network failures after retries.
 
     Example:

--- a/sportsdataverse/wnba/wnba_game_rosters.py
+++ b/sportsdataverse/wnba/wnba_game_rosters.py
@@ -139,7 +139,7 @@ def helper_wnba_team_items(items, **kwargs):
 
 
 def helper_wnba_roster_items(items, summary_url, **kwargs):
-    from sportsdataverse.errors import NoESPNDataError
+    from sportsdataverse.errors import NoDataError
 
     team_ids = list(items["team_id"])
     game_rosters = pl.DataFrame()
@@ -147,7 +147,7 @@ def helper_wnba_roster_items(items, summary_url, **kwargs):
         team_roster_url = "{x}/{t}/roster".format(x=summary_url, t=tm)
         try:
             team_roster_resp = download(team_roster_url, **kwargs)
-        except NoESPNDataError:
+        except NoDataError:
             # ESPN has no roster resource for this team in this game (a 404 —
             # common for older games). Skip it so the other team's roster is
             # still recovered instead of failing the whole game.
@@ -162,7 +162,7 @@ def helper_wnba_roster_items(items, summary_url, **kwargs):
         game_rosters = pl.concat([game_rosters, team_roster], how="diagonal")
     if game_rosters.is_empty():
         # No team in this game exposes a roster resource — genuinely no data.
-        raise NoESPNDataError(f"NoESPNDataError: No roster data found for any team at {summary_url}")
+        raise NoDataError(f"NoDataError: No roster data found for any team at {summary_url}")
     game_rosters = game_rosters.drop([c for c in ["period", "for_player_id", "active"] if c in game_rosters.columns])
     game_rosters = game_rosters.with_columns(
         player_id=pl.col("player_id").cast(pl.Int64),

--- a/sportsdataverse/wnba/wnba_player_stats.py
+++ b/sportsdataverse/wnba/wnba_player_stats.py
@@ -90,7 +90,7 @@ def espn_wnba_player_stats(
 
     Raises:
         ValueError: ``season_type`` is not ``"regular"``/``"postseason"``.
-        sportsdataverse.errors.NoESPNDataError: ESPN returned 404.
+        sportsdataverse.errors.NoDataError: ESPN returned 404.
 
     Example:
         Pull A'ja Wilson's 2024 season line as a single wide row::

--- a/sportsdataverse/wnba/wnba_standings.py
+++ b/sportsdataverse/wnba/wnba_standings.py
@@ -72,7 +72,7 @@ def espn_wnba_standings(
         column list. If ``raw=True``, returns the raw response dict.
 
     Raises:
-        sportsdataverse.errors.NoESPNDataError: ESPN returned 404.
+        sportsdataverse.errors.NoDataError: ESPN returned 404.
         requests.exceptions.RequestException: Other network failures after
             retries.
 

--- a/sportsdataverse/wnba/wnba_team_roster.py
+++ b/sportsdataverse/wnba/wnba_team_roster.py
@@ -46,7 +46,7 @@ def espn_wnba_team_roster(
         returns the raw response dict.
 
     Raises:
-        sportsdataverse.errors.NoESPNDataError: ESPN returned 404.
+        sportsdataverse.errors.NoDataError: ESPN returned 404.
         requests.exceptions.RequestException: Other network failures after retries.
 
     Example:

--- a/sportsdataverse/wnba/wnba_team_stats.py
+++ b/sportsdataverse/wnba/wnba_team_stats.py
@@ -76,7 +76,7 @@ def espn_wnba_team_stats(
         response dict.
 
     Raises:
-        sportsdataverse.errors.NoESPNDataError: ESPN returned 404.
+        sportsdataverse.errors.NoDataError: ESPN returned 404.
         requests.exceptions.RequestException: Other network failures after
             retries.
 

--- a/tests/codegen/test_loader_season_convention.py
+++ b/tests/codegen/test_loader_season_convention.py
@@ -11,6 +11,9 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
+from sportsdataverse import _codegen_runtime as runtime
+from sportsdataverse.errors import NoDataError
+
 import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -68,8 +71,11 @@ def _requested_url(fn_name: str, league: str, season: int) -> str:
         raise FileNotFoundError("404 not found")  # 404-safe path: warn + skip
 
     with patch.object(mod.pl, "read_parquet", side_effect=fake):
-        with pytest.warns(UserWarning):
-            getattr(mod, fn_name)(seasons=season)
+        # `_read_release_parquet` classifies a failed read by asking the transport
+        # what the server said, so keep that lookup offline too.
+        with patch.object(runtime, "download", side_effect=NoDataError("404")):
+            with pytest.warns(UserWarning):
+                getattr(mod, fn_name)(seasons=season)
     return box["url"]
 
 
@@ -147,8 +153,9 @@ def test_shim_warns_and_names_its_replacement(shim, target):
 
     mod = importlib.import_module("sportsdataverse.nba.nba_loaders")
     with patch.object(mod.pl, "read_parquet", side_effect=FileNotFoundError("404")):
-        with pytest.warns(DeprecationWarning, match=target):
-            getattr(mod, shim)(seasons=2025)
+        with patch.object(runtime, "download", side_effect=NoDataError("404")):
+            with pytest.warns(DeprecationWarning, match=target):
+                getattr(mod, shim)(seasons=2025)
 
 
 def test_shifted_loaders_document_the_season_column_divergence():

--- a/tests/codegen/test_loaders_parity.py
+++ b/tests/codegen/test_loaders_parity.py
@@ -6,6 +6,9 @@ import importlib
 from pathlib import Path
 from unittest.mock import patch
 
+from sportsdataverse import _codegen_runtime as runtime
+from sportsdataverse.errors import NoDataError
+
 from tools.codegen import generate, spec
 
 REL = Path("tools/codegen/endpoints/releases.yaml")
@@ -39,10 +42,13 @@ def _existing_url(fn_name: str, league: str):
         raise FileNotFoundError("404")  # short-circuit after first fetch
 
     with patch.object(mod.pl, "read_parquet", side_effect=fake):
-        try:
-            getattr(mod, fn_name)(seasons=2024)
-        except Exception:  # noqa: BLE001
-            pass
+        # `_read_release_parquet` classifies a failed read by asking the transport
+        # what the server said, so keep that lookup offline too.
+        with patch.object(runtime, "download", side_effect=NoDataError("404")):
+            try:
+                getattr(mod, fn_name)(seasons=2024)
+            except Exception:  # noqa: BLE001
+                pass
     return box.get("url")
 
 

--- a/tests/codegen/test_runtime_release.py
+++ b/tests/codegen/test_runtime_release.py
@@ -1,10 +1,40 @@
-"""404-safe release-parquet helper + season-list normalization (generated loaders)."""
+"""404-safe release-parquet helper + season-list normalization (generated loaders).
 
+``_read_release_parquet`` reads the asset DIRECTLY with Arrow and uses
+:func:`sportsdataverse.dl_utils.download` only to *classify* a failure. These tests
+lock both halves of that split:
+
+* the success path must not touch the HTTP gateway at all -- buffering the bytes
+  through it measured +33% peak RSS and +68% wall on a 59 MB asset (issue #397),
+  so ``test_success_path_never_calls_the_transport`` is a deliberate regression
+  guard, not an implementation detail;
+* a failed read must be classified by what the SERVER says, not by a substring of
+  the reader's exception message -- a genuinely missing asset returns ``None``, a
+  403 raises ``AssetFetchError``, and a real parse error is re-raised untouched.
+"""
+
+import io
 from unittest.mock import patch
 
 import polars as pl
+import pytest
 
 from sportsdataverse import _codegen_runtime as rt
+from sportsdataverse.errors import AssetFetchError, NoDataError
+
+
+class _Resp:
+    """Minimal stand-in for the ``requests.Response`` ``download`` returns."""
+
+    def __init__(self, content: bytes = b"", status_code: int = 200):
+        self.content = content
+        self.status_code = status_code
+
+
+def _parquet_bytes(df: pl.DataFrame) -> bytes:
+    buf = io.BytesIO()
+    df.write_parquet(buf)
+    return buf.getvalue()
 
 
 def test_as_season_list_normalizes():
@@ -15,27 +45,96 @@ def test_as_season_list_normalizes():
 
 
 def test_read_release_parquet_returns_df_on_success():
-    df = pl.DataFrame({"a": [1]})
-    with patch("sportsdataverse._codegen_runtime.pl.read_parquet", return_value=df):
+    frame = pl.DataFrame({"a": [1, 2, 3]})
+    with patch.object(rt.pl, "read_parquet", return_value=frame):
         out = rt._read_release_parquet("https://x/ok.parquet")
-    assert out is not None and out.shape == (1, 1)
+    assert out is not None and out.shape == (3, 1)
+
+
+def test_success_path_never_calls_the_transport():
+    """The bytes must NOT be routed through ``download``.
+
+    Fetch-then-parse co-resides the compressed asset with the decoded frame; Arrow's
+    direct read does not. This asserts the fast path stays fast -- if someone later
+    reroutes the read through the gateway "for consistency", this fails first.
+    """
+    calls = {"n": 0}
+
+    def counting(*a, **k):
+        calls["n"] += 1
+        return _Resp(b"")
+
+    with patch.object(rt.pl, "read_parquet", return_value=pl.DataFrame({"a": [1]})):
+        with patch.object(rt, "download", side_effect=counting):
+            rt._read_release_parquet("https://x/ok.parquet")
+
+    assert calls["n"] == 0, f"success path made {calls['n']} gateway call(s), expected 0"
 
 
 def test_read_release_parquet_returns_none_on_404():
-    def boom(*a, **k):
-        raise FileNotFoundError("404 Not Found")
+    """A missing asset is the gateway's typed 404, so the season is skipped."""
+    with patch.object(rt.pl, "read_parquet", side_effect=OSError("arrow could not open")):
+        with patch.object(rt, "download", side_effect=NoDataError("404")):
+            assert rt._read_release_parquet("https://x/missing.parquet") is None
 
-    with patch("sportsdataverse._codegen_runtime.pl.read_parquet", side_effect=boom):
-        assert rt._read_release_parquet("https://x/missing.parquet") is None
+
+def test_read_release_parquet_raises_on_non_200():
+    """A 403 that outlived the retry budget must NOT be masked as "no data"."""
+    with patch.object(rt.pl, "read_parquet", side_effect=OSError("arrow could not open")):
+        with patch.object(rt, "download", return_value=_Resp(b"", status_code=403)):
+            with pytest.raises(AssetFetchError, match="403"):
+                rt._read_release_parquet("https://x/forbidden.parquet")
 
 
-def test_read_release_parquet_reraises_unexpected():
-    def boom(*a, **k):
-        raise ValueError("schema mismatch")
+def test_readable_asset_reraises_the_parse_error():
+    """Asset fetches fine but won't parse -> the real error surfaces, not ``None``."""
 
-    with patch("sportsdataverse._codegen_runtime.pl.read_parquet", side_effect=boom):
-        try:
-            rt._read_release_parquet("https://x/bad.parquet")
-            raise AssertionError("expected ValueError")
-        except ValueError:
-            pass
+    class _Corrupt(Exception):
+        pass
+
+    with patch.object(rt.pl, "read_parquet", side_effect=_Corrupt("invalid parquet footer")):
+        with patch.object(rt, "download", return_value=_Resp(b"bytes", status_code=200)):
+            with pytest.raises(_Corrupt, match="footer"):
+                rt._read_release_parquet("https://x/corrupt.parquet")
+
+
+def test_keyboard_interrupt_is_not_swallowed_into_a_fetch():
+    """``PanicException`` handling must not turn Ctrl-C into an HTTP request."""
+    calls = {"n": 0}
+
+    def counting(*a, **k):
+        calls["n"] += 1
+        return _Resp(b"")
+
+    with patch.object(rt.pl, "read_parquet", side_effect=KeyboardInterrupt()):
+        with patch.object(rt, "download", side_effect=counting):
+            with pytest.raises(KeyboardInterrupt):
+                rt._read_release_parquet("https://x/interrupted.parquet")
+
+    assert calls["n"] == 0
+
+
+def test_panic_falls_back_to_metadata_stripped_read():
+    """R-producer ``arrow.r.vctrs`` metadata panics polars' FFI import; recover."""
+    payload = _parquet_bytes(pl.DataFrame({"a": [1]}))
+
+    class _Panic(BaseException):
+        pass
+
+    _Panic.__name__ = "PanicException"
+
+    with patch.object(rt.pl, "read_parquet", side_effect=_Panic("arrow-ffi metadata panic")):
+        with patch.object(rt, "download", return_value=_Resp(payload)):
+            out = rt._read_release_parquet("https://x/rvctrs.parquet")
+
+    assert out is not None and out.shape == (1, 1)
+
+
+def test_failed_fetch_is_not_a_missing_asset():
+    """``AssetFetchError`` and ``NoDataError`` must stay distinguishable.
+
+    Both subclass ``SportsDataverseError``, but only the latter means "skip this
+    season" -- collapsing them would turn a rate-limited fetch into an empty frame.
+    """
+    assert not issubclass(AssetFetchError, NoDataError)
+    assert not issubclass(NoDataError, AssetFetchError)

--- a/tests/test_errors_suggest.py
+++ b/tests/test_errors_suggest.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import pytest
 
 from sportsdataverse.errors import (
+    AssetFetchError,
+    NoDataError,
     NoESPNDataError,
     SeasonNotFoundError,
     SportsDataverseError,
@@ -21,6 +23,36 @@ def test_error_hierarchy_under_base() -> None:
     assert issubclass(SportsDataverseError, Exception)
     with pytest.raises(SportsDataverseError):
         raise NoESPNDataError("no data")
+
+
+def test_no_espn_data_error_alias_is_the_canonical_class() -> None:
+    """``NoESPNDataError`` must stay a true alias, not a parallel class.
+
+    The error was named when it was ESPN-only, but ``download`` raises it for any
+    404 -- release assets included -- so the canonical name is ``NoDataError``. If
+    a refactor ever makes these two distinct classes, existing
+    ``except NoESPNDataError`` code silently stops catching, which is exactly the
+    failure this locks out.
+    """
+    assert NoESPNDataError is NoDataError
+    # catchable in both directions, whichever name the caller happens to use
+    with pytest.raises(NoESPNDataError):
+        raise NoDataError("missing")
+    with pytest.raises(NoDataError):
+        raise NoESPNDataError("missing")
+
+
+def test_failed_fetch_is_not_missing_data() -> None:
+    """A fetch that FAILED must not be catchable as "there is no data".
+
+    Collapsing the two would let a rate-limited (403) season be recorded as an
+    empty one -- silent data loss rather than a visible error.
+    """
+    assert issubclass(AssetFetchError, SportsDataverseError)
+    assert not issubclass(AssetFetchError, NoDataError)
+    assert not issubclass(NoDataError, AssetFetchError)
+    with pytest.raises(AssetFetchError):
+        raise AssetFetchError("HTTP 403")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #397.

## Outcome: the read stays direct, the *classification* moves to the gateway

#397 asked whether `_read_release_parquet` should route its bytes through
`dl_utils.download()`, and set its own acceptance bar: "memory not regressing on a
50 MB+ asset". I built the buffered version first and **it failed that bar**, so this
PR ships the half that is a strict win and scopes the guideline for the half that is not.

### The measurement

On the 59 MB `play_by_play_2025.parquet` (best of 3, one read per process, identical
imports in both modes so package-import cost cancels):

| path | peak RSS | wall |
|---|---:|---:|
| direct (Arrow reads the URL) | **1010 MB** | **6.0 s** |
| buffered through `download()` | 1081 MB | 10.5 s |
| | +7% | **+75%** |

A temp file (1424 MB) and a zero-copy `pa.py_buffer` (2051 MB) were both worse. This is
structural, not a tuning problem: Arrow overlaps the fetch with decoding and range-reads
column chunks, whereas any fetch-then-parse design necessarily co-resides the compressed
asset with the decoded frame.

So the bytes stay on the direct path, and `CLAUDE.md` now says so explicitly — with the
numbers and a pointer to the guard test — instead of stating a rule the code contradicts.
That should stop this from being re-raised on every release-loader PR.

### What did change

Failure **classification** now goes through the gateway. Previously a missing asset was
detected by searching the reader's exception message for `"404"` / `"not found"` /
`"no such"`. Now the server is asked what it actually said:

- **404** → `NoDataError` → return `None`, so the caller skips that season;
- **any other non-200** → `AssetFetchError`, so a 403 or an exhausted retry budget can
  never be masked as "this season is empty";
- **reachable and readable** → the original parse error is re-raised untouched.

The extra round trip happens only on the failure path, and costs ~0.1 s per missing season.

### Two things found on the way

1. **Ctrl-C was swallowed into an HTTP request.** The `PanicException` fallback caught
   `BaseException` broadly, so a `KeyboardInterrupt` mid-read triggered a fetch instead of
   interrupting. Now re-raised, with a test.
2. **Three loader tests mocked `pl.read_parquet` to intercept a network fetch** — exactly
   the leaked abstraction this change removes. They now patch the transport. This mattered:
   while the buffered version was in place those mocks stopped firing and one "offline"
   test silently downloaded 94,602 live rows, visible only as the suite going 4 s → 158 s.

`test_success_path_never_calls_the_transport` asserts the success path makes **zero**
gateway calls, so a later "let's make this consistent" refactor cannot quietly reintroduce
buffering without turning that test red.

### Error hierarchy (first commit)

`NoESPNDataError` → **`NoDataError`**, since `download()` raises it for any 404 including
release assets. The old name stays as an alias and a test asserts the two are the same
object — if they ever became parallel classes, existing `except NoESPNDataError` would
silently stop catching. New **`AssetFetchError`** expresses what the hierarchy could not:
a fetch that *failed* versus one that *succeeded and found nothing*. A test asserts neither
is a subclass of the other, because collapsing them is how a rate-limited season becomes an
empty one.

### Deliberately out of scope

`nfl_loaders.py` (~35 sites) and `cfb_loaders_extra.py` (3 URLs) are hand-written and still
read URLs directly. That is a real inconsistency, but #397 scopes itself to "change
`_read_release_parquet` once… no per-loader edits", so it belongs in its own issue rather
than a 38-site refactor smuggled in here.

### Gates

Two-pass regen → drift check clean (no doc changes), ruff clean, mypy clean (400 files),
`pytest tests/codegen tests/cfb tests/nfl tests/test_errors_suggest.py tests/test_dl_utils.py`
→ **1578 passed, 116 skipped, 9 xfailed**. Acceptance criteria verified against real
assets: 404 → `None`, 200 → frame, `arrow.r.vctrs` R-producer asset round-trips (130×26),
403 → `AssetFetchError`.

## Summary by Sourcery

Classify release-asset read failures through the HTTP gateway without buffering successful parquet reads, and distinguish missing data from fetch failures.

New Features:
- Classify release-asset read failures using server responses, distinguishing missing assets from failed fetches and genuine parse errors.
- Introduce the general NoDataError and AssetFetchError exceptions while preserving NoESPNDataError as a backward-compatible alias.

Bug Fixes:
- Prevent KeyboardInterrupt from being swallowed and converted into a fallback HTTP request.
- Ensure non-404 release-asset failures such as authorization or rate-limit responses are no longer misclassified as missing seasons.

Enhancements:
- Keep successful release parquet reads on Arrow’s direct path while using the HTTP gateway only for failure classification.
- Update loaders, documentation, and error handling to use the generalized missing-data exception semantics.

Documentation:
- Document the measured performance rationale for direct remote parquet reads and the failure-classification behavior.

Tests:
- Add coverage for direct-read transport isolation, 404 and non-200 classification, parse-error propagation, interrupt handling, panic fallback, and exception compatibility.