### PR TITLE
fix(transport): route the hand-written loaders through the classifier (#403)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -786,9 +786,15 @@ recent exception when the retry budget is exhausted (instead of returning an
 unbound variable). Wrappers do NOT wrap the call in try/except — they trust
 `download()` to either return a usable `requests.Response` or raise.
 
-**Exception — remote columnar reads.** `_read_release_parquet()` in
-`_codegen_runtime.py` (backing 226 generated-loader call sites) hands the release
-URL straight to Arrow rather than buffering it through `download()`. This is
+**Exception — remote columnar reads.** `_fetch_release_parquet()` in
+`_codegen_runtime.py` hands the release URL straight to Arrow rather than
+buffering it through `download()`. Two variants share that one implementation:
+`_fetch_release_parquet` **raises** `NoDataError` when an asset is absent (used by
+the hand-written `nfl_loaders.py` and `cfb_loaders_extra.py`, where a missing
+season is an error), and `_read_release_parquet` returns **`None`** instead (used
+by the 226 generated call sites, where a season gap is routine). Only "absent"
+differs — a failed fetch raises `AssetFetchError` from both, so the wrapper can
+never soften a rate limit into an empty frame. This is
 deliberate and measured, not an oversight: Arrow overlaps the fetch with decoding
 and range-reads column chunks, while any fetch-then-parse path serializes the two
 and holds an extra copy of the compressed asset. On the 59 MB

--- a/sportsdataverse/_codegen_runtime.py
+++ b/sportsdataverse/_codegen_runtime.py
@@ -109,10 +109,10 @@ def cli_warn(msg: str) -> None:
     warnings.warn(msg, stacklevel=2)
 
 
-def _read_release_parquet(url: str) -> Optional[pl.DataFrame]:
-    """Read a release parquet; return ``None`` on 404 / missing asset (404-safe loaders).
+def _fetch_release_parquet(url: str) -> pl.DataFrame:
+    """Read a release parquet, RAISING when the asset is missing.
 
-    The read itself stays a direct Arrow fetch, and the bytes deliberately do NOT go
+    The read stays a direct Arrow fetch, and the bytes deliberately do NOT go
     through the HTTP gateway. Arrow overlaps the fetch with decoding and range-reads
     column chunks; buffering the asset first serializes the two and holds an extra copy
     of the compressed file. Measured on the 59 MB ``play_by_play_2025.parquet`` (best of
@@ -124,16 +124,15 @@ def _read_release_parquet(url: str) -> Optional[pl.DataFrame]:
     direct read fails we ask ``download`` what the server actually said instead of
     pattern-matching the reader's exception message:
 
-    * a 404 (``NoDataError``) means the asset is genuinely absent -- return ``None``
-      so the caller skips that season;
-    * any other non-200 -- notably a 403 or a rate-limit that outlived the retry
+    * a 404 raises :class:`~sportsdataverse.errors.NoDataError` -- the asset is
+      genuinely absent;
+    * any other non-200 -- notably a 403 or a rate limit that outlived the retry
       budget -- raises :class:`~sportsdataverse.errors.AssetFetchError`, so a fetch
-      that FAILED is never recorded as a season that is EMPTY;
+      that FAILED is never confused with an asset that is ABSENT;
     * a reachable, readable asset means the failure was a genuine parse/schema error,
       which is re-raised untouched.
 
-    The extra round trip happens only on the failure path and costs ~0.1s per missing
-    season, versus the several seconds a buffered success path would cost every time.
+    The extra round trip happens only on the failure path and costs ~0.1s.
 
     R-producer assets can carry an ``arrow.r.vctrs`` field-extension whose metadata is
     raw RDS bytes (not UTF-8) -- e.g. a ``glue`` character column. polars' arrow-FFI
@@ -141,8 +140,11 @@ def _read_release_parquet(url: str) -> Optional[pl.DataFrame]:
     an ``except Exception`` handler never sees), so on panic we re-read via pyarrow
     with all field/schema metadata stripped; the storage types are plain, so this is
     lossless.
+
+    Use :func:`_read_release_parquet` instead when a missing season should be skipped
+    rather than raised.
     """
-    from sportsdataverse.errors import AssetFetchError, NoDataError
+    from sportsdataverse.errors import AssetFetchError
 
     try:
         return pl.read_parquet(url, use_pyarrow=True)
@@ -153,15 +155,29 @@ def _read_release_parquet(url: str) -> Optional[pl.DataFrame]:
             raise  # never swallow KeyboardInterrupt / SystemExit into an HTTP call
         return _read_parquet_stripped_metadata(url)
 
-    try:
-        resp = download(url)
-    except NoDataError:
-        return None
+    resp = download(url)  # raises NoDataError on a 404 -- the "absent" signal
 
     status = getattr(resp, "status_code", None)
     if status is not None and status != 200:
         raise AssetFetchError(f"release asset fetch failed with HTTP {status}: {url}") from original
     raise original
+
+
+def _read_release_parquet(url: str) -> Optional[pl.DataFrame]:
+    """404-safe read: ``None`` when the asset is absent (season-gap-tolerant loaders).
+
+    Thin wrapper over :func:`_fetch_release_parquet` -- identical read path and
+    identical failure classification. The ONLY difference is that a genuinely missing
+    asset becomes ``None`` so the caller can skip that season, while a failed fetch
+    (``AssetFetchError``) still propagates. Keeping the two apart in one place is what
+    stops a rate-limited season from being recorded as an empty one.
+    """
+    from sportsdataverse.errors import NoDataError
+
+    try:
+        return _fetch_release_parquet(url)
+    except NoDataError:
+        return None
 
 
 def _read_parquet_stripped_metadata(url: str) -> pl.DataFrame:

--- a/sportsdataverse/_codegen_runtime.py
+++ b/sportsdataverse/_codegen_runtime.py
@@ -181,13 +181,26 @@ def _read_release_parquet(url: str) -> Optional[pl.DataFrame]:
 
 
 def _read_parquet_stripped_metadata(url: str) -> pl.DataFrame:
-    """Fetch a parquet and load it with every field/schema metadata entry dropped."""
+    """Fetch a parquet and load it with every field/schema metadata entry dropped.
+
+    Classifies the refetch the same way the caller does. This path runs only after
+    a panic, so it issues its OWN request -- and that one can fail even though the
+    first read reached the asset. Without the status check, a 403 or 5xx body would
+    be handed to ``pq.read_table`` and surface as a parquet parse error, which is
+    precisely the "failed fetch wearing the wrong clothes" this module exists to
+    prevent. A 404 still arrives as ``NoDataError`` from ``download``.
+    """
     import io
 
     import pyarrow as pa
     import pyarrow.parquet as pq
 
+    from sportsdataverse.errors import AssetFetchError
+
     resp = download(url)
+    status = getattr(resp, "status_code", None)
+    if status is not None and status != 200:
+        raise AssetFetchError(f"release asset fetch failed with HTTP {status}: {url}")
     tbl = pq.read_table(io.BytesIO(resp.content))
     plain = pa.schema([pa.field(f.name, f.type) for f in tbl.schema])
     out = pl.from_arrow(tbl.cast(plain).replace_schema_metadata(None))

--- a/sportsdataverse/cfb/cfb_loaders_extra.py
+++ b/sportsdataverse/cfb/cfb_loaders_extra.py
@@ -9,6 +9,7 @@ from typing import List  # noqa: F401
 
 import polars as pl
 
+from sportsdataverse._codegen_runtime import _fetch_release_parquet
 from sportsdataverse.config import (
     CFB_BETTING_LINES_URL,
     CFB_ROSTERS_CROSSWALK_URL,
@@ -52,11 +53,11 @@ def load_cfb_betting_lines(return_as_pandas=False) -> pl.DataFrame:
     """
 
     return (
-        pl.read_parquet(CFB_BETTING_LINES_URL, use_pyarrow=True, columns=None).to_pandas(
+        _fetch_release_parquet(CFB_BETTING_LINES_URL).to_pandas(
             use_pyarrow_extension_array=True,
         )
         if return_as_pandas
-        else pl.read_parquet(CFB_BETTING_LINES_URL, use_pyarrow=True, columns=None)
+        else _fetch_release_parquet(CFB_BETTING_LINES_URL)
     )
 
 
@@ -91,9 +92,9 @@ def get_cfb_teams(return_as_pandas=False) -> pl.DataFrame:
     """
 
     return (
-        pl.read_parquet(CFB_TEAM_LOGO_URL, use_pyarrow=True, columns=None).to_pandas(use_pyarrow_extension_array=True)
+        _fetch_release_parquet(CFB_TEAM_LOGO_URL).to_pandas(use_pyarrow_extension_array=True)
         if return_as_pandas
-        else pl.read_parquet(CFB_TEAM_LOGO_URL, use_pyarrow=True, columns=None)
+        else _fetch_release_parquet(CFB_TEAM_LOGO_URL)
     )
 
 
@@ -138,9 +139,9 @@ def load_cfb_rosters_crosswalk(return_as_pandas: bool = False) -> pl.DataFrame:
     """
 
     return (
-        pl.read_parquet(CFB_ROSTERS_CROSSWALK_URL, use_pyarrow=True, columns=None).to_pandas(
+        _fetch_release_parquet(CFB_ROSTERS_CROSSWALK_URL).to_pandas(
             use_pyarrow_extension_array=True,
         )
         if return_as_pandas
-        else pl.read_parquet(CFB_ROSTERS_CROSSWALK_URL, use_pyarrow=True, columns=None)
+        else _fetch_release_parquet(CFB_ROSTERS_CROSSWALK_URL)
     )

--- a/sportsdataverse/nfl/nfl_loaders.py
+++ b/sportsdataverse/nfl/nfl_loaders.py
@@ -5,6 +5,7 @@ from typing import List
 import polars as pl
 from tqdm import tqdm
 
+from sportsdataverse._codegen_runtime import _fetch_release_parquet
 from sportsdataverse._deprecation import warn_deprecated as _warn_deprecated
 from sportsdataverse.config import (
     NFL_BASE_URL,
@@ -128,7 +129,7 @@ def load_nfl_pbp(seasons: List[int], return_as_pandas=False, *, source: str = "n
         seasons = [seasons]
     for i in tqdm(seasons):
         season_not_found_error(int(i), 1999)
-        i_data = pl.read_parquet(base_url.format(season=i), use_pyarrow=True, columns=None)
+        i_data = _fetch_release_parquet(base_url.format(season=i))
         # diagonal_relaxed: per-season release schemas drift (columns added or
         # dropped, and dtypes widened) -- union columns, null-fill gaps.
         data = pl.concat([data, i_data], how="diagonal_relaxed")
@@ -183,7 +184,7 @@ def load_nfl_schedule(seasons: List[int], return_as_pandas=False) -> pl.DataFram
         season_not_found_error(int(i), 1999)
     # Upstream (nflverse-data `schedules/games`) is a single combined parquet
     # covering all seasons (1999-present). Read once and post-filter by season.
-    data = pl.read_parquet(NFL_TEAM_SCHEDULE_URL, use_pyarrow=True, columns=None)
+    data = _fetch_release_parquet(NFL_TEAM_SCHEDULE_URL)
     if "season" in data.columns and seasons:
         season_ints = [int(s) for s in seasons]
         data = data.filter(pl.col("season").is_in(season_ints))
@@ -267,7 +268,7 @@ def load_nfl_player_stats(kicking=False, return_as_pandas=False, *, source: str 
     else:
         raise ValueError(f"Invalid source {source!r}; expected one of 'nflverse', None, 'sportsdataverse', or 'sdv'.")
 
-    data = pl.read_parquet(url, use_pyarrow=True, columns=None)
+    data = _fetch_release_parquet(url)
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -349,7 +350,7 @@ def load_nfl_nextgen_stats(
     url = _NFL_NGS_URLS[stat_type]
     # The upstream NGS parquet is a single combined file per stat type,
     # so the read happens once and we filter by season afterwards.
-    data = pl.read_parquet(url, use_pyarrow=True, columns=None)
+    data = _fetch_release_parquet(url)
 
     if "season" in data.columns and seasons:
         season_ints = [int(s) for s in seasons]
@@ -378,7 +379,7 @@ def load_nfl_ngs_passing(seasons: List[int] = None, return_as_pandas: bool = Fal
     )
     if seasons is None:
         # Preserve the legacy "load every season" behavior of the original alias.
-        data = pl.read_parquet(NFL_NGS_PASSING_URL, use_pyarrow=True, columns=None)
+        data = _fetch_release_parquet(NFL_NGS_PASSING_URL)
         return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
     return load_nfl_nextgen_stats(seasons, stat_type="passing", return_as_pandas=return_as_pandas)
 
@@ -402,7 +403,7 @@ def load_nfl_ngs_rushing(seasons: List[int] = None, return_as_pandas: bool = Fal
         removed_in="0.1.0",
     )
     if seasons is None:
-        data = pl.read_parquet(NFL_NGS_RUSHING_URL, use_pyarrow=True, columns=None)
+        data = _fetch_release_parquet(NFL_NGS_RUSHING_URL)
         return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
     return load_nfl_nextgen_stats(seasons, stat_type="rushing", return_as_pandas=return_as_pandas)
 
@@ -426,7 +427,7 @@ def load_nfl_ngs_receiving(seasons: List[int] = None, return_as_pandas: bool = F
         removed_in="0.1.0",
     )
     if seasons is None:
-        data = pl.read_parquet(NFL_NGS_RECEIVING_URL, use_pyarrow=True, columns=None)
+        data = _fetch_release_parquet(NFL_NGS_RECEIVING_URL)
         return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
     return load_nfl_nextgen_stats(seasons, stat_type="receiving", return_as_pandas=return_as_pandas)
 
@@ -538,7 +539,7 @@ def load_nfl_pfr_advstats(
     if summary_level == "season":
         # Single combined parquet per stat type — read once and filter
         # by season afterwards.
-        data = pl.read_parquet(url, use_pyarrow=True, columns=None)
+        data = _fetch_release_parquet(url)
         if "season" in data.columns and seasons:
             season_ints = [int(s) for s in seasons]
             for s in season_ints:
@@ -553,7 +554,7 @@ def load_nfl_pfr_advstats(
     frames: list[pl.DataFrame] = []
     for i in tqdm(seasons):
         season_not_found_error(int(i), 2018)
-        i_data = pl.read_parquet(url.format(season=i), use_pyarrow=True, columns=None)
+        i_data = _fetch_release_parquet(url.format(season=i))
         frames.append(i_data)
 
     if not frames:
@@ -589,7 +590,7 @@ def load_nfl_pfr_pass(return_as_pandas: bool = False) -> pl.DataFrame:
         removed_in="0.1.0",
     )
     # Preserve the legacy "no seasons filter" behavior — read the full combined parquet.
-    data = pl.read_parquet(NFL_PFR_SEASON_PASS_URL, use_pyarrow=True, columns=None)
+    data = _fetch_release_parquet(NFL_PFR_SEASON_PASS_URL)
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -636,7 +637,7 @@ def load_nfl_pfr_rush(return_as_pandas: bool = False) -> pl.DataFrame:
         replacement="load_nfl_pfr_advstats(stat_type='rush', summary_level='season')",
         removed_in="0.1.0",
     )
-    data = pl.read_parquet(NFL_PFR_SEASON_RUSH_URL, use_pyarrow=True, columns=None)
+    data = _fetch_release_parquet(NFL_PFR_SEASON_RUSH_URL)
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -683,7 +684,7 @@ def load_nfl_pfr_rec(return_as_pandas: bool = False) -> pl.DataFrame:
         replacement="load_nfl_pfr_advstats(stat_type='rec', summary_level='season')",
         removed_in="0.1.0",
     )
-    data = pl.read_parquet(NFL_PFR_SEASON_REC_URL, use_pyarrow=True, columns=None)
+    data = _fetch_release_parquet(NFL_PFR_SEASON_REC_URL)
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -730,7 +731,7 @@ def load_nfl_pfr_def(return_as_pandas: bool = False) -> pl.DataFrame:
         replacement="load_nfl_pfr_advstats(stat_type='def', summary_level='season')",
         removed_in="0.1.0",
     )
-    data = pl.read_parquet(NFL_PFR_SEASON_DEF_URL, use_pyarrow=True, columns=None)
+    data = _fetch_release_parquet(NFL_PFR_SEASON_DEF_URL)
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
 
@@ -841,7 +842,7 @@ def load_nfl_rosters(seasons: List[int], return_as_pandas=False, *, source: str 
         seasons = [seasons]
     for i in tqdm(seasons):
         season_not_found_error(int(i), 1920)
-        i_data = pl.read_parquet(base_url.format(season=i), use_pyarrow=True, columns=None)
+        i_data = _fetch_release_parquet(base_url.format(season=i))
         # diagonal_relaxed: per-season release schemas drift (columns added or
         # dropped, and dtypes widened) -- union columns, null-fill gaps.
         data = pl.concat([data, i_data], how="diagonal_relaxed")
@@ -908,7 +909,7 @@ def load_nfl_weekly_rosters(seasons: List[int], return_as_pandas=False) -> pl.Da
         seasons = [seasons]
     for i in tqdm(seasons):
         season_not_found_error(int(i), 2002)
-        i_data = pl.read_parquet(NFL_WEEKLY_ROSTER_URL.format(season=i), use_pyarrow=True, columns=None)
+        i_data = _fetch_release_parquet(NFL_WEEKLY_ROSTER_URL.format(season=i))
         # diagonal_relaxed: per-season release schemas drift (columns added or
         # dropped, and dtypes widened) -- union columns, null-fill gaps.
         data = pl.concat([data, i_data], how="diagonal_relaxed")
@@ -1030,9 +1031,9 @@ def load_nfl_players(return_as_pandas=False, *, source: str = "nflverse") -> pl.
     else:
         raise ValueError(f"Invalid source {source!r}; expected one of 'nflverse', None, 'sportsdataverse', or 'sdv'.")
     return (
-        pl.read_parquet(url, use_pyarrow=True, columns=None).to_pandas(use_pyarrow_extension_array=True)
+        _fetch_release_parquet(url).to_pandas(use_pyarrow_extension_array=True)
         if return_as_pandas
-        else pl.read_parquet(url, use_pyarrow=True, columns=None)
+        else _fetch_release_parquet(url)
     )
 
 
@@ -1073,7 +1074,7 @@ def load_nfl_snap_counts(seasons: List[int], return_as_pandas=False) -> pl.DataF
         seasons = [seasons]
     for i in tqdm(seasons):
         season_not_found_error(int(i), 2012)
-        i_data = pl.read_parquet(NFL_SNAP_COUNTS_URL.format(season=i), use_pyarrow=True, columns=None)
+        i_data = _fetch_release_parquet(NFL_SNAP_COUNTS_URL.format(season=i))
         # diagonal_relaxed: per-season release schemas drift (columns added or
         # dropped, and dtypes widened) -- union columns, null-fill gaps.
         data = pl.concat([data, i_data], how="diagonal_relaxed")
@@ -1113,7 +1114,7 @@ def load_nfl_pbp_participation(seasons: List[int], return_as_pandas=False) -> pl
         seasons = [seasons]
     for i in tqdm(seasons):
         season_not_found_error(int(i), 2016)
-        i_data = pl.read_parquet(NFL_PBP_PARTICIPATION_URL.format(season=i), use_pyarrow=True, columns=None)
+        i_data = _fetch_release_parquet(NFL_PBP_PARTICIPATION_URL.format(season=i))
         # play_id is a join key against load_nfl_pbp, and the release parquets
         # ship it as Int32 through 2022 then Float64 from 2023. Pin it to the
         # pbp dtype HERE rather than letting the diagonal_relaxed supertype
@@ -1164,7 +1165,7 @@ def load_nfl_injuries(seasons: List[int], return_as_pandas=False) -> pl.DataFram
         seasons = [seasons]
     for i in tqdm(seasons):
         season_not_found_error(int(i), 2009)
-        i_data = pl.read_parquet(NFL_INJURIES_URL.format(season=i), use_pyarrow=True, columns=None)
+        i_data = _fetch_release_parquet(NFL_INJURIES_URL.format(season=i))
         # diagonal_relaxed: per-season release schemas drift (columns added or
         # dropped, and dtypes widened) -- union columns, null-fill gaps.
         data = pl.concat([data, i_data], how="diagonal_relaxed")
@@ -1204,7 +1205,7 @@ def load_nfl_depth_charts(seasons: List[int], return_as_pandas=False) -> pl.Data
         seasons = [seasons]
     for i in tqdm(seasons):
         season_not_found_error(int(i), 2001)
-        i_data = pl.read_parquet(NFL_DEPTH_CHARTS_URL.format(season=i), use_pyarrow=True, columns=None)
+        i_data = _fetch_release_parquet(NFL_DEPTH_CHARTS_URL.format(season=i))
         # diagonal_relaxed: per-season release schemas drift (columns added or
         # dropped, and dtypes widened) -- union columns, null-fill gaps.
         data = pl.concat([data, i_data], how="diagonal_relaxed")
@@ -1241,9 +1242,9 @@ def load_nfl_contracts(return_as_pandas=False) -> pl.DataFrame:
         .. _nflverse: https://nflverse.nflverse.com
     """
     return (
-        pl.read_parquet(NFL_CONTRACTS_URL, use_pyarrow=True, columns=None).to_pandas(use_pyarrow_extension_array=True)
+        _fetch_release_parquet(NFL_CONTRACTS_URL).to_pandas(use_pyarrow_extension_array=True)
         if return_as_pandas
-        else pl.read_parquet(NFL_CONTRACTS_URL, use_pyarrow=True, columns=None)
+        else _fetch_release_parquet(NFL_CONTRACTS_URL)
     )
 
 
@@ -1280,9 +1281,9 @@ def load_nfl_combine(return_as_pandas=False) -> pl.DataFrame:
         .. _nflverse: https://nflverse.nflverse.com
     """
     return (
-        pl.read_parquet(NFL_COMBINE_URL, use_pyarrow=True, columns=None).to_pandas(use_pyarrow_extension_array=True)
+        _fetch_release_parquet(NFL_COMBINE_URL).to_pandas(use_pyarrow_extension_array=True)
         if return_as_pandas
-        else pl.read_parquet(NFL_COMBINE_URL, use_pyarrow=True, columns=None)
+        else _fetch_release_parquet(NFL_COMBINE_URL)
     )
 
 
@@ -1319,9 +1320,9 @@ def load_nfl_draft_picks(return_as_pandas=False) -> pl.DataFrame:
         .. _nflverse: https://nflverse.nflverse.com
     """
     return (
-        pl.read_parquet(NFL_DRAFT_PICKS_URL, use_pyarrow=True, columns=None).to_pandas(use_pyarrow_extension_array=True)
+        _fetch_release_parquet(NFL_DRAFT_PICKS_URL).to_pandas(use_pyarrow_extension_array=True)
         if return_as_pandas
-        else pl.read_parquet(NFL_DRAFT_PICKS_URL, use_pyarrow=True, columns=None)
+        else _fetch_release_parquet(NFL_DRAFT_PICKS_URL)
     )
 
 
@@ -1355,9 +1356,9 @@ def load_nfl_officials(return_as_pandas=False) -> pl.DataFrame:
         .. _nflreadpy: https://github.com/nflverse/nflreadpy
     """
     return (
-        pl.read_parquet(NFL_OFFICIALS_URL, use_pyarrow=True, columns=None).to_pandas(use_pyarrow_extension_array=True)
+        _fetch_release_parquet(NFL_OFFICIALS_URL).to_pandas(use_pyarrow_extension_array=True)
         if return_as_pandas
-        else pl.read_parquet(NFL_OFFICIALS_URL, use_pyarrow=True, columns=None)
+        else _fetch_release_parquet(NFL_OFFICIALS_URL)
     )
 
 
@@ -1415,7 +1416,7 @@ def load_nfl_team_stats(
     if source in ("sportsdataverse", "sdv"):
         for i in seasons:
             season_not_found_error(int(i), 1999)
-        data = pl.read_parquet(NFL_SDV_TEAM_STATS_URL, use_pyarrow=True)
+        data = _fetch_release_parquet(NFL_SDV_TEAM_STATS_URL)
         data = data.filter(pl.col("season").is_in([int(i) for i in seasons]))
         return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
@@ -1430,11 +1431,7 @@ def load_nfl_team_stats(
     data = pl.DataFrame()
     for i in tqdm(seasons):
         season_not_found_error(int(i), 1999)
-        i_data = pl.read_parquet(
-            NFL_TEAM_STATS_URL.format(level=level_str, season=i),
-            use_pyarrow=True,
-            columns=None,
-        )
+        i_data = _fetch_release_parquet(NFL_TEAM_STATS_URL.format(level=level_str, season=i))
         # diagonal_relaxed: per-season release schemas drift (columns added or
         # dropped, and dtypes widened) -- union columns, null-fill gaps.
         data = pl.concat([data, i_data], how="diagonal_relaxed")
@@ -1485,7 +1482,7 @@ def load_nfl_ftn_charting(seasons: List[int], return_as_pandas=False) -> pl.Data
         seasons = [seasons]
     for i in tqdm(seasons):
         season_not_found_error(int(i), 2022)
-        i_data = pl.read_parquet(NFL_FTN_CHARTING_URL.format(season=i), use_pyarrow=True, columns=None)
+        i_data = _fetch_release_parquet(NFL_FTN_CHARTING_URL.format(season=i))
         # diagonal_relaxed: per-season release schemas drift (columns added or
         # dropped, and dtypes widened) -- union columns, null-fill gaps.
         data = pl.concat([data, i_data], how="diagonal_relaxed")
@@ -1522,9 +1519,9 @@ def load_nfl_trades(return_as_pandas=False) -> pl.DataFrame:
         .. _nflreadpy: https://github.com/nflverse/nflreadpy
     """
     return (
-        pl.read_parquet(NFL_TRADES_URL, use_pyarrow=True, columns=None).to_pandas(use_pyarrow_extension_array=True)
+        _fetch_release_parquet(NFL_TRADES_URL).to_pandas(use_pyarrow_extension_array=True)
         if return_as_pandas
-        else pl.read_parquet(NFL_TRADES_URL, use_pyarrow=True, columns=None)
+        else _fetch_release_parquet(NFL_TRADES_URL)
     )
 
 
@@ -1653,7 +1650,7 @@ def load_nfl_ff_rankings(
     elif effective == "week":
         data = _read_csv_retry(NFL_FF_RANKINGS_WEEK_URL, null_values=["NA", "NULL", ""])
     else:  # all
-        data = pl.read_parquet(NFL_FF_RANKINGS_ALL_URL, use_pyarrow=True, columns=None)
+        data = _fetch_release_parquet(NFL_FF_RANKINGS_ALL_URL)
 
     return data.to_pandas(use_pyarrow_extension_array=True) if return_as_pandas else data
 
@@ -1714,10 +1711,8 @@ def load_nfl_ff_opportunity(
         seasons = [seasons]
     for i in tqdm(seasons):
         season_not_found_error(int(i), 2006)
-        i_data = pl.read_parquet(
-            NFL_FF_OPPORTUNITY_URL.format(model_version=model_version, stat_type=stat_type, season=i),
-            use_pyarrow=True,
-            columns=None,
+        i_data = _fetch_release_parquet(
+            NFL_FF_OPPORTUNITY_URL.format(model_version=model_version, stat_type=stat_type, season=i)
         )
         # diagonal_relaxed: per-season release schemas drift (columns added or
         # dropped, and dtypes widened) -- union columns, null-fill gaps.
@@ -1814,7 +1809,7 @@ def load_nfl_espn_qbr(
         season_not_found_error(int(i), 2006)
     # The espn_data release ships ONE combined parquet per summary_type (all
     # seasons, 2006-present). Read once and post-filter by season.
-    data = pl.read_parquet(url, use_pyarrow=True, columns=None)
+    data = _fetch_release_parquet(url)
     if "season" in data.columns and seasons:
         season_ints = [int(s) for s in seasons]
         data = data.filter(pl.col("season").is_in(season_ints))
@@ -1868,7 +1863,7 @@ def load_nfl_ratings_weekly(seasons: List[int], return_as_pandas: bool = False) 
     frames = []
     for i in seasons:
         season_not_found_error(int(i), 1999)
-        frames.append(pl.read_parquet(NFL_RATINGS_WEEKLY_URL.format(season=i), use_pyarrow=True, columns=None))
+        frames.append(_fetch_release_parquet(NFL_RATINGS_WEEKLY_URL.format(season=i)))
     # diagonal_relaxed: per-season release schemas drift (columns added or
     # dropped, and dtypes widened) -- union columns, null-fill gaps.
     # vertical_relaxed tolerated the dtype half of that but not the columns.

--- a/tests/codegen/test_runtime_release.py
+++ b/tests/codegen/test_runtime_release.py
@@ -187,3 +187,38 @@ def test_fetch_success_path_never_calls_the_transport():
             rt._fetch_release_parquet("https://x/ok.parquet")
 
     assert calls["n"] == 0
+
+
+def test_panic_refetch_that_fails_raises_rather_than_parsing_the_error_body():
+    """The metadata fallback issues its OWN request, which can fail on its own.
+
+    The first read reached the asset (that is why it panicked), but the refetch can
+    still come back 403 or 5xx. Handing that body to ``pq.read_table`` would surface
+    a parquet parse error for what is really a failed fetch -- the same confusion
+    ``AssetFetchError`` exists to prevent, just one layer down.
+    """
+
+    class _Panic(BaseException):
+        pass
+
+    _Panic.__name__ = "PanicException"
+
+    with patch.object(rt.pl, "read_parquet", side_effect=_Panic("arrow-ffi metadata panic")):
+        with patch.object(rt, "download", return_value=_Resp(b"<html>rate limited</html>", status_code=403)):
+            with pytest.raises(AssetFetchError, match="403"):
+                rt._fetch_release_parquet("https://x/rvctrs.parquet")
+
+
+def test_panic_refetch_404_is_still_a_missing_asset():
+    """A refetch 404 keeps its "absent" meaning through both entry points."""
+
+    class _Panic(BaseException):
+        pass
+
+    _Panic.__name__ = "PanicException"
+
+    with patch.object(rt.pl, "read_parquet", side_effect=_Panic("arrow-ffi metadata panic")):
+        with patch.object(rt, "download", side_effect=NoDataError("404")):
+            with pytest.raises(NoDataError):
+                rt._fetch_release_parquet("https://x/gone.parquet")
+            assert rt._read_release_parquet("https://x/gone.parquet") is None

--- a/tests/codegen/test_runtime_release.py
+++ b/tests/codegen/test_runtime_release.py
@@ -138,3 +138,52 @@ def test_failed_fetch_is_not_a_missing_asset():
     """
     assert not issubclass(AssetFetchError, NoDataError)
     assert not issubclass(NoDataError, AssetFetchError)
+
+
+# --------------------------------------------------------------------------
+# raise-vs-skip: two semantics, one implementation
+#
+# `_fetch_release_parquet` raises on a missing asset; `_read_release_parquet`
+# returns None. Hand-written loaders (nfl_loaders, cfb_loaders_extra) use the
+# raising form because a missing NFL season is an error there, while the 226
+# generated call sites use the wrapper because a season gap is routine. Both must
+# classify failures identically -- only "absent" is allowed to differ.
+# --------------------------------------------------------------------------
+
+
+def test_fetch_raises_where_read_skips():
+    """The same missing asset: one raises, the other returns ``None``."""
+    with patch.object(rt.pl, "read_parquet", side_effect=OSError("arrow could not open")):
+        with patch.object(rt, "download", side_effect=NoDataError("404")):
+            with pytest.raises(NoDataError):
+                rt._fetch_release_parquet("https://x/missing.parquet")
+            assert rt._read_release_parquet("https://x/missing.parquet") is None
+
+
+def test_both_variants_surface_a_failed_fetch():
+    """A 403 must NOT be softened by either variant.
+
+    The wrapper only converts "absent" to ``None``. If it also swallowed
+    ``AssetFetchError``, a rate-limited season would silently become an empty
+    frame -- the exact failure the split exists to prevent.
+    """
+    for fn in (rt._fetch_release_parquet, rt._read_release_parquet):
+        with patch.object(rt.pl, "read_parquet", side_effect=OSError("arrow could not open")):
+            with patch.object(rt, "download", return_value=_Resp(b"", status_code=403)):
+                with pytest.raises(AssetFetchError, match="403"):
+                    fn("https://x/forbidden.parquet")
+
+
+def test_fetch_success_path_never_calls_the_transport():
+    """The raising variant keeps the direct-read fast path too."""
+    calls = {"n": 0}
+
+    def counting(*a, **k):
+        calls["n"] += 1
+        return _Resp(b"")
+
+    with patch.object(rt.pl, "read_parquet", return_value=pl.DataFrame({"a": [1]})):
+        with patch.object(rt, "download", side_effect=counting):
+            rt._fetch_release_parquet("https://x/ok.parquet")
+
+    assert calls["n"] == 0


### PR DESCRIPTION
Closes #403. Follow-up to #402.

## The gap

#402 changed `_read_release_parquet` once and 226 generated call sites inherited
the new failure classification. Two hand-written modules fetch their own URLs and
inherited nothing:

| module | sites | why hand-written |
|---|---:|---|
| `sportsdataverse/nfl/nfl_loaders.py` | 38 | NFL is deliberately not in `_GENERATED_LOADER_LEAGUES` |
| `sportsdataverse/cfb/cfb_loaders_extra.py` | 6 | season-less crosswalk + logo/betting assets |

There, a 403, a rate limit and a missing asset were indistinguishable — all
surfaced as whatever Arrow happened to raise.

## Why not just give them the 404-safe helper

`_read_release_parquet` returns `None` for a missing asset, and `nfl_loaders.py`
has **zero** missing-season handling today — it raises. Swapping it in would have
silently converted a missing NFL season into a skipped one: a behaviour change,
and the wrong direction, since the whole point of #402 was to stop absent data
being confused with failed fetches.

## The split

One implementation, two entry points:

- **`_fetch_release_parquet`** — raises `NoDataError` when the asset is absent.
  Used by the hand-written loaders, so raise-on-missing is preserved; the error is
  now *typed and readable* rather than an opaque Arrow message, and it goes through
  the gateway's retry/pooling.
- **`_read_release_parquet`** — a thin wrapper converting only that one exception
  to `None`, for the generated loaders where a season gap is routine.

Only "absent" differs. `AssetFetchError` propagates from **both** — asserted
directly in `test_both_variants_surface_a_failed_fetch`, because a wrapper that
also swallowed a 403 would reintroduce exactly the silent-empty-season failure
#402 removed.

## The performance decision is still locked

The direct-read fast path is preserved in both entry points, and the
never-calls-the-transport guard now covers the raising variant too. The measured
+7% peak RSS / +75% wall regression from buffering cannot creep back in through
either door.

## Verification

- Live: a missing asset now raises `NoDataError` (previously an opaque reader
  error); `load_nfl_combine()` → (8968, 18) and `load_cfb_rosters_crosswalk()` →
  (37740, 14), both unchanged.
- Full suite: **5701 passed, 346 skipped, 10 xfailed**. Drift clean, ruff clean,
  mypy clean (400 files).

## Note

`CFB_ROSTER_URL` in `config.py` is now orphaned — `cfb_loaders.py` carries the same
URL as a literal. Left alone here deliberately: `cfb_loaders.py` is generated, so
deduping it means editing `releases.yaml`, which is a separate change and not worth
folding into a transport PR.

## Summary by Sourcery

Route hand-written parquet loaders through the shared classifier without changing missing-season semantics or direct-read performance.

Bug Fixes:
- Route hand-written NFL and CFB parquet loaders through shared transport handling so missing assets and failed fetches are surfaced with distinct, typed errors.

Enhancements:
- Provide separate raising and missing-season-tolerant parquet loader entry points while preserving the direct-read performance path and consistent failure classification.

Documentation:
- Document the distinct semantics of the raising and 404-safe parquet loader variants.

Tests:
- Add coverage for missing-asset behavior, failed-fetch propagation, fast-path transport avoidance, and metadata-refetch failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing sports data assets across NFL and college football loaders.
  * Missing assets are now safely skipped where appropriate, while failed or unauthorized requests consistently report an error instead of appearing as empty data.
  * Preserved existing output formats and data conversion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->