### PR TITLE
fix(cfb): passers vanished from advBoxScore when participants were joined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
+- [0.1.2 Release: August 27, 2026](#012-release-august-27-2026)
+  - [Fixed — passers vanished from the CFB advanced box score (#405)](#fixed--passers-vanished-from-the-cfb-advanced-box-score-405)
 - [0.1.1 Release: August 27, 2026](#011-release-august-27-2026)
   - [Fixed — every source family now reaches the top-level namespace](#fixed--every-source-family-now-reaches-the-top-level-namespace)
   - [Fixed — the distribution shipped `dev/` and `tools/` as top-level packages](#fixed--the-distribution-shipped-dev-and-tools-as-top-level-packages)
@@ -140,7 +142,7 @@
 - [0.0.67 Release: June 17, 2026](#0067-release-june-17-2026)
   - [Documentation — return-table column descriptions filled (~3,061 columns)](#documentation--return-table-column-descriptions-filled-3061-columns)
   - [Documentation — doctest-prompt cleanup, native returns-tables, new tutorials](#documentation--doctest-prompt-cleanup-native-returns-tables-new-tutorials)
-  - [NFL — PBP ETL ↔ nflfastR alignment + faithful model artifacts](#nfl--pbp-etl-%E2%86%94-nflfastr-alignment--faithful-model-artifacts)
+  - [NFL — PBP ETL ↔ nflfastR alignment + faithful model artifacts](#nfl--pbp-etl--nflfastr-alignment--faithful-model-artifacts)
   - [CFB — EP + WP models retrained on the full 2004–2025 history](#cfb--ep--wp-models-retrained-on-the-full-20042025-history)
 - [0.0.66 Release: June 17, 2026](#0066-release-june-17-2026)
   - [CFB — `cfb_pbp` sparse-game `ColumnNotFoundError` guard (`end.team.id` et al.)](#cfb--cfb_pbp-sparse-game-columnnotfounderror-guard-endteamid-et-al)
@@ -185,7 +187,7 @@
   - [NFL — Next Gen Stats (`nfl_ngs_*`) + api.nfl.com football/v2 (`nfl_*`) modules](#nfl--next-gen-stats-nfl_ngs_--apinflcom-footballv2-nfl_-modules)
   - [NFL — restored the api.nfl.com game schedule + play-by-play wrappers](#nfl--restored-the-apinflcom-game-schedule--play-by-play-wrappers)
   - [ESPN — remove always-erroring endpoint variants + NFL R-parity](#espn--remove-always-erroring-endpoint-variants--nfl-r-parity)
-  - [Documentation — per-league Python ↔ R parity tables](#documentation--per-league-python-%E2%86%94-r-parity-tables)
+  - [Documentation — per-league Python ↔ R parity tables](#documentation--per-league-python--r-parity-tables)
   - [Documentation — example notebooks repaired, expanded, and rendered on-site](#documentation--example-notebooks-repaired-expanded-and-rendered-on-site)
   - [NHL / PWHL — loader naming-parity aliases + games-manifest loaders (fastRhockey parity)](#nhl--pwhl--loader-naming-parity-aliases--games-manifest-loaders-fastrhockey-parity)
   - [Documentation — NFL return-table descriptions mined from nflverse](#documentation--nfl-return-table-descriptions-mined-from-nflverse)
@@ -223,7 +225,7 @@
   - [New: `return_parsed=True` dispatch shim](#new-return_parsedtrue-dispatch-shim)
   - [New: `nhl_edge_parsers.py`](#new-nhl_edge_parserspy)
   - [New: Site v2 summary dispatcher (20 sub-parsers)](#new-site-v2-summary-dispatcher-20-sub-parsers)
-  - [New: 100% ENDPOINT_PARSERS coverage (121/121)](#new-100%25-endpoint_parsers-coverage-121121)
+  - [New: 100% ENDPOINT_PARSERS coverage (121/121)](#new-100-endpoint_parsers-coverage-121121)
   - [New: weekly cron live-test drift detector](#new-weekly-cron-live-test-drift-detector)
   - [New: MLB Stats API parser layer](#new-mlb-stats-api-parser-layer)
   - [New: NHL Stats REST + Records parser layers](#new-nhl-stats-rest--records-parser-layers)
@@ -263,6 +265,49 @@
 - [0.0.5 Release: October 20, 2021](#005-release-october-20-2021)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## 0.1.2 Release: August 27, 2026
+
+### Fixed — passers vanished from the CFB advanced box score (#405)
+
+`create_box_score` returned an empty `advBoxScore["pass"]` for **every** game
+whenever `join_participants=True`, while `rush` and `receiver` filled in
+normally. There cannot be receptions without passes, so the play data was fine
+and the aggregation was not. Game on Paper renders that section directly, so
+every box score on the site showed no passers.
+
+`athlete_name` is derived during QBR feature setup, which runs *before* the
+participants join rewrites `passer_player_name` / `rusher_player_name` with
+cleaned names. It therefore kept the raw participant text while the passer list
+built later held the cleaned name -- all 119 rows of the sample game
+disagreed:
+
+| `athlete_name` (stale) | `passer_player_name` (cleaned) |
+| --- | --- |
+| `No Huddle-Shotgun #2 E.Buehler` | `Eddie Buehler` |
+| `dle-Shotgun #5 R.Marshall` | `Rashawn Marshall` |
+
+`athlete_name.is_in(qbs_list)` then matched nothing, the QBR frame came back
+empty, and the **inner** join onto it deleted every passer.
+
+Two changes, one for the cause and one for the blast radius:
+
+- `athlete_name` is recomputed inside `create_box_score` from the current
+  passer/rusher columns, so it cannot go stale behind a later rewrite however
+  the pipeline order evolves.
+- The QBR join is now a **left** join. QBR is an enrichment; an inner join lets
+  any failure to score it delete the whole passing box score rather than leaving
+  one column null. That fragility is what turned a single stale column into an
+  empty table on every game.
+
+Only reproduces with `join_participants=True`. The offline fixtures use `False`,
+which is why the suite stayed green -- the added regression test is a live test
+asserting that passers exist wherever receivers do, and that no raw participant
+text (a `#`) leaks into a name.
+
+Verified across three games: 401866532 0 -> 2 passers, 401867894 0 -> 3, and
+401752921 0 -> 2 (Sayin 26/19/233/3TD, QBR 88.5). Rush and receiver counts are
+unchanged.
 
 ## 0.1.1 Release: August 27, 2026
 

--- a/docs/src/pages/CHANGELOG.md
+++ b/docs/src/pages/CHANGELOG.md
@@ -2,6 +2,8 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
+- [0.1.2 Release: August 27, 2026](#012-release-august-27-2026)
+  - [Fixed — passers vanished from the CFB advanced box score (#405)](#fixed--passers-vanished-from-the-cfb-advanced-box-score-405)
 - [0.1.1 Release: August 27, 2026](#011-release-august-27-2026)
   - [Fixed — every source family now reaches the top-level namespace](#fixed--every-source-family-now-reaches-the-top-level-namespace)
   - [Fixed — the distribution shipped `dev/` and `tools/` as top-level packages](#fixed--the-distribution-shipped-dev-and-tools-as-top-level-packages)
@@ -140,7 +142,7 @@
 - [0.0.67 Release: June 17, 2026](#0067-release-june-17-2026)
   - [Documentation — return-table column descriptions filled (~3,061 columns)](#documentation--return-table-column-descriptions-filled-3061-columns)
   - [Documentation — doctest-prompt cleanup, native returns-tables, new tutorials](#documentation--doctest-prompt-cleanup-native-returns-tables-new-tutorials)
-  - [NFL — PBP ETL ↔ nflfastR alignment + faithful model artifacts](#nfl--pbp-etl-%E2%86%94-nflfastr-alignment--faithful-model-artifacts)
+  - [NFL — PBP ETL ↔ nflfastR alignment + faithful model artifacts](#nfl--pbp-etl--nflfastr-alignment--faithful-model-artifacts)
   - [CFB — EP + WP models retrained on the full 2004–2025 history](#cfb--ep--wp-models-retrained-on-the-full-20042025-history)
 - [0.0.66 Release: June 17, 2026](#0066-release-june-17-2026)
   - [CFB — `cfb_pbp` sparse-game `ColumnNotFoundError` guard (`end.team.id` et al.)](#cfb--cfb_pbp-sparse-game-columnnotfounderror-guard-endteamid-et-al)
@@ -185,7 +187,7 @@
   - [NFL — Next Gen Stats (`nfl_ngs_*`) + api.nfl.com football/v2 (`nfl_*`) modules](#nfl--next-gen-stats-nfl_ngs_--apinflcom-footballv2-nfl_-modules)
   - [NFL — restored the api.nfl.com game schedule + play-by-play wrappers](#nfl--restored-the-apinflcom-game-schedule--play-by-play-wrappers)
   - [ESPN — remove always-erroring endpoint variants + NFL R-parity](#espn--remove-always-erroring-endpoint-variants--nfl-r-parity)
-  - [Documentation — per-league Python ↔ R parity tables](#documentation--per-league-python-%E2%86%94-r-parity-tables)
+  - [Documentation — per-league Python ↔ R parity tables](#documentation--per-league-python--r-parity-tables)
   - [Documentation — example notebooks repaired, expanded, and rendered on-site](#documentation--example-notebooks-repaired-expanded-and-rendered-on-site)
   - [NHL / PWHL — loader naming-parity aliases + games-manifest loaders (fastRhockey parity)](#nhl--pwhl--loader-naming-parity-aliases--games-manifest-loaders-fastrhockey-parity)
   - [Documentation — NFL return-table descriptions mined from nflverse](#documentation--nfl-return-table-descriptions-mined-from-nflverse)
@@ -223,7 +225,7 @@
   - [New: `return_parsed=True` dispatch shim](#new-return_parsedtrue-dispatch-shim)
   - [New: `nhl_edge_parsers.py`](#new-nhl_edge_parserspy)
   - [New: Site v2 summary dispatcher (20 sub-parsers)](#new-site-v2-summary-dispatcher-20-sub-parsers)
-  - [New: 100% ENDPOINT_PARSERS coverage (121/121)](#new-100%25-endpoint_parsers-coverage-121121)
+  - [New: 100% ENDPOINT_PARSERS coverage (121/121)](#new-100-endpoint_parsers-coverage-121121)
   - [New: weekly cron live-test drift detector](#new-weekly-cron-live-test-drift-detector)
   - [New: MLB Stats API parser layer](#new-mlb-stats-api-parser-layer)
   - [New: NHL Stats REST + Records parser layers](#new-nhl-stats-rest--records-parser-layers)
@@ -263,6 +265,49 @@
 - [0.0.5 Release: October 20, 2021](#005-release-october-20-2021)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## 0.1.2 Release: August 27, 2026
+
+### Fixed — passers vanished from the CFB advanced box score (#405)
+
+`create_box_score` returned an empty `advBoxScore["pass"]` for **every** game
+whenever `join_participants=True`, while `rush` and `receiver` filled in
+normally. There cannot be receptions without passes, so the play data was fine
+and the aggregation was not. Game on Paper renders that section directly, so
+every box score on the site showed no passers.
+
+`athlete_name` is derived during QBR feature setup, which runs *before* the
+participants join rewrites `passer_player_name` / `rusher_player_name` with
+cleaned names. It therefore kept the raw participant text while the passer list
+built later held the cleaned name -- all 119 rows of the sample game
+disagreed:
+
+| `athlete_name` (stale) | `passer_player_name` (cleaned) |
+| --- | --- |
+| `No Huddle-Shotgun #2 E.Buehler` | `Eddie Buehler` |
+| `dle-Shotgun #5 R.Marshall` | `Rashawn Marshall` |
+
+`athlete_name.is_in(qbs_list)` then matched nothing, the QBR frame came back
+empty, and the **inner** join onto it deleted every passer.
+
+Two changes, one for the cause and one for the blast radius:
+
+- `athlete_name` is recomputed inside `create_box_score` from the current
+  passer/rusher columns, so it cannot go stale behind a later rewrite however
+  the pipeline order evolves.
+- The QBR join is now a **left** join. QBR is an enrichment; an inner join lets
+  any failure to score it delete the whole passing box score rather than leaving
+  one column null. That fragility is what turned a single stale column into an
+  empty table on every game.
+
+Only reproduces with `join_participants=True`. The offline fixtures use `False`,
+which is why the suite stayed green -- the added regression test is a live test
+asserting that passers exist wherever receivers do, and that no raw participant
+text (a `#`) leaks into a name.
+
+Verified across three games: 401866532 0 -> 2 passers, 401867894 0 -> 3, and
+401752921 0 -> 2 (Sayin 26/19/233/3TD, QBR 88.5). Rush and receiver counts are
+unchanged.
 
 ## 0.1.1 Release: August 27, 2026
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sportsdataverse"
-version = "0.1.1"
+version = "0.1.2"
 description = "Retrieve Sports data in Python"
 readme = "README.md"
 license = "MIT"

--- a/sportsdataverse/cfb/cfb_pbp.py
+++ b/sportsdataverse/cfb/cfb_pbp.py
@@ -6565,6 +6565,17 @@ class CFBPlayProcess(object):
         # passer_box = passer_box.replace(pl.all(), pl.Null)
         qbs_list = passer_box["passer_player_name"].to_list()
 
+        # Recompute athlete_name here rather than trusting the copy made during
+        # QBR feature setup. That earlier copy is taken before the participants
+        # join rewrites passer_player_name / rusher_player_name with cleaned
+        # names, so it keeps the raw participant text ("No Huddle-Shotgun #2
+        # E.Buehler") while qbs_list holds the cleaned name ("Eddie Buehler").
+        # The is_in below then matched nothing and every passer vanished from
+        # the box score -- see tests/cfb/test_cfb_box_score.py.
+        play_df = play_df.with_columns(
+            athlete_name=pl.coalesce([pl.col("passer_player_name"), pl.col("rusher_player_name")])
+        )
+
         pass_qbr_box = play_df.filter(
             (pl.col("athlete_name").is_not_null() == True)
             & (pl.col("scrimmage_play") == True)
@@ -6597,10 +6608,14 @@ class CFBPlayProcess(object):
         dtest_qbr = DMatrix(pass_qbr[qbr_vars])
         qbr_result = qbr_model.predict(dtest_qbr)
         pass_qbr = pass_qbr.with_columns(exp_qbr=pl.lit(qbr_result))
+        # LEFT, not inner: QBR is an enrichment. An inner join means any failure
+        # to score QBR deletes the passing box score outright, which is how a
+        # stale athlete_name silently emptied the passers table on every game.
         passer_box = passer_box.join(
             pass_qbr,
             left_on=["passer_player_name", "pos_team"],
             right_on=["athlete_name", "pos_team"],
+            how="left",
         ).sort("Att", descending=True)  # 0.36-live: box tables sorted by volume
 
         rusher_box = (

--- a/tests/cfb/test_create_box_score.py
+++ b/tests/cfb/test_create_box_score.py
@@ -24,3 +24,36 @@ def test_create_box_score_adds_defensive_players_and_specialists():
     assert all("player_name" in r and ("pos_team" in r) for r in sp)
     assert any(r.get("sacks", 0) for r in dp), "expected at least one sack attributed"
     assert any(r.get("punts", 0) for r in sp), "expected at least one punt attributed"
+
+
+@skip_if_no_live
+def test_passer_box_survives_the_participants_join():
+    """Passers must appear when join_participants=True (the production config).
+
+    Regression: athlete_name was copied during QBR feature setup, i.e. BEFORE
+    the participants join rewrites passer_player_name / rusher_player_name with
+    cleaned names. It therefore kept the raw participant text
+    ("No Huddle-Shotgun #2 E.Buehler") while qbs_list held "Eddie Buehler", the
+    is_in() matched nothing, the QBR frame came back empty, and the INNER join
+    onto it deleted every passer. advBoxScore["pass"] was [] on every game while
+    rush and receiver looked fine -- there cannot be receptions without passes,
+    which is what made it obvious the aggregation, not the data, was at fault.
+    """
+    proc = CFBPlayProcess(gameId=401628455)
+    proc.join_participants = True
+    proc.espn_cfb_pbp()
+    abx = proc.run_processing_pipeline()["advBoxScore"]
+
+    passers = abx["pass"]
+    receivers = abx["receiver"]
+    assert receivers, "fixture game should have receiving rows"
+    assert passers, "passers vanished: receptions exist, so passes must too"
+
+    # names come from the cleaned column, never the raw participant text
+    for row in passers:
+        name = row["passer_player_name"]
+        assert name and "#" not in name, f"raw participant text leaked into box score: {name!r}"
+        assert row["Att"] >= 1
+
+    # QBR is an enrichment; its absence must not delete rows (left join)
+    assert set(passers[0]) >= {"Comp", "Att", "Yds", "Pass_TD", "EPA"}


### PR DESCRIPTION
## Symptom

`advBoxScore["pass"]` is empty on **every** game when `join_participants=True`, while `rush` and `receiver` are populated. Surfaced as an empty passers table on every Game on Paper box score, e.g. https://gameonpaper.com/game/401866532.

There cannot be receptions without passes, so the play data was fine and the aggregation was not.

## Cause

`athlete_name` is copied during QBR feature setup, which runs **before** the participants join rewrites `passer_player_name` / `rusher_player_name` with cleaned names. It keeps the raw participant text while `qbs_list` holds the cleaned name:

| athlete_name (stale) | passer_player_name (clean) |
|---|---|
| `No Huddle-Shotgun #2 E.Buehler` | `Eddie Buehler` |
| `dle-Shotgun #5 R.Marshall` | `Rashawn Marshall` |

All 119 rows of game 401866532 mismatched. `athlete_name.is_in(qbs_list)` then matched nothing → `pass_qbr` empty → the **inner** join onto it deleted every passer.

## Fix

- **Recompute `athlete_name` in `create_box_score`** from the current passer/rusher columns, so it cannot go stale behind a later rewrite regardless of how the pipeline order evolves.
- **Make the QBR join `how="left"`.** QBR is an enrichment; an inner join lets any failure to score it delete the entire passing box score instead of dropping one stat. That fragility is why a single stale column emptied the table on every game.

## Verification

| game | before | after |
|---|---|---|
| 401866532 | 0 passers | 2 (Buehler 27/17/203/2TD, QBR 58.2) |
| 401867894 | 0 | 3 (Brungard 29/20/232/3TD, QBR 81.3) |
| 401752921 | 0 | 2 (Sayin 26/19/233/3TD, QBR 88.5) |

Rush/receiver counts unchanged. Full `tests/cfb` suite: **732 passed, 55 skipped, 2 xfailed**.

## Note on coverage

This only reproduces with `join_participants=True`; the offline fixtures use `False`, which is why the existing suite stayed green throughout. The added regression test is `@skip_if_no_live` and asserts both that passers exist when receivers do, and that no raw participant text (`#`) leaks into a name.

## Summary by Sourcery

Restore CFB passer statistics in advanced box scores and make QBR enrichment non-destructive.

Bug Fixes:
- Restore passer rows in CFB advanced box scores when participant names are joined.
- Prevent missing QBR enrichment from removing otherwise valid passer statistics.

Build:
- Bump the package version to 0.1.2.

Documentation:
- Document the CFB passer box score fix in the changelogs.

Tests:
- Add a live regression test covering participant joins, cleaned passer names, and preservation of passer rows without QBR data.

Chores:
- Regenerate changelog table-of-contents links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved passing box-score entries when advanced quarterback rating data is unavailable.
  - Corrected passer and rusher names displayed after participant information is processed.
  - Ensured passing statistics retain expected attempts and quarterback rating details.

- **Tests**
  - Added coverage confirming passing box-score rows and cleaned player names remain available through the full processing workflow.

- **Documentation**
  - Updated release notes for version 0.1.2 and corrected related navigation links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->