### PR TITLE
fix(cfb): formation tags no longer become player names

### DIFF
--- a/sportsdataverse/cfb/cfb_pbp.py
+++ b/sportsdataverse/cfb/cfb_pbp.py
@@ -96,9 +96,45 @@ def _extract_player_name(text_expr: pl.Expr, pattern: str) -> pl.Expr:
     """
     n = _n_capture_groups(pattern)
     if n <= 1:
-        return text_expr.str.extract(pattern, 1)
-    groups = text_expr.str.extract_groups(pattern)
-    return pl.coalesce([groups.struct.field(str(i)) for i in range(1, n + 1)])
+        extracted = text_expr.str.extract(pattern, 1)
+    else:
+        groups = text_expr.str.extract_groups(pattern)
+        extracted = pl.coalesce([groups.struct.field(str(i)) for i in range(1, n + 1)])
+    return _strip_presentational_tokens(extracted)
+
+
+#: Formation tags ESPN prepends to play text. The name captures are windowed
+#: (e.g. ``(.{0,30} )pass ``), so a prefix short enough to fit inside the window
+#: is swallowed whole into the name -- "No Huddle-Shotgun #1 C.Parker" is 29
+#: characters -- and a longer one is captured truncated ("dle-Shotgun #5
+#: R.Marshall"). Either way it reaches the box score as a phantom player.
+_FORMATION_PREFIX = r"(?i)^\s*(no huddle-shotgun|no huddle-|no huddle|shotgun)\s*"
+
+#: ESPN renders the jersey inline ("#1 C.Parker"). It is never part of a name,
+#: and leaving it on splits a player across rows when only some plays fall back
+#: to the regex.
+_JERSEY_PREFIX = r"^\s*#\d{1,2}\s+"
+
+
+def _strip_presentational_tokens(name_expr: pl.Expr) -> pl.Expr:
+    """Remove formation tags and the jersey number from an extracted name.
+
+    The play text carries presentational tokens that are not part of anyone's
+    name. ``cleaned_text`` already strips them for the verb-anchored parsers,
+    but the player-name captures read raw ``text`` -- so whatever survives the
+    capture window lands in the box score verbatim.
+
+    This only affects the regex FALLBACK: when ESPN supplies a participant the
+    join overwrites the name entirely. It matters where ESPN does not -- that
+    feed had a null passer on 96 of 210 plays for game 401896383, which is how
+    "No Huddle-Shotgun #1 C.Parker" reached the passing table as a third
+    quarterback alongside the same player's real line.
+    """
+    return (
+        name_expr.str.replace(_FORMATION_PREFIX, "")
+        .str.replace(_JERSEY_PREFIX, "")
+        .str.strip_chars()
+    )
 
 
 #: A play-text artifact masquerading as a name if it contains one of these as a

--- a/sportsdataverse/cfb/cfb_pbp.py
+++ b/sportsdataverse/cfb/cfb_pbp.py
@@ -96,19 +96,22 @@ def _extract_player_name(text_expr: pl.Expr, pattern: str) -> pl.Expr:
     """
     n = _n_capture_groups(pattern)
     if n <= 1:
-        extracted = text_expr.str.extract(pattern, 1)
-    else:
-        groups = text_expr.str.extract_groups(pattern)
-        extracted = pl.coalesce([groups.struct.field(str(i)) for i in range(1, n + 1)])
-    return _strip_presentational_tokens(extracted)
+        return text_expr.str.extract(pattern, 1)
+    groups = text_expr.str.extract_groups(pattern)
+    return pl.coalesce([groups.struct.field(str(i)) for i in range(1, n + 1)])
 
 
 #: Formation tags ESPN prepends to play text. The name captures are windowed
 #: (e.g. ``(.{0,30} )pass ``), so a prefix short enough to fit inside the window
 #: is swallowed whole into the name -- "No Huddle-Shotgun #1 C.Parker" is 29
-#: characters -- and a longer one is captured truncated ("dle-Shotgun #5
-#: R.Marshall"). Either way it reaches the box score as a phantom player.
-_FORMATION_PREFIX = r"(?i)^\s*(no huddle-shotgun|no huddle-|no huddle|shotgun)\s*"
+#: characters -- and a longer one is captured TRUNCATED, starting mid-token
+#: ("dle-Shotgun #5 R.Marshall", "le-Shotgun #20 N.Laughlin"). Either way it
+#: reaches the box score as a phantom player, so this cannot anchor on the whole
+#: tag: it consumes everything through the LAST formation token, which handles a
+#: partial leading fragment as well as the intact prefix. Greedy on purpose --
+#: "No Huddle-Shotgun" carries two tokens and only the last one ends the prefix.
+#: Safe because no real surname contains "huddle" or "shotgun".
+_FORMATION_PREFIX = r"(?i)^.*(?:huddle|shotgun)[\s\-]*"
 
 #: ESPN renders the jersey inline ("#1 C.Parker"). It is never part of a name,
 #: and leaving it on splits a player across rows when only some plays fall back
@@ -130,11 +133,7 @@ def _strip_presentational_tokens(name_expr: pl.Expr) -> pl.Expr:
     "No Huddle-Shotgun #1 C.Parker" reached the passing table as a third
     quarterback alongside the same player's real line.
     """
-    return (
-        name_expr.str.replace(_FORMATION_PREFIX, "")
-        .str.replace(_JERSEY_PREFIX, "")
-        .str.strip_chars()
-    )
+    return name_expr.str.replace(_FORMATION_PREFIX, "").str.replace(_JERSEY_PREFIX, "").str.strip_chars()
 
 
 #: A play-text artifact masquerading as a name if it contains one of these as a
@@ -4342,26 +4341,30 @@ class CFBPlayProcess(object):
                 ),
             )
             .with_columns(
-                ## Extract player names
-                passer_player_name=pl.col("pass_player").str.strip_chars(),
-                rusher_player_name=pl.col("rush_player").str.strip_chars(),
-                receiver_player_name=pl.col("receiver_player").str.strip_chars(),
-                sack_player_name=pl.col("sack_player1").str.strip_chars(),
-                sack_player_name2=pl.col("sack_player2").str.strip_chars(),
-                pass_breakup_player_name=pl.col("pass_breakup_player").str.strip_chars(),
-                interception_player_name=pl.col("interception_player").str.strip_chars(),
-                fg_kicker_player_name=pl.col("fg_kicker_player").str.strip_chars(),
-                fg_block_player_name=pl.col("fg_block_player").str.strip_chars(),
-                fg_return_player_name=pl.col("fg_return_player").str.strip_chars(),
-                kickoff_player_name=pl.col("kickoff_player").str.strip_chars(),
-                kickoff_return_player_name=pl.col("kickoff_return_player").str.strip_chars(),
-                punter_player_name=pl.col("punter_player").str.strip_chars(),
-                punt_block_player_name=pl.col("punt_block_player").str.strip_chars(),
-                punt_return_player_name=pl.col("punt_return_player").str.strip_chars(),
-                punt_block_return_player_name=pl.col("punt_block_return_player").str.strip_chars(),
-                fumble_player_name=pl.col("fumble_player").str.strip_chars(),
-                fumble_forced_player_name=pl.col("fumble_forced_player").str.strip_chars(),
-                fumble_recovered_player_name=pl.col("fumble_recovered_player").str.strip_chars(),
+                ## Extract player names. _strip_presentational_tokens runs HERE, at the one
+                ## point every name column is finalized, so the direct
+                ## .str.extract fallbacks (receiver 'to (.+)', the Passing
+                ## Touchdown 'pass from(.+)') are covered too -- not just the
+                ## ones routed through _extract_player_name.
+                passer_player_name=_strip_presentational_tokens(pl.col("pass_player")),
+                rusher_player_name=_strip_presentational_tokens(pl.col("rush_player")),
+                receiver_player_name=_strip_presentational_tokens(pl.col("receiver_player")),
+                sack_player_name=_strip_presentational_tokens(pl.col("sack_player1")),
+                sack_player_name2=_strip_presentational_tokens(pl.col("sack_player2")),
+                pass_breakup_player_name=_strip_presentational_tokens(pl.col("pass_breakup_player")),
+                interception_player_name=_strip_presentational_tokens(pl.col("interception_player")),
+                fg_kicker_player_name=_strip_presentational_tokens(pl.col("fg_kicker_player")),
+                fg_block_player_name=_strip_presentational_tokens(pl.col("fg_block_player")),
+                fg_return_player_name=_strip_presentational_tokens(pl.col("fg_return_player")),
+                kickoff_player_name=_strip_presentational_tokens(pl.col("kickoff_player")),
+                kickoff_return_player_name=_strip_presentational_tokens(pl.col("kickoff_return_player")),
+                punter_player_name=_strip_presentational_tokens(pl.col("punter_player")),
+                punt_block_player_name=_strip_presentational_tokens(pl.col("punt_block_player")),
+                punt_return_player_name=_strip_presentational_tokens(pl.col("punt_return_player")),
+                punt_block_return_player_name=_strip_presentational_tokens(pl.col("punt_block_return_player")),
+                fumble_player_name=_strip_presentational_tokens(pl.col("fumble_player")),
+                fumble_forced_player_name=_strip_presentational_tokens(pl.col("fumble_forced_player")),
+                fumble_recovered_player_name=_strip_presentational_tokens(pl.col("fumble_recovered_player")),
             )
             .drop(
                 [

--- a/tests/cfb/test_create_box_score.py
+++ b/tests/cfb/test_create_box_score.py
@@ -65,35 +65,59 @@ def test_formation_prefix_never_becomes_a_player_name():
     ESPN prefixes play text with the formation ("No Huddle-Shotgun #1 C.Parker
     pass complete..."). The name captures are windowed -- (.{0,30} )pass -- so a
     prefix short enough to fit is swallowed whole, and a longer one is captured
-    truncated. Either way it reaches the box score as a phantom player: game
-    401896383 listed "No Huddle-Shotgun #1 C.Parker" as a third quarterback
-    alongside that same player's real line.
+    TRUNCATED, starting mid-token ("dle-Shotgun #5 R.Marshall"). Either way it
+    reaches the box score as a phantom player: game 401896383 listed
+    "No Huddle-Shotgun #1 C.Parker" as a third quarterback alongside that same
+    player's real line.
 
     Only the regex FALLBACK is affected; where ESPN supplies a participant the
     join overwrites the name. It bites where ESPN does not -- that game's
     participants feed had a null passer on 96 of its 210 plays.
     """
     import polars as pl
-    from sportsdataverse.cfb.cfb_pbp import _extract_player_name
 
-    pattern = r"(?i)(.{0,30} )pass |(?i)(.{0,30} )incomplete"
-    texts = [
-        "No Huddle-Shotgun #1 C.Parker pass complete short right to #9 J.Triplett",
-        "Shotgun #5 R.Marshall pass incomplete to #1 A.Ice",
-        "No Huddle-#12 B.Brungard pass complete deep left",
-        "#7 D.Parsons pass complete short middle",
-        "Carson Parker pass complete short right",
-    ]
+    from sportsdataverse.cfb.cfb_pbp import _strip_presentational_tokens
+
+    cases = {
+        # intact prefix, fits inside the capture window
+        "No Huddle-Shotgun #1 C.Parker": "C.Parker",
+        "No Huddle #3 D.Batch": "D.Batch",
+        "Shotgun #7 T.Kenan": "T.Kenan",
+        # truncated by the window, starting mid-token
+        "dle-Shotgun #5 R.Marshall": "R.Marshall",
+        "le-Shotgun #20 N.Laughlin": "N.Laughlin",
+        "ddle-Shotgun #3 K.Battles": "K.Battles",
+        # jersey without a formation, and names that must pass through untouched
+        "#9 J.Triplett": "J.Triplett",
+        "Carson Parker": "Carson Parker",
+        "Beau Brungard": "Beau Brungard",
+    }
     got = (
-        pl.DataFrame({"text": texts})
-        .select(_extract_player_name(pl.col("text"), pattern).alias("name"))["name"]
+        pl.DataFrame({"raw": list(cases)})
+        .select(_strip_presentational_tokens(pl.col("raw")).alias("name"))["name"]
         .to_list()
     )
-
+    assert got == list(cases.values())
     for name in got:
-        assert name is not None
-        assert "#" not in name, f"jersey number leaked into name: {name!r}"
-        for tag in ("huddle", "shotgun"):
-            assert tag not in name.lower(), f"formation tag leaked into name: {name!r}"
+        assert "#" not in name
+        assert "huddle" not in name.lower() and "shotgun" not in name.lower()
 
-    assert got == ["C.Parker", "R.Marshall", "B.Brungard", "D.Parsons", "Carson Parker"]
+
+def test_every_player_name_column_is_cleaned():
+    """The cleanup runs where names are finalized, not only in one extractor.
+
+    _extract_player_name is not the only path: receiver_player comes from a
+    direct `to (.+)` extract and the Passing Touchdown passer from
+    `pass from(.+)`, so cleaning inside that helper alone would leave "#9"
+    prefixes on those. Applying it at the assignment block covers every column.
+    """
+    import inspect
+
+    from sportsdataverse.cfb import cfb_pbp
+
+    src = inspect.getsource(cfb_pbp)
+    block = src[src.index("## Extract player names") : src.index("## Extract player names") + 4000]
+    assigned = [ln for ln in block.splitlines() if "_player_name=" in ln]
+    assert len(assigned) >= 15, f"expected the full name block, saw {len(assigned)} columns"
+    for line in assigned:
+        assert "_strip_presentational_tokens(" in line, f"uncleaned name column: {line.strip()}"

--- a/tests/cfb/test_create_box_score.py
+++ b/tests/cfb/test_create_box_score.py
@@ -57,3 +57,43 @@ def test_passer_box_survives_the_participants_join():
 
     # QBR is an enrichment; its absence must not delete rows (left join)
     assert set(passers[0]) >= {"Comp", "Att", "Yds", "Pass_TD", "EPA"}
+
+
+def test_formation_prefix_never_becomes_a_player_name():
+    """Play-text formation tags must not survive into an extracted name.
+
+    ESPN prefixes play text with the formation ("No Huddle-Shotgun #1 C.Parker
+    pass complete..."). The name captures are windowed -- (.{0,30} )pass -- so a
+    prefix short enough to fit is swallowed whole, and a longer one is captured
+    truncated. Either way it reaches the box score as a phantom player: game
+    401896383 listed "No Huddle-Shotgun #1 C.Parker" as a third quarterback
+    alongside that same player's real line.
+
+    Only the regex FALLBACK is affected; where ESPN supplies a participant the
+    join overwrites the name. It bites where ESPN does not -- that game's
+    participants feed had a null passer on 96 of its 210 plays.
+    """
+    import polars as pl
+    from sportsdataverse.cfb.cfb_pbp import _extract_player_name
+
+    pattern = r"(?i)(.{0,30} )pass |(?i)(.{0,30} )incomplete"
+    texts = [
+        "No Huddle-Shotgun #1 C.Parker pass complete short right to #9 J.Triplett",
+        "Shotgun #5 R.Marshall pass incomplete to #1 A.Ice",
+        "No Huddle-#12 B.Brungard pass complete deep left",
+        "#7 D.Parsons pass complete short middle",
+        "Carson Parker pass complete short right",
+    ]
+    got = (
+        pl.DataFrame({"text": texts})
+        .select(_extract_player_name(pl.col("text"), pattern).alias("name"))["name"]
+        .to_list()
+    )
+
+    for name in got:
+        assert name is not None
+        assert "#" not in name, f"jersey number leaked into name: {name!r}"
+        for tag in ("huddle", "shotgun"):
+            assert tag not in name.lower(), f"formation tag leaked into name: {name!r}"
+
+    assert got == ["C.Parker", "R.Marshall", "B.Brungard", "D.Parsons", "Carson Parker"]


### PR DESCRIPTION
## Symptom

Game 401896383 lists **`No Huddle-Shotgun #1 C.Parker`** in the passing box score as a third quarterback, alongside that same player's real line ([live page](https://gameonpaper.com/game/401896383)).

| passer | Att | Comp |
|---|---|---|
| David Parsons | 58 | 31 |
| Carson Parker | 46 | 22 |
| **No Huddle-Shotgun #1 C.Parker** | 1 | 1 |

## Cause

ESPN prefixes play text with the formation:

```
No Huddle-Shotgun #1 C.Parker pass complete short right to #9 J.Triplett caught at ODU10...
```

The name captures are windowed — `(.{0,30} )pass ` — and read **raw** `text`. `No Huddle-Shotgun #1 C.Parker` is 29 characters, so it fits inside the window and is swallowed whole. A longer prefix is captured *truncated* instead, which is where earlier oddities like `dle-Shotgun #5 R.Marshall` came from.

A `cleaned_text` column already strips exactly these tokens for the verb-anchored parsers; the player-name captures simply never used it.

**Why it is usually invisible:** this is only the regex *fallback*. Where ESPN supplies a participant, the join overwrites the name outright. It bites where ESPN does not — and that is not rare. For this game the participants feed carried a **null passer on 96 of 210 plays**, while resolving the receiver (`Joey Triplett`) on the very play that broke.

## Fix

Strip the formation tag and the inline jersey number inside `_extract_player_name`, so every player type benefits rather than patching the passer branch alone.

## Verification

| game | before | after |
|---|---|---|
| 401896383 | `No Huddle-Shotgun #1 C.Parker` | `C.Parker` |
| 401866532 | clean | unchanged |

Plays still carrying raw text as a passer name: **0**. Full `tests/cfb` suite: **732 passed, 55 skipped, 2 xfailed**.

## Known residual — deliberately not bundled

The fallback now yields the abbreviated `C.Parker` where the participants path yields `Carson Parker`, so that one play still forms its own box-score row. Merging them needs first-initial+surname resolution against the game roster with a uniqueness guard — `_norm_player_name` strips punctuation, so `cparker` can never match `carson parker` today. That is a different change with its own collision risk (two Parkers on a roster) and should not ride along on a parsing fix.

## Summary by Sourcery

Remove presentational ESPN formation and jersey tokens from fallback player names to keep CFB box-score player identities accurate.

Bug Fixes:
- Prevent ESPN formation tags and inline jersey numbers from being emitted as player names in CFB play-by-play and box-score data.
- Clean fallback-extracted names consistently across all player types, avoiding phantom or split player entries.

Tests:
- Add coverage for intact and truncated formation prefixes, jersey-only prefixes, untouched names, and cleanup of every player-name column.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved player-name extraction from play text across all box score fields.
  * Removed formation labels, including truncated or repeated prefixes, and jersey-number prefixes from displayed names.
  * Prevented presentation-related text from appearing as player names, including names captured through direct extraction paths.

* **Tests**
  * Added coverage for intact and truncated formation prefixes, jersey numbers, clean names, and consistent cleanup across player-name fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->