### PR TITLE
ci: dispatch the Game on Paper deploy on every push to main

### DIFF
--- a/.github/workflows/deploy-gop.yml
+++ b/.github/workflows/deploy-gop.yml
@@ -1,0 +1,37 @@
+name: dispatch Game on Paper deploy
+
+# Game on Paper builds its API image against this repo's main at build time
+# (python/Dockerfile re-resolves the sportsdataverse pin). A merge here does
+# nothing for the site until that image is rebuilt, so tell it to rebuild.
+#
+# Cross-repo dispatch needs a token with `repo` scope on game-on-paper-app;
+# GITHUB_TOKEN is scoped to this repository only. Until the GOP_DEPLOY_TOKEN
+# secret exists this job explains itself and exits green rather than failing
+# every push to main.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "sportsdataverse/**"
+      - "pyproject.toml"
+      - "uv.lock"
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger game-on-paper-app deploy
+        env:
+          TOKEN: ${{ secrets.GOP_DEPLOY_TOKEN }}
+        run: |
+          if [ -z "$TOKEN" ]; then
+            echo "::notice::GOP_DEPLOY_TOKEN is not set; skipping the Game on Paper deploy dispatch."
+            exit 0
+          fi
+          curl --fail-with-body -sS -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $TOKEN" \
+            https://api.github.com/repos/saiemgilani/game-on-paper-app/dispatches \
+            -d "{\"event_type\":\"deploy\",\"client_payload\":{\"sportsdataverse_py_sha\":\"${GITHUB_SHA}\"}}"
+          echo "dispatched deploy for sportsdataverse-py ${GITHUB_SHA}"

--- a/.github/workflows/deploy-gop.yml
+++ b/.github/workflows/deploy-gop.yml
@@ -1,13 +1,17 @@
-name: dispatch Game on Paper deploy
+name: dispatch Game on Paper deploy (package pushes to main)
 
 # Game on Paper builds its API image against this repo's main at build time
 # (python/Dockerfile re-resolves the sportsdataverse pin). A merge here does
-# nothing for the site until that image is rebuilt, so tell it to rebuild.
+# nothing for the site until that image is rebuilt, so tell it to rebuild --
+# on pushes to main that touch the package or its dependency pins. Docs-only
+# and CI-only pushes do not trigger a deploy; that is the `paths` filter below.
 #
-# Cross-repo dispatch needs a token with `repo` scope on game-on-paper-app;
-# GITHUB_TOKEN is scoped to this repository only. Until the GOP_DEPLOY_TOKEN
-# secret exists this job explains itself and exits green rather than failing
-# every push to main.
+# Cross-repo dispatch needs a token with access to game-on-paper-app;
+# GITHUB_TOKEN is scoped to this repository only. Least privilege for the
+# repository_dispatch endpoint is a fine-grained PAT with `Contents: read` on
+# saiemgilani/game-on-paper-app -- not the classic `repo` scope. Until the
+# GOP_DEPLOY_TOKEN secret exists this job explains itself and exits green
+# rather than failing every push to main.
 
 on:
   push:


### PR DESCRIPTION
CodeRabbit: the repository_dispatch endpoint needs a fine-grained PAT with
Contents: read on game-on-paper-app, not the classic repo scope -- the comment
said repo. And the comment promised 'every push to main' while the paths filter
restricts it to the package and its pins; the filter is the intent (docs-only
pushes should not redeploy the site), so the comment and the workflow name now
say so.

**Needs one secret to become live:** `GOP_DEPLOY_TOKEN` on this repo — a fine-grained PAT with **Contents: read** on `saiemgilani/game-on-paper-app` (least privilege for `repository_dispatch`). Until it exists the job prints a notice and passes.

## Summary by Sourcery

Trigger Game on Paper deployments for relevant changes merged into main.

New Features:
- Add a workflow that dispatches the Game on Paper deployment when package or dependency changes reach main.

Enhancements:
- Limit deployment dispatches to relevant package and dependency updates while allowing pushes to pass cleanly when the deployment token is unavailable.

CI:
- Configure cross-repository deployment triggering with an optional least-privilege deployment token.

Deployment:
- Pass the source commit SHA to the Game on Paper deployment workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated deployment updates when relevant sports data or project configuration changes are merged.
  * Deployment notifications now include the specific source revision, improving release consistency and traceability.
  * Missing deployment credentials are handled gracefully without causing unrelated workflow failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->