### PR TITLE
perf(ci): stop re-rendering the docs tree; split the offline and live test jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,56 +1,49 @@
-# Run the full test suite (live API tests included) on push to main and
-# workflow_dispatch. Live tests are gated by SDV_PY_LIVE_TESTS=1 and run by
-# default; the workflow_dispatch input can flip them off (live_tests:
-# "false") for runs where third-party API churn would produce
-# false-negative failures.
+# Test suite, split into a fast offline job and a slower live-API job.
 #
-# SCOPE (deliberately narrowed 2026-08-12, operator decision): a SINGLE job —
-# macos-latest on the canonical interpreter — running ONLY on main. Two
-# consequences to know about, because neither is caught anywhere else:
-#   - Python 3.9 (the declared floor) and Linux/Windows are no longer
-#     exercised. CONTRIBUTING.md promises the floor is covered; it is not.
-#     A 3.9-incompatible construct or a platform-specific regression now
-#     ships and surfaces at release time.
-#   - PRs no longer run tests. Merge-time signal is the codegen drift gate
-#     plus whatever ran locally, so `uv run pytest` before pushing is now
-#     load-bearing rather than a convenience.
-# Restore by re-adding the matrix `include:` block and the `pull_request:`
-# trigger below.
+# WHY THE SPLIT (2026-08-27): the single combined job ran 60-100 minutes and was
+# routinely cancelled by the next merge before it finished, so in practice the
+# suite verified nothing. Profiling found the cost was NOT spread across 6,000
+# tests -- four codegen tests were 2,222s of a 2,755s offline run (81%), almost
+# all of it the SAME doc render repeated four to five times. That is fixed in
+# tests/codegen/conftest.py; the jobs below carry the rest.
 #
-# Uses `uv sync --all-extras --all-groups` against the committed uv.lock for
-# reproducible installs, then `uv run --frozen pytest` for execution. See
-# CONTRIBUTING.md.
+#   offline  ubuntu, parallel, no live network. Fast enough to run on PRs, which
+#            restores the pre-2026-08-12 merge-time signal.
+#   live     macOS, live APIs. Keeps the platform the narrowing kept -- it is the
+#            only job that exercises the xgboost/libomp import path -- and keeps
+#            the live coverage, off the critical path.
+#
+# SCOPE (still narrowed, unchanged by this split): Python 3.9 (the declared floor)
+# and Windows are NOT exercised. CONTRIBUTING.md promises the floor is covered; it
+# is not. Restore by re-adding a matrix `include:` block.
+#
+# Uses `uv sync --all-extras --all-groups` against the committed uv.lock.
 name: tests
+
 on:
   push:
     branches: [main]
+  pull_request:
   workflow_dispatch:
     inputs:
       live_tests:
         description: "Set SDV_PY_LIVE_TESTS=1 to include live API tests"
         required: false
         default: "true"
-# Cancel in-flight runs on the same ref when a new push comes in.
+
+# Cancel superseded runs on the same ref. On main this used to mean each merge
+# killed the previous run mid-flight and the suite never completed on any commit;
+# it is survivable now only because the offline job finishes in minutes.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 permissions:
   contents: read
+
 jobs:
-  test:
-    name: pytest (${{ matrix.os }} / py${{ matrix.python-version }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        # Single job by operator decision (2026-08-12): macOS on the
-        # canonical interpreter. 3.14 is still excluded — pyarrow / polars
-        # wheels for cp314 are landing across the index. The dropped legs
-        # were ubuntu 3.9 (the declared floor), ubuntu 3.13.2, and windows
-        # 3.13.2; see the scope note in the header before assuming a green
-        # run means the floor or Linux/Windows are covered.
-        os: [macos-latest]
-        python-version: ["3.13.2"]
+  offline:
+    name: pytest (offline, parallel)
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - name: Install uv
@@ -61,31 +54,65 @@ jobs:
         with:
           version: "latest"
           enable-cache: true
-          # Cache key tracks the lockfile; re-resolves on dep bumps.
           cache-dependency-glob: "uv.lock"
-      - name: Set up Python ${{ matrix.python-version }}
-        run: uv python install ${{ matrix.python-version }}
-      # xgboost on macOS dynamically links against libomp.dylib and
-      # apple-clang doesn't ship OpenMP. The macos-15 runner image
-      # stopped pre-installing libomp via Homebrew, so xgboost.core
-      # raises "OpenMP runtime is not installed" at import time.
-      - name: Install macOS runtime deps for xgboost (libomp)
-        if: runner.os == 'macOS'
-        run: brew install libomp
-      # `uv sync` against the committed lockfile installs:
-      #   - the project (editable)
-      #   - every [project.optional-dependencies] group (--all-extras)
-      #   - every [dependency-groups] group (--all-groups)
-      # into a managed .venv. --frozen guarantees CI doesn't drift from
-      # the lockfile.
+      - name: Set up Python
+        run: uv python install 3.13.2
       - name: Install project + extras + dep groups
-        run: uv sync --all-extras --all-groups --frozen --python ${{ matrix.python-version }}
+        run: uv sync --all-extras --all-groups --frozen --python 3.13.2
+      # -n auto: measured 1.79x on a 1,439-test subset. pytest-xdist was already a
+      # declared dependency in three groups and simply never used.
+      #
+      # --dist loadgroup is load-bearing, not a tuning knob: a session fixture is
+      # scoped to a WORKER, so without it the three codegen tests that share one
+      # render can land on three workers and each re-renders, silently undoing the
+      # saving. The xdist_group marker pins them to one worker.
+      #
+      # No --cov here: coverage instruments every call and this job exists for fast
+      # feedback. It runs in the live job, which is not on the critical path.
+      # Excluded here because codegen.yml ALREADY runs both, on ubuntu, on the same
+      # triggers -- running them again costs ~11 min per CI run for no extra signal:
+      #   tests/codegen/                     <- codegen.yml "Codegen test suite"
+      #   test_codegen_drift_clean           <- codegen.yml "Codegen drift check"
+      #                                         (it shells out to generate.py --check)
+      # This is a CI-level dedupe only. A bare `uv run pytest` locally still runs
+      # everything, and the pre-push hook still gates the drift check.
+      - name: Run tests (offline)
+        run: >
+          uv run --frozen pytest -n auto --dist loadgroup --maxfail=10 -q
+          --ignore=tests/codegen
+          --deselect tests/test_mlb_statcast_codegen.py::test_codegen_drift_clean
+
+  live:
+    name: pytest (live APIs, macOS)
+    # Only on main and manual runs: live endpoints are third-party and flaky, and a
+    # PR author cannot act on an upstream outage.
+    if: github.event_name != 'pull_request'
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      - name: Set up Python
+        run: uv python install 3.13.2
+      # xgboost on macOS dynamically links against libomp.dylib and apple-clang
+      # doesn't ship OpenMP. The macos-15 runner image stopped pre-installing
+      # libomp via Homebrew, so xgboost.core raises "OpenMP runtime is not
+      # installed" at import time. This job is the only one that catches that.
+      - name: Install macOS runtime deps for xgboost (libomp)
+        run: brew install libomp
+      - name: Install project + extras + dep groups
+        run: uv sync --all-extras --all-groups --frozen --python 3.13.2
       - name: Run tests (live API tests included)
         env:
-          # On by default for every trigger (push, PR, workflow_dispatch).
-          # The workflow_dispatch input can override with live_tests: "false"
-          # to skip live tests for a one-off run when upstream APIs are flaky.
           SDV_PY_LIVE_TESTS: ${{ github.event.inputs.live_tests != 'false' && '1' || '' }}
-        # --cov reports coverage (term-missing) without a hard fail-under floor
-        # yet; once a baseline is established a ratchet floor can be added.
-        run: uv run --frozen pytest --maxfail=10 --cov=sportsdataverse --cov-report=term-missing:skip-covered
+          # Bound the retry budget. The library default is 15 retries at a 30s
+          # timeout -- correct for a scraper that must not lose a game, badly wrong
+          # here, where one unreachable host can park a single call for 15 x 30s
+          # plus backoff. A CI failure should surface in seconds, not minutes.
+          SDV_PY_HTTP_RETRIES: "3"
+          SDV_PY_HTTP_TIMEOUT: "15"
+        run: uv run --frozen pytest -n auto --dist loadgroup --maxfail=10 --cov=sportsdataverse --cov-report=term-missing:skip-covered

--- a/sportsdataverse/dl_utils.py
+++ b/sportsdataverse/dl_utils.py
@@ -122,6 +122,23 @@ _DEFAULT_TIMEOUT = 30
 _DEFAULT_RETRIES = 15
 
 
+class _Unset:
+    """Sentinel for "argument omitted", distinct from an explicit ``None``.
+
+    ``timeout=None`` is meaningful to ``requests``: it means *no* timeout, wait
+    forever. Defaulting the parameter to ``None`` would have quietly reinterpreted
+    that as "use 30s", changing behaviour for any caller who passed it deliberately.
+    No caller in this repo does -- both variable call sites are typed ``int`` -- but
+    ``download`` is public API, so the two cases stay distinguishable.
+    """
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return "<unset>"
+
+
+_UNSET = _Unset()
+
+
 def _env_int(name: str, default: int) -> int:
     """Read a positive int from the environment, falling back on anything unusable.
 
@@ -150,8 +167,8 @@ def download(
     params=None,
     headers=None,
     proxy=None,
-    timeout=None,
-    num_retries=None,
+    timeout=_UNSET,
+    num_retries=_UNSET,
     session=None,
     logger=None,
     cache_ttl=None,
@@ -173,8 +190,12 @@ def download(
         headers: Extra HTTP headers as a ``dict``.
         proxy: Proxy configuration in the ``requests`` ``proxies=`` shape
             (e.g. ``{"http": "http://host:port", "https": "http://host:port"}``).
-        timeout: Per-request timeout in seconds. Defaults to ``30``.
-        num_retries: Maximum retries before giving up. Defaults to ``15``.
+        timeout: Per-request timeout in seconds. When omitted, reads
+            ``SDV_PY_HTTP_TIMEOUT`` and falls back to ``30``. Pass ``None``
+            explicitly for NO timeout (``requests`` waits indefinitely) -- that is
+            forwarded unchanged and does NOT consult the environment.
+        num_retries: Maximum retries before giving up. When omitted, reads
+            ``SDV_PY_HTTP_RETRIES`` and falls back to ``15``.
         session: Optional ``requests.Session`` to reuse. Defaults to the
             module-level pooled ``_SHARED_SESSION`` when ``None`` — its
             connection pool *and cookie jar* are shared across all calls that
@@ -187,6 +208,21 @@ def download(
             :data:`_RETRYABLE_STATUS` (403/408/429/500/502/503/504). Pass a
             narrower set (e.g. ``{429, 503}``) for an auth'd endpoint where a
             403 is a real forbidden rather than ESPN-under-load.
+
+    Raises:
+        NoDataError: When the host answers 404, or ESPN answers 200 with a
+            ``{"code": 404, ...}`` body. Not retried -- it is a definitive
+            "no data", and retrying only adds load against a rate-limited host.
+        requests.exceptions.RequestException: When the retry budget is exhausted
+            on a connection-level failure; the most recent exception is re-raised.
+
+    Note:
+        Precedence for ``timeout`` / ``num_retries`` is **explicit argument >
+        environment > default**. The environment is read at CALL time, not import
+        time, so a test or CI step can set it after the module is imported. A
+        malformed or non-positive env value is ignored in favour of the default
+        rather than raising -- this runs on every request, so a typo must not take
+        the process down.
 
     Returns:
         The final ``requests.Response``. When the retry budget is exhausted on
@@ -232,11 +268,15 @@ def download(
         .. _requests: https://requests.readthedocs.io
         .. _httpx: https://www.python-httpx.org
     """
-    # Resolve the sentinels HERE, not in the signature: reading the env at call
-    # time means a test (or a CI step) can set it after import and still be
-    # honoured, and an explicit kwarg always wins over the environment.
-    timeout = _env_int(_ENV_TIMEOUT, _DEFAULT_TIMEOUT) if timeout is None else timeout
-    num_retries = _env_int(_ENV_RETRIES, _DEFAULT_RETRIES) if num_retries is None else num_retries
+    # Resolve HERE, not in the signature: reading the env at call time means a test
+    # (or a CI step) can set it after import and still be honoured. Precedence is
+    # explicit argument > environment > default. Only an OMITTED argument consults
+    # the environment -- an explicit ``timeout=None`` still means "no timeout" and
+    # is forwarded to requests unchanged.
+    if timeout is _UNSET:
+        timeout = _env_int(_ENV_TIMEOUT, _DEFAULT_TIMEOUT)
+    if num_retries is _UNSET:
+        num_retries = _env_int(_ENV_RETRIES, _DEFAULT_RETRIES)
 
     session, params, logger = init_request_settings(params, session, logger)
 

--- a/sportsdataverse/dl_utils.py
+++ b/sportsdataverse/dl_utils.py
@@ -194,8 +194,10 @@ def download(
             ``SDV_PY_HTTP_TIMEOUT`` and falls back to ``30``. Pass ``None``
             explicitly for NO timeout (``requests`` waits indefinitely) -- that is
             forwarded unchanged and does NOT consult the environment.
-        num_retries: Maximum retries before giving up. When omitted, reads
-            ``SDV_PY_HTTP_RETRIES`` and falls back to ``15``.
+        num_retries: Maximum retries before giving up. When omitted or ``None``,
+            reads ``SDV_PY_HTTP_RETRIES`` and falls back to ``15``. Unlike
+            ``timeout``, ``None`` is treated as "omitted" -- there is no
+            "infinite retries" reading for it to mean.
         session: Optional ``requests.Session`` to reuse. Defaults to the
             module-level pooled ``_SHARED_SESSION`` when ``None`` — its
             connection pool *and cookie jar* are shared across all calls that
@@ -275,7 +277,11 @@ def download(
     # is forwarded to requests unchanged.
     if timeout is _UNSET:
         timeout = _env_int(_ENV_TIMEOUT, _DEFAULT_TIMEOUT)
-    if num_retries is _UNSET:
+    if num_retries is _UNSET or num_retries is None:
+        # `None` is accepted as "omitted" here, unlike `timeout`, because it has no
+        # meaningful retry semantics -- there is no "infinite retries" reading. On
+        # main it reached `int(None)` and raised TypeError, so this only widens what
+        # is accepted; it takes nothing away.
         num_retries = _env_int(_ENV_RETRIES, _DEFAULT_RETRIES)
 
     session, params, logger = init_request_settings(params, session, logger)

--- a/sportsdataverse/dl_utils.py
+++ b/sportsdataverse/dl_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import random
 import re
 import time
@@ -109,13 +110,48 @@ def _retry_delay(
     return delay
 
 
+#: Default retry budget and per-request timeout, overridable by environment so a
+#: caller that cannot pass kwargs -- CI, a batch job, a notebook -- can bound how
+#: long a hostile endpoint parks the process. The defaults are unchanged: 15
+#: retries at a 30s timeout is right for a scraper that must not lose a game, but
+#: it is badly wrong for a test suite, where one unreachable host can burn
+#: 15 x 30s plus backoff on a single call. CI sets these low.
+_ENV_TIMEOUT = "SDV_PY_HTTP_TIMEOUT"
+_ENV_RETRIES = "SDV_PY_HTTP_RETRIES"
+_DEFAULT_TIMEOUT = 30
+_DEFAULT_RETRIES = 15
+
+
+def _env_int(name: str, default: int) -> int:
+    """Read a positive int from the environment, falling back on anything unusable.
+
+    A malformed or non-positive value is IGNORED rather than raising: this runs on
+    every request, and a typo in an env var must not take the whole process down.
+
+    Args:
+        name: Environment variable to read.
+        default: Value to use when unset, unparseable, or not positive.
+
+    Returns:
+        The parsed override, or ``default``.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
 def download(
     url,
     params=None,
     headers=None,
     proxy=None,
-    timeout=30,
-    num_retries=15,
+    timeout=None,
+    num_retries=None,
     session=None,
     logger=None,
     cache_ttl=None,
@@ -196,6 +232,12 @@ def download(
         .. _requests: https://requests.readthedocs.io
         .. _httpx: https://www.python-httpx.org
     """
+    # Resolve the sentinels HERE, not in the signature: reading the env at call
+    # time means a test (or a CI step) can set it after import and still be
+    # honoured, and an explicit kwarg always wins over the environment.
+    timeout = _env_int(_ENV_TIMEOUT, _DEFAULT_TIMEOUT) if timeout is None else timeout
+    num_retries = _env_int(_ENV_RETRIES, _DEFAULT_RETRIES) if num_retries is None else num_retries
+
     session, params, logger = init_request_settings(params, session, logger)
 
     # Cache lookup (mode=off → no-op; LIVE-tier URLs → no-op).

--- a/tests/codegen/conftest.py
+++ b/tests/codegen/conftest.py
@@ -1,0 +1,48 @@
+"""Shared render cache for the codegen tests.
+
+Four tests dominated the suite -- 2,222s of a 2,755s run, 81% of the whole thing
+-- and almost all of it was the SAME work repeated. ``_render_docs_all()`` ran
+four to five times per session:
+
+* ``test_render_is_deterministic[_render_docs_all]`` rendered twice (965s),
+* ``test_rendered_content_is_lf_only`` rendered both corpora again (417s),
+* ``test_generated_docs_tree_is_current`` rendered the tree again (320s).
+
+Only the determinism test needs a second render -- that IS its assertion. The
+other two just need *a* corpus, so they can share one.
+
+``first_render`` renders each renderer once per session and hands back the cached
+result. Determinism still compares two INDEPENDENT invocations (one cached, one
+fresh), so the property under test is unchanged; it simply stops paying for a
+render another test already did.
+
+xdist caveat, and why the group marker matters: a session fixture is scoped to a
+WORKER, not the run. Under ``-n auto`` these tests can land on three different
+workers and each would render from scratch, silently undoing the saving. They are
+marked ``xdist_group("codegen_render")`` and CI passes ``--dist loadgroup`` so they
+share one worker -- and one cache -- while the rest of the suite still spreads out.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def first_render() -> Callable[[Callable[[], Dict[str, str]]], Dict[str, str]]:
+    """Return a getter that renders each renderer at most once per session.
+
+    Returns:
+        A callable taking a ``generate._render_*`` function and returning its
+        rendered corpus, computed on first request and cached thereafter.
+    """
+    cache: Dict[Callable[[], Dict[str, str]], Dict[str, str]] = {}
+
+    def get(render: Callable[[], Dict[str, str]]) -> Dict[str, str]:
+        if render not in cache:
+            cache[render] = render()
+        return cache[render]
+
+    return get

--- a/tests/codegen/test_determinism.py
+++ b/tests/codegen/test_determinism.py
@@ -24,15 +24,21 @@ from tools.codegen import generate
         generate._render_flat_all,
     ],
 )
-def test_render_is_deterministic(render) -> None:
+@pytest.mark.xdist_group("codegen_render")
+def test_render_is_deterministic(render, first_render) -> None:
     # Same inputs -> identical output on repeat (no dict-ordering / timestamp /
-    # randomness leaking into generated artifacts).
-    assert render() == render()
+    # randomness leaking into generated artifacts). Still two INDEPENDENT
+    # invocations; the second is the session-cached one the other codegen tests
+    # reuse, so the property is unchanged and nothing renders a third time.
+    assert render() == first_render(render)
 
 
-def test_rendered_content_is_lf_only() -> None:
+@pytest.mark.xdist_group("codegen_render")
+def test_rendered_content_is_lf_only(first_render) -> None:
     # Rendered source + docs must contain no carriage returns, so the write step
     # (now newline="\n" everywhere) yields the same bytes on every platform.
-    corpus = {**generate._render_all(), **generate._render_docs_all()}
+    # Reuses the session render: this asserts a property OF the corpus, not that
+    # rendering repeats, so a fresh render buys nothing here.
+    corpus = {**first_render(generate._render_all), **first_render(generate._render_docs_all)}
     offenders = [name for name, content in corpus.items() if "\r" in content]
     assert not offenders, f"rendered content has CR characters: {offenders}"

--- a/tests/codegen/test_docs.py
+++ b/tests/codegen/test_docs.py
@@ -8,6 +8,8 @@ tree (``docs/docs/{league}/``); a drift guard asserts that tree matches a fresh 
 
 from __future__ import annotations
 
+import pytest
+
 from tools.codegen import generate
 
 
@@ -87,6 +89,8 @@ def test_category_json_is_valid_json():
 # ===========================================================================
 
 
-def test_generated_docs_tree_is_current():
-    stale = generate._docs_stale()
+@pytest.mark.xdist_group("codegen_render")
+def test_generated_docs_tree_is_current(first_render):
+    # Compare against the session render rather than a fourth identical one.
+    stale = generate._docs_stale(rendered=first_render(generate._render_docs_all))
     assert stale == [], f"stale generated docs (run `python tools/codegen/generate.py --docs`): {stale}"

--- a/tests/test_dl_utils.py
+++ b/tests/test_dl_utils.py
@@ -280,3 +280,77 @@ class TestDownload:
         monkeypatch.setattr(requests.Session, "get", _resp(200))
         download("https://site.api.espn.com/docache", num_retries=1)
         assert writes == ["https://site.api.espn.com/docache"]  # 200 cached
+
+
+# ---------------------------------------------------------------------------
+# Env-tunable retry budget
+#
+# The library defaults (15 retries / 30s) suit a scraper that must not lose a
+# game, but they are wrong for a test suite: one unreachable host parks a single
+# call for 15 x 30s plus backoff, which is how CI runs reached 60-100 minutes.
+# These lock the contract that makes CI able to bound it WITHOUT changing what
+# ordinary callers get.
+# ---------------------------------------------------------------------------
+
+
+def test_retry_budget_defaults_are_unchanged(monkeypatch):
+    """No env set -> the historical 15 / 30 defaults, exactly as before."""
+    from sportsdataverse import dl_utils as d
+
+    monkeypatch.delenv(d._ENV_RETRIES, raising=False)
+    monkeypatch.delenv(d._ENV_TIMEOUT, raising=False)
+    assert d._env_int(d._ENV_RETRIES, d._DEFAULT_RETRIES) == 15
+    assert d._env_int(d._ENV_TIMEOUT, d._DEFAULT_TIMEOUT) == 30
+
+
+def test_retry_budget_env_override(monkeypatch):
+    from sportsdataverse import dl_utils as d
+
+    monkeypatch.setenv(d._ENV_RETRIES, "3")
+    monkeypatch.setenv(d._ENV_TIMEOUT, "10")
+    assert d._env_int(d._ENV_RETRIES, d._DEFAULT_RETRIES) == 3
+    assert d._env_int(d._ENV_TIMEOUT, d._DEFAULT_TIMEOUT) == 10
+
+
+@pytest.mark.parametrize("bad", ["", "abc", "0", "-5", "3.5"])
+def test_malformed_env_falls_back_rather_than_raising(monkeypatch, bad):
+    """A typo in an env var must not take the process down.
+
+    This runs on EVERY request, so raising here would turn a harmless
+    misconfiguration into a total outage. Non-positive values are ignored too --
+    zero retries with a zero timeout would make every call fail instantly.
+    """
+    from sportsdataverse import dl_utils as d
+
+    monkeypatch.setenv(d._ENV_RETRIES, bad)
+    assert d._env_int(d._ENV_RETRIES, d._DEFAULT_RETRIES) == 15
+
+
+def test_explicit_kwarg_beats_the_environment(monkeypatch):
+    """An explicit ``num_retries=`` must win, or callers lose control in CI.
+
+    ``cfb_fourth_down`` and ``ep_wp`` both pass ``num_retries=5`` deliberately;
+    the env is a floor for callers that cannot pass kwargs, not an override of
+    those that can.
+    """
+    from sportsdataverse import dl_utils as d
+
+    seen = {}
+
+    class _Resp:
+        status_code = 200
+        content = b"{}"
+        url = "https://example.invalid/x"
+        headers: dict = {}
+
+        def json(self):
+            return {}
+
+    def fake_get(url, **kw):
+        seen["timeout"] = kw.get("timeout")
+        return _Resp()
+
+    monkeypatch.setenv(d._ENV_TIMEOUT, "99")
+    session = types.SimpleNamespace(get=fake_get)
+    d.download("https://example.invalid/x", session=session, timeout=7)
+    assert seen["timeout"] == 7, "explicit timeout kwarg was overridden by the environment"

--- a/tests/test_dl_utils.py
+++ b/tests/test_dl_utils.py
@@ -354,3 +354,39 @@ def test_explicit_kwarg_beats_the_environment(monkeypatch):
     session = types.SimpleNamespace(get=fake_get)
     d.download("https://example.invalid/x", session=session, timeout=7)
     assert seen["timeout"] == 7, "explicit timeout kwarg was overridden by the environment"
+
+
+def test_explicit_none_timeout_still_means_no_timeout(monkeypatch):
+    """``timeout=None`` is meaningful to requests: wait forever.
+
+    Defaulting the parameter to ``None`` would have silently reinterpreted that as
+    "use 30s", changing behaviour for anyone who passed it deliberately. A sentinel
+    keeps "omitted" and "explicitly None" apart, so only the omitted case consults
+    the environment.
+    """
+    from sportsdataverse import dl_utils as d
+
+    seen = {}
+
+    class _Resp:
+        status_code = 200
+        content = b"{}"
+        url = "https://example.invalid/x"
+        headers: dict = {}
+
+        def json(self):
+            return {}
+
+    def fake_get(url, **kw):
+        seen["timeout"] = kw.get("timeout", "absent")
+        return _Resp()
+
+    monkeypatch.setenv(d._ENV_TIMEOUT, "99")
+    session = types.SimpleNamespace(get=fake_get)
+
+    d.download("https://example.invalid/x", session=session, timeout=None)
+    assert seen["timeout"] is None, "explicit None must reach requests as None (no timeout)"
+
+    # omitted -> the environment applies
+    d.download("https://example.invalid/x", session=session)
+    assert seen["timeout"] == 99

--- a/tests/test_dl_utils.py
+++ b/tests/test_dl_utils.py
@@ -390,3 +390,27 @@ def test_explicit_none_timeout_still_means_no_timeout(monkeypatch):
     # omitted -> the environment applies
     d.download("https://example.invalid/x", session=session)
     assert seen["timeout"] == 99
+
+
+def test_none_num_retries_is_treated_as_omitted(monkeypatch):
+    """``num_retries=None`` resolves to the default instead of raising.
+
+    Asymmetric with ``timeout`` on purpose: ``None`` has no "infinite retries"
+    reading, and on main it reached ``int(None)`` and raised ``TypeError``. This
+    only widens what is accepted.
+    """
+    from sportsdataverse import dl_utils as d
+
+    class _Resp:
+        status_code = 200
+        content = b"{}"
+        url = "https://example.invalid/x"
+        headers: dict = {}
+
+        def json(self):
+            return {}
+
+    session = types.SimpleNamespace(get=lambda url, **kw: _Resp())
+    monkeypatch.setenv(d._ENV_RETRIES, "4")
+    # would raise TypeError before this change
+    assert d.download("https://example.invalid/x", session=session, num_retries=None) is not None

--- a/tools/codegen/generate.py
+++ b/tools/codegen/generate.py
@@ -3525,11 +3525,19 @@ def build_docs() -> list[Path]:
     return sorted(written)
 
 
-def _docs_stale() -> list[str]:
+def _docs_stale(rendered: dict[str, str] | None = None) -> list[str]:
     """Live docs/docs generated files that differ from a fresh render. Orphan-checks
     ONLY the fully-generated roots (league dirs + reference/) so preserved conceptual
-    pages outside them are never flagged."""
-    rendered = _render_docs_all()
+    pages outside them are never flagged.
+
+    Args:
+        rendered: An already-rendered docs corpus to compare against. Defaults to
+            ``None``, which renders one. Rendering the docs tree is the single most
+            expensive operation in the test suite, and callers that already hold a
+            corpus (see ``tests/codegen/conftest.py``) can pass it instead of paying
+            for an identical second render.
+    """
+    rendered = _render_docs_all() if rendered is None else rendered
     stale = []
     for rel, content in rendered.items():
         f = DOCS / rel


### PR DESCRIPTION
## The problem

The test job ran **60-100 minutes** and was routinely cancelled by the next merge before finishing — every recent run reads `cancelled`. In practice it verified nothing.

Profiling showed the cost was **not** spread across 6,000 tests. Four were **2,222s of a 2,755s offline run (81%)**, and almost all of it was the same work repeated: `_render_docs_all()` ran four to five times per session.

## The fix, measured

Only the determinism test needs a second render — that *is* its assertion. The other two just needed *a* corpus, so a session-scoped cache (`tests/codegen/conftest.py`) renders once and shares it.

| | before | after |
|---|---:|---:|
| `test_render_is_deterministic[_render_docs_all]` | 964.8s | 613.4s |
| `test_rendered_content_is_lf_only` | 416.9s | **<5s** |
| `test_generated_docs_tree_is_current` | 320.3s | **<5s** |
| `tests/codegen` (whole dir, serial) | 1043.6s | 678.9s |
| **offline job, exactly as CI runs it** | 60-100 min | **985s — 5,542 passed, 0 failed** |

Determinism still compares two **independent** invocations, so the property under test is unchanged; it just stops re-deriving input another test already produced. `_docs_stale()` gains an optional `rendered=` argument as the injection point, with default behaviour untouched.

## Why `--dist loadgroup` is load-bearing

A session fixture is scoped to a **worker**, not the run. Under `-n auto` these three tests can land on three workers and each re-renders, silently undoing the entire saving. They are marked `xdist_group("codegen_render")` and CI passes `--dist loadgroup` to pin them to one worker while the rest of the suite spreads out. This is correctness for the optimisation, not a tuning knob.

## CI-level dedupe

`codegen.yml` already runs **both** `tests/codegen/` and `generate.py --check`, on ubuntu, on the same triggers. The offline job now skips them — roughly 11 min per run for no extra signal. A bare `uv run pytest` locally still runs everything, and the pre-push hook still gates the drift check.

## Job split

- **offline** (ubuntu, parallel, no live network, no coverage) — fast enough to run on PRs again, restoring the merge-time signal removed on 2026-08-12.
- **live** (macOS, live APIs) — kept off the PR path.

macOS is **deliberately retained** rather than moved wholesale to ubuntu: it is currently the only platform under test, and the only job exercising the xgboost/`libomp` import path (which has its own dedicated step).

## Retry budget

`download()` hardcoded 15 retries at a 30s timeout with no override, so one unreachable host could park a single call for 15 x 30s plus backoff — right for a scraper that must not lose a game, wrong for a test suite.

`SDV_PY_HTTP_RETRIES` / `SDV_PY_HTTP_TIMEOUT` are now read **at call time** (so CI can set them after import). Defaults unchanged at 15/30, an explicit kwarg still wins, and a malformed or non-positive value falls back rather than raising — this runs on every request, so a typo must not take the process down. The live job sets 3/15. Four tests cover each rule.

## Gates

ruff clean · ruff format (1,286 files) · mypy clean (400 files) · codegen drift current · `tests/codegen` 168 passed under `-n auto --dist loadgroup` · offline job 5,542 passed / 0 failed.

## Note for reviewers

`uv.lock` on main is stale — `pyproject.toml` says `0.1.2`, the lock says `0.1.1`. I deliberately kept that out of this PR. It is **not** breaking CI (`uv sync --frozen` tolerates a local project-version mismatch; verified), but it wants a separate deliberate re-lock.

## Summary by Sourcery

Restore practical CI feedback by eliminating redundant code-generation work, splitting offline and live test execution, and bounding live API retry budgets.

Bug Fixes:
- Allow HTTP retry counts and timeouts to be configured through environment variables while preserving existing defaults and explicit argument precedence.

Enhancements:
- Cache shared code-generation renders to avoid redundant documentation-tree generation while preserving determinism checks.
- Allow documentation staleness checks to consume an already-rendered corpus.

CI:
- Split CI into a fast parallel offline test job that runs on pull requests and a macOS live-API job that remains off the pull-request path.
- Use xdist load-group scheduling for code-generation tests and remove duplicate codegen checks from the offline job.
- Bound live-job HTTP retries and timeouts through CI environment settings.

Tests:
- Add coverage for environment-configured HTTP retry behavior and argument precedence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP request retry counts and timeouts can now be configured through environment variables.
  * Explicit request settings, including disabling timeouts, take priority over environment defaults.
  * Invalid or non-positive configuration values safely fall back to standard defaults.

* **Bug Fixes**
  * Improved validation reliability and reduced unnecessary repeated generated-content rendering.

* **Tests**
  * Added coverage for configurable request behavior, fallback handling, and deterministic generated output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->