### PR TITLE
fix(cfb): side the catch spot by the game's own text abbreviations

### DIFF
--- a/sportsdataverse/cfb/cfb_pbp.py
+++ b/sportsdataverse/cfb/cfb_pbp.py
@@ -945,8 +945,8 @@ def _spot_key(abbr: pl.Expr) -> pl.Expr:
 def _spot_side_map(play_df: pl.DataFrame) -> pl.DataFrame:
     """Learn which team each text abbreviation refers to, from this game's end spots.
 
-    For every play whose text ends "... to the ABC nn" and whose ESPN
-    ``end.yardsToEndzone`` is known, the yardline is either ``nn`` (ABC is the
+    For every play whose text carries a "... to the ABC nn" spot (the LAST one
+    when there are several) and whose ESPN ``end.yardsToEndzone`` is known, the yardline is either ``nn`` (ABC is the
     defending team's side) or ``100 - nn`` (ABC is the possessing team's side).
     Each such play votes; the majority per abbreviation wins, with a floor of two
     votes and 60% agreement so a single mis-stated spot cannot flip a side. The
@@ -960,10 +960,13 @@ def _spot_side_map(play_df: pl.DataFrame) -> pl.DataFrame:
     needed = {"text", "end.yardsToEndzone", "pos_team", "def_pos_team"}
     if not needed.issubset(play_df.columns):
         return pl.DataFrame(schema={"_catch_abbr": pl.Utf8, "_catch_team": play_df.schema["pos_team"]})
+    # A play can carry several "to the ..." spots (a fumble return, a penalty
+    # restatement); ESPN's end.yardsToEndzone describes the LAST one.
+    last_spot = pl.col("text").str.extract_all(_END_SPOT_RE).list.last()
     votes = (
         play_df.select(
-            _catch_abbr=_spot_key(pl.col("text").str.extract(_END_SPOT_RE, 1)),
-            _yl=pl.col("text").str.extract(_END_SPOT_RE, 2).cast(pl.Int64),
+            _catch_abbr=_spot_key(last_spot.str.extract(_END_SPOT_RE, 1)),
+            _yl=last_spot.str.extract(_END_SPOT_RE, 2).cast(pl.Int64),
             _end=pl.col("end.yardsToEndzone").cast(pl.Int64),
             _pos=pl.col("pos_team"),
             _def=pl.col("def_pos_team"),

--- a/sportsdataverse/cfb/cfb_pbp.py
+++ b/sportsdataverse/cfb/cfb_pbp.py
@@ -928,6 +928,70 @@ def _abbr_compat(abbr_col: pl.Expr, team_u: pl.Expr) -> pl.Expr:
     return (abbr_col == team_u) | team_u.str.starts_with(abbr_col) | abbr_col.str.starts_with(team_u)
 
 
+#: A field-position token in the 2025+ vendor play text: a school abbreviation of
+#: up to two words in any case ("SDSU", "Sac St", "NC ST", "Mizzou", "Wake F",
+#: "BC."), an optional dot/space, then the 1-2 digit yardline. The abbreviation is
+#: optional so a bare "50" (midfield) still yields the yardline.
+_SPOT_TOKEN_RE = r"(?:([A-Za-z][A-Za-z&.\-]*(?: [A-Za-z][A-Za-z&.\-]*)?)\.? ?)?(\d{1,2})\b"
+_CATCH_SPOT_RE = r"(?i)(?:caught at|thrown to) (?:the )?" + _SPOT_TOKEN_RE
+_END_SPOT_RE = r"(?i)to the " + _SPOT_TOKEN_RE
+
+
+def _spot_key(abbr: pl.Expr) -> pl.Expr:
+    """Normalise a text abbreviation for matching: upper-case, no spaces or dots."""
+    return abbr.str.to_uppercase().str.replace_all(r"[ .]", "")
+
+
+def _spot_side_map(play_df: pl.DataFrame) -> pl.DataFrame:
+    """Learn which team each text abbreviation refers to, from this game's end spots.
+
+    For every play whose text ends "... to the ABC nn" and whose ESPN
+    ``end.yardsToEndzone`` is known, the yardline is either ``nn`` (ABC is the
+    defending team's side) or ``100 - nn`` (ABC is the possessing team's side).
+    Each such play votes; the majority per abbreviation wins, with a floor of two
+    votes and 60% agreement so a single mis-stated spot cannot flip a side. The
+    50 is skipped (it votes for both).
+
+    Returns:
+        polars.DataFrame: ``_catch_abbr`` (normalised key) -> ``_catch_team``
+        (team id, same dtype as ``pos_team``); empty when the frame lacks the
+        columns the vote needs.
+    """
+    needed = {"text", "end.yardsToEndzone", "pos_team", "def_pos_team"}
+    if not needed.issubset(play_df.columns):
+        return pl.DataFrame(schema={"_catch_abbr": pl.Utf8, "_catch_team": play_df.schema["pos_team"]})
+    votes = (
+        play_df.select(
+            _catch_abbr=_spot_key(pl.col("text").str.extract(_END_SPOT_RE, 1)),
+            _yl=pl.col("text").str.extract(_END_SPOT_RE, 2).cast(pl.Int64),
+            _end=pl.col("end.yardsToEndzone").cast(pl.Int64),
+            _pos=pl.col("pos_team"),
+            _def=pl.col("def_pos_team"),
+        )
+        .drop_nulls(["_catch_abbr", "_yl", "_end"])
+        .filter(pl.col("_yl") != 50)
+        .with_columns(
+            _catch_team=pl.when(pl.col("_end") == 100 - pl.col("_yl"))
+            .then(pl.col("_pos"))
+            .when(pl.col("_end") == pl.col("_yl"))
+            .then(pl.col("_def"))
+            .otherwise(None)
+        )
+        .drop_nulls("_catch_team")
+        .group_by("_catch_abbr", "_catch_team")
+        .len()
+    )
+    if votes.height == 0:
+        return votes.select("_catch_abbr", "_catch_team")
+    return (
+        votes.with_columns(_total=pl.col("len").sum().over("_catch_abbr"))
+        .sort(["_catch_abbr", "len"], descending=[False, True])
+        .unique(subset=["_catch_abbr"], keep="first", maintain_order=True)
+        .filter((pl.col("len") >= 2) & (pl.col("len") >= 0.6 * pl.col("_total")))
+        .select("_catch_abbr", "_catch_team")
+    )
+
+
 def _reorder_late_inserts(plays_df: pl.DataFrame) -> pl.DataFrame:
     """Move plays ESPN inserted late (2014+ feed) back to where their sequence says they belong.
 
@@ -4600,14 +4664,27 @@ class CFBPlayProcess(object):
         ESPN annotates pass plays with the on-field catch/target point as
         ``"caught at OU35"`` (completions) or ``"thrown to TEX42"`` (targets).
         The stated yardline is relative to whichever team owns that side of the
-        field, not the offense, so the abbreviation in the text is resolved to
-        the possessing-vs-defending team -- using the same prefix-tolerant
-        matcher (:func:`_abbr_compat`) that resolves recovery/penalty teams, so
-        ESPN's BUF/BUFF two-abbreviation-form inconsistency still resolves --
-        then converted to yards-to-endzone:
+        field, not the offense, so the abbreviation in the text has to be sided
+        as possessing-vs-defending. The 2025+ vendor text uses each school's OWN
+        abbreviation (``UHM``, ``GSO``, ``USC`` for South Carolina, ``Sac St``,
+        ``BC.``) which frequently is not ESPN's ``homeTeamAbbrev`` /
+        ``awayTeamAbbrev`` (``HAW``, ``GASO``, ``SC``) -- in 2025 that dropped
+        one whole team's plays in a quarter of new-template games. So the side
+        is resolved in this order:
+
+        1. the game's own text: every ``"... to the ABC nn"`` end spot is
+           compared with ESPN's numeric ``end.yardsToEndzone`` and votes for
+           ``ABC`` being the possessing or the defending team
+           (:func:`_spot_side_map`); the majority per abbreviation wins;
+        2. ESPN's abbreviations through the prefix-tolerant :func:`_abbr_compat`
+           (BUF/BUFF still resolves);
+        3. otherwise null -- never a guess.
+
+        Then converted to yards-to-endzone:
 
         * catch abbrev on the possessing team's side -> ``100 - yardline``
         * catch abbrev on the defending team's side  -> ``yardline``
+        * a spot at the 50 -> ``50`` (no abbreviation needed)
         * no air-yards text / unresolved abbreviation -> null
 
         ``air_yards = start.yardsToEndzone - air_yardsToEndzone`` and
@@ -4638,18 +4715,29 @@ class CFBPlayProcess(object):
         def_abbr = pl.when(pl.col("def_pos_team") == pl.col("homeTeamId")).then(home_u).otherwise(away_u)
 
         play_df = play_df.with_columns(
-            _catch_abbr=pl.col("text")
-            .str.extract(r"(?i)(?:caught at|thrown to) ([A-Za-z]+)\d{1,2}", 1)
-            .str.to_uppercase(),
-            _catch_yardline=pl.col("text")
-            .str.extract(r"(?i)(?:caught at|thrown to) [A-Za-z]+(\d{1,2})", 1)
-            .cast(pl.Int64),
+            _catch_abbr=_spot_key(pl.col("text").str.extract(_CATCH_SPOT_RE, 1)),
+            _catch_yardline=pl.col("text").str.extract(_CATCH_SPOT_RE, 2).cast(pl.Int64),
         )
+        # Learn this game's text abbreviations from its end spots, then side the
+        # catch spot with that map first; ESPN's abbreviation is only the fallback.
+        sides = _spot_side_map(play_df)
+        if sides.height:
+            play_df = play_df.join(sides, on="_catch_abbr", how="left")
+        else:
+            play_df = play_df.with_columns(_catch_team=pl.lit(None, dtype=play_df.schema["pos_team"]))
         play_df = play_df.with_columns(
-            air_yardsToEndzone=pl.when(
-                pl.col("_catch_abbr").is_null().or_(pl.col("_catch_yardline").is_null()),
-            )
+            air_yardsToEndzone=pl.when(pl.col("_catch_yardline").is_null())
             .then(pl.lit(None, dtype=pl.Int64))
+            # midfield is 50 from either endzone; the text often carries no abbreviation there
+            .when(pl.col("_catch_yardline") == 50)
+            .then(pl.lit(50, dtype=pl.Int64))
+            .when(pl.col("_catch_abbr").is_null())
+            .then(pl.lit(None, dtype=pl.Int64))
+            # game-learned side of the field
+            .when(pl.col("_catch_team") == pl.col("pos_team"))
+            .then(100 - pl.col("_catch_yardline"))
+            .when(pl.col("_catch_team") == pl.col("def_pos_team"))
+            .then(pl.col("_catch_yardline"))
             # possessing-team side of the field: yards still to go from the catch point
             .when(_abbr_compat(pl.col("_catch_abbr"), pos_abbr))
             .then(100 - pl.col("_catch_yardline"))
@@ -4670,7 +4758,7 @@ class CFBPlayProcess(object):
             .then(pl.col("statYardage").cast(pl.Int64) - pl.col("air_yards"))
             .otherwise(pl.lit(None, dtype=pl.Int64)),
         )
-        return play_df.drop("_catch_abbr", "_catch_yardline")
+        return play_df.drop("_catch_abbr", "_catch_yardline", "_catch_team")
 
     def __add_player_cols(self, play_df):
         play_df = (

--- a/tests/cfb/test_cfb_air_yards.py
+++ b/tests/cfb/test_cfb_air_yards.py
@@ -381,3 +381,32 @@ def test_side_vote_needs_a_majority_and_two_votes():
     )
     out = _run_air_yards(rows)
     assert out["air_yardsToEndzone"].to_list()[-2:] == [20, None]  # JSU still defending side (3 of 4 votes)
+
+
+def test_side_vote_uses_the_last_spot_of_a_multi_spot_play():
+    """A fumble return names two spots; only the final one matches ESPN's end yardline."""
+    rows = [
+        # NDSU rush to the JSU 30, fumble, returned by JSU to the NDSU 45: ball ends 55 from the
+        # NDSU goal, i.e. ESPN end.yardsToEndzone (NDSU still charted as pos_team) = 55.
+        # First spot would vote JSU = defending (30 == ... no: 30 != 55 and 30 != 45), so it must
+        # not be used; the LAST spot NDSU45 -> 100 - 45 == 55 -> NDSU is the possessing side.
+        _vendor_row(
+            "#3 C.Miller rush for 5 yards to the JSU30, fumble forced, recovered by JSU #9 returned to the NDSU45",
+            pos_team=_NDSU_ID,
+            start_ytg=35,
+            end_ytg=55,
+        ),
+        _vendor_row("#3 C.Miller rush for 3 yards to the NDSU43", pos_team=_NDSU_ID, start_ytg=60, end_ytg=57),
+        # no direct JSU end spots: JSU's side must come only from the fumble play NOT mis-voting
+        _vendor_row(
+            "pass complete to Y caught at NDSU40, for 5 yards",
+            pos_team=_JSU_ID,
+            start_ytg=45,
+            end_ytg=35,
+            stat_yardage=5,
+            completion=True,
+        ),
+    ]
+    out = _run_air_yards(rows)
+    # NDSU learned as itself from two clean last-spot votes; JSU throwing to the NDSU 40 -> 40 to go -> 5 air yards
+    assert out["air_yardsToEndzone"][-1] == 40 and out["air_yards"][-1] == 5

--- a/tests/cfb/test_cfb_air_yards.py
+++ b/tests/cfb/test_cfb_air_yards.py
@@ -220,3 +220,164 @@ def test_unresolved_abbreviation_is_null():
     assert out["air_yardsToEndzone"][0] is None
     assert out["air_yards"][0] is None
     assert out["yards_after_catch"][0] is None
+
+
+# --- 2025+ vendor text: the school's own abbreviation, not ESPN's -------------
+
+_JSU_ID, _NDSU_ID = 55, 2449  # Jacksonville St (ESPN "JVST", text "JSU") at North Dakota St
+
+
+def _vendor_row(text: str, *, pos_team: int, start_ytg: int, end_ytg: int | None, **kw) -> dict:
+    """A 2025+-template row: real ESPN abbreviations, vendor text, ESPN end spot."""
+    def_team = _JSU_ID if pos_team == _NDSU_ID else _NDSU_ID
+    row = _row(
+        text,
+        pos_team=pos_team,
+        def_pos_team=def_team,
+        start_ytg=start_ytg,
+        home_abbr="NDSU",
+        away_abbr="JVST",
+        **kw,
+    )
+    row.update({"homeTeamId": _NDSU_ID, "awayTeamId": _JSU_ID, "end.yardsToEndzone": end_ytg})
+    return row
+
+
+def _vendor_game(extra: list[dict]) -> list[dict]:
+    """Enough end spots for the vote: NDSU rushes ending on both sides of the field."""
+    return [
+        # NDSU ball, ends at the JSU 30 -> ESPN yards-to-endzone 30 -> JSU is the defending side
+        _vendor_row("#3 C.Miller rush for 5 yards to the JSU30", pos_team=_NDSU_ID, start_ytg=35, end_ytg=30),
+        _vendor_row("#3 C.Miller rush for 4 yards to the JSU26", pos_team=_NDSU_ID, start_ytg=30, end_ytg=26),
+        # NDSU ball, ends at its own 40 -> yards-to-endzone 60 -> NDSU is the possessing side
+        _vendor_row("#3 C.Miller rush for 2 yards to the NDSU40", pos_team=_NDSU_ID, start_ytg=62, end_ytg=60),
+        _vendor_row("#3 C.Miller rush for 3 yards to the NDSU43", pos_team=_NDSU_ID, start_ytg=60, end_ytg=57),
+    ] + extra
+
+
+def test_vendor_abbreviation_learned_from_end_spots():
+    """'JSU' is not a prefix of ESPN's 'JVST'; the game's own end spots side it."""
+    out = _run_air_yards(
+        _vendor_game(
+            [
+                # JSU ball at its own 35 (65 to go); caught at the JSU 47 -> 53 to go -> 12 air yards
+                _vendor_row(
+                    "Shotgun #2 N.Hayes pass complete short left to #18 J.Williams caught at JSU47, for 14 yards",
+                    pos_team=_JSU_ID,
+                    start_ytg=65,
+                    end_ytg=51,
+                    stat_yardage=14,
+                    completion=True,
+                ),
+                # NDSU ball at the JSU 40; thrown to the JSU 33 -> 33 to go -> 7 air yards, no YAC
+                _vendor_row(
+                    "#12 C.Creel pass incomplete short right to #9 R.Johnson thrown to JSU33",
+                    pos_team=_NDSU_ID,
+                    start_ytg=40,
+                    end_ytg=40,
+                ),
+            ]
+        )
+    )
+    assert out["air_yardsToEndzone"].to_list()[-2:] == [53, 33]
+    assert out["air_yards"].to_list()[-2:] == [12, 7]
+    assert out["yards_after_catch"].to_list()[-2:] == [2, None]
+    assert "_catch_team" not in out.columns and "_catch_abbr" not in out.columns
+
+
+def test_vendor_token_shapes_space_dot_and_two_words():
+    """'UA 10', 'BC.41', 'Sac St10' and 'NC ST19' all parse as an abbreviation + yardline."""
+    rows = [
+        _row(
+            "pass complete to X caught at OU 10, for 2 yards",
+            pos_team=_HOME_ID,
+            def_pos_team=_AWAY_ID,
+            start_ytg=20,
+            stat_yardage=2,
+            completion=True,
+        ),
+        _row(
+            "pass complete to X caught at TEX.41, for 9 yards",
+            pos_team=_HOME_ID,
+            def_pos_team=_AWAY_ID,
+            start_ytg=50,
+            stat_yardage=9,
+            completion=True,
+        ),
+        _row(
+            "pass incomplete to X thrown to Sac St10",
+            pos_team=_HOME_ID,
+            def_pos_team=_AWAY_ID,
+            start_ytg=30,
+            home_abbr="SACST",
+            away_abbr="TEX",
+        ),
+        _row(
+            "pass incomplete to X thrown to NC ST19",
+            pos_team=_HOME_ID,
+            def_pos_team=_AWAY_ID,
+            start_ytg=30,
+            home_abbr="NCST",
+            away_abbr="TEX",
+        ),
+    ]
+    out = _run_air_yards(rows)
+    # OU (possessing) 10 -> 90 to go; TEX (defending) 41 -> 41; Sac St (possessing) 10 -> 90; NC ST (possessing) 19 -> 81
+    assert out["air_yardsToEndzone"].to_list() == [90, 41, 90, 81]
+    assert out["air_yards"].to_list() == [-70, 9, -60, -51]
+
+
+def test_midfield_spot_needs_no_abbreviation():
+    out = _run_air_yards(
+        [
+            _row(
+                "pass complete to X caught at 50, for 3 yards",
+                pos_team=_HOME_ID,
+                def_pos_team=_AWAY_ID,
+                start_ytg=60,
+                stat_yardage=3,
+                completion=True,
+            ),
+            _row(
+                "pass complete to X caught at the 50, for 3 yards",
+                pos_team=_HOME_ID,
+                def_pos_team=_AWAY_ID,
+                start_ytg=60,
+                stat_yardage=3,
+                completion=True,
+            ),
+        ]
+    )
+    assert out["air_yardsToEndzone"].to_list() == [50, 50]
+    assert out["air_yards"].to_list() == [10, 10]
+    assert out["yards_after_catch"].to_list() == [-7, -7]
+
+
+def test_side_vote_needs_a_majority_and_two_votes():
+    """One contradictory end spot cannot flip a side; a lone spot cannot establish one."""
+    rows = _vendor_game(
+        [
+            # a mis-stated spot that says JSU is the possessing side (end 70 at 'JSU30')
+            _vendor_row("#3 C.Miller rush for 1 yard to the JSU30", pos_team=_NDSU_ID, start_ytg=71, end_ytg=70),
+            # a single 'XYZ' end spot: one vote only -> no mapping -> the catch below stays null
+            _vendor_row("#3 C.Miller rush for 1 yard to the XYZ30", pos_team=_NDSU_ID, start_ytg=31, end_ytg=30),
+            _vendor_row(
+                "pass complete to Y caught at JSU20, for 5 yards",
+                pos_team=_NDSU_ID,
+                start_ytg=25,
+                end_ytg=20,
+                stat_yardage=5,
+                completion=True,
+            ),
+            _vendor_row(
+                "pass complete to Y caught at XYZ20, for 5 yards",
+                pos_team=_NDSU_ID,
+                start_ytg=25,
+                end_ytg=20,
+                stat_yardage=5,
+                completion=True,
+            ),
+        ]
+    )
+    out = _run_air_yards(rows)
+    assert out["air_yardsToEndzone"].to_list()[-2:] == [20, None]  # JSU still defending side (3 of 4 votes)


### PR DESCRIPTION
## Why
Air-yards coverage audit (2026-09-01): in 2025's new-template games only 72 % of pass plays resolve `air_yards`; **17.5 % of pass plays have a `caught at` / `thrown to` spot in the text and still come out null**. Root cause: the vendor text uses each school's own abbreviation (`UHM`, `USC`=South Carolina, `GSO`, `OSU`=Oregon St, `Sac St`, `BC.` …) and `__add_air_yards_cols` only matched ESPN's `homeTeamAbbrev`/`awayTeamAbbrev` (`HAW`, `SC`, `GASO`, `ORST`). Of 6,131 such misses, 0 matched either ESPN abbreviation; one whole team's plays vanish in 103 of 411 games. Same defect in 2026 (`JSU` vs ESPN `JVST`).

## What
- `_spot_side_map`: learn this game's abbreviation → team map from its `… to the ABC nn` end spots vs ESPN's numeric `end.yardsToEndzone` (majority vote, ≥2 votes, ≥60 %). Used first; `_abbr_compat` against ESPN's abbreviations remains the fallback; never a guess.
- One spot regex for all observed token shapes (`SDSU47`, `UA 10`, `BC.41`, `Sac St10`, `NC ST19`, `Mizzou31`), normalised key (upper, no spaces/dots); a spot at the `50` resolves without an abbreviation.
- Docstring rewritten to describe the resolution order.

## Verified
- `tests/cfb/test_cfb_air_yards.py`: 11 passed (4 new: learned map, token shapes, midfield, minority-vote guard); box air-yards tests pass.
- Offline pipeline re-run on nine affected games (2025 UNLV-HAW, TA&M-SC, CCU-GAST, ORST-SHSU, LIB-DEL, LOU-UK, CCU-MRSH; 2026 NDSU-JVST): spot-phrase resolution **21.8 % → 100 %** (490 plays). The 74 plays that already resolved are byte-identical; new values mean 9.5 / median 6 / range −6…44 air yards, YAC mean 7.0.

## Follow-up (not here)
cfbfastR-cfb-raw rebuild of 2024–2026 finals only (stamp bump), then the cfb-data compile for those seasons; R port of the same logic in `cfbfastR/R/helper_pbp_air_yards.R`.

## Summary by Sourcery

Improve college football air-yards spot resolution for vendor-specific team abbreviations while preserving safe fallback behavior.

New Features:
- Resolve 2025+ vendor catch and target spots using game-specific school abbreviations learned from play text.

Bug Fixes:
- Restore air-yards resolution for plays whose vendor abbreviations differ from ESPN team abbreviations.
- Handle varied spot-token formats and abbreviation-free midfield spots without producing incorrect side assignments.

Enhancements:
- Use validated majority-vote mappings before falling back to ESPN abbreviation compatibility, leaving ambiguous abbreviations unresolved.

Tests:
- Add coverage for learned abbreviation mappings, varied spot formats, midfield handling, vote safeguards, and multi-spot plays.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved air-yard calculations when team abbreviations differ between data sources.
  * Added support for multi-word, mixed-case, dotted, and midfield field-position labels.
  * More reliably identifies whether a catch occurred on the possessing or defending team’s side.
  * Returns consistent null results for missing or unresolved abbreviations.

* **Tests**
  * Added coverage for alternate vendor text formats, ambiguous abbreviations, and real-game scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->