### PR TITLE
docs: complete the social metadata on py.sportsdataverse.org

### DIFF
--- a/docs/docs/ahl/index.md
+++ b/docs/docs/ahl/index.md
@@ -1,6 +1,7 @@
 ---
 title: AHL
 sidebar_label: AHL
+description: "sdv-py AHL: endpoint references, dataset loaders and parsers for AHL in the SportsDataverse Python package."
 ---
 # AHL (`sportsdataverse.ahl`)
 

--- a/docs/docs/ahl/reference/additional.md
+++ b/docs/docs/ahl/reference/additional.md
@@ -1,6 +1,7 @@
 ---
 title: AHL — additional Python functions
 sidebar_label: Additional functions
+description: "AHL — additional Python functions — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: 50
 ---
 # AHL — additional Python functions

--- a/docs/docs/ajhl/index.md
+++ b/docs/docs/ajhl/index.md
@@ -1,6 +1,7 @@
 ---
 title: AJHL
 sidebar_label: AJHL
+description: "sdv-py AJHL: endpoint references, dataset loaders and parsers for AJHL in the SportsDataverse Python package."
 ---
 # AJHL (`sportsdataverse.ajhl`)
 

--- a/docs/docs/ajhl/reference/additional.md
+++ b/docs/docs/ajhl/reference/additional.md
@@ -1,6 +1,7 @@
 ---
 title: AJHL — additional Python functions
 sidebar_label: Additional functions
+description: "AJHL — additional Python functions — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: 50
 ---
 # AJHL — additional Python functions

--- a/docs/docs/bchl/index.md
+++ b/docs/docs/bchl/index.md
@@ -1,6 +1,7 @@
 ---
 title: BCHL
 sidebar_label: BCHL
+description: "sdv-py BCHL: endpoint references, dataset loaders and parsers for BCHL in the SportsDataverse Python package."
 ---
 # BCHL (`sportsdataverse.bchl`)
 

--- a/docs/docs/bchl/reference/additional.md
+++ b/docs/docs/bchl/reference/additional.md
@@ -1,6 +1,7 @@
 ---
 title: BCHL — additional Python functions
 sidebar_label: Additional functions
+description: "BCHL — additional Python functions — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: 50
 ---
 # BCHL — additional Python functions

--- a/docs/docs/bundesliga/index.md
+++ b/docs/docs/bundesliga/index.md
@@ -1,6 +1,7 @@
 ---
 title: BUNDESLIGA
 sidebar_label: BUNDESLIGA
+description: "sdv-py BUNDESLIGA: endpoint references, dataset loaders and parsers for BUNDESLIGA in the SportsDataverse Python package."
 ---
 # BUNDESLIGA (`sportsdataverse.bundesliga`)
 

--- a/docs/docs/bundesliga/reference/core.md
+++ b/docs/docs/bundesliga/reference/core.md
@@ -1,6 +1,7 @@
 ---
 title: BUNDESLIGA — ESPN core API (v2)
 sidebar_label: ESPN core API (v2)
+description: "BUNDESLIGA — ESPN core API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 22
 ---
 # BUNDESLIGA — ESPN core API (v2)

--- a/docs/docs/bundesliga/reference/fitt.md
+++ b/docs/docs/bundesliga/reference/fitt.md
@@ -1,6 +1,7 @@
 ---
 title: BUNDESLIGA — ESPN FPI API (fitt v3)
 sidebar_label: ESPN FPI API (fitt v3)
+description: "BUNDESLIGA — ESPN FPI API (fitt v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 23
 ---
 # BUNDESLIGA — ESPN FPI API (fitt v3)

--- a/docs/docs/bundesliga/reference/site.md
+++ b/docs/docs/bundesliga/reference/site.md
@@ -1,6 +1,7 @@
 ---
 title: BUNDESLIGA — ESPN site API (v2)
 sidebar_label: ESPN site API (v2)
+description: "BUNDESLIGA — ESPN site API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 20
 ---
 # BUNDESLIGA — ESPN site API (v2)

--- a/docs/docs/bundesliga/reference/web.md
+++ b/docs/docs/bundesliga/reference/web.md
@@ -1,6 +1,7 @@
 ---
 title: BUNDESLIGA — ESPN web API (v3)
 sidebar_label: ESPN web API (v3)
+description: "BUNDESLIGA — ESPN web API (v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 21
 ---
 # BUNDESLIGA — ESPN web API (v3)

--- a/docs/docs/cchl/index.md
+++ b/docs/docs/cchl/index.md
@@ -1,6 +1,7 @@
 ---
 title: CCHL
 sidebar_label: CCHL
+description: "sdv-py CCHL: endpoint references, dataset loaders and parsers for CCHL in the SportsDataverse Python package."
 ---
 # CCHL (`sportsdataverse.cchl`)
 

--- a/docs/docs/cchl/reference/additional.md
+++ b/docs/docs/cchl/reference/additional.md
@@ -1,6 +1,7 @@
 ---
 title: CCHL — additional Python functions
 sidebar_label: Additional functions
+description: "CCHL — additional Python functions — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: 50
 ---
 # CCHL — additional Python functions

--- a/docs/docs/cfb/index.md
+++ b/docs/docs/cfb/index.md
@@ -1,6 +1,7 @@
 ---
 title: CFB
 sidebar_label: CFB
+description: "sdv-py CFB: endpoint references, dataset loaders and parsers for CFB in the SportsDataverse Python package."
 ---
 # CFB (`sportsdataverse.cfb`)
 

--- a/docs/docs/cfb/reference/additional.md
+++ b/docs/docs/cfb/reference/additional.md
@@ -1,6 +1,7 @@
 ---
 title: CFB — additional Python functions
 sidebar_label: Additional functions
+description: "CFB — additional Python functions — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: 50
 ---
 # CFB — additional Python functions

--- a/docs/docs/cfb/reference/core.md
+++ b/docs/docs/cfb/reference/core.md
@@ -1,6 +1,7 @@
 ---
 title: CFB — ESPN core API (v2)
 sidebar_label: ESPN core API (v2)
+description: "CFB — ESPN core API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 22
 ---
 # CFB — ESPN core API (v2)

--- a/docs/docs/cfb/reference/fitt.md
+++ b/docs/docs/cfb/reference/fitt.md
@@ -1,6 +1,7 @@
 ---
 title: CFB — ESPN FPI API (fitt v3)
 sidebar_label: ESPN FPI API (fitt v3)
+description: "CFB — ESPN FPI API (fitt v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 23
 ---
 # CFB — ESPN FPI API (fitt v3)

--- a/docs/docs/cfb/reference/loaders.md
+++ b/docs/docs/cfb/reference/loaders.md
@@ -1,6 +1,7 @@
 ---
 title: CFB dataset loaders
 sidebar_label: Loaders
+description: "CFB dataset loaders in sdv-py: the load_* functions that read the SportsDataverse release assets."
 sidebar_position: 1
 ---
 # CFB dataset loaders

--- a/docs/docs/cfb/reference/on3.md
+++ b/docs/docs/cfb/reference/on3.md
@@ -1,6 +1,7 @@
 ---
 title: CFB — On3 Recruit Database (api.on3.com)
 sidebar_label: On3 Recruit Database (api.on3.com)
+description: "CFB — On3 Recruit Database (api.on3.com) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 10
 ---
 # CFB — On3 Recruit Database (api.on3.com)

--- a/docs/docs/cfb/reference/site.md
+++ b/docs/docs/cfb/reference/site.md
@@ -1,6 +1,7 @@
 ---
 title: CFB — ESPN site API (v2)
 sidebar_label: ESPN site API (v2)
+description: "CFB — ESPN site API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 20
 ---
 # CFB — ESPN site API (v2)

--- a/docs/docs/cfb/reference/sports247.md
+++ b/docs/docs/cfb/reference/sports247.md
@@ -1,6 +1,7 @@
 ---
 title: CFB — 247Sports Recruit Database (ipa.247sports.com)
 sidebar_label: 247Sports Recruit Database (ipa.247sports.com)
+description: "CFB — 247Sports Recruit Database (ipa.247sports.com) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 11
 ---
 # CFB — 247Sports Recruit Database (ipa.247sports.com)

--- a/docs/docs/cfb/reference/sports247_site_pages.md
+++ b/docs/docs/cfb/reference/sports247_site_pages.md
@@ -1,6 +1,7 @@
 ---
 title: CFB — 247Sports Site Pages (247sports.com)
 sidebar_label: 247Sports Site Pages (247sports.com)
+description: "CFB — 247Sports Site Pages (247sports.com) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 12
 ---
 # CFB — 247Sports Site Pages (247sports.com)

--- a/docs/docs/cfb/reference/web.md
+++ b/docs/docs/cfb/reference/web.md
@@ -1,6 +1,7 @@
 ---
 title: CFB — ESPN web API (v3)
 sidebar_label: ESPN web API (v3)
+description: "CFB — ESPN web API (v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 21
 ---
 # CFB — ESPN web API (v3)

--- a/docs/docs/cfl/index.md
+++ b/docs/docs/cfl/index.md
@@ -1,6 +1,7 @@
 ---
 title: CFL
 sidebar_label: CFL
+description: "sdv-py CFL: endpoint references, dataset loaders and parsers for CFL in the SportsDataverse Python package."
 ---
 # CFL (`sportsdataverse.cfl`)
 

--- a/docs/docs/cfl/reference/core.md
+++ b/docs/docs/cfl/reference/core.md
@@ -1,6 +1,7 @@
 ---
 title: CFL — ESPN core API (v2)
 sidebar_label: ESPN core API (v2)
+description: "CFL — ESPN core API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 22
 ---
 # CFL — ESPN core API (v2)

--- a/docs/docs/cfl/reference/fitt.md
+++ b/docs/docs/cfl/reference/fitt.md
@@ -1,6 +1,7 @@
 ---
 title: CFL — ESPN FPI API (fitt v3)
 sidebar_label: ESPN FPI API (fitt v3)
+description: "CFL — ESPN FPI API (fitt v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 23
 ---
 # CFL — ESPN FPI API (fitt v3)

--- a/docs/docs/cfl/reference/site.md
+++ b/docs/docs/cfl/reference/site.md
@@ -1,6 +1,7 @@
 ---
 title: CFL — ESPN site API (v2)
 sidebar_label: ESPN site API (v2)
+description: "CFL — ESPN site API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 20
 ---
 # CFL — ESPN site API (v2)

--- a/docs/docs/cfl/reference/web.md
+++ b/docs/docs/cfl/reference/web.md
@@ -1,6 +1,7 @@
 ---
 title: CFL — ESPN web API (v3)
 sidebar_label: ESPN web API (v3)
+description: "CFL — ESPN web API (v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 21
 ---
 # CFL — ESPN web API (v3)

--- a/docs/docs/chl/index.md
+++ b/docs/docs/chl/index.md
@@ -1,6 +1,7 @@
 ---
 title: CHL
 sidebar_label: CHL
+description: "sdv-py CHL: endpoint references, dataset loaders and parsers for CHL in the SportsDataverse Python package."
 ---
 # CHL (`sportsdataverse.chl`)
 

--- a/docs/docs/chl/reference/additional.md
+++ b/docs/docs/chl/reference/additional.md
@@ -1,6 +1,7 @@
 ---
 title: CHL — additional Python functions
 sidebar_label: Additional functions
+description: "CHL — additional Python functions — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: 50
 ---
 # CHL — additional Python functions

--- a/docs/docs/college_baseball/index.md
+++ b/docs/docs/college_baseball/index.md
@@ -1,6 +1,7 @@
 ---
 title: COLLEGE_BASEBALL
 sidebar_label: COLLEGE_BASEBALL
+description: "sdv-py COLLEGE_BASEBALL: endpoint references, dataset loaders and parsers for COLLEGE_BASEBALL in the SportsDataverse Python package."
 ---
 # COLLEGE_BASEBALL (`sportsdataverse.college_baseball`)
 

--- a/docs/docs/college_baseball/reference/core.md
+++ b/docs/docs/college_baseball/reference/core.md
@@ -1,6 +1,7 @@
 ---
 title: COLLEGE_BASEBALL — ESPN core API (v2)
 sidebar_label: ESPN core API (v2)
+description: "COLLEGE_BASEBALL — ESPN core API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 22
 ---
 # COLLEGE_BASEBALL — ESPN core API (v2)

--- a/docs/docs/college_baseball/reference/fitt.md
+++ b/docs/docs/college_baseball/reference/fitt.md
@@ -1,6 +1,7 @@
 ---
 title: COLLEGE_BASEBALL — ESPN FPI API (fitt v3)
 sidebar_label: ESPN FPI API (fitt v3)
+description: "COLLEGE_BASEBALL — ESPN FPI API (fitt v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 23
 ---
 # COLLEGE_BASEBALL — ESPN FPI API (fitt v3)

--- a/docs/docs/college_baseball/reference/site.md
+++ b/docs/docs/college_baseball/reference/site.md
@@ -1,6 +1,7 @@
 ---
 title: COLLEGE_BASEBALL — ESPN site API (v2)
 sidebar_label: ESPN site API (v2)
+description: "COLLEGE_BASEBALL — ESPN site API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 20
 ---
 # COLLEGE_BASEBALL — ESPN site API (v2)

--- a/docs/docs/college_baseball/reference/web.md
+++ b/docs/docs/college_baseball/reference/web.md
@@ -1,6 +1,7 @@
 ---
 title: COLLEGE_BASEBALL — ESPN web API (v3)
 sidebar_label: ESPN web API (v3)
+description: "COLLEGE_BASEBALL — ESPN web API (v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 21
 ---
 # COLLEGE_BASEBALL — ESPN web API (v3)

--- a/docs/docs/college_softball/index.md
+++ b/docs/docs/college_softball/index.md
@@ -1,6 +1,7 @@
 ---
 title: COLLEGE_SOFTBALL
 sidebar_label: COLLEGE_SOFTBALL
+description: "sdv-py COLLEGE_SOFTBALL: endpoint references, dataset loaders and parsers for COLLEGE_SOFTBALL in the SportsDataverse Python package."
 ---
 # COLLEGE_SOFTBALL (`sportsdataverse.college_softball`)
 

--- a/docs/docs/college_softball/reference/core.md
+++ b/docs/docs/college_softball/reference/core.md
@@ -1,6 +1,7 @@
 ---
 title: COLLEGE_SOFTBALL — ESPN core API (v2)
 sidebar_label: ESPN core API (v2)
+description: "COLLEGE_SOFTBALL — ESPN core API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 22
 ---
 # COLLEGE_SOFTBALL — ESPN core API (v2)

--- a/docs/docs/college_softball/reference/fitt.md
+++ b/docs/docs/college_softball/reference/fitt.md
@@ -1,6 +1,7 @@
 ---
 title: COLLEGE_SOFTBALL — ESPN FPI API (fitt v3)
 sidebar_label: ESPN FPI API (fitt v3)
+description: "COLLEGE_SOFTBALL — ESPN FPI API (fitt v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 23
 ---
 # COLLEGE_SOFTBALL — ESPN FPI API (fitt v3)

--- a/docs/docs/college_softball/reference/site.md
+++ b/docs/docs/college_softball/reference/site.md
@@ -1,6 +1,7 @@
 ---
 title: COLLEGE_SOFTBALL — ESPN site API (v2)
 sidebar_label: ESPN site API (v2)
+description: "COLLEGE_SOFTBALL — ESPN site API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 20
 ---
 # COLLEGE_SOFTBALL — ESPN site API (v2)

--- a/docs/docs/college_softball/reference/web.md
+++ b/docs/docs/college_softball/reference/web.md
@@ -1,6 +1,7 @@
 ---
 title: COLLEGE_SOFTBALL — ESPN web API (v3)
 sidebar_label: ESPN web API (v3)
+description: "COLLEGE_SOFTBALL — ESPN web API (v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 21
 ---
 # COLLEGE_SOFTBALL — ESPN web API (v3)

--- a/docs/docs/cricket/index.md
+++ b/docs/docs/cricket/index.md
@@ -1,6 +1,7 @@
 ---
 title: CRICKET
 sidebar_label: CRICKET
+description: "sdv-py CRICKET: endpoint references, dataset loaders and parsers for CRICKET in the SportsDataverse Python package."
 ---
 # CRICKET (`sportsdataverse.cricket`)
 

--- a/docs/docs/cricket/reference/core.md
+++ b/docs/docs/cricket/reference/core.md
@@ -1,6 +1,7 @@
 ---
 title: CRICKET — ESPN core API (v2)
 sidebar_label: ESPN core API (v2)
+description: "CRICKET — ESPN core API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 22
 ---
 # CRICKET — ESPN core API (v2)

--- a/docs/docs/cricket/reference/fitt.md
+++ b/docs/docs/cricket/reference/fitt.md
@@ -1,6 +1,7 @@
 ---
 title: CRICKET — ESPN FPI API (fitt v3)
 sidebar_label: ESPN FPI API (fitt v3)
+description: "CRICKET — ESPN FPI API (fitt v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 23
 ---
 # CRICKET — ESPN FPI API (fitt v3)

--- a/docs/docs/cricket/reference/site.md
+++ b/docs/docs/cricket/reference/site.md
@@ -1,6 +1,7 @@
 ---
 title: CRICKET — ESPN site API (v2)
 sidebar_label: ESPN site API (v2)
+description: "CRICKET — ESPN site API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 20
 ---
 # CRICKET — ESPN site API (v2)

--- a/docs/docs/cricket/reference/web.md
+++ b/docs/docs/cricket/reference/web.md
@@ -1,6 +1,7 @@
 ---
 title: CRICKET — ESPN web API (v3)
 sidebar_label: ESPN web API (v3)
+description: "CRICKET — ESPN web API (v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 21
 ---
 # CRICKET — ESPN web API (v3)

--- a/docs/docs/echl/index.md
+++ b/docs/docs/echl/index.md
@@ -1,6 +1,7 @@
 ---
 title: ECHL
 sidebar_label: ECHL
+description: "sdv-py ECHL: endpoint references, dataset loaders and parsers for ECHL in the SportsDataverse Python package."
 ---
 # ECHL (`sportsdataverse.echl`)
 

--- a/docs/docs/echl/reference/additional.md
+++ b/docs/docs/echl/reference/additional.md
@@ -1,6 +1,7 @@
 ---
 title: ECHL — additional Python functions
 sidebar_label: Additional functions
+description: "ECHL — additional Python functions — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: 50
 ---
 # ECHL — additional Python functions

--- a/docs/docs/epl/index.md
+++ b/docs/docs/epl/index.md
@@ -1,6 +1,7 @@
 ---
 title: EPL
 sidebar_label: EPL
+description: "sdv-py EPL: endpoint references, dataset loaders and parsers for EPL in the SportsDataverse Python package."
 ---
 # EPL (`sportsdataverse.epl`)
 

--- a/docs/docs/epl/reference/core.md
+++ b/docs/docs/epl/reference/core.md
@@ -1,6 +1,7 @@
 ---
 title: EPL — ESPN core API (v2)
 sidebar_label: ESPN core API (v2)
+description: "EPL — ESPN core API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 22
 ---
 # EPL — ESPN core API (v2)

--- a/docs/docs/epl/reference/fitt.md
+++ b/docs/docs/epl/reference/fitt.md
@@ -1,6 +1,7 @@
 ---
 title: EPL — ESPN FPI API (fitt v3)
 sidebar_label: ESPN FPI API (fitt v3)
+description: "EPL — ESPN FPI API (fitt v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 23
 ---
 # EPL — ESPN FPI API (fitt v3)

--- a/docs/docs/epl/reference/site.md
+++ b/docs/docs/epl/reference/site.md
@@ -1,6 +1,7 @@
 ---
 title: EPL — ESPN site API (v2)
 sidebar_label: ESPN site API (v2)
+description: "EPL — ESPN site API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 20
 ---
 # EPL — ESPN site API (v2)

--- a/docs/docs/epl/reference/web.md
+++ b/docs/docs/epl/reference/web.md
@@ -1,6 +1,7 @@
 ---
 title: EPL — ESPN web API (v3)
 sidebar_label: ESPN web API (v3)
+description: "EPL — ESPN web API (v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 21
 ---
 # EPL — ESPN web API (v3)

--- a/docs/docs/gojhl/index.md
+++ b/docs/docs/gojhl/index.md
@@ -1,6 +1,7 @@
 ---
 title: GOJHL
 sidebar_label: GOJHL
+description: "sdv-py GOJHL: endpoint references, dataset loaders and parsers for GOJHL in the SportsDataverse Python package."
 ---
 # GOJHL (`sportsdataverse.gojhl`)
 

--- a/docs/docs/gojhl/reference/additional.md
+++ b/docs/docs/gojhl/reference/additional.md
@@ -1,6 +1,7 @@
 ---
 title: GOJHL — additional Python functions
 sidebar_label: Additional functions
+description: "GOJHL — additional Python functions — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: 50
 ---
 # GOJHL — additional Python functions

--- a/docs/docs/kijhl/index.md
+++ b/docs/docs/kijhl/index.md
@@ -1,6 +1,7 @@
 ---
 title: KIJHL
 sidebar_label: KIJHL
+description: "sdv-py KIJHL: endpoint references, dataset loaders and parsers for KIJHL in the SportsDataverse Python package."
 ---
 # KIJHL (`sportsdataverse.kijhl`)
 

--- a/docs/docs/kijhl/reference/additional.md
+++ b/docs/docs/kijhl/reference/additional.md
@@ -1,6 +1,7 @@
 ---
 title: KIJHL — additional Python functions
 sidebar_label: Additional functions
+description: "KIJHL — additional Python functions — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: 50
 ---
 # KIJHL — additional Python functions

--- a/docs/docs/laliga/index.md
+++ b/docs/docs/laliga/index.md
@@ -1,6 +1,7 @@
 ---
 title: LALIGA
 sidebar_label: LALIGA
+description: "sdv-py LALIGA: endpoint references, dataset loaders and parsers for LALIGA in the SportsDataverse Python package."
 ---
 # LALIGA (`sportsdataverse.laliga`)
 

--- a/docs/docs/laliga/reference/core.md
+++ b/docs/docs/laliga/reference/core.md
@@ -1,6 +1,7 @@
 ---
 title: LALIGA — ESPN core API (v2)
 sidebar_label: ESPN core API (v2)
+description: "LALIGA — ESPN core API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 22
 ---
 # LALIGA — ESPN core API (v2)

--- a/docs/docs/laliga/reference/fitt.md
+++ b/docs/docs/laliga/reference/fitt.md
@@ -1,6 +1,7 @@
 ---
 title: LALIGA — ESPN FPI API (fitt v3)
 sidebar_label: ESPN FPI API (fitt v3)
+description: "LALIGA — ESPN FPI API (fitt v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 23
 ---
 # LALIGA — ESPN FPI API (fitt v3)

--- a/docs/docs/laliga/reference/site.md
+++ b/docs/docs/laliga/reference/site.md
@@ -1,6 +1,7 @@
 ---
 title: LALIGA — ESPN site API (v2)
 sidebar_label: ESPN site API (v2)
+description: "LALIGA — ESPN site API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 20
 ---
 # LALIGA — ESPN site API (v2)

--- a/docs/docs/laliga/reference/web.md
+++ b/docs/docs/laliga/reference/web.md
@@ -1,6 +1,7 @@
 ---
 title: LALIGA — ESPN web API (v3)
 sidebar_label: ESPN web API (v3)
+description: "LALIGA — ESPN web API (v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 21
 ---
 # LALIGA — ESPN web API (v3)

--- a/docs/docs/ligamx/index.md
+++ b/docs/docs/ligamx/index.md
@@ -1,6 +1,7 @@
 ---
 title: LIGAMX
 sidebar_label: LIGAMX
+description: "sdv-py LIGAMX: endpoint references, dataset loaders and parsers for LIGAMX in the SportsDataverse Python package."
 ---
 # LIGAMX (`sportsdataverse.ligamx`)
 

--- a/docs/docs/ligamx/reference/core.md
+++ b/docs/docs/ligamx/reference/core.md
@@ -1,6 +1,7 @@
 ---
 title: LIGAMX — ESPN core API (v2)
 sidebar_label: ESPN core API (v2)
+description: "LIGAMX — ESPN core API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 22
 ---
 # LIGAMX — ESPN core API (v2)

--- a/docs/docs/ligamx/reference/fitt.md
+++ b/docs/docs/ligamx/reference/fitt.md
@@ -1,6 +1,7 @@
 ---
 title: LIGAMX — ESPN FPI API (fitt v3)
 sidebar_label: ESPN FPI API (fitt v3)
+description: "LIGAMX — ESPN FPI API (fitt v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 23
 ---
 # LIGAMX — ESPN FPI API (fitt v3)

--- a/docs/docs/ligamx/reference/site.md
+++ b/docs/docs/ligamx/reference/site.md
@@ -1,6 +1,7 @@
 ---
 title: LIGAMX — ESPN site API (v2)
 sidebar_label: ESPN site API (v2)
+description: "LIGAMX — ESPN site API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 20
 ---
 # LIGAMX — ESPN site API (v2)

--- a/docs/docs/ligamx/reference/web.md
+++ b/docs/docs/ligamx/reference/web.md
@@ -1,6 +1,7 @@
 ---
 title: LIGAMX — ESPN web API (v3)
 sidebar_label: ESPN web API (v3)
+description: "LIGAMX — ESPN web API (v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 21
 ---
 # LIGAMX — ESPN web API (v3)

--- a/docs/docs/ligue1/index.md
+++ b/docs/docs/ligue1/index.md
@@ -1,6 +1,7 @@
 ---
 title: LIGUE1
 sidebar_label: LIGUE1
+description: "sdv-py LIGUE1: endpoint references, dataset loaders and parsers for LIGUE1 in the SportsDataverse Python package."
 ---
 # LIGUE1 (`sportsdataverse.ligue1`)
 

--- a/docs/docs/ligue1/reference/core.md
+++ b/docs/docs/ligue1/reference/core.md
@@ -1,6 +1,7 @@
 ---
 title: LIGUE1 — ESPN core API (v2)
 sidebar_label: ESPN core API (v2)
+description: "LIGUE1 — ESPN core API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 22
 ---
 # LIGUE1 — ESPN core API (v2)

--- a/docs/docs/ligue1/reference/fitt.md
+++ b/docs/docs/ligue1/reference/fitt.md
@@ -1,6 +1,7 @@
 ---
 title: LIGUE1 — ESPN FPI API (fitt v3)
 sidebar_label: ESPN FPI API (fitt v3)
+description: "LIGUE1 — ESPN FPI API (fitt v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 23
 ---
 # LIGUE1 — ESPN FPI API (fitt v3)

--- a/docs/docs/ligue1/reference/site.md
+++ b/docs/docs/ligue1/reference/site.md
@@ -1,6 +1,7 @@
 ---
 title: LIGUE1 — ESPN site API (v2)
 sidebar_label: ESPN site API (v2)
+description: "LIGUE1 — ESPN site API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 20
 ---
 # LIGUE1 — ESPN site API (v2)

--- a/docs/docs/ligue1/reference/web.md
+++ b/docs/docs/ligue1/reference/web.md
@@ -1,6 +1,7 @@
 ---
 title: LIGUE1 — ESPN web API (v3)
 sidebar_label: ESPN web API (v3)
+description: "LIGUE1 — ESPN web API (v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 21
 ---
 # LIGUE1 — ESPN web API (v3)

--- a/docs/docs/mbb/index.md
+++ b/docs/docs/mbb/index.md
@@ -1,6 +1,7 @@
 ---
 title: MBB
 sidebar_label: MBB
+description: "sdv-py MBB: endpoint references, dataset loaders and parsers for MBB in the SportsDataverse Python package."
 ---
 # MBB (`sportsdataverse.mbb`)
 

--- a/docs/docs/mbb/reference/additional.md
+++ b/docs/docs/mbb/reference/additional.md
@@ -1,6 +1,7 @@
 ---
 title: MBB — additional Python functions
 sidebar_label: Additional functions
+description: "MBB — additional Python functions — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: 50
 ---
 # MBB — additional Python functions

--- a/docs/docs/mbb/reference/core.md
+++ b/docs/docs/mbb/reference/core.md
@@ -1,6 +1,7 @@
 ---
 title: MBB — ESPN core API (v2)
 sidebar_label: ESPN core API (v2)
+description: "MBB — ESPN core API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 22
 ---
 # MBB — ESPN core API (v2)

--- a/docs/docs/mbb/reference/fitt.md
+++ b/docs/docs/mbb/reference/fitt.md
@@ -1,6 +1,7 @@
 ---
 title: MBB — ESPN FPI API (fitt v3)
 sidebar_label: ESPN FPI API (fitt v3)
+description: "MBB — ESPN FPI API (fitt v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 23
 ---
 # MBB — ESPN FPI API (fitt v3)

--- a/docs/docs/mbb/reference/loaders.md
+++ b/docs/docs/mbb/reference/loaders.md
@@ -1,6 +1,7 @@
 ---
 title: MBB dataset loaders
 sidebar_label: Loaders
+description: "MBB dataset loaders in sdv-py: the load_* functions that read the SportsDataverse release assets."
 sidebar_position: 1
 ---
 # MBB dataset loaders

--- a/docs/docs/mbb/reference/site.md
+++ b/docs/docs/mbb/reference/site.md
@@ -1,6 +1,7 @@
 ---
 title: MBB — ESPN site API (v2)
 sidebar_label: ESPN site API (v2)
+description: "MBB — ESPN site API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 20
 ---
 # MBB — ESPN site API (v2)

--- a/docs/docs/mbb/reference/torvik.md
+++ b/docs/docs/mbb/reference/torvik.md
@@ -1,6 +1,7 @@
 ---
 title: MBB — Bart Torvik T-Rank (barttorvik.com)
 sidebar_label: Bart Torvik T-Rank (barttorvik.com)
+description: "MBB — Bart Torvik T-Rank (barttorvik.com) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 10
 ---
 # MBB — Bart Torvik T-Rank (barttorvik.com)

--- a/docs/docs/mbb/reference/web.md
+++ b/docs/docs/mbb/reference/web.md
@@ -1,6 +1,7 @@
 ---
 title: MBB — ESPN web API (v3)
 sidebar_label: ESPN web API (v3)
+description: "MBB — ESPN web API (v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 21
 ---
 # MBB — ESPN web API (v3)

--- a/docs/docs/mch/index.md
+++ b/docs/docs/mch/index.md
@@ -1,6 +1,7 @@
 ---
 title: MCH
 sidebar_label: MCH
+description: "sdv-py MCH: endpoint references, dataset loaders and parsers for MCH in the SportsDataverse Python package."
 ---
 # MCH (`sportsdataverse.mch`)
 

--- a/docs/docs/mch/reference/core.md
+++ b/docs/docs/mch/reference/core.md
@@ -1,6 +1,7 @@
 ---
 title: MCH — ESPN core API (v2)
 sidebar_label: ESPN core API (v2)
+description: "MCH — ESPN core API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 22
 ---
 # MCH — ESPN core API (v2)

--- a/docs/docs/mch/reference/fitt.md
+++ b/docs/docs/mch/reference/fitt.md
@@ -1,6 +1,7 @@
 ---
 title: MCH — ESPN FPI API (fitt v3)
 sidebar_label: ESPN FPI API (fitt v3)
+description: "MCH — ESPN FPI API (fitt v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 23
 ---
 # MCH — ESPN FPI API (fitt v3)

--- a/docs/docs/mch/reference/site.md
+++ b/docs/docs/mch/reference/site.md
@@ -1,6 +1,7 @@
 ---
 title: MCH — ESPN site API (v2)
 sidebar_label: ESPN site API (v2)
+description: "MCH — ESPN site API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 20
 ---
 # MCH — ESPN site API (v2)

--- a/docs/docs/mch/reference/web.md
+++ b/docs/docs/mch/reference/web.md
@@ -1,6 +1,7 @@
 ---
 title: MCH — ESPN web API (v3)
 sidebar_label: ESPN web API (v3)
+description: "MCH — ESPN web API (v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 21
 ---
 # MCH — ESPN web API (v3)

--- a/docs/docs/mhl/index.md
+++ b/docs/docs/mhl/index.md
@@ -1,6 +1,7 @@
 ---
 title: MHL
 sidebar_label: MHL
+description: "sdv-py MHL: endpoint references, dataset loaders and parsers for MHL in the SportsDataverse Python package."
 ---
 # MHL (`sportsdataverse.mhl`)
 

--- a/docs/docs/mhl/reference/additional.md
+++ b/docs/docs/mhl/reference/additional.md
@@ -1,6 +1,7 @@
 ---
 title: MHL — additional Python functions
 sidebar_label: Additional functions
+description: "MHL — additional Python functions — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: 50
 ---
 # MHL — additional Python functions

--- a/docs/docs/mjhl/index.md
+++ b/docs/docs/mjhl/index.md
@@ -1,6 +1,7 @@
 ---
 title: MJHL
 sidebar_label: MJHL
+description: "sdv-py MJHL: endpoint references, dataset loaders and parsers for MJHL in the SportsDataverse Python package."
 ---
 # MJHL (`sportsdataverse.mjhl`)
 

--- a/docs/docs/mjhl/reference/additional.md
+++ b/docs/docs/mjhl/reference/additional.md
@@ -1,6 +1,7 @@
 ---
 title: MJHL — additional Python functions
 sidebar_label: Additional functions
+description: "MJHL — additional Python functions — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: 50
 ---
 # MJHL — additional Python functions

--- a/docs/docs/mlb/index.md
+++ b/docs/docs/mlb/index.md
@@ -1,6 +1,7 @@
 ---
 title: MLB
 sidebar_label: MLB
+description: "sdv-py MLB: endpoint references, dataset loaders and parsers for MLB in the SportsDataverse Python package."
 ---
 # MLB (`sportsdataverse.mlb`)
 

--- a/docs/docs/mlb/reference/additional.md
+++ b/docs/docs/mlb/reference/additional.md
@@ -1,6 +1,7 @@
 ---
 title: MLB — additional Python functions
 sidebar_label: Additional functions
+description: "MLB — additional Python functions — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: 50
 ---
 # MLB — additional Python functions

--- a/docs/docs/mlb/reference/core.md
+++ b/docs/docs/mlb/reference/core.md
@@ -1,6 +1,7 @@
 ---
 title: MLB — ESPN core API (v2)
 sidebar_label: ESPN core API (v2)
+description: "MLB — ESPN core API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 22
 ---
 # MLB — ESPN core API (v2)

--- a/docs/docs/mlb/reference/fitt.md
+++ b/docs/docs/mlb/reference/fitt.md
@@ -1,6 +1,7 @@
 ---
 title: MLB — ESPN FPI API (fitt v3)
 sidebar_label: ESPN FPI API (fitt v3)
+description: "MLB — ESPN FPI API (fitt v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 23
 ---
 # MLB — ESPN FPI API (fitt v3)

--- a/docs/docs/mlb/reference/loaders.md
+++ b/docs/docs/mlb/reference/loaders.md
@@ -1,6 +1,7 @@
 ---
 title: MLB dataset loaders
 sidebar_label: Loaders
+description: "MLB dataset loaders in sdv-py: the load_* functions that read the SportsDataverse release assets."
 sidebar_position: 1
 ---
 # MLB dataset loaders

--- a/docs/docs/mlb/reference/mlb_api.md
+++ b/docs/docs/mlb/reference/mlb_api.md
@@ -1,6 +1,7 @@
 ---
 title: MLB — MLB Stats API
 sidebar_label: MLB Stats API
+description: "MLB — MLB Stats API — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 10
 ---
 # MLB — MLB Stats API

--- a/docs/docs/mlb/reference/mlb_statcast.md
+++ b/docs/docs/mlb/reference/mlb_statcast.md
@@ -1,6 +1,7 @@
 ---
 title: MLB — MLB Statcast (Baseball Savant)
 sidebar_label: MLB Statcast (Baseball Savant)
+description: "MLB — MLB Statcast (Baseball Savant) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 11
 ---
 # MLB — MLB Statcast (Baseball Savant)

--- a/docs/docs/mlb/reference/site.md
+++ b/docs/docs/mlb/reference/site.md
@@ -1,6 +1,7 @@
 ---
 title: MLB — ESPN site API (v2)
 sidebar_label: ESPN site API (v2)
+description: "MLB — ESPN site API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 20
 ---
 # MLB — ESPN site API (v2)

--- a/docs/docs/mlb/reference/web.md
+++ b/docs/docs/mlb/reference/web.md
@@ -1,6 +1,7 @@
 ---
 title: MLB — ESPN web API (v3)
 sidebar_label: ESPN web API (v3)
+description: "MLB — ESPN web API (v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 21
 ---
 # MLB — ESPN web API (v3)

--- a/docs/docs/mls/index.md
+++ b/docs/docs/mls/index.md
@@ -1,6 +1,7 @@
 ---
 title: MLS
 sidebar_label: MLS
+description: "sdv-py MLS: endpoint references, dataset loaders and parsers for MLS in the SportsDataverse Python package."
 ---
 # MLS (`sportsdataverse.mls`)
 

--- a/docs/docs/mls/reference/core.md
+++ b/docs/docs/mls/reference/core.md
@@ -1,6 +1,7 @@
 ---
 title: MLS — ESPN core API (v2)
 sidebar_label: ESPN core API (v2)
+description: "MLS — ESPN core API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 22
 ---
 # MLS — ESPN core API (v2)

--- a/docs/docs/mls/reference/fitt.md
+++ b/docs/docs/mls/reference/fitt.md
@@ -1,6 +1,7 @@
 ---
 title: MLS — ESPN FPI API (fitt v3)
 sidebar_label: ESPN FPI API (fitt v3)
+description: "MLS — ESPN FPI API (fitt v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 23
 ---
 # MLS — ESPN FPI API (fitt v3)

--- a/docs/docs/mls/reference/site.md
+++ b/docs/docs/mls/reference/site.md
@@ -1,6 +1,7 @@
 ---
 title: MLS — ESPN site API (v2)
 sidebar_label: ESPN site API (v2)
+description: "MLS — ESPN site API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 20
 ---
 # MLS — ESPN site API (v2)

--- a/docs/docs/mls/reference/web.md
+++ b/docs/docs/mls/reference/web.md
@@ -1,6 +1,7 @@
 ---
 title: MLS — ESPN web API (v3)
 sidebar_label: ESPN web API (v3)
+description: "MLS — ESPN web API (v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 21
 ---
 # MLS — ESPN web API (v3)

--- a/docs/docs/nba/index.md
+++ b/docs/docs/nba/index.md
@@ -1,6 +1,7 @@
 ---
 title: NBA
 sidebar_label: NBA
+description: "sdv-py NBA: endpoint references, dataset loaders and parsers for NBA in the SportsDataverse Python package."
 ---
 # NBA (`sportsdataverse.nba`)
 

--- a/docs/docs/nba/reference/additional.md
+++ b/docs/docs/nba/reference/additional.md
@@ -1,6 +1,7 @@
 ---
 title: NBA — additional Python functions
 sidebar_label: Additional functions
+description: "NBA — additional Python functions — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: 50
 ---
 # NBA — additional Python functions

--- a/docs/docs/nba/reference/core.md
+++ b/docs/docs/nba/reference/core.md
@@ -1,6 +1,7 @@
 ---
 title: NBA — ESPN core API (v2)
 sidebar_label: ESPN core API (v2)
+description: "NBA — ESPN core API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 22
 ---
 # NBA — ESPN core API (v2)

--- a/docs/docs/nba/reference/fitt.md
+++ b/docs/docs/nba/reference/fitt.md
@@ -1,6 +1,7 @@
 ---
 title: NBA — ESPN FPI API (fitt v3)
 sidebar_label: ESPN FPI API (fitt v3)
+description: "NBA — ESPN FPI API (fitt v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 23
 ---
 # NBA — ESPN FPI API (fitt v3)

--- a/docs/docs/nba/reference/loaders.md
+++ b/docs/docs/nba/reference/loaders.md
@@ -1,6 +1,7 @@
 ---
 title: NBA dataset loaders
 sidebar_label: Loaders
+description: "NBA dataset loaders in sdv-py: the load_* functions that read the SportsDataverse release assets."
 sidebar_position: 1
 ---
 # NBA dataset loaders

--- a/docs/docs/nba/reference/nba_stats.md
+++ b/docs/docs/nba/reference/nba_stats.md
@@ -1,6 +1,7 @@
 ---
 title: NBA — NBA Stats API (stats.nba.com)
 sidebar_label: NBA Stats API (stats.nba.com)
+description: "NBA — NBA Stats API (stats.nba.com) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 10
 ---
 # NBA — NBA Stats API (stats.nba.com)

--- a/docs/docs/nba/reference/site.md
+++ b/docs/docs/nba/reference/site.md
@@ -1,6 +1,7 @@
 ---
 title: NBA — ESPN site API (v2)
 sidebar_label: ESPN site API (v2)
+description: "NBA — ESPN site API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 20
 ---
 # NBA — ESPN site API (v2)

--- a/docs/docs/nba/reference/web.md
+++ b/docs/docs/nba/reference/web.md
@@ -1,6 +1,7 @@
 ---
 title: NBA — ESPN web API (v3)
 sidebar_label: ESPN web API (v3)
+description: "NBA — ESPN web API (v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 21
 ---
 # NBA — ESPN web API (v3)

--- a/docs/docs/nfl/index.md
+++ b/docs/docs/nfl/index.md
@@ -1,6 +1,7 @@
 ---
 title: NFL
 sidebar_label: NFL
+description: "sdv-py NFL: endpoint references, dataset loaders and parsers for NFL in the SportsDataverse Python package."
 ---
 # NFL (`sportsdataverse.nfl`)
 

--- a/docs/docs/nfl/reference/additional.md
+++ b/docs/docs/nfl/reference/additional.md
@@ -1,6 +1,7 @@
 ---
 title: NFL — additional Python functions
 sidebar_label: Additional functions
+description: "NFL — additional Python functions — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: 50
 ---
 # NFL — additional Python functions

--- a/docs/docs/nfl/reference/core.md
+++ b/docs/docs/nfl/reference/core.md
@@ -1,6 +1,7 @@
 ---
 title: NFL — ESPN core API (v2)
 sidebar_label: ESPN core API (v2)
+description: "NFL — ESPN core API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 22
 ---
 # NFL — ESPN core API (v2)

--- a/docs/docs/nfl/reference/fitt.md
+++ b/docs/docs/nfl/reference/fitt.md
@@ -1,6 +1,7 @@
 ---
 title: NFL — ESPN FPI API (fitt v3)
 sidebar_label: ESPN FPI API (fitt v3)
+description: "NFL — ESPN FPI API (fitt v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 23
 ---
 # NFL — ESPN FPI API (fitt v3)

--- a/docs/docs/nfl/reference/loaders.md
+++ b/docs/docs/nfl/reference/loaders.md
@@ -1,6 +1,7 @@
 ---
 title: NFL dataset loaders
 sidebar_label: Loaders
+description: "NFL dataset loaders in sdv-py: the load_* functions that read the SportsDataverse release assets."
 sidebar_position: 1
 ---
 # NFL dataset loaders

--- a/docs/docs/nfl/reference/nfl_api.md
+++ b/docs/docs/nfl/reference/nfl_api.md
@@ -1,6 +1,7 @@
 ---
 title: NFL — NFL.com API
 sidebar_label: NFL.com API
+description: "NFL — NFL.com API — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 10
 ---
 # NFL — NFL.com API

--- a/docs/docs/nfl/reference/pff_core.md
+++ b/docs/docs/nfl/reference/pff_core.md
@@ -1,6 +1,7 @@
 ---
 title: NFL — PFF Premium Stats (premium.pff.com)
 sidebar_label: PFF Premium Stats (premium.pff.com)
+description: "NFL — PFF Premium Stats (premium.pff.com) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 11
 ---
 # NFL — PFF Premium Stats (premium.pff.com)

--- a/docs/docs/nfl/reference/site.md
+++ b/docs/docs/nfl/reference/site.md
@@ -1,6 +1,7 @@
 ---
 title: NFL — ESPN site API (v2)
 sidebar_label: ESPN site API (v2)
+description: "NFL — ESPN site API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 20
 ---
 # NFL — ESPN site API (v2)

--- a/docs/docs/nfl/reference/web.md
+++ b/docs/docs/nfl/reference/web.md
@@ -1,6 +1,7 @@
 ---
 title: NFL — ESPN web API (v3)
 sidebar_label: ESPN web API (v3)
+description: "NFL — ESPN web API (v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 21
 ---
 # NFL — ESPN web API (v3)

--- a/docs/docs/nhl/index.md
+++ b/docs/docs/nhl/index.md
@@ -1,6 +1,7 @@
 ---
 title: NHL
 sidebar_label: NHL
+description: "sdv-py NHL: endpoint references, dataset loaders and parsers for NHL in the SportsDataverse Python package."
 ---
 # NHL (`sportsdataverse.nhl`)
 

--- a/docs/docs/nhl/reference/additional.md
+++ b/docs/docs/nhl/reference/additional.md
@@ -1,6 +1,7 @@
 ---
 title: NHL — additional Python functions
 sidebar_label: Additional functions
+description: "NHL — additional Python functions — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: 50
 ---
 # NHL — additional Python functions

--- a/docs/docs/nhl/reference/core.md
+++ b/docs/docs/nhl/reference/core.md
@@ -1,6 +1,7 @@
 ---
 title: NHL — ESPN core API (v2)
 sidebar_label: ESPN core API (v2)
+description: "NHL — ESPN core API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 22
 ---
 # NHL — ESPN core API (v2)

--- a/docs/docs/nhl/reference/fitt.md
+++ b/docs/docs/nhl/reference/fitt.md
@@ -1,6 +1,7 @@
 ---
 title: NHL — ESPN FPI API (fitt v3)
 sidebar_label: ESPN FPI API (fitt v3)
+description: "NHL — ESPN FPI API (fitt v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 23
 ---
 # NHL — ESPN FPI API (fitt v3)

--- a/docs/docs/nhl/reference/loaders.md
+++ b/docs/docs/nhl/reference/loaders.md
@@ -1,6 +1,7 @@
 ---
 title: NHL dataset loaders
 sidebar_label: Loaders
+description: "NHL dataset loaders in sdv-py: the load_* functions that read the SportsDataverse release assets."
 sidebar_position: 1
 ---
 # NHL dataset loaders

--- a/docs/docs/nhl/reference/nhl_api_web.md
+++ b/docs/docs/nhl/reference/nhl_api_web.md
@@ -1,6 +1,7 @@
 ---
 title: NHL — NHL Web API
 sidebar_label: NHL Web API
+description: "NHL — NHL Web API — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 10
 ---
 # NHL — NHL Web API

--- a/docs/docs/nhl/reference/nhl_edge.md
+++ b/docs/docs/nhl/reference/nhl_edge.md
@@ -1,6 +1,7 @@
 ---
 title: NHL — NHL EDGE API
 sidebar_label: NHL EDGE API
+description: "NHL — NHL EDGE API — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 11
 ---
 # NHL — NHL EDGE API

--- a/docs/docs/nhl/reference/nhl_records.md
+++ b/docs/docs/nhl/reference/nhl_records.md
@@ -1,6 +1,7 @@
 ---
 title: NHL — NHL Records API
 sidebar_label: NHL Records API
+description: "NHL — NHL Records API — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 13
 ---
 # NHL — NHL Records API

--- a/docs/docs/nhl/reference/nhl_stats_rest.md
+++ b/docs/docs/nhl/reference/nhl_stats_rest.md
@@ -1,6 +1,7 @@
 ---
 title: NHL — NHL Stats REST API
 sidebar_label: NHL Stats REST API
+description: "NHL — NHL Stats REST API — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 12
 ---
 # NHL — NHL Stats REST API

--- a/docs/docs/nhl/reference/site.md
+++ b/docs/docs/nhl/reference/site.md
@@ -1,6 +1,7 @@
 ---
 title: NHL — ESPN site API (v2)
 sidebar_label: ESPN site API (v2)
+description: "NHL — ESPN site API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 20
 ---
 # NHL — ESPN site API (v2)

--- a/docs/docs/nhl/reference/web.md
+++ b/docs/docs/nhl/reference/web.md
@@ -1,6 +1,7 @@
 ---
 title: NHL — ESPN web API (v3)
 sidebar_label: ESPN web API (v3)
+description: "NHL — ESPN web API (v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 21
 ---
 # NHL — ESPN web API (v3)

--- a/docs/docs/nojhl/index.md
+++ b/docs/docs/nojhl/index.md
@@ -1,6 +1,7 @@
 ---
 title: NOJHL
 sidebar_label: NOJHL
+description: "sdv-py NOJHL: endpoint references, dataset loaders and parsers for NOJHL in the SportsDataverse Python package."
 ---
 # NOJHL (`sportsdataverse.nojhl`)
 

--- a/docs/docs/nojhl/reference/additional.md
+++ b/docs/docs/nojhl/reference/additional.md
@@ -1,6 +1,7 @@
 ---
 title: NOJHL — additional Python functions
 sidebar_label: Additional functions
+description: "NOJHL — additional Python functions — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: 50
 ---
 # NOJHL — additional Python functions

--- a/docs/docs/nwsl/index.md
+++ b/docs/docs/nwsl/index.md
@@ -1,6 +1,7 @@
 ---
 title: NWSL
 sidebar_label: NWSL
+description: "sdv-py NWSL: endpoint references, dataset loaders and parsers for NWSL in the SportsDataverse Python package."
 ---
 # NWSL (`sportsdataverse.nwsl`)
 

--- a/docs/docs/nwsl/reference/core.md
+++ b/docs/docs/nwsl/reference/core.md
@@ -1,6 +1,7 @@
 ---
 title: NWSL — ESPN core API (v2)
 sidebar_label: ESPN core API (v2)
+description: "NWSL — ESPN core API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 22
 ---
 # NWSL — ESPN core API (v2)

--- a/docs/docs/nwsl/reference/fitt.md
+++ b/docs/docs/nwsl/reference/fitt.md
@@ -1,6 +1,7 @@
 ---
 title: NWSL — ESPN FPI API (fitt v3)
 sidebar_label: ESPN FPI API (fitt v3)
+description: "NWSL — ESPN FPI API (fitt v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 23
 ---
 # NWSL — ESPN FPI API (fitt v3)

--- a/docs/docs/nwsl/reference/site.md
+++ b/docs/docs/nwsl/reference/site.md
@@ -1,6 +1,7 @@
 ---
 title: NWSL — ESPN site API (v2)
 sidebar_label: ESPN site API (v2)
+description: "NWSL — ESPN site API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 20
 ---
 # NWSL — ESPN site API (v2)

--- a/docs/docs/nwsl/reference/web.md
+++ b/docs/docs/nwsl/reference/web.md
@@ -1,6 +1,7 @@
 ---
 title: NWSL — ESPN web API (v3)
 sidebar_label: ESPN web API (v3)
+description: "NWSL — ESPN web API (v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 21
 ---
 # NWSL — ESPN web API (v3)

--- a/docs/docs/odds/index.md
+++ b/docs/docs/odds/index.md
@@ -1,6 +1,7 @@
 ---
 title: ODDS
 sidebar_label: ODDS
+description: "sdv-py ODDS: endpoint references, dataset loaders and parsers for ODDS in the SportsDataverse Python package."
 ---
 # ODDS (`sportsdataverse.odds`)
 

--- a/docs/docs/odds/reference/additional.md
+++ b/docs/docs/odds/reference/additional.md
@@ -1,6 +1,7 @@
 ---
 title: ODDS — additional Python functions
 sidebar_label: Additional functions
+description: "ODDS — additional Python functions — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: 50
 ---
 # ODDS — additional Python functions

--- a/docs/docs/ohl/index.md
+++ b/docs/docs/ohl/index.md
@@ -1,6 +1,7 @@
 ---
 title: OHL
 sidebar_label: OHL
+description: "sdv-py OHL: endpoint references, dataset loaders and parsers for OHL in the SportsDataverse Python package."
 ---
 # OHL (`sportsdataverse.ohl`)
 

--- a/docs/docs/ohl/reference/additional.md
+++ b/docs/docs/ohl/reference/additional.md
@@ -1,6 +1,7 @@
 ---
 title: OHL — additional Python functions
 sidebar_label: Additional functions
+description: "OHL — additional Python functions — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: 50
 ---
 # OHL — additional Python functions

--- a/docs/docs/ojhl/index.md
+++ b/docs/docs/ojhl/index.md
@@ -1,6 +1,7 @@
 ---
 title: OJHL
 sidebar_label: OJHL
+description: "sdv-py OJHL: endpoint references, dataset loaders and parsers for OJHL in the SportsDataverse Python package."
 ---
 # OJHL (`sportsdataverse.ojhl`)
 

--- a/docs/docs/ojhl/reference/additional.md
+++ b/docs/docs/ojhl/reference/additional.md
@@ -1,6 +1,7 @@
 ---
 title: OJHL — additional Python functions
 sidebar_label: Additional functions
+description: "OJHL — additional Python functions — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: 50
 ---
 # OJHL — additional Python functions

--- a/docs/docs/pwhl/index.md
+++ b/docs/docs/pwhl/index.md
@@ -1,6 +1,7 @@
 ---
 title: PWHL
 sidebar_label: PWHL
+description: "sdv-py PWHL: endpoint references, dataset loaders and parsers for PWHL in the SportsDataverse Python package."
 ---
 # PWHL (`sportsdataverse.pwhl`)
 

--- a/docs/docs/pwhl/reference/additional.md
+++ b/docs/docs/pwhl/reference/additional.md
@@ -1,6 +1,7 @@
 ---
 title: PWHL — additional Python functions
 sidebar_label: Additional functions
+description: "PWHL — additional Python functions — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: 50
 ---
 # PWHL — additional Python functions

--- a/docs/docs/pwhl/reference/loaders.md
+++ b/docs/docs/pwhl/reference/loaders.md
@@ -1,6 +1,7 @@
 ---
 title: PWHL dataset loaders
 sidebar_label: Loaders
+description: "PWHL dataset loaders in sdv-py: the load_* functions that read the SportsDataverse release assets."
 sidebar_position: 1
 ---
 # PWHL dataset loaders

--- a/docs/docs/qmjhl/index.md
+++ b/docs/docs/qmjhl/index.md
@@ -1,6 +1,7 @@
 ---
 title: QMJHL
 sidebar_label: QMJHL
+description: "sdv-py QMJHL: endpoint references, dataset loaders and parsers for QMJHL in the SportsDataverse Python package."
 ---
 # QMJHL (`sportsdataverse.qmjhl`)
 

--- a/docs/docs/qmjhl/reference/additional.md
+++ b/docs/docs/qmjhl/reference/additional.md
@@ -1,6 +1,7 @@
 ---
 title: QMJHL — additional Python functions
 sidebar_label: Additional functions
+description: "QMJHL — additional Python functions — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: 50
 ---
 # QMJHL — additional Python functions

--- a/docs/docs/reference/parameters.md
+++ b/docs/docs/reference/parameters.md
@@ -1,6 +1,7 @@
 ---
 title: Parameters
 sidebar_label: Parameters
+description: "Parameter reference for sdv-py endpoint functions."
 ---
 # Parameter reference
 

--- a/docs/docs/reference/python-helpers.md
+++ b/docs/docs/reference/python-helpers.md
@@ -1,6 +1,7 @@
 ---
 title: Package — additional Python functions
 sidebar_label: Additional functions
+description: "Package — additional Python functions — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: 50
 ---
 # Package — additional Python functions

--- a/docs/docs/seriea/index.md
+++ b/docs/docs/seriea/index.md
@@ -1,6 +1,7 @@
 ---
 title: SERIEA
 sidebar_label: SERIEA
+description: "sdv-py SERIEA: endpoint references, dataset loaders and parsers for SERIEA in the SportsDataverse Python package."
 ---
 # SERIEA (`sportsdataverse.seriea`)
 

--- a/docs/docs/seriea/reference/core.md
+++ b/docs/docs/seriea/reference/core.md
@@ -1,6 +1,7 @@
 ---
 title: SERIEA — ESPN core API (v2)
 sidebar_label: ESPN core API (v2)
+description: "SERIEA — ESPN core API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 22
 ---
 # SERIEA — ESPN core API (v2)

--- a/docs/docs/seriea/reference/fitt.md
+++ b/docs/docs/seriea/reference/fitt.md
@@ -1,6 +1,7 @@
 ---
 title: SERIEA — ESPN FPI API (fitt v3)
 sidebar_label: ESPN FPI API (fitt v3)
+description: "SERIEA — ESPN FPI API (fitt v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 23
 ---
 # SERIEA — ESPN FPI API (fitt v3)

--- a/docs/docs/seriea/reference/site.md
+++ b/docs/docs/seriea/reference/site.md
@@ -1,6 +1,7 @@
 ---
 title: SERIEA — ESPN site API (v2)
 sidebar_label: ESPN site API (v2)
+description: "SERIEA — ESPN site API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 20
 ---
 # SERIEA — ESPN site API (v2)

--- a/docs/docs/seriea/reference/web.md
+++ b/docs/docs/seriea/reference/web.md
@@ -1,6 +1,7 @@
 ---
 title: SERIEA — ESPN web API (v3)
 sidebar_label: ESPN web API (v3)
+description: "SERIEA — ESPN web API (v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 21
 ---
 # SERIEA — ESPN web API (v3)

--- a/docs/docs/sjhl/index.md
+++ b/docs/docs/sjhl/index.md
@@ -1,6 +1,7 @@
 ---
 title: SJHL
 sidebar_label: SJHL
+description: "sdv-py SJHL: endpoint references, dataset loaders and parsers for SJHL in the SportsDataverse Python package."
 ---
 # SJHL (`sportsdataverse.sjhl`)
 

--- a/docs/docs/sjhl/reference/additional.md
+++ b/docs/docs/sjhl/reference/additional.md
@@ -1,6 +1,7 @@
 ---
 title: SJHL — additional Python functions
 sidebar_label: Additional functions
+description: "SJHL — additional Python functions — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: 50
 ---
 # SJHL — additional Python functions

--- a/docs/docs/soccer/index.md
+++ b/docs/docs/soccer/index.md
@@ -1,6 +1,7 @@
 ---
 title: SOCCER
 sidebar_label: SOCCER
+description: "sdv-py SOCCER: endpoint references, dataset loaders and parsers for SOCCER in the SportsDataverse Python package."
 ---
 # SOCCER (`sportsdataverse.soccer`)
 

--- a/docs/docs/soccer/reference/core.md
+++ b/docs/docs/soccer/reference/core.md
@@ -1,6 +1,7 @@
 ---
 title: SOCCER — ESPN core API (v2)
 sidebar_label: ESPN core API (v2)
+description: "SOCCER — ESPN core API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 22
 ---
 # SOCCER — ESPN core API (v2)

--- a/docs/docs/soccer/reference/fitt.md
+++ b/docs/docs/soccer/reference/fitt.md
@@ -1,6 +1,7 @@
 ---
 title: SOCCER — ESPN FPI API (fitt v3)
 sidebar_label: ESPN FPI API (fitt v3)
+description: "SOCCER — ESPN FPI API (fitt v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 23
 ---
 # SOCCER — ESPN FPI API (fitt v3)

--- a/docs/docs/soccer/reference/site.md
+++ b/docs/docs/soccer/reference/site.md
@@ -1,6 +1,7 @@
 ---
 title: SOCCER — ESPN site API (v2)
 sidebar_label: ESPN site API (v2)
+description: "SOCCER — ESPN site API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 20
 ---
 # SOCCER — ESPN site API (v2)

--- a/docs/docs/soccer/reference/web.md
+++ b/docs/docs/soccer/reference/web.md
@@ -1,6 +1,7 @@
 ---
 title: SOCCER — ESPN web API (v3)
 sidebar_label: ESPN web API (v3)
+description: "SOCCER — ESPN web API (v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 21
 ---
 # SOCCER — ESPN web API (v3)

--- a/docs/docs/sphl/index.md
+++ b/docs/docs/sphl/index.md
@@ -1,6 +1,7 @@
 ---
 title: SPHL
 sidebar_label: SPHL
+description: "sdv-py SPHL: endpoint references, dataset loaders and parsers for SPHL in the SportsDataverse Python package."
 ---
 # SPHL (`sportsdataverse.sphl`)
 

--- a/docs/docs/sphl/reference/additional.md
+++ b/docs/docs/sphl/reference/additional.md
@@ -1,6 +1,7 @@
 ---
 title: SPHL — additional Python functions
 sidebar_label: Additional functions
+description: "SPHL — additional Python functions — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: 50
 ---
 # SPHL — additional Python functions

--- a/docs/docs/ucl/index.md
+++ b/docs/docs/ucl/index.md
@@ -1,6 +1,7 @@
 ---
 title: UCL
 sidebar_label: UCL
+description: "sdv-py UCL: endpoint references, dataset loaders and parsers for UCL in the SportsDataverse Python package."
 ---
 # UCL (`sportsdataverse.ucl`)
 

--- a/docs/docs/ucl/reference/core.md
+++ b/docs/docs/ucl/reference/core.md
@@ -1,6 +1,7 @@
 ---
 title: UCL — ESPN core API (v2)
 sidebar_label: ESPN core API (v2)
+description: "UCL — ESPN core API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 22
 ---
 # UCL — ESPN core API (v2)

--- a/docs/docs/ucl/reference/fitt.md
+++ b/docs/docs/ucl/reference/fitt.md
@@ -1,6 +1,7 @@
 ---
 title: UCL — ESPN FPI API (fitt v3)
 sidebar_label: ESPN FPI API (fitt v3)
+description: "UCL — ESPN FPI API (fitt v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 23
 ---
 # UCL — ESPN FPI API (fitt v3)

--- a/docs/docs/ucl/reference/site.md
+++ b/docs/docs/ucl/reference/site.md
@@ -1,6 +1,7 @@
 ---
 title: UCL — ESPN site API (v2)
 sidebar_label: ESPN site API (v2)
+description: "UCL — ESPN site API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 20
 ---
 # UCL — ESPN site API (v2)

--- a/docs/docs/ucl/reference/web.md
+++ b/docs/docs/ucl/reference/web.md
@@ -1,6 +1,7 @@
 ---
 title: UCL — ESPN web API (v3)
 sidebar_label: ESPN web API (v3)
+description: "UCL — ESPN web API (v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 21
 ---
 # UCL — ESPN web API (v3)

--- a/docs/docs/uel/index.md
+++ b/docs/docs/uel/index.md
@@ -1,6 +1,7 @@
 ---
 title: UEL
 sidebar_label: UEL
+description: "sdv-py UEL: endpoint references, dataset loaders and parsers for UEL in the SportsDataverse Python package."
 ---
 # UEL (`sportsdataverse.uel`)
 

--- a/docs/docs/uel/reference/core.md
+++ b/docs/docs/uel/reference/core.md
@@ -1,6 +1,7 @@
 ---
 title: UEL — ESPN core API (v2)
 sidebar_label: ESPN core API (v2)
+description: "UEL — ESPN core API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 22
 ---
 # UEL — ESPN core API (v2)

--- a/docs/docs/uel/reference/fitt.md
+++ b/docs/docs/uel/reference/fitt.md
@@ -1,6 +1,7 @@
 ---
 title: UEL — ESPN FPI API (fitt v3)
 sidebar_label: ESPN FPI API (fitt v3)
+description: "UEL — ESPN FPI API (fitt v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 23
 ---
 # UEL — ESPN FPI API (fitt v3)

--- a/docs/docs/uel/reference/site.md
+++ b/docs/docs/uel/reference/site.md
@@ -1,6 +1,7 @@
 ---
 title: UEL — ESPN site API (v2)
 sidebar_label: ESPN site API (v2)
+description: "UEL — ESPN site API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 20
 ---
 # UEL — ESPN site API (v2)

--- a/docs/docs/uel/reference/web.md
+++ b/docs/docs/uel/reference/web.md
@@ -1,6 +1,7 @@
 ---
 title: UEL — ESPN web API (v3)
 sidebar_label: ESPN web API (v3)
+description: "UEL — ESPN web API (v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 21
 ---
 # UEL — ESPN web API (v3)

--- a/docs/docs/ufl/index.md
+++ b/docs/docs/ufl/index.md
@@ -1,6 +1,7 @@
 ---
 title: UFL
 sidebar_label: UFL
+description: "sdv-py UFL: endpoint references, dataset loaders and parsers for UFL in the SportsDataverse Python package."
 ---
 # UFL (`sportsdataverse.ufl`)
 

--- a/docs/docs/ufl/reference/core.md
+++ b/docs/docs/ufl/reference/core.md
@@ -1,6 +1,7 @@
 ---
 title: UFL — ESPN core API (v2)
 sidebar_label: ESPN core API (v2)
+description: "UFL — ESPN core API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 22
 ---
 # UFL — ESPN core API (v2)

--- a/docs/docs/ufl/reference/fitt.md
+++ b/docs/docs/ufl/reference/fitt.md
@@ -1,6 +1,7 @@
 ---
 title: UFL — ESPN FPI API (fitt v3)
 sidebar_label: ESPN FPI API (fitt v3)
+description: "UFL — ESPN FPI API (fitt v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 23
 ---
 # UFL — ESPN FPI API (fitt v3)

--- a/docs/docs/ufl/reference/site.md
+++ b/docs/docs/ufl/reference/site.md
@@ -1,6 +1,7 @@
 ---
 title: UFL — ESPN site API (v2)
 sidebar_label: ESPN site API (v2)
+description: "UFL — ESPN site API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 20
 ---
 # UFL — ESPN site API (v2)

--- a/docs/docs/ufl/reference/web.md
+++ b/docs/docs/ufl/reference/web.md
@@ -1,6 +1,7 @@
 ---
 title: UFL — ESPN web API (v3)
 sidebar_label: ESPN web API (v3)
+description: "UFL — ESPN web API (v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 21
 ---
 # UFL — ESPN web API (v3)

--- a/docs/docs/ushl/index.md
+++ b/docs/docs/ushl/index.md
@@ -1,6 +1,7 @@
 ---
 title: USHL
 sidebar_label: USHL
+description: "sdv-py USHL: endpoint references, dataset loaders and parsers for USHL in the SportsDataverse Python package."
 ---
 # USHL (`sportsdataverse.ushl`)
 

--- a/docs/docs/ushl/reference/additional.md
+++ b/docs/docs/ushl/reference/additional.md
@@ -1,6 +1,7 @@
 ---
 title: USHL — additional Python functions
 sidebar_label: Additional functions
+description: "USHL — additional Python functions — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: 50
 ---
 # USHL — additional Python functions

--- a/docs/docs/vijhl/index.md
+++ b/docs/docs/vijhl/index.md
@@ -1,6 +1,7 @@
 ---
 title: VIJHL
 sidebar_label: VIJHL
+description: "sdv-py VIJHL: endpoint references, dataset loaders and parsers for VIJHL in the SportsDataverse Python package."
 ---
 # VIJHL (`sportsdataverse.vijhl`)
 

--- a/docs/docs/vijhl/reference/additional.md
+++ b/docs/docs/vijhl/reference/additional.md
@@ -1,6 +1,7 @@
 ---
 title: VIJHL — additional Python functions
 sidebar_label: Additional functions
+description: "VIJHL — additional Python functions — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: 50
 ---
 # VIJHL — additional Python functions

--- a/docs/docs/wbb/index.md
+++ b/docs/docs/wbb/index.md
@@ -1,6 +1,7 @@
 ---
 title: WBB
 sidebar_label: WBB
+description: "sdv-py WBB: endpoint references, dataset loaders and parsers for WBB in the SportsDataverse Python package."
 ---
 # WBB (`sportsdataverse.wbb`)
 

--- a/docs/docs/wbb/reference/additional.md
+++ b/docs/docs/wbb/reference/additional.md
@@ -1,6 +1,7 @@
 ---
 title: WBB — additional Python functions
 sidebar_label: Additional functions
+description: "WBB — additional Python functions — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: 50
 ---
 # WBB — additional Python functions

--- a/docs/docs/wbb/reference/bart_wbb.md
+++ b/docs/docs/wbb/reference/bart_wbb.md
@@ -1,6 +1,7 @@
 ---
 title: WBB — Bart Torvik Women's T-Rank (barttorvik.com/ncaaw)
 sidebar_label: Bart Torvik Women's T-Rank (barttorvik.com/ncaaw)
+description: "WBB — Bart Torvik Women's T-Rank (barttorvik.com/ncaaw) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 10
 ---
 # WBB — Bart Torvik Women's T-Rank (barttorvik.com/ncaaw)

--- a/docs/docs/wbb/reference/core.md
+++ b/docs/docs/wbb/reference/core.md
@@ -1,6 +1,7 @@
 ---
 title: WBB — ESPN core API (v2)
 sidebar_label: ESPN core API (v2)
+description: "WBB — ESPN core API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 22
 ---
 # WBB — ESPN core API (v2)

--- a/docs/docs/wbb/reference/fitt.md
+++ b/docs/docs/wbb/reference/fitt.md
@@ -1,6 +1,7 @@
 ---
 title: WBB — ESPN FPI API (fitt v3)
 sidebar_label: ESPN FPI API (fitt v3)
+description: "WBB — ESPN FPI API (fitt v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 23
 ---
 # WBB — ESPN FPI API (fitt v3)

--- a/docs/docs/wbb/reference/loaders.md
+++ b/docs/docs/wbb/reference/loaders.md
@@ -1,6 +1,7 @@
 ---
 title: WBB dataset loaders
 sidebar_label: Loaders
+description: "WBB dataset loaders in sdv-py: the load_* functions that read the SportsDataverse release assets."
 sidebar_position: 1
 ---
 # WBB dataset loaders

--- a/docs/docs/wbb/reference/site.md
+++ b/docs/docs/wbb/reference/site.md
@@ -1,6 +1,7 @@
 ---
 title: WBB — ESPN site API (v2)
 sidebar_label: ESPN site API (v2)
+description: "WBB — ESPN site API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 20
 ---
 # WBB — ESPN site API (v2)

--- a/docs/docs/wbb/reference/web.md
+++ b/docs/docs/wbb/reference/web.md
@@ -1,6 +1,7 @@
 ---
 title: WBB — ESPN web API (v3)
 sidebar_label: ESPN web API (v3)
+description: "WBB — ESPN web API (v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 21
 ---
 # WBB — ESPN web API (v3)

--- a/docs/docs/wc/index.md
+++ b/docs/docs/wc/index.md
@@ -1,6 +1,7 @@
 ---
 title: WC
 sidebar_label: WC
+description: "sdv-py WC: endpoint references, dataset loaders and parsers for WC in the SportsDataverse Python package."
 ---
 # WC (`sportsdataverse.wc`)
 

--- a/docs/docs/wc/reference/core.md
+++ b/docs/docs/wc/reference/core.md
@@ -1,6 +1,7 @@
 ---
 title: WC — ESPN core API (v2)
 sidebar_label: ESPN core API (v2)
+description: "WC — ESPN core API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 22
 ---
 # WC — ESPN core API (v2)

--- a/docs/docs/wc/reference/fitt.md
+++ b/docs/docs/wc/reference/fitt.md
@@ -1,6 +1,7 @@
 ---
 title: WC — ESPN FPI API (fitt v3)
 sidebar_label: ESPN FPI API (fitt v3)
+description: "WC — ESPN FPI API (fitt v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 23
 ---
 # WC — ESPN FPI API (fitt v3)

--- a/docs/docs/wc/reference/site.md
+++ b/docs/docs/wc/reference/site.md
@@ -1,6 +1,7 @@
 ---
 title: WC — ESPN site API (v2)
 sidebar_label: ESPN site API (v2)
+description: "WC — ESPN site API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 20
 ---
 # WC — ESPN site API (v2)

--- a/docs/docs/wc/reference/web.md
+++ b/docs/docs/wc/reference/web.md
@@ -1,6 +1,7 @@
 ---
 title: WC — ESPN web API (v3)
 sidebar_label: ESPN web API (v3)
+description: "WC — ESPN web API (v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 21
 ---
 # WC — ESPN web API (v3)

--- a/docs/docs/wch/index.md
+++ b/docs/docs/wch/index.md
@@ -1,6 +1,7 @@
 ---
 title: WCH
 sidebar_label: WCH
+description: "sdv-py WCH: endpoint references, dataset loaders and parsers for WCH in the SportsDataverse Python package."
 ---
 # WCH (`sportsdataverse.wch`)
 

--- a/docs/docs/wch/reference/core.md
+++ b/docs/docs/wch/reference/core.md
@@ -1,6 +1,7 @@
 ---
 title: WCH — ESPN core API (v2)
 sidebar_label: ESPN core API (v2)
+description: "WCH — ESPN core API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 22
 ---
 # WCH — ESPN core API (v2)

--- a/docs/docs/wch/reference/fitt.md
+++ b/docs/docs/wch/reference/fitt.md
@@ -1,6 +1,7 @@
 ---
 title: WCH — ESPN FPI API (fitt v3)
 sidebar_label: ESPN FPI API (fitt v3)
+description: "WCH — ESPN FPI API (fitt v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 23
 ---
 # WCH — ESPN FPI API (fitt v3)

--- a/docs/docs/wch/reference/site.md
+++ b/docs/docs/wch/reference/site.md
@@ -1,6 +1,7 @@
 ---
 title: WCH — ESPN site API (v2)
 sidebar_label: ESPN site API (v2)
+description: "WCH — ESPN site API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 20
 ---
 # WCH — ESPN site API (v2)

--- a/docs/docs/wch/reference/web.md
+++ b/docs/docs/wch/reference/web.md
@@ -1,6 +1,7 @@
 ---
 title: WCH — ESPN web API (v3)
 sidebar_label: ESPN web API (v3)
+description: "WCH — ESPN web API (v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 21
 ---
 # WCH — ESPN web API (v3)

--- a/docs/docs/whl/index.md
+++ b/docs/docs/whl/index.md
@@ -1,6 +1,7 @@
 ---
 title: WHL
 sidebar_label: WHL
+description: "sdv-py WHL: endpoint references, dataset loaders and parsers for WHL in the SportsDataverse Python package."
 ---
 # WHL (`sportsdataverse.whl`)
 

--- a/docs/docs/whl/reference/additional.md
+++ b/docs/docs/whl/reference/additional.md
@@ -1,6 +1,7 @@
 ---
 title: WHL — additional Python functions
 sidebar_label: Additional functions
+description: "WHL — additional Python functions — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: 50
 ---
 # WHL — additional Python functions

--- a/docs/docs/wnba/index.md
+++ b/docs/docs/wnba/index.md
@@ -1,6 +1,7 @@
 ---
 title: WNBA
 sidebar_label: WNBA
+description: "sdv-py WNBA: endpoint references, dataset loaders and parsers for WNBA in the SportsDataverse Python package."
 ---
 # WNBA (`sportsdataverse.wnba`)
 

--- a/docs/docs/wnba/reference/additional.md
+++ b/docs/docs/wnba/reference/additional.md
@@ -1,6 +1,7 @@
 ---
 title: WNBA — additional Python functions
 sidebar_label: Additional functions
+description: "WNBA — additional Python functions — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: 50
 ---
 # WNBA — additional Python functions

--- a/docs/docs/wnba/reference/core.md
+++ b/docs/docs/wnba/reference/core.md
@@ -1,6 +1,7 @@
 ---
 title: WNBA — ESPN core API (v2)
 sidebar_label: ESPN core API (v2)
+description: "WNBA — ESPN core API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 22
 ---
 # WNBA — ESPN core API (v2)

--- a/docs/docs/wnba/reference/fitt.md
+++ b/docs/docs/wnba/reference/fitt.md
@@ -1,6 +1,7 @@
 ---
 title: WNBA — ESPN FPI API (fitt v3)
 sidebar_label: ESPN FPI API (fitt v3)
+description: "WNBA — ESPN FPI API (fitt v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 23
 ---
 # WNBA — ESPN FPI API (fitt v3)

--- a/docs/docs/wnba/reference/loaders.md
+++ b/docs/docs/wnba/reference/loaders.md
@@ -1,6 +1,7 @@
 ---
 title: WNBA dataset loaders
 sidebar_label: Loaders
+description: "WNBA dataset loaders in sdv-py: the load_* functions that read the SportsDataverse release assets."
 sidebar_position: 1
 ---
 # WNBA dataset loaders

--- a/docs/docs/wnba/reference/site.md
+++ b/docs/docs/wnba/reference/site.md
@@ -1,6 +1,7 @@
 ---
 title: WNBA — ESPN site API (v2)
 sidebar_label: ESPN site API (v2)
+description: "WNBA — ESPN site API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 20
 ---
 # WNBA — ESPN site API (v2)

--- a/docs/docs/wnba/reference/web.md
+++ b/docs/docs/wnba/reference/web.md
@@ -1,6 +1,7 @@
 ---
 title: WNBA — ESPN web API (v3)
 sidebar_label: ESPN web API (v3)
+description: "WNBA — ESPN web API (v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 21
 ---
 # WNBA — ESPN web API (v3)

--- a/docs/docs/wnba/reference/wnba_stats.md
+++ b/docs/docs/wnba/reference/wnba_stats.md
@@ -1,6 +1,7 @@
 ---
 title: WNBA — WNBA Stats API (stats.wnba.com)
 sidebar_label: WNBA Stats API (stats.wnba.com)
+description: "WNBA — WNBA Stats API (stats.wnba.com) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 10
 ---
 # WNBA — WNBA Stats API (stats.wnba.com)

--- a/docs/docs/wwc/index.md
+++ b/docs/docs/wwc/index.md
@@ -1,6 +1,7 @@
 ---
 title: WWC
 sidebar_label: WWC
+description: "sdv-py WWC: endpoint references, dataset loaders and parsers for WWC in the SportsDataverse Python package."
 ---
 # WWC (`sportsdataverse.wwc`)
 

--- a/docs/docs/wwc/reference/core.md
+++ b/docs/docs/wwc/reference/core.md
@@ -1,6 +1,7 @@
 ---
 title: WWC — ESPN core API (v2)
 sidebar_label: ESPN core API (v2)
+description: "WWC — ESPN core API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 22
 ---
 # WWC — ESPN core API (v2)

--- a/docs/docs/wwc/reference/fitt.md
+++ b/docs/docs/wwc/reference/fitt.md
@@ -1,6 +1,7 @@
 ---
 title: WWC — ESPN FPI API (fitt v3)
 sidebar_label: ESPN FPI API (fitt v3)
+description: "WWC — ESPN FPI API (fitt v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 23
 ---
 # WWC — ESPN FPI API (fitt v3)

--- a/docs/docs/wwc/reference/site.md
+++ b/docs/docs/wwc/reference/site.md
@@ -1,6 +1,7 @@
 ---
 title: WWC — ESPN site API (v2)
 sidebar_label: ESPN site API (v2)
+description: "WWC — ESPN site API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 20
 ---
 # WWC — ESPN site API (v2)

--- a/docs/docs/wwc/reference/web.md
+++ b/docs/docs/wwc/reference/web.md
@@ -1,6 +1,7 @@
 ---
 title: WWC — ESPN web API (v3)
 sidebar_label: ESPN web API (v3)
+description: "WWC — ESPN web API (v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 21
 ---
 # WWC — ESPN web API (v3)

--- a/docs/docs/xfl/index.md
+++ b/docs/docs/xfl/index.md
@@ -1,6 +1,7 @@
 ---
 title: XFL
 sidebar_label: XFL
+description: "sdv-py XFL: endpoint references, dataset loaders and parsers for XFL in the SportsDataverse Python package."
 ---
 # XFL (`sportsdataverse.xfl`)
 

--- a/docs/docs/xfl/reference/core.md
+++ b/docs/docs/xfl/reference/core.md
@@ -1,6 +1,7 @@
 ---
 title: XFL — ESPN core API (v2)
 sidebar_label: ESPN core API (v2)
+description: "XFL — ESPN core API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 22
 ---
 # XFL — ESPN core API (v2)

--- a/docs/docs/xfl/reference/fitt.md
+++ b/docs/docs/xfl/reference/fitt.md
@@ -1,6 +1,7 @@
 ---
 title: XFL — ESPN FPI API (fitt v3)
 sidebar_label: ESPN FPI API (fitt v3)
+description: "XFL — ESPN FPI API (fitt v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 23
 ---
 # XFL — ESPN FPI API (fitt v3)

--- a/docs/docs/xfl/reference/site.md
+++ b/docs/docs/xfl/reference/site.md
@@ -1,6 +1,7 @@
 ---
 title: XFL — ESPN site API (v2)
 sidebar_label: ESPN site API (v2)
+description: "XFL — ESPN site API (v2) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 20
 ---
 # XFL — ESPN site API (v2)

--- a/docs/docs/xfl/reference/web.md
+++ b/docs/docs/xfl/reference/web.md
@@ -1,6 +1,7 @@
 ---
 title: XFL — ESPN web API (v3)
 sidebar_label: ESPN web API (v3)
+description: "XFL — ESPN web API (v3) — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: 21
 ---
 # XFL — ESPN web API (v3)

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -33,7 +33,10 @@ const config: Config = {
   },
   title: 'sdv-py',
   tagline: "The SportsDataverse's Python Package for Sports Data.",
-  url: 'https://sportsdataverse-py.sportsdataverse.org',
+  // The site is served from the CNAME host. With the old subdomain here, every
+  // canonical, og:url and og:image pointed off-host, so shares canonicalised and
+  // previewed against a domain no link ever used.
+  url: 'https://py.sportsdataverse.org',
   baseUrl: '/',
   // The per-league reference subtree under docs/docs/{league}/ is generated from
   // endpoint metadata (`python tools/codegen/generate.py --docs`); the conceptual
@@ -126,6 +129,19 @@ const config: Config = {
       respectPrefersColorScheme: true,
     },
     image: 'img/Sportsdataverse_gh.png',
+    // Social metadata Docusaurus does not emit on its own. og:image alone renders
+    // a bare card on several platforms; the type, site name, image dimensions and
+    // Twitter attribution are what make the preview complete.
+    metadata: [
+      { property: 'og:type', content: 'website' },
+      { property: 'og:site_name', content: 'sdv-py | SportsDataverse' },
+      { property: 'og:image:width', content: '1080' },
+      { property: 'og:image:height', content: '540' },
+      { property: 'og:image:alt', content: 'SportsDataverse' },
+      { name: 'twitter:site', content: '@sportsdataverse' },
+      { name: 'twitter:creator', content: '@saiemgilani' },
+      { name: 'twitter:image:alt', content: 'SportsDataverse' },
+    ],
     navbar: {
       hideOnScroll: true,
       title: 'sdv-py',

--- a/tools/codegen/templates/autodoc_page.md.jinja
+++ b/tools/codegen/templates/autodoc_page.md.jinja
@@ -1,6 +1,7 @@
 ---
 title: {{ title }}
 sidebar_label: Additional functions
+description: "{{ title }} — additional functions in sdv-py, the SportsDataverse Python package."
 sidebar_position: {{ sidebar_position }}
 ---
 # {{ title }}

--- a/tools/codegen/templates/league_index.md.jinja
+++ b/tools/codegen/templates/league_index.md.jinja
@@ -1,6 +1,7 @@
 ---
 title: {{ prefix|upper }}
 sidebar_label: {{ prefix|upper }}
+description: "sdv-py {{ prefix|upper }}: endpoint references, dataset loaders and parsers for {{ prefix|upper }} in the SportsDataverse Python package."
 ---
 # {{ prefix|upper }} (`sportsdataverse.{{ prefix }}`)
 

--- a/tools/codegen/templates/loaders_page.md.jinja
+++ b/tools/codegen/templates/loaders_page.md.jinja
@@ -1,6 +1,7 @@
 ---
 title: {{ prefix|upper }} dataset loaders
 sidebar_label: Loaders
+description: "{{ prefix|upper }} dataset loaders in sdv-py: the load_* functions that read the SportsDataverse release assets."
 sidebar_position: {{ sidebar_position }}
 ---
 # {{ prefix|upper }} dataset loaders

--- a/tools/codegen/templates/packages_page.mdx.jinja
+++ b/tools/codegen/templates/packages_page.mdx.jinja
@@ -1,6 +1,7 @@
 ---
 title: SportsDataVerse Packages
 sidebar_label: Packages
+description: "The SportsDataverse family of packages across R, Python and JavaScript."
 ---
 # SportsDataVerse Packages
 

--- a/tools/codegen/templates/parameter_reference.md.jinja
+++ b/tools/codegen/templates/parameter_reference.md.jinja
@@ -1,6 +1,7 @@
 ---
 title: Parameters
 sidebar_label: Parameters
+description: "Parameter reference for sdv-py endpoint functions."
 ---
 # Parameter reference
 

--- a/tools/codegen/templates/reference_page.md.jinja
+++ b/tools/codegen/templates/reference_page.md.jinja
@@ -1,6 +1,7 @@
 ---
 title: {{ title }}
 sidebar_label: {{ label }}
+description: "{{ title }} — endpoint reference in sdv-py, the SportsDataverse Python package."
 sidebar_position: {{ sidebar_position }}
 ---
 {% from "_reference_block.jinja" import block %}


### PR DESCRIPTION
Every link to the Python docs previewed badly on every platform. The site was
not bare of metadata -- Docusaurus emits og:title, og:description, og:image and
twitter:card from themeConfig -- but three things were wrong with what it emitted.

1. The wrong host. docusaurus.config.ts declared url as
   sportsdataverse-py.sportsdataverse.org while the CNAME is
   py.sportsdataverse.org, so the canonical, og:url and og:image on every page
   pointed at a domain no link ever used. Platforms canonicalise on og:url and
   fetch the image from it; both resolve, but the preview is built for the
   wrong page. url now matches the CNAME.

2. Nothing beyond the basics. No og:type, og:site_name, image dimensions or
   Twitter attribution -- the fields that turn an image into a complete card.
   Added as themeConfig.metadata; the existing 1080x540 image is exactly 2:1
   and stays.

3. A table header as every docs page's description. Generated pages carried no
   description frontmatter, so Docusaurus used the first paragraph -- which on
   a league index is "| Reference | Functions | Base URL |". Descriptions are
   now emitted by the codegen templates (league index, reference, loaders,
   additional functions, parameters, packages), built only from variables each
   template already receives; the 228 regenerated pages under docs/ are the
   output, never hand-edited. Drift check clean.

Verified on a local build: canonical/og:url on py.sportsdataverse.org, the new
metadata present, and each docs page's og:description reading as prose.

## Summary by Sourcery

Improve the Python documentation site's social sharing metadata and page descriptions.

New Features:
- Add complete Open Graph and Twitter metadata for richer social previews.

Bug Fixes:
- Correct the documentation site URL so canonical links and social image URLs use py.sportsdataverse.org.
- Replace generated documentation descriptions that defaulted to table headers with meaningful page-specific prose.

Enhancements:
- Generate descriptions consistently across league indexes, endpoint references, loaders, helper functions, parameters, and package pages, then regenerate the documentation output.

Documentation:
- Add descriptive frontmatter to the generated documentation pages.

Tests:
- Verify the local build produces correct canonical URLs, social metadata, and prose descriptions, with no generated-content drift.