### PR TITLE
fix(cfb): key returning production on the ESPN roster's team_id

### DIFF
--- a/sportsdataverse/cfb/cfb_returning_production.py
+++ b/sportsdataverse/cfb/cfb_returning_production.py
@@ -273,6 +273,16 @@ def _roster_keys(season: int) -> pl.DataFrame:
     if roster is None or roster.height == 0:
         return pl.DataFrame(schema={"season": pl.Int64, "team_id": pl.Utf8, "player_id": pl.Utf8})
 
+    if "team_id" in roster.columns:
+        # espn_cfb_rosters (#399) carries the ESPN team id directly, so no name
+        # crosswalk is needed -- and none is possible: it has no `team` column.
+        # The name path below is kept for the CFBD-shaped roster (`team` = school).
+        return roster.select(
+            pl.lit(season, dtype=pl.Int64).alias("season"),
+            pl.col("team_id").cast(pl.Int64).cast(pl.Utf8).alias("team_id"),
+            pl.col("athlete_id").cast(pl.Utf8).alias("player_id"),
+        ).drop_nulls(["team_id", "player_id"])
+
     info = load_cfb_team_info(season)
     if isinstance(info, pd.DataFrame):
         info = pl.from_pandas(info)

--- a/sportsdataverse/cfb/cfb_returning_production.py
+++ b/sportsdataverse/cfb/cfb_returning_production.py
@@ -249,23 +249,24 @@ def _production_from_box(box: pl.DataFrame, season: int) -> pl.DataFrame:
 def _roster_keys(season: int) -> pl.DataFrame:
     """Season-S roster as ``(season, team_id, player_id)`` with REAL team ids.
 
-    Rosters ship a team NAME and no team id, so this is the one place a name is
-    still involved. It resolves against ``load_cfb_team_info``'s ``school``
-    column, NOT the teams crosswalk: the crosswalk keys on school+mascot
-    ("western kentucky hilltoppers") while rosters carry school only ("Western
-    Kentucky"), which matched 0.0% of 2023 rows. `team_info` carries school and
-    `team_id` side by side, so the join is direct.
+    Two roster shapes reach this function:
 
-    Matching folds case (CLAUDE.md: names join case-insensitively unless case is
-    load-bearing) and falls back through ESPN's alternate names.
-
-    The match rate is ASSERTED rather than assumed -- an unresolved roster makes
-    every player look departed, which reads as "this team returns nobody"
-    instead of as a failure.
+    * **ESPN** (``espn_cfb_rosters``, what :func:`load_cfb_rosters` serves since
+      #399): carries ``team_id`` directly. Keys are taken as-is; rows with a null
+      ``team_id`` or ``athlete_id`` are dropped (ESPN emits none in practice) and
+      no match-rate check applies -- there is nothing to resolve.
+    * **CFBD-shaped** (a ``team`` school-name column, no id): resolved against
+      ``load_cfb_team_info``'s ``school`` column, NOT the teams crosswalk -- the
+      crosswalk keys on school+mascot ("western kentucky hilltoppers") while
+      that roster carries school only ("Western Kentucky"), which matched 0.0%
+      of 2023 rows. Matching folds case and falls back through ESPN's
+      alternate names. The match rate is ASSERTED rather than assumed: an
+      unresolved roster makes every player look departed, which reads as
+      "this team returns nobody" instead of as a failure.
 
     Raises:
-        ValueError: If fewer than :data:`_MIN_ROSTER_MATCH` of roster rows
-            resolve to a team id.
+        ValueError: CFBD-shaped roster only -- if fewer than
+            :data:`_MIN_ROSTER_MATCH` of roster rows resolve to a team id.
     """
     roster = load_cfb_rosters(season)
     if isinstance(roster, pd.DataFrame):
@@ -444,8 +445,10 @@ def cfb_returning_production(
         (typed) when the box data is unavailable.
 
     Raises:
-        ValueError: If the season-S roster cannot be resolved to team ids above
-            the crosswalk match floor.
+        ValueError: Only when the season-S roster is CFBD-shaped (``team`` name,
+            no ``team_id``) and cannot be resolved to team ids above the
+            crosswalk match floor; the ESPN roster carries ``team_id`` and
+            needs no resolution.
 
     Example:
         Quick start::

--- a/tests/cfb/test_cfb_returning_production.py
+++ b/tests/cfb/test_cfb_returning_production.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+import importlib
+
 import polars as pl
 
 from sportsdataverse.cfb.cfb_returning_production import _returning_from_frames
+
+# The package re-exports the FUNCTION under the module's name, so attribute
+# import would hand back the callable; resolve the module explicitly.
+rp = importlib.import_module("sportsdataverse.cfb.cfb_returning_production")
 
 
 def test_half_offense_returns() -> None:
@@ -72,3 +78,26 @@ def test_empty_input_returns_documented_schema() -> None:
     assert out.height == 0
     assert out.schema["off_returning"] == pl.Float64
     assert out.schema["n_returning"] == pl.Int64
+
+
+def test_roster_keys_use_espn_team_id_without_name_crosswalk(monkeypatch) -> None:
+    """espn_cfb_rosters (#399) has team_id but no `team`; the name join must be skipped."""
+    espn_roster = pl.DataFrame(
+        {
+            "season": [2025, 2025, 2025],
+            "team_id": [333, 333, None],
+            "athlete_id": [1, 2, 3],
+            "team_name": ["Crimson Tide", "Crimson Tide", "Crimson Tide"],
+        }
+    )
+    monkeypatch.setattr(rp, "load_cfb_rosters", lambda season: espn_roster)
+
+    def _no_info(season):  # pragma: no cover - the assertion is that it is never reached
+        raise AssertionError("team_info crosswalk must not run for an ESPN roster")
+
+    monkeypatch.setattr(rp, "load_cfb_team_info", _no_info)
+    out = rp._roster_keys(2025)
+    assert out.columns == ["season", "team_id", "player_id"]
+    assert out["team_id"].to_list() == ["333", "333"]  # null team_id row dropped
+    assert out["player_id"].to_list() == ["1", "2"]
+    assert out.schema["team_id"] == pl.Utf8 and out.schema["player_id"] == pl.Utf8


### PR DESCRIPTION
## Why
#399 repointed `load_cfb_rosters` at the `espn_cfb_rosters` release (`team_id`, no `team`). `cfb_returning_production._roster_keys` still keyed on `pl.col("team")` and name-joined through `load_cfb_team_info`, so every call raised `ColumnNotFoundError: unable to find column "team"`. First seen on the cfbfastR-cfb-data 2025 compile against sdv-py main (`7be22b5a`); the 2026 CI compile earlier today still ran on a pre-#399 lock and passed.

## What
`_roster_keys`: when the roster has `team_id`, select `(season, team_id, athlete_id→player_id)` directly (Int64→Utf8 to match the production frame) and skip the crosswalk. The name path is unchanged for a CFBD-shaped roster.

## Verified
`pytest tests/cfb/test_cfb_returning_production.py`: 4 passed (new test asserts the ESPN shape never reaches `load_cfb_team_info` and that null `team_id` rows drop). ruff clean.

## Summary by Sourcery

Support direct team IDs in ESPN CFB rosters so returning-production calculations no longer fail after the roster schema change.

Bug Fixes:
- Fix returning-production roster key generation for ESPN-shaped CFB rosters by using their direct team IDs instead of requiring a missing team-name column.

Enhancements:
- Retain support for CFBD-shaped rosters through the existing team-name resolution path while normalizing ESPN roster identifiers and excluding incomplete rows.

Tests:
- Add coverage verifying ESPN roster processing skips the team-info crosswalk, drops null identifiers, and returns the expected key schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved returning-production calculations for ESPN roster data by using available team identifiers directly.
  * Excluded roster entries missing team identifiers and normalized player and team IDs for more reliable results.
  * Preserved support for roster data that requires team-name matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->