### PR TITLE
fix(cfb): union the ESPN game roster with the CFBD preseason roster

### DIFF
--- a/sportsdataverse/cfb/cfb_returning_production.py
+++ b/sportsdataverse/cfb/cfb_returning_production.py
@@ -39,7 +39,12 @@ import warnings
 import pandas as pd
 import polars as pl
 
-from sportsdataverse.cfb.cfb_loaders import load_cfb_player_box, load_cfb_rosters, load_cfb_team_info
+from sportsdataverse.cfb.cfb_loaders import (
+    load_cfb_player_box,
+    load_cfb_rosters,
+    load_cfb_rosters_cfbd,
+    load_cfb_team_info,
+)
 from sportsdataverse._codegen_runtime import _read_release_parquet
 from sportsdataverse.cfb.cfb_crosswalk import _norm_team
 from sportsdataverse.cfb.cfb_projection_constants import get_constants
@@ -246,43 +251,65 @@ def _production_from_box(box: pl.DataFrame, season: int) -> pl.DataFrame:
     )
 
 
+_EMPTY_KEYS = {"season": pl.Int64, "team_id": pl.Utf8, "player_id": pl.Utf8}
+
+
 def _roster_keys(season: int) -> pl.DataFrame:
     """Season-S roster as ``(season, team_id, player_id)`` with REAL team ids.
 
-    Two roster shapes reach this function:
+    Two sources are UNIONED, because neither is complete on its own:
 
     * **ESPN** (``espn_cfb_rosters``, what :func:`load_cfb_rosters` serves since
-      #399): carries ``team_id`` directly. Keys are taken as-is; rows with a null
-      ``team_id`` or ``athlete_id`` are dropped (ESPN emits none in practice) and
-      no match-rate check applies -- there is nothing to resolve.
-    * **CFBD-shaped** (a ``team`` school-name column, no id): resolved against
-      ``load_cfb_team_info``'s ``school`` column, NOT the teams crosswalk -- the
-      crosswalk keys on school+mascot ("western kentucky hilltoppers") while
-      that roster carries school only ("Western Kentucky"), which matched 0.0%
-      of 2023 rows. Matching folds case and falls back through ESPN's
-      alternate names. The match rate is ASSERTED rather than assumed: an
-      unresolved roster makes every player look departed, which reads as
-      "this team returns nobody" instead of as a failure.
+      #399): built from game rosters, so it carries ``team_id`` directly but
+      only lists players who have dressed -- for the season in progress that is
+      a handful of teams (2026 week 1: 4 teams, 476 rows), which made every
+      returning-production fraction collapse toward zero.
+    * **CFBD** (``cfbfastR-data`` rosters, :func:`load_cfb_rosters_cfbd`): the
+      preseason roster for every team, keyed by school name and ESPN athlete
+      id. Resolved against ``load_cfb_team_info``'s ``school`` column, NOT the
+      teams crosswalk -- the crosswalk keys on school+mascot ("western kentucky
+      hilltoppers") while this roster carries school only ("Western Kentucky"),
+      which matched 0.0% of 2023 rows. Matching folds case and falls back
+      through ESPN's alternate names. Its match rate is ASSERTED: an unresolved
+      roster makes every player look departed, which reads as "this team
+      returns nobody" instead of as a failure.
+
+    A player is "on the roster" if either source lists them (Connelly's
+    definition is roster membership, not appearances). Rows with a null id are
+    dropped; the union is de-duplicated on ``(team_id, player_id)``.
 
     Raises:
-        ValueError: CFBD-shaped roster only -- if fewer than
-            :data:`_MIN_ROSTER_MATCH` of roster rows resolve to a team id.
+        ValueError: If the CFBD roster is present but fewer than
+            :data:`_MIN_ROSTER_MATCH` of its rows resolve to a team id.
     """
+    parts = [_espn_roster_keys(season), _cfbd_roster_keys(season)]
+    parts = [p for p in parts if p.height]
+    if not parts:
+        return pl.DataFrame(schema=_EMPTY_KEYS)
+    return pl.concat(parts).unique(subset=["team_id", "player_id"], maintain_order=True)
+
+
+def _espn_roster_keys(season: int) -> pl.DataFrame:
+    """ESPN game-roster keys: ``team_id`` is carried directly, nothing to resolve."""
     roster = load_cfb_rosters(season)
     if isinstance(roster, pd.DataFrame):
         roster = pl.from_pandas(roster)
-    if roster is None or roster.height == 0:
-        return pl.DataFrame(schema={"season": pl.Int64, "team_id": pl.Utf8, "player_id": pl.Utf8})
+    if roster is None or roster.height == 0 or "team_id" not in roster.columns:
+        return pl.DataFrame(schema=_EMPTY_KEYS)
+    return roster.select(
+        pl.lit(season, dtype=pl.Int64).alias("season"),
+        pl.col("team_id").cast(pl.Int64).cast(pl.Utf8).alias("team_id"),
+        pl.col("athlete_id").cast(pl.Utf8).alias("player_id"),
+    ).drop_nulls(["team_id", "player_id"])
 
-    if "team_id" in roster.columns:
-        # espn_cfb_rosters (#399) carries the ESPN team id directly, so no name
-        # crosswalk is needed -- and none is possible: it has no `team` column.
-        # The name path below is kept for the CFBD-shaped roster (`team` = school).
-        return roster.select(
-            pl.lit(season, dtype=pl.Int64).alias("season"),
-            pl.col("team_id").cast(pl.Int64).cast(pl.Utf8).alias("team_id"),
-            pl.col("athlete_id").cast(pl.Utf8).alias("player_id"),
-        ).drop_nulls(["team_id", "player_id"])
+
+def _cfbd_roster_keys(season: int) -> pl.DataFrame:
+    """CFBD preseason-roster keys, school name resolved to the ESPN team id."""
+    roster = load_cfb_rosters_cfbd(season)
+    if isinstance(roster, pd.DataFrame):
+        roster = pl.from_pandas(roster)
+    if roster is None or roster.height == 0 or "team" not in roster.columns:
+        return pl.DataFrame(schema=_EMPTY_KEYS)
 
     info = load_cfb_team_info(season)
     if isinstance(info, pd.DataFrame):
@@ -445,10 +472,10 @@ def cfb_returning_production(
         (typed) when the box data is unavailable.
 
     Raises:
-        ValueError: Only when the season-S roster is CFBD-shaped (``team`` name,
-            no ``team_id``) and cannot be resolved to team ids above the
-            crosswalk match floor; the ESPN roster carries ``team_id`` and
-            needs no resolution.
+        ValueError: If the season-S CFBD roster cannot be resolved to team ids
+            above the crosswalk match floor (the ESPN roster carries ``team_id``
+            and needs no resolution; the two are unioned, see
+            :func:`_roster_keys`).
 
     Example:
         Quick start::

--- a/tests/cfb/test_cfb_returning_production.py
+++ b/tests/cfb/test_cfb_returning_production.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import importlib
 
+import pytest
+
 import polars as pl
 
 from sportsdataverse.cfb.cfb_returning_production import _returning_from_frames
@@ -91,9 +93,10 @@ def test_roster_keys_use_espn_team_id_without_name_crosswalk(monkeypatch) -> Non
         }
     )
     monkeypatch.setattr(rp, "load_cfb_rosters", lambda season: espn_roster)
+    monkeypatch.setattr(rp, "load_cfb_rosters_cfbd", lambda season: pl.DataFrame())
 
     def _no_info(season):  # pragma: no cover - the assertion is that it is never reached
-        raise AssertionError("team_info crosswalk must not run for an ESPN roster")
+        raise AssertionError("team_info crosswalk must not run when only the ESPN roster is present")
 
     monkeypatch.setattr(rp, "load_cfb_team_info", _no_info)
     out = rp._roster_keys(2025)
@@ -101,3 +104,39 @@ def test_roster_keys_use_espn_team_id_without_name_crosswalk(monkeypatch) -> Non
     assert out["team_id"].to_list() == ["333", "333"]  # null team_id row dropped
     assert out["player_id"].to_list() == ["1", "2"]
     assert out.schema["team_id"] == pl.Utf8 and out.schema["player_id"] == pl.Utf8
+
+
+def test_roster_keys_union_espn_and_cfbd_for_the_season_in_progress(monkeypatch) -> None:
+    """Week 1: ESPN game rosters cover a handful of teams; the CFBD preseason roster fills the rest.
+
+    A player listed by both sources appears once; the CFBD school name is resolved
+    through team_info to the same ESPN team id the ESPN roster carries.
+    """
+    espn_roster = pl.DataFrame({"season": [2026, 2026], "team_id": [333, 333], "athlete_id": [1, 2]})
+    cfbd_roster = pl.DataFrame(
+        {
+            "athlete_id": ["2", "3", "4", "5"],
+            "team": ["Alabama", "Alabama", "Auburn", "Nowhere State"],
+        }
+    )
+    info = pl.DataFrame({"team_id": [333, 2], "school": ["Alabama", "Auburn"], "alt_name1": [None, None]})
+    monkeypatch.setattr(rp, "load_cfb_rosters", lambda season: espn_roster)
+    monkeypatch.setattr(rp, "load_cfb_rosters_cfbd", lambda season: cfbd_roster)
+    monkeypatch.setattr(rp, "load_cfb_team_info", lambda season: info)
+    monkeypatch.setattr(rp, "_MIN_ROSTER_MATCH", 0.5)  # 3 of 4 CFBD rows resolve; "Nowhere State" does not
+    out = rp._roster_keys(2026).sort("team_id", "player_id")
+    assert out.rows() == [(2026, "2", "4"), (2026, "333", "1"), (2026, "333", "2"), (2026, "333", "3")]
+
+
+def test_roster_keys_cfbd_match_floor_still_asserts(monkeypatch) -> None:
+    monkeypatch.setattr(rp, "load_cfb_rosters", lambda season: pl.DataFrame())
+    monkeypatch.setattr(
+        rp,
+        "load_cfb_rosters_cfbd",
+        lambda season: pl.DataFrame({"athlete_id": ["1", "2"], "team": ["Nowhere", "Elsewhere"]}),
+    )
+    monkeypatch.setattr(
+        rp, "load_cfb_team_info", lambda season: pl.DataFrame({"team_id": [1], "school": ["Somewhere"]})
+    )
+    with pytest.raises(ValueError, match="resolved to a team id"):
+        rp._roster_keys(2026)


### PR DESCRIPTION
## Why
Since #399 `cfb_returning_production` took the season-S roster only from `espn_cfb_rosters`, which is built from **game** rosters. For the season in progress that is the teams that have played (2026 week 1: 4 teams, 476 rows), so every player looked departed, `off_returning` collapsed to 0.006, and cfbfastR-cfb-data's sanity guard refused the 2026 build (see tonight's compile logs).

## What
`_roster_keys` unions two sources and de-duplicates on `(team_id, player_id)`:
- `_espn_roster_keys` — `espn_cfb_rosters`, `team_id` direct;
- `_cfbd_roster_keys` — the CFBD preseason roster (`load_cfb_rosters_cfbd`, every team, school name + ESPN athlete id), resolved through `load_cfb_team_info` with the existing asserted match floor.

Roster membership is Connelly's definition, so the union is the correct set rather than a fallback; it also covers mid-season transfers-in that have not dressed yet.

## Verified
- `tests/cfb/test_cfb_returning_production.py`: 6 passed (new: union + dedup with a CFBD name resolved to the same ESPN id; CFBD match floor still raises).
- Live: **2026 → 236 team rows, off/def returning 0.452 / 0.463** (was 0.006); 2025 → 236 rows, 0.406 / 0.417; roster union 29,319 rows / 275 teams for 2026.

## Follow-up
cfbfastR-cfb-data: re-lock and re-run `returning_production` for 2026.

## Summary by Sourcery

Union ESPN game rosters with CFBD preseason rosters to accurately identify season roster membership for returning-production calculations.

Bug Fixes:
- Restore accurate in-season returning-production calculations by combining ESPN game-roster membership with CFBD preseason-roster membership.
- Include mid-season rostered players who have not yet appeared in a game while de-duplicating players listed by both sources.

Enhancements:
- Retain validation that rejects CFBD rosters when team-name resolution falls below the required match threshold.

Tests:
- Add coverage for roster-source unioning, duplicate removal, ESPN team identifiers, and CFBD team-resolution failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved returning-production data accuracy by linking teams through official ESPN identifiers.
  * Combined available ESPN and preseason roster data to provide more complete results during an in-progress season.
  * Added validation to flag insufficient team matching in roster data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->