### PR TITLE
feat(cfb): air yards, aDOT and YAC aggregates in the passer and receiver box scores

### DIFF
--- a/docs/docs/cfb/reference/additional.md
+++ b/docs/docs/cfb/reference/additional.md
@@ -698,7 +698,7 @@ so the input `play_df` is expected to be the post-pipeline plays frame.
 
 **Returns**
 
-Box-score sections, each a list of records — `"pass"` / `"rush"` / `"receiver"` (per-player advanced + EPA lines), `"team"` and `"situational"` (per-team), `"defensive"` and `"defensive_players"` (team- and player-level havoc), `"specialists"` (kicking / punting / return players), `"turnover"`, `"drives"`, and the ESPN-sourced `"espn_team"` / `"espn_players"` totals.
+Box-score sections, each a list of records — `"pass"` / `"rush"` / `"receiver"` (per-player advanced + EPA lines; the pass and receiver lines carry `AirYds` / `aDOT` / `CompAirYds` / `YAC` / `AirYdsPct`, null when ESPN's text has no catch spot), `"team"` and `"situational"` (per-team), `"defensive"` and `"defensive_players"` (team- and player-level havoc), `"specialists"` (kicking / punting / return players), `"turnover"`, `"drives"`, and the ESPN-sourced `"espn_team"` / `"espn_players"` totals.
 
 **Example**
 

--- a/sportsdataverse/cfb/cfb_pbp.py
+++ b/sportsdataverse/cfb/cfb_pbp.py
@@ -1118,6 +1118,49 @@ def _parse_espn_player_box(boxscore):
     return rows
 
 
+def _air_yards_box(pass_box: "pl.DataFrame", key: str) -> "pl.DataFrame":
+    """Per-``key`` air-yards / YAC aggregate for the passer + receiver box scores.
+
+    Runs on the UNFILLED pass frame: ``_fill_missing`` zero-fills numerics, and a
+    zero air-yard is a real observation (a screen) while a null means ESPN's text
+    carried no catch spot (pre-2025 games, sacks, throwaways). Every output is null
+    when no play in the group has ``air_yards``, so a game without the data shows
+    blanks, not 0.0.
+
+    Columns: ``AirYds`` (all attempts), ``aDOT`` (mean air yards per attempt with
+    data), ``CompAirYds`` (completions only), ``YAC``, and ``AirYdsPct``
+    (``CompAirYds / Yds`` -- share of receiving yards earned in the air).
+    """
+    has_air = pl.col("air_yards").is_not_null()
+    return (
+        pass_box.group_by(["pos_team", key])
+        .agg(
+            _n_air=has_air.sum(),
+            AirYds=pl.col("air_yards").sum(),
+            aDOT=pl.col("air_yards").mean(),
+            CompAirYds=pl.when(pl.col("completion") == True).then(pl.col("air_yards")).otherwise(None).sum(),
+            YAC=pl.col("yards_after_catch").sum(),
+            _yds=pl.col("yds_receiving").sum(),
+        )
+        .with_columns(
+            AirYds=pl.when(pl.col("_n_air") > 0).then(pl.col("AirYds")).otherwise(None),
+            CompAirYds=pl.when(pl.col("_n_air") > 0).then(pl.col("CompAirYds")).otherwise(None),
+            YAC=pl.when(pl.col("_n_air") > 0).then(pl.col("YAC")).otherwise(None),
+        )
+        .with_columns(
+            AirYdsPct=pl.when((pl.col("_n_air") > 0) & (pl.col("_yds") != 0))
+            .then(pl.col("CompAirYds") / pl.col("_yds"))
+            .otherwise(None)
+        )
+        .drop("_n_air", "_yds")
+        .with_columns(
+            pos_team=pl.col("pos_team").cast(pl.Int32),  # join key: both boxes cast pos_team Int32 first
+            aDOT=pl.col("aDOT").cast(pl.Float32).round(2),
+            AirYdsPct=pl.col("AirYdsPct").cast(pl.Float32).round(2),
+        )
+    )
+
+
 def _fill_missing(df: "pl.DataFrame") -> "pl.DataFrame":
     """Fill nulls for aggregation: 0.0 for numerics, False for booleans.
 
@@ -7687,7 +7730,9 @@ class CFBPlayProcess(object):
 
         Returns:
             dict: Box-score sections, each a list of records — ``"pass"`` /
-            ``"rush"`` / ``"receiver"`` (per-player advanced + EPA lines),
+            ``"rush"`` / ``"receiver"`` (per-player advanced + EPA lines; the
+            pass and receiver lines carry ``AirYds`` / ``aDOT`` / ``CompAirYds``
+            / ``YAC`` / ``AirYdsPct``, null when ESPN's text has no catch spot),
             ``"team"`` and ``"situational"`` (per-team), ``"defensive"`` and
             ``"defensive_players"`` (team- and player-level havoc),
             ``"specialists"`` (kicking / punting / return players),
@@ -7799,6 +7844,7 @@ class CFBPlayProcess(object):
             )
             .with_columns(pl.col(pl.Float32).round(2))
             .with_columns(pos_team=pl.col("pos_team").cast(pl.Int32))
+            .join(_air_yards_box(pass_box, "passer_player_name"), on=["pos_team", "passer_player_name"], how="left")
         )
         # passer_box = passer_box.replace(pl.all(), pl.Null)
         qbs_list = passer_box["passer_player_name"].to_list()
@@ -7895,6 +7941,7 @@ class CFBPlayProcess(object):
             )
             .with_columns(pl.col(pl.Float32).round(2))
             .with_columns(pos_team=pl.col("pos_team").cast(pl.Int32))
+            .join(_air_yards_box(pass_box, "receiver_player_name"), on=["pos_team", "receiver_player_name"], how="left")
             .sort("Tar", descending=True)  # 0.36-live: box tables sorted by volume
         )
 

--- a/tests/cfb/test_cfb_box_air_yards.py
+++ b/tests/cfb/test_cfb_box_air_yards.py
@@ -40,11 +40,13 @@ def test_passer_and_receiver_air_yards_on_real_game(monkeypatch):
 
     # Decomposition: CompAirYds + YAC == receiving yards on completions, per passer.
     comp = plays.filter((pl.col("completion") == True) & (pl.col("yards_after_catch").is_not_null()))
-    per_qb = comp.group_by("passer_player_name").agg(
+    per_qb = comp.group_by(["pos_team", "passer_player_name"]).agg(
         air=pl.col("air_yards").sum(), yac=pl.col("yards_after_catch").sum(), yds=pl.col("statYardage").sum()
     )
     assert (per_qb["air"] + per_qb["yac"] == per_qb["yds"]).all()
-    joined = passers.join(per_qb, on="passer_player_name", how="inner")
+    # passers casts pos_team to Int32; match it before joining (id-dtype discipline).
+    per_qb = per_qb.with_columns(pos_team=pl.col("pos_team").cast(pl.Int32))
+    joined = passers.join(per_qb, on=["pos_team", "passer_player_name"], how="inner")
     assert joined.height > 0
     assert (joined["YAC"] == joined["yac"]).all()
 

--- a/tests/cfb/test_cfb_box_air_yards.py
+++ b/tests/cfb/test_cfb_box_air_yards.py
@@ -1,0 +1,86 @@
+"""Air-yards aggregates in ``create_box_score`` (passer + receiver lines)."""
+
+import json
+from pathlib import Path
+
+import polars as pl
+
+from sportsdataverse.cfb.cfb_pbp import CFBPlayProcess, _air_yards_box
+
+FIX = Path(__file__).parent / "fixtures"
+
+
+def _box(monkeypatch, game_id=401754598):
+    summary = json.loads((FIX / f"summary_{game_id}.json").read_text(encoding="utf-8"))
+
+    class _Resp:
+        def json(self):
+            return summary
+
+    monkeypatch.setattr("sportsdataverse.cfb.cfb_pbp.download", lambda *a, **k: _Resp())
+    proc = CFBPlayProcess(gameId=game_id)
+    proc.join_participants = False
+    proc.espn_cfb_pbp()
+    proc.run_processing_pipeline()
+    plays = pl.from_dicts(proc.plays_json, infer_schema_length=None)
+    return plays, proc.create_box_score(plays)
+
+
+def test_passer_and_receiver_air_yards_on_real_game(monkeypatch):
+    plays, box = _box(monkeypatch)
+    passers = pl.from_dicts(box["pass"], infer_schema_length=None)
+    receivers = pl.from_dicts(box["receiver"], infer_schema_length=None)
+    for df in (passers, receivers):
+        assert {"AirYds", "aDOT", "CompAirYds", "YAC", "AirYdsPct"} <= set(df.columns)
+
+    # The fixture has catch spots -> the starting QBs must have populated aDOT.
+    top = passers.sort("Att", descending=True).head(2)
+    assert top["aDOT"].drop_nulls().len() == 2
+    assert (top["AirYdsPct"].drop_nulls() <= 1.0).all()
+
+    # Decomposition: CompAirYds + YAC == receiving yards on completions, per passer.
+    comp = plays.filter((pl.col("completion") == True) & (pl.col("yards_after_catch").is_not_null()))
+    per_qb = comp.group_by("passer_player_name").agg(
+        air=pl.col("air_yards").sum(), yac=pl.col("yards_after_catch").sum(), yds=pl.col("statYardage").sum()
+    )
+    assert (per_qb["air"] + per_qb["yac"] == per_qb["yds"]).all()
+    joined = passers.join(per_qb, on="passer_player_name", how="inner")
+    assert joined.height > 0
+    assert (joined["YAC"] == joined["yac"]).all()
+
+
+def test_air_yards_box_is_null_not_zero_without_data():
+    """A game whose text carries no catch spot must show blanks, not 0.0."""
+    pass_box = pl.DataFrame(
+        {
+            "pos_team": [1, 1, 1],
+            "passer_player_name": ["A", "A", "B"],
+            "completion": [True, False, True],
+            "air_yards": [None, None, None],
+            "yards_after_catch": [None, None, None],
+            "yds_receiving": [10.0, 0.0, 5.0],
+        },
+        schema_overrides={"air_yards": pl.Int64, "yards_after_catch": pl.Int64},
+    )
+    out = _air_yards_box(pass_box, "passer_player_name")
+    for c in ("AirYds", "aDOT", "CompAirYds", "YAC", "AirYdsPct"):
+        assert out[c].is_null().all(), c
+
+
+def test_air_yards_box_zero_air_yard_screen_counts():
+    """A screen (air_yards == 0) is data: aDOT is 0.0, not null."""
+    pass_box = pl.DataFrame(
+        {
+            "pos_team": [1, 1],
+            "passer_player_name": ["A", "A"],
+            "completion": [True, True],
+            "air_yards": [0, 10],
+            "yards_after_catch": [12, 0],
+            "yds_receiving": [12.0, 10.0],
+        }
+    )
+    out = _air_yards_box(pass_box, "passer_player_name")
+    row = out.row(0, named=True)
+    assert row["AirYds"] == 10 and row["CompAirYds"] == 10 and row["YAC"] == 12
+    assert row["aDOT"] == 5.0
+    assert abs(row["AirYdsPct"] - round(10 / 22, 2)) < 1e-6  # helper rounds to 2 dp


### PR DESCRIPTION
## Summary
- `create_box_score` `pass` and `receiver` sections gain **`AirYds`** (all attempts / targets), **`aDOT`** (mean air yards per attempt with data), **`CompAirYds`** (completions only), **`YAC`**, and **`AirYdsPct`** (`CompAirYds / Yds`).
- New `_air_yards_box(pass_box, key)` runs on the **unfilled** pass frame and left-joins back after the box's own `pos_team` Int32 cast — `_fill_missing` zero-fills numerics, and a 0 air-yard is a real screen while a null is "ESPN's text has no catch spot", so every field is null (not 0.0) when no play in the group carries `air_yards`.
- Docstring + generated reference updated; codegen `--check` green.

Consumed by game-on-paper-app saiemgilani/game-on-paper-app#180.

## Test plan
- [x] `tests/cfb/test_cfb_box_air_yards.py` — real game (401754598): fields present, top-2 passers have aDOT, `CompAirYds + YAC == receiving yards` per passer; synthetic all-null → all-null; screen (`air_yards == 0`) counts as data
- [x] `tests/cfb/test_cfb_air_yards.py`, `test_cfb_pbp_offline.py` still green (15 passed)
- [x] `ruff check` / `ruff format` clean; `generate.py --check` current

## Summary by Sourcery

Add air-yard and yards-after-catch aggregates to CFB passer and receiver box scores.

New Features:
- Add air-yards, average depth of target, completion air-yards, yards after catch, and air-yards percentage aggregates to passer and receiver box-score records.

Enhancements:
- Preserve null aggregate values when a group has no air-yard data while treating zero-air-yard plays as valid observations.

Documentation:
- Update the box-score reference and docstring to document the new receiving and passing metrics and their null semantics.

Tests:
- Add coverage for real-game aggregates, missing air-yard data, and zero-air-yard screen plays.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added air-yard metrics to college football passer and receiver box scores, including average depth of target, completed air yards, yards after catch, and air-yard percentage.
  - Preserved null values when catch-location data is unavailable.
  - Correctly reports zero-air-yard plays, such as screens.

- **Documentation**
  - Updated the CFB reference documentation to describe the new box-score columns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->